### PR TITLE
test(parsers): deprecate Rust tests duplicated by YAML fixtures

### DIFF
--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -306,6 +306,12 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // DEPRECATED(parser-fixture-duplicate): Legacy V4 coverage manifest.
+    // The blackbox case mapping now lives in the YAML parser fixtures under
+    // tests/parity/parser/fixtures/deepseek_v4/ and the taxonomy in
+    // lib/parsers/PARSER_CASES.md; keep this temporarily as a pointer while
+    // the duplicate Rust tests are being retired.
+    //
     // DeepSeek V4 coverage (see lib/parsers/PARSER_CASES.md for PARSER.* taxonomy).
     //
     // Covered by the V4 tests below (or by a shared DSML generic test):
@@ -397,6 +403,7 @@ mod tests {
         assert_eq!(&text[pos..], "more");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_single_tool_call_string_param() {
         let input = r#"<｜DSML｜function_calls>
@@ -425,6 +432,7 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_single_tool_call_mixed_params() {
         let input = r#"<｜DSML｜function_calls>
@@ -444,6 +452,7 @@ mod tests {
         assert_eq!(args["topn"], 10);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<｜DSML｜function_calls>
@@ -471,6 +480,7 @@ mod tests {
     }
 
     /// `PARSER.batch.2` multi-calls + `PARSER.batch.8` interleaved-text (prefix text before the block).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_multiple_tool_calls() {
         let input = r#"Let's check this. <｜DSML｜tool_calls>
@@ -504,6 +514,7 @@ mod tests {
     }
 
     /// `PARSER.batch.6` — empty args (no-parameter invoke).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6, PARSER.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_no_parameters() {
         let input = r#"<｜DSML｜tool_calls>
@@ -521,6 +532,7 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_with_normal_text() {
         let input = r#"Here's the result: <｜DSML｜function_calls>
@@ -568,6 +580,7 @@ mod tests {
         assert_eq!(normal, Some(input.to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_json_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
@@ -586,6 +599,7 @@ mod tests {
         assert_eq!(args["config"]["count"], 42);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_array_parameter_value() {
         let input = r#"<｜DSML｜function_calls>
@@ -604,6 +618,7 @@ mod tests {
         assert_eq!(args["items"][2], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_boolean_parameters() {
         let input = r#"<｜DSML｜function_calls>
@@ -622,6 +637,7 @@ mod tests {
         assert_eq!(args["disabled"], false);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_number_parameters() {
         let input = r#"<｜DSML｜function_calls>
@@ -642,6 +658,7 @@ mod tests {
         assert_eq!(args["negative"], -100);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_mixed_types_realistic() {
         // Realistic example based on test data
@@ -664,6 +681,7 @@ mod tests {
         assert_eq!(args["source"], "web");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_nested_object_parameter() {
         let input = r#"<｜DSML｜function_calls>
@@ -684,6 +702,7 @@ mod tests {
         assert_eq!(args["settings"]["endpoints"][0], "a");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_empty_string_parameter() {
         let input = r#"<｜DSML｜function_calls>
@@ -858,6 +877,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a, PARSER.batch.9 in tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml.
     #[test] // PARSER.batch.7, PARSER.batch.9
     fn test_parse_null_parameter() {
         let input = r#"<｜DSML｜function_calls>
@@ -896,6 +916,7 @@ mod tests {
     /// into `normal_text` when block-start appears but no invokes parse —
     /// it returns the pre-block text only (empty here, since the input
     /// starts with the block-start fence). The call is still dropped.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5, PARSER.fmt.3 — V4 variant
     fn test_parse_deepseek_v4_missing_end_token() {
         // Start fence + complete invoke, but no </｜DSML｜tool_calls>.
@@ -927,6 +948,7 @@ mod tests {
     /// absence of the closing fence prevents the block regex from matching.
     /// All calls are dropped. If the parser ever gains partial-block
     /// recovery, this test will fail and force an intentional update.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.5.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.5, PARSER.fmt.3
     fn test_parse_deepseek_v4_missing_end_token_multiple_calls() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -952,6 +974,7 @@ mod tests {
     /// (unwrap_or_else → Value::String). Pin the fallback so removing it
     /// (which would cause the whole call to 500 on ragged-edge JSON) is a
     /// deliberate change.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_malformed_json_value_falls_back_to_string() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -976,6 +999,7 @@ mod tests {
     /// `PARSER.batch.4` — malformed invoke (missing `</｜DSML｜invoke>` but block fences
     /// intact). The invoke regex requires its own close tag, so the call is
     /// silently dropped. Pin the behavior.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_missing_invoke_close_drops_call() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -1000,6 +1024,7 @@ mod tests {
     /// TODO(PARSER.batch.4) — BUG, NEEDS FIX: parser silently loses the parameter
     /// and ships an under-specified call to the user. The fix should keep
     /// the raw value up to `</｜DSML｜invoke>`. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_missing_parameter_close_loses_param() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -1030,6 +1055,7 @@ mod tests {
     /// silently dropped — caller receives wrong args for A and never sees
     /// B at all. Fix: anchor on `<｜DSML｜invoke name=` to re-sync between
     /// invokes. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4, PARSER.fmt.3
     fn test_parse_deepseek_v4_middle_invoke_truncation_corrupts_next() {
         let input = "<｜DSML｜tool_calls>\n\
@@ -1079,6 +1105,7 @@ mod tests {
     /// `<think>...</think>` before the DSML block; the tool parser is
     /// concerned only with the DSML, but normal text must round-trip
     /// the reasoning markup verbatim for the reasoning parser to pick up.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_reasoning_plus_tool_v4() {
         let input = "<think>Let me check the weather.</think>\
@@ -1150,6 +1177,7 @@ mod tests {
 
     /// `PARSER.batch.9` — empty / null content variants. Pin behavior on truly
     /// empty bytes and whitespace-only inputs.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml.
     #[test] // PARSER.batch.9
     fn test_parse_empty_and_whitespace_inputs_v4() {
         let config = get_v4_test_config();
@@ -1173,6 +1201,7 @@ mod tests {
 
     /// `PARSER.batch.10` — duplicate calls (same invoke name twice in one block).
     /// Universal gap noted in the test taxonomy; first DSML coverage.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml.
     #[test] // PARSER.batch.10
     fn test_parse_duplicate_invokes_same_name_v4() {
         let input = "<｜DSML｜tool_calls>\n\

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -476,6 +476,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.1 — single string argument
     fn parse_single_string_argument() {
         let input = r#"<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>"#;
@@ -484,6 +485,7 @@ mod tests {
         assert_eq!(args["location"], "Tokyo");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml, tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7 — multiple typed arguments
     fn parse_multiple_typed_arguments() {
         let input = r#"<|tool_call>call:f{loc:<|"|>San Francisco, CA<|"|>,unit:<|"|>celsius<|"|>,count:42,flag:true,nope:null}<tool_call|>"#;
@@ -496,6 +498,7 @@ mod tests {
         assert_eq!(args["nope"], Value::Null);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — empty argument object
     fn parse_no_arg_call() {
         let input = "<|tool_call>call:get_time{}<tool_call|>";
@@ -504,6 +507,7 @@ mod tests {
         assert!(args.as_object().unwrap().is_empty());
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — nested object value
     fn parse_nested_object_value() {
         let input = r#"<|tool_call>call:f{cfg:{ssl:true,pool:{min:5,max:20}}}<tool_call|>"#;
@@ -513,6 +517,7 @@ mod tests {
         assert_eq!(args["cfg"]["pool"]["max"], 20);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — array of strings
     fn parse_array_of_strings() {
         let input = r#"<|tool_call>call:f{tags:[<|"|>a<|"|>,<|"|>b<|"|>,<|"|>c<|"|>]}<tool_call|>"#;
@@ -520,6 +525,7 @@ mod tests {
         assert_eq!(args["tags"], serde_json::json!(["a", "b", "c"]));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — array of mixed primitives
     fn parse_array_of_mixed_primitives() {
         let input = "<|tool_call>call:f{xs:[1,2,3.5,true,false,null]}<tool_call|>";
@@ -532,6 +538,7 @@ mod tests {
         assert_eq!(args["xs"][5], Value::Null);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2 — multiple parallel calls, zero spacing
     fn parse_multiple_parallel_calls() {
         let input = concat!(
@@ -562,6 +569,7 @@ mod tests {
         assert_eq!(normal, Some("just plain prose here".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.c in tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 — complete prior call survives; truncated tail dropped (matches vLLM)
     fn truncated_tail_dropped_complete_prior_survives() {
         let input = concat!(
@@ -577,6 +585,7 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — malformed args body falls back to empty object, call still emitted
     fn malformed_args_falls_back_to_empty_object() {
         let input = "<|tool_call>call:f{garbage no colons here}<tool_call|>";
@@ -609,6 +618,7 @@ mod tests {
         }
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — angle brackets / HTML inside string values
     fn parse_html_in_string_value() {
         let input = r#"<|tool_call>call:render{html:<|"|><div class="x"><h1>Hi</h1></div><|"|>}<tool_call|>"#;
@@ -616,6 +626,7 @@ mod tests {
         assert_eq!(args["html"], "<div class=\"x\"><h1>Hi</h1></div>");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — newlines inside string values
     fn parse_newlines_in_string_value() {
         let input = "<|tool_call>call:f{body:<|\"|>line1\nline2\nline3<|\"|>}<tool_call|>";
@@ -631,6 +642,7 @@ mod tests {
         assert_eq!(args["y"], "z");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — negative numbers and floats
     fn parse_signed_numbers_and_floats() {
         let input = "<|tool_call>call:f{a:-1,b:-2.5,c:0,d:0.0}<tool_call|>";
@@ -732,6 +744,7 @@ mod tests {
         let _ = parse_args_object("x:nullable").unwrap_err();
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.c in tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 — missing end-marker, markup suppressed (no-leak contract)
     fn incomplete_tool_call_suppresses_markup() {
         let input = "<|tool_call>call:foo{x:1";
@@ -747,6 +760,7 @@ mod tests {
     #[test] // PARSER.batch.7 — `<tool_call|>` literal inside a string-typed argument
     // must not truncate the call. The extraction regex requires
     // `}<tool_call|>` adjacency, so a bare embedded marker is safe.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml.
     fn embedded_tool_call_marker_in_string_value() {
         let input = r#"<|tool_call>call:render{html:<|"|><tool_call|> example<|"|>}<tool_call|>"#;
         let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
@@ -768,6 +782,7 @@ mod tests {
     // (in production the reasoning parser runs first and strips `<|channel>`,
     // but the tool-call parser must remain correct if it sees the full
     // emission, e.g. when reasoning parsing is disabled).
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml.
     fn paired_reasoning_and_tool_call_in_same_emission() {
         let input = concat!(
             "<|channel>thought\nthinking about the request<channel|>",
@@ -783,6 +798,7 @@ mod tests {
         assert!(normal.unwrap().contains("<|channel>thought"));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — empty input, no tool calls
     fn empty_input_yields_zero_calls_empty_content() {
         let (calls, normal) = try_tool_call_parse_gemma4("", None).unwrap();
@@ -790,6 +806,7 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — `null` argument values round-trip as JSON null
     fn null_argument_values_preserved() {
         let input = "<|tool_call>call:f{x:null,y:none,z:nil}<tool_call|>";
@@ -804,6 +821,7 @@ mod tests {
     #[test] // PARSER.batch.10 — duplicate calls to the same function name. Both must
     // appear with distinct IDs; client decides whether duplicate invocation
     // is intended.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml.
     fn duplicate_tool_call_same_name() {
         let input = concat!(
             "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>",

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -429,6 +429,7 @@ mod tests {
         (call.function.name, args)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
     #[tokio::test] // PARSER.batch.1, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_complete_basic() {
         let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}<|call|>"#;
@@ -443,6 +444,7 @@ mod tests {
         assert_eq!(args["format"], "celsius");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
     #[tokio::test] // PARSER.batch.4, PARSER.harmony.2
     async fn test_parse_tools_harmony_without_start_token() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|message|>{"location":"San Francisco"}<|call|>"#;
@@ -454,6 +456,7 @@ mod tests {
         assert_eq!(tool_calls.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d, PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml, tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
     #[tokio::test] // PARSER.batch.7, PARSER.batch.8, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_with_multi_args() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
@@ -469,6 +472,7 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
     #[tokio::test] // PARSER.batch.8, PARSER.batch.8, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_with_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>"#;
@@ -511,6 +515,7 @@ mod tests {
     // Harmony's strict tokenizer rejects two back-to-back commentary
     // blocks, so EOF recovery falls back to regex extraction and pins that
     // both calls are surfaced without leaking the raw envelopes.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml.
     #[tokio::test] // PARSER.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
@@ -527,6 +532,7 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.a in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
     #[tokio::test] // PARSER.batch.4 — gpt-oss
     async fn test_parse_harmony_malformed_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>"#;
@@ -539,6 +545,7 @@ mod tests {
         assert_eq!(tool_calls[0].function.arguments, "not json at all");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml.
     #[tokio::test] // PARSER.batch.4 — gpt-oss
     async fn test_parse_harmony_unterminated_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
@@ -560,6 +567,7 @@ mod tests {
     // Bare-envelope PARSER.batch.5: no preceding `analysis` block, no `<|call|>`
     // at the end. Harmony requires the explicit call stop token, so fallback
     // must not accept EOS as a synthetic close.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml.
     #[tokio::test] // PARSER.batch.5 — gpt-oss
     async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
@@ -640,6 +648,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a, PARSER.batch.8.a in tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml, tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml.
     #[tokio::test] // PARSER.batch.4, PARSER.batch.5, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
@@ -668,6 +677,7 @@ mod tests {
 
     /// PARSER.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
     /// the function name.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml.
     #[tokio::test] // PARSER.batch.6 — gpt-oss
     async fn test_parse_harmony_empty_args() {
         let text = r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}<|call|>"#;
@@ -685,6 +695,7 @@ mod tests {
     /// XML/JSON parsers (which trim whitespace down to `Some("")`), the
     /// harmony parser passes the input verbatim through to normal_text —
     /// pin that distinction here.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
     #[tokio::test] // PARSER.batch.9 — gpt-oss
     async fn test_parse_harmony_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -710,6 +721,7 @@ mod tests {
     /// back-to-back commentary blocks for the same function. Pin
     /// parser-level behavior — both calls returned with distinct ids
     /// and distinct args.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/harmony/PARSER.batch.yaml.
     #[tokio::test] // PARSER.batch.10 — gpt-oss
     async fn test_parse_harmony_duplicate_calls_same_name() {
         let text = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"LA"}<|call|>"#;

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -270,6 +270,7 @@ mod tests {
         (call.function.name, args)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_tool_calls_deepseek_v3_1_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Paris"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
@@ -288,6 +289,7 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_1_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "New York"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
@@ -306,6 +308,7 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_1_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather宽带}{location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
@@ -318,6 +321,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.7
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Berlin", "units": "metric"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather_forecast<｜tool▁sep｜>{"location": "Berlin", "days": 7, "units": "imperial"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_air_quality<｜tool▁sep｜>{"location": "Berlin", "radius": 50}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
@@ -343,6 +347,7 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_tool_calls_deepseek_v3_1_with_invalid_json() {
         // Everything is normal text in case of invalid json
@@ -356,6 +361,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_1_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
@@ -369,6 +375,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7, PARSER.fmt.2
     fn test_parse_tool_calls_deepseek_v3_1_with_multiline_json() {
         let text = r#"I'll help you understand this codebase. Let me start by exploring the structure and key

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -274,6 +274,7 @@ mod tests {
         (call.function.name, args)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_tool_calls_deepseek_v3_basic() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
@@ -298,6 +299,7 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_with_normal_text() {
         let text = r#"The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
@@ -319,6 +321,7 @@ mod tests {
         assert_eq!(args["location"], "New York");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — recovery from missing start
     fn test_parse_tool_calls_deepseek_v3_without_tool_call_start_token() {
         let text = r#"<｜tool▁call▁begin｜>function宽带}{location": "HongKong"}
@@ -334,6 +337,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.7
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_multiple_args() {
         let text = r#"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
@@ -368,6 +372,7 @@ mod tests {
         assert_eq!(args["radius"], 50);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_tool_calls_deepseek_v3_with_invalid_json() {
         // Everything is normal text in case of invalid json
@@ -384,6 +389,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml, tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8
     fn test_parse_tool_calls_deepseek_v3_with_multi_tool_calls_with_normal_text() {
         // Everything is normal text in case of invalid json
@@ -406,6 +412,7 @@ mod tests {
         assert_eq!(result.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7, PARSER.fmt.2
     fn test_parse_tool_calls_deepseek_v3_with_multiline_json() {
         let text = r#"I'll help you understand this Xiaohongshu codebase. Let me start by exploring the structure

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -153,6 +153,7 @@ mod tests {
     // Recovery for missing outer </TOOLCALL> (max_tokens / EOS truncation):
     // when the inner JSON array is well-formed, treat EOF as the end token
     // and extract the call rather than silently dropping it.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 — nemotron_deci
     fn test_parse_nemotron_deci_no_outer_close_recovers() {
         let config = JsonParserConfig {
@@ -177,6 +178,7 @@ mod tests {
     // but no parser-level test pinned it. This test makes the contract
     // visible at the per-parser surface so a JSON-family refactor can't
     // silently break parallel-call extraction without a per-parser failure.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2 — nemotron_deci
     fn test_parse_nemotron_deci_multiple_calls() {
         let config = JsonParserConfig {
@@ -198,6 +200,7 @@ mod tests {
     // `"city":"NYC` with no closing quote, brace, or array bracket). The
     // base parser balances unclosed strings/braces and retries the parse,
     // surfacing the call rather than silently dropping it.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4 — nemotron_deci
     fn test_parse_nemotron_deci_truncated_json_recovers() {
         let config = JsonParserConfig {
@@ -239,6 +242,7 @@ mod tests {
 
     /// PARSER.batch.6 — empty args. A no-arg call (`{}`) must still be returned
     /// with the function name intact.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — nemotron_deci
     fn test_parse_nemotron_deci_empty_args() {
         let config = nemotron_deci_config();

--- a/lib/parsers/src/tool_calling/pythonic/pythonic_parser.rs
+++ b/lib/parsers/src/tool_calling/pythonic/pythonic_parser.rs
@@ -262,6 +262,7 @@ mod tests {
         assert_eq!(matches.len(), 0);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_tool_call_parse_pythonic_basic() {
         let message = "[foo(a=1, b=2), bar(x=3)]";
@@ -278,6 +279,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.c in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml, tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8
     fn test_parse_tool_call_parse_pythonic_with_text() {
         let message = "Hey yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
@@ -294,6 +296,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.c in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml, tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.8, PARSER.fmt.2
     fn test_parse_tool_call_parse_pythonic_with_text_and_new_line() {
         let message = "Hey \n yo ! [foo(a=1, b=2), bar(x=3)] Hey yo";
@@ -319,6 +322,7 @@ mod tests {
         assert_eq!(result.len(), 0)
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2, PARSER.fmt.3
     fn test_parse_tool_call_parse_pythonic_with_python_tags() {
         let message = "<|python_start|>[foo(a=1, b=2), bar(x=3)]<|python_end|>";
@@ -335,6 +339,7 @@ mod tests {
         assert_eq!(args["x"], 3);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.a in tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_tool_call_parse_pythonic_with_list_arg_values() {
         let message = "[foo(a=[1, 2, 3], b=2), bar(x=[3, 4, 5])]";
@@ -350,6 +355,7 @@ mod tests {
         assert_eq!(args["x"], json!([3, 4, 5]));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_tool_call_parse_pythonic_with_dict_arg_values() {
         let message = "[foo(a={'a': 1, 'b': 2}, b=2), bar(x={'x': 3, 'y': {'e': 'f'}})]";

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -423,6 +423,7 @@ mod tests {
         assert!(!detect_tool_call_start_glm47("Just normal text", &config));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_simple_tool_call() {
         let config = get_test_config();
@@ -442,6 +443,7 @@ mod tests {
         assert_eq!(normal_text, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_tool_call_with_multiple_args() {
         let config = get_test_config();
@@ -459,6 +461,7 @@ mod tests {
         assert_eq!(args.get("date").unwrap().as_str().unwrap(), "2026-03-15");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_tool_call_with_json_value() {
         let config = get_test_config();
@@ -475,6 +478,7 @@ mod tests {
         assert!(filters.is_object());
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let config = get_test_config();
@@ -487,6 +491,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.a in tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_with_normal_text() {
         let config = get_test_config();
@@ -502,6 +507,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6
     fn test_parse_tool_call_no_args() {
         let config = get_test_config();
@@ -569,6 +575,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.c, PARSER.batch.8.a in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.2 + PARSER.batch.8 — bug report repro: text + parallel calls
     fn test_parse_text_then_parallel_calls() {
         let config = get_test_config();
@@ -597,6 +604,7 @@ mod tests {
         );
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7, PARSER.fmt.2
     fn test_parse_multiline_arg_value() {
         let config = get_test_config();
@@ -618,6 +626,7 @@ mod tests {
         assert!(content.contains("print(\"Hello, World!\")"));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_malformed_tool_call() {
         let config = get_test_config();
@@ -635,6 +644,7 @@ mod tests {
     // when the inner arg pairs are well-formed, treat EOF as the end token
     // and extract the call. The arg_key opener gates recovery so plain text
     // that happens to start with `<tool_call>` is still preserved verbatim.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5
     fn test_parse_no_end_tag_complete_args_recovers() {
         let config = Glm47ParserConfig {
@@ -651,6 +661,7 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.5.a in tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5
     fn test_parse_no_end_tag_multiple_calls_recovers() {
         let config = Glm47ParserConfig {
@@ -666,6 +677,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c, PARSER.batch.13 in tests/parity/parser/fixtures/glm47/PARSER.batch.13.yaml, tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.4, PARSER.batch.8
     fn test_unparseable_block_dropped_no_tag_leak() {
         let config = get_test_config();
@@ -839,6 +851,7 @@ mod tests {
     /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.9
     fn test_parse_glm47_empty_and_whitespace_inputs() {
         let config = get_test_config();
@@ -861,6 +874,7 @@ mod tests {
     /// PARSER.batch.10 — duplicate calls (same function name twice in one section).
     /// Universal gap noted in the test taxonomy; pin parser-level behavior —
     /// both calls returned with distinct ids.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/glm47/PARSER.batch.yaml.
     #[test] // PARSER.batch.10
     fn test_parse_glm47_duplicate_calls_same_name() {
         let config = get_test_config();

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -409,6 +409,7 @@ mod tests {
         assert_eq!(pos, None, "should return None when section_end is missing");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_simple_tool_call() {
         let config = default_config();
@@ -423,6 +424,7 @@ mod tests {
         assert_eq!(args["location"], "NYC");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_multiple_args() {
         let config = default_config();
@@ -437,6 +439,7 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let config = default_config();
@@ -454,6 +457,7 @@ mod tests {
         assert_eq!(args1["timezone"], "EST");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8.c
     fn test_parse_keeps_prefix_drops_post_tool_text() {
         let config = default_config();
@@ -522,6 +526,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6
     fn test_parse_no_arg_call() {
         let config = default_config();
@@ -556,6 +561,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.1 (with declared `ToolDefinition` tools provided)
     fn test_parse_with_tool_validation() {
         let config = default_config();
@@ -583,6 +589,7 @@ mod tests {
     // `serde_json::from_str` falls back to raw-string arguments when the
     // payload doesn't parse, matching the behavior of the existing
     // `test_parse_invalid_json_falls_back_to_raw_string` case.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_truncated_json_inside_complete_fences_recovers() {
         let config = default_config();
@@ -595,6 +602,7 @@ mod tests {
         assert_eq!(calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 (PR #8208)
     fn test_parse_malformed_no_section_end() {
         let config = default_config();
@@ -612,6 +620,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b, PARSER.batch.5.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.4, PARSER.batch.5
     fn test_parse_truncated_mid_argument_no_section_end() {
         let config = default_config();
@@ -631,6 +640,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.5.a in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.5
     fn test_parse_multiple_calls_no_section_end() {
         let config = default_config();
@@ -647,6 +657,7 @@ mod tests {
         assert_eq!(calls[1].function.name, "get_time");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.4.b, PARSER.batch.5.c in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.4, PARSER.batch.5
     fn test_parse_complete_plus_truncated_no_section_end() {
         let config = default_config();
@@ -675,6 +686,7 @@ mod tests {
         assert_eq!(args["query"], "rust programming");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_complex_json_arguments() {
         let config = default_config();
@@ -689,6 +701,7 @@ mod tests {
         assert_eq!(args["config"]["nested"], true);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.a, PARSER.batch.7.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.7
     fn test_parse_deeply_nested_json_multiple_calls() {
         let config = default_config();
@@ -754,6 +767,7 @@ mod tests {
 
     // --- Tests inspired by vllm/sglang coverage gaps ---
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_invalid_json_falls_back_to_raw_string() {
         // vllm: test_extract_tool_calls_invalid_json
@@ -797,6 +811,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "valid");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — special characters in arg values
     fn test_parse_angle_brackets_in_json_arguments() {
         // vllm: angle_brackets_in_json
@@ -815,6 +830,7 @@ mod tests {
         assert_eq!(args["format"], "html");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2 — parallel calls, zero-spacing edge case
     fn test_parse_three_concatenated_calls_no_spacing() {
         // vllm: concatenated_tool_calls_bug_fix, three_concatenated_tool_calls
@@ -844,6 +860,7 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.b in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7 — newlines in arg values
     fn test_parse_newlines_in_json_arguments() {
         // vllm: newlines_in_json
@@ -910,6 +927,7 @@ mod tests {
     /// `<|tool_call_end|>` is missing and section fences are complete. Fix:
     /// anchor on the next `<|tool_call_begin|>` or `<|tool_calls_section_end|>`
     /// to terminate the args region. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_call_end_inside_complete_section_silent_drop() {
         let config = default_config();
@@ -932,6 +950,7 @@ mod tests {
     /// markup, and C is dropped — caller gets garbage args for B and
     /// never sees C. Fix: same anchor on `<|tool_call_begin|>` as the
     /// silent-drop case above. Flip this test once fixed.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b, PARSER.batch.4.d in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml, tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.2, PARSER.batch.4
     fn test_parse_middle_call_missing_end_corrupts_next() {
         let config = default_config();
@@ -988,6 +1007,7 @@ mod tests {
     /// `PARSER.batch.9` — empty / null content variants. Empty section already
     /// covered by `test_parse_empty_tool_section`; this pins the
     /// truly-empty (zero bytes) and null-ish ("\n", whitespace-only) inputs.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.9
     fn test_parse_empty_and_whitespace_inputs() {
         let config = default_config();
@@ -1009,6 +1029,7 @@ mod tests {
 
     /// `PARSER.batch.10` — duplicate calls (same function name twice in one section).
     /// Universal gap noted in the test taxonomy; first parser to land coverage.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml.
     #[test] // PARSER.batch.10
     fn test_parse_duplicate_calls_same_name() {
         let config = default_config();

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -770,6 +770,7 @@ mod tests {
         assert_eq!(html_unescape(input), expected);
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.1
     fn test_parse_simple_tool_call() {
         let input = r#"<tool_call>
@@ -790,6 +791,7 @@ pwd && ls
         assert_eq!(args["command"], "pwd && ls");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.1, PARSER.batch.7.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml, tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.1, PARSER.batch.7
     fn test_parse_multiple_parameters() {
         let input = r#"<tool_call>
@@ -816,6 +818,7 @@ fahrenheit
         assert_eq!(args["unit"], "fahrenheit");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.8.c in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml.
     #[test] // PARSER.batch.8
     fn test_parse_with_normal_text() {
         let input = r#"I'll help you with that. <tool_call>
@@ -833,6 +836,7 @@ Dallas
         assert_eq!(normal, Some("I'll help you with that. ".to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.2.b in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml.
     #[test] // PARSER.batch.2
     fn test_parse_multiple_tool_calls() {
         let input = r#"<tool_call>
@@ -861,6 +865,7 @@ Orlando
         assert_eq!(args1["city"], "Orlando");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.7.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml.
     #[test] // PARSER.batch.7
     fn test_parse_json_parameter_value() {
         // With schema-aware parsing, we need to provide a schema to parse JSON objects
@@ -901,6 +906,7 @@ Orlando
         assert_eq!(normal, Some(input.to_string()));
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_malformed_tool_call() {
         let input = r#"<tool_call>
@@ -914,6 +920,7 @@ value
         assert!(result.is_ok());
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_parameter_closing_tag() {
         let input = r#"<tool_call>
@@ -931,6 +938,7 @@ ls -la
         assert_eq!(args["command"], "ls -la");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_function_closing_tag() {
         let input = r#"<tool_call>
@@ -948,6 +956,7 @@ Boston
         assert_eq!(args["city"], "Boston");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_missing_both_closing_tags() {
         let input = r#"<tool_call>
@@ -965,6 +974,7 @@ SELECT * FROM users
         assert_eq!(args["sql"], "SELECT * FROM users\n</tool_call>");
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.4.d in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml.
     #[test] // PARSER.batch.4
     fn test_parse_multiple_parameters_missing_closing_tags() {
         let input = r#"<tool_call>
@@ -990,6 +1000,7 @@ rust programming
     // token and extract the call. Recovery is gated on a function-start
     // opener in the trailing slice so plain text that happens to start with
     // `<tool_call>` is preserved verbatim.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.5.a in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml.
     #[test] // PARSER.batch.5 — qwen3_coder
     fn test_parse_qwen3_no_outer_close_recovers() {
         let input = r#"<tool_call>
@@ -1306,6 +1317,7 @@ NYC
 
     /// PARSER.batch.6 — empty args. A no-arg call (no `<parameter=...>` block)
     /// must still surface the function name with empty arguments.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — qwen3_coder
     fn test_parse_qwen3_empty_args() {
         let input = r#"<tool_call>
@@ -1320,6 +1332,7 @@ NYC
     }
 
     /// PARSER.batch.6 — empty args, minimax_m2 format.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.6.a in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml.
     #[test] // PARSER.batch.6 — minimax_m2
     fn test_parse_minimax_m2_empty_args() {
         let config = minimax_m2_config();
@@ -1365,6 +1378,7 @@ NYC
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string. Tested under both qwen3_coder and
     /// minimax_m2 configs.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — qwen3_coder
     fn test_parse_qwen3_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
@@ -1384,6 +1398,7 @@ NYC
         }
     }
 
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.9 in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml.
     #[test] // PARSER.batch.9 — minimax_m2
     fn test_parse_minimax_m2_empty_and_whitespace_inputs() {
         let config = minimax_m2_config();
@@ -1406,6 +1421,7 @@ NYC
     /// PARSER.batch.10 — duplicate calls (same function name twice). qwen3_coder
     /// format; pin parser-level behavior — both calls must come back with
     /// distinct ids.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml.
     #[test] // PARSER.batch.10 — qwen3_coder
     fn test_parse_qwen3_duplicate_calls_same_name() {
         let input = r#"<tool_call>
@@ -1437,6 +1453,7 @@ LA
     /// PARSER.batch.10 — duplicate calls (same function name twice). minimax_m2
     /// format; pin parser-level behavior — both calls must come back with
     /// distinct ids.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: PARSER.batch.10 in tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml.
     #[test] // PARSER.batch.10 — minimax_m2
     fn test_parse_minimax_m2_duplicate_calls_same_name() {
         let config = minimax_m2_config();


### PR DESCRIPTION
Marks Rust parser input/output tests as deprecated when their blackbox behavior is already covered by YAML parser fixtures.

Tests and legacy coverage manifests are kept in place; comments point to the duplicate YAML fixture to support a later removal pass.

Verification:
- `cargo test --locked -p dynamo-parsers --lib`
- container pre-commit hooks