### PR TITLE
test: restore online replay smoke coverage

### DIFF
--- a/lib/bindings/python/tests/replay/test_replay_smoke.py
+++ b/lib/bindings/python/tests/replay/test_replay_smoke.py
@@ -23,18 +23,10 @@ from .replay_utils import (
 
 pytestmark = [
     pytest.mark.gpu_0,
-    pytest.mark.parallel,
     pytest.mark.pre_merge,
     pytest.mark.unit,
     pytest.mark.timeout(120),
 ]
-
-
-@pytest.fixture(autouse=True)
-def _skip_online(request):
-    callspec = getattr(request.node, "callspec", None)
-    if callspec and callspec.params.get("replay_mode") == "online":
-        pytest.skip("intermittent hang in online replay mode (#9548)")
 
 
 @pytest.mark.parametrize("engine_type", ["vllm", "sglang"])


### PR DESCRIPTION
Reverts the autouse skip for online replay smoke variants and moves the replay smoke module out of the parallel pre-merge bucket so it runs serially.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration markers for improved test categorization and execution constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->