### PR TITLE
feat(runtime): fire activity notifier on TRT-LLM prefill request entry

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Optional
 
-from dynamo._core import Context
+from dynamo._core import Context, fire_activity_notifier, register_activity_notifier
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
@@ -99,6 +99,7 @@ class PrefillHandler(HandlerBase):
     ):
         super().__init__(config)
         self._encoder_cache = encoder_cache
+        register_activity_notifier("kv_transfer")
 
     async def remote_encode_with_nixl(self, request: dict, context=None):
         """
@@ -137,7 +138,7 @@ class PrefillHandler(HandlerBase):
         Frontend routes to decode workers automatically.
         """
         logging.debug(f"Prefill Request ID: {context.id()}")
-        logging.debug(f"PrefillHandler.generate received request: {request}")
+        fire_activity_notifier("kv_transfer")
         embeddings_tensor = None
         ep_disaggregated_params = None
 

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import AsyncGenerator
 from typing import Optional
 
-from dynamo._core import Context, fire_activity_notifier, register_activity_notifier
+from dynamo._core import Context
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
@@ -99,7 +99,8 @@ class PrefillHandler(HandlerBase):
     ):
         super().__init__(config)
         self._encoder_cache = encoder_cache
-        register_activity_notifier("kv_transfer")
+        if self.runtime and self.generate_endpoint:
+            self.runtime.register_activity_notifier(self.generate_endpoint.name())
 
     async def remote_encode_with_nixl(self, request: dict, context=None):
         """
@@ -138,7 +139,8 @@ class PrefillHandler(HandlerBase):
         Frontend routes to decode workers automatically.
         """
         logging.debug(f"Prefill Request ID: {context.id()}")
-        fire_activity_notifier("kv_transfer")
+        if self.runtime and self.generate_endpoint:
+            self.runtime.fire_activity_notifier(self.generate_endpoint.name())
         embeddings_tensor = None
         ep_disaggregated_params = None
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -868,6 +868,15 @@ impl DistributedRuntime {
 
 #[pymethods]
 impl Endpoint {
+    /// Return the endpoint's name (e.g. "generate").
+    ///
+    /// This is the same key used by serve_endpoint when it registers the
+    /// endpoint with SystemHealth, so it can be passed directly to
+    /// DistributedRuntime.register_activity_notifier / fire_activity_notifier.
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
     #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None))]
     fn serve_endpoint<'p>(
         &self,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -840,7 +840,8 @@ impl DistributedRuntime {
     /// Fire the activity notifier with the given name (wake its Waiter).
     /// Returns true if the notifier was found and fired, false if not registered (no-op).
     fn fire_activity_notifier(&self, name: String) -> PyResult<bool> {
-        let health = self.inner.system_health().lock();
+        let system_health = self.inner.system_health();
+        let health = system_health.lock();
         if let Some(notifier) = health.get_endpoint_activity_check_notifier(&name) {
             notifier.notify_one();
             Ok(true)

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -827,6 +827,28 @@ impl DistributedRuntime {
         Ok(())
     }
 
+    /// Register an activity notifier with the given name.
+    /// Idempotent: subsequent calls with the same name are no-ops.
+    fn register_activity_notifier(&self, name: String) -> PyResult<()> {
+        self.inner
+            .system_health()
+            .lock()
+            .register_activity_notifier(&name, Arc::new(tokio::sync::Notify::new()));
+        Ok(())
+    }
+
+    /// Fire the activity notifier with the given name (wake its Waiter).
+    /// Returns true if the notifier was found and fired, false if not registered (no-op).
+    fn fire_activity_notifier(&self, name: String) -> PyResult<bool> {
+        let health = self.inner.system_health().lock();
+        if let Some(notifier) = health.get_endpoint_activity_check_notifier(&name) {
+            notifier.notify_one();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     // This is used to pass the DistributedRuntime from the dynamo-runtime bindings
     // to the KVBM bindings, since KVBM cannot directly use the struct from this cdylib.
     // TODO: Create a separate crate "dynamo-python" so that all binding crates can import

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -120,6 +120,20 @@ class DistributedRuntime:
         """
         ...
 
+    def register_activity_notifier(self, name: str) -> None:
+        """
+        Register an activity notifier with the given name.
+        Idempotent: subsequent calls with the same name are no-ops.
+        """
+        ...
+
+    def fire_activity_notifier(self, name: str) -> bool:
+        """
+        Fire the activity notifier with the given name (wake its Waiter).
+        Returns true if the notifier was found and fired, false if not registered (no-op).
+        """
+        ...
+
     def register_engine_route(
         self,
         route_name: str,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -168,6 +168,15 @@ class Endpoint:
 
     ...
 
+    def name(self) -> str:
+        """Return the endpoint name (e.g. ``"generate"``).
+
+        This is the same key used by serve_endpoint when registering with
+        SystemHealth — pass it to DistributedRuntime.register_activity_notifier
+        and fire_activity_notifier so the health check can observe the signal.
+        """
+        ...
+
     async def serve_endpoint(self, handler: RequestHandler, graceful_shutdown: bool = True, metrics_labels: Optional[List[Tuple[str, str]]] = None, health_check_payload: Optional[Dict[str, Any]] = None) -> None:
         """
         Serve an endpoint discoverable by all connected clients at


### PR DESCRIPTION
## Summary

- Fires the activity notifier when a TRT-LLM prefill request enters the worker, enabling the disagg-aware canary health check to distinguish an idle worker from a dead one.

Companion to: https://github.com/ai-dynamo/dynamo/pull/9495

Note: Previously opened as PR#9497, which was accidentally merged into a different factory branch and reverted. This re-opens the change correctly targeting `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal system with activity notifier registration and event-firing capabilities for improved system monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9618)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->