### PR TITLE
fix(self-host): harvest non-weight siblings into slug_dir (gh-8749)

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -330,10 +330,6 @@ fn is_weight_file(path: &Path) -> bool {
     )
 }
 
-/// Symlink non-weight files from `snapshot_dir` into `slug_dir`, skipping
-/// any name already present (typed slots own those). Picks up
-/// `preprocessor_config.json` and other sibling files that
-/// `from_pretrained(slug_dir)` consumers need.
 /// Parent directory of a `file://` URI when it resolves to a real local
 /// directory. Returns `None` for any other scheme or unreachable path.
 fn file_uri_parent(uri: &str) -> Option<PathBuf> {
@@ -346,7 +342,20 @@ fn file_uri_parent(uri: &str) -> Option<PathBuf> {
     parent.is_dir().then(|| parent.to_path_buf())
 }
 
-fn harvest_siblings(snapshot_dir: &Path, slug_dir: &Path) -> anyhow::Result<()> {
+/// Symlink non-weight files from `snapshot_dir` into `slug_dir`. Picks up
+/// `preprocessor_config.json` and other sibling files that
+/// `from_pretrained(slug_dir)` consumers need.
+///
+/// Names in `typed_filenames` are owned by the resolve loop's typed-slot
+/// pass — never overwritten. Every other harvested sibling is re-linked
+/// unconditionally so a re-registration with the same `mdcsum` but a
+/// different upstream snapshot picks up fresh contents (mdcsum doesn't
+/// cover harvested files).
+fn harvest_siblings(
+    snapshot_dir: &Path,
+    slug_dir: &Path,
+    typed_filenames: &std::collections::HashSet<String>,
+) -> anyhow::Result<()> {
     let entries = match std::fs::read_dir(snapshot_dir) {
         Ok(e) => e,
         Err(e) => {
@@ -368,13 +377,14 @@ fn harvest_siblings(snapshot_dir: &Path, slug_dir: &Path) -> anyhow::Result<()> 
             Some(n) if !n.is_empty() => n.to_owned(),
             _ => continue,
         };
-        let dst = slug_dir.join(&name);
-        if dst.exists() {
+        if typed_filenames.contains(&name) {
             continue;
         }
+        let dst = slug_dir.join(&name);
         // Resolve through the canonical target so a downstream
         // `canonicalize` lands on a stable blob path rather than
-        // chasing snapshot-dir symlinks.
+        // chasing snapshot-dir symlinks. `symlink_force` is idempotent
+        // and atomic via `stage_and_rename_sync`.
         let target = std::fs::canonicalize(&path).unwrap_or(path);
         symlink_force(&target, &dst)
             .with_context(|| format!("harvesting {} -> {}", target.display(), dst.display()))?;
@@ -1063,7 +1073,12 @@ impl ModelDeploymentCard {
         );
 
         // Harvest non-weight siblings (preprocessor_config.json, …) from
-        // every snapshot dir we touched. No-op for `http://`.
+        // every snapshot dir we touched. Typed-slot basenames are passed
+        // through so the harvest never overwrites them. No-op for `http://`.
+        let typed_filenames: std::collections::HashSet<String> = entries
+            .iter()
+            .filter_map(|(uri, _)| uri_basename(uri).ok())
+            .collect();
         let mut snapshot_dirs: std::collections::HashSet<PathBuf> =
             hf_snapshots.values().cloned().collect();
         for (uri, _) in &entries {
@@ -1072,7 +1087,7 @@ impl ModelDeploymentCard {
             }
         }
         for snap in &snapshot_dirs {
-            harvest_siblings(snap, &slug_dir)?;
+            harvest_siblings(snap, &slug_dir, &typed_filenames)?;
         }
 
         // Pass 3: rewrite cf.path to the cache symlink so downstream
@@ -2048,7 +2063,7 @@ mod tests {
         std::fs::write(snap.path().join("tokenizer.model"), b"sp")?;
         // `.safetensors.index.json` is `.json`, not a weight — must be kept.
         std::fs::write(snap.path().join("model.safetensors.index.json"), b"idx")?;
-        super::harvest_siblings(snap.path(), slug.path())?;
+        super::harvest_siblings(snap.path(), slug.path(), &Default::default())?;
         assert!(slug.path().join("preprocessor_config.json").exists());
         assert!(slug.path().join("tokenizer.model").exists());
         assert!(slug.path().join("model.safetensors.index.json").exists());
@@ -2063,7 +2078,7 @@ mod tests {
         for weight in ["model.safetensors", "pytorch_model.bin", "model.gguf"] {
             std::fs::write(snap.path().join(weight), b"WEIGHTS")?;
         }
-        super::harvest_siblings(snap.path(), slug.path())?;
+        super::harvest_siblings(snap.path(), slug.path(), &Default::default())?;
         for weight in ["model.safetensors", "pytorch_model.bin", "model.gguf"] {
             assert!(!slug.path().join(weight).exists());
         }
@@ -2074,24 +2089,43 @@ mod tests {
     #[test]
     fn harvest_tolerates_missing_snapshot() -> anyhow::Result<()> {
         let slug = tempfile::tempdir()?;
-        super::harvest_siblings(&slug.path().join("does-not-exist"), slug.path())?;
+        super::harvest_siblings(
+            &slug.path().join("does-not-exist"),
+            slug.path(),
+            &Default::default(),
+        )?;
         Ok(())
     }
 
-    /// Typed slots already in slug_dir survive a harvest pass untouched.
+    /// Names in `typed_filenames` survive a harvest pass even when the
+    /// snapshot dir contains a different file at the same basename — the
+    /// resolve loop's typed slots own those.
     #[test]
-    fn harvest_preserves_existing_dst() -> anyhow::Result<()> {
+    fn harvest_preserves_typed_filenames() -> anyhow::Result<()> {
+        let blob_dir = tempfile::tempdir()?;
         let snap = tempfile::tempdir()?;
         let slug = tempfile::tempdir()?;
-        let typed = snap.path().join("config.json");
-        std::fs::write(&typed, b"cfg")?;
-        // Use the production helper so the test works on non-Unix too.
-        super::symlink_force(&typed, &slug.path().join("config.json"))?;
-        // Drop a different file in snap so the harvest does something.
+
+        // Typed slot: blob in the dynamo cache; slug_dir links to it.
+        let typed_blob = blob_dir.path().join("config-blob");
+        std::fs::write(&typed_blob, b"typed-slot-content")?;
+        super::symlink_force(&typed_blob, &slug.path().join("config.json"))?;
+
+        // Snapshot dir has a different `config.json` — the stale-payload
+        // case the harvest must NOT import over the typed slot.
+        std::fs::write(snap.path().join("config.json"), b"STALE-DO-NOT-IMPORT")?;
         std::fs::write(snap.path().join("special_tokens_map.json"), b"st")?;
-        super::harvest_siblings(snap.path(), slug.path())?;
-        let preserved = slug.path().join("config.json");
-        assert!(preserved.is_symlink());
+
+        let typed_filenames: std::collections::HashSet<String> =
+            ["config.json".to_string()].into_iter().collect();
+        super::harvest_siblings(snap.path(), slug.path(), &typed_filenames)?;
+
+        // Content equality is portable: `symlink_force` degrades to a copy
+        // on non-Unix, so we can't depend on `is_symlink()`.
+        assert_eq!(
+            std::fs::read(slug.path().join("config.json"))?,
+            b"typed-slot-content"
+        );
         assert!(slug.path().join("special_tokens_map.json").exists());
         Ok(())
     }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -2085,7 +2085,8 @@ mod tests {
         let slug = tempfile::tempdir()?;
         let typed = snap.path().join("config.json");
         std::fs::write(&typed, b"cfg")?;
-        std::os::unix::fs::symlink(&typed, slug.path().join("config.json"))?;
+        // Use the production helper so the test works on non-Unix too.
+        super::symlink_force(&typed, &slug.path().join("config.json"))?;
         // Drop a different file in snap so the harvest does something.
         std::fs::write(snap.path().join("special_tokens_map.json"), b"st")?;
         super::harvest_siblings(snap.path(), slug.path())?;

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -330,20 +330,22 @@ fn is_weight_file(path: &Path) -> bool {
     )
 }
 
-/// Symlink any non-weight file in `snapshot_dir` into `slug_dir` that
-/// isn't already present. The typed-slot resolve loop has already
-/// symlinked the 5 typed artifacts; this pass picks up the sibling
-/// metadata files (`preprocessor_config.json`, `special_tokens_map.json`,
-/// `added_tokens.json`, `tokenizer.model`, …) that downstream consumers
-/// — lightseek-mm in particular — need to instantiate HF preprocessors
-/// from `slug_dir` via `from_pretrained()`.
-///
-/// Trust model: `snapshot_dir` is either an `hub::from_hf` snapshot
-/// (HF / ModelExpress-verified) or a `file://`-resolved local
-/// directory the worker already pointed the typed slots at — i.e. a
-/// directory the typed-slot resolve trusted. Files harvested here are
-/// by definition the same canonical artifacts that ship alongside the
-/// typed slots; no new trust surface is introduced.
+/// Symlink non-weight files from `snapshot_dir` into `slug_dir`, skipping
+/// any name already present (typed slots own those). Picks up
+/// `preprocessor_config.json` and other sibling files that
+/// `from_pretrained(slug_dir)` consumers need.
+/// Parent directory of a `file://` URI when it resolves to a real local
+/// directory. Returns `None` for any other scheme or unreachable path.
+fn file_uri_parent(uri: &str) -> Option<PathBuf> {
+    let url = url::Url::parse(uri).ok()?;
+    if url.scheme() != "file" {
+        return None;
+    }
+    let path = url.to_file_path().ok()?;
+    let parent = path.parent()?;
+    parent.is_dir().then(|| parent.to_path_buf())
+}
+
 fn harvest_siblings(snapshot_dir: &Path, slug_dir: &Path) -> anyhow::Result<()> {
     let entries = match std::fs::read_dir(snapshot_dir) {
         Ok(e) => e,
@@ -1060,28 +1062,13 @@ impl ModelDeploymentCard {
             "resolved model metadata files",
         );
 
-        // Pass 2.5: harvest non-weight sibling files from any directory
-        // the typed-slot resolve actually walked — hf:// snapshot dirs
-        // and file:// parent dirs (shared-mount, --model-path overlay).
-        // Consumers (lightseek-mm, vllm/sglang chat processors) read
-        // sibling files like `preprocessor_config.json` from `slug_dir`
-        // via `from_pretrained()`; without this MM-aware routing
-        // silently degrades to text-prefix. No-op for http:// (the
-        // self-host route surface — when default-ON ships, the worker
-        // will need to advertise extras itself).
+        // Harvest non-weight siblings (preprocessor_config.json, …) from
+        // every snapshot dir we touched. No-op for `http://`.
         let mut snapshot_dirs: std::collections::HashSet<PathBuf> =
-            std::collections::HashSet::new();
-        for snap in hf_snapshots.values() {
-            snapshot_dirs.insert(snap.clone());
-        }
+            hf_snapshots.values().cloned().collect();
         for (uri, _) in &entries {
-            if let Ok(u) = url::Url::parse(uri)
-                && u.scheme() == "file"
-                && let Ok(p) = u.to_file_path()
-                && let Some(parent) = p.parent()
-                && parent.is_dir()
-            {
-                snapshot_dirs.insert(parent.to_path_buf());
+            if let Some(parent) = file_uri_parent(uri) {
+                snapshot_dirs.insert(parent);
             }
         }
         for snap in &snapshot_dirs {
@@ -1936,6 +1923,13 @@ mod tests {
             assert!(snap.join("tokenizer.json").exists());
             assert!(snap.join("generation_config.json").exists());
 
+            // Sibling harvest: TinyLlama_v1.1 fixture ships
+            // `special_tokens_map.json` and `tokenizer.model` outside the
+            // typed slots — both must land in slug_dir for
+            // `from_pretrained()` to see a complete model dir.
+            assert!(snap.join("special_tokens_map.json").exists());
+            assert!(snap.join("tokenizer.model").exists());
+
             for (cf, _) in mdc.iter_metadata_files() {
                 let path = cf.path().expect("post-download local path");
                 assert!(path.starts_with(&snap));
@@ -2045,72 +2039,59 @@ mod tests {
         assert!(!dest.exists(), "dest must not exist after cancel");
     }
 
-    /// The harvest must:
-    /// - bring in non-weight sibling files (preprocessor_config.json,
-    ///   special_tokens_map.json) so MM consumers can `from_pretrained`
-    ///   the slug_dir,
-    /// - skip weight blobs (*.safetensors, *.bin, *.pt, …) so we don't
-    ///   bloat the metadata cache,
-    /// - leave existing entries alone (typed slots already symlinked
-    ///   by the resolve loop must not be overwritten or duplicated),
-    /// - keep `.safetensors.index.json` (json extension, not a weight).
+    /// Brings in the sibling that `lightseek-mm` needs.
     #[test]
-    fn harvest_siblings_copies_non_weights_skipping_existing() -> anyhow::Result<()> {
+    fn harvest_brings_in_non_weight_siblings() -> anyhow::Result<()> {
         let snap = tempfile::tempdir()?;
         let slug = tempfile::tempdir()?;
-
-        // Sibling files we want to land in slug_dir.
         std::fs::write(snap.path().join("preprocessor_config.json"), b"pre")?;
-        std::fs::write(snap.path().join("special_tokens_map.json"), b"st")?;
-        std::fs::write(snap.path().join("added_tokens.json"), b"at")?;
-        std::fs::write(snap.path().join("model.safetensors.index.json"), b"idx")?;
-        // Sentencepiece tokenizer model — non-weight `.model` extension.
         std::fs::write(snap.path().join("tokenizer.model"), b"sp")?;
-
-        // Weight blobs we must NOT copy.
-        std::fs::write(snap.path().join("model.safetensors"), b"WEIGHTS")?;
-        std::fs::write(snap.path().join("pytorch_model.bin"), b"WEIGHTS")?;
-        std::fs::write(snap.path().join("model.gguf"), b"WEIGHTS")?;
-        std::fs::write(snap.path().join("model.onnx"), b"WEIGHTS")?;
-
-        // Typed slot already symlinked by the resolve loop. Harvest must
-        // skip it (and must not error on the pre-existing dst).
-        let typed_slot_blob = snap.path().join("config.json");
-        std::fs::write(&typed_slot_blob, b"cfg")?;
-        std::os::unix::fs::symlink(&typed_slot_blob, slug.path().join("config.json"))?;
-
+        // `.safetensors.index.json` is `.json`, not a weight — must be kept.
+        std::fs::write(snap.path().join("model.safetensors.index.json"), b"idx")?;
         super::harvest_siblings(snap.path(), slug.path())?;
-
         assert!(slug.path().join("preprocessor_config.json").exists());
-        assert!(slug.path().join("special_tokens_map.json").exists());
-        assert!(slug.path().join("added_tokens.json").exists());
-        assert!(slug.path().join("model.safetensors.index.json").exists());
         assert!(slug.path().join("tokenizer.model").exists());
-
-        for weight in [
-            "model.safetensors",
-            "pytorch_model.bin",
-            "model.gguf",
-            "model.onnx",
-        ] {
-            assert!(
-                !slug.path().join(weight).exists(),
-                "weight {weight} must not be harvested",
-            );
-        }
-
-        // The pre-existing typed-slot symlink is intact and untouched.
-        let preserved = slug.path().join("config.json");
-        assert!(preserved.is_symlink() || preserved.exists());
+        assert!(slug.path().join("model.safetensors.index.json").exists());
         Ok(())
     }
 
-    /// Snapshot dir missing entirely: harvest is a no-op (best-effort).
+    /// Weight blobs stay out so the metadata cache doesn't bloat.
     #[test]
-    fn harvest_siblings_tolerates_missing_snapshot() -> anyhow::Result<()> {
+    fn harvest_skips_weight_blobs() -> anyhow::Result<()> {
+        let snap = tempfile::tempdir()?;
         let slug = tempfile::tempdir()?;
-        let missing = slug.path().join("does-not-exist");
-        super::harvest_siblings(&missing, slug.path())?;
+        for weight in ["model.safetensors", "pytorch_model.bin", "model.gguf"] {
+            std::fs::write(snap.path().join(weight), b"WEIGHTS")?;
+        }
+        super::harvest_siblings(snap.path(), slug.path())?;
+        for weight in ["model.safetensors", "pytorch_model.bin", "model.gguf"] {
+            assert!(!slug.path().join(weight).exists());
+        }
+        Ok(())
+    }
+
+    /// Missing snapshot dir is best-effort: no error, no work.
+    #[test]
+    fn harvest_tolerates_missing_snapshot() -> anyhow::Result<()> {
+        let slug = tempfile::tempdir()?;
+        super::harvest_siblings(&slug.path().join("does-not-exist"), slug.path())?;
+        Ok(())
+    }
+
+    /// Typed slots already in slug_dir survive a harvest pass untouched.
+    #[test]
+    fn harvest_preserves_existing_dst() -> anyhow::Result<()> {
+        let snap = tempfile::tempdir()?;
+        let slug = tempfile::tempdir()?;
+        let typed = snap.path().join("config.json");
+        std::fs::write(&typed, b"cfg")?;
+        std::os::unix::fs::symlink(&typed, slug.path().join("config.json"))?;
+        // Drop a different file in snap so the harvest does something.
+        std::fs::write(snap.path().join("special_tokens_map.json"), b"st")?;
+        super::harvest_siblings(snap.path(), slug.path())?;
+        let preserved = slug.path().join("config.json");
+        assert!(preserved.is_symlink());
+        assert!(slug.path().join("special_tokens_map.json").exists());
         Ok(())
     }
 }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -314,8 +314,76 @@ fn symlink_force(target: &Path, link: &Path) -> anyhow::Result<()> {
 
 /// 1 GiB cap on metadata fetch — realistic files are <20 MiB. Bounds
 /// disk usage if a worker advertises a bogus `CheckedFile.size`, and is
-/// the fallback when `size` is absent (legacy MDCs).
+/// the fallback when `size` is absent on a `CheckedFile`.
 const ABSOLUTE_MAX_METADATA_BYTES: u64 = 1024 * 1024 * 1024;
+
+/// File extensions that identify model weights. Used by the hf:// sibling
+/// harvest to skip weight blobs (which `hub::from_hf(_, ignore_weights=true)`
+/// also already filters at download, but the snapshot dir may contain
+/// pre-existing weights from a prior unrestricted pull).
+///
+/// `.safetensors.index.json` is correctly kept: extension is `.json`.
+fn is_weight_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("safetensors" | "bin" | "gguf" | "onnx" | "tflite" | "h5" | "pt" | "pth" | "msgpack")
+    )
+}
+
+/// Symlink any non-weight file in `snapshot_dir` into `slug_dir` that
+/// isn't already present. The typed-slot resolve loop has already
+/// symlinked the 5 typed artifacts; this pass picks up the sibling
+/// metadata files (`preprocessor_config.json`, `special_tokens_map.json`,
+/// `added_tokens.json`, `tokenizer.model`, …) that downstream consumers
+/// — lightseek-mm in particular — need to instantiate HF preprocessors
+/// from `slug_dir` via `from_pretrained()`.
+///
+/// Trust model: `snapshot_dir` is either an `hub::from_hf` snapshot
+/// (HF / ModelExpress-verified) or a `file://`-resolved local
+/// directory the worker already pointed the typed slots at — i.e. a
+/// directory the typed-slot resolve trusted. Files harvested here are
+/// by definition the same canonical artifacts that ship alongside the
+/// typed slots; no new trust surface is introduced.
+fn harvest_siblings(snapshot_dir: &Path, slug_dir: &Path) -> anyhow::Result<()> {
+    let entries = match std::fs::read_dir(snapshot_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                snapshot = %snapshot_dir.display(),
+                error = %e,
+                "sibling harvest: snapshot dir unreadable, skipping",
+            );
+            return Ok(());
+        }
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() || is_weight_file(&path) {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) if !n.is_empty() => n.to_owned(),
+            _ => continue,
+        };
+        let dst = slug_dir.join(&name);
+        if dst.exists() {
+            continue;
+        }
+        // Resolve through the canonical target so a downstream
+        // `canonicalize` lands on a stable blob path rather than
+        // chasing snapshot-dir symlinks.
+        let target = std::fs::canonicalize(&path).unwrap_or(path);
+        symlink_force(&target, &dst)
+            .with_context(|| format!("harvesting {} -> {}", target.display(), dst.display()))?;
+        tracing::debug!(
+            file = %name,
+            target = %target.display(),
+            "harvested sibling into slug_dir",
+        );
+    }
+    Ok(())
+}
 
 /// Stage `uri` into `dest`, verifying staged bytes against `expected`
 /// before publishing. Schemes: `http(s)`, `file`, `hf`. For `hf://`,
@@ -991,6 +1059,34 @@ impl ModelDeploymentCard {
             cache_root = %mdc_cache_root().display(),
             "resolved model metadata files",
         );
+
+        // Pass 2.5: harvest non-weight sibling files from any directory
+        // the typed-slot resolve actually walked — hf:// snapshot dirs
+        // and file:// parent dirs (shared-mount, --model-path overlay).
+        // Consumers (lightseek-mm, vllm/sglang chat processors) read
+        // sibling files like `preprocessor_config.json` from `slug_dir`
+        // via `from_pretrained()`; without this MM-aware routing
+        // silently degrades to text-prefix. No-op for http:// (the
+        // self-host route surface — when default-ON ships, the worker
+        // will need to advertise extras itself).
+        let mut snapshot_dirs: std::collections::HashSet<PathBuf> =
+            std::collections::HashSet::new();
+        for snap in hf_snapshots.values() {
+            snapshot_dirs.insert(snap.clone());
+        }
+        for (uri, _) in &entries {
+            if let Ok(u) = url::Url::parse(uri)
+                && u.scheme() == "file"
+                && let Ok(p) = u.to_file_path()
+                && let Some(parent) = p.parent()
+                && parent.is_dir()
+            {
+                snapshot_dirs.insert(parent.to_path_buf());
+            }
+        }
+        for snap in &snapshot_dirs {
+            harvest_siblings(snap, &slug_dir)?;
+        }
 
         // Pass 3: rewrite cf.path to the cache symlink so downstream
         // tokenizer/config loaders read from a verified location.
@@ -1947,5 +2043,74 @@ mod tests {
             "TmpGuard should have unlinked the tmp on cancel; leaked: {leaked_after:?}"
         );
         assert!(!dest.exists(), "dest must not exist after cancel");
+    }
+
+    /// The harvest must:
+    /// - bring in non-weight sibling files (preprocessor_config.json,
+    ///   special_tokens_map.json) so MM consumers can `from_pretrained`
+    ///   the slug_dir,
+    /// - skip weight blobs (*.safetensors, *.bin, *.pt, …) so we don't
+    ///   bloat the metadata cache,
+    /// - leave existing entries alone (typed slots already symlinked
+    ///   by the resolve loop must not be overwritten or duplicated),
+    /// - keep `.safetensors.index.json` (json extension, not a weight).
+    #[test]
+    fn harvest_siblings_copies_non_weights_skipping_existing() -> anyhow::Result<()> {
+        let snap = tempfile::tempdir()?;
+        let slug = tempfile::tempdir()?;
+
+        // Sibling files we want to land in slug_dir.
+        std::fs::write(snap.path().join("preprocessor_config.json"), b"pre")?;
+        std::fs::write(snap.path().join("special_tokens_map.json"), b"st")?;
+        std::fs::write(snap.path().join("added_tokens.json"), b"at")?;
+        std::fs::write(snap.path().join("model.safetensors.index.json"), b"idx")?;
+        // Sentencepiece tokenizer model — non-weight `.model` extension.
+        std::fs::write(snap.path().join("tokenizer.model"), b"sp")?;
+
+        // Weight blobs we must NOT copy.
+        std::fs::write(snap.path().join("model.safetensors"), b"WEIGHTS")?;
+        std::fs::write(snap.path().join("pytorch_model.bin"), b"WEIGHTS")?;
+        std::fs::write(snap.path().join("model.gguf"), b"WEIGHTS")?;
+        std::fs::write(snap.path().join("model.onnx"), b"WEIGHTS")?;
+
+        // Typed slot already symlinked by the resolve loop. Harvest must
+        // skip it (and must not error on the pre-existing dst).
+        let typed_slot_blob = snap.path().join("config.json");
+        std::fs::write(&typed_slot_blob, b"cfg")?;
+        std::os::unix::fs::symlink(&typed_slot_blob, slug.path().join("config.json"))?;
+
+        super::harvest_siblings(snap.path(), slug.path())?;
+
+        assert!(slug.path().join("preprocessor_config.json").exists());
+        assert!(slug.path().join("special_tokens_map.json").exists());
+        assert!(slug.path().join("added_tokens.json").exists());
+        assert!(slug.path().join("model.safetensors.index.json").exists());
+        assert!(slug.path().join("tokenizer.model").exists());
+
+        for weight in [
+            "model.safetensors",
+            "pytorch_model.bin",
+            "model.gguf",
+            "model.onnx",
+        ] {
+            assert!(
+                !slug.path().join(weight).exists(),
+                "weight {weight} must not be harvested",
+            );
+        }
+
+        // The pre-existing typed-slot symlink is intact and untouched.
+        let preserved = slug.path().join("config.json");
+        assert!(preserved.is_symlink() || preserved.exists());
+        Ok(())
+    }
+
+    /// Snapshot dir missing entirely: harvest is a no-op (best-effort).
+    #[test]
+    fn harvest_siblings_tolerates_missing_snapshot() -> anyhow::Result<()> {
+        let slug = tempfile::tempdir()?;
+        let missing = slug.path().join("does-not-exist");
+        super::harvest_siblings(&missing, slug.path())?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

After [PR #9057](https://github.com/ai-dynamo/dynamo/pull/9057) (MDC verify-and-cache pipeline), the per-model `slug_dir` only contained the 5 typed metadata slots — `config.json`, `tokenizer.json`, `tokenizer_config.json`, `generation_config.json`, `chat_template.*`. Consumers that instantiate via `from_pretrained(slug_dir)` — lightseek-mm in particular — silently degraded to text-prefix-only KV routing because sibling files (`preprocessor_config.json`, `special_tokens_map.json`, `added_tokens.json`, `tokenizer.model`) were no longer reachable from the model directory.

This PR closes that regression with a ~80-LoC harvest pass at the end of `resolve_metadata_files`. After the typed-slot resolve loop, walk every directory the resolve actually touched and symlink non-weight sibling files into `slug_dir` if they aren't already there.

## How it works

1. Collect snapshot directories from two sources:
   - every `hf://` snapshot dir returned by `hub::from_hf` (already populated in `hf_snapshots`)
   - the parent directory of every `file://` URI that the typed-slot loop resolved (covers shared-mount workers and pre-PR1 workers whose CheckedFiles rewrite through `checked_file_uri`'s rung 4 to `hf://`)
2. For each snapshot dir, walk it and symlink any file that is:
   - a regular file
   - not in the weight-extension deny-list (`.safetensors`, `.bin`, `.gguf`, `.onnx`, `.tflite`, `.h5`, `.pt`, `.pth`, `.msgpack`)
   - not already present as a typed-slot entry in `slug_dir`

The symlink target is `canonicalize`d so downstream `canonicalize`s land on a stable blob path.

## Trust boundary

No new trust surface. Every harvested file comes from a snapshot directory the typed-slot resolve already trusted — either an `hub::from_hf` snapshot (ModelExpress / HF Hub verified) or a `file://`-resolved directory the worker pointed the typed slots at. Files in `slug_dir` that arrived via this pass and files that arrived via the typed-slot loop share the same provenance.

## Coverage

| Worker mode | MDC slot URIs | Harvest fires? |
|---|---|---|
| Current `DYN_SELF_HOST_METADATA=false` (HF-backed) | `hf://` | ✅ from snapshot |
| Shared-mount worker (worker and frontend on same host / mount) | `file://` (path reachable) | ✅ from file parent |
| Pre-PR1 worker (e.g. v1.1.0 image) without shared mount | `file://` rewritten to `hf://` at rung 4 | ✅ from snapshot |
| Future `DYN_SELF_HOST_METADATA=true` | `http://` | ✗ — needs worker-advertised extras list (separate follow-up, lands before default-ON flip) |

## Compared to #9441's piece #4

[#9441](https://github.com/ai-dynamo/dynamo/pull/9441) addresses the same symptom for lightseek-mm via a new `hub::find_local_snapshot()` helper called from a `cfg(feature = "lightseek-mm")` fallback in `mdc_model_dir()`. This PR is the same fix one layer earlier and more general:

- ~15 LoC of wire-up + a ~50 LoC helper + tests, vs ~30 LoC + a new public API
- Generic across all consumers (sglang/vllm chat processors, future `image_processor_config.json` readers, …), not just lightseek-mm
- Lives in the unified `resolve_metadata_files` pipeline rather than a per-consumer fallback
- No new public API; reuses the `hf_snapshots` map the typed-slot loop already builds

If this lands, pieces 1–3 of #9441 (Phi-3 substitution, Qwen2-VL chat-template placeholder, tokenizer-loader merge) stay as-is and piece #4 plus `find_local_snapshot` can be dropped.

## Stale comment cleanup

The `ABSOLUTE_MAX_METADATA_BYTES` doc referenced a "fallback when `size` is absent (legacy MDCs)" — `is_new_format()` was already removed during the PR #9057 collapse. Updated to drop the legacy framing.

## Test plan

- [x] Unit: `harvest_siblings_copies_non_weights_skipping_existing` — non-weight siblings land, weights filtered, existing typed-slot symlinks preserved
- [x] Unit: `harvest_siblings_tolerates_missing_snapshot` — missing snapshot dir is a no-op
- [x] `cargo test -p dynamo-llm --lib model_card::` — all 15 tests pass
- [x] `cargo test -p dynamo-llm --lib` — 1101 tests pass, no regressions
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [ ] E2E: existing `mm_agg_router_qwen2-vl-2b` / `mm_agg_router_qwen2.5-vl-3b` / `mm_agg_router_phi3-vision` post-merge profiles (require GPU dispatch) — these tests use `make_image_payload_cached_tokens` and assert `cached_tokens >= 1` on a repeat MM request, which is exactly what fails today and should pass after this change
- [ ] E2E: pre-PR1 (v1.1.0) worker + this branch frontend — verify backcompat through rung-4 rewrite

## Related

- Closes the slug_dir narrowing regression in #9057
- Supersedes piece #4 of #9441
- `gh-8749` umbrella — worker self-host metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced model deployment to better handle and include sibling metadata files during resolution.

* **Tests**
  * Added unit tests for the metadata file harvesting mechanism during model resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->