### PR TITLE
test: add SGLang's Gemma4 + Llama coverage (missed)

### DIFF
--- a/lib/parsers/PARSER_CASES.md
+++ b/lib/parsers/PARSER_CASES.md
@@ -54,6 +54,9 @@ fed the full model output as a single string.
 - **`PARSER.batch.8`** Normal text interleaved with tool calls.
 - **`PARSER.batch.9`** Empty content / empty `tool_calls` array / null response.
 - **`PARSER.batch.10`** Duplicate tool calls (same name twice, possibly with same args).
+- **`PARSER.batch.11`** Separator characters inside argument string values.
+- **`PARSER.batch.12`** Multiple calls where one argument contains a separator character.
+- **`PARSER.batch.13`** Unknown / unregistered tool name (valid grammar, name absent from supplied `tools`).
 
 ### Parser, stream mode
 
@@ -193,6 +196,9 @@ class.
 - **`PARSER.batch.4.d`** Malformed wrapper / XML structure. Unclosed tags,
   missing delimiters, mismatched fences. Tests the wrapper-parser layer
   (vs the JSON-body layer in `.b`).
+- **`PARSER.batch.4.e`** Recovery after malformed prefix. A bad tool-looking
+  fragment is followed by a valid complete call; parsers may either treat the
+  whole string as normal text or resynchronize and extract the later valid call.
 
 ## `PARSER.batch.5` — Missing end-token recovery
 
@@ -343,6 +349,55 @@ the same arguments.
 - Expected behavior: both calls must appear in `tool_calls` with
   distinct IDs. (The runtime / client is responsible for deciding
   whether duplicate invocation is intended.)
+
+## `PARSER.batch.11` — Separator characters inside argument strings
+
+A single call contains a grammar-level separator character inside an
+argument string value. Examples: Llama JSON uses semicolon-separated
+calls while the SQL argument contains `SELECT a; SELECT b`; JSON-array
+families use commas between calls while the SQL argument contains
+`SELECT a, SELECT b`; Gemma4 uses comma/colon/brace delimiters inside
+its custom argument object.
+
+- Applies to delimiter-separated formats.
+- The parser must not split inside a JSON string.
+- Related existing tests: `PARSER.batch.7.b` already covers escaped /
+  special string values, but not a grammar separator embedded in a
+  string. SGLang's `JsonArrayParser` tests cover comma-separator state
+  and `}` inside string values; Dynamo's `base_json_parser` documents
+  the exact `<|python_tag|>` semicolon hazard. Keep this as a separate
+  delimiter-state regression rather than folding it into generic
+  string escaping.
+
+## `PARSER.batch.12` — Separator characters inside one call of a multi-call response
+
+Two or more calls are present, and one call's argument string contains a
+separator-looking character before the real call separator.
+
+- Applies to delimiter-separated formats.
+- Extends `PARSER.batch.11` to the parallel-call path so the parser has to
+  distinguish in-string separators from inter-call separators while continuing
+  to parse later calls.
+- Related existing tests: `PARSER.batch.2.a` covers real call
+  separators, but not a separator-looking character inside the first
+  call's argument. This case is the combined `2.a + 11` state-machine
+  check.
+
+## `PARSER.batch.13` — Unknown / unregistered tool name
+
+The model emits a syntactically valid tool call, but the function name is
+not present in the request's supplied `tools` list.
+
+- Applies to every parser that receives the tool schema at parse time.
+- Behavior is implementation-defined: some parsers forward the call with
+  an unknown name, some drop it, and some return the original block as
+  normal text. The fixture should record the parser's chosen contract.
+- Source: SGLang `test_unknown_tool_name.py` pins both default drop
+  behavior and opt-in forwarding via `SGLANG_FORWARD_UNKNOWN_TOOLS`.
+- Related existing tests: this is not `PARSER.batch.4.c` because the
+  emitted call is syntactically valid and contains the expected
+  structural keys. The unknown part is the function registry lookup
+  against the request's supplied `tools` list.
 
 ---
 
@@ -582,7 +637,8 @@ Minimum viable set:
    non-negotiable for any parser that sits behind a streaming
    frontend.
 6. `PARSER.batch.8` — interleaved text.
-7. `PARSER.batch.{9, 10}` — empty/null and duplicate calls.
+7. `PARSER.batch.{9, 10, 13}` — empty/null, duplicate calls, and
+   unknown tool names.
 8. Format variants where applicable (`PARSER.fmt.{1..5}`): cover
    any that the parser's grammar permits. Mark `N/A` for those that
    don't apply. JSON-family parsers (Mistral, Llama 3 JSON, Hermes)

--- a/lib/parsers/SGLANG_TEST_AUDIT.md
+++ b/lib/parsers/SGLANG_TEST_AUDIT.md
@@ -1,0 +1,141 @@
+# SGLang Tool Parser Test Audit
+
+Source: local SGLang checkout at `612785ffdcaf35552f1ed433a981d596ca9fe900`
+under `/sgl-workspace/sglang`.
+
+Scope: in-tree Python parser and detector tests:
+
+- `test/registered/unit/function_call/test_function_call_parser.py`
+- `test/registered/unit/function_call/test_{hermes,llama32,mistral}_detector.py`
+- `test/registered/unit/function_call/test_{parallel_tool_calls,unknown_tool_name}.py`
+- `test/registered/function_call/test_kimik2_detector.py`
+- `test/registered/unit/parser/test_harmony_parser.py`
+
+Excluded from parser-taxonomy changes:
+
+- `test_json_schema_constraint.py` and `openai_server/function_call/*` test request
+  shaping, guided schema constraints, `tool_choice`, and API wiring. Those are
+  `FRONTEND.*` / guided-decoding concerns, not parser extraction cases.
+- Hunyuan, LFM2, GigaChat, GLM4-MoE, and similar SGLang-only detectors do not
+  have Dynamo parser families today. Their rows were used as gap signal only.
+
+## Bucket Summary
+
+| SGLang test shape | Bucket |
+| -- | -- |
+| Single complete call | `PARSER.batch.1` |
+| Multiple / parallel calls | `PARSER.batch.2`, `PARSER.batch.2.{a,b,c,d}` |
+| Plain text / no tool call | `PARSER.batch.3` |
+| Malformed body / missing key / malformed wrapper | `PARSER.batch.4.{a,b,c,d}` |
+| Malformed prefix followed by a later valid call | `PARSER.batch.4.e` |
+| Missing end token / partial call | `PARSER.batch.5.{a,c}` |
+| Empty args / no args / no arguments key | `PARSER.batch.6.{a,b,c}` |
+| Nested args, arrays, unicode, escaped chars, typed values | `PARSER.batch.7.{a,b,c,d}` |
+| Text before / after / around tool calls | `PARSER.batch.8.{a,b,c,d}` |
+| Empty input | `PARSER.batch.9` |
+| Duplicate tool calls | `PARSER.batch.10` |
+| Separator character inside a string argument | `PARSER.batch.11` |
+| Multi-call response with separator character inside one argument | `PARSER.batch.12` |
+| Tool name absent from supplied `tools` | `PARSER.batch.13` |
+| Streaming assembly, multi-call streaming, token-boundary splits, termination | `PARSER.stream.{1,2,3,4}` |
+| Function-name surface, token variants, arguments-vs-parameters aliases | `PARSER.fmt.{1,3,5}` |
+| Harmony channel / recipient / envelope grammar | `PARSER.harmony.{1,2}` |
+| White-box helper-only state tests | `// helper` |
+
+## Existing-Test Overlap Decision
+
+- `PARSER.batch.11` is close to `PARSER.batch.7.b` because both involve
+  special characters inside argument strings. The difference is parser state:
+  `7.b` proves JSON/string decoding, while `11` proves a delimiter-aware
+  parser does not split on a grammar separator while it is inside a string.
+- `PARSER.batch.12` is the same delimiter-state check on the parallel-call
+  path. It overlaps with `PARSER.batch.2.a`, but `2.a` only proves real
+  separators between calls; it does not prove the parser ignores an earlier
+  separator-looking character inside a string value.
+- `PARSER.batch.13` does not fit `PARSER.batch.4.c`: the call is structurally
+  valid and parseable. The tested behavior is the schema/tool-registry
+  lookup after syntax parsing, which SGLang explicitly tests with both drop
+  and forwarding modes.
+
+## SGLang-Only Taxonomy Additions
+
+### `PARSER.batch.4.e`
+
+SGLang's `TestLlama32Detector.test_invalid_then_valid_json` verifies that a
+malformed JSON object followed by a valid JSON object can still recover the
+later call. Dynamo and vLLM currently treat the whole string as normal text.
+This is still an impl-defined malformed-input contract, but it needs its own
+subcase because it tests resynchronization, not just "invalid JSON does not
+crash."
+
+Fixture added:
+
+- `tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml`
+
+### `PARSER.batch.11` / `PARSER.batch.12`
+
+SGLang's Llama tests cover semicolon-separated JSON objects, and its generic
+JSON-array parser tests cover separator-state handling for commas and braces in
+string values. Dynamo already had `llama3_json` fixture rows for the exact
+semicolon-in-string shape (`PARSER.batch.11` and `.12`); this audit expanded
+the same delimiter-state check to other applicable grammars.
+
+Fixtures documented or added:
+
+- `tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml`
+- `tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml`
+- `tests/parity/parser/fixtures/jamba/PARSER.batch.yaml`
+- `tests/parity/parser/fixtures/mistral/PARSER.batch.yaml`
+- `tests/parity/parser/fixtures/phi4/PARSER.batch.yaml`
+- `tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml`
+
+### `PARSER.batch.13`
+
+SGLang has explicit tests for unknown tool names:
+
+- default: drop unknown tool calls and log a warning
+- opt-in: forward unknown tool calls with `tool_index = -1`
+
+Dynamo and vLLM generally forward unknown tool names. SGLang behavior depends
+on detector family: base-JSON-derived detectors drop by default, while some
+detectors that do not route through `parse_base_json` forward.
+
+Fixtures added:
+
+- `tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml` — all three forward
+- `tests/parity/parser/fixtures/hermes/PARSER.batch.yaml` — SGLang default drop
+- `tests/parity/parser/fixtures/jamba/PARSER.batch.yaml` — no SGLang detector
+- `tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml` — SGLang default drop
+- `tests/parity/parser/fixtures/mistral/PARSER.batch.yaml` — SGLang Mistral format divergence masks unknown-tool lookup
+- `tests/parity/parser/fixtures/phi4/PARSER.batch.yaml` — no SGLang detector
+- `tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml` — SGLang default drop
+
+## Existing-Bucket Mapping
+
+| SGLang file / class | Representative tests | Bucket(s) |
+| -- | -- | -- |
+| `test_hermes_detector.py::TestHermesDetector` | `test_single_tool_call`, `test_multiple_tool_calls`, `test_tool_call_with_leading_text`, `test_malformed_json_returns_original_text`, streaming variants | `batch.{1,2,3,4,7,8}`, `stream.{1,3}` |
+| `test_llama32_detector.py::TestLlama32Detector` | with/without `<|python_tag|>`, semicolon-separated calls, normal text before call, streaming split tag | `batch.{1,2,3,7,8}`, `fmt.3`, `stream.{1,3}` |
+| `test_function_call_parser.py::TestLlama32Detector` | trailing text, invalid-then-valid JSON, repeated `<|python_tag|>` separator | `batch.4.e`, `batch.8.b`, `fmt.3` |
+| `test_mistral_detector.py::TestMistralDetector` | JSON-array and compact formats, nested JSON, invalid JSON, streaming compact format | `batch.{1,2,3,4,7,8}`, `fmt.3`, `stream.{1,3}` |
+| `test_function_call_parser.py::TestPythonicDetector` | no brackets, complete call, partial call, nested brackets, text after tool call | `batch.{1,2,3,4,7,8}`, `stream.{1,2,3}` |
+| `test_function_call_parser.py::TestQwen3CoderDetector` | XML-style plain text, single/multiple calls, typed conversion, special chars, incomplete call | `batch.{1,2,3,4,7,8}`, `xml.2`, `stream.{1,2}` |
+| `test_function_call_parser.py::TestGlm47MoeDetector` | single/multiple calls, tool IDs, invalid/partial calls, escaped JSON arrays, whitespace preservation | `batch.{1,2,4,5,7}`, `fmt.{1,2}`, `stream.{1,2}` |
+| `test_function_call_parser.py::TestDeepSeekV32Detector` | XML and JSON formats, no parameters, whitespace in no-parameter calls, streaming XML/JSON | `batch.{1,6}`, `fmt.3`, `stream.{1,3}` |
+| `test_function_call_parser.py::TestGemma4Detector` | unknown tool index, nested args, multiple calls, empty args, char-by-char streaming | `batch.{1,2,3,6,7,13}`, `stream.{1,2,3}` |
+| `test_kimik2_detector.py::TestKimiK2Detector*` | hyphenated names, multiple calls, state reset, special-token leakage, reasoning-to-tool transitions | `batch.{1,2,3,8}`, `fmt.1`, `stream.{1,2,3,4}`, `REASONING.*` |
+| `test_parallel_tool_calls.py` | JSON-array parallel calls with array parameters and separators | `batch.2`, `batch.7`, `stream.2` |
+| `test_unknown_tool_name.py` | default drop and opt-in forwarding of unknown tools | `PARSER.batch.13` |
+| `test_harmony_parser.py` | canonical channels, commentary tool calls, built-in analysis tool calls, malformed/partial tokens, commentary filler | `PARSER.harmony.{1,2}`, `batch.{1,2,3,4,6,8,9}`, `stream.{1,3}` |
+
+## Follow-Up Gaps
+
+- SGLang has extensive streaming tests; Dynamo's shared YAML harness is still
+  batch-only. The stream rows above should feed future stream fixture work.
+- SGLang's `JsonArrayParser` has many separator-state tests around commas,
+  trailing commas, braces in strings, and three-call streams. These mostly fit
+  `PARSER.stream.{2,3}` plus `PARSER.batch.{7,11,12}` and do not require more
+  taxonomy labels yet.
+- SGLang's unknown-tool forwarding mode is environment-controlled. The parity
+  fixture added here pins the default mode; testing opt-in forwarding would
+  require a fixture-level environment override in the harness.

--- a/tests/parity/parser/capture_parser_outputs.py
+++ b/tests/parity/parser/capture_parser_outputs.py
@@ -109,6 +109,25 @@ FAMILY_FILTER = set(_args.family or [])
 if OVERWRITE and not MERGE_MODE:
     _ap.error("--overwrite-if-exists requires --merge")
 
+
+def _known_fixture_families() -> set[str]:
+    families = set()
+    for fp in sorted(FIXTURES.glob("*/PARSER.*.yaml")):
+        doc = yaml.safe_load(fp.read_text())
+        families.add(doc["family"])
+    return families
+
+
+if FAMILY_FILTER:
+    known_families = _known_fixture_families()
+    unknown_families = FAMILY_FILTER - known_families
+    if unknown_families:
+        _ap.error(
+            "unknown --family value(s): "
+            f"{', '.join(sorted(unknown_families))}. "
+            f"Known families: {', '.join(sorted(known_families))}"
+        )
+
 wrapper = importlib.import_module(
     f"tests.parity.parser.{IMPL}"
 )  # noqa: E402 — needs sys.path tweak above
@@ -374,6 +393,13 @@ def main() -> int:
                 d = check_drift(case, family, case_id, got)
                 if d is not None:
                     drift.append((key, d))
+
+    if FAMILY_FILTER and n_total == 0:
+        print(
+            f"ERROR: --family matched no cases: {', '.join(sorted(FAMILY_FILTER))}",
+            file=sys.stderr,
+        )
+        return 2
 
     mode = "MERGE" if MERGE_MODE else "CHECK"
     print(

--- a/tests/parity/parser/capture_parser_outputs.py
+++ b/tests/parity/parser/capture_parser_outputs.py
@@ -68,6 +68,14 @@ _ap.add_argument(
     ),
 )
 _ap.add_argument(
+    "--family",
+    action="append",
+    help=(
+        "Limit capture to one parser family. May be repeated. Useful when "
+        "refreshing a newly wired peer without rewriting the full fixture corpus."
+    ),
+)
+_ap.add_argument(
     "--merge",
     action="store_true",
     help=(
@@ -96,6 +104,7 @@ _args = _ap.parse_args()
 IMPL = _args.impl
 MERGE_MODE = _args.merge
 OVERWRITE = _args.overwrite_if_exists
+FAMILY_FILTER = set(_args.family or [])
 
 if OVERWRITE and not MERGE_MODE:
     _ap.error("--overwrite-if-exists requires --merge")
@@ -292,6 +301,8 @@ def merge_into_fixtures(
     for fp in sorted(FIXTURES.glob("*/PARSER.*.yaml")):
         doc = yaml.safe_load(fp.read_text(encoding="utf-8"))
         family = doc["family"]
+        if FAMILY_FILTER and family not in FAMILY_FILTER:
+            continue
         cases = doc.get("cases") or {}
         changed = False
         for case_id, case in cases.items():
@@ -345,6 +356,8 @@ def main() -> int:
     for fp in sorted(FIXTURES.glob("*/PARSER.*.yaml")):
         doc = yaml.safe_load(fp.read_text())
         family = doc["family"]
+        if FAMILY_FILTER and family not in FAMILY_FILTER:
+            continue
         for case_id, case in doc["cases"].items():
             n_total += 1
             key = f"{family}/{case_id}"

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
@@ -9,14 +9,14 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L207
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -24,7 +24,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -33,19 +33,18 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
     model_text: 'Both: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
       Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -54,18 +53,26 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both:'
-      vllm: *d_2_c
+      vllm: *id004
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: '
+        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -74,6 +81,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
@@ -23,9 +23,11 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>nonsense<tool_call|>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: <|tool_call>nonsense<tool_call|>
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path
   PARSER.batch.4.b:
     description: Missing close brace in body
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L572
@@ -39,9 +41,14 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+        reason: accepts missing close brace before closing sentinel
   PARSER.batch.4.c:
     description: No call:name prefix
     ref: dynamo
@@ -55,9 +62,11 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path
   PARSER.batch.4.d:
     description: Mismatched sentinels
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L252
@@ -71,6 +80,8 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
@@ -23,9 +23,11 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path
   PARSER.batch.5.b:
     description: Closing <tool_call|> without matching <|tool_call> open
     ref: dynamo
@@ -39,9 +41,11 @@ cases:
       vllm:
         calls: []
         normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path
   PARSER.batch.5.c:
     description: Truncation mid-argument value
     ref: dynamo
@@ -55,9 +59,11 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>N
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>N
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path
   PARSER.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
@@ -66,15 +72,14 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_d
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *d_5_d
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -83,12 +88,11 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_e
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *d_5_e
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      vllm: *id003
+      sglang: *id003

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
@@ -21,8 +21,7 @@ cases:
           arguments: {}
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
@@ -36,8 +35,7 @@ cases:
           arguments: {}
         normal_text: ''
       vllm: *id003
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id003
   PARSER.batch.6.c:
     description: No body (just call:name)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L280
@@ -51,6 +49,8 @@ cases:
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_time<tool_call|>
-        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls: []
+        normal_text: <|tool_call>call:get_time<tool_call|>
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -29,8 +29,7 @@ cases:
             first_class: true
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode in value
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L630
@@ -50,8 +49,7 @@ cases:
             location: Tōkyō central
         normal_text: ''
       vllm: *id002
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -71,8 +69,7 @@ cases:
             celsius: '20'
         normal_text: ''
       vllm: *id003
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L179
@@ -99,5 +96,4 @@ cases:
               nested: true
         normal_text: ''
       vllm: *id004
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id004

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
@@ -9,7 +9,7 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L194
     model_text: I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,57 +17,66 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: I will check the weather.
-      vllm: *d_8_a
+      vllm: *id001
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+        reason: preserves whitespace before tool-call wrapper start
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
     model_text: I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Let me know if
       you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: I will check the weather.
-      vllm: *d_8_c
+      vllm: *id004
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
     model_text: I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Then check LA weather.
       <|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -76,6 +85,14 @@ cases:
           arguments:
             location: LA
         normal_text: I will check the weather.
-      vllm: *d_8_d
+      vllm: *id005
       sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '
+        reason: preserves pre-tool-call whitespace and drops trailing normal_text after tool-call wrapper end

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -64,3 +64,67 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Single call with argument delimiters inside string value
+    ref: dynamo
+    model_text: <|tool_call>call:run_query{sql:<|"|>SELECT a,b:and{brace}<|"|>}<tool_call|>
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo: &d_11
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a,b:and{brace}
+        normal_text: ''
+      vllm: *d_11
+      sglang: *d_11
+  PARSER.batch.12:
+    description: Parallel calls where one argument contains delimiter characters
+    ref: dynamo
+    model_text: <|tool_call>call:run_query{sql:<|"|>SELECT a,b:and{brace}<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_12
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a,b:and{brace}
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_12
+      sglang: *d_12
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L4312
+    model_text: <|tool_call>call:unknown_tool{location:<|"|>NYC<|"|>}<tool_call|>
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang: *d_13

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -24,8 +24,7 @@ cases:
             location: NYC
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -36,8 +35,7 @@ cases:
         calls: []
         normal_text: Hello, how can I help you today?
       vllm: *id003
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
@@ -48,8 +46,7 @@ cases:
         calls: []
         normal_text: ''
       vllm: *id004
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
@@ -66,5 +63,4 @@ cases:
             location: LA
         normal_text: ''
       vllm: *id005
-      sglang:
-        unavailable: SGLang has no detector for family='gemma4'
+      sglang: *id005

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -65,3 +65,21 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29
+    model_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -69,3 +69,67 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.11:
+    description: Single JSON-array call with comma inside argument string value
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}]</tool_calls>'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo: &d_11
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
+      vllm: *d_11
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.12:
+    description: Parallel JSON-array calls where one argument contains a comma
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls>'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_12
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_12
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    model_text: '<tool_calls>[{"name": "unknown_tool", "arguments": {"location": "NYC"}}]</tool_calls>'
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -35,8 +35,7 @@ cases:
             timezone: EST
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id001
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -66,7 +65,15 @@ cases:
         normal_text: ''
         reason: vLLM llama3_json drops leading normal_text before the python_tag token
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: Done.'
+        reason: preserves trailing text after final parsed JSON object
   PARSER.batch.2.d:
     description: Same-name twice (semicolon-separated)
     ref: dynamo
@@ -86,5 +93,4 @@ cases:
             location: LA
         normal_text: ''
       vllm: *id004
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id004

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
@@ -24,7 +24,9 @@ cases:
         calls: []
         normal_text: <|python_tag|>not even json
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls: []
+        normal_text: not even json
+        reason: impl-defined recovery contract; strips python_tag before returning malformed action text
   PARSER.batch.4.b:
     description: Missing close brace
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L66
@@ -39,7 +41,9 @@ cases:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"'
+        reason: impl-defined recovery contract; strips python_tag before returning malformed action text
   PARSER.batch.4.c:
     description: Missing name key
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L234
@@ -47,11 +51,10 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &id002
         calls: []
         normal_text: ''
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id002

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
@@ -23,6 +23,7 @@ cases:
       vllm:
         calls: []
         normal_text: <|python_tag|>not even json
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         calls: []
         normal_text: not even json
@@ -40,6 +41,7 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"'
@@ -57,4 +59,25 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang: *id002
+  PARSER.batch.4.e:
+    description: Malformed JSON prefix followed by a valid complete call
+    ref: SGLang TestLlama32Detector.test_invalid_then_valid_json
+    model_text: '{"name": "get_weather", "arguments": {{"name": "get_weather", "arguments": {}}'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      dynamo: &id003
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {{"name": "get_weather", "arguments": {}}'
+      vllm: *id003
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+        reason: SGLang Llama32Detector scans past the malformed prefix and recovers the later valid JSON object.

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
@@ -24,7 +24,9 @@ cases:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}'
+        reason: impl-defined recovery contract; strips python_tag before returning incomplete action text
   PARSER.batch.5.c:
     description: Truncation deeper inside arguments JSON (vs .a which truncates at the closing brace)
     ref: dynamo
@@ -39,7 +41,9 @@ cases:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"loc'
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"loc'
+        reason: impl-defined recovery contract; strips python_tag before returning incomplete action text
   PARSER.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
@@ -55,7 +59,13 @@ cases:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!{"name": "get_weather",
+          "arguments": {"location": "New York"}'
+        reason: impl-defined recovery contract; strips python_tag and preserves malformed trailing JSON after first recovered call
       vllm:
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<|python_tag|>{"name":
@@ -75,7 +85,13 @@ cases:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!{"name": "get_weather",
+          "arguments": {"location": "New York'
+        reason: impl-defined recovery contract; strips python_tag and preserves malformed trailing JSON after first recovered call
       vllm:
         calls: []
         normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<|python_tag|>{"name":

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
@@ -21,8 +21,7 @@ cases:
           arguments: {}
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -36,8 +35,7 @@ cases:
           arguments: {}
         normal_text: ''
       vllm: *id003
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id003
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -52,4 +50,8 @@ cases:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_time"}'
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+        reason: treats missing arguments key as an empty argument object

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -30,8 +30,7 @@ cases:
             passengers: 2
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L217
@@ -51,8 +50,7 @@ cases:
             location: Tōkyō "central"
         normal_text: ''
       vllm: *id002
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -72,8 +70,7 @@ cases:
             celsius: '20'
         normal_text: ''
       vllm: *id003
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested object + array
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L146
@@ -100,5 +97,4 @@ cases:
             - 3
         normal_text: ''
       vllm: *id004
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id004

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
@@ -29,8 +29,14 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+        reason: vLLM llama3_json drops leading normal_text before the python_tag token
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+        reason: preserves whitespace before python_tag in normal_text
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -46,7 +52,12 @@ cases:
         normal_text: ''
       vllm: *id002
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+        reason: preserves trailing text after parsed JSON object
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128
@@ -67,8 +78,14 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+        reason: vLLM llama3_json drops leading normal_text before the python_tag token
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather. Let me know if you need more.
+        reason: preserves leading normal_text and trailing text around parsed JSON object
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -95,5 +112,14 @@ cases:
           arguments:
             location: LA
         normal_text: ''
+        reason: vLLM llama3_json drops leading normal_text before the python_tag token
       sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '
+        reason: uses next JSON object recovery and drops interstitial text between parsed calls

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -91,6 +91,7 @@ cases:
       sglang: *id006
   PARSER.batch.11:
     description: Single call with semicolon inside argument string value
+    ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}}'
     tools:
     - name: run_query
@@ -110,6 +111,7 @@ cases:
       sglang: *id007
   PARSER.batch.12:
     description: Parallel calls where one argument contains a semicolon (streaming split safety)
+    ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}}'
     tools:
@@ -137,3 +139,21 @@ cases:
         normal_text: ''
       vllm: *id008
       sglang: *id008
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29
+    model_text: '<|python_tag|>{"name": "unknown_tool", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -24,8 +24,7 @@ cases:
             location: NYC
         normal_text: ''
       vllm: *id001
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id001
   PARSER.batch.2:
     description: Multiple tool calls (parallel, semicolon-separated)
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
@@ -49,8 +48,7 @@ cases:
             timezone: EST
         normal_text: ''
       vllm: *id003
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id003
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -61,8 +59,7 @@ cases:
         calls: []
         normal_text: Hello, how can I help you today?
       vllm: *id004
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id004
   PARSER.batch.9:
     description: Empty input
     model_text: ''
@@ -73,8 +70,7 @@ cases:
         calls: []
         normal_text: ''
       vllm: *id005
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id005
   PARSER.batch.10:
     description: Duplicate calls (same name twice, semicolon-separated)
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
@@ -92,8 +88,7 @@ cases:
             location: LA
         normal_text: ''
       vllm: *id006
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id006
   PARSER.batch.11:
     description: Single call with semicolon inside argument string value
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}}'
@@ -112,8 +107,7 @@ cases:
             sql: SELECT a; SELECT b
         normal_text: ''
       vllm: *id007
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id007
   PARSER.batch.12:
     description: Parallel calls where one argument contains a semicolon (streaming split safety)
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments":
@@ -142,5 +136,4 @@ cases:
             timezone: EST
         normal_text: ''
       vllm: *id008
-      sglang:
-        unavailable: SGLang has no detector for family='llama3_json'
+      sglang: *id008

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -27,6 +27,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -69,3 +70,77 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
+  PARSER.batch.11:
+    description: Single JSON-array call with comma inside argument string value
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}][/TOOL_CALLS]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo: &d_11
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
+      vllm: *d_11
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
+  PARSER.batch.12:
+    description: Parallel JSON-array calls where one argument contains a comma
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_12
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_12
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29
+    model_text: '[TOOL_CALLS][{"name": "unknown_tool", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -69,3 +69,67 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.11:
+    description: Single JSON-array call with comma inside argument string value
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo: &d_11
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
+      vllm: *d_11
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.12:
+    description: Parallel JSON-array calls where one argument contains a comma
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_12
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_12
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    model_text: 'functools[{"name": "unknown_tool", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -64,3 +64,70 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Single call with comma inside argument string value
+    ref: dynamo
+    model_text: '[run_query(sql="SELECT a, SELECT b")]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo: &d_11
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
+      vllm: *d_11
+      sglang: *d_11
+  PARSER.batch.12:
+    description: Parallel calls where one argument contains a comma
+    ref: dynamo
+    model_text: '[run_query(sql="SELECT a, SELECT b"), get_time(timezone="EST")]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_12
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_12
+      sglang: *d_12
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L3147
+    model_text: '[unknown_tool(location="NYC")]'
+    tools:
+    - *id002
+    expected:
+      dynamo: &d_13
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *d_13
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang PythonicDetector drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -21,6 +21,9 @@ from sglang.srt.function_call.function_call_parser import (  # type: ignore[impo
     DeepSeekV31Detector,
     Glm47MoeDetector,
 )
+from sglang.srt.function_call.gemma4_detector import (
+    Gemma4Detector,  # type: ignore[import-untyped]
+)
 from sglang.srt.function_call.gpt_oss_detector import (
     GptOssDetector,  # type: ignore[import-untyped]
 )
@@ -29,6 +32,9 @@ from sglang.srt.function_call.hermes_detector import (
 )
 from sglang.srt.function_call.kimik2_detector import (
     KimiK2Detector,  # type: ignore[import-untyped]
+)
+from sglang.srt.function_call.llama32_detector import (
+    Llama32Detector,  # type: ignore[import-untyped]
 )
 from sglang.srt.function_call.minimax_m2 import (
     MinimaxM2Detector,  # type: ignore[import-untyped]
@@ -58,7 +64,9 @@ _FAMILY_TO_SGLANG_DETECTOR = {
     "deepseek_v3_1": DeepSeekV31Detector,
     "deepseek_v3_2": DeepSeekV32Detector,
     "deepseek_v3": DeepSeekV3Detector,
+    "gemma4": Gemma4Detector,
     "harmony": GptOssDetector,
+    "llama3_json": Llama32Detector,
     "minimax_m2": MinimaxM2Detector,
     "pythonic": PythonicDetector,
     "hermes": HermesDetector,
@@ -66,7 +74,7 @@ _FAMILY_TO_SGLANG_DETECTOR = {
 }
 
 # Families with no SGLang detector today: nemotron_deci, nemotron_nano,
-# gemma4, deepseek_v4, jamba, llama3_json, phi4.
+# deepseek_v4, jamba, phi4.
 
 
 def parse(


### PR DESCRIPTION
#### Overview:

SGLang has Gemma 4 and Llama 3.x JSON detectors, but the parser parity wrapper still marked both families unavailable; this PR wires those detectors and records their actual parity outputs.

#### Details:

- **How is this fixed?** Add `Gemma4Detector` and `Llama32Detector` to `tests/parity/parser/sglang.py`, then refresh only the Gemma 4 and Llama 3.x JSON SGLang fixture expectations.
- Add `--family` filtering to `tests/parity/parser/capture_parser_outputs.py` so a newly wired peer family can be refreshed without rewriting the full fixture corpus.
- Replace `expected.sglang.unavailable` blocks for Gemma 4 and Llama 3.x JSON with concrete `calls` / `normal_text` outputs and `reason:` fields where SGLang intentionally diverges.
- Leave no-detector comments updated so remaining SGLang gaps are only `nemotron_deci`, `nemotron_nano`, `deepseek_v4`, `jamba`, and `phi4`.

#### Verification:

`python3 -m pytest -xvv --basetemp=/tmp/pytest_temp tests/parity/parser/test_parity_parser.py -k "test_parity_sglang and (gemma4 or llama3_json)"` in the existing dynamo2 SGLang container: 51 passed.

#### Where should the reviewer start?

`tests/parity/parser/sglang.py`, then `tests/parity/parser/capture_parser_outputs.py`, then `tests/parity/parser/fixtures/{gemma4,llama3_json}/`.

#### Related Issues:

Relates to [DIS-1927](https://linear.app/nvidia/issue/DIS-1927)

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended SGLang parser backend support to Gemma4 and Llama3-JSON model families with comprehensive tool-call parsing capabilities
  * Added `--family` CLI filtering option for parity test case selection

* **Tests**
  * Updated parser test fixtures to document expected SGLang parsing behavior across Gemma4 and Llama3-JSON families, including tool-call extraction and text normalization semantics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9605)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->