### PR TITLE
docs(parity): move Nemotron DeciLM out of Top-N

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -192,9 +192,9 @@ in the HTML chart), `V?` / `S?` = divergence not yet classified
   future SGLang releases** — re-audit on each version bump.
 
 `nemotron_deci` and `nemotron_nano` carry both daggers (`†§`) — neither
-upstream has a peer parser, so the rows are fully `n/a`. Listed here for
-completeness; Dynamo-only self-parity could be added in a follow-up but
-yields no cross-impl signal.
+upstream has a peer parser, so the rows are fully `n/a`. They live under
+**Others** for completeness; Dynamo-only self-parity could be added in a
+follow-up but yields no cross-impl signal.
 
 ### Coverage gaps — missing upstream peer parsers
 

--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -276,11 +276,10 @@ def _build_family_to_rust_ref() -> dict[str, tuple[str, int]]:
 # fixture YAML's `model_label:` field, so the label travels with the
 # family definition, not with this script.
 #
-# Source of truth: the Top-8 models in DIS-1839's Medium Term Plan,
-# mirrored in DIS-1842 ("Top-N model unit-test coverage matrix") under
-# its "Top 8 models → parser mapping" table. When DIS-1842 changes, this
-# list and the corresponding `model_label:` fields under
-# `fixtures/<family>/PARSER.batch.yaml` must be updated together.
+# Source of truth: the tracked Top-N model mapping used by the parity
+# planning notes. When that list changes, this list and the corresponding
+# `model_label:` fields under `fixtures/<family>/PARSER.batch.yaml` must
+# be updated together.
 # Alphabetical-by-family-id within the list (matches DIS-1842's chart
 # row order).
 TOP_N_FAMILIES = [
@@ -290,7 +289,6 @@ TOP_N_FAMILIES = [
     "harmony",
     "kimi_k2",
     "minimax_m2",
-    "nemotron_deci",
     "qwen3_coder",
 ]
 


### PR DESCRIPTION
Moves `nemotron_deci` out of the Top-N parity chart list so Nemotron (DeciLM) renders under Others.

Verification: `python3 -m py_compile tests/parity/parser/generate_parity_chart.py`; `git diff --check`; generated chart shows seven Top-N rows.

/coderabbit profile chill