### PR TITLE
fix(operator): avoid LWS service name collision

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -65,6 +65,10 @@ const (
 	KubeAnnotationDeploymentStrategy                    = "nvidia.com/deployment-strategy"
 	KubeAnnotationDeploymentRollingUpdateMaxSurge       = "nvidia.com/deployment-rolling-update-max-surge"
 	KubeAnnotationDeploymentRollingUpdateMaxUnavailable = "nvidia.com/deployment-rolling-update-max-unavailable"
+	// legacyLWSInstanceIDLabel was used by the pre-native-scaling LWS path,
+	// which created one LeaderWorkerSet per DCD replica: <dcd-name>-0,
+	// <dcd-name>-1, etc. New native-scaling LWS objects must not carry it.
+	legacyLWSInstanceIDLabel = "instance-id"
 )
 
 // DynamoComponentDeploymentReconciler reconciles a DynamoComponentDeployment object
@@ -316,12 +320,25 @@ func (r *DynamoComponentDeploymentReconciler) reconcileLeaderWorkerSetResources(
 		anyModified = true
 	}
 
+	// During a v1.1.0 -> native-scaling upgrade, the desired LWS name
+	// deliberately matches the old first indexed object (<dcd-name>-0).
+	// SyncResource updates that object's spec but does not rewrite metadata, so
+	// remove the old instance-id label before the legacy cleanup below runs.
+	if _, ok := lwsObj.Labels[legacyLWSInstanceIDLabel]; ok {
+		original := lwsObj.DeepCopy()
+		delete(lwsObj.Labels, legacyLWSInstanceIDLabel)
+		if err := r.Patch(ctx, lwsObj, client.MergeFrom(original)); err != nil {
+			return ComponentReconcileResult{}, fmt.Errorf("remove legacy instance-id label from LeaderWorkerSet %q: %w", lwsObj.Name, err)
+		}
+		anyModified = true
+	}
+
 	// Clean up legacy per-replica LeaderWorkerSets and PodGroups created
 	// before the move to native LWS scaling. The legacy code path stamped an
 	// "instance-id" label on each per-replica resource; the single-LWS path
 	// no longer sets it, so its presence reliably identifies legacy objects.
 	// We list once per resource type and prune anything we still own.
-	hasInstanceID, err := labels.NewRequirement("instance-id", selection.Exists, nil)
+	hasInstanceID, err := labels.NewRequirement(legacyLWSInstanceIDLabel, selection.Exists, nil)
 	if err != nil {
 		return ComponentReconcileResult{}, fmt.Errorf("build legacy label selector: %w", err)
 	}
@@ -337,6 +354,11 @@ func (r *DynamoComponentDeploymentReconciler) reconcileLeaderWorkerSetResources(
 	for i := range legacyLWSList.Items {
 		legacy := &legacyLWSList.Items[i]
 		if !metav1.IsControlledBy(legacy, dynamoComponentDeployment) {
+			continue
+		}
+		// The active native-scaling LWS reuses the old "-0" name. If it was
+		// listed with stale metadata, never delete it as a legacy excess object.
+		if legacy.Name == lwsObj.Name {
 			continue
 		}
 		logger.Info("Deleting legacy indexed LeaderWorkerSet", "name", legacy.Name)
@@ -540,7 +562,7 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	logs := log.FromContext(ctx)
 	logs.Info("Generating LeaderWorkerSet")
 
-	kubeName := opt.dynamoComponentDeployment.Name
+	kubeName := leaderWorkerSetName(opt.dynamoComponentDeployment)
 	kubeNs := opt.dynamoComponentDeployment.Namespace
 	labels := dynamo.GetDCDKubeLabels(opt.dynamoComponentDeployment)
 
@@ -591,6 +613,18 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	}
 
 	return leaderWorkerSet, false, nil
+}
+
+// leaderWorkerSetName returns the single native-scaling LWS name.
+//
+// Before native LWS scaling, the operator created one LWS per DCD replica,
+// named <dcd-name>-0, <dcd-name>-1, and so on. Native scaling creates exactly
+// one LWS and stores the replica count in LeaderWorkerSet.Spec.Replicas, but we
+// keep the <dcd-name>-0 resource name so an existing v1.1.0 first replica can
+// be adopted and so the LWS-owned headless service does not collide with the
+// operator's ClusterIP component service at <dcd-name>.
+func leaderWorkerSetName(dcd *nvidiacomv1beta1.DynamoComponentDeployment) string {
+	return fmt.Sprintf("%s-0", dcd.Name)
 }
 
 func (r *DynamoComponentDeploymentReconciler) FinalizeResource(ctx context.Context, dynamoComponentDeployment *nvidiacomv1beta1.DynamoComponentDeployment) error {
@@ -1111,8 +1145,12 @@ func (r *DynamoComponentDeploymentReconciler) hasExistingLegacyWorkerSelector(
 	}
 
 	if r.RuntimeConfig != nil && r.RuntimeConfig.LWSEnabled {
+		// Check the restored native LWS name for legacy worker selectors. This
+		// keeps alpha-era worker labels stable while an existing "-0" LWS is
+		// being adopted during upgrade.
+		lwsName := leaderWorkerSetName(dcd)
 		leaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
-		if err := r.Get(ctx, types.NamespacedName{Name: dcd.Name, Namespace: dcd.Namespace}, leaderWorkerSet); err == nil {
+		if err := r.Get(ctx, types.NamespacedName{Name: lwsName, Namespace: dcd.Namespace}, leaderWorkerSet); err == nil {
 			template := leaderWorkerSet.Spec.LeaderWorkerTemplate
 			if template.LeaderTemplate != nil && hasLegacyWorkerSelector(template.LeaderTemplate.Labels, componentType) {
 				return true, nil
@@ -1121,7 +1159,7 @@ func (r *DynamoComponentDeploymentReconciler) hasExistingLegacyWorkerSelector(
 				return true, nil
 			}
 		} else if !k8serrors.IsNotFound(err) {
-			return false, fmt.Errorf("failed to get leaderworkerset %s/%s: %w", dcd.Namespace, dcd.Name, err)
+			return false, fmt.Errorf("failed to get leaderworkerset %s/%s: %w", dcd.Namespace, lwsName, err)
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -65,9 +65,8 @@ const (
 	KubeAnnotationDeploymentStrategy                    = "nvidia.com/deployment-strategy"
 	KubeAnnotationDeploymentRollingUpdateMaxSurge       = "nvidia.com/deployment-rolling-update-max-surge"
 	KubeAnnotationDeploymentRollingUpdateMaxUnavailable = "nvidia.com/deployment-rolling-update-max-unavailable"
-	// legacyLWSInstanceIDLabel was used by the pre-native-scaling LWS path,
-	// which created one LeaderWorkerSet per DCD replica: <dcd-name>-0,
-	// <dcd-name>-1, etc. New native-scaling LWS objects must not carry it.
+	// Marks pre-native-scaling LWS/PodGroup objects: <dcd-name>-0, -1, ...
+	// Native-scaling LWS objects must not carry it.
 	legacyLWSInstanceIDLabel = "instance-id"
 )
 
@@ -320,10 +319,8 @@ func (r *DynamoComponentDeploymentReconciler) reconcileLeaderWorkerSetResources(
 		anyModified = true
 	}
 
-	// During a v1.1.0 -> native-scaling upgrade, the desired LWS name
-	// deliberately matches the old first indexed object (<dcd-name>-0).
-	// SyncResource updates that object's spec but does not rewrite metadata, so
-	// remove the old instance-id label before the legacy cleanup below runs.
+	// The native LWS adopts the old <dcd-name>-0 object. Drop stale legacy
+	// metadata so the cleanup below does not classify it as excess.
 	if _, ok := lwsObj.Labels[legacyLWSInstanceIDLabel]; ok {
 		original := lwsObj.DeepCopy()
 		delete(lwsObj.Labels, legacyLWSInstanceIDLabel)
@@ -333,11 +330,8 @@ func (r *DynamoComponentDeploymentReconciler) reconcileLeaderWorkerSetResources(
 		anyModified = true
 	}
 
-	// Clean up legacy per-replica LeaderWorkerSets and PodGroups created
-	// before the move to native LWS scaling. The legacy code path stamped an
-	// "instance-id" label on each per-replica resource; the single-LWS path
-	// no longer sets it, so its presence reliably identifies legacy objects.
-	// We list once per resource type and prune anything we still own.
+	// Prune old per-replica LWS/PodGroups. The legacy path stamped
+	// instance-id; native scaling does not.
 	hasInstanceID, err := labels.NewRequirement(legacyLWSInstanceIDLabel, selection.Exists, nil)
 	if err != nil {
 		return ComponentReconcileResult{}, fmt.Errorf("build legacy label selector: %w", err)
@@ -356,8 +350,7 @@ func (r *DynamoComponentDeploymentReconciler) reconcileLeaderWorkerSetResources(
 		if !metav1.IsControlledBy(legacy, dynamoComponentDeployment) {
 			continue
 		}
-		// The active native-scaling LWS reuses the old "-0" name. If it was
-		// listed with stale metadata, never delete it as a legacy excess object.
+		// Keep the adopted <dcd-name>-0 LWS even if stale labels remain.
 		if legacy.Name == lwsObj.Name {
 			continue
 		}
@@ -615,14 +608,8 @@ func (r *DynamoComponentDeploymentReconciler) generateLeaderWorkerSet(ctx contex
 	return leaderWorkerSet, false, nil
 }
 
-// leaderWorkerSetName returns the single native-scaling LWS name.
-//
-// Before native LWS scaling, the operator created one LWS per DCD replica,
-// named <dcd-name>-0, <dcd-name>-1, and so on. Native scaling creates exactly
-// one LWS and stores the replica count in LeaderWorkerSet.Spec.Replicas, but we
-// keep the <dcd-name>-0 resource name so an existing v1.1.0 first replica can
-// be adopted and so the LWS-owned headless service does not collide with the
-// operator's ClusterIP component service at <dcd-name>.
+// leaderWorkerSetName keeps the native LWS at <dcd-name>-0 so it can adopt
+// legacy replicas and avoid colliding with the operator ClusterIP service.
 func leaderWorkerSetName(dcd *nvidiacomv1beta1.DynamoComponentDeployment) string {
 	return fmt.Sprintf("%s-0", dcd.Name)
 }
@@ -1145,9 +1132,7 @@ func (r *DynamoComponentDeploymentReconciler) hasExistingLegacyWorkerSelector(
 	}
 
 	if r.RuntimeConfig != nil && r.RuntimeConfig.LWSEnabled {
-		// Check the restored native LWS name for legacy worker selectors. This
-		// keeps alpha-era worker labels stable while an existing "-0" LWS is
-		// being adopted during upgrade.
+		// Check the adopted "-0" LWS to keep alpha-era worker labels stable.
 		lwsName := leaderWorkerSetName(dcd)
 		leaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
 		if err := r.Get(ctx, types.NamespacedName{Name: lwsName, Namespace: dcd.Namespace}, leaderWorkerSet); err == nil {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -2563,7 +2563,7 @@ func Test_reconcileLeaderWorkerSetResources_UpgradesLegacyIndexedLWSReplicas(t *
 	}
 
 	dcd := makeDCD()
-	var objects []client.Object
+	objects := make([]client.Object, 0, 2+2*int(replicas))
 	objects = append(objects, dcd, serviceAccount.DeepCopy())
 	// v1.1.0 represented DCD replicas as separate one-replica LWS objects.
 	// Native LWS scaling should adopt the old "-0" object, set its

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -42,6 +43,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -629,6 +631,80 @@ func TestDynamoComponentDeploymentReconciler_generateService_DottedDeleteStub(t 
 	require.Equal(t, testNormalizedDCDName, service.Name)
 }
 
+func TestDynamoComponentDeploymentReconciler_LWSNameDoesNotCollideWithComponentService(t *testing.T) {
+	s := scheme.Scheme
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, leaderworkersetv1.AddToScheme(s))
+
+	replicas := int32(1)
+	dcd := betaDCD(t, &v1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vllm-disagg-decode-4e5bb2af",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DynamoComponentDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+				ServiceName:     "decode",
+				DynamoNamespace: ptr.To("default"),
+				ComponentType:   commonconsts.ComponentTypeDecode,
+				Replicas:        &replicas,
+				Multinode: &v1alpha1.MultinodeSpec{
+					NodeCount: 2,
+				},
+				Resources: &v1alpha1.Resources{
+					Limits: &v1alpha1.ResourceItem{
+						GPU: "1",
+					},
+				},
+				ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+					MainContainer: &corev1.Container{
+						Image:   "test-image:latest",
+						Command: []string{"python3"},
+						Args:    []string{"-m", "dynamo.vllm"},
+					},
+				},
+			},
+		},
+	})
+
+	r := &DynamoComponentDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(dcd, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-test-sa",
+					Namespace: "default",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoComponentPod: commonconsts.KubeLabelValueTrue,
+					},
+				},
+			}).
+			Build(),
+		Config: &configv1alpha1.OperatorConfiguration{
+			Discovery: configv1alpha1.DiscoveryConfiguration{Backend: configv1alpha1.DiscoveryBackendKubernetes},
+		},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	service, toDelete, err := r.generateService(context.Background(), generateResourceOption{dynamoComponentDeployment: dcd})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+
+	lws, toDelete, err := r.generateLeaderWorkerSet(context.Background(), generateResourceOption{dynamoComponentDeployment: dcd})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+
+	require.Equal(t, "vllm-disagg-decode-4e5bb2af", service.Name)
+	require.Equal(t, "vllm-disagg-decode-4e5bb2af-0", lws.Name)
+	require.NotEqual(t, service.Name, lws.Name)
+}
+
 func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t *testing.T) {
 	s := scheme.Scheme
 	require.NoError(t, v1alpha1.AddToScheme(s))
@@ -789,7 +865,7 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentTypeFro
 	}
 	existingLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dcd.Name,
+			Name:      leaderWorkerSetName(dcd),
 			Namespace: dcd.Namespace,
 		},
 		Spec: leaderworkersetv1.LeaderWorkerSetSpec{
@@ -1085,7 +1161,7 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 			},
 			want: &leaderworkersetv1.LeaderWorkerSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-lws-deploy",
+					Name:      "test-lws-deploy-0",
 					Namespace: "default",
 					Labels: map[string]string{
 						"nvidia.com/label1":                          "label1",
@@ -2197,7 +2273,7 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 			existingLeaderWorkerSets: []*leaderworkersetv1.LeaderWorkerSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-component",
+						Name:      "test-component-0",
 						Namespace: "default",
 					},
 					Spec: leaderworkersetv1.LeaderWorkerSetSpec{
@@ -2223,7 +2299,7 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 				message:  "LeaderWorkerSet is ready",
 				serviceReplicaStatus: &v1beta1.ComponentReplicaStatus{
 					ComponentKind:   v1beta1.ComponentKindLeaderWorkerSet,
-					ComponentNames:  []string{"test-component"},
+					ComponentNames:  []string{"test-component-0"},
 					ReadyReplicas:   ptr.To(int32(1)),
 					UpdatedReplicas: 1,
 					Replicas:        1,
@@ -2236,7 +2312,7 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 			existingLeaderWorkerSets: []*leaderworkersetv1.LeaderWorkerSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-component",
+						Name:      "test-component-0",
 						Namespace: "default",
 					},
 					Spec: leaderworkersetv1.LeaderWorkerSetSpec{
@@ -2262,7 +2338,7 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 				message:  "LeaderWorkerSet is not ready",
 				serviceReplicaStatus: &v1beta1.ComponentReplicaStatus{
 					ComponentKind:   v1beta1.ComponentKindLeaderWorkerSet,
-					ComponentNames:  []string{"test-component"},
+					ComponentNames:  []string{"test-component-0"},
 					ReadyReplicas:   ptr.To(int32(2)),
 					UpdatedReplicas: 2,
 					Replicas:        3,
@@ -2275,7 +2351,7 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 			existingLeaderWorkerSets: []*leaderworkersetv1.LeaderWorkerSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-component",
+						Name:      "test-component-0",
 						Namespace: "default",
 					},
 					Spec: leaderworkersetv1.LeaderWorkerSetSpec{
@@ -2301,7 +2377,7 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 				message:  "LeaderWorkerSet is ready",
 				serviceReplicaStatus: &v1beta1.ComponentReplicaStatus{
 					ComponentKind:   v1beta1.ComponentKindLeaderWorkerSet,
-					ComponentNames:  []string{"test-component"},
+					ComponentNames:  []string{"test-component-0"},
 					ReadyReplicas:   ptr.To(int32(3)),
 					UpdatedReplicas: 3,
 					Replicas:        3,
@@ -2401,6 +2477,145 @@ func Test_reconcileLeaderWorkerSetResources(t *testing.T) {
 			// Assert the ComponentReconcileResult
 			g.Expect(result).To(gomega.Equal(tt.wantComponentReconcileResult))
 		})
+	}
+}
+
+func Test_reconcileLeaderWorkerSetResources_UpgradesLegacyIndexedLWSReplicas(t *testing.T) {
+	ctx := context.Background()
+	s := scheme.Scheme
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, v1beta1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, leaderworkersetv1.AddToScheme(s))
+	require.NoError(t, volcanov1beta1.AddToScheme(s))
+
+	replicas := int32(3)
+	makeDCD := func() *v1beta1.DynamoComponentDeployment {
+		dcd := betaDCD(t, &v1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-component",
+				Namespace: "default",
+				UID:       "test-dcd-uid",
+			},
+			Spec: v1alpha1.DynamoComponentDeploymentSpec{
+				BackendFramework: string(dynamo.BackendFrameworkVLLM),
+				DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+					ServiceName:     "test-service",
+					DynamoNamespace: ptr.To("default"),
+					ComponentType:   string(commonconsts.ComponentTypeDecode),
+					Replicas:        &replicas,
+					Multinode: &v1alpha1.MultinodeSpec{
+						NodeCount: 2,
+					},
+					Resources: &v1alpha1.Resources{
+						Limits: &v1alpha1.ResourceItem{
+							GPU: "1",
+						},
+					},
+					ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+						MainContainer: &corev1.Container{
+							Image:   "test-image:latest",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm"},
+						},
+					},
+				},
+			},
+		})
+		dcd.UID = "test-dcd-uid"
+		return dcd
+	}
+
+	makeOwnerRef := func(dcd *v1beta1.DynamoComponentDeployment) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: v1beta1.GroupVersion.String(),
+			Kind:       "DynamoComponentDeployment",
+			Name:       dcd.Name,
+			UID:        dcd.UID,
+			Controller: ptr.To(true),
+		}
+	}
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-test-sa",
+			Namespace: "default",
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoComponentPod: commonconsts.KubeLabelValueTrue,
+			},
+		},
+	}
+	makeReconciler := func(objs ...client.Object) *DynamoComponentDeploymentReconciler {
+		return &DynamoComponentDeploymentReconciler{
+			Client: fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(objs...).
+				WithStatusSubresource(objs...).
+				Build(),
+			Recorder:      record.NewFakeRecorder(100),
+			Config:        &configv1alpha1.OperatorConfiguration{},
+			RuntimeConfig: &controller_common.RuntimeConfig{},
+			DockerSecretRetriever: &mockDockerSecretRetriever{
+				GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+					return []string{}, nil
+				},
+			},
+		}
+	}
+
+	dcd := makeDCD()
+	var objects []client.Object
+	objects = append(objects, dcd, serviceAccount.DeepCopy())
+	// v1.1.0 represented DCD replicas as separate one-replica LWS objects.
+	// Native LWS scaling should adopt the old "-0" object, set its
+	// Spec.Replicas to the DCD replica count, and delete the excess indexed
+	// objects and their legacy PodGroups.
+	for i := range int(replicas) {
+		instanceID := fmt.Sprintf("%d", i)
+		name := fmt.Sprintf("%s-%d", dcd.Name, i)
+		objects = append(objects,
+			&leaderworkersetv1.LeaderWorkerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels: map[string]string{
+						legacyLWSInstanceIDLabel: instanceID,
+					},
+					OwnerReferences: []metav1.OwnerReference{makeOwnerRef(dcd)},
+				},
+				Spec: leaderworkersetv1.LeaderWorkerSetSpec{
+					Replicas: ptr.To(int32(1)),
+				},
+			},
+			&volcanov1beta1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					Labels: map[string]string{
+						legacyLWSInstanceIDLabel: instanceID,
+					},
+					OwnerReferences: []metav1.OwnerReference{makeOwnerRef(dcd)},
+				},
+			},
+		)
+	}
+	r := makeReconciler(objects...)
+
+	_, err := r.reconcileLeaderWorkerSetResources(ctx, dcd)
+	require.NoError(t, err)
+
+	got := &leaderworkersetv1.LeaderWorkerSet{}
+	require.NoError(t, r.Get(ctx, client.ObjectKey{Name: "test-component-0", Namespace: "default"}, got))
+	require.NotContains(t, got.Labels, legacyLWSInstanceIDLabel)
+	require.NotNil(t, got.Spec.Replicas)
+	require.Equal(t, replicas, *got.Spec.Replicas)
+
+	for _, name := range []string{"test-component-1", "test-component-2"} {
+		err = r.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &leaderworkersetv1.LeaderWorkerSet{})
+		require.True(t, k8serrors.IsNotFound(err), "expected legacy LeaderWorkerSet %q to be deleted, got %v", name, err)
+	}
+	for _, name := range []string{"test-component-0", "test-component-1", "test-component-2"} {
+		err = r.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &volcanov1beta1.PodGroup{})
+		require.True(t, k8serrors.IsNotFound(err), "expected legacy PodGroup %q to be deleted, got %v", name, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix multinode LWS deployments by restoring the LeaderWorkerSet resource name to the v1.1.0-compatible `<dcd-name>-0` form.

Bug was introduced by #5468 

This avoids a service name collision between:

- the operator-created ClusterIP component service: `<dcd-name>`
- the LWS-created headless service: `<lws-name>`

## Root Cause

Native LWS scaling changed the generated LeaderWorkerSet name from the legacy indexed form (`<dcd-name>-0`) to the DCD name directly (`<dcd-name>`).

LWS creates a headless service with the same name as the LeaderWorkerSet. The Dynamo operator also creates a ClusterIP service with the DCD name. When both used `<dcd-name>`, the LWS headless service could not be created, which broke pod DNS such as:

`<pod-name>.<headless-service-name>.<namespace>`

That caused worker pods to wait indefinitely for leader DNS resolution.

## Fix

- Generate the single native-scaling LeaderWorkerSet as <dcd-name>-0.
- Keep the operator ClusterIP component service at <dcd-name>.
- Adopt the existing v1.1.0 -0 LeaderWorkerSet during upgrade.
- Remove stale legacy instance-id metadata from the adopted -0 LeaderWorkerSet.
- Clean up excess legacy indexed LWS/PodGroup resources such as <dcd-name>-1, <dcd-name>-2, etc.
- Update legacy selector detection to look at the restored -0 LWS name.

## Upgrade Behavior
For a v1.1.0 deployment with replicas: 3:

```
<dcd-name>-0
<dcd-name>-1
<dcd-name>-2
```


the upgraded operator converges to:

`<dcd-name>-0`


with:

```
spec:
  replicas: 3
```

Closes DYN-3045

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9612" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved native LeaderWorkerSet upgrade compatibility for v1.1.0 migrations to native-scaling configurations.
  * Enhanced legacy component cleanup logic during upgrades.
  * Strengthened test coverage for LeaderWorkerSet naming and upgrade scenarios, including collision detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9612)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->