### PR TITLE
fix(xpu): code convention cleanups for XPU launch scripts and tests

### DIFF
--- a/examples/backends/vllm/launch/xpu/agg_lmcache_multiproc_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/agg_lmcache_multiproc_xpu.sh
@@ -46,7 +46,6 @@ python -m dynamo.frontend &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
   PROMETHEUS_MULTIPROC_DIR="$PROMETHEUS_MULTIPROC_DIR" \
-  ZE_AFFINITY_MASK=$ZE_AFFINITY_MASK \
   python -m dynamo.vllm --model "$MODEL" --enforce-eager \
   --max-model-len "$MAX_MODEL_LEN" \
   --max-num-seqs "$MAX_CONCURRENT_SEQS" \

--- a/examples/backends/vllm/launch/xpu/agg_lmcache_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/agg_lmcache_xpu.sh
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 set -e
+trap 'echo Cleaning up...; kill 0' EXIT
 
 # Explicitly unset PROMETHEUS_MULTIPROC_DIR to let LMCache or Dynamo manage it internally
 unset PROMETHEUS_MULTIPROC_DIR
@@ -16,8 +17,6 @@ export VLLM_TARGET_DEVICE=xpu
 # otherwise default to device 0
 ZE_AFFINITY_MASK=${ZE_AFFINITY_MASK:-0}
 export ZE_AFFINITY_MASK
-
-trap 'echo Cleaning up...; kill 0' EXIT
 
 MODEL="Qwen/Qwen3-0.6B"
 
@@ -36,7 +35,6 @@ print_launch_banner "Launching Aggregated Serving + LMCache (1 GPU)" "$MODEL" "$
 python -m dynamo.frontend &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
-  ZE_AFFINITY_MASK=$ZE_AFFINITY_MASK \
   python -m dynamo.vllm --model "$MODEL" --enforce-eager \
   --max-model-len "$MAX_MODEL_LEN" \
   --max-num-seqs "$MAX_CONCURRENT_SEQS" \

--- a/examples/backends/vllm/launch/xpu/agg_request_planes_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/agg_request_planes_xpu.sh
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 set -e
+trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../../common/gpu_utils.sh"
@@ -13,8 +14,6 @@ export VLLM_TARGET_DEVICE=xpu
 # otherwise default to device 0
 ZE_AFFINITY_MASK=${ZE_AFFINITY_MASK:-0}
 export ZE_AFFINITY_MASK
-
-trap 'echo Cleaning up...; kill 0' EXIT
 
 # Parse command-line arguments for request plane mode
 REQUEST_PLANE="tcp"  # Default to TCP
@@ -67,7 +66,6 @@ python -m dynamo.frontend &
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
 DYN_HEALTH_CHECK_ENABLED=true \
-ZE_AFFINITY_MASK=$ZE_AFFINITY_MASK \
     python -m dynamo.vllm --model "$MODEL" --enforce-eager \
     --max-model-len "$MAX_MODEL_LEN" \
     --max-num-seqs "$MAX_CONCURRENT_SEQS" \

--- a/examples/backends/vllm/launch/xpu/agg_xpu.sh
+++ b/examples/backends/vllm/launch/xpu/agg_xpu.sh
@@ -52,7 +52,6 @@ python -m dynamo.frontend &
 # run worker
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
-    ZE_AFFINITY_MASK=$ZE_AFFINITY_MASK \
     python -m dynamo.vllm --model "$MODEL" --enforce-eager \
     --max-model-len "$MAX_MODEL_LEN" \
     --max-num-seqs "$MAX_CONCURRENT_SEQS" \

--- a/tests/serve/test_vllm_xpu.py
+++ b/tests/serve/test_vllm_xpu.py
@@ -477,7 +477,7 @@ vllm_configs = {
             pytest.mark.multimodal,
             pytest.mark.pre_merge,
             pytest.mark.skip(
-                reason="Temporary: video stream load failure for local media URI in CI"
+                reason="Flaky: https://github.com/ai-dynamo/dynamo/issues/9601"
             ),
             pytest.mark.timeout(600),  # TODO: profile to get tighter timeout
         ],  # TODO: profile to get max_vram
@@ -762,8 +762,7 @@ def lora_chat_payload(
 @pytest.mark.vllm
 @pytest.mark.e2e
 @pytest.mark.xpu_1
-@pytest.mark.model("Qwen/Qwen3-0.6B")
-@pytest.mark.model("codelion/Qwen3-0.6B-accuracy-recovery-lora")
+@pytest.mark.model("Qwen/Qwen3-0.6B", "codelion/Qwen3-0.6B-accuracy-recovery-lora")
 @pytest.mark.timeout(600)
 @pytest.mark.post_merge
 def test_lora_aggregated(


### PR DESCRIPTION
#### Overview:

Address code convention issues identified during review of the XPU CI PR, covering shell script hygiene and test marker consistency.

#### Details:

**Shell scripts** (`examples/backends/vllm/launch/xpu/`):

1. **Remove redundant inline `ZE_AFFINITY_MASK=$ZE_AFFINITY_MASK`** — scripts that `export ZE_AFFINITY_MASK` at the top level also redundantly pass it inline before `python -m dynamo.vllm`. Since the export already places it in the subprocess env, the inline assignment is a no-op. Affected scripts:
   - `agg_xpu.sh`
   - `agg_lmcache_xpu.sh`
   - `agg_request_planes_xpu.sh`
   - `agg_lmcache_multiproc_xpu.sh`

2. **Restore `set -e` / `trap` ordering** — `agg_lmcache_xpu.sh` and `agg_request_planes_xpu.sh` had the `trap ... EXIT` line shifted below env setup. Moved it back to immediately after `set -e` to match the repo convention (`agg_xpu.sh`, `agg_router_xpu.sh`, `agg_multimodal_xpu.sh`).

**Tests** (`tests/serve/test_vllm_xpu.py`):

3. **`multimodal_video_agg` skip marker** — follow the `@pytest.mark.skip(reason="Flaky: <ticket link>")` convention with tracking issue #9601.

4. **Consolidate double `@pytest.mark.model(...)`** on `test_lora_aggregated` — merged two separate decorators into the single variadic form to match repo convention.

#### Where should the reviewer start?

- Shell script diffs are minimal (line removals / reordering only)
- `tests/serve/test_vllm_xpu.py` for the test marker changes

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #9601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored XPU launch scripts to consolidate environment variable handling and remove duplicate cleanup trap definitions.
  * Updated worker launch configuration to use updated environment variable assignments.

* **Tests**
  * Updated test markers and skip reasons for vLLM XPU multimodal tests to reflect current test status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9603)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->