### PR TITLE
feat(RL): add nvext Tokens-in-Tokens-Out protocol

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -389,6 +389,7 @@ impl
                     completion_usage: data.completion_usage,
                     disaggregated_params: data.disaggregated_params,
                     engine_data: data.engine_data,
+                    prompt_logprobs: data.prompt_logprobs,
                 })
             })
         });

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -386,6 +386,7 @@ mod tests {
             disaggregated_params: None,
             completion_usage: None,
             engine_data: None,
+            prompt_logprobs: None,
         })
     }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -240,6 +240,39 @@ pub struct OpenAIPreprocessor {
 }
 
 impl OpenAIPreprocessor {
+    fn nvext_passthrough_args<R: NvExtProvider>(
+        request: &R,
+    ) -> Option<serde_json::Map<String, serde_json::Value>> {
+        let mut nvext_passthrough = serde_json::Map::new();
+
+        if let Some(nvext) = request.nvext() {
+            if let Some(ref fields) = nvext.extra_fields {
+                nvext_passthrough.insert("extra_fields".to_string(), serde_json::json!(fields));
+            }
+            if let Some(ref salt) = nvext.cache_salt {
+                nvext_passthrough.insert("cache_salt".to_string(), serde_json::json!(salt));
+            }
+            if nvext.token_data.is_some() {
+                nvext_passthrough.insert("token_in".to_string(), serde_json::Value::Bool(true));
+            }
+        }
+
+        if !nvext_passthrough.contains_key("cache_salt")
+            && let Some(salt) = request
+                .unsupported_fields()
+                .and_then(|fields| fields.get("cache_salt"))
+                .and_then(|value| value.as_str())
+        {
+            nvext_passthrough.insert("cache_salt".to_string(), serde_json::json!(salt));
+        }
+
+        if nvext_passthrough.is_empty() {
+            None
+        } else {
+            Some(nvext_passthrough)
+        }
+    }
+
     pub fn new(mdc: ModelDeploymentCard) -> Result<Arc<Self>> {
         let formatter = PromptFormatter::from_mdc(&mdc)?;
         let tokenizer = mdc.tokenizer()?;
@@ -465,7 +498,16 @@ impl OpenAIPreprocessor {
             .with_label_values(&[STAGE_PREPROCESS])
             .observe(preprocess_start.elapsed().as_secs_f64());
 
-        Ok((builder.build()?, annotations, prompt_injected_reasoning))
+        let mut preprocessed = builder.build()?;
+
+        // If omitted, allow generation up to the remaining context length.
+        if preprocessed.stop_conditions.max_tokens.is_none() && self.context_length > 0 {
+            let prompt_len = preprocessed.token_ids.len() as u32;
+            preprocessed.stop_conditions.max_tokens =
+                Some(self.context_length.saturating_sub(prompt_len));
+        }
+
+        Ok((preprocessed, annotations, prompt_injected_reasoning))
     }
 
     pub fn builder<
@@ -556,6 +598,12 @@ impl OpenAIPreprocessor {
             }));
         }
 
+        if let Some(nvext_passthrough) = Self::nvext_passthrough_args(request) {
+            builder.extra_args(Some(
+                serde_json::json!({ "nvext": serde_json::Value::Object(nvext_passthrough) }),
+            ));
+        }
+
         // Forward mm_processor_kwargs (e.g. use_audio_in_video) to the backend.
         builder.mm_processor_kwargs(request.mm_processor_kwargs().cloned());
 
@@ -623,7 +671,7 @@ impl OpenAIPreprocessor {
         }
     }
 
-    pub async fn gather_multi_modal_data<R: OAIChatLikeRequest>(
+    pub async fn gather_multi_modal_data<R: OAIChatLikeRequest + NvExtProvider>(
         &self,
         request: &R,
         builder: &mut PreprocessedRequestBuilder,
@@ -857,6 +905,10 @@ impl OpenAIPreprocessor {
 
             if let Some(ref prompt) = formatted_prompt {
                 extra_args["formatted_prompt"] = serde_json::Value::String(prompt.clone());
+            }
+
+            if let Some(nvext_passthrough) = Self::nvext_passthrough_args(request) {
+                extra_args["nvext"] = serde_json::Value::Object(nvext_passthrough);
             }
 
             // Forward routing-side mm_hashes as `multi_modal_uuids` so vLLM

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -343,6 +343,18 @@ pub struct SamplingOptions {
 
     /// Guided Decoding Options
     pub guided_decoding: Option<GuidedDecodingOptions>,
+
+    /// When `Some(false)`, the engine should skip text decoding if supported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detokenize: Option<bool>,
+
+    /// Token IDs that are allowed during generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_token_ids: Option<Vec<TokenIdType>>,
+
+    /// Token ID sequences that must not be generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bad_words_token_ids: Option<Vec<Vec<TokenIdType>>>,
 }
 
 /// Guided Decoding Options

--- a/lib/llm/src/protocols/common/llm_backend.rs
+++ b/lib/llm/src/protocols/common/llm_backend.rs
@@ -14,6 +14,20 @@ use dynamo_runtime::protocols::maybe_error::MaybeError;
 pub type TokenType = Option<String>;
 pub type LogProbs = Vec<f64>;
 
+/// Per-position prompt logprob entry reported by an engine adapter.
+#[derive(Serialize, Deserialize, utoipa::ToSchema, Debug, Clone, PartialEq)]
+pub struct PromptLogprobEntry {
+    pub logprob: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decoded_token: Option<String>,
+}
+
+/// Per-token map of `token_id -> PromptLogprobEntry`. The first position
+/// is `None` (no logprob exists for BOS / the very first prompt token).
+pub type PromptLogprobs = Vec<Option<std::collections::HashMap<TokenIdType, PromptLogprobEntry>>>;
+
 /// Output type discriminator for different modalities
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
@@ -111,6 +125,10 @@ pub struct BackendOutput {
     /// Dynamo does not inspect this field; it is serialized as-is into `nvext.engine_data`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine_data: Option<serde_json::Value>,
+
+    /// Per-prompt-token top-k logprobs surfaced via `nvext.prompt_logprobs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_logprobs: Option<PromptLogprobs>,
 }
 
 /// The LLM engine and backnd with manage it's own state, specifically translating how a
@@ -177,6 +195,10 @@ pub struct LLMEngineOutput {
     /// Dynamo does not inspect this field; it is serialized as-is into `nvext.engine_data`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine_data: Option<serde_json::Value>,
+
+    /// Per-prompt-token top-k logprobs, if supported by the engine adapter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_logprobs: Option<PromptLogprobs>,
 }
 
 impl LLMEngineOutput {
@@ -197,6 +219,7 @@ impl LLMEngineOutput {
             extra_args: None,
             completion_usage: None,
             engine_data: None,
+            prompt_logprobs: None,
         }
     }
 
@@ -217,6 +240,7 @@ impl LLMEngineOutput {
             extra_args: None,
             completion_usage: None,
             engine_data: None,
+            prompt_logprobs: None,
         }
     }
 
@@ -237,6 +261,7 @@ impl LLMEngineOutput {
             extra_args: None,
             completion_usage: None,
             engine_data: None,
+            prompt_logprobs: None,
         }
     }
 
@@ -257,6 +282,7 @@ impl LLMEngineOutput {
             extra_args: None,
             completion_usage: None,
             engine_data: None,
+            prompt_logprobs: None,
         }
     }
 }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -144,6 +144,8 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
         let guided_grammar = self.get_guided_grammar();
         let guided_choice = self.get_guided_choice();
         let guided_whitespace_pattern = self.get_guided_whitespace_pattern();
+        let allowed_token_ids = self.get_allowed_token_ids();
+        let bad_words_token_ids = self.get_bad_words_token_ids();
 
         let guided_decoding = match common::GuidedDecodingOptions::from_optional(
             guided_json,
@@ -162,6 +164,9 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             }
         };
 
+        // Surface `detokenize` so engines can skip text decoding when requested.
+        let detokenize = self.common_ext().and_then(|c| c.detokenize);
+
         Ok(common::SamplingOptions {
             n,
             best_of,
@@ -177,6 +182,9 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             length_penalty: None,
             guided_decoding,
             include_stop_str_in_output,
+            detokenize,
+            allowed_token_ids,
+            bad_words_token_ids,
         })
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -101,6 +101,10 @@ impl NvExtProvider for NvCreateChatCompletionRequest {
     fn raw_prompt(&self) -> Option<String> {
         None
     }
+
+    fn unsupported_fields(&self) -> Option<&std::collections::HashMap<String, serde_json::Value>> {
+        Some(&self.unsupported_fields)
+    }
 }
 
 /// Implements `AnnotationsProvider` for `NvCreateChatCompletionRequest`,
@@ -258,6 +262,22 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
     fn get_skip_special_tokens(&self) -> Option<bool> {
         self.common.skip_special_tokens
     }
+
+    fn get_prompt_logprobs_count(&self) -> Option<u32> {
+        self.common.prompt_logprobs
+    }
+
+    fn get_detokenize(&self) -> Option<bool> {
+        self.common.detokenize
+    }
+
+    fn get_allowed_token_ids(&self) -> Option<Vec<crate::types::TokenIdType>> {
+        self.common.allowed_token_ids.clone()
+    }
+
+    fn get_bad_words_token_ids(&self) -> Option<Vec<Vec<crate::types::TokenIdType>>> {
+        self.common.bad_words_token_ids.clone()
+    }
 }
 
 /// Implements `OpenAIStopConditionsProvider` for `NvCreateChatCompletionRequest`,
@@ -288,7 +308,14 @@ impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
     }
 
     fn get_stop_token_ids(&self) -> Option<Vec<crate::types::TokenIdType>> {
-        self.inner.stop.as_ref().and_then(|stop| stop.token_ids())
+        // Token IDs may be provided in the standard OpenAI `stop` array.
+        if let Some(ids) = self.inner.stop.as_ref().and_then(|stop| stop.token_ids()) {
+            return Some(ids);
+        }
+        // Also accept top-level `stop_token_ids` from passthrough clients.
+        self.unsupported_fields
+            .get("stop_token_ids")
+            .and_then(|v| serde_json::from_value::<Vec<crate::types::TokenIdType>>(v.clone()).ok())
     }
 
     /// Returns a reference to the optional `NvExt` extension, if available.
@@ -320,7 +347,8 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
     }
 
     fn get_prompt_logprobs(&self) -> Option<u32> {
-        None
+        // Top-level `prompt_logprobs` is carried through CommonExt.
+        self.common.prompt_logprobs
     }
 
     fn get_skip_special_tokens(&self) -> Option<bool> {
@@ -386,7 +414,9 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
 mod tests {
     use super::*;
     use crate::engines::ValidateRequest;
-    use crate::protocols::common::{OutputOptionsProvider, StopConditionsProvider};
+    use crate::protocols::common::{
+        OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider,
+    };
     use serde_json::json;
 
     #[test]
@@ -504,14 +534,63 @@ mod tests {
             serde_json::from_value(scalar_token_id_stop);
         assert!(result.is_err());
 
-        let unsupported_stop_token_ids = json!({
+        // `stop_token_ids` is accepted and plumbed by the provider trait.
+        let whitelisted_stop_token_ids = json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "stop_token_ids": [576]
         });
         let request: NvCreateChatCompletionRequest =
-            serde_json::from_value(unsupported_stop_token_ids)
+            serde_json::from_value(whitelisted_stop_token_ids)
                 .expect("Failed to deserialize request");
+        assert_eq!(request.get_stop_token_ids(), Some(vec![576]));
+        assert!(
+            ValidateRequest::validate(&request).is_ok(),
+            "stop_token_ids must be accepted via PASSTHROUGH_EXTRA_FIELDS"
+        );
+
+        let invalid_stop_token_ids = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stop_token_ids": "bad"
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(invalid_stop_token_ids).expect("Failed to deserialize request");
+        let err = ValidateRequest::validate(&request).expect_err("invalid stop_token_ids");
+        assert!(err.to_string().contains("stop_token_ids"));
+    }
+
+    #[test]
+    fn test_sampling_token_constraints() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "allowed_token_ids": [10, 11],
+            "bad_words_token_ids": [[12, 13]]
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let sampling_options = request
+            .extract_sampling_options()
+            .expect("extract sampling options");
+        assert_eq!(sampling_options.allowed_token_ids, Some(vec![10, 11]));
+        assert_eq!(
+            sampling_options.bad_words_token_ids,
+            Some(vec![vec![12, 13]])
+        );
+    }
+
+    #[test]
+    fn test_truncate_prompt_tokens_rejected_until_supported() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "truncate_prompt_tokens": 2
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
         assert!(ValidateRequest::validate(&request).is_err());
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -311,12 +311,17 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
         // `NvExtResponseFieldSelection` (see `nvext.rs`). Both chat and
         // completions delta generators go through the same helper so the gating
         // rules stay in one place.
+        // Move prompt logprobs before borrowing token IDs for nvext emission.
+        let prompt_logprobs_payload = delta.prompt_logprobs;
+        let completion_token_ids_slice: &[u32] = &delta.token_ids;
         if let Some(nvext_response) = self.options.response_fields.build_response_nvext(
             Some(&self.tracker),
             delta.disaggregated_params.as_ref(),
             finish_reason.is_some(),
             delta.engine_data,
             stop_reason,
+            Some(completion_token_ids_slice),
+            prompt_logprobs_payload,
         ) && let Ok(nvext_json) = serde_json::to_value(&nvext_response)
         {
             stream_response.nvext = Some(nvext_json);
@@ -330,6 +335,12 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
             if let Some(ref tokens) = nvext_response.token_ids {
                 tracing::debug!(
                     "Injected token_ids into chat completion nvext: {} tokens",
+                    tokens.len()
+                );
+            }
+            if let Some(ref tokens) = nvext_response.completion_token_ids {
+                tracing::debug!(
+                    "Injected completion_token_ids into chat completion nvext: {} tokens",
                     tokens.len()
                 );
             }
@@ -459,6 +470,7 @@ mod tests {
                 "routed_experts": {"layer_0": [1, 3]}
             })),
             engine_data: None,
+            prompt_logprobs: None,
         }
     }
 
@@ -511,6 +523,7 @@ mod tests {
                 "disaggregated_kv_transfer_time_ms": 8.1,
                 "prefill_compute_time_ms": 45.6
             })),
+            prompt_logprobs: None,
         }
     }
 
@@ -715,6 +728,7 @@ mod tests {
             completion_usage: None,
             disaggregated_params: None,
             engine_data: None, // engine didn't provide any data
+            prompt_logprobs: None,
         };
 
         let response = generator

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use validator::Validate;
 
+use crate::types::TokenIdType;
+
 /// Common extensions for OpenAI API requests that are not part of the standard OpenAI spec
 /// but are commonly needed across different request types.
 #[derive(ToSchema, Serialize, Deserialize, Builder, Validate, Debug, Clone, Default)]
@@ -81,6 +83,26 @@ pub struct CommonExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub skip_special_tokens: Option<bool>,
+
+    /// Number of log probabilities to return per prompt token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub prompt_logprobs: Option<u32>,
+
+    /// When `Some(false)`, the engine should skip text decoding if supported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub detokenize: Option<bool>,
+
+    /// Token IDs that are allowed during generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub allowed_token_ids: Option<Vec<TokenIdType>>,
+
+    /// Token ID sequences that must not be generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub bad_words_token_ids: Option<Vec<Vec<TokenIdType>>>,
 }
 
 impl CommonExt {
@@ -111,6 +133,16 @@ pub trait CommonExtProvider {
 
     /// Output Options
     fn get_skip_special_tokens(&self) -> Option<bool>;
+
+    /// Number of prompt logprobs to request from the engine.
+    fn get_prompt_logprobs_count(&self) -> Option<u32>;
+
+    /// Whether the engine should decode generated tokens into text.
+    fn get_detokenize(&self) -> Option<bool>;
+
+    /// Token ID constraints forwarded to compatible backends.
+    fn get_allowed_token_ids(&self) -> Option<Vec<TokenIdType>>;
+    fn get_bad_words_token_ids(&self) -> Option<Vec<Vec<TokenIdType>>>;
 }
 
 #[cfg(test)]
@@ -133,6 +165,8 @@ mod tests {
         assert_eq!(common_ext.guided_decoding_backend, None);
         assert_eq!(common_ext.include_stop_str_in_output, None);
         assert_eq!(common_ext.skip_special_tokens, None);
+        assert_eq!(common_ext.allowed_token_ids, None);
+        assert_eq!(common_ext.bad_words_token_ids, None);
     }
 
     #[test]
@@ -149,6 +183,8 @@ mod tests {
             .guided_choice(vec!["choice1".to_string(), "choice2".to_string()])
             .guided_decoding_backend("backend".to_string())
             .skip_special_tokens(false)
+            .allowed_token_ids(vec![1, 2])
+            .bad_words_token_ids(vec![vec![3, 4]])
             .build()
             .unwrap();
 
@@ -172,6 +208,8 @@ mod tests {
             Some("backend".to_string())
         );
         assert_eq!(common_ext.skip_special_tokens, Some(false));
+        assert_eq!(common_ext.allowed_token_ids, Some(vec![1, 2]));
+        assert_eq!(common_ext.bad_words_token_ids, Some(vec![vec![3, 4]]));
     }
 
     #[test]
@@ -206,6 +244,10 @@ mod tests {
             guided_decoding_backend: None,
             guided_whitespace_pattern: None,
             skip_special_tokens: None,
+            prompt_logprobs: None,
+            detokenize: None,
+            allowed_token_ids: None,
+            bad_words_token_ids: None,
         };
         assert!(common_ext.validate().is_ok());
     }

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -135,6 +135,10 @@ impl NvExtProvider for NvCreateCompletionRequest {
         }
         None
     }
+
+    fn unsupported_fields(&self) -> Option<&std::collections::HashMap<String, serde_json::Value>> {
+        Some(&self.unsupported_fields)
+    }
 }
 
 impl AnnotationsProvider for NvCreateCompletionRequest {
@@ -236,6 +240,22 @@ impl CommonExtProvider for NvCreateCompletionRequest {
     fn get_skip_special_tokens(&self) -> Option<bool> {
         self.common.skip_special_tokens
     }
+
+    fn get_prompt_logprobs_count(&self) -> Option<u32> {
+        self.common.prompt_logprobs
+    }
+
+    fn get_detokenize(&self) -> Option<bool> {
+        self.common.detokenize
+    }
+
+    fn get_allowed_token_ids(&self) -> Option<Vec<crate::types::TokenIdType>> {
+        self.common.allowed_token_ids.clone()
+    }
+
+    fn get_bad_words_token_ids(&self) -> Option<Vec<Vec<crate::types::TokenIdType>>> {
+        self.common.bad_words_token_ids.clone()
+    }
 }
 
 impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
@@ -252,7 +272,12 @@ impl OpenAIStopConditionsProvider for NvCreateCompletionRequest {
     }
 
     fn get_stop_token_ids(&self) -> Option<Vec<crate::types::TokenIdType>> {
-        self.inner.stop.as_ref().and_then(|stop| stop.token_ids())
+        if let Some(ids) = self.inner.stop.as_ref().and_then(|stop| stop.token_ids()) {
+            return Some(ids);
+        }
+        self.unsupported_fields
+            .get("stop_token_ids")
+            .and_then(|v| serde_json::from_value::<Vec<crate::types::TokenIdType>>(v.clone()).ok())
     }
 
     fn nvext(&self) -> Option<&NvExt> {
@@ -409,9 +434,11 @@ impl OpenAIOutputOptionsProvider for NvCreateCompletionRequest {
     }
 
     fn get_prompt_logprobs(&self) -> Option<u32> {
-        self.inner
-            .echo
-            .and_then(|echo| if echo { Some(1) } else { None })
+        self.common.prompt_logprobs.or_else(|| {
+            self.inner
+                .echo
+                .and_then(|echo| if echo { Some(1) } else { None })
+        })
     }
 
     fn get_skip_special_tokens(&self) -> Option<bool> {
@@ -518,6 +545,22 @@ mod tests {
 
             assert_eq!(output_options.skip_special_tokens, Some(skip_value));
         }
+    }
+
+    #[test]
+    fn test_prompt_logprobs_propagates() {
+        let request_json = json!({
+            "model": "test-model",
+            "prompt": [1, 2, 3],
+            "prompt_logprobs": 3
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let output_options = request
+            .extract_output_options()
+            .expect("Failed to extract output options");
+        assert_eq!(output_options.prompt_logprobs, Some(3));
     }
 
     #[test]
@@ -733,13 +776,67 @@ mod tests {
         assert_eq!(request.get_stop(), Some(vec!["token_id:576".to_string()]));
         assert_eq!(request.get_stop_token_ids(), None);
 
-        let unsupported_stop_token_ids = json!({
+        // Top-level stop_token_ids should be accepted and plumbed.
+        let whitelisted_stop_token_ids = json!({
             "model": "test-model",
             "prompt": [1, 2, 3],
             "stop_token_ids": [576]
         });
-        let request: NvCreateCompletionRequest = serde_json::from_value(unsupported_stop_token_ids)
+        let request: NvCreateCompletionRequest = serde_json::from_value(whitelisted_stop_token_ids)
             .expect("Failed to deserialize request");
+        assert_eq!(request.get_stop_token_ids(), Some(vec![576]));
+        assert!(
+            ValidateRequest::validate(&request).is_ok(),
+            "stop_token_ids must be accepted via PASSTHROUGH_EXTRA_FIELDS"
+        );
+
+        let stop_conditions = request
+            .extract_stop_conditions()
+            .expect("extract stop conditions");
+        assert_eq!(stop_conditions.stop_token_ids, Some(vec![576]));
+
+        let invalid_stop_token_ids = json!({
+            "model": "test-model",
+            "prompt": [1, 2, 3],
+            "stop_token_ids": "bad"
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(invalid_stop_token_ids).expect("Failed to deserialize request");
+        let err = ValidateRequest::validate(&request).expect_err("invalid stop_token_ids");
+        assert!(err.to_string().contains("stop_token_ids"));
+    }
+
+    #[test]
+    fn test_sampling_token_constraints() {
+        let request_json = json!({
+            "model": "test-model",
+            "prompt": [1, 2, 3],
+            "allowed_token_ids": [10, 11],
+            "bad_words_token_ids": [[12, 13]]
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let sampling_options = request
+            .extract_sampling_options()
+            .expect("extract sampling options");
+        assert_eq!(sampling_options.allowed_token_ids, Some(vec![10, 11]));
+        assert_eq!(
+            sampling_options.bad_words_token_ids,
+            Some(vec![vec![12, 13]])
+        );
+    }
+
+    #[test]
+    fn test_truncate_prompt_tokens_rejected_until_supported() {
+        let request_json = json!({
+            "model": "test-model",
+            "prompt": [1, 2, 3],
+            "truncate_prompt_tokens": 2
+        });
+        let request: NvCreateCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
         assert!(ValidateRequest::validate(&request).is_err());
     }
 }

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -232,6 +232,8 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
             }
         }
 
+        // Keep token IDs available for optional nvext emission.
+        let completion_token_ids_for_nvext: Vec<TokenIdType> = delta.token_ids.clone();
         let logprobs = self.create_logprobs(
             delta.tokens,
             delta.token_ids,
@@ -256,12 +258,16 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         // `NvExtResponseFieldSelection` (see `nvext.rs`). Both chat and
         // completions delta generators go through the same helper so the gating
         // rules stay in one place.
+        // Use the cloned token IDs because create_logprobs consumes the originals.
+        let prompt_logprobs_payload = delta.prompt_logprobs;
         if let Some(nvext_response) = self.options.response_fields.build_response_nvext(
             Some(&self.tracker),
             delta.disaggregated_params.as_ref(),
             finish_reason.is_some(),
             delta.engine_data,
             stop_reason,
+            Some(&completion_token_ids_for_nvext),
+            prompt_logprobs_payload,
         ) && let Ok(nvext_json) = serde_json::to_value(&nvext_response)
         {
             response.nvext = Some(nvext_json);
@@ -275,6 +281,12 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
             if let Some(ref tokens) = nvext_response.token_ids {
                 tracing::debug!(
                     "Injected token_ids into completions nvext: {} tokens",
+                    tokens.len()
+                );
+            }
+            if let Some(ref tokens) = nvext_response.completion_token_ids {
+                tracing::debug!(
+                    "Injected completion_token_ids into completions nvext: {} tokens",
                     tokens.len()
                 );
             }
@@ -357,6 +369,7 @@ mod tests {
                 "routed_experts": {"layer_0": [1, 3]}
             })),
             engine_data: None,
+            prompt_logprobs: None,
         }
     }
 
@@ -400,6 +413,7 @@ mod tests {
                 "disaggregated_kv_transfer_time_ms": 8.1,
                 "prefill_compute_time_ms": 45.6
             })),
+            prompt_logprobs: None,
         }
     }
 
@@ -668,6 +682,7 @@ mod tests {
             completion_usage: None,
             disaggregated_params: None,
             engine_data: None, // engine didn't provide any data
+            prompt_logprobs: None,
         };
 
         let response = generator

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -9,11 +9,15 @@ use utoipa::ToSchema;
 use validator::{Validate, ValidationError};
 
 pub use crate::agents::context::AgentContext;
+use crate::protocols::TokenIdType;
+pub use crate::protocols::common::llm_backend::PromptLogprobs;
 pub use crate::protocols::common::timing::TimingInfo;
 
 pub const HEADER_WORKER_INSTANCE_ID: &str = "x-worker-instance-id";
 pub const HEADER_PREFILL_INSTANCE_ID: &str = "x-prefill-instance-id";
 pub const HEADER_DP_RANK: &str = "x-dp-rank";
+/// Alias for data-parallel rank routing.
+pub const HEADER_DP_RANK_ALIAS: &str = "x-data-parallel-rank";
 pub const HEADER_PREFILL_DP_RANK: &str = "x-prefill-dp-rank";
 const UNSET_DP_RANK_SENTINEL: u32 = u32::MAX;
 
@@ -38,8 +42,10 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<u64>().ok());
 
+    // Accept the alternate data-parallel rank header used by some clients.
     let dp_rank = headers
         .get(HEADER_DP_RANK)
+        .or_else(|| headers.get(HEADER_DP_RANK_ALIAS))
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<u32>().ok());
 
@@ -74,6 +80,9 @@ pub fn apply_header_routing_overrides(nvext: Option<NvExt>, headers: &HeaderMap)
 pub trait NvExtProvider {
     fn nvext(&self) -> Option<&NvExt>;
     fn raw_prompt(&self) -> Option<String>;
+    fn unsupported_fields(&self) -> Option<&std::collections::HashMap<String, serde_json::Value>> {
+        None
+    }
 }
 
 /// Worker ID information for disaggregated serving
@@ -129,6 +138,15 @@ pub struct NvExtResponse {
     /// If `n > 1` is supported here, this needs an indexed/per-choice shape.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<serde_json::Value>,
+
+    /// Engine-emitted output token IDs, returned when explicitly requested.
+    /// Streaming chunks carry delta token IDs; aggregated responses concatenate them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_token_ids: Option<Vec<TokenIdType>>,
+
+    /// Per-prompt-token top-k logprobs, returned on the final chunk when requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_logprobs: Option<PromptLogprobs>,
 }
 
 pub(crate) fn merge_response_nvext(
@@ -141,7 +159,28 @@ pub(crate) fn merge_response_nvext(
 
     match (target.as_mut(), incoming) {
         (Some(serde_json::Value::Object(target_obj)), serde_json::Value::Object(incoming_obj)) => {
-            target_obj.extend(incoming_obj);
+            // Token IDs are chunk deltas, so aggregation concatenates them.
+            for (key, value) in incoming_obj {
+                match key.as_str() {
+                    "completion_token_ids" => {
+                        let entry = target_obj
+                            .entry(&key)
+                            .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+                        if let (serde_json::Value::Array(acc), serde_json::Value::Array(new)) =
+                            (entry, value)
+                        {
+                            acc.extend(new);
+                        }
+                    }
+                    "prompt_logprobs" => {
+                        // Prompt logprobs are final-chunk-only; keep the latest.
+                        target_obj.insert(key, value);
+                    }
+                    _ => {
+                        target_obj.insert(key, value);
+                    }
+                }
+            }
         }
         (_, incoming) => {
             *target = Some(incoming);
@@ -165,6 +204,10 @@ pub struct NvExtResponseFieldSelection {
     pub routed_experts: bool,
     pub engine_data: bool,
     pub stop_reason: bool,
+    /// Emit completion token IDs when requested.
+    pub completion_token_ids: bool,
+    /// Emit prompt logprobs on the final chunk when requested.
+    pub prompt_logprobs: bool,
 }
 
 impl NvExtResponseFieldSelection {
@@ -182,6 +225,8 @@ impl NvExtResponseFieldSelection {
                     "routed_experts" => selection.routed_experts = true,
                     "engine_data" => selection.engine_data = true,
                     "stop_reason" => selection.stop_reason = true,
+                    "completion_token_ids" => selection.completion_token_ids = true,
+                    "prompt_logprobs" => selection.prompt_logprobs = true,
                     _ => {}
                 }
             }
@@ -215,6 +260,7 @@ impl NvExtResponseFieldSelection {
     /// - `timing` requires the selection flag, `finish_reason_present == true`, **and** a tracker.
     /// - `engine_data` requires the selection flag **and** a non-`None` `engine_data_from_backend`.
     /// - `stop_reason` requires the selection flag **and** a non-`None` `stop_reason_from_backend`.
+    #[allow(clippy::too_many_arguments)]
     pub fn build_response_nvext(
         &self,
         tracker: Option<&std::sync::Arc<crate::protocols::common::timing::RequestTracker>>,
@@ -222,6 +268,8 @@ impl NvExtResponseFieldSelection {
         finish_reason_present: bool,
         engine_data_from_backend: Option<serde_json::Value>,
         stop_reason_from_backend: Option<StopReason>,
+        completion_token_ids_from_backend: Option<&[TokenIdType]>,
+        prompt_logprobs_from_backend: Option<PromptLogprobs>,
     ) -> Option<NvExtResponse> {
         let worker_id = if self.worker_id {
             tracker.and_then(|t| t.get_worker_info())
@@ -263,12 +311,28 @@ impl NvExtResponseFieldSelection {
             None
         };
 
+        // Pass through chunk or aggregated completion token IDs as provided.
+        let completion_token_ids = if self.completion_token_ids {
+            completion_token_ids_from_backend.map(<[u32]>::to_vec)
+        } else {
+            None
+        };
+
+        // Prompt logprobs describe the full prompt, so emit them once.
+        let prompt_logprobs = if self.prompt_logprobs && finish_reason_present {
+            prompt_logprobs_from_backend
+        } else {
+            None
+        };
+
         if worker_id.is_none()
             && token_ids.is_none()
             && routed_experts.is_none()
             && timing.is_none()
             && engine_data.is_none()
             && stop_reason.is_none()
+            && completion_token_ids.is_none()
+            && prompt_logprobs.is_none()
         {
             return None;
         }
@@ -280,6 +344,8 @@ impl NvExtResponseFieldSelection {
             routed_experts,
             engine_data,
             stop_reason,
+            completion_token_ids,
+            prompt_logprobs,
         })
     }
 }
@@ -327,6 +393,21 @@ pub struct NvExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub max_thinking_tokens: Option<u32>,
+
+    /// KV prefix-cache isolation hint from RL orchestrators.
+    ///
+    /// Prime-RL's orchestrator tags every rollout request with a `cache_salt`
+    /// derived from the current checkpoint step (e.g. `"step_7"`). When the
+    /// salt changes across requests, the inference engine treats their prompt
+    /// prefixes as distinct cache keys even if the token sequences are
+    /// byte-identical — ensuring KV cache hits from the pre-weight-update
+    /// policy do not leak into post-update generations.
+    ///
+    /// Dynamo passes this through to the backend as a sampling-params hint.
+    /// Backends that do not support cache salting may ignore it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub cache_salt: Option<String>,
 
     /// Extra fields to be included in the response's nvext
     /// This is a list of field names that should be populated in the response
@@ -507,6 +588,7 @@ mod tests {
         assert_eq!(nv_ext.backend_instance_id, None);
         assert_eq!(nv_ext.token_data, None);
         assert_eq!(nv_ext.max_thinking_tokens, None);
+        assert_eq!(nv_ext.cache_salt, None);
         assert_eq!(nv_ext.extra_fields, None);
         assert_eq!(nv_ext.prefill_worker_id, None);
         assert_eq!(nv_ext.decode_worker_id, None);
@@ -791,12 +873,12 @@ mod tests {
     fn test_build_response_nvext_all_false_returns_none() {
         let sel = sel_all_false();
         assert!(
-            sel.build_response_nvext(None, None, false, None, None)
+            sel.build_response_nvext(None, None, false, None, None, None, None)
                 .is_none(),
             "no fields selected → None"
         );
         assert!(
-            sel.build_response_nvext(None, None, true, None, None)
+            sel.build_response_nvext(None, None, true, None, None, None, None)
                 .is_none(),
             "finish_reason alone does not force emission"
         );
@@ -812,7 +894,7 @@ mod tests {
 
         // finish_reason=false: worker_id still emitted (only timing is finish-gated).
         let out = sel
-            .build_response_nvext(Some(&tracker), None, false, None, None)
+            .build_response_nvext(Some(&tracker), None, false, None, None, None, None)
             .expect("worker_id should emit regardless of finish_reason");
 
         assert!(out.worker_id.is_some());
@@ -831,7 +913,7 @@ mod tests {
 
         // timing alone + finish_reason=false → nothing to emit, returns None.
         assert!(
-            sel.build_response_nvext(Some(&tracker), None, false, None, None)
+            sel.build_response_nvext(Some(&tracker), None, false, None, None, None, None)
                 .is_none(),
             "timing is gated on finish_reason_present"
         );
@@ -846,7 +928,7 @@ mod tests {
         let tracker = tracker_with_prefill_worker();
 
         let out = sel
-            .build_response_nvext(Some(&tracker), None, true, None, None)
+            .build_response_nvext(Some(&tracker), None, true, None, None, None, None)
             .expect("timing should emit on finish");
 
         assert!(out.timing.is_some());
@@ -863,7 +945,7 @@ mod tests {
         };
         // finish=true but no tracker → timing not populated → None.
         assert!(
-            sel.build_response_nvext(None, None, true, None, None)
+            sel.build_response_nvext(None, None, true, None, None, None, None)
                 .is_none()
         );
     }
@@ -877,7 +959,7 @@ mod tests {
         let params = disagg_params_full();
 
         let out = sel
-            .build_response_nvext(None, Some(&params), false, None, None)
+            .build_response_nvext(None, Some(&params), false, None, None, None, None)
             .expect("token_ids should emit when present");
 
         assert_eq!(out.token_ids, Some(vec![11u32, 22, 33]));
@@ -896,7 +978,7 @@ mod tests {
         let params = serde_json::json!({ "token_ids": "not-an-array" });
 
         assert!(
-            sel.build_response_nvext(None, Some(&params), false, None, None)
+            sel.build_response_nvext(None, Some(&params), false, None, None, None, None)
                 .is_none(),
             "malformed token_ids silently suppressed; nothing else selected → None"
         );
@@ -911,7 +993,7 @@ mod tests {
         let params = disagg_params_full();
 
         let out = sel
-            .build_response_nvext(None, Some(&params), false, None, None)
+            .build_response_nvext(None, Some(&params), false, None, None, None, None)
             .expect("routed_experts should emit when present");
 
         assert_eq!(
@@ -934,6 +1016,8 @@ mod tests {
                 true,
                 None,
                 Some(StopReason::String("END".to_string())),
+                None,
+                None,
             )
             .expect("stop_reason should emit when requested and present");
 
@@ -952,7 +1036,7 @@ mod tests {
         };
 
         assert!(
-            sel.build_response_nvext(None, None, true, None, None)
+            sel.build_response_nvext(None, None, true, None, None, None, None)
                 .is_none()
         );
     }
@@ -966,12 +1050,14 @@ mod tests {
             routed_experts: true,
             engine_data: false,
             stop_reason: false,
+            completion_token_ids: false,
+            prompt_logprobs: false,
         };
         let tracker = tracker_with_prefill_worker();
         let params = disagg_params_full();
 
         let out = sel
-            .build_response_nvext(Some(&tracker), Some(&params), true, None, None)
+            .build_response_nvext(Some(&tracker), Some(&params), true, None, None, None, None)
             .expect("all fields selected and available → Some");
 
         assert!(out.worker_id.is_some());
@@ -1003,7 +1089,97 @@ mod tests {
                 routed_experts: true,
                 engine_data: false,
                 stop_reason: false,
+                completion_token_ids: false,
+                prompt_logprobs: false,
             }
         );
+    }
+
+    #[test]
+    fn tito_parity_completion_token_ids_pass_through() {
+        // Per-chunk delta tokens pass through unchanged.
+        let sel = NvExtResponseFieldSelection {
+            completion_token_ids: true,
+            ..Default::default()
+        };
+        let chunk_tokens: &[u32] = &[101, 102, 103];
+        let out = sel
+            .build_response_nvext(None, None, false, None, None, Some(chunk_tokens), None)
+            .expect("completion_token_ids must be present when requested + provided");
+        assert_eq!(out.completion_token_ids, Some(vec![101u32, 102, 103]));
+        // Accumulation happens in the response aggregator.
+        assert!(out.prompt_logprobs.is_none());
+        assert!(out.engine_data.is_none());
+    }
+
+    #[test]
+    fn tito_parity_prompt_logprobs_final_chunk_only() {
+        // Prompt logprobs are emitted only with the final chunk.
+        let sel = NvExtResponseFieldSelection {
+            prompt_logprobs: true,
+            ..Default::default()
+        };
+        let mut entry = std::collections::HashMap::new();
+        entry.insert(
+            42u32,
+            crate::protocols::common::llm_backend::PromptLogprobEntry {
+                logprob: -1.234,
+                rank: Some(1),
+                decoded_token: None,
+            },
+        );
+        let payload: crate::protocols::common::llm_backend::PromptLogprobs =
+            vec![None, Some(entry)];
+
+        // Intermediate chunk (no finish): suppressed.
+        assert!(
+            sel.build_response_nvext(None, None, false, None, None, None, Some(payload.clone()))
+                .is_none(),
+            "prompt_logprobs must be suppressed on intermediate chunks"
+        );
+
+        // Final chunk: surfaced.
+        let out = sel
+            .build_response_nvext(None, None, true, None, None, None, Some(payload.clone()))
+            .expect("prompt_logprobs must emit on the final chunk");
+        let got = out.prompt_logprobs.expect("prompt_logprobs payload");
+        assert_eq!(got.len(), 2);
+        assert!(got[0].is_none());
+        assert_eq!(
+            got[1].as_ref().unwrap().get(&42u32).unwrap().logprob,
+            -1.234
+        );
+    }
+
+    #[test]
+    fn tito_parity_aggregator_concatenates_completion_token_ids() {
+        // Aggregation concatenates per-chunk completion token IDs.
+        let mut target: Option<serde_json::Value> = None;
+        // Chunk 1: tokens [10, 11, 12]
+        merge_response_nvext(
+            &mut target,
+            Some(serde_json::json!({ "completion_token_ids": [10, 11, 12] })),
+        );
+        // Chunk 2 appends tokens.
+        merge_response_nvext(
+            &mut target,
+            Some(serde_json::json!({ "completion_token_ids": [13, 14] })),
+        );
+        // Chunk 3 (final): one more token + non-token field that should overwrite.
+        merge_response_nvext(
+            &mut target,
+            Some(serde_json::json!({
+                "completion_token_ids": [15],
+                "worker_id": { "decode_worker_id": 7 }
+            })),
+        );
+
+        let aggregated = target.expect("aggregator state");
+        assert_eq!(
+            aggregated["completion_token_ids"],
+            serde_json::json!([10, 11, 12, 13, 14, 15]),
+            "completion_token_ids must concatenate across chunks"
+        );
+        assert_eq!(aggregated["worker_id"]["decode_worker_id"], 7);
     }
 }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -97,16 +97,31 @@ pub const MAX_REPETITION_PENALTY: f32 = 2.0;
 // Shared Fields
 //
 
-/// Validates that no unsupported fields are present in the request
+/// Extra-body fields accepted for backend-specific handling.
+pub const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &["cache_salt", "stop_token_ids"];
+
+/// Validates that no unsupported fields are present in the request.
+///
+/// Fields in `PASSTHROUGH_EXTRA_FIELDS` are validated by downstream handlers.
 pub fn validate_no_unsupported_fields(
     unsupported_fields: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Result<(), anyhow::Error> {
-    if !unsupported_fields.is_empty() {
-        let fields: Vec<_> = unsupported_fields
-            .keys()
-            .map(|s| format!("`{}`", s))
-            .collect();
-        anyhow::bail!("Unsupported parameter(s): {}", fields.join(", "));
+    let unknown: Vec<_> = unsupported_fields
+        .keys()
+        .filter(|k| !PASSTHROUGH_EXTRA_FIELDS.contains(&k.as_str()))
+        .map(|s| format!("`{}`", s))
+        .collect();
+    if !unknown.is_empty() {
+        anyhow::bail!("Unsupported parameter(s): {}", unknown.join(", "));
+    }
+    if let Some(value) = unsupported_fields.get("cache_salt")
+        && !value.is_string()
+    {
+        anyhow::bail!("`cache_salt` must be a string");
+    }
+    if let Some(value) = unsupported_fields.get("stop_token_ids") {
+        serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
+            .map_err(|_| anyhow::anyhow!("`stop_token_ids` must be an array of token IDs"))?;
     }
     Ok(())
 }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -388,6 +388,22 @@ impl CommonExtProvider for UnifiedRequest {
     fn get_skip_special_tokens(&self) -> Option<bool> {
         self.inner.common.skip_special_tokens
     }
+
+    fn get_prompt_logprobs_count(&self) -> Option<u32> {
+        self.inner.common.prompt_logprobs
+    }
+
+    fn get_detokenize(&self) -> Option<bool> {
+        self.inner.common.detokenize
+    }
+
+    fn get_allowed_token_ids(&self) -> Option<Vec<crate::types::TokenIdType>> {
+        self.inner.common.allowed_token_ids.clone()
+    }
+
+    fn get_bad_words_token_ids(&self) -> Option<Vec<Vec<crate::types::TokenIdType>>> {
+        self.inner.common.bad_words_token_ids.clone()
+    }
 }
 
 impl OpenAIStopConditionsProvider for UnifiedRequest {

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -111,6 +111,7 @@ fn build_backend_outputs_with_cached_tokens(cached_tokens: Option<u32>) -> Vec<B
             completion_usage: None,
             disaggregated_params: None,
             engine_data: None,
+            prompt_logprobs: None,
         },
         BackendOutput {
             token_ids: vec![1917],
@@ -125,6 +126,7 @@ fn build_backend_outputs_with_cached_tokens(cached_tokens: Option<u32>) -> Vec<B
             completion_usage: None,
             disaggregated_params: None,
             engine_data: None,
+            prompt_logprobs: None,
         },
         BackendOutput {
             token_ids: vec![0],
@@ -148,6 +150,7 @@ fn build_backend_outputs_with_cached_tokens(cached_tokens: Option<u32>) -> Vec<B
             }),
             disaggregated_params: None,
             engine_data: None,
+            prompt_logprobs: None,
         },
     ]
 }

--- a/lib/llm/tests/tool_choice.rs
+++ b/lib/llm/tests/tool_choice.rs
@@ -136,6 +136,7 @@ fn build_backend_output(text: &str) -> BackendOutput {
         completion_usage: None,
         disaggregated_params: None,
         engine_data: None,
+        prompt_logprobs: None,
     }
 }
 
@@ -305,6 +306,7 @@ async fn test_streaming_named_tool_buffers_until_finish() {
             completion_usage: None,
             disaggregated_params: None,
             engine_data: None,
+            prompt_logprobs: None,
         };
 
         let response = generator
@@ -373,6 +375,7 @@ async fn test_streaming_required_tool_parallel() {
             completion_usage: None,
             disaggregated_params: None,
             engine_data: None,
+            prompt_logprobs: None,
         };
 
         let response = generator
@@ -443,6 +446,7 @@ fn test_no_tool_choice_outputs_normal_text() {
         completion_usage: None,
         disaggregated_params: None,
         engine_data: None,
+        prompt_logprobs: None,
     };
 
     let response = generator

--- a/lib/llm/tests/tool_choice_finish_reasons.rs
+++ b/lib/llm/tests/tool_choice_finish_reasons.rs
@@ -52,6 +52,7 @@ fn build_backend_output_with_finish(text: &str, finish: common::FinishReason) ->
         completion_usage: None,
         disaggregated_params: None,
         engine_data: None,
+        prompt_logprobs: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- add Rust `lib/llm` protocol, preprocessor, and response plumbing for nvext Tokens-in-Tokens-Out
- carry `nvext.token_data`, `cache_salt`, `extra_fields`, token constraints, `prompt_logprobs`, detokenize, and stop token IDs through the Rust request/response path
- validate passthrough `cache_salt` and `stop_token_ids`; reject `truncate_prompt_tokens` until it is supported
- add Rust unit coverage for chat/completion request extraction and nvext response fields

## Split
- This PR is now Rust `lib/llm` only.
- The vLLM implementation was moved to branch `bis/nvext-tito-vllm`, stacked on top of this branch.
- The follow-up vLLM PR should target this branch or be opened after this PR lands so its diff remains `components/src/dynamo/vllm/*` only.

## Local Tests
- `cargo test -p dynamo-llm protocols::openai::completions::tests:: --lib`
- `cargo test -p dynamo-llm protocols::openai::chat_completions::tests:: --lib`
- `rustfmt --edition 2024 --check lib/llm/src/protocols/openai/validate.rs lib/llm/src/protocols/openai/completions.rs lib/llm/src/protocols/openai/chat_completions.rs`
- `git diff --check`

## Follow-up vLLM Branch Validation
- `PYTHONPATH=components/src uv run --no-project --with pytest --with pytest-benchmark python -m pytest -c /dev/null components/src/dynamo/vllm/tests/test_vllm_tito_parity.py -q`