### PR TITLE
fix(grpc): wait for WorkerSet readiness in KServe model_ready/server_ready

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -275,51 +275,35 @@ impl Model {
 
     /// Whether this model can serve at least one inference request right now.
     ///
-    /// Stricter than [`Self::is_displayable`]: requires a WorkerSet that has at
-    /// least one non-prefill serving engine attached, workers connected, and
-    /// `can_serve_requests()` true. Used by KServe gRPC `model_ready` /
-    /// `server_ready` to avoid the race where a `ModelDeploymentCard` is
-    /// registered before its WorkerSet has been wired up.
+    /// Differs from [`Self::is_displayable`] in that it does **not** fall back
+    /// to prefill-only WorkerSets: requires a WorkerSet that has a serving
+    /// engine attached, workers connected, and `can_serve_requests()` true.
+    /// Used by KServe gRPC `model_ready` / `server_ready` to avoid the race
+    /// where a `ModelDeploymentCard` is registered before its WorkerSet has
+    /// been wired up.
     pub fn is_ready_to_serve(&self) -> bool {
         self.worker_sets.iter().any(|entry| {
             let ws = entry.value();
             if ws.worker_count() == 0 || !ws.can_serve_requests() {
                 return false;
             }
-            ws.has_chat_engine()
-                || ws.has_completions_engine()
-                || ws.has_embeddings_engine()
-                || ws.has_images_engine()
-                || ws.has_tensor_engine()
-                || ws.has_videos_engine()
-                || ws.has_audios_engine()
+            ws.has_any_serving_engine()
         })
     }
 
     /// Whether this model should be visible in /v1/models.
     pub fn is_displayable(&self) -> bool {
-        let has_serving_engine = |ws: &WorkerSet| {
-            ws.has_chat_engine()
-                || ws.has_completions_engine()
-                || ws.has_embeddings_engine()
-                || ws.has_images_engine()
-                || ws.has_tensor_engine()
-                || ws.has_videos_engine()
-                || ws.has_audios_engine()
-                || ws.has_realtime_engine()
-        };
-
-        let has_any_serving_engine = self.worker_sets.iter().any(|entry| {
-            let ws = entry.value();
-            has_serving_engine(ws.as_ref())
-        });
+        let any_set_has_engine = self
+            .worker_sets
+            .iter()
+            .any(|entry| entry.value().has_any_serving_engine());
 
         self.worker_sets.iter().any(|entry| {
             let ws = entry.value();
             if ws.worker_count() == 0 || !ws.can_serve_requests() {
                 return false;
             }
-            has_serving_engine(ws.as_ref()) || (!has_any_serving_engine && ws.is_prefill_set())
+            ws.has_any_serving_engine() || (!any_set_has_engine && ws.is_prefill_set())
         })
     }
 
@@ -1167,12 +1151,11 @@ mod tests {
             "abc".to_string(),
             crate::model_card::ModelDeploymentCard::default(),
         );
+        // Keep the sender bound for the duration of the test so the watcher
+        // doesn't close.
         let (_tx, rx) = watch::channel::<Vec<u64>>(vec![]);
         ws.set_instance_watcher(rx);
         ws.chat_engine = Some(make_test_chat_engine());
-        // Keep the sender alive for the duration of the test so the watcher
-        // doesn't close.
-        let _tx_keep = _tx;
         model.add_worker_set("ns1".to_string(), Arc::new(ws));
 
         assert!(

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -273,6 +273,29 @@ impl Model {
         self.first_ready_workers().is_some()
     }
 
+    /// Whether this model can serve at least one inference request right now.
+    ///
+    /// Stricter than [`Self::is_displayable`]: requires a WorkerSet that has at
+    /// least one non-prefill serving engine attached, workers connected, and
+    /// `can_serve_requests()` true. Used by KServe gRPC `model_ready` /
+    /// `server_ready` to avoid the race where a `ModelDeploymentCard` is
+    /// registered before its WorkerSet has been wired up.
+    pub fn is_ready_to_serve(&self) -> bool {
+        self.worker_sets.iter().any(|entry| {
+            let ws = entry.value();
+            if ws.worker_count() == 0 || !ws.can_serve_requests() {
+                return false;
+            }
+            ws.has_chat_engine()
+                || ws.has_completions_engine()
+                || ws.has_embeddings_engine()
+                || ws.has_images_engine()
+                || ws.has_tensor_engine()
+                || ws.has_videos_engine()
+                || ws.has_audios_engine()
+        })
+    }
+
     /// Whether this model should be visible in /v1/models.
     pub fn is_displayable(&self) -> bool {
         let has_serving_engine = |ws: &WorkerSet| {
@@ -1101,5 +1124,84 @@ mod tests {
         model.add_worker_set("dynamo".to_string(), _ws);
 
         assert!(model.is_workers_ready("dynamo"));
+    }
+
+    // -- is_ready_to_serve tests --
+    //
+    // Regression coverage for the KServe gRPC `model_ready` race: a
+    // ModelDeploymentCard is saved before the WorkerSet's engines are wired up,
+    // and `is_ready_to_serve` must remain false until at least one serving
+    // engine is attached to a WorkerSet that has workers.
+
+    #[test]
+    fn test_is_ready_to_serve_false_when_no_worker_sets() {
+        let model = Model::new("llama".to_string());
+        assert!(!model.is_ready_to_serve());
+    }
+
+    #[test]
+    fn test_is_ready_to_serve_false_for_prefill_only_set() {
+        // A WorkerSet without any serving engine attached (the lifecycle state
+        // between ModelDeploymentCard save and engine attach) must not count
+        // as ready, even though `is_displayable` treats prefill-only as visible.
+        let model = Model::new("llama".to_string());
+        model.add_worker_set("ns1".to_string(), make_worker_set("ns1", "abc"));
+
+        assert!(
+            model.is_displayable(),
+            "displayable fallback covers prefill"
+        );
+        assert!(
+            !model.is_ready_to_serve(),
+            "prefill-only set must not be ready to serve inference"
+        );
+    }
+
+    #[test]
+    fn test_is_ready_to_serve_false_when_zero_workers_even_with_engine() {
+        // Engine attached but the discovery watcher reports zero connected
+        // workers. KServe must report not-ready until a worker is available.
+        let model = Model::new("llama".to_string());
+        let mut ws = WorkerSet::new(
+            "ns1".to_string(),
+            "abc".to_string(),
+            crate::model_card::ModelDeploymentCard::default(),
+        );
+        let (_tx, rx) = watch::channel::<Vec<u64>>(vec![]);
+        ws.set_instance_watcher(rx);
+        ws.chat_engine = Some(make_test_chat_engine());
+        // Keep the sender alive for the duration of the test so the watcher
+        // doesn't close.
+        let _tx_keep = _tx;
+        model.add_worker_set("ns1".to_string(), Arc::new(ws));
+
+        assert!(
+            !model.is_ready_to_serve(),
+            "engine attached but no workers connected -> not ready"
+        );
+    }
+
+    #[test]
+    fn test_is_ready_to_serve_true_with_chat_engine() {
+        // In-process WorkerSet (no instance_count_rx → worker_count==1) with a
+        // chat engine attached is ready to serve.
+        let model = Model::new("llama".to_string());
+        let mut ws = WorkerSet::new(
+            "ns1".to_string(),
+            "abc".to_string(),
+            crate::model_card::ModelDeploymentCard::default(),
+        );
+        ws.chat_engine = Some(make_test_chat_engine());
+        model.add_worker_set("ns1".to_string(), Arc::new(ws));
+
+        assert!(model.is_ready_to_serve());
+    }
+
+    /// Build a chat completions engine backed by the in-tree echo engine.
+    fn make_test_chat_engine()
+    -> crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine {
+        Arc::new(crate::engines::StreamingEngineAdapter::new(
+            crate::engines::make_echo_engine(),
+        ))
     }
 }

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -217,6 +217,22 @@ impl ModelManager {
         }
     }
 
+    /// Whether `model` has at least one WorkerSet that can serve an inference
+    /// request right now. See [`Model::is_ready_to_serve`].
+    pub fn is_model_ready_to_serve(&self, model: &str) -> bool {
+        self.models
+            .get(model)
+            .is_some_and(|m| m.is_ready_to_serve())
+    }
+
+    /// Whether any registered model can serve at least one inference request
+    /// right now. See [`Model::is_ready_to_serve`].
+    pub fn has_any_ready_model(&self) -> bool {
+        self.models
+            .iter()
+            .any(|entry| entry.value().is_ready_to_serve())
+    }
+
     pub fn model_display_names(&self) -> HashSet<String> {
         self.models
             .iter()
@@ -1605,5 +1621,89 @@ mod tests {
             mm.model_display_names().contains("llama"),
             "model must be visible again after prefill rejoin"
         );
+    }
+
+    // -- is_model_ready_to_serve / has_any_ready_model tests --
+    //
+    // Regression coverage for the KServe gRPC race where `model_ready` returned
+    // true as soon as a ModelDeploymentCard was saved -- before the WorkerSet
+    // with engines was attached. These checks must stay false until at least
+    // one WorkerSet carries an actual serving engine.
+
+    fn make_chat_engine()
+    -> crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine {
+        Arc::new(crate::engines::StreamingEngineAdapter::new(
+            crate::engines::make_echo_engine(),
+        ))
+    }
+
+    #[test]
+    fn test_is_model_ready_to_serve_false_for_unknown_model() {
+        let mm = ModelManager::new();
+        assert!(!mm.is_model_ready_to_serve("llama"));
+        assert!(!mm.has_any_ready_model());
+    }
+
+    #[test]
+    fn test_is_model_ready_to_serve_false_for_card_only() {
+        // Reproduces the KServe race: a ModelDeploymentCard is saved before the
+        // WorkerSet is registered. `is_model_ready_to_serve` must still be false.
+        let mm = ModelManager::new();
+        let mut card = ModelDeploymentCard::default();
+        card.display_name = "llama".to_string();
+        mm.save_model_card("instance-1", card).unwrap();
+
+        assert!(!mm.get_model_cards().is_empty(), "card was saved");
+        assert!(
+            !mm.is_model_ready_to_serve("llama"),
+            "card-only registration must not report ready"
+        );
+        assert!(
+            !mm.has_any_ready_model(),
+            "card-only registration must not flip server_ready"
+        );
+    }
+
+    #[test]
+    fn test_is_model_ready_to_serve_false_for_prefill_only_worker_set() {
+        // Worker set exists but has no engines attached (the lifecycle state
+        // between save_model_card and engine wire-up).
+        let mm = ModelManager::new();
+        mm.add_worker_set("llama", "ns1", make_worker_set("ns1", "abc"));
+
+        assert!(
+            !mm.is_model_ready_to_serve("llama"),
+            "WorkerSet without engines must not report ready"
+        );
+        assert!(!mm.has_any_ready_model());
+    }
+
+    #[test]
+    fn test_is_model_ready_to_serve_true_after_chat_engine_added() {
+        let mm = ModelManager::new();
+        mm.add_chat_completions_model("llama", "abc", make_chat_engine())
+            .unwrap();
+
+        assert!(mm.is_model_ready_to_serve("llama"));
+        assert!(mm.has_any_ready_model());
+    }
+
+    #[test]
+    fn test_has_any_ready_model_with_mixed_models() {
+        // One model is fully wired, another is only card-registered. The
+        // server-wide check must report ready as soon as any one model is.
+        let mm = ModelManager::new();
+        let mut card = ModelDeploymentCard::default();
+        card.display_name = "pending-llama".to_string();
+        mm.save_model_card("instance-pending", card).unwrap();
+
+        assert!(!mm.has_any_ready_model());
+
+        mm.add_chat_completions_model("ready-llama", "abc", make_chat_engine())
+            .unwrap();
+
+        assert!(mm.has_any_ready_model());
+        assert!(mm.is_model_ready_to_serve("ready-llama"));
+        assert!(!mm.is_model_ready_to_serve("pending-llama"));
     }
 }

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -132,15 +132,24 @@ impl WorkerSet {
         self.has_chat_engine() || self.has_completions_engine()
     }
 
+    /// Whether this set has any engine capable of producing output for an
+    /// inference request. Single source of truth for the "is something attached
+    /// that can serve a request?" question — keep the engine-kind list here so
+    /// new modalities don't need to be added in multiple readiness predicates.
+    pub fn has_any_serving_engine(&self) -> bool {
+        self.has_chat_engine()
+            || self.has_completions_engine()
+            || self.has_embeddings_engine()
+            || self.has_images_engine()
+            || self.has_tensor_engine()
+            || self.has_videos_engine()
+            || self.has_audios_engine()
+            || self.has_realtime_engine()
+    }
+
     /// Whether this set tracks a prefill model (no engine, just lifecycle)
     pub fn is_prefill_set(&self) -> bool {
-        !self.has_decode_engine()
-            && !self.has_embeddings_engine()
-            && !self.has_images_engine()
-            && !self.has_videos_engine()
-            && !self.has_audios_engine()
-            && !self.has_tensor_engine()
-            && !self.has_realtime_engine()
+        !self.has_any_serving_engine()
     }
 
     /// Build ParsingOptions from this WorkerSet's card configuration.

--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -784,9 +784,11 @@ impl GrpcInferenceService for KserveService {
         &self,
         _request: Request<inference::ServerReadyRequest>,
     ) -> Result<Response<inference::ServerReadyResponse>, Status> {
-        let has_models = !self.state.manager().get_model_cards().is_empty();
+        // Only report ready when at least one model has a WorkerSet that can
+        // actually serve an inference request — a registered ModelDeploymentCard
+        // is not enough (the WorkerSet is wired up afterwards).
         Ok(Response::new(inference::ServerReadyResponse {
-            ready: has_models,
+            ready: self.state.manager().has_any_ready_model(),
         }))
     }
 
@@ -795,14 +797,11 @@ impl GrpcInferenceService for KserveService {
         request: Request<inference::ModelReadyRequest>,
     ) -> Result<Response<inference::ModelReadyResponse>, Status> {
         let request_model_name = &request.into_inner().name;
-        let is_ready = self
-            .state
-            .manager()
-            .get_model_cards()
-            .into_iter()
-            .any(|card| request_model_name == &card.display_name);
         Ok(Response::new(inference::ModelReadyResponse {
-            ready: is_ready,
+            ready: self
+                .state
+                .manager()
+                .is_model_ready_to_serve(request_model_name),
         }))
     }
 }

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -76,10 +76,15 @@ def start_services_with_http(
         yield ports.frontend_port, ports.system_ports[0]
 
 
-def check_grpc_server_ready(
+def check_grpc_server_live(
     port: int, max_attempts: int = 30, retry_delay: float = 0.5
 ) -> bool:
-    """Check if gRPC server is ready to accept connections.
+    """Check if the gRPC server process is up and accepting connections.
+
+    Uses KServe `server_live` rather than `server_ready` because this fixture
+    runs before any worker is launched — `server_ready` only flips true once
+    a model has a WorkerSet ready to serve, which won't happen until callers
+    of this fixture start their worker processes.
 
     Args:
         port: gRPC server port
@@ -87,24 +92,24 @@ def check_grpc_server_ready(
         retry_delay: Delay between retry attempts in seconds
 
     Returns:
-        True if server is ready
+        True if server is live
 
     Raises:
-        Exception: If server is not ready after max_attempts
+        Exception: If server is not live after max_attempts
     """
     import tritonclient.grpc as grpcclient
 
     for attempt in range(max_attempts):
         try:
             client = grpcclient.InferenceServerClient(f"localhost:{port}")
-            if client.is_server_ready():
+            if client.is_server_live():
                 logger.info(
-                    f"gRPC server is ready on port {port} (attempt {attempt + 1}/{max_attempts})"
+                    f"gRPC server is live on port {port} (attempt {attempt + 1}/{max_attempts})"
                 )
-                # Add delay after readiness check to ensure server is fully stable for parallel tests
+                # Add delay after liveness check to ensure server is fully stable for parallel tests
                 # Retry the check once more to confirm stability
                 time.sleep(0.5)
-                if client.is_server_ready():
+                if client.is_server_live():
                     logger.info(f"gRPC server confirmed stable on port {port}")
                     return True
                 else:
@@ -114,11 +119,11 @@ def check_grpc_server_ready(
                     continue
         except Exception as e:
             if attempt < max_attempts - 1:
-                logger.debug(f"gRPC server not ready on attempt {attempt + 1}: {e}")
+                logger.debug(f"gRPC server not live on attempt {attempt + 1}: {e}")
                 time.sleep(retry_delay)
             else:
                 logger.error(
-                    f"gRPC server not ready after {max_attempts} attempts: {e}"
+                    f"gRPC server not live after {max_attempts} attempts: {e}"
                 )
                 raise
     return False
@@ -213,7 +218,7 @@ def start_services_with_grpc(
                 f"gRPC Frontend starting on port {ports.frontend_port} "
                 f"(metrics on {grpc_metrics_port})"
             )
-            check_grpc_server_ready(ports.frontend_port)
+            check_grpc_server_live(ports.frontend_port)
             yield ports.frontend_port, ports.system_ports[0]
     finally:
         deallocate_port(grpc_metrics_port)

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -122,9 +122,7 @@ def check_grpc_server_live(
                 logger.debug(f"gRPC server not live on attempt {attempt + 1}: {e}")
                 time.sleep(retry_delay)
             else:
-                logger.error(
-                    f"gRPC server not live after {max_attempts} attempts: {e}"
-                )
+                logger.error(f"gRPC server not live after {max_attempts} attempts: {e}")
                 raise
     return False
 


### PR DESCRIPTION
## Summary

- Fix race in KServe gRPC `model_ready` / `server_ready` where the RPC returned `true` as soon as a `ModelDeploymentCard` was registered — before the corresponding `WorkerSet` and engines were attached. Clients that immediately sent an inference request after `is_model_ready()` returned true would fail with `Connection closed unexpectedly`.
- Add `Model::is_ready_to_serve()` and `ModelManager::is_model_ready_to_serve` / `has_any_ready_model` that mirror the HTTP path: require a WorkerSet with workers connected, `can_serve_requests()` true, and at least one serving engine attached.
- Both gRPC readiness RPCs now use these helpers, so the HTTP and gRPC notions of "ready" agree.

## Background

Reported timeline (from the bug):
```
12:40:39.786  Registered base model 'Qwen3-8B' MDC   ← model_ready=true here (bug)
12:40:40.900  Connection closed unexpectedly         ← inference failed
12:40:40.929  Completions is ready                   ← WorkerSet actually attached
```

The HTTP API already gates engine selection through `select_worker_set_with` (filters `worker_count == 0 || !can_serve_requests()`). The gRPC RPCs only checked `get_model_cards()` and the model_ready check considered a model ready before any WorkerSet existed.

## Test plan

- [x] `cargo test -p dynamo-llm --lib discovery::model::` — 26 passed (4 new `is_ready_to_serve` tests)
- [x] `cargo test -p dynamo-llm --lib discovery::model_manager::` — 38 passed (5 new tests including the card-only race scenario)
- [x] `cargo clippy -p dynamo-llm --lib --tests --no-deps` — clean
- [x] Manual integration: tritonclient `is_model_ready` polling followed by immediate `infer` should now succeed (requires GPU/vLLM stack — not exercised locally)

## Related Issues

- **JIRA:** [DYN-653](https://jirasw.nvidia.com/browse/DYN-653)
- **Linear:** [DYN-3027](https://linear.app/nvidia/issue/DYN-3027)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced model readiness detection to accurately reflect when models are ready to serve inference requests.
  * Improved gRPC health check endpoints to report service and model-specific readiness based on actual worker availability.
  * Fixed race condition handling for prefill-only models and engine attachment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
