### PR TITLE
test(parity): resolve Harmony divergences and remove tool-call leaks

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -994,7 +994,7 @@ impl JailedStream {
                             Some(Role::Assistant),
                             normal_text.as_deref().unwrap_or(""),
                             Some(tool_call_chunks),
-                            None,
+                            base_choice.finish_reason,
                             base_choice.logprobs.clone(),
                         )
                     }

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1874,7 +1874,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_jailed_stream_harmony_parser() {
-        // Harmony format with analysis text and a tool call encoded in special tags
+        // Harmony format with hidden analysis text and a tool call encoded in special tags
         let chunks = vec![
             create_mock_response_chunk(
                 "<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|>"
@@ -1899,10 +1899,10 @@ mod tests {
         let jail = JailedStream::builder().tool_call_parser("harmony").build();
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have at least one output containing both analysis text and parsed tool call
+        // Should have at least one output containing the parsed tool call.
         assert!(!results.is_empty());
 
-        // Verify the analysis text appears as content in one of the outputs
+        // Verify hidden analysis text is not emitted as user-visible content.
         let has_analysis_text = results.iter().any(|r| {
             r.data
                 .as_ref()
@@ -1914,7 +1914,10 @@ mod tests {
                 })
                 .unwrap_or(false)
         });
-        assert!(has_analysis_text, "Should contain extracted analysis text");
+        assert!(
+            !has_analysis_text,
+            "Should not expose Harmony analysis text as content"
+        );
 
         // Verify a tool call was parsed with expected name and args
         let tool_call_idx = results

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -16,6 +16,8 @@ use std::sync::OnceLock;
 
 static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::Error>> =
     OnceLock::new();
+static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
+const HARMONY_CALL_MARKER: &str = "<|call|>";
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
     GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
@@ -73,10 +75,51 @@ fn encode_text_to_tokens(text: &str) -> anyhow::Result<Vec<u32>> {
     Ok(enc.tokenizer().encode_with_special_tokens(text))
 }
 
-fn decode_input_text(text: &str, token_ids: &[u32]) -> String {
+fn harmony_call_token_ids() -> Option<&'static [u32]> {
+    let ids = HARMONY_CALL_TOKEN_IDS.get_or_init(|| {
+        get_harmony_encoding()
+            .as_ref()
+            .map(|enc| {
+                enc.tokenizer()
+                    .encode_with_special_tokens(HARMONY_CALL_MARKER)
+            })
+            .unwrap_or_default()
+    });
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids.as_slice())
+    }
+}
+
+fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
+    !marker_ids.is_empty()
+        && marker_ids.len() <= token_ids.len()
+        && token_ids
+            .windows(marker_ids.len())
+            .any(|window| window == marker_ids)
+}
+
+fn input_contains_call_marker(
+    text: &str,
+    token_ids: &[u32],
+    caller_supplied_token_ids: bool,
+) -> bool {
     if !token_ids.is_empty()
-        && let Ok(enc) = get_harmony_encoding()
+        && let Some(call_ids) = harmony_call_token_ids()
     {
+        return token_ids_contain_sequence(token_ids, call_ids);
+    }
+
+    !caller_supplied_token_ids && text.contains(HARMONY_CALL_MARKER)
+}
+
+fn raw_input_text_for_tool_parser(
+    text: &str,
+    token_ids: &[u32],
+    caller_supplied_token_ids: bool,
+) -> String {
+    if caller_supplied_token_ids && let Ok(enc) = get_harmony_encoding() {
         return enc.tokenizer().decode_utf8(token_ids).unwrap_or_default();
     }
 
@@ -189,6 +232,7 @@ impl ReasoningParser for GptOssReasoningParser {
         text: &str,
         token_ids: &[u32],
     ) -> ParserResult {
+        let caller_supplied_token_ids = !token_ids.is_empty();
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
             let encoded_tokens = match encode_text_to_tokens(text) {
@@ -235,8 +279,9 @@ impl ReasoningParser for GptOssReasoningParser {
             }
         }
 
-        let raw_input_text = decode_input_text(text, token_ids);
-        if raw_input_text.contains("<|call|>") {
+        if input_contains_call_marker(text, token_ids, caller_supplied_token_ids) {
+            let raw_input_text =
+                raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
             normal_delta.push_str(&raw_input_text);
         }
 

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -73,6 +73,16 @@ fn encode_text_to_tokens(text: &str) -> anyhow::Result<Vec<u32>> {
     Ok(enc.tokenizer().encode_with_special_tokens(text))
 }
 
+fn decode_input_text(text: &str, token_ids: &[u32]) -> String {
+    if !token_ids.is_empty()
+        && let Ok(enc) = get_harmony_encoding()
+    {
+        return enc.tokenizer().decode_utf8(token_ids).unwrap_or_default();
+    }
+
+    text.to_string()
+}
+
 impl ReasoningParser for GptOssReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
         let token_ids = if token_ids.is_empty() {
@@ -223,6 +233,11 @@ impl ReasoningParser for GptOssReasoningParser {
                     _ => {}
                 }
             }
+        }
+
+        let raw_input_text = decode_input_text(text, token_ids);
+        if raw_input_text.contains("<|call|>") {
+            normal_delta.push_str(&raw_input_text);
         }
 
         if !normal_delta.is_empty() || !reasoning_delta.is_empty() {

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ToolDefinition;
-use super::super::json::base_json_parser::try_repair_truncated_json;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 use openai_harmony::chat::{Content::Text, Role};
@@ -21,17 +20,15 @@ static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
 /// input — alternative on this path is silent-drop. Worst case is missing
-/// a call, never fabricating one (full structural signature required).
+/// a call, never fabricating one: Harmony tool calls must end with `<|call|>`.
 fn commentary_block_regex() -> &'static Regex {
     COMMENTARY_BLOCK_REGEX.get_or_init(|| {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
         // Between name and `<|message|>` we tolerate optional
         // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
-        // Args end at either `<|call|>` (normal close) or end-of-string
-        // (`\z`, the bare-envelope PARSER.batch.5 variant where the model never
-        // emitted `<|call|>` before EOS / max_tokens).
+        // Args must end at `<|call|>`, the required Harmony tool-call stop token.
         Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
         )
         .expect("commentary block regex")
     })
@@ -164,6 +161,29 @@ fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> 
     cleaned
 }
 
+fn normal_text_after_parse_failure(text: &str, reason: &'static str) -> String {
+    let cleaned = strip_harmony_protocol_from_normal_text(text, reason);
+    if cleaned == text && !text.trim().is_empty() {
+        tracing::warn!(
+            family = "harmony",
+            reason,
+            original_len = text.len(),
+            "dropped bare text without a Harmony final/commentary message"
+        );
+        String::new()
+    } else {
+        cleaned
+    }
+}
+
+fn serialize_harmony_arguments(raw_args: &str) -> String {
+    let trimmed = raw_args.trim();
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value) => serde_json::to_string(&value).unwrap_or_else(|_| trimmed.to_string()),
+        Err(_) => trimmed.to_string(),
+    }
+}
+
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
 /// (truncated JSON, multiple back-to-back commentary blocks, etc.).
 /// Returns (calls, residual_text) where residual_text is everything not
@@ -191,16 +211,7 @@ fn extract_calls_via_regex(
         if name.is_empty() {
             continue;
         }
-        let args_json = match serde_json::from_str::<Value>(raw_args) {
-            Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-            Err(_) if allow_eof_recovery => match try_repair_truncated_json(raw_args)
-                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
-            {
-                Some(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-                None => raw_args.to_string(),
-            },
-            Err(_) => continue,
-        };
+        let args_json = serialize_harmony_arguments(raw_args);
         let call_idx = out.len() + 1;
         out.push(ToolCallResponse {
             id: format!("call-{call_idx}"),
@@ -243,9 +254,9 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// or token-by-token streaming, making it more efficient for complete chunks.
 ///
 /// # Arguments
-/// * `text` - The full Harmony-format string to be parsed, excluding any trailing stop tokens.
+/// * `text` - The full Harmony-format string to be parsed, including required Harmony stop tokens.
 ///   Example:
-///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}`
+///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>`
 /// * `_config` - Parser configuration (currently unused but kept for API consistency)
 ///
 /// # Returns
@@ -260,8 +271,7 @@ pub async fn parse_tool_calls_harmony_complete(
         Ok(e) => e,
         Err(e) => {
             tracing::debug!("Failed to load harmony encoding: {e}. Tool calls will not be parsed.");
-            let normal_text =
-                strip_harmony_protocol_from_normal_text(text, "harmony_encoding_unavailable");
+            let normal_text = normal_text_after_parse_failure(text, "harmony_encoding_unavailable");
             return Ok((vec![], Some(normal_text)));
         }
     };
@@ -284,15 +294,16 @@ pub async fn parse_tool_calls_harmony_complete(
                 return Ok((calls, Some(normal_text)));
             }
             let normal_text =
-                strip_harmony_protocol_from_normal_text(text, "parse_failed_no_recovered_calls");
+                normal_text_after_parse_failure(text, "parse_failed_no_recovered_calls");
             return Ok((vec![], Some(normal_text)));
         }
     };
 
-    let normal_text = String::new();
-
     let mut res = Vec::with_capacity(messages.len());
     let mut call_idx = 0; // Index of the tool call
+    let mut final_text: Option<String> = None;
+    let mut commentary_text: Option<String> = None;
+    let has_tool_call_stop = text.contains("<|call|>");
 
     for message in messages.iter() {
         if message.author.role != Role::Assistant {
@@ -304,6 +315,10 @@ pub async fn parse_tool_calls_harmony_complete(
 
         // Handle commentary channel
         if channel == Some("commentary") && recipient.starts_with("functions.") {
+            if !has_tool_call_stop {
+                continue;
+            }
+
             let Some(fname) = message
                 .recipient
                 .as_ref()
@@ -314,43 +329,37 @@ pub async fn parse_tool_calls_harmony_complete(
                 continue;
             };
 
-            let args = match message.content.first() {
-                Some(Text(text)) => {
-                    let trimmed = text.text.trim();
-                    match serde_json::from_str::<Value>(trimmed) {
-                        Ok(value) => value,
-                        Err(_) if config.allow_eof_recovery => {
-                            // Truncation recovery: balance unclosed strings /
-                            // braces (max_tokens / EOS pattern) and retry.
-                            // Gated so streaming early-exit doesn't extract
-                            // a partial call with synthesized closers.
-                            try_repair_truncated_json(trimmed)
-                                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
-                                .unwrap_or(Value::Null)
-                        }
-                        Err(_) => Value::Null,
-                    }
-                }
-                _ => {
-                    Value::Null // Set args to null if it's not a text content
-                }
+            let Some(args_json) = message.content.first().and_then(|content| match content {
+                Text(text) => Some(serialize_harmony_arguments(&text.text)),
+                _ => None,
+            }) else {
+                continue;
             };
-            // Add tool call to result if args is valid JSON
-            if !args.is_null() {
-                call_idx += 1;
-                res.push(ToolCallResponse {
-                    id: format!("call-{}", call_idx),
-                    tp: ToolCallType::Function,
-                    function: CalledFunction {
-                        name: fname.to_string(),
-                        // Safety: `Value::Object` is always valid JSON, so serialization cannot fail
-                        arguments: serde_json::to_string(&args).unwrap(),
-                    },
-                });
+
+            call_idx += 1;
+            res.push(ToolCallResponse {
+                id: format!("call-{}", call_idx),
+                tp: ToolCallType::Function,
+                function: CalledFunction {
+                    name: fname.to_string(),
+                    arguments: args_json,
+                },
+            });
+        } else if channel == Some("final") {
+            if let Some(Text(text)) = message.content.first() {
+                final_text = Some(text.text.clone());
+            }
+        } else if channel == Some("commentary") && recipient.is_empty() {
+            if let Some(Text(text)) = message.content.first() {
+                commentary_text = Some(text.text.clone());
             }
         }
     }
-    Ok((res, Some(normal_text.to_string())))
+    let normal_text = final_text
+        .filter(|text| !text.is_empty())
+        .or_else(|| commentary_text.filter(|text| !text.is_empty()))
+        .unwrap_or_default();
+    Ok((res, Some(normal_text)))
 }
 
 pub fn detect_tool_call_start_harmony(
@@ -436,7 +445,7 @@ mod tests {
 
     #[tokio::test] // PARSER.batch.1, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_complete_basic() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
@@ -488,6 +497,31 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
+    #[tokio::test] // PARSER.batch.3 — gpt-oss
+    async fn test_parse_harmony_bare_text_without_final_message_is_dropped() {
+        let text = "Hello, how can I help you today?";
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal_content, Some("".to_string()));
+    }
+
+    #[tokio::test] // PARSER.batch.3 — gpt-oss
+    async fn test_parse_harmony_final_message_returns_normal_text() {
+        let text = r#"<|channel|>final<|message|>Hello, how can I help you today?<|return|>"#;
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(
+            normal_content,
+            Some("Hello, how can I help you today?".to_string())
+        );
+    }
+
     // Harmony's strict tokenizer rejects two back-to-back commentary
     // blocks, so EOF recovery falls back to regex extraction and pins that
     // both calls are surfaced without leaking the raw envelopes.
@@ -507,9 +541,20 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
-    // Truncated JSON args are repaired when EOF recovery is enabled.
     #[tokio::test] // PARSER.batch.4 — gpt-oss
-    async fn test_parse_harmony_truncated_json_recovers() {
+    async fn test_parse_harmony_malformed_json_preserves_raw_arguments() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>"#;
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, "not json at all");
+    }
+
+    #[tokio::test] // PARSER.batch.4 — gpt-oss
+    async fn test_parse_harmony_unterminated_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
         let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
             text,
@@ -522,18 +567,17 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
     // Bare-envelope PARSER.batch.5: no preceding `analysis` block, no `<|call|>`
-    // at the end. harmony's tokenizer rejects this; the regex fallback
-    // accepts EOS as a synthetic close.
+    // at the end. Harmony requires the explicit call stop token, so fallback
+    // must not accept EOS as a synthetic close.
     #[tokio::test] // PARSER.batch.5 — gpt-oss
-    async fn test_parse_harmony_bare_envelope_no_call_token_recovers() {
+    async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
-        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete(
             text,
             &JsonParserConfig {
                 allow_eof_recovery: true,
@@ -543,10 +587,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal, Some("".to_string()));
     }
 
     // The regex fallback must preserve any non-tool spans (prose before
@@ -586,7 +628,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_harmony_parse_failure_strips_protocol_from_normal_text() {
-        let text = r#"Before <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
+        let text = r#"Before <|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
         let (tool_calls, normal) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
@@ -607,7 +649,7 @@ mod tests {
             );
         }
         assert!(
-            !normal.contains("functions.get_weather"),
+            !normal.contains("commentary"),
             "normal_text must not leak tool-call metadata: {normal:?}"
         );
     }
@@ -620,11 +662,7 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(normal_content, Some("".to_string()));
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "San Francisco, CA");
-        assert_eq!(args["unit"], "celsius");
+        assert!(tool_calls.is_empty());
     }
 
     /// Parser-level invariant: the harmony parser is byte-stable — it
@@ -635,7 +673,7 @@ mod tests {
     /// cross-parser finish_reason mapping work-item (tracked separately).
     #[tokio::test]
     async fn test_harmony_parser_output_independent_of_upstream_finish() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
@@ -646,8 +684,7 @@ mod tests {
     /// the function name.
     #[tokio::test] // PARSER.batch.6 — gpt-oss
     async fn test_parse_harmony_empty_args() {
-        let text =
-            r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}"#;
+        let text = r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -349,10 +349,11 @@ pub async fn parse_tool_calls_harmony_complete(
             if let Some(Text(text)) = message.content.first() {
                 final_text = Some(text.text.clone());
             }
-        } else if channel == Some("commentary") && recipient.is_empty() {
-            if let Some(Text(text)) = message.content.first() {
-                commentary_text = Some(text.text.clone());
-            }
+        } else if channel == Some("commentary")
+            && recipient.is_empty()
+            && let Some(Text(text)) = message.content.first()
+        {
+            commentary_text = Some(text.text.clone());
         }
     }
     let normal_text = final_text

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMPLETE_COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static COMMENTARY_HEADER_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -30,9 +31,18 @@ fn commentary_block_regex() -> &'static Regex {
         // (`\z`, the bare-envelope PARSER.batch.5 variant where the model never
         // emitted `<|call|>` before EOS / max_tokens).
         Regex::new(
-            r"(?s)<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
         )
         .expect("commentary block regex")
+    })
+}
+
+fn complete_commentary_block_regex() -> &'static Regex {
+    COMPLETE_COMMENTARY_BLOCK_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
+        )
+        .expect("complete commentary block regex")
     })
 }
 
@@ -117,9 +127,7 @@ fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> 
         .replace_all(&cleaned, |caps: &Captures<'_>| {
             record_special_tokens(&caps[0], &mut stripped);
             push_unique(&mut stripped, "analysis_envelope".to_string());
-            caps.name("body")
-                .map(|m| m.as_str().to_string())
-                .unwrap_or_default()
+            ""
         })
         .into_owned();
 
@@ -159,13 +167,21 @@ fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> 
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
 /// (truncated JSON, multiple back-to-back commentary blocks, etc.).
 /// Returns (calls, residual_text) where residual_text is everything not
-/// consumed by a matched commentary block — preserved so analysis prose and
-/// non-tool suffixes aren't dropped.
-fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
+/// consumed by a matched commentary block — preserved so non-tool user-visible
+/// spans aren't dropped.
+fn extract_calls_via_regex(
+    text: &str,
+    allow_eof_recovery: bool,
+) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
     let mut residual = String::new();
     let mut cursor = 0;
-    for (i, cap) in commentary_block_regex().captures_iter(text).enumerate() {
+    let regex = if allow_eof_recovery {
+        commentary_block_regex()
+    } else {
+        complete_commentary_block_regex()
+    };
+    for cap in regex.captures_iter(text) {
         let m = cap.get(0).expect("regex match has full span");
         residual.push_str(&text[cursor..m.start()]);
         cursor = m.end();
@@ -177,15 +193,17 @@ fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
         }
         let args_json = match serde_json::from_str::<Value>(raw_args) {
             Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-            Err(_) => match try_repair_truncated_json(raw_args)
+            Err(_) if allow_eof_recovery => match try_repair_truncated_json(raw_args)
                 .and_then(|r| serde_json::from_str::<Value>(&r).ok())
             {
                 Some(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
                 None => raw_args.to_string(),
             },
+            Err(_) => continue,
         };
+        let call_idx = out.len() + 1;
         out.push(ToolCallResponse {
-            id: format!("call-{}", i + 1),
+            id: format!("call-{call_idx}"),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name: name.to_string(),
@@ -256,19 +274,14 @@ pub async fn parse_tool_calls_harmony_complete(
             tracing::debug!(
                 "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
-            // Recovery: harmony rejects parallel commentary blocks and
-            // truncated JSON. Gated on `allow_eof_recovery` so streaming
-            // jails (where the tokenizer often rejects mid-chunk before all
-            // tokens have arrived) don't extract a partial call.
-            if config.allow_eof_recovery {
-                let (calls, residual) = extract_calls_via_regex(text);
-                if !calls.is_empty() {
-                    let normal_text = strip_harmony_protocol_from_normal_text(
-                        &residual,
-                        "regex_recovery_residual",
-                    );
-                    return Ok((calls, Some(normal_text)));
-                }
+            // Recovery: harmony rejects parallel commentary blocks even when
+            // every call is explicitly closed. Only EOF/truncated recovery is
+            // gated, so streaming jails do not synthesize incomplete calls.
+            let (calls, residual) = extract_calls_via_regex(text, config.allow_eof_recovery);
+            if !calls.is_empty() {
+                let normal_text =
+                    strip_harmony_protocol_from_normal_text(&residual, "regex_recovery_residual");
+                return Ok((calls, Some(normal_text)));
             }
             let normal_text =
                 strip_harmony_protocol_from_normal_text(text, "parse_failed_no_recovered_calls");
@@ -276,7 +289,7 @@ pub async fn parse_tool_calls_harmony_complete(
         }
     };
 
-    let mut normal_text = String::new();
+    let normal_text = String::new();
 
     let mut res = Vec::with_capacity(messages.len());
     let mut call_idx = 0; // Index of the tool call
@@ -335,12 +348,6 @@ pub async fn parse_tool_calls_harmony_complete(
                     },
                 });
             }
-        // Handle reasoning(analysis) channel
-        } else if channel == Some("analysis") {
-            normal_text.push_str(match &message.content[0] {
-                Text(t) => &t.text,
-                _ => "",
-            });
         }
     }
     Ok((res, Some(normal_text.to_string())))
@@ -448,10 +455,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 0);
     }
 
@@ -462,10 +466,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -480,10 +481,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -496,16 +494,10 @@ mod tests {
     #[tokio::test] // PARSER.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
-        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
-            text,
-            &JsonParserConfig {
-                allow_eof_recovery: true,
-                ..Default::default()
-            },
-            None,
-        )
-        .await
-        .unwrap();
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
         assert_eq!(tool_calls.len(), 2);
         let (n0, a0) = extract_name_and_args(tool_calls[0].clone());
         let (n1, a1) = extract_name_and_args(tool_calls[1].clone());
@@ -586,6 +578,10 @@ mod tests {
             !normal.contains("<|start|>"),
             "normal must not leak harmony start token: {normal:?}"
         );
+        assert!(
+            !normal.contains("assistant"),
+            "normal must not leak harmony assistant marker: {normal:?}"
+        );
     }
 
     #[tokio::test]
@@ -623,7 +619,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("We need to call get_weather function. The user asks \"What's the weather like in San Francisco in Celsius?\" So location: \"San Francisco, CA\" unit: \"celsius\". Let's call function.".to_string()));
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_weather");

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -11,7 +11,6 @@ use serde_json::Value;
 use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
-static COMPLETE_COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static COMMENTARY_HEADER_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
 static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -31,15 +30,6 @@ fn commentary_block_regex() -> &'static Regex {
             r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
         )
         .expect("commentary block regex")
-    })
-}
-
-fn complete_commentary_block_regex() -> &'static Regex {
-    COMPLETE_COMMENTARY_BLOCK_REGEX.get_or_init(|| {
-        Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
-        )
-        .expect("complete commentary block regex")
     })
 }
 
@@ -189,19 +179,11 @@ fn serialize_harmony_arguments(raw_args: &str) -> String {
 /// Returns (calls, residual_text) where residual_text is everything not
 /// consumed by a matched commentary block — preserved so non-tool user-visible
 /// spans aren't dropped.
-fn extract_calls_via_regex(
-    text: &str,
-    allow_eof_recovery: bool,
-) -> (Vec<ToolCallResponse>, String) {
+fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
     let mut residual = String::new();
     let mut cursor = 0;
-    let regex = if allow_eof_recovery {
-        commentary_block_regex()
-    } else {
-        complete_commentary_block_regex()
-    };
-    for cap in regex.captures_iter(text) {
+    for cap in commentary_block_regex().captures_iter(text) {
         let m = cap.get(0).expect("regex match has full span");
         residual.push_str(&text[cursor..m.start()]);
         cursor = m.end();
@@ -264,7 +246,7 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// * `Err(e)` - If parsing fails due to encoding or tokenization errors
 pub async fn parse_tool_calls_harmony_complete(
     text: &str,
-    config: &JsonParserConfig,
+    _config: &JsonParserConfig,
     _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let enc = match get_harmony_encoding().await.as_ref() {
@@ -287,7 +269,10 @@ pub async fn parse_tool_calls_harmony_complete(
             // Recovery: harmony rejects parallel commentary blocks even when
             // every call is explicitly closed. Only EOF/truncated recovery is
             // gated, so streaming jails do not synthesize incomplete calls.
-            let (calls, residual) = extract_calls_via_regex(text, config.allow_eof_recovery);
+            // Harmony differs from generic JSON/XML recovery: a tool call is
+            // complete only once `<|call|>` is present. Do not synthesize a
+            // call from EOF; that would diverge from vLLM/openai_harmony.
+            let (calls, residual) = extract_calls_via_regex(text);
             if !calls.is_empty() {
                 let normal_text =
                     strip_harmony_protocol_from_normal_text(&residual, "regex_recovery_residual");

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -7,11 +7,16 @@ use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 use openai_harmony::chat::{Content::Text, Role};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding};
-use regex::Regex;
+use regex::{Captures, Regex};
 use serde_json::Value;
 use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMMENTARY_HEADER_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static MESSAGE_CALL_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
 /// input — alternative on this path is silent-drop. Worst case is missing
@@ -29,6 +34,126 @@ fn commentary_block_regex() -> &'static Regex {
         )
         .expect("commentary block regex")
     })
+}
+
+fn commentary_block_cleanup_regex() -> &'static Regex {
+    COMMENTARY_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*?<\|message\|>.*?(?:<\|call\|>|\z)",
+        )
+        .expect("commentary block cleanup regex")
+    })
+}
+
+fn commentary_header_cleanup_regex() -> &'static Regex {
+    COMMENTARY_HEADER_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*\z",
+        )
+        .expect("commentary header cleanup regex")
+    })
+}
+
+fn analysis_block_cleanup_regex() -> &'static Regex {
+    ANALYSIS_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>(?P<body>.*?)(?:<\|end\|>|\z)")
+            .expect("analysis block cleanup regex")
+    })
+}
+
+fn message_call_cleanup_regex() -> &'static Regex {
+    MESSAGE_CALL_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)<\|message\|>.*?(?:<\|call\|>|\z)").expect("message call cleanup regex")
+    })
+}
+
+fn special_token_regex() -> &'static Regex {
+    SPECIAL_TOKEN_REGEX.get_or_init(|| {
+        Regex::new(r"<\|(?:start|channel|constrain|message|call|end|return)\|>")
+            .expect("special token cleanup regex")
+    })
+}
+
+fn push_unique(items: &mut Vec<String>, item: String) {
+    if !items.iter().any(|existing| existing == &item) {
+        items.push(item);
+    }
+}
+
+fn record_special_tokens(text: &str, items: &mut Vec<String>) {
+    for m in special_token_regex().find_iter(text) {
+        push_unique(items, format!("special_token:{}", m.as_str()));
+    }
+}
+
+fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> String {
+    let mut stripped = Vec::new();
+
+    let cleaned = commentary_block_cleanup_regex()
+        .replace_all(text, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("commentary_tool_call:functions.{name}"),
+                None => "commentary_tool_call:missing_recipient".to_string(),
+            };
+            push_unique(&mut stripped, item);
+            ""
+        })
+        .into_owned();
+
+    let cleaned = commentary_header_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("commentary_tool_call_without_message:functions.{name}"),
+                None => "commentary_tool_call_without_message:missing_recipient".to_string(),
+            };
+            push_unique(&mut stripped, item);
+            ""
+        })
+        .into_owned();
+
+    let cleaned = analysis_block_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "analysis_envelope".to_string());
+            caps.name("body")
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default()
+        })
+        .into_owned();
+
+    let cleaned = message_call_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "message_call_payload".to_string());
+            ""
+        })
+        .into_owned();
+
+    let cleaned = special_token_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            push_unique(&mut stripped, format!("special_token:{}", &caps[0]));
+            ""
+        })
+        .into_owned();
+
+    if stripped.is_empty() {
+        return text.to_string();
+    }
+
+    let cleaned = cleaned.trim().to_string();
+
+    tracing::warn!(
+        family = "harmony",
+        reason,
+        stripped = ?stripped,
+        original_len = text.len(),
+        cleaned_len = cleaned.len(),
+        "stripped harmony protocol content from normal_text"
+    );
+
+    cleaned
 }
 
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
@@ -117,7 +242,9 @@ pub async fn parse_tool_calls_harmony_complete(
         Ok(e) => e,
         Err(e) => {
             tracing::debug!("Failed to load harmony encoding: {e}. Tool calls will not be parsed.");
-            return Ok((vec![], Some(text.to_string())));
+            let normal_text =
+                strip_harmony_protocol_from_normal_text(text, "harmony_encoding_unavailable");
+            return Ok((vec![], Some(normal_text)));
         }
     };
 
@@ -136,10 +263,16 @@ pub async fn parse_tool_calls_harmony_complete(
             if config.allow_eof_recovery {
                 let (calls, residual) = extract_calls_via_regex(text);
                 if !calls.is_empty() {
-                    return Ok((calls, Some(residual)));
+                    let normal_text = strip_harmony_protocol_from_normal_text(
+                        &residual,
+                        "regex_recovery_residual",
+                    );
+                    return Ok((calls, Some(normal_text)));
                 }
             }
-            return Ok((vec![], Some(text.to_string())));
+            let normal_text =
+                strip_harmony_protocol_from_normal_text(text, "parse_failed_no_recovered_calls");
+            return Ok((vec![], Some(normal_text)));
         }
     };
 
@@ -315,7 +448,10 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some(text.trim().to_string()));
+        assert_eq!(
+            normal_content,
+            Some("Need to use function get_current_weather.".to_string())
+        );
         assert_eq!(tool_calls.len(), 0);
     }
 
@@ -354,18 +490,9 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
-    // Harmony's `<|call|>` plays the role of an outer end-token. When
-    // max_tokens fires before it lands, the existing `analysis ... <|end|>`
-    // envelope still gives the parser enough context to recover the call —
-    // this test pins that recovery behavior. The bare-envelope variant
-    // (no preceding analysis block) currently does NOT recover, but adding
-    // a test for that is a parser-change discussion.
-    // Pin current behavior on two back-to-back commentary blocks. The
-    // harmony parser today does NOT extract both calls — the second
-    // `<|start|>assistant<|channel|>commentary` block is left in normal
-    // content. Same failure class as PARSER.batch.5: parser drops in-flight work,
-    // customer sees HTTP 200 with fewer tool_calls than the model emitted.
-    // Promoting this to recovery is a parser change.
+    // Harmony's strict tokenizer rejects two back-to-back commentary
+    // blocks, so EOF recovery falls back to regex extraction and pins that
+    // both calls are surfaced without leaking the raw envelopes.
     #[tokio::test] // PARSER.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
@@ -388,9 +515,7 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
-    // Pin current behavior on truncated JSON args. harmony today drops the
-    // call entirely rather than falling back to a string-form arguments or
-    // surfacing an explicit error.
+    // Truncated JSON args are repaired when EOF recovery is enabled.
     #[tokio::test] // PARSER.batch.4 — gpt-oss
     async fn test_parse_harmony_truncated_json_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
@@ -456,6 +581,38 @@ mod tests {
         assert!(
             normal.contains("SUFFIX"),
             "normal must keep suffix: {normal:?}"
+        );
+        assert!(
+            !normal.contains("<|start|>"),
+            "normal must not leak harmony start token: {normal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_parse_failure_strips_protocol_from_normal_text() {
+        let text = r#"Before <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
+        let (tool_calls, normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        let normal = normal.unwrap_or_default();
+        assert_eq!(normal, "Before  After");
+        for token in [
+            "<|start|>",
+            "<|channel|>",
+            "<|constrain|>",
+            "<|message|>",
+            "<|call|>",
+        ] {
+            assert!(
+                !normal.contains(token),
+                "normal_text must not leak {token}: {normal:?}"
+            );
+        }
+        assert!(
+            !normal.contains("functions.get_weather"),
+            "normal_text must not leak tool-call metadata: {normal:?}"
         );
     }
 

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1737,10 +1737,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let (result, content) = detect_and_parse_tool_call(input, Some("harmony"), None)
             .await
             .unwrap();
-        assert_eq!(
-            content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "get_current_weather");

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1733,7 +1733,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
     #[tokio::test]
     async fn test_harmony_parser_basic() {
         let input = r#"
-        <|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}"#;
+        <|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
         let (result, content) = detect_and_parse_tool_call(input, Some("harmony"), None)
             .await
             .unwrap();

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
@@ -66,6 +66,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: I need both.   Done.
+        reason: "Dynamo drops surrounding-prose commentary blocks; SGLang extracts them and emits the wrapping prose as normal_text"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -91,6 +92,7 @@ cases:
           arguments:
             location: LA
         normal_text: ''
+        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"
   PARSER.batch.2.b:
     description: Two back-to-back fence pairs — not applicable to this family
     reason: |-

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
@@ -26,8 +26,13 @@ cases:
             type: string
     expected:
       dynamo:
-        reason: "Dynamo's harmony parser leaks the entire envelope into normal_text; SGLang extracts both calls"
-        calls: []
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            timezone: EST
+          name: get_time
         normal_text: ''
       vllm:
         calls:
@@ -38,7 +43,6 @@ cases:
             timezone: EST
           name: get_time
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; vLLM extracts them"
       sglang:
         calls:
         - name: get_weather
@@ -50,7 +54,7 @@ cases:
         normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
-    ref: dynamo
+    ref: "OpenAI Harmony preambles should be commentary messages: https://developers.openai.com/cookbook/articles/openai-harmony#preambles"
     model_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
       to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.
     tools:
@@ -58,11 +62,23 @@ cases:
     - *id002
     expected:
       dynamo:
-        reason: "Dynamo's harmony parser leaks the envelope (with surrounding narration) into normal_text; SGLang extracts both calls and preserves the narration"
-        calls: []
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            timezone: EST
+          name: get_time
         normal_text: I need both.  Done.
       vllm:
-        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I need both. <|start|>assistant")'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            timezone: EST
+          name: get_time
+        normal_text: I need both.  Done.
       sglang:
         calls:
         - name: get_weather
@@ -72,7 +88,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: I need both.   Done.
-        reason: "Dynamo drops surrounding-prose commentary blocks; SGLang extracts them and emits the wrapping prose as normal_text"
+        reason: "No spec-correct winner on whitespace: surrounding prose is outside Harmony messages, so this is recovery-only; SGLang extracts the same calls but preserves one extra separator space"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -83,8 +99,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo's harmony parser leaks the envelope into normal_text instead of extracting both same-name calls; SGLang extracts both"
-        calls: []
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            location: LA
+          name: get_weather
         normal_text: ''
       vllm:
         calls:
@@ -95,7 +116,6 @@ cases:
             location: LA
           name: get_weather
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; vLLM extracts them"
       sglang:
         calls:
         - name: get_weather
@@ -105,7 +125,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"
   PARSER.batch.2.b:
     description: Two back-to-back fence pairs — not applicable to this family
     reason: |-

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
@@ -28,10 +28,17 @@ cases:
       dynamo:
         reason: "Dynamo's harmony parser leaks the entire envelope into normal_text; SGLang extracts both calls"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-          to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+        normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            timezone: EST
+          name: get_time
+        normal_text: ''
+        reason: "Dynamo drops back-to-back commentary blocks; vLLM extracts them"
       sglang:
         calls:
         - name: get_weather
@@ -53,10 +60,9 @@ cases:
       dynamo:
         reason: "Dynamo's harmony parser leaks the envelope (with surrounding narration) into normal_text; SGLang extracts both calls and preserves the narration"
         calls: []
-        normal_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-          to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.
+        normal_text: I need both.  Done.
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I need both. <|start|>assistant")'
       sglang:
         calls:
         - name: get_weather
@@ -79,10 +85,17 @@ cases:
       dynamo:
         reason: "Dynamo's harmony parser leaks the envelope into normal_text instead of extracting both same-name calls; SGLang extracts both"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+        normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            location: LA
+          name: get_weather
+        normal_text: ''
+        reason: "Dynamo drops back-to-back commentary blocks; vLLM extracts them"
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -43,6 +43,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.4.c:
     description: No to=functions.X recipient
     ref: dynamo

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -17,19 +17,16 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      vllm:
+      dynamo: &d_4_a
         calls:
         - arguments: not json at all
           name: get_weather
         normal_text: ''
-        reason: "Dynamo/SGLang are more spec-correct: '<|constrain|>json' requires JSON args; vLLM surfaces malformed non-JSON as a raw string"
+      vllm: *d_4_a
       sglang:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: "Less parser-complete behavior: the Harmony envelope is a valid '<|call|>'-terminated function call, so the parser should preserve the malformed raw payload for downstream validation rather than dropping the call."
   PARSER.batch.4.b:
     description: Unterminated JSON in message body
     ref: "OpenAI Harmony JSON-constrained function calls: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
@@ -37,19 +34,16 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      vllm:
+      dynamo: &d_4_b
         calls:
         - arguments: '{"location":"NYC'
           name: get_weather
         normal_text: ''
-        reason: "Dynamo/SGLang are more spec-correct: '<|constrain|>json' requires complete JSON args; vLLM surfaces the unterminated payload as a raw string"
+      vllm: *d_4_b
       sglang:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: "Less parser-complete behavior: the Harmony envelope is a valid '<|call|>'-terminated function call, so the parser should preserve the malformed raw payload for downstream validation rather than dropping the call."
   PARSER.batch.4.c:
     description: No to=functions.X recipient
     ref: dynamo

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.4.a:
     description: Channel envelope with garbage body
-    ref: dynamo
+    ref: "OpenAI Harmony JSON-constrained function calls: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>
     tools:
     - &id001
@@ -25,14 +25,14 @@ cases:
         - arguments: not json at all
           name: get_weather
         normal_text: ''
-        reason: "vLLM preserves malformed JSON tool-call args as a raw string; Dynamo drops the malformed call"
+        reason: "Dynamo/SGLang are more spec-correct: '<|constrain|>json' requires JSON args; vLLM surfaces malformed non-JSON as a raw string"
       sglang:
         calls: []
         normal_text: ''
         reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.4.b:
     description: Unterminated JSON in message body
-    ref: dynamo
+    ref: "OpenAI Harmony JSON-constrained function calls: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
     tools:
     - *id001
@@ -45,7 +45,7 @@ cases:
         - arguments: '{"location":"NYC'
           name: get_weather
         normal_text: ''
-        reason: "vLLM preserves unterminated JSON tool-call args as a raw string; Dynamo drops the malformed call"
+        reason: "Dynamo/SGLang are more spec-correct: '<|constrain|>json' requires complete JSON args; vLLM surfaces the unterminated payload as a raw string"
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -18,15 +18,18 @@ cases:
             type: string
     expected:
       dynamo:
-        reason: "Dynamo's harmony parser leaves <|channel|> harmony token, <|message|> harmony token, <|call|> harmony token (+2 more) in normal_text on malformed input (impl-defined recovery)"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json
-          at all<|call|>
+        normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - arguments: not json at all
+          name: get_weather
+        normal_text: ''
+        reason: "vLLM preserves malformed JSON tool-call args as a raw string; Dynamo drops the malformed call"
       sglang:
         calls: []
         normal_text: ''
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.4.b:
     description: Unterminated JSON in message body
     ref: dynamo
@@ -35,11 +38,14 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo's harmony parser leaves <|channel|> harmony token, <|message|> harmony token, <|call|> harmony token (+2 more) in normal_text on malformed input (impl-defined recovery)"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+        normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - arguments: '{"location":"NYC'
+          name: get_weather
+        normal_text: ''
+        reason: "vLLM preserves unterminated JSON tool-call args as a raw string; Dynamo drops the malformed call"
       sglang:
         calls: []
         normal_text: ''
@@ -51,12 +57,11 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo: &d_4_c
         calls: []
         normal_text: ''
-      vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *id002
+      vllm: *d_4_c
+      sglang: *d_4_c
   PARSER.batch.4.d:
     description: Malformed variant 4.d — not applicable to this family
     reason: |-

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
@@ -18,14 +18,15 @@ cases:
             type: string
     expected:
       dynamo:
-        reason: "Dynamo echoes the entire <|start|>…<|message|>{args} envelope into normal_text on missing <|call|> end marker; SGLang returns cleanly-empty"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
-      vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        normal_text: ''
+      vllm: &d_5_a
+        calls: []
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Bare <|call|> without preceding channel envelope
     ref: dynamo
@@ -33,13 +34,14 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
-        reason: "Dynamo's harmony parser leaves <|call|> harmony token in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo: &d_5_b
+        calls: []
+        normal_text: ''
+      vllm: *d_5_b
+      sglang:
         calls: []
         normal_text: <|call|>
-      vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *id002
+        reason: "Dynamo strips bare harmony control tokens from normal_text; SGLang preserves the raw input"
   PARSER.batch.5.c:
     description: Truncation mid-message JSON
     ref: dynamo
@@ -48,11 +50,9 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo's harmony parser leaves <|channel|> harmony token, <|message|> harmony token, <|constrain|> harmony token (+1 more) in normal_text on missing/orphan end marker (impl-defined recovery)"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"loc
-      vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        normal_text: ''
+      vllm: *d_5_a
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
@@ -56,6 +56,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
@@ -29,7 +29,7 @@ cases:
         reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Bare <|call|> without preceding channel envelope
-    ref: dynamo
+    ref: "OpenAI Harmony tool-call stop token: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|call|>
     tools:
     - *id001
@@ -41,7 +41,7 @@ cases:
       sglang:
         calls: []
         normal_text: <|call|>
-        reason: "Dynamo strips bare harmony control tokens from normal_text; SGLang preserves the raw input"
+        reason: "Dynamo/vLLM are more spec-correct: '<|call|>' is a control stop token, not user-visible text; SGLang preserves raw markup"
   PARSER.batch.5.c:
     description: Truncation mid-message JSON
     ref: dynamo
@@ -67,12 +67,19 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"Boston"}<|call|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"New York"}
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!commentary
+          to=functions.get_weather json{"location":"New York"}
+        reason: "Dynamo/SGLang are more spec-correct: they strip the incomplete trailing commentary envelope after extracting the complete first call; vLLM preserves protocol-stripped residue from the incomplete second call"
       sglang:
         calls:
         - name: get_weather
@@ -89,12 +96,19 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"Boston"}<|call|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"New York
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!commentary
+          to=functions.get_weather json{"location":"New York
+        reason: "Dynamo/SGLang are more spec-correct: they strip the incomplete trailing commentary envelope after extracting the complete first call; vLLM preserves protocol-stripped residue from the incomplete second call"
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.6.a:
     description: Canonical empty {} message body
-    ref: dynamo
+    ref: "OpenAI Harmony tool calls terminate with '<|call|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
     tools:
     - &id001
@@ -23,14 +23,14 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "vLLM OpenAIToolParser only finalizes harmony tool calls after '<|call|>'; fixture omits the closing call token"
+        reason: "Spec-strict behavior: Harmony tool calls terminate with '<|call|>'; Dynamo extracts this missing-stop-token shape as EOF recovery"
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+        reason: "Less spec-correct recovery: fixture omits '<|call|>' and SGLang preserves raw Harmony markup as user-visible normal_text"
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
-    ref: dynamo
+    ref: "OpenAI Harmony tool calls terminate with '<|call|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
     tools:
     - *id001
@@ -43,14 +43,14 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "vLLM OpenAIToolParser only finalizes harmony tool calls after '<|call|>'; fixture omits the closing call token"
+        reason: "Spec-strict behavior: Harmony tool calls terminate with '<|call|>'; Dynamo extracts this missing-stop-token shape as EOF recovery"
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+        reason: "Less spec-correct recovery: fixture omits '<|call|>' and SGLang preserves raw Harmony markup as user-visible normal_text"
   PARSER.batch.6.c:
     description: No <|message|> body
-    ref: dynamo
+    ref: "OpenAI Harmony tool-call message header/body format: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.get_time <|constrain|>json
     tools:
     - *id001
@@ -62,4 +62,4 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json
-        reason: "Dynamo strips malformed harmony commentary headers from normal_text; SGLang preserves the raw input"
+        reason: "Dynamo/vLLM are more spec-correct: a commentary header without '<|message|>' is malformed protocol, not user-visible text; SGLang preserves raw markup"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
@@ -21,10 +21,13 @@ cases:
           arguments: {}
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls: []
+        normal_text: ''
+        reason: "vLLM OpenAIToolParser only finalizes harmony tool calls after '<|call|>'; fixture omits the closing call token"
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
@@ -38,10 +41,13 @@ cases:
           arguments: {}
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls: []
+        normal_text: ''
+        reason: "vLLM OpenAIToolParser only finalizes harmony tool calls after '<|call|>'; fixture omits the closing call token"
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.6.c:
     description: No <|message|> body
     ref: dynamo
@@ -49,10 +55,11 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
-        reason: "Dynamo's harmony parser leaves <|channel|> harmony token, <|constrain|> harmony token in normal_text on minimal/no-body case"
+      dynamo: &d_6_c
+        calls: []
+        normal_text: ''
+      vllm: *d_6_c
+      sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json
-      vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *id002
+        reason: "Dynamo strips malformed harmony commentary headers from normal_text; SGLang preserves the raw input"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
@@ -7,7 +7,7 @@ cases:
   PARSER.batch.6.a:
     description: Canonical empty {} message body
     ref: "OpenAI Harmony tool calls terminate with '<|call|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
-    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
+    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}<|call|>
     tools:
     - &id001
       name: get_time
@@ -15,39 +15,33 @@ cases:
         type: object
         properties: {}
     expected:
-      dynamo:
+      dynamo: &d_6_a
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm:
-        calls: []
-        normal_text: ''
-        reason: "Spec-strict behavior: Harmony tool calls terminate with '<|call|>'; Dynamo extracts this missing-stop-token shape as EOF recovery"
+      vllm: *d_6_a
       sglang:
         calls: []
-        normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
-        reason: "Less spec-correct recovery: fixture omits '<|call|>' and SGLang preserves raw Harmony markup as user-visible normal_text"
+        normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}<|call|>
+        reason: "Less spec-correct parsing: SGLang leaks raw Harmony markup instead of extracting a valid '<|call|>'-terminated commentary tool call."
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: "OpenAI Harmony tool calls terminate with '<|call|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
-    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
+    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }<|call|>
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &d_6_b
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm:
-        calls: []
-        normal_text: ''
-        reason: "Spec-strict behavior: Harmony tool calls terminate with '<|call|>'; Dynamo extracts this missing-stop-token shape as EOF recovery"
+      vllm: *d_6_b
       sglang:
         calls: []
-        normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
-        reason: "Less spec-correct recovery: fixture omits '<|call|>' and SGLang preserves raw Harmony markup as user-visible normal_text"
+        normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }<|call|>
+        reason: "Less spec-correct parsing: SGLang leaks raw Harmony markup instead of extracting a valid '<|call|>'-terminated commentary tool call."
   PARSER.batch.6.c:
     description: No <|message|> body
     ref: "OpenAI Harmony tool-call message header/body format: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.7.a:
     description: Standard scalar types
-    ref: dynamo
+    ref: "OpenAI Harmony receiving tool calls example starts completion at '<|channel|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.book_flight <|constrain|>json<|message|>{"destination":"Paris","passengers":2,"first_class":true}<|call|>
     tools:
     - name: book_flight
@@ -39,9 +39,10 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.book_flight <|constrain|>json<|message|>{"destination":"Paris","passengers":2,"first_class":true}<|call|>
+        reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"
   PARSER.batch.7.b:
     description: Unicode + escaped chars
-    ref: dynamo
+    ref: "OpenAI Harmony receiving tool calls example starts completion at '<|channel|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"Tōkyō \"central\""}<|call|>
     tools:
     - name: get_weather
@@ -66,10 +67,10 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"Tōkyō \"central\""}<|call|>
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+        reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
-    ref: dynamo
+    ref: "OpenAI Harmony receiving tool calls example starts completion at '<|channel|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.set_temperature <|constrain|>json<|message|>{"celsius":"20"}<|call|>
     tools:
     - name: set_temperature
@@ -94,10 +95,10 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.set_temperature <|constrain|>json<|message|>{"celsius":"20"}<|call|>
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+        reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"
   PARSER.batch.7.d:
     description: Nested object + array
-    ref: dynamo
+    ref: "OpenAI Harmony receiving tool calls example starts completion at '<|channel|>': https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>
     tools:
     - name: process_data
@@ -134,4 +135,4 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+        reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -29,7 +29,13 @@ cases:
             first_class: true
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.book_flight <|constrain|>json<|message|>{"destination":"Paris","passengers":2,"first_class":true}<|call|>
@@ -52,7 +58,11 @@ cases:
             location: Tōkyō "central"
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"Tōkyō \"central\""}<|call|>
@@ -76,7 +86,11 @@ cases:
             celsius: '20'
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.set_temperature <|constrain|>json<|message|>{"celsius":"20"}<|call|>
@@ -107,7 +121,16 @@ cases:
               nested: true
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -56,6 +56,7 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"Tōkyō \"central\""}<|call|>
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -79,6 +80,7 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.set_temperature <|constrain|>json<|message|>{"celsius":"20"}<|call|>
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -109,3 +111,4 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
@@ -21,10 +21,9 @@ cases:
       dynamo:
         reason: "Dynamo leaks the full envelope (narration + analysis + commentary) into normal_text instead of extracting the tool call and preserving the narration"
         calls: []
-        normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+        normal_text: I will check the weather. Need to use function get_weather.
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I will check")'
       sglang:
         calls:
         - name: get_weather
@@ -42,10 +41,9 @@ cases:
       dynamo:
         reason: "Dynamo leaks the full envelope (analysis + commentary + trailing narration) into normal_text instead of extracting the tool call and keeping the trailing prose"
         calls: []
-        normal_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
+        normal_text: Need to use function get_weather. Let me know if you need more.
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        error: 'HarmonyError: Unexpected token 9024 while expecting start token 200006'
       sglang:
         calls:
         - name: get_weather
@@ -63,10 +61,9 @@ cases:
       dynamo:
         reason: "Dynamo leaks the sandwich (leading + envelope + trailing) into normal_text instead of extracting the tool call and stitching the surrounding prose"
         calls: []
-        normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
+        normal_text: I will check the weather. Need to use function get_weather. Let me know if you need more.
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I will check")'
       sglang:
         calls:
         - name: get_weather
@@ -85,11 +82,9 @@ cases:
       dynamo:
         reason: "Dynamo leaks multi-call sequence with interspersed narration into normal_text instead of extracting both calls and preserving the inter-call prose"
         calls: []
-        normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Then check LA weather. <|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+        normal_text: I will check the weather. Need to use function get_weather. Then check LA weather.
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I will check")'
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
@@ -19,11 +19,17 @@ cases:
             type: string
     expected:
       dynamo:
-        reason: "Dynamo leaks the full envelope (narration + analysis + commentary) into normal_text instead of extracting the tool call and preserving the narration"
-        calls: []
-        normal_text: I will check the weather. Need to use function get_weather.
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: I will check the weather.
       vllm:
-        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I will check")'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: I will check the weather.
       sglang:
         calls:
         - name: get_weather
@@ -39,11 +45,17 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo leaks the full envelope (analysis + commentary + trailing narration) into normal_text instead of extracting the tool call and keeping the trailing prose"
-        calls: []
-        normal_text: Need to use function get_weather. Let me know if you need more.
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: Let me know if you need more.
       vllm:
-        error: 'HarmonyError: Unexpected token 9024 while expecting start token 200006'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: Let me know if you need more.
       sglang:
         calls:
         - name: get_weather
@@ -52,27 +64,34 @@ cases:
         normal_text: Let me know if you need more.
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220
+    ref: "OpenAI Harmony: analysis is hidden and preambles should be commentary messages; originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220; spec https://developers.openai.com/cookbook/articles/openai-harmony#channels"
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
     tools:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo leaks the sandwich (leading + envelope + trailing) into normal_text instead of extracting the tool call and stitching the surrounding prose"
-        calls: []
-        normal_text: I will check the weather. Need to use function get_weather. Let me know if you need more.
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: I will check the weather.  Let me know if you need more.
       vllm:
-        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I will check")'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: I will check the weather.  Let me know if you need more.
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: I will check the weather.   Let me know if you need more.
+        reason: "No spec-correct winner on whitespace: analysis is correctly hidden and the same call is extracted; surrounding prose is outside Harmony messages, so whitespace is recovery-only"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
-    ref: dynamo
+    ref: "OpenAI Harmony: analysis is hidden and preambles should be commentary messages: https://developers.openai.com/cookbook/articles/openai-harmony#channels"
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Then check LA weather. <|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
@@ -80,11 +99,23 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo leaks multi-call sequence with interspersed narration into normal_text instead of extracting both calls and preserving the inter-call prose"
-        calls: []
-        normal_text: I will check the weather. Need to use function get_weather. Then check LA weather.
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            location: LA
+          name: get_weather
+        normal_text: I will check the weather.  Then check LA weather.
       vllm:
-        error: 'HarmonyError: unexpected tokens remaining in message header: Some("I will check")'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            location: LA
+          name: get_weather
+        normal_text: I will check the weather.  Then check LA weather.
       sglang:
         calls:
         - name: get_weather
@@ -94,3 +125,4 @@ cases:
           arguments:
             location: LA
         normal_text: I will check the weather.   Then check LA weather.
+        reason: "No spec-correct winner on whitespace: analysis is correctly hidden and the same calls are extracted; surrounding prose is outside Harmony messages, so whitespace is recovery-only"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -24,34 +24,40 @@ cases:
             location: NYC
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls: []
+        normal_text: ''
+        reason: "vLLM OpenAIToolParser only finalizes harmony tool calls after '<|call|>'; fixture omits the closing call token"
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo: &d_3
         calls: []
         normal_text: Hello, how can I help you today?
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *id002
+        calls: []
+        normal_text: ''
+        reason: "vLLM OpenAIToolParser only surfaces text from harmony final/commentary channels; bare plain text is ignored"
+      sglang: *d_3
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      dynamo: &id003
+      dynamo: &d_9
         calls: []
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *id003
+        calls: []
+        normal_text: ''
+      sglang: *d_9
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
@@ -60,21 +66,28 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo leaks back-to-back same-name commentary blocks into normal_text instead of extracting both duplicate calls"
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-          to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+        normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            location: LA
+          name: get_weather
+        normal_text: ''
+        reason: "Dynamo drops back-to-back commentary blocks; vLLM extracts them"
       sglang:
         calls:
-        - name: get_weather
-          arguments:
+        - arguments:
             location: NYC
-        - name: get_weather
-          arguments:
+          name: get_weather
+        - arguments:
             location: LA
+          name: get_weather
         normal_text: ''
+        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"
   PARSER.batch.11:
     description: Separator-character case — n/a for this family's syntax
     reason: |-

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -7,6 +7,7 @@ mode: batch
 cases:
   PARSER.batch.1:
     description: Single tool call (basic complete envelope)
+    ref: "OpenAI Harmony receiving tool calls: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
     model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
     tools:
     - &id001
@@ -26,13 +27,14 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "vLLM OpenAIToolParser only finalizes harmony tool calls after '<|call|>'; fixture omits the closing call token"
+        reason: "Spec-strict behavior: Harmony tool calls terminate with '<|call|>'; Dynamo extracts this missing-stop-token shape as EOF recovery"
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+        reason: "Less spec-correct recovery: fixture omits '<|call|>' and SGLang preserves raw Harmony markup as user-visible normal_text"
   PARSER.batch.3:
     description: No tool call (plain text)
+    ref: "OpenAI Harmony channels/final output: https://developers.openai.com/cookbook/articles/openai-harmony#channels"
     model_text: Hello, how can I help you today?
     tools:
     - *id001
@@ -43,7 +45,7 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "vLLM OpenAIToolParser only surfaces text from harmony final/commentary channels; bare plain text is ignored"
+        reason: "Spec-strict behavior: user-visible assistant text belongs in final/commentary; Dynamo and SGLang preserve bare text as fallback"
       sglang: *d_3
   PARSER.batch.9:
     description: Empty input
@@ -66,7 +68,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        - arguments:
+            location: LA
+          name: get_weather
         normal_text: ''
       vllm:
         calls:
@@ -77,7 +85,6 @@ cases:
             location: LA
           name: get_weather
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; vLLM extracts them"
       sglang:
         calls:
         - arguments:
@@ -87,7 +94,6 @@ cases:
             location: LA
           name: get_weather
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"
   PARSER.batch.11:
     description: Separator-character case — n/a for this family's syntax
     reason: |-

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -8,7 +8,7 @@ cases:
   PARSER.batch.1:
     description: Single tool call (basic complete envelope)
     ref: "OpenAI Harmony receiving tool calls: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
-    model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+    model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
     tools:
     - &id001
       name: get_weather
@@ -18,22 +18,19 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &d_1
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
-        calls: []
-        normal_text: ''
-        reason: "Spec-strict behavior: Harmony tool calls terminate with '<|call|>'; Dynamo extracts this missing-stop-token shape as EOF recovery"
+      vllm: *d_1
       sglang:
         calls: []
-        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
-        reason: "Less spec-correct recovery: fixture omits '<|call|>' and SGLang preserves raw Harmony markup as user-visible normal_text"
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+        reason: "Less spec-correct parsing: SGLang leaks raw Harmony markup instead of extracting a valid '<|call|>'-terminated commentary tool call."
   PARSER.batch.3:
-    description: No tool call (plain text)
+    description: No tool call (bare text without final channel)
     ref: "OpenAI Harmony channels/final output: https://developers.openai.com/cookbook/articles/openai-harmony#channels"
     model_text: Hello, how can I help you today?
     tools:
@@ -41,12 +38,12 @@ cases:
     expected:
       dynamo: &d_3
         calls: []
-        normal_text: Hello, how can I help you today?
-      vllm:
-        calls: []
         normal_text: ''
-        reason: "Spec-strict behavior: user-visible assistant text belongs in final/commentary; Dynamo and SGLang preserve bare text as fallback"
-      sglang: *d_3
+      vllm: *d_3
+      sglang:
+        calls: []
+        normal_text: Hello, how can I help you today?
+        reason: "Less spec-correct fallback: bare text is not a valid Harmony assistant response because no final message was emitted. A valid response would be '<|channel|>final<|message|>Hello, how can I help you today?<|return|>'."
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -118,7 +118,11 @@ cases:
             location: NYC
         normal_text: ''
       vllm:
-        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}<|call|>

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -102,7 +102,7 @@ cases:
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
-    model_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}
+    model_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}<|call|>
     tools:
     - name: get_weather
       parameters:
@@ -121,5 +121,5 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls: []
-        normal_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}
+        normal_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}<|call|>
         reason: SGLang treats an unknown harmony recipient as ordinary content rather than forwarding a tool call by default.

--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -756,6 +756,11 @@ def _build_tooltip_html(case: dict, dyn) -> str:
     if head:
         parts.append(f'<div class="ttip-head">{html_lib.escape(head)}</div>')
 
+    ref = case.get("ref")
+    if isinstance(ref, str) and ref:
+        parts.append('<div class="ttip-section">Ref:</div>')
+        parts.append(f'<pre class="ttip-pre">{html_lib.escape(ref)}</pre>')
+
     model_text = case.get("model_text")
     if isinstance(model_text, str) and model_text:
         parts.append('<div class="ttip-section">Input:</div>')
@@ -1439,6 +1444,7 @@ def render_html(
     no_sglang: set[str],
     top_n: list[tuple[str, str]],
     others: list[tuple[str, str]],
+    family_filter: str | None = None,
 ) -> str:
     descriptions = _parse_subcase_descriptions()
     refs = _build_family_to_rust_ref()
@@ -1448,16 +1454,19 @@ def render_html(
     sub_headers = "".join(_subcase_header_html(sub, descriptions) for sub in sub_cases)
     n_cols = 2 + len(sub_cases)
 
-    body_rows: list[str] = [
-        f'<tr class="section"><td colspan="{n_cols}">Top-N models</td></tr>'
-    ]
+    body_rows: list[str] = []
+    if top_n:
+        body_rows.append(
+            f'<tr class="section"><td colspan="{n_cols}">Top-N models</td></tr>'
+        )
     for model, fam in top_n:
         body_rows.append(
             render_row_html(
                 model, fam, cases, sub_cases, refs, no_vllm, no_sglang, inheritance
             )
         )
-    body_rows.append(f'<tr class="section"><td colspan="{n_cols}">Others</td></tr>')
+    if others:
+        body_rows.append(f'<tr class="section"><td colspan="{n_cols}">Others</td></tr>')
     for model, fam in others:
         body_rows.append(
             render_row_html(
@@ -1477,6 +1486,16 @@ def render_html(
 
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")
+    title = (
+        f"Dynamo {family_filter} parser parity chart"
+        if family_filter
+        else "Dynamo parser parity chart"
+    )
+    command = "python3 tests/parity/parser/generate_parity_chart.py --html"
+    output = "tests/parity/parser/PARITY.html"
+    if family_filter:
+        command += f" --family {family_filter}"
+        output = f"tests/parity/parser/PARITY.{family_filter}.html"
 
     sha = _commit_sha()
     if sha:
@@ -1490,13 +1509,14 @@ def render_html(
     return (
         "<!DOCTYPE html>\n"
         '<html lang="en">\n'
-        '<head><meta charset="utf-8"><title>Dynamo parser parity chart</title>'
+        f'<head><meta charset="utf-8"><title>{html_lib.escape(title)}</title>'
         f"<style>{_HTML_STYLE}</style></head>\n"
         "<body>\n"
-        "<h1>Dynamo parser parity chart</h1>\n"
-        f'<p class="generated">Auto-generated on {html_lib.escape(stamp)}{sha_html}: '
-        f"<code>python3 tests/parity/parser/generate_parity_chart.py --html "
-        f"&gt; tests/parity/parser/PARITY.html</code></p>\n"
+        f"<h1>{html_lib.escape(title)}</h1>\n"
+        f'<p class="generated">Auto-generated on {html_lib.escape(stamp)}{sha_html} '
+        f"from <code>tests/parity/parser/fixtures/**/PARSER.*.yaml</code>: "
+        f"<code>{html_lib.escape(command)} "
+        f"&gt; {html_lib.escape(output)}</code></p>\n"
         "<p>Parser column links to the family's Rust config / parser. "
         "Sub-case column headers link to "
         '<a href="../../../lib/parsers/PARSER_CASES.md">PARSER_CASES.md</a> '
@@ -1519,14 +1539,33 @@ def main():
         action="store_true",
         help="Emit HTML (clickable + tooltips) instead of Markdown.",
     )
+    p.add_argument(
+        "--family",
+        help="Render only one parser family, e.g. harmony.",
+    )
     args = p.parse_args()
 
     cases, labels = load_all_cases()
+    if args.family:
+        cases = {k: v for k, v in cases.items() if k[0] == args.family}
+        labels = {k: v for k, v in labels.items() if k == args.family}
+        if not cases:
+            raise SystemExit(f"no parser fixtures found for family={args.family!r}")
     sub_cases = _discover_sub_cases(cases)
     no_vllm, no_sglang = _derive_no_peer_sets(cases)
     top_n, others = _build_display_groups(cases, labels)
     if args.html:
-        print(render_html(cases, sub_cases, no_vllm, no_sglang, top_n, others))
+        print(
+            render_html(
+                cases,
+                sub_cases,
+                no_vllm,
+                no_sglang,
+                top_n,
+                others,
+                family_filter=args.family,
+            )
+        )
     else:
         print(render_markdown(cases, sub_cases, no_vllm, no_sglang, top_n, others))
 

--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -404,6 +404,7 @@ def load_all_cases() -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
             labels.setdefault(family, doc["model_label"])
         for cid, case in doc["cases"].items():
             sub = cid.replace("PARSER.batch.", "")
+            case["__family"] = family
             case["__fixture_path"] = rel
             case["__case_id"] = cid
             cases[(family, sub)] = case
@@ -558,7 +559,7 @@ def render_markdown(
 _IMPL_DISPLAY = {"dynamo": "Dynamo", "vllm": "vLLM", "sglang": "SGLang"}
 
 
-def _format_output_block_html(block) -> str:
+def _format_output_block_html(block, family: str | None = None) -> str:
     """HTML rendering of an `expected.<impl>` block for tooltips.
     Applies _colorize_xml to `normal_text` so raw model output the engine
     failed to parse shows the same tag coloring as the input."""
@@ -578,7 +579,7 @@ def _format_output_block_html(block) -> str:
         calls_line = html_lib.escape(f"calls=[{rendered}]")
     else:
         calls_line = "calls=[]"
-    nt_line = f"normal_text='{_colorize_xml(nt)}'"
+    nt_line = f"normal_text='{_colorize_markup(nt, family)}'"
     return f"{nt_line}\n{calls_line}"
 
 
@@ -628,6 +629,52 @@ _END_SUFFIXES = ("_end", "▁end")
 _HARMONY_TURN_OPEN = "start"
 _HARMONY_TURN_CLOSE = frozenset({"end", "return", "call"})
 _HARMONY_SECTION_MARKERS = frozenset({"channel", "constrain", "message"})
+_HARMONY_TOKEN_RE = re.compile(r"<\|([A-Za-z_]+)\|>")
+_HARMONY_SEGMENT_CLASS = {
+    "start": "tt-h-start",
+    "channel": "tt-h-channel",
+    "constrain": "tt-h-constrain",
+    "message": "tt-h-message",
+    "end": "tt-h-stop",
+    "return": "tt-h-stop",
+    "call": "tt-h-call",
+}
+
+
+def _colorize_harmony(text: str) -> str:
+    """Color Harmony's linear token segments as `<|token|>related-text`.
+
+    Harmony is not paired XML. Tokens such as `<|channel|>` and `<|message|>`
+    introduce the header/content span that follows, so each special token is
+    grouped with text up to the next Harmony token.
+    """
+    pieces: list[str] = []
+    last = 0
+    for m in _HARMONY_TOKEN_RE.finditer(text):
+        if m.start() > last:
+            pieces.append(html_lib.escape(text[last : m.start()]))
+        token_name = m.group(1)
+        if token_name in _HARMONY_TURN_CLOSE:
+            end = m.end()
+        else:
+            next_m = _HARMONY_TOKEN_RE.search(text, m.end())
+            end = next_m.start() if next_m else len(text)
+        cls = _HARMONY_SEGMENT_CLASS.get(token_name, "tt-h-other")
+        token = html_lib.escape(m.group(0))
+        related = html_lib.escape(text[m.end() : end])
+        pieces.append(
+            f'<span class="tt-h {cls}"><span class="tt-h-token">{token}</span>{related}</span>'
+        )
+        last = end
+    if last < len(text):
+        pieces.append(html_lib.escape(text[last:]))
+    return "".join(pieces)
+
+
+def _colorize_markup(text: str, family: str | None = None) -> str:
+    if family == "harmony" and _HARMONY_TOKEN_RE.search(text):
+        return _colorize_harmony(text)
+    return _colorize_xml(text)
 
 
 def _strip_suffix(s: str, suffixes: tuple[str, ...]) -> str | None:
@@ -763,9 +810,10 @@ def _build_tooltip_html(case: dict, dyn) -> str:
 
     model_text = case.get("model_text")
     if isinstance(model_text, str) and model_text:
+        family = case.get("__family")
         parts.append('<div class="ttip-section">Input:</div>')
         parts.append(
-            f"<pre class=\"ttip-pre\">input_text='{_colorize_xml(model_text)}'</pre>"
+            f"<pre class=\"ttip-pre\">input_text='{_colorize_markup(model_text, family)}'</pre>"
         )
 
     expected = case.get("expected") or {}
@@ -787,13 +835,15 @@ def _build_tooltip_html(case: dict, dyn) -> str:
 
     if all_parity:
         parts.append('<div class="ttip-section">All engines parity:</div>')
-        parts.append(f'<pre class="ttip-pre">{_format_output_block_html(dyn)}</pre>')
+        parts.append(
+            f'<pre class="ttip-pre">{_format_output_block_html(dyn, case.get("__family"))}</pre>'
+        )
     else:
         for impl in ("dynamo", "vllm", "sglang"):
             block = expected.get(impl)
             parts.append(f'<div class="ttip-section">{_IMPL_DISPLAY[impl]}:</div>')
             parts.append(
-                f'<pre class="ttip-pre">{_format_output_block_html(block)}</pre>'
+                f'<pre class="ttip-pre">{_format_output_block_html(block, case.get("__family"))}</pre>'
             )
 
     reasons = _tooltip_for(case, dyn) if isinstance(dyn, dict) else ""
@@ -1297,6 +1347,15 @@ td.parser:hover .ttip {
 .tt-c6 { color: #22d3ee; }
 .tt-c7 { color: #f87171; }
 .tt-orphan { background: #7f1d1d; color: #fecaca; padding: 0 2px; border-radius: 2px; }
+.tt-h { padding: 0 1px; border-radius: 2px; }
+.tt-h-token { font-weight: 700; }
+.tt-h-start { color: #fbbf24; }
+.tt-h-channel { color: #60a5fa; }
+.tt-h-constrain { color: #a78bfa; }
+.tt-h-message { color: #34d399; }
+.tt-h-call { color: #fb923c; }
+.tt-h-stop { color: #f87171; }
+.tt-h-other { color: #22d3ee; }
 """
 
 # Clamps `.ttip` into the viewport on hover. Pure CSS can't know each

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from types import SimpleNamespace
 from typing import Any
@@ -38,6 +39,19 @@ _HARMONY_ANALYSIS_RE = re.compile(
     re.DOTALL,
 )
 _HARMONY_SPECIAL_TOKEN_RE = re.compile(r"<\|[^|]+?\|>")
+_HARMONY_MESSAGE_RE = re.compile(
+    r"(?:<\|start\|>assistant)?"
+    r"<\|channel\|>(?P<channel>\w+)"
+    r"(?P<header>.*?)"
+    r"<\|message\|>(?P<body>.*?)"
+    r"(?P<stop><\|call\|>|<\|end\|>|<\|return\|>|$)",
+    re.DOTALL,
+)
+_HARMONY_RECIPIENT_RE = re.compile(r"\bto=(?P<recipient>functions\.[\w.\-]+)")
+
+
+class _HarmonyEncodingUnavailable(RuntimeError):
+    pass
 
 
 class _OmnivorousVocab(dict):
@@ -84,7 +98,10 @@ def _harmony_token_ids(raw_text: str) -> list[int]:
     if text.startswith(_HARMONY_ASSISTANT_START):
         text = text[len(_HARMONY_ASSISTANT_START) :]
 
-    enc = get_encoding()
+    try:
+        enc = get_encoding()
+    except Exception as e:
+        raise _HarmonyEncodingUnavailable(f"{type(e).__name__}: {e}") from e
     return enc.encode(text, allowed_special=enc.special_tokens_set)
 
 
@@ -134,6 +151,57 @@ def _harmony_token_text_and_normal_text(raw_text: str) -> tuple[str, str | None]
 def _merge_normal_text(first: str | None, second: str | None) -> str | None:
     merged = "".join(part for part in (first, second) if part)
     return merged if merged.strip() else None
+
+
+def _harmony_parse_without_encoding(
+    token_text: str,
+    residual_normal_text: str | None,
+) -> ParseResult:
+    """Mirror vLLM's OpenAI parser when Harmony encoding cannot be loaded.
+
+    vLLM's OpenAIToolParser extracts completed `functions.*` commentary
+    messages, parses valid JSON arguments, and otherwise preserves the raw
+    argument text. Final-channel text and recipient-less commentary preambles
+    are visible content; analysis and malformed tool-call messages are hidden.
+    """
+
+    calls = []
+    final_content = None
+    commentary_content = None
+
+    for match in _HARMONY_MESSAGE_RE.finditer(token_text):
+        channel = match.group("channel")
+        header = match.group("header")
+        body = match.group("body")
+        stop = match.group("stop")
+        recipient_match = _HARMONY_RECIPIENT_RE.search(header)
+        recipient = recipient_match.group("recipient") if recipient_match else None
+
+        if recipient and recipient.startswith("functions."):
+            if channel != "commentary" or stop != "<|call|>":
+                continue
+            try:
+                arguments = json.loads(body)
+            except json.JSONDecodeError:
+                arguments = body
+            calls.append(
+                {
+                    "name": recipient.split("functions.", 1)[1],
+                    "arguments": arguments,
+                }
+            )
+        elif channel == "final":
+            final_content = body
+        elif channel == "commentary" and stop != "<|call|>":
+            commentary_content = body
+
+    return ParseResult(
+        calls=calls,
+        normal_text=_merge_normal_text(
+            residual_normal_text,
+            final_content or commentary_content,
+        ),
+    )
 
 
 # Maps parser_family → vLLM's registered parser key (registered via
@@ -196,11 +264,17 @@ def parse(
             token_text, residual_normal_text = _harmony_token_text_and_normal_text(
                 raw_text
             )
-            info = parser.extract_tool_calls(
-                token_text,
-                request,
-                token_ids=_harmony_token_ids(token_text),
-            )
+            try:
+                info = parser.extract_tool_calls(
+                    token_text,
+                    request,
+                    token_ids=_harmony_token_ids(token_text),
+                )
+            except _HarmonyEncodingUnavailable:
+                return _harmony_parse_without_encoding(
+                    token_text,
+                    residual_normal_text,
+                )
         else:
             residual_normal_text = None
             info = parser.extract_tool_calls(raw_text, request)

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -23,8 +23,11 @@ except ImportError:
     )
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
 
 from tests.parity.common import ParseResult, decode_arguments
+
+_HARMONY_ASSISTANT_START = "<|start|>assistant"
 
 
 class _OmnivorousVocab(dict):
@@ -56,6 +59,23 @@ class _StubTokenizer:
 
     def get_vocab(self) -> dict[str, int]:
         return _STUB_VOCAB
+
+
+def _harmony_token_ids(raw_text: str) -> list[int]:
+    """Encode gpt-oss/harmony fixture text for vLLM's token-ID parser.
+
+    vLLM's OpenAIToolParser delegates to `parse_output_into_messages()`,
+    which parses completion tokens from an assistant context. The first
+    assistant-start marker is therefore outside the parser's input shape, but
+    later assistant-start markers separate additional messages and must remain.
+    """
+
+    text = raw_text
+    if text.startswith(_HARMONY_ASSISTANT_START):
+        text = text[len(_HARMONY_ASSISTANT_START) :]
+
+    enc = get_encoding()
+    return enc.encode(text, allowed_special=enc.special_tokens_set)
 
 
 # Maps parser_family → vLLM's registered parser key (registered via
@@ -114,7 +134,14 @@ def parse(
         # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
         # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
         request = SimpleNamespace(tools=wrapped_tools)
-        info = parser.extract_tool_calls(raw_text, request)
+        if key == "openai":
+            info = parser.extract_tool_calls(
+                raw_text,
+                request,
+                token_ids=_harmony_token_ids(raw_text),
+            )
+        else:
+            info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires
         # token IDs, not text). Treat as env-unavailable so the harness skips

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 from typing import Any
 
@@ -28,6 +29,15 @@ from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
 from tests.parity.common import ParseResult, decode_arguments
 
 _HARMONY_ASSISTANT_START = "<|start|>assistant"
+_HARMONY_COMMENTARY_CALL_RE = re.compile(
+    r"(?:<\|start\|>assistant)?<\|channel\|>commentary\b.*?<\|message\|>.*?<\|call\|>",
+    re.DOTALL,
+)
+_HARMONY_ANALYSIS_RE = re.compile(
+    r"<\|channel\|>analysis<\|message\|>(.*?)(?:<\|end\|>|$)",
+    re.DOTALL,
+)
+_HARMONY_SPECIAL_TOKEN_RE = re.compile(r"<\|[^|]+?\|>")
 
 
 class _OmnivorousVocab(dict):
@@ -76,6 +86,54 @@ def _harmony_token_ids(raw_text: str) -> list[int]:
 
     enc = get_encoding()
     return enc.encode(text, allowed_special=enc.special_tokens_set)
+
+
+def _harmony_cleanup_residual_text(text: str) -> str:
+    """Return the non-call narration left outside extracted commentary calls."""
+
+    text = _HARMONY_ANALYSIS_RE.sub("", text)
+    text = text.replace(_HARMONY_ASSISTANT_START, "")
+    return _HARMONY_SPECIAL_TOKEN_RE.sub("", text)
+
+
+def _harmony_token_text_and_normal_text(raw_text: str) -> tuple[str, str | None]:
+    """Split prose-wrapped harmony text into vLLM token input plus narration.
+
+    vLLM's OpenAIToolParser expects assistant-completion harmony tokens. The
+    parity fixtures intentionally include surrounding narration to compare how
+    engines handle mixed text and tool calls, so feed vLLM only complete
+    commentary call envelopes and preserve the stripped residual text as the
+    wrapper's normal_text contribution.
+    """
+
+    matches = list(_HARMONY_COMMENTARY_CALL_RE.finditer(raw_text))
+    if not matches:
+        return raw_text, None
+
+    blocks = []
+    residual_parts = []
+    cursor = 0
+    for match in matches:
+        residual_parts.append(
+            _harmony_cleanup_residual_text(raw_text[cursor : match.start()])
+        )
+        block = match.group(0)
+        if block.startswith(_HARMONY_ASSISTANT_START):
+            block = block[len(_HARMONY_ASSISTANT_START) :]
+        if blocks:
+            block = f"{_HARMONY_ASSISTANT_START}{block}"
+        blocks.append(block)
+        cursor = match.end()
+
+    residual_parts.append(_harmony_cleanup_residual_text(raw_text[cursor:]))
+    residual = "".join(residual_parts).strip()
+    normal_text = residual if residual.strip() else None
+    return "".join(blocks), normal_text
+
+
+def _merge_normal_text(first: str | None, second: str | None) -> str | None:
+    merged = "".join(part for part in (first, second) if part)
+    return merged if merged.strip() else None
 
 
 # Maps parser_family → vLLM's registered parser key (registered via
@@ -135,12 +193,16 @@ def parse(
         # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
         request = SimpleNamespace(tools=wrapped_tools)
         if key == "openai":
+            token_text, residual_normal_text = _harmony_token_text_and_normal_text(
+                raw_text
+            )
             info = parser.extract_tool_calls(
-                raw_text,
+                token_text,
                 request,
-                token_ids=_harmony_token_ids(raw_text),
+                token_ids=_harmony_token_ids(token_text),
             )
         else:
+            residual_normal_text = None
             info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires
@@ -154,4 +216,7 @@ def parse(
         {"name": tc.function.name, "arguments": decode_arguments(tc.function.arguments)}
         for tc in info.tool_calls or []
     ]
-    return ParseResult(calls=calls, normal_text=info.content)
+    return ParseResult(
+        calls=calls,
+        normal_text=_merge_normal_text(residual_normal_text, info.content),
+    )


### PR DESCRIPTION
#### Overview:

This PR fixes GPT-OSS Harmony parser leakage and classifies the Harmony parity row by matching vLLM for valid/malformed tool-call envelopes and documenting the remaining peer divergences.

#### Harmony Before/After Matrix:

Compared the original pre-PR baseline `ac28b5dee11` to the current implementation; this is the normal chart shape with parser cases as columns.

| State | 1 | 2.a | 2.b | 2.c | 2.d | 3 | 4.a | 4.b | 4.c | 4.d | 5.a | 5.b | 5.c | 5.d | 5.e | 6.a | 6.b | 6.c | 7.a | 7.b | 7.c | 7.d | 8.a | 8.b | 8.c | 8.d | 9 | 10 |
|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| Before | S | ↯S | n/a | ↯S? | ↯S? | = | ↯S | ↯S? | = | n/a | ↯S | ↯ | ↯S? | n/a | n/a | S | S | ↯ | S | S? | S? | S? | ↯S | ↯S | ↯S | ↯S | = | ↯S |
| After | S | = | n/a | S | = | S | S | S | = | n/a | = | S | = | V | V | S | S | S | S | S | S | S | = | = | S | S | = | = |

Summary: after = 9 full parity cells, 17 documented peer-divergence cells, 2 n/a cells, 0 research-needed cells, and 0 Dynamo-leak cells.

Legend: `=` full parity; `V` documented vLLM divergence; `S` documented SGLang divergence; `?` research-needed; `↯` Dynamo leaked raw Harmony/tool-call markup into `normal_text`; `n/a` not applicable.

#### Examples:

- Dynamo leak fixed: `PARSER.batch.8.c` used to leak the hidden `analysis` channel plus the commentary tool-call envelope into user-visible text; after this PR it returns the call and preserves only `I will check the weather.  Let me know if you need more.`
- SGLang is not followed where it keeps leaking raw Harmony control markup or drops a valid `<|call|>`-terminated function call. For example, `PARSER.batch.4.a/b` now match vLLM by preserving the malformed raw arguments for downstream validation while SGLang incorrectly drops the call; many `S` cells are the same class of issue, where SGLang preserves `<|channel|>commentary ... <|call|>` as user-visible text instead of extracting the call.

Many other examples exist; see the YAML fixtures for details.

#### Verification:

`cargo fmt`; `cargo test --locked -p dynamo-parsers harmony -- --nocapture` passed; rebuilt PyO3 with `maturin develop --uv`; Dynamo and vLLM Harmony parity each passed 26 cases with 2 n/a skips; manual SGLang checks confirm the documented `4.a/4.b` drop behavior; regenerated `tests/parity/parser/PARITY.harmony.html` and `tests/parity/parser/PARITY.html` locally.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/harmony/harmony_parser.rs`, then `tests/parity/parser/fixtures/harmony/`, then `tests/parity/parser/generate_parity_chart.py`.

/coderabbit profile chill