### PR TITLE
fix(vllm-omni): force eager mode for Wan2.2 video launchers (cherry-pick #9563)

### DIFF
--- a/examples/backends/vllm/launch/agg_omni_i2v.sh
+++ b/examples/backends/vllm/launch/agg_omni_i2v.sh
@@ -65,11 +65,17 @@ FRONTEND_PID=$!
 sleep 2
 
 echo "Starting Omni worker..."
+# --enforce-eager works around a CUDA illegal memory access in the upstream
+# vllm-omni Wan2.2 transformer: WanSelfAttention.forward constructs and assigns
+# RotaryEmbeddingWan to self inside the forward pass, mutating self._modules
+# under torch.compile and triggering a graph break. Remove this flag once
+# vllm-omni hoists the rotary embedding into __init__.
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     python -m dynamo.vllm.omni \
     --model "$MODEL" \
     --output-modalities video \
     --media-output-fs-url file:///tmp/dynamo_media \
+    --enforce-eager \
     "${EXTRA_ARGS[@]}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/backends/vllm/launch/agg_omni_video.sh
+++ b/examples/backends/vllm/launch/agg_omni_video.sh
@@ -51,11 +51,17 @@ FRONTEND_PID=$!
 sleep 2
 
 echo "Starting Omni worker..."
+# --enforce-eager works around a CUDA illegal memory access in the upstream
+# vllm-omni Wan2.2 transformer: WanSelfAttention.forward constructs and assigns
+# RotaryEmbeddingWan to self inside the forward pass, mutating self._modules
+# under torch.compile and triggering a graph break. Remove this flag once
+# vllm-omni hoists the rotary embedding into __init__.
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     python -m dynamo.vllm.omni \
     --model "$MODEL" \
     --output-modalities video \
     --media-output-fs-url file:///tmp/dynamo_media \
+    --enforce-eager \
     $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 


### PR DESCRIPTION
Cherry-pick of #9563 onto `release/1.2.0`.

## Summary

Adds `--enforce-eager` to `agg_omni_video.sh` and `agg_omni_i2v.sh` (matching `agg_omni_audio.sh`) to bypass a CUDA illegal memory access in vllm-omni's Wan2.2 transformer.

Root cause is upstream: `WanSelfAttention.forward` assigns a fresh `RotaryEmbeddingWan` to `self` on every forward, mutating `self._modules` under `torch.compile` and triggering a graph break that surfaces as an async CUDA fault. Drop this flag once vllm-omni hoists the rotary embedding into `__init__`.

## Test plan

- [x] `--enforce-eager` parses through `dynamo.vllm.omni.args.parse_omni_args` (`cfg.diffusion.enforce_eager == True`).
- [ ] Run both launchers on H100 and confirm the worker boots and serves a `/v1/videos` request.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->