### PR TITLE
docs(parity): update parser parity matrix and fill missing entries

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -137,6 +137,7 @@ Cell values show how each engine's recorded `expected.<impl>` block relates to D
 - `S`, `S?`, `S!` — same as V/V?/V! for SGLang.
 - `VS`, `VS?`, `V?S`, `V!S`, `VS!`, `V?S?`, `V!S!`, … — combinations (both engines diverge with any mix of intentional/research-needed/error).
 - `n/a` — **not applicable**: engine marked `unavailable` (no parser registered for that family), OR the sub-case shape doesn't apply to this grammar (e.g. attribute-encoded DSML families have no `4.b` because there's no embedded JSON to malform).
+- `—` — **missing fixture coverage**: no fixture entry exists for that family/case yet. If the case is intentionally not applicable, add an explicit chart-only n/a stub with `description:` and `reason:` so the chart can explain it.
 
 19 parsers total — split into the **Top-N models** we prioritize and
 **Others** wired into the harness for completeness. Both sections sorted

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
@@ -103,3 +103,7 @@ cases:
         normal_text: |-
           <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
           {"location": "NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -75,3 +75,43 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>unknown_tool
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
@@ -81,3 +81,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -64,3 +64,39 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3_1 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3_1 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.4.yaml
@@ -84,3 +84,7 @@ cases:
     description: Malformed variant 4.b — not yet authored for this family
     reason: |-
       Malformed-input variant 4.b not yet authored for deepseek_v3_2; see 4.a / 4.c / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -77,3 +77,32 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v3_2 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v3_2 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      sglang:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -88,7 +88,12 @@ cases:
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
-    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="unknown_tool">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
     tools:
     - name: get_weather
       parameters:
@@ -98,11 +103,20 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
-        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       vllm:
-        calls: []
-        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
-        calls: []
-        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>unknown_tool<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -115,8 +115,6 @@ cases:
             location: NYC
         normal_text: ''
       sglang:
-        calls:
-        - name: unknown_tool
-          arguments:
-            location: NYC
+        reason: SGLang's DeepSeek V3.2 detector ignores DSML calls whose invoke name is absent from the supplied tool list; Dynamo and vLLM preserve the unknown tool call.
+        calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
@@ -83,3 +83,7 @@ cases:
     description: Malformed variant 4.b — not yet authored for this family
     reason: |-
       Malformed-input variant 4.b not yet authored for deepseek_v4; see 4.a / 4.c / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -81,3 +81,42 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v4 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v4 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="unknown_tool">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
@@ -85,3 +85,7 @@ cases:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
         reason: SGLang leaks the tool call tag into normal_text on the recovery path
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
@@ -51,3 +51,7 @@ cases:
     description: Malformed variant 4.c — not yet authored for this family
     reason: |-
       Malformed-input variant 4.c not yet authored for glm47; see 4.a / 4.b / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -64,3 +64,36 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. glm47 uses explicit <arg_key>/<arg_value> tags inside a <tool_call> envelope rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. glm47 uses explicit <arg_key>/<arg_value> tags inside a <tool_call> envelope rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: <tool_call>unknown_tool<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+        reason: vLLM forwards the unknown GLM tool name, while Dynamo validates against the supplied tools and drops the unparseable block.
+      sglang:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -60,3 +60,7 @@ cases:
     description: Malformed variant 4.d — not applicable to this family
     reason: |-
       Malformed-input variant 4.d does not apply to harmony's parser syntax (no equivalent end-marker recovery scenario).
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -75,3 +75,35 @@ cases:
           arguments:
             location: LA
         normal_text: ''
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. harmony uses channel/recipient/message envelope tokens plus a JSON payload rather than delimiter-splitting multiple calls with an in-band separator, so this separator-state regression has no separate grammar surface here.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. harmony uses channel/recipient/message envelope tokens plus a JSON payload rather than delimiter-splitting multiple calls with an in-band separator, so this separator-state regression has no separate grammar surface here. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+      sglang:
+        calls: []
+        normal_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}
+        reason: SGLang treats an unknown harmony recipient as ordinary content rather than forwarding a tool call by default.

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
@@ -72,3 +72,7 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -83,3 +83,11 @@ cases:
         calls: []
         normal_text: ''
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. hermes uses <tool_call> envelopes around JSON objects rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. hermes uses <tool_call> envelopes around JSON objects rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
@@ -71,3 +71,7 @@ cases:
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
       sglang:
         unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
@@ -62,3 +62,7 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -64,3 +64,41 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. kimi_k2 uses section/call/argument sentinel tokens rather than delimiter-splitting call bodies, so separator-looking text inside JSON arguments is not a distinct parser state from generic string escaping.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. kimi_k2 uses section/call/argument sentinel tokens rather than delimiter-splitting call bodies, so separator-looking text inside JSON arguments is not a distinct parser state from generic string escaping. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.unknown_tool:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
@@ -102,3 +102,7 @@ cases:
     description: Malformed variant 4.b — not yet authored for this family
     reason: |-
       Malformed-input variant 4.b not yet authored for minimax_m2; see 4.a / 4.c / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -77,3 +77,41 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. minimax_m2 uses XML-style tool_name/tool_args tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. minimax_m2 uses XML-style tool_name/tool_args tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <minimax:tool_name>unknown_tool</minimax:tool_name>
+      <minimax:tool_args>{"location":"NYC"}</minimax:tool_args>
+      </minimax:tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <minimax:tool_name>unknown_tool</minimax:tool_name>
+          <minimax:tool_args>{"location":"NYC"}</minimax:tool_args>
+          </minimax:tool_call>
+        reason: vLLM leaves the unknown MiniMax tool-call block in normal_text, while Dynamo drops it after tool-name validation.
+      sglang:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
@@ -75,3 +75,7 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml
@@ -73,3 +73,7 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -73,3 +73,33 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 would only exercise Dynamo-local JSON-array parsing here because neither vLLM nor SGLang has a nemotron_deci peer parser. Until a peer exists, this cross-implementation matrix intentionally treats the separator-state case as n/a for this family.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 would only exercise Dynamo-local JSON-array parsing here because neither vLLM nor SGLang has a nemotron_deci peer parser. Until a peer exists, this cross-implementation matrix intentionally treats the separator-state case as n/a for this family. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "unknown_tool", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
@@ -61,3 +61,7 @@ cases:
     description: Malformed variant 4.c — not yet authored for this family
     reason: |-
       Malformed-input variant 4.c not yet authored for nemotron_nano; see 4.a / 4.b / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -93,3 +93,30 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. nemotron_nano is a qwen3_coder-style alias with XML-ish function/parameter tags and no vLLM/SGLang peer parser, so this separator-state parity case is n/a for this family.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. nemotron_nano is a qwen3_coder-style alias with XML-ish function/parameter tags and no vLLM/SGLang peer parser, so this separator-state parity case is n/a for this family. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: <tool_call>unknown_tool<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: <tool_call>unknown_tool<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -104,7 +104,12 @@ cases:
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
-    model_text: <tool_call>unknown_tool<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    model_text: |-
+      <tool_call>
+      <function=unknown_tool>
+      <parameter=location>NYC</parameter>
+      </function>
+      </tool_call>
     tools:
     - name: get_weather
       parameters:
@@ -114,8 +119,11 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
-        normal_text: <tool_call>unknown_tool<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
@@ -66,3 +66,7 @@ cases:
         normal_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
       sglang:
         unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
@@ -50,3 +50,7 @@ cases:
     description: Malformed variant 4.c — not yet authored for this family
     reason: |-
       Malformed-input variant 4.c not yet authored for pythonic; see 4.a / 4.b / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
@@ -74,3 +74,7 @@ cases:
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -74,3 +74,35 @@ cases:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
           "get_weather", "arguments": {"location": "LA"}}</tool_call>'
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. qwen25 uses a <tool_call> envelope around a JSON object rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. qwen25 uses a <tool_call> envelope around a JSON object rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
+        reason: SGLang treats the unknown qwen25 tool call as ordinary content rather than forwarding it by default.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
@@ -65,3 +65,7 @@ cases:
     description: Malformed variant 4.c — not yet authored for this family
     reason: |-
       Malformed-input variant 4.c not yet authored for qwen3_coder; see 4.a / 4.b / 4.d for this family's malformed-input scenarios.
+  PARSER.batch.4.e:
+    description: Malformed-prefix recovery — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.4.e is specific to llama3_json's raw JSON-object scanner: a malformed JSON-looking prefix is followed by a complete JSON object, and the detector may resynchronize on the later object. This family uses a framed parser grammar instead of that raw JSON-prefix scanner; malformed-input coverage for this family lives in PARSER.batch.4.a through 4.d.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -85,3 +85,46 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
+  PARSER.batch.11:
+    description: Separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. qwen3_coder uses XML-ish function/parameter tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b.
+  PARSER.batch.12:
+    description: Multi-call separator-character case — n/a for this family's syntax
+    reason: |-
+      PARSER.batch.11 targets delimiter-separated parser formats. qwen3_coder uses XML-ish function/parameter tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+  PARSER.batch.13:
+    description: Unknown tool name absent from supplied tools
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=unknown_tool>
+      <parameter=location>NYC</parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -30,6 +30,7 @@ Cell markers (per peer, vllm + sglang):
   V!/S! peer has `error: <substring>` (expected to crash)
   VS, V?S, VS!, etc. — combinations
   n/a   peer marked `unavailable`, or family/case doesn't apply
+  —     no fixture entry exists for this family/case yet
 
 Footnote markers `†` (no vLLM peer) and `§` (no SGLang peer) are auto-derived
 from `expected.<impl>.unavailable` across each family's cases.
@@ -294,11 +295,51 @@ TOP_N_FAMILIES = [
     "qwen3_coder",
 ]
 
+SUB_CASE_GROUPS = [
+    ("Core", ("1", "3", "9", "10", "13")),
+    ("Multi-call", ("2.a", "2.b", "2.c", "2.d", "12")),
+    (
+        "Malformed / recovery",
+        ("4.a", "4.b", "4.c", "4.d", "4.e", "5.a", "5.b", "5.c", "5.d", "5.e"),
+    ),
+    ("Args", ("6.a", "6.b", "6.c", "7.a", "7.b", "7.c", "7.d", "11")),
+    ("Text interleaving", ("8.a", "8.b", "8.c", "8.d")),
+]
 
-def _sub_sort_key(sub: str) -> tuple[int, str]:
+_SUB_CASE_DISPLAY_ORDER = {
+    sub: (group_idx, sub_idx)
+    for group_idx, (_label, subs) in enumerate(SUB_CASE_GROUPS)
+    for sub_idx, sub in enumerate(subs)
+}
+
+_SUB_CASE_GROUP_INDEX_BY_SUB = {
+    sub: group_idx
+    for group_idx, (_label, subs) in enumerate(SUB_CASE_GROUPS)
+    for sub in subs
+}
+
+_SUB_CASE_GROUP_BY_SUB = {sub: label for label, subs in SUB_CASE_GROUPS for sub in subs}
+
+
+def _natural_sub_sort_key(sub: str) -> tuple[int, str]:
     """`8.a` → (8, 'a'); `9` → (9, '')."""
     parts = sub.split(".")
     return (int(parts[0]), parts[1] if len(parts) > 1 else "")
+
+
+def _sub_sort_key(sub: str) -> tuple[int, int, int, str]:
+    """Sort known cases by semantic display group, future cases naturally last."""
+    display_order = _SUB_CASE_DISPLAY_ORDER.get(sub)
+    if display_order is not None:
+        group_idx, sub_idx = display_order
+        return (0, group_idx, sub_idx, "")
+    num, suffix = _natural_sub_sort_key(sub)
+    return (1, num, 0, suffix)
+
+
+def _subcase_band_class(sub: str) -> str:
+    group_idx = _SUB_CASE_GROUP_INDEX_BY_SUB.get(sub, len(SUB_CASE_GROUPS))
+    return f"case-band-{group_idx % 2}"
 
 
 def _discover_sub_cases(cases: dict) -> list[str]:
@@ -433,7 +474,7 @@ def peer_status(case: dict, dyn: dict, impl: str) -> tuple[str, bool]:
 
 def cell_for(case: dict | None) -> str:
     if case is None:
-        return "n/a"
+        return "—"
     dyn = case.get("expected", {}).get("dynamo")
     if not isinstance(dyn, dict):
         return "n/a"
@@ -488,6 +529,7 @@ _LEGEND_MD = (
     "(`expected.dynamo.reason:` carries the explanation) · "
     "`!` expected-error suffix (e.g. V!, S! — engine crashes by design) · "
     "`n/a` not applicable · "
+    "`—` missing fixture coverage · "
     "`†` (parser column) = no vLLM peer parser for this family · "
     "`§` (parser column) = no SGLang peer parser for this family."
 )
@@ -808,6 +850,8 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
 
 
 def _cell_class(text: str) -> str:
+    if text == "—":
+        return "missing"
     if text == "n/a":
         return "na"
     if "!" in text:
@@ -838,11 +882,36 @@ def _build_na_tooltip_html(case: dict) -> str:
     return "".join(parts)
 
 
-def render_cell_html(case: dict | None) -> str:
+def _build_missing_tooltip_html(family: str, sub: str) -> str:
+    """Tooltip for an absent fixture entry.
+
+    This is intentionally distinct from an explicit n/a stub. Missing means
+    the chart has no fixture data for this family/case; explicit n/a means a
+    fixture author recorded why the case does not apply.
+    """
+    case_id = f"PARSER.batch.{sub}"
+    parts = ['<div class="ttip">']
+    parts.append(
+        f'<div class="ttip-head">{html_lib.escape(case_id)} — '
+        f"{html_lib.escape(family)}</div>"
+    )
+    parts.append('<div class="ttip-section">Missing fixture:</div>')
+    parts.append(
+        '<pre class="ttip-pre">No fixture entry exists for this family/case. '
+        "If the case is intentionally not applicable, add an explicit n/a "
+        "stub with description: and reason: so the chart can explain it.</pre>"
+    )
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def render_cell_html(case: dict | None, family: str, sub: str) -> str:
     text = cell_for(case)
     cls = _cell_class(text)
+    band_cls = _subcase_band_class(sub)
     if case is None:
-        return f'<td class="cell {cls}">{text}</td>'
+        ttip = _build_missing_tooltip_html(family, sub)
+        return f'<td class="cell {cls} {band_cls}">{text}{ttip}</td>'
 
     dyn = case.get("expected", {}).get("dynamo")
     if not isinstance(dyn, dict):
@@ -850,18 +919,20 @@ def render_cell_html(case: dict | None) -> str:
         fp = case.get("__fixture_path", "")
         ttip = _build_na_tooltip_html(case)
         if not fp:
-            return f'<td class="cell {cls}">{text}{ttip}</td>'
+            return f'<td class="cell {cls} {band_cls}">{text}{ttip}</td>'
         href = html_lib.escape(fp)
-        return f'<td class="cell {cls}"><a href="{href}">{text}</a>{ttip}</td>'
+        return (
+            f'<td class="cell {cls} {band_cls}"><a href="{href}">{text}</a>{ttip}</td>'
+        )
 
     fp = case.get("__fixture_path", "")
     # Case id + description live in the rich CSS tooltip head — don't also
     # set `title=` on the link, or browsers stack a native tooltip on top.
     ttip = _build_tooltip_html(case, dyn)
     if not fp:
-        return f'<td class="cell {cls}">{text}{ttip}</td>'
+        return f'<td class="cell {cls} {band_cls}">{text}{ttip}</td>'
     href = html_lib.escape(fp)
-    return f'<td class="cell {cls}"><a href="{href}">{text}</a>{ttip}</td>'
+    return f'<td class="cell {cls} {band_cls}"><a href="{href}">{text}</a>{ttip}</td>'
 
 
 def _parser_inheritance_tooltip_html(
@@ -1035,7 +1106,9 @@ def render_row_html(
     no_sglang: set[str],
     inheritance: dict[str, dict],
 ) -> str:
-    cells = "".join(render_cell_html(cases.get((family, sub))) for sub in sub_cases)
+    cells = "".join(
+        render_cell_html(cases.get((family, sub)), family, sub) for sub in sub_cases
+    )
     return (
         f'<tr><td class="model">{html_lib.escape(model)}</td>'
         f"{_parser_cell_html(family, refs, no_vllm, no_sglang, inheritance)}"
@@ -1088,7 +1161,36 @@ def _subcase_header_html(sub: str, descriptions: dict[str, str]) -> str:
     desc = descriptions.get(sub) or descriptions.get(sub.split(".")[0]) or ""
     href = "../../../lib/parsers/PARSER_CASES.md"
     title = html_lib.escape(desc) if desc else ""
-    return f'<th><a href="{href}" title="{title}">{html_lib.escape(sub)}</a></th>'
+    band_cls = _subcase_band_class(sub)
+    return (
+        f'<th class="case-sub {band_cls}">'
+        f'<a href="{href}" title="{title}">{html_lib.escape(sub)}</a></th>'
+    )
+
+
+def _subcase_group_label(sub: str) -> str:
+    return _SUB_CASE_GROUP_BY_SUB.get(sub, "Other")
+
+
+def _subcase_group_headers_html(sub_cases: list[str]) -> str:
+    """Build semantic group headers spanning the displayed sub-case columns."""
+    spans: list[str] = [
+        '<th rowspan="2">model</th>',
+        '<th rowspan="2">parser</th>',
+    ]
+    start = 0
+    while start < len(sub_cases):
+        label = _subcase_group_label(sub_cases[start])
+        end = start + 1
+        while end < len(sub_cases) and _subcase_group_label(sub_cases[end]) == label:
+            end += 1
+        band_cls = _subcase_band_class(sub_cases[start])
+        spans.append(
+            f'<th class="case-group {band_cls}" colspan="{end - start}">'
+            f"{html_lib.escape(label)}</th>"
+        )
+        start = end
+    return "".join(spans)
 
 
 def _glossary_html(descriptions: dict[str, str], sub_cases: list[str]) -> str:
@@ -1115,6 +1217,11 @@ body { font-family: -apple-system, system-ui, sans-serif; margin: 1.5em; }
 table { border-collapse: collapse; font-family: ui-monospace, monospace; font-size: 13px; }
 th, td { border: 1px solid #ccc; padding: 3px 4px; }
 th { background: #f5f5f5; }
+th.case-group { font-family: -apple-system, system-ui, sans-serif; font-size: 12px; }
+th.case-group.case-band-0 { background: #f1f3f5; }
+th.case-group.case-band-1 { background: #ffffff; }
+th.case-sub.case-band-0, td.cell.case-band-0 { background: #f8f9fa; }
+th.case-sub.case-band-1, td.cell.case-band-1 { background: #ffffff; }
 .parser-base   { color: #888;    font-size: 11px; margin-left: 4px; }
 .parser-suffix { color: #007acc; font-weight: bold; vertical-align: super; font-size: 0.75em; }
 th a { color: inherit; text-decoration: none; }
@@ -1128,6 +1235,7 @@ td.cell.documented { color: #555; }
 td.cell.research   { color: #c63;    font-weight: bold; }
 td.cell.err        { color: #b00;    font-weight: bold; }
 td.cell.na         { color: #aaa; }
+td.cell.missing    { color: #8a6d3b; }
 td.cell a { color: inherit; text-decoration: none; display: block; }
 td.cell a:hover { background: #ffd; }
 tr.section td { background: #eef; font-weight: bold; text-align: left; }
@@ -1255,6 +1363,7 @@ def _legend_html(versions: dict[str, str]) -> str:
         '<span style="color:#b00">!</span> expected-error suffix '
         "(e.g. V!, S! — engine crashes by design) · "
         '<span style="color:#aaa">n/a</span> not applicable · '
+        '<span style="color:#8a6d3b">—</span> missing fixture coverage · '
         '<span class="parser-suffix">†</span> = no vLLM peer parser for this family · '
         '<span class="parser-suffix">§</span> = no SGLang peer parser for this family.'
         "<br><br>"
@@ -1285,12 +1394,16 @@ def _compute_stats(
         "research": 0,
         "errors": 0,
         "na": 0,
+        "missing": 0,
     }
     for fam in families:
         for sub in sub_cases:
             case = cases.get((fam, sub))
             text = cell_for(case)
-            if case is None or text == "n/a":
+            if text == "—":
+                s["missing"] += 1
+                continue
+            if text == "n/a":
                 s["na"] += 1
                 continue
             s["real"] += 1
@@ -1309,7 +1422,7 @@ def _stats_html(s: dict[str, int]) -> str:
     return (
         '<p class="stats">'
         f"Stats: {s['families']} families × {s['sub_cases']} sub-cases "
-        f"= {s['slots']} grid slots ({s['na']} n/a). "
+        f"= {s['slots']} grid slots ({s['na']} n/a, {s['missing']} missing). "
         f"<strong>{s['real']}</strong> real cases: "
         f'<span style="color:#0a7d2c">{s["parity"]} full parity</span> · '
         f'<span style="color:#555">{s["documented"]} documented divergences</span> '
@@ -1333,9 +1446,7 @@ def render_html(
     refs = _build_family_to_rust_ref()
     inheritance = _build_family_inheritance(refs)
 
-    fixed_headers = "".join(
-        f"<th>{html_lib.escape(h)}</th>" for h in ("model", "parser")
-    )
+    group_headers = _subcase_group_headers_html(sub_cases)
     sub_headers = "".join(_subcase_header_html(sub, descriptions) for sub in sub_cases)
     n_cols = 2 + len(sub_cases)
 
@@ -1361,7 +1472,7 @@ def render_html(
 
     table_html = (
         "<table>"
-        f"<thead><tr>{fixed_headers}{sub_headers}</tr></thead>"
+        f"<thead><tr>{group_headers}</tr><tr>{sub_headers}</tr></thead>"
         f"<tbody>{''.join(body_rows)}</tbody>"
         "</table>"
     )


### PR DESCRIPTION
#### Overview:

There were quite a few missing fixture slots (e.g. n/a cells). This PR adds the n/a explanations, and re-groups the generated chart.

#### Details:

<img width="1715" height="741" alt="image" src="https://github.com/user-attachments/assets/3d7e26ac-d0b2-4695-962e-a19a00c76930" />

- **How is this fixed?** Fill missing parser-family entries with explicit fixtures/reasons and group chart columns by behavior.
- Use `—` only for truly missing fixture coverage; keep generated `PARITY.md` / `PARITY.html` local-only.

#### Verification:

`python3 -m py_compile tests/parity/parser/generate_parity_chart.py`, regenerated local PARITY.md/HTML, and `git diff --check` passed; parser parity pytest passed before the presentation-only regrouping (`933 passed, 891 skipped`).

#### Where should the reviewer start?

`tests/parity/parser/generate_parity_chart.py`, then `tests/parity/parser/fixtures/*/PARSER.batch*.yaml`

#### Related Issues:

Relates to DIS-1842

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded parser parity test coverage across multiple model families with new test cases for malformed input recovery, separator character handling, and unknown tool name scenarios.
  * Enhanced parity chart visualization with improved tracking of missing fixture coverage and semantic grouping of related test sub-cases.

* **Documentation**
  * Updated test documentation to clarify fixture coverage markers and applicability guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9614)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->