### PR TITLE
ci(frontend): bump EPP image build timeout from 20 to 30 minutes

### DIFF
--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -228,7 +228,7 @@ jobs:
           IMAGE_REPOSITORY: ai-dynamo/dynamo
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           SCCACHE_S3_BUCKET: ${{ secrets.SCCACHE_S3_BUCKET }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           set -x
           EPP_REPOSITORY="${{ env.IMAGE_REPOSITORY }}/dynamo-epp"


### PR DESCRIPTION
## Summary
- Increase the `timeout-minutes` on the "Build EPP Image (For Frontend Only)" step in `.github/workflows/shared-build-image.yml` from 20 to 30 minutes to give the frontend EPP multi-arch build more headroom.

Example timeouts today:
- https://github.com/ai-dynamo/dynamo/actions/runs/25892972070/job/76100058624?pr=9524
- https://github.com/ai-dynamo/dynamo/actions/runs/25893102821/job/76100488445?pr=9594

## Test plan
- [ ] CI runs to completion on a frontend build invocation of the shared workflow.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->