### PR TITLE
test(parity): expand PARSER.batch cases based on SGLang tests

### DIFF
--- a/lib/parsers/PARSER_CASES.md
+++ b/lib/parsers/PARSER_CASES.md
@@ -217,7 +217,7 @@ or the model emitted EOS mid-generation.
 
 ### Sub-cases
 
-Three distinct truncation shapes with different recovery contracts:
+Five distinct truncation shapes with different recovery contracts:
 
 - **`PARSER.batch.5.a`** Missing closing tag. Open fence present,
   matching close absent. The most common shape (model hit `max_tokens`
@@ -229,6 +229,14 @@ Three distinct truncation shapes with different recovery contracts:
   partway through the call body (mid-arguments, mid-name). The
   recovery contract differs from `.a`/`.b`: the call body itself is
   incomplete, not just the wrapper.
+- **`PARSER.batch.5.d`** Multi-call response where the last call is
+  complete but missing only the final end marker. Tests whether the
+  parser can recover already-closed earlier calls without treating the
+  unfinished tail as a valid call.
+- **`PARSER.batch.5.e`** Multi-call response where the last call is
+  truncated inside an argument value. Tests that completed earlier
+  calls remain recoverable while the partial trailing call is dropped,
+  preserved as text, or surfaced as an impl-defined error.
 
 ## `PARSER.batch.6` — Empty args
 
@@ -287,10 +295,14 @@ splits along four type-handling axes:
   produce `20` (int) instead. The test asserts preservation
   (Dynamo's behavior); schema-coercing impls show up as registered
   divergences.
-- **`PARSER.batch.7.d`** Multi-arg / nested / quoted / split-across-chunks.
-  Multiple parameters in one call, deeply-nested arguments, quotes/
-  brackets inside string values, and primitives split across streaming
-  token boundaries. Tests the streaming-aware concatenation logic.
+- **`PARSER.batch.7.d`** Multi-arg / nested. Multiple parameters in
+  one call plus ordinary nested object / array values. This is the
+  batch-mode nested-argument baseline.
+- **`PARSER.batch.7.e`** Large / deep / JSON-edge argument payloads.
+  Covers unusually deep objects, larger arrays, explicit JSON `null`,
+  empty nested objects, and duplicate-key / last-key-wins policy when
+  a grammar can represent it. Chunk-boundary versions of these shapes
+  belong under `PARSER.stream.3`, not here.
 
 ## `PARSER.batch.8` — Normal text interleaved with tool calls
 
@@ -335,10 +347,23 @@ Engine emits a chunk with `delta.content = ""`, or a final response
 with `tool_calls: []`, or `null` values inside arguments.
 
 - Applies to every tool-call parser.
-- Null-value handling inside parameters is parser-level
-  (`parse_parameters` in DSML handles it via
-  `serde_json::Value::Null`). Empty-choices / empty-stream handling
-  is typically at the e2e integration layer.
+- Null-value handling inside parameters is parser-level argument
+  coverage and belongs under `PARSER.batch.7` (or `PARSER.xml.2` for
+  XML schema coercion), not under this empty-output bucket.
+- Empty-choices / empty-stream handling is typically at the e2e
+  integration layer; parser fixtures should pin only what can be
+  represented as parser input.
+
+### Sub-cases
+
+- **`PARSER.batch.9.a`** Empty model text (`""`). The parser should
+  return no calls and empty normal text.
+- **`PARSER.batch.9.b`** Blank / whitespace-only model text. The
+  parser should not invent a call; preservation vs trimming of
+  whitespace is an implementation contract recorded in the fixture.
+- **`PARSER.batch.9.c`** Explicit empty tool-call container when the
+  grammar has one, such as an empty JSON-array wrapper. Grammars
+  without an empty-container spelling should mark this `N/A`.
 
 ## `PARSER.batch.10` — Duplicate tool calls (same name twice)
 
@@ -369,6 +394,17 @@ its custom argument object.
   delimiter-state regression rather than folding it into generic
   string escaping.
 
+### Sub-cases
+
+- **`PARSER.batch.11.a`** Call separator character inside a single
+  argument string value, such as semicolon or comma.
+- **`PARSER.batch.11.b`** Structural delimiter inside a string value,
+  such as braces or brackets that would otherwise affect wrapper
+  depth tracking.
+- **`PARSER.batch.11.c`** Tool-call marker / format sentinel text
+  inside a string value. Tests marker detection state, not generic
+  Unicode or escaping.
+
 ## `PARSER.batch.12` — Separator characters inside one call of a multi-call response
 
 Two or more calls are present, and one call's argument string contains a
@@ -382,6 +418,15 @@ separator-looking character before the real call separator.
   separators, but not a separator-looking character inside the first
   call's argument. This case is the combined `2.a + 11` state-machine
   check.
+
+### Sub-cases
+
+- **`PARSER.batch.12.a`** Two or more calls, with a call-separator
+  character inside one argument string before the real inter-call
+  separator.
+- **`PARSER.batch.12.b`** Two or more calls, with nested structures or
+  structural delimiters inside one call before later calls. Streaming
+  chunk-boundary versions remain `PARSER.stream.2` / `.3` co-tags.
 
 ## `PARSER.batch.13` — Unknown / unregistered tool name
 
@@ -398,6 +443,20 @@ not present in the request's supplied `tools` list.
   emitted call is syntactically valid and contains the expected
   structural keys. The unknown part is the function registry lookup
   against the request's supplied `tools` list.
+
+### Sub-cases
+
+- **`PARSER.batch.13.a`** Unknown-only call under the implementation's
+  default behavior (drop, forward, or preserve as text).
+- **`PARSER.batch.13.b`** Unknown-only call under an explicit
+  forward-unknown-tools mode, where the implementation has such a
+  switch. Mark `N/A` when the parser has no opt-in mode.
+- **`PARSER.batch.13.c`** Mixed known and unknown calls in the same
+  response. The fixture records whether the implementation extracts
+  the known call and drops / forwards / preserves the unknown one.
+- **`PARSER.batch.13.d`** Unknown native index or registry index out
+  of range for grammars that reference tools by ordinal instead of
+  name.
 
 ---
 
@@ -637,8 +696,9 @@ Minimum viable set:
    non-negotiable for any parser that sits behind a streaming
    frontend.
 6. `PARSER.batch.8` — interleaved text.
-7. `PARSER.batch.{9, 10, 13}` — empty/null, duplicate calls, and
-   unknown tool names.
+7. `PARSER.batch.9.{a,b,c}`, `PARSER.batch.10`, and
+   `PARSER.batch.13.{a,c}` — empty / blank / empty-container inputs,
+   duplicate calls, and unknown tool names.
 8. Format variants where applicable (`PARSER.fmt.{1..5}`): cover
    any that the parser's grammar permits. Mark `N/A` for those that
    don't apply. JSON-family parsers (Mistral, Llama 3 JSON, Hermes)

--- a/lib/parsers/PARSER_CASES.md
+++ b/lib/parsers/PARSER_CASES.md
@@ -54,9 +54,9 @@ fed the full model output as a single string.
 - **`PARSER.batch.8`** Normal text interleaved with tool calls.
 - **`PARSER.batch.9`** Empty content / empty `tool_calls` array / null response.
 - **`PARSER.batch.10`** Duplicate tool calls (same name twice, possibly with same args).
-- **`PARSER.batch.11`** Separator characters inside argument string values.
-- **`PARSER.batch.12`** Multiple calls where one argument contains a separator character.
 - **`PARSER.batch.13`** Unknown / unregistered tool name (valid grammar, name absent from supplied `tools`).
+- **`PARSER.batch.30`** Separator characters inside argument string values.
+- **`PARSER.batch.31`** Multiple calls where one argument contains a separator character.
 
 ### Parser, stream mode
 
@@ -375,59 +375,6 @@ the same arguments.
   distinct IDs. (The runtime / client is responsible for deciding
   whether duplicate invocation is intended.)
 
-## `PARSER.batch.11` — Separator characters inside argument strings
-
-A single call contains a grammar-level separator character inside an
-argument string value. Examples: Llama JSON uses semicolon-separated
-calls while the SQL argument contains `SELECT a; SELECT b`; JSON-array
-families use commas between calls while the SQL argument contains
-`SELECT a, SELECT b`; Gemma4 uses comma/colon/brace delimiters inside
-its custom argument object.
-
-- Applies to delimiter-separated formats.
-- The parser must not split inside a JSON string.
-- Related existing tests: `PARSER.batch.7.b` already covers escaped /
-  special string values, but not a grammar separator embedded in a
-  string. SGLang's `JsonArrayParser` tests cover comma-separator state
-  and `}` inside string values; Dynamo's `base_json_parser` documents
-  the exact `<|python_tag|>` semicolon hazard. Keep this as a separate
-  delimiter-state regression rather than folding it into generic
-  string escaping.
-
-### Sub-cases
-
-- **`PARSER.batch.11.a`** Call separator character inside a single
-  argument string value, such as semicolon or comma.
-- **`PARSER.batch.11.b`** Structural delimiter inside a string value,
-  such as braces or brackets that would otherwise affect wrapper
-  depth tracking.
-- **`PARSER.batch.11.c`** Tool-call marker / format sentinel text
-  inside a string value. Tests marker detection state, not generic
-  Unicode or escaping.
-
-## `PARSER.batch.12` — Separator characters inside one call of a multi-call response
-
-Two or more calls are present, and one call's argument string contains a
-separator-looking character before the real call separator.
-
-- Applies to delimiter-separated formats.
-- Extends `PARSER.batch.11` to the parallel-call path so the parser has to
-  distinguish in-string separators from inter-call separators while continuing
-  to parse later calls.
-- Related existing tests: `PARSER.batch.2.a` covers real call
-  separators, but not a separator-looking character inside the first
-  call's argument. This case is the combined `2.a + 11` state-machine
-  check.
-
-### Sub-cases
-
-- **`PARSER.batch.12.a`** Two or more calls, with a call-separator
-  character inside one argument string before the real inter-call
-  separator.
-- **`PARSER.batch.12.b`** Two or more calls, with nested structures or
-  structural delimiters inside one call before later calls. Streaming
-  chunk-boundary versions remain `PARSER.stream.2` / `.3` co-tags.
-
 ## `PARSER.batch.13` — Unknown / unregistered tool name
 
 The model emits a syntactically valid tool call, but the function name is
@@ -457,6 +404,59 @@ not present in the request's supplied `tools` list.
 - **`PARSER.batch.13.d`** Unknown native index or registry index out
   of range for grammars that reference tools by ordinal instead of
   name.
+
+## `PARSER.batch.30` — Separator characters inside argument strings
+
+A single call contains a grammar-level separator character inside an
+argument string value. Examples: Llama JSON uses semicolon-separated
+calls while the SQL argument contains `SELECT a; SELECT b`; JSON-array
+families use commas between calls while the SQL argument contains
+`SELECT a, SELECT b`; Gemma4 uses comma/colon/brace delimiters inside
+its custom argument object.
+
+- Applies to delimiter-separated formats.
+- The parser must not split inside a JSON string.
+- Related existing tests: `PARSER.batch.7.b` already covers escaped /
+  special string values, but not a grammar separator embedded in a
+  string. SGLang's `JsonArrayParser` tests cover comma-separator state
+  and `}` inside string values; Dynamo's `base_json_parser` documents
+  the exact `<|python_tag|>` semicolon hazard. Keep this as a separate
+  delimiter-state regression rather than folding it into generic
+  string escaping.
+
+### Sub-cases
+
+- **`PARSER.batch.30.a`** Call separator character inside a single
+  argument string value, such as semicolon or comma.
+- **`PARSER.batch.30.b`** Structural delimiter inside a string value,
+  such as braces or brackets that would otherwise affect wrapper
+  depth tracking.
+- **`PARSER.batch.30.c`** Tool-call marker / format sentinel text
+  inside a string value. Tests marker detection state, not generic
+  Unicode or escaping.
+
+## `PARSER.batch.31` — Separator characters inside one call of a multi-call response
+
+Two or more calls are present, and one call's argument string contains a
+separator-looking character before the real call separator.
+
+- Applies to delimiter-separated formats.
+- Extends `PARSER.batch.30` to the parallel-call path so the parser has to
+  distinguish in-string separators from inter-call separators while continuing
+  to parse later calls.
+- Related existing tests: `PARSER.batch.2.a` covers real call
+  separators, but not a separator-looking character inside the first
+  call's argument. This case is the combined `2.a + 30` state-machine
+  check.
+
+### Sub-cases
+
+- **`PARSER.batch.31.a`** Two or more calls, with a call-separator
+  character inside one argument string before the real inter-call
+  separator.
+- **`PARSER.batch.31.b`** Two or more calls, with nested structures or
+  structural delimiters inside one call before later calls. Streaming
+  chunk-boundary versions remain `PARSER.stream.2` / `.3` co-tags.
 
 ---
 

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
@@ -113,3 +113,85 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data
+
+      ```json
+
+      {"payload": {"regions": [{"name": "west", "scores": [1, 2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled":
+      true, "retry": null}, "empty": {}}}
+
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
@@ -115,7 +115,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data
 
       ```json

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -105,14 +105,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to deepseek_v3 because <｜tool▁sep｜> separates the function name from JSON arguments, not calls from each other.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to deepseek_v3 because <｜tool▁sep｜> separates the function name from JSON arguments, not calls from each other.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -145,3 +145,7 @@ cases:
         calls: []
         normal_text: ''
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to deepseek_v3 because there is no peer mixed known/unknown DeepSeek V3 parser case to align against.

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -40,17 +40,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
@@ -97,3 +97,78 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
@@ -99,7 +99,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
     - name: process_data

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -94,14 +94,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3_1 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to deepseek_v3_1 because <｜tool▁sep｜> separates the function name from JSON arguments, not calls from each other.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets grammar-level call separators embedded inside argument string values. deepseek_v3_1 frames each call with begin/end tokens; its <｜tool▁sep｜> token separates the function name from the JSON argument block, not calls from each other or values inside the argument JSON. Generic escaped/string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to deepseek_v3_1 because <｜tool▁sep｜> separates the function name from JSON arguments, not calls from each other.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -130,3 +130,7 @@ cases:
         calls: []
         normal_text: ''
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to deepseek_v3_1 because there is no peer mixed known/unknown DeepSeek V3.1 parser case to align against.

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -36,17 +36,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
@@ -70,3 +70,6 @@ cases:
     description: Nested-arguments test 7.d — not yet authored for this family
     reason: |-
       Nested-arguments test 7.d not yet authored for deepseek_v3_2; see 7.a / 7.b for simpler argument shapes.
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
+    reason: Large/deep JSON-edge payload test 7.e not yet authored for deepseek_v3_2; existing batch.7 coverage remains in 7.a-d.

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -41,17 +41,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -107,14 +107,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v3_2 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to deepseek_v3_2 because it uses DSML invoke/parameter tags, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v3_2 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to deepseek_v3_2 because it uses DSML invoke/parameter tags, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -148,3 +148,7 @@ cases:
         reason: SGLang's DeepSeek V3.2 detector ignores DSML calls whose invoke name is absent from the supplied tool list; Dynamo and vLLM preserve the unknown tool call.
         calls: []
         normal_text: ''
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to deepseek_v3_2 because there is no peer mixed known/unknown DeepSeek V3.2 parser case to align against.

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
@@ -72,3 +72,6 @@ cases:
     description: Nested-arguments test 7.d — not yet authored for this family
     reason: |-
       Nested-arguments test 7.d not yet authored for deepseek_v4; see 7.a / 7.b for simpler argument shapes.
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
+    reason: Large/deep JSON-edge payload test 7.e not yet authored for deepseek_v4; existing batch.7 coverage remains in 7.a-d.

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -31,6 +31,10 @@ cases:
       vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to deepseek_v4 because SGLang has no peer detector for this parser family.
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -108,14 +112,14 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v4 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to deepseek_v4 because it uses DSML invoke/parameter tags, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. deepseek_v4 uses DSML invoke/parameter tags rather than delimiter-splitting call bodies, so separator-looking characters inside values are not a distinct parser state from the existing malformed/string-value coverage. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to deepseek_v4 because it uses DSML invoke/parameter tags, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -43,16 +43,43 @@ cases:
       vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.10:

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -127,7 +127,7 @@ cases:
                 - 6
               flags:
                 enabled: true
-                retry: null
+                retry: 'null'
               empty: {}
         normal_text: ''
       vllm:

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -131,6 +131,7 @@ cases:
               empty: {}
         normal_text: ''
       vllm:
+        reason: vLLM parses Gemma-style bare null as JSON null; Dynamo and SGLang keep the token as the string 'null'.
         calls:
         - name: process_data
           arguments:
@@ -148,7 +149,7 @@ cases:
                 - 6
               flags:
                 enabled: true
-                retry: null
+                retry: 'null'
               empty: {}
         normal_text: ''
       sglang:

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -97,3 +97,78 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: <|tool_call>call:process_data{payload:{regions:[{name:<|"|>west<|"|>,scores:[1,2,3]},{name:<|"|>east<|"|>,scores:[4,5,6]}],flags:{enabled:true,retry:null},empty:{}}}<tool_call|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -127,7 +127,7 @@ cases:
                 - 6
               flags:
                 enabled: true
-                retry: 'null'
+                retry: null
               empty: {}
         normal_text: ''
       vllm:
@@ -152,7 +152,7 @@ cases:
               empty: {}
         normal_text: ''
       sglang:
-        reason: SGLang keeps the Gemma-style bare null token as the string 'null', matching Dynamo rather than vLLM JSON null coercion.
+        reason: SGLang keeps the Gemma-style bare null token as the string 'null'; Dynamo and vLLM parse it as JSON null.
         calls:
         - name: process_data
           arguments:

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -99,7 +99,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: <|tool_call>call:process_data{payload:{regions:[{name:<|"|>west<|"|>,scores:[1,2,3]},{name:<|"|>east<|"|>,scores:[4,5,6]}],flags:{enabled:true,retry:null},empty:{}}}<tool_call|>
     tools:
     - name: process_data

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -131,28 +131,6 @@ cases:
               empty: {}
         normal_text: ''
       vllm:
-        reason: vLLM parses Gemma-style bare null as JSON null; Dynamo and SGLang keep the token as the string 'null'.
-        calls:
-        - name: process_data
-          arguments:
-            payload:
-              regions:
-              - name: west
-                scores:
-                - 1
-                - 2
-                - 3
-              - name: east
-                scores:
-                - 4
-                - 5
-                - 6
-              flags:
-                enabled: true
-                retry: 'null'
-              empty: {}
-        normal_text: ''
-      sglang:
         calls:
         - name: process_data
           arguments:
@@ -171,5 +149,27 @@ cases:
               flags:
                 enabled: true
                 retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        reason: SGLang keeps the Gemma-style bare null token as the string 'null', matching Dynamo rather than vLLM JSON null coercion.
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: 'null'
               empty: {}
         normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -126,7 +126,7 @@ cases:
         normal_text: ''
   PARSER.batch.11.b:
     description: Structural delimiter inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT value WHERE note has brace } and bracket ]<|"|>}<tool_call|>
     tools:
     - name: run_query
@@ -156,8 +156,8 @@ cases:
         normal_text: ''
   PARSER.batch.11.c:
     description: Tool-call marker text inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
-    model_text: <|tool_call>call:run_query{sql:<|"|>literal <|tool_call>call:get_time{}<tool_call|> stays text<|"|>}<tool_call|>
+    ref: dynamo
+    model_text: <|tool_call>call:run_query{sql:<|"|>literal <|tool_call marker> call:get_time{} stays text<|"|>}<tool_call|>
     tools:
     - name: run_query
       parameters:
@@ -170,19 +170,19 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal <|tool_call>call:get_time{}<tool_call|> stays text
+            sql: literal <|tool_call marker> call:get_time{} stays text
         normal_text: ''
       vllm:
         calls:
         - name: run_query
           arguments:
-            sql: literal <|tool_call>call:get_time{}<tool_call|> stays text
+            sql: literal <|tool_call marker> call:get_time{} stays text
         normal_text: ''
       sglang:
         calls:
         - name: run_query
           arguments:
-            sql: literal <|tool_call>call:get_time{}<tool_call|> stays text
+            sql: literal <|tool_call marker> call:get_time{} stays text
         normal_text: ''
   PARSER.batch.12.a:
     description: Multi-call response with a separator character inside one argument string value
@@ -231,7 +231,7 @@ cases:
         normal_text: ''
   PARSER.batch.12.b:
     description: Multi-call response with structural delimiters inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT value WHERE note has brace } and bracket ]<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
     tools:
     - name: run_query
@@ -306,7 +306,7 @@ cases:
         normal_text: ''
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:unknown_tool{location:<|"|>LA<|"|>}<tool_call|>
     tools:
     - name: get_weather

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -36,17 +36,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
@@ -64,8 +94,8 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Single call with argument delimiters inside string value
+  PARSER.batch.11.a:
+    description: Call separator character inside one argument string value
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT a,b:and{brace}<|"|>}<tool_call|>
     tools:
@@ -76,16 +106,86 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &d_11
+      dynamo:
         calls:
         - name: run_query
           arguments:
             sql: SELECT a,b:and{brace}
         normal_text: ''
-      vllm: *d_11
-      sglang: *d_11
-  PARSER.batch.12:
-    description: Parallel calls where one argument contains delimiter characters
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a,b:and{brace}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a,b:and{brace}
+        normal_text: ''
+  PARSER.batch.11.b:
+    description: Structural delimiter inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: <|tool_call>call:run_query{sql:<|"|>SELECT value WHERE note has brace } and bracket ]<|"|>}<tool_call|>
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+  PARSER.batch.11.c:
+    description: Tool-call marker text inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: <|tool_call>call:run_query{sql:<|"|>literal <|tool_call>call:get_time{}<tool_call|> stays text<|"|>}<tool_call|>
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <|tool_call>call:get_time{}<tool_call|> stays text
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <|tool_call>call:get_time{}<tool_call|> stays text
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <|tool_call>call:get_time{}<tool_call|> stays text
+        normal_text: ''
+  PARSER.batch.12.a:
+    description: Multi-call response with a separator character inside one argument string value
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT a,b:and{brace}<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
     tools:
@@ -102,7 +202,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_12
+      dynamo:
         calls:
         - name: run_query
           arguments:
@@ -111,20 +211,135 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_12
-      sglang: *d_12
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a,b:and{brace}
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a,b:and{brace}
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+  PARSER.batch.12.b:
+    description: Multi-call response with structural delimiters inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: <|tool_call>call:run_query{sql:<|"|>SELECT value WHERE note has brace } and bracket ]<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L4312
     model_text: <|tool_call>call:unknown_tool{location:<|"|>NYC<|"|>}<tool_call|>
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
-      sglang: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:unknown_tool{location:<|"|>LA<|"|>}<tool_call|>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -94,8 +94,8 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11.a:
-    description: Call separator character inside one argument string value
+  PARSER.batch.30.a:
+    description: Call/body delimiters `,`, `:`, and `{}` inside one argument string value
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT a,b:and{brace}<|"|>}<tool_call|>
     tools:
@@ -124,8 +124,8 @@ cases:
           arguments:
             sql: SELECT a,b:and{brace}
         normal_text: ''
-  PARSER.batch.11.b:
-    description: Structural delimiter inside one argument string value
+  PARSER.batch.30.b:
+    description: Structural delimiters `}` and `]` inside one argument string value
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT value WHERE note has brace } and bracket ]<|"|>}<tool_call|>
     tools:
@@ -154,8 +154,8 @@ cases:
           arguments:
             sql: SELECT value WHERE note has brace } and bracket ]
         normal_text: ''
-  PARSER.batch.11.c:
-    description: Tool-call marker text inside one argument string value
+  PARSER.batch.30.c:
+    description: Tool-call marker `<|tool_call>` text inside one argument string value
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>literal <|tool_call marker> call:get_time{} stays text<|"|>}<tool_call|>
     tools:
@@ -184,8 +184,8 @@ cases:
           arguments:
             sql: literal <|tool_call marker> call:get_time{} stays text
         normal_text: ''
-  PARSER.batch.12.a:
-    description: Multi-call response with a separator character inside one argument string value
+  PARSER.batch.31.a:
+    description: Multi-call response with Gemma delimiters `,`, `:`, and `{}` inside the first argument string
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT a,b:and{brace}<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
     tools:
@@ -229,7 +229,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-  PARSER.batch.12.b:
+  PARSER.batch.31.b:
     description: Multi-call response with structural delimiters inside one argument string value
     ref: dynamo
     model_text: <|tool_call>call:run_query{sql:<|"|>SELECT value WHERE note has brace } and bracket ]<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
@@ -58,3 +58,6 @@ cases:
     description: Nested-arguments test 7.d — not yet authored for this family
     reason: |-
       Nested-arguments test 7.d not yet authored for glm47; see 7.a / 7.b for simpler argument shapes.
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
+    reason: Large/deep JSON-edge payload test 7.e not yet authored for glm47; existing batch.7 coverage remains in 7.a-d.

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -56,6 +56,10 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to glm47 because there is no peer mixed known/unknown GLM parser case to align against.
   PARSER.batch.9.b:
     description: Blank / whitespace-only model text
     ref: dynamo
@@ -94,14 +98,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. glm47 uses explicit <arg_key>/<arg_value> tags inside a <tool_call> envelope rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to glm47 because it uses <arg_key>/<arg_value> tags, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. glm47 uses explicit <arg_key>/<arg_value> tags inside a <tool_call> envelope rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to glm47 because it uses <arg_key>/<arg_value> tags, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -36,17 +36,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -138,7 +138,7 @@ cases:
         reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<|call|>
     tools:
     - name: process_data

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -136,3 +136,61 @@ cases:
         calls: []
         normal_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>
         reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<|call|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<|call|>
+        reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -110,14 +110,14 @@ cases:
             location: LA
           name: get_weather
         normal_text: ''
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. harmony uses channel/recipient/message envelope tokens plus a JSON payload rather than delimiter-splitting multiple calls with an in-band separator, so this separator-state regression has no separate grammar surface here.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to harmony because it uses channel/recipient/message envelope tokens, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. harmony uses channel/recipient/message envelope tokens plus a JSON payload rather than delimiter-splitting multiple calls with an in-band separator, so this separator-state regression has no separate grammar surface here. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to harmony because it uses channel/recipient/message envelope tokens, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -146,3 +146,7 @@ cases:
         calls: []
         normal_text: <|channel|>commentary to=functions.unknown_tool <|constrain|>json<|message|>{"location":"NYC"}<|call|>
         reason: SGLang treats an unknown harmony recipient as ordinary content rather than forwarding a tool call by default.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to harmony because there is no peer mixed known/unknown Harmony parser case to align against.

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -44,19 +44,38 @@ cases:
         calls: []
         normal_text: Hello, how can I help you today?
         reason: "Less spec-correct fallback: bare text is not a valid Harmony assistant response because no final message was emitted. A valid response would be '<|channel|>final<|message|>Hello, how can I help you today?<|return|>'."
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
     - *id001
     expected:
-      dynamo: &d_9
+      dynamo:
         calls: []
         normal_text: ''
       vllm:
         calls: []
         normal_text: ''
-      sglang: *d_9
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: '   '
+        reason: "Less spec-correct fallback: blank text is not a valid Harmony assistant response because no final message was emitted."
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
@@ -100,7 +100,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
       3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
     tools:

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
@@ -98,3 +98,79 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
+      3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -115,7 +115,7 @@ cases:
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "unknown_tool",
       "arguments": {"location": "LA"}}</tool_call>'
     tools:

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -36,17 +36,37 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
@@ -65,22 +85,70 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29
     model_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
         calls: []
+        normal_text: ''
+        reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "unknown_tool",
+      "arguments": {"location": "LA"}}</tool_call>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
   PARSER.batch.11:

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -151,11 +151,11 @@ cases:
             location: NYC
         normal_text: ''
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. hermes uses <tool_call> envelopes around JSON objects rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to hermes because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. hermes uses <tool_call> envelopes around JSON objects rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to hermes because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
@@ -104,7 +104,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '<tool_calls>[{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
       2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</tool_calls>'
     tools:

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
@@ -102,3 +102,60 @@ cases:
       vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '<tool_calls>[{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
+      2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</tool_calls>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -123,7 +123,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.11.b:
     description: Structural delimiter inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}]</tool_calls>'
     tools:
     - name: run_query
@@ -149,8 +149,8 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.11.c:
     description: Tool-call marker text inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
-    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "literal <tool_calls>[]</tool_calls> stays text"}}]</tool_calls>'
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "literal <tool_calls marker>[]</tool_calls marker> stays text"}}]</tool_calls>'
     tools:
     - name: run_query
       parameters:
@@ -163,13 +163,13 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal <tool_calls>[]</tool_calls> stays text
+            sql: literal <tool_calls marker>[]</tool_calls marker> stays text
         normal_text: ''
       vllm:
         calls:
         - name: run_query
           arguments:
-            sql: literal <tool_calls>[]</tool_calls> stays text
+            sql: literal <tool_calls marker>[]</tool_calls marker> stays text
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
@@ -213,7 +213,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.12.b:
     description: Multi-call response with structural delimiters inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},
       {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls>'
     tools:
@@ -277,7 +277,7 @@ cases:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "unknown_tool", "arguments":
       {"location": "LA"}}]</tool_calls>'
     tools:

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -96,8 +96,8 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.11.a:
-    description: Call separator character inside one argument string value
+  PARSER.batch.30.a:
+    description: JSON-array call separator `,` inside one argument string value
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}]</tool_calls>'
     tools:
     - name: run_query
@@ -121,8 +121,8 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.11.b:
-    description: Structural delimiter inside one argument string value
+  PARSER.batch.30.b:
+    description: JSON structural delimiters `}` and `]` inside one argument string value
     ref: dynamo
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}]</tool_calls>'
     tools:
@@ -147,8 +147,8 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.11.c:
-    description: Tool-call marker text inside one argument string value
+  PARSER.batch.30.c:
+    description: XML wrapper marker `<tool_calls>...</tool_calls>` text inside one argument string value
     ref: dynamo
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "literal <tool_calls marker>[]</tool_calls marker> stays text"}}]</tool_calls>'
     tools:
@@ -173,8 +173,8 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.12.a:
-    description: Multi-call response with a separator character inside one argument string value
+  PARSER.batch.31.a:
+    description: Multi-call JSON array with call separator `,` inside the first argument string
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}]</tool_calls>'
     tools:
@@ -211,7 +211,7 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.12.b:
+  PARSER.batch.31.b:
     description: Multi-call response with structural delimiters inside one argument string value
     ref: dynamo
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -38,16 +38,43 @@ cases:
       vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.10:
@@ -69,8 +96,8 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.11:
-    description: Single JSON-array call with comma inside argument string value
+  PARSER.batch.11.a:
+    description: Call separator character inside one argument string value
     model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}]</tool_calls>'
     tools:
     - name: run_query
@@ -80,18 +107,76 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &d_11
+      dynamo:
         calls:
         - name: run_query
           arguments:
             sql: SELECT a, SELECT b
         normal_text: ''
-      vllm: *d_11
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.12:
-    description: Parallel JSON-array calls where one argument contains a comma
-    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls>'
+  PARSER.batch.11.b:
+    description: Structural delimiter inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}]</tool_calls>'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.11.c:
+    description: Tool-call marker text inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "literal <tool_calls>[]</tool_calls> stays text"}}]</tool_calls>'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <tool_calls>[]</tool_calls> stays text
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <tool_calls>[]</tool_calls> stays text
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.12.a:
+    description: Multi-call response with a separator character inside one argument string value
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}]</tool_calls>'
     tools:
     - name: run_query
       parameters:
@@ -106,7 +191,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_12
+      dynamo:
         calls:
         - name: run_query
           arguments:
@@ -115,21 +200,111 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_12
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+  PARSER.batch.12.b:
+    description: Multi-call response with structural delimiters inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '<tool_calls>[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},
+      {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls>'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     model_text: '<tool_calls>[{"name": "unknown_tool", "arguments": {"location": "NYC"}}]</tool_calls>'
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "unknown_tool", "arguments":
+      {"location": "LA"}}]</tool_calls>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
@@ -98,3 +98,78 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
@@ -100,7 +100,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<|tool_call_end|><|tool_calls_section_end|>
     tools:
     - name: process_data

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -94,14 +94,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. kimi_k2 uses section/call/argument sentinel tokens rather than delimiter-splitting call bodies, so separator-looking text inside JSON arguments is not a distinct parser state from generic string escaping.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to kimi_k2 because it uses section/call/argument sentinel tokens, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. kimi_k2 uses section/call/argument sentinel tokens rather than delimiter-splitting call bodies, so separator-looking text inside JSON arguments is not a distinct parser state from generic string escaping. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to kimi_k2 because it uses section/call/argument sentinel tokens, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -132,3 +132,7 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to kimi_k2 because there is no peer mixed known/unknown Kimi K2 parser case to align against.

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -36,17 +36,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -98,3 +98,79 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '<|python_tag|>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
+      2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -100,7 +100,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '<|python_tag|>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
       2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}'
     tools:

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -127,7 +127,7 @@ cases:
         normal_text: ''
   PARSER.batch.11.b:
     description: Structural delimiter inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}'
     tools:
     - name: run_query
@@ -157,8 +157,8 @@ cases:
         normal_text: ''
   PARSER.batch.11.c:
     description: Tool-call marker text inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
-    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "literal <|python_tag|>{name:x} stays text"}}'
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "literal <|python_tag marker|>{name:x} stays text"}}'
     tools:
     - name: run_query
       parameters:
@@ -171,19 +171,19 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal <|python_tag|>{name:x} stays text
+            sql: literal <|python_tag marker|>{name:x} stays text
         normal_text: ''
       vllm:
         calls:
         - name: run_query
           arguments:
-            sql: literal <|python_tag|>{name:x} stays text
+            sql: literal <|python_tag marker|>{name:x} stays text
         normal_text: ''
       sglang:
         calls:
         - name: run_query
           arguments:
-            sql: literal <|python_tag|>{name:x} stays text
+            sql: literal <|python_tag marker|>{name:x} stays text
         normal_text: ''
   PARSER.batch.12.a:
     description: Multi-call response with a separator character inside one argument string value
@@ -233,7 +233,7 @@ cases:
         normal_text: ''
   PARSER.batch.12.b:
     description: Multi-call response with structural delimiters inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}};{"name":
       "get_time", "arguments": {"timezone": "EST"}}'
     tools:
@@ -307,7 +307,7 @@ cases:
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "unknown_tool", "arguments":
       {"location": "LA"}}'
     tools:

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -95,8 +95,8 @@ cases:
         normal_text: ''
       vllm: *id006
       sglang: *id006
-  PARSER.batch.11.a:
-    description: Call separator character inside one argument string value
+  PARSER.batch.30.a:
+    description: Llama JSON call separator `;` inside one argument string value
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}}'
     tools:
@@ -125,8 +125,8 @@ cases:
           arguments:
             sql: SELECT a; SELECT b
         normal_text: ''
-  PARSER.batch.11.b:
-    description: Structural delimiter inside one argument string value
+  PARSER.batch.30.b:
+    description: JSON structural delimiters `}` and `]` inside one argument string value
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}'
     tools:
@@ -155,8 +155,8 @@ cases:
           arguments:
             sql: SELECT value WHERE note has brace } and bracket ]
         normal_text: ''
-  PARSER.batch.11.c:
-    description: Tool-call marker text inside one argument string value
+  PARSER.batch.30.c:
+    description: Start marker `<|python_tag|>` text inside one argument string value
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "literal <|python_tag marker|>{name:x} stays text"}}'
     tools:
@@ -185,8 +185,8 @@ cases:
           arguments:
             sql: literal <|python_tag marker|>{name:x} stays text
         normal_text: ''
-  PARSER.batch.12.a:
-    description: Multi-call response with a separator character inside one argument string value
+  PARSER.batch.31.a:
+    description: Multi-call Llama JSON response with call separator `;` inside the first argument string
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}}'
@@ -231,7 +231,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-  PARSER.batch.12.b:
+  PARSER.batch.31.b:
     description: Multi-call response with structural delimiters inside one argument string value
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}};{"name":

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -36,17 +36,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id004
       sglang: *id004
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id005
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id005
-      sglang: *id005
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice, semicolon-separated)
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
@@ -65,8 +95,8 @@ cases:
         normal_text: ''
       vllm: *id006
       sglang: *id006
-  PARSER.batch.11:
-    description: Single call with semicolon inside argument string value
+  PARSER.batch.11.a:
+    description: Call separator character inside one argument string value
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}}'
     tools:
@@ -77,16 +107,86 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &id007
+      dynamo:
         calls:
         - name: run_query
           arguments:
             sql: SELECT a; SELECT b
         normal_text: ''
-      vllm: *id007
-      sglang: *id007
-  PARSER.batch.12:
-    description: Parallel calls where one argument contains a semicolon (streaming split safety)
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a; SELECT b
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a; SELECT b
+        normal_text: ''
+  PARSER.batch.11.b:
+    description: Structural delimiter inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+  PARSER.batch.11.c:
+    description: Tool-call marker text inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "literal <|python_tag|>{name:x} stays text"}}'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <|python_tag|>{name:x} stays text
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <|python_tag|>{name:x} stays text
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal <|python_tag|>{name:x} stays text
+        normal_text: ''
+  PARSER.batch.12.a:
+    description: Multi-call response with a separator character inside one argument string value
     ref: dynamo
     model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}}'
@@ -104,7 +204,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &id008
+      dynamo:
         calls:
         - name: run_query
           arguments:
@@ -113,23 +213,133 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *id008
-      sglang: *id008
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a; SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a; SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+  PARSER.batch.12.b:
+    description: Multi-call response with structural delimiters inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}};{"name":
+      "get_time", "arguments": {"timezone": "EST"}}'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29
     model_text: '<|python_tag|>{"name": "unknown_tool", "arguments": {"location": "NYC"}}'
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
         calls: []
+        normal_text: ''
+        reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "unknown_tool", "arguments":
+      {"location": "LA"}}'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
         reason: SGLang drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
@@ -70,3 +70,6 @@ cases:
     description: Nested-arguments test 7.d — not yet authored for this family
     reason: |-
       Nested-arguments test 7.d not yet authored for minimax_m2; see 7.a / 7.b for simpler argument shapes.
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
+    reason: Large/deep JSON-edge payload test 7.e not yet authored for minimax_m2; existing batch.7 coverage remains in 7.a-d.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -41,17 +41,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -61,6 +61,10 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to minimax_m2 because there is no peer mixed known/unknown MiniMax parser case to align against.
   PARSER.batch.9.b:
     description: Blank / whitespace-only model text
     ref: dynamo
@@ -107,14 +111,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. minimax_m2 uses XML-style tool_name/tool_args tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to minimax_m2 because it uses XML-style tool_name/tool_args tags, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. minimax_m2 uses XML-style tool_name/tool_args tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to minimax_m2 because it uses XML-style tool_name/tool_args tags, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
@@ -108,7 +108,7 @@ cases:
         normal_text: ''
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
       2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}][/TOOL_CALLS]'
     tools:

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
@@ -106,3 +106,61 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
+      2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}][/TOOL_CALLS]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -131,7 +131,7 @@ cases:
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   PARSER.batch.11.b:
     description: Structural delimiter inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}][/TOOL_CALLS]'
     tools:
     - name: run_query
@@ -158,8 +158,8 @@ cases:
         normal_text: ''
   PARSER.batch.11.c:
     description: Tool-call marker text inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
-    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "literal [TOOL_CALLS][][/TOOL_CALLS] stays text"}}][/TOOL_CALLS]'
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "literal [TOOL_CALLS marker][][/TOOL_CALLS marker] stays text"}}][/TOOL_CALLS]'
     tools:
     - name: run_query
       parameters:
@@ -172,13 +172,13 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal [TOOL_CALLS][][/TOOL_CALLS] stays text
+            sql: literal [TOOL_CALLS marker][][/TOOL_CALLS marker] stays text
         normal_text: ''
       vllm:
         calls:
         - name: run_query
           arguments:
-            sql: literal [TOOL_CALLS][][/TOOL_CALLS] stays text
+            sql: literal [TOOL_CALLS marker][][/TOOL_CALLS marker] stays text
         normal_text: ''
       sglang:
         calls: []
@@ -226,7 +226,7 @@ cases:
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   PARSER.batch.12.b:
     description: Multi-call response with structural delimiters inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},
       {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]'
     tools:
@@ -294,7 +294,7 @@ cases:
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "unknown_tool", "arguments":
       {"location": "LA"}}][/TOOL_CALLS]'
     tools:

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -39,17 +39,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
@@ -71,8 +101,8 @@ cases:
         calls: []
         normal_text: ''
         reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
-  PARSER.batch.11:
-    description: Single JSON-array call with comma inside argument string value
+  PARSER.batch.11.a:
+    description: Call separator character inside one argument string value
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}][/TOOL_CALLS]'
     tools:
@@ -83,21 +113,81 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &d_11
+      dynamo:
         calls:
         - name: run_query
           arguments:
             sql: SELECT a, SELECT b
         normal_text: ''
-      vllm: *d_11
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
-  PARSER.batch.12:
-    description: Parallel JSON-array calls where one argument contains a comma
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
+  PARSER.batch.11.b:
+    description: Structural delimiter inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}][/TOOL_CALLS]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.11.c:
+    description: Tool-call marker text inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "literal [TOOL_CALLS][][/TOOL_CALLS] stays text"}}][/TOOL_CALLS]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal [TOOL_CALLS][][/TOOL_CALLS] stays text
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal [TOOL_CALLS][][/TOOL_CALLS] stays text
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.12.a:
+    description: Multi-call response with a separator character inside one argument string value
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
-    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]'
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}][/TOOL_CALLS]'
     tools:
     - name: run_query
       parameters:
@@ -112,7 +202,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_12
+      dynamo:
         calls:
         - name: run_query
           arguments:
@@ -121,26 +211,119 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_12
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
+  PARSER.batch.12.b:
+    description: Multi-call response with structural delimiters inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},
+      {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_unknown_tool_name.py#L29
     model_text: '[TOOL_CALLS][{"name": "unknown_tool", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "unknown_tool", "arguments":
+      {"location": "LA"}}][/TOOL_CALLS]'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+        reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -101,8 +101,8 @@ cases:
         calls: []
         normal_text: ''
         reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
-  PARSER.batch.11.a:
-    description: Call separator character inside one argument string value
+  PARSER.batch.30.a:
+    description: JSON-array call separator `,` inside one argument string value
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}][/TOOL_CALLS]'
     tools:
@@ -129,8 +129,8 @@ cases:
         calls: []
         normal_text: ''
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
-  PARSER.batch.11.b:
-    description: Structural delimiter inside one argument string value
+  PARSER.batch.30.b:
+    description: JSON structural delimiters `}` and `]` inside one argument string value
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}][/TOOL_CALLS]'
     tools:
@@ -156,8 +156,8 @@ cases:
       sglang:
         calls: []
         normal_text: ''
-  PARSER.batch.11.c:
-    description: Tool-call marker text inside one argument string value
+  PARSER.batch.30.c:
+    description: Mistral wrapper marker `[TOOL_CALLS]...[/TOOL_CALLS]` text inside one argument string value
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "literal [TOOL_CALLS marker][][/TOOL_CALLS marker] stays text"}}][/TOOL_CALLS]'
     tools:
@@ -183,8 +183,8 @@ cases:
       sglang:
         calls: []
         normal_text: ''
-  PARSER.batch.12.a:
-    description: Multi-call response with a separator character inside one argument string value
+  PARSER.batch.31.a:
+    description: Multi-call JSON array with call separator `,` inside the first argument string
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L2736
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}][/TOOL_CALLS]'
@@ -224,7 +224,7 @@ cases:
         calls: []
         normal_text: ''
         reason: SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits
-  PARSER.batch.12.b:
+  PARSER.batch.31.b:
     description: Multi-call response with structural delimiters inside one argument string value
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
@@ -106,3 +106,41 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
+      3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</TOOLCALL>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
@@ -108,7 +108,7 @@ cases:
         unavailable: SGLang has no detector for family='nemotron_deci'
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
       3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]</TOOLCALL>'
     tools:

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -27,6 +27,10 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to nemotron_deci because neither vLLM nor SGLang has a peer parser for this family.
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -97,14 +101,14 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 would only exercise Dynamo-local JSON-array parsing here because neither vLLM nor SGLang has a nemotron_deci peer parser. Until a peer exists, this cross-implementation matrix intentionally treats the separator-state case as n/a for this family.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to nemotron_deci because neither vLLM nor SGLang has a peer parser for this family.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 would only exercise Dynamo-local JSON-array parsing here because neither vLLM nor SGLang has a nemotron_deci peer parser. Until a peer exists, this cross-implementation matrix intentionally treats the separator-state case as n/a for this family. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to nemotron_deci because neither vLLM nor SGLang has a peer parser for this family.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -40,15 +40,39 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
       dynamo:
         calls: []
         normal_text: ''
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
@@ -82,3 +82,6 @@ cases:
     description: Nested-arguments test 7.d — not yet authored for this family
     reason: |-
       Nested-arguments test 7.d not yet authored for nemotron_nano; see 7.a / 7.b for simpler argument shapes.
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
+    reason: Large/deep JSON-edge payload test 7.e not yet authored for nemotron_nano; existing batch.7 coverage remains in 7.a-d.

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -34,6 +34,10 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to nemotron_nano because neither vLLM nor SGLang has a peer parser for this family.
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -117,14 +121,14 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. nemotron_nano is a qwen3_coder-style alias with XML-ish function/parameter tags and no vLLM/SGLang peer parser, so this separator-state parity case is n/a for this family.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to nemotron_nano because it is a qwen3_coder-style XML parser with no vLLM/SGLang peer parser.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. nemotron_nano is a qwen3_coder-style alias with XML-ish function/parameter tags and no vLLM/SGLang peer parser, so this separator-state parity case is n/a for this family. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to nemotron_nano because it is a qwen3_coder-style XML parser with no vLLM/SGLang peer parser.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -47,15 +47,39 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
       dynamo:
         calls: []
         normal_text: ''
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
@@ -105,7 +105,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: 'functools[{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
       3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]'
     tools:

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
@@ -103,3 +103,42 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: 'functools[{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
+      3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -145,9 +145,9 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.30.c:
-    description: Phi-4 marker text `functools` and `[]` inside one argument string value
+    description: Phi-4 marker-like text `func-tools` and `[]` inside one argument string value
     ref: dynamo
-    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "literal functools marker[] stays text"}}]'
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "literal func-tools marker[] stays text"}}]'
     tools:
     - name: run_query
       parameters:
@@ -160,7 +160,7 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal functools marker[] stays text
+            sql: literal func-tools marker[] stays text
         normal_text: ''
       vllm:
         reason: vLLM Phi-4 splits on the marker-like bracket inside the argument string, then drops the call when JSON parsing fails.

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -140,11 +140,8 @@ cases:
             sql: SELECT value WHERE note has brace } and bracket ]
         normal_text: ''
       vllm:
-        calls:
-        - name: run_query
-          arguments:
-            sql: SELECT value WHERE note has brace } and bracket ]
-        normal_text: ''
+        reason: vLLM Phi-4 splits on the closing bracket inside the argument string, then drops the call when JSON parsing fails.
+        calls: []
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.11.c:
@@ -166,11 +163,8 @@ cases:
             sql: literal functools marker[] stays text
         normal_text: ''
       vllm:
-        calls:
-        - name: run_query
-          arguments:
-            sql: literal functools marker[] stays text
-        normal_text: ''
+        reason: vLLM Phi-4 splits on the marker-like bracket inside the argument string, then drops the call when JSON parsing fails.
+        calls: []
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.12.a:
@@ -240,14 +234,8 @@ cases:
             timezone: EST
         normal_text: ''
       vllm:
-        calls:
-        - name: run_query
-          arguments:
-            sql: SELECT value WHERE note has brace } and bracket ]
-        - name: get_time
-          arguments:
-            timezone: EST
-        normal_text: ''
+        reason: vLLM Phi-4 splits on the closing bracket inside the first argument string, then drops all calls when JSON parsing fails.
+        calls: []
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.13.a:

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -38,16 +38,43 @@ cases:
       vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.10:
@@ -69,8 +96,8 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.11:
-    description: Single JSON-array call with comma inside argument string value
+  PARSER.batch.11.a:
+    description: Call separator character inside one argument string value
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}]'
     tools:
     - name: run_query
@@ -80,18 +107,76 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &d_11
+      dynamo:
         calls:
         - name: run_query
           arguments:
             sql: SELECT a, SELECT b
         normal_text: ''
-      vllm: *d_11
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.12:
-    description: Parallel JSON-array calls where one argument contains a comma
-    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]'
+  PARSER.batch.11.b:
+    description: Structural delimiter inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.11.c:
+    description: Tool-call marker text inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "literal functools[] stays text"}}]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal functools[] stays text
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal functools[] stays text
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.12.a:
+    description: Multi-call response with a separator character inside one argument string value
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}]'
     tools:
     - name: run_query
       parameters:
@@ -106,7 +191,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_12
+      dynamo:
         calls:
         - name: run_query
           arguments:
@@ -115,21 +200,111 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_12
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+  PARSER.batch.12.b:
+    description: Multi-call response with structural delimiters inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},
+      {"name": "get_time", "arguments": {"timezone": "EST"}}]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     model_text: 'functools[{"name": "unknown_tool", "arguments": {"location": "NYC"}}]'
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "unknown_tool", "arguments":
+      {"location": "LA"}}]'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -96,8 +96,8 @@ cases:
       vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.11.a:
-    description: Call separator character inside one argument string value
+  PARSER.batch.30.a:
+    description: JSON-array call separator `,` inside one argument string value
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}]'
     tools:
     - name: run_query
@@ -121,8 +121,8 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.11.b:
-    description: Structural delimiter inside one argument string value
+  PARSER.batch.30.b:
+    description: JSON structural delimiters `}` and `]` inside one argument string value
     ref: dynamo
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}]'
     tools:
@@ -144,8 +144,8 @@ cases:
         calls: []
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.11.c:
-    description: Tool-call marker text inside one argument string value
+  PARSER.batch.30.c:
+    description: Phi-4 marker text `functools` and `[]` inside one argument string value
     ref: dynamo
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "literal functools marker[] stays text"}}]'
     tools:
@@ -167,8 +167,8 @@ cases:
         calls: []
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.12.a:
-    description: Multi-call response with a separator character inside one argument string value
+  PARSER.batch.31.a:
+    description: Multi-call JSON array with call separator `,` inside the first argument string
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT a, SELECT b"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}]'
     tools:
@@ -205,7 +205,7 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
-  PARSER.batch.12.b:
+  PARSER.batch.31.b:
     description: Multi-call response with structural delimiters inside one argument string value
     ref: dynamo
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -123,7 +123,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.11.b:
     description: Structural delimiter inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}]'
     tools:
     - name: run_query
@@ -149,8 +149,8 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.11.c:
     description: Tool-call marker text inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
-    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "literal functools[] stays text"}}]'
+    ref: dynamo
+    model_text: 'functools[{"name": "run_query", "arguments": {"sql": "literal functools marker[] stays text"}}]'
     tools:
     - name: run_query
       parameters:
@@ -163,13 +163,13 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal functools[] stays text
+            sql: literal functools marker[] stays text
         normal_text: ''
       vllm:
         calls:
         - name: run_query
           arguments:
-            sql: literal functools[] stays text
+            sql: literal functools marker[] stays text
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
@@ -213,7 +213,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.12.b:
     description: Multi-call response with structural delimiters inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: 'functools[{"name": "run_query", "arguments": {"sql": "SELECT value WHERE note has brace } and bracket ]"}},
       {"name": "get_time", "arguments": {"timezone": "EST"}}]'
     tools:
@@ -277,7 +277,7 @@ cases:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "unknown_tool", "arguments":
       {"location": "LA"}}]'
     tools:

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
@@ -97,3 +97,78 @@ cases:
         normal_text: ''
       vllm: *id004
       sglang: *id004
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '[process_data(payload={"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":True,"retry":None},"empty":{}})]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
@@ -99,7 +99,7 @@ cases:
       sglang: *id004
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '[process_data(payload={"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":True,"retry":None},"empty":{}})]'
     tools:
     - name: process_data

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -36,17 +36,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
@@ -64,8 +94,8 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Single call with comma inside argument string value
+  PARSER.batch.11.a:
+    description: Call separator character inside one argument string value
     ref: dynamo
     model_text: '[run_query(sql="SELECT a, SELECT b")]'
     tools:
@@ -76,16 +106,86 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &d_11
+      dynamo:
         calls:
         - name: run_query
           arguments:
             sql: SELECT a, SELECT b
         normal_text: ''
-      vllm: *d_11
-      sglang: *d_11
-  PARSER.batch.12:
-    description: Parallel calls where one argument contains a comma
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        normal_text: ''
+  PARSER.batch.11.b:
+    description: Structural delimiter inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket ]")]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+  PARSER.batch.11.c:
+    description: Tool-call marker text inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '[run_query(sql="literal [get_time()] stays text")]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal [get_time()] stays text
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal [get_time()] stays text
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: literal [get_time()] stays text
+        normal_text: ''
+  PARSER.batch.12.a:
+    description: Multi-call response with a separator character inside one argument string value
     ref: dynamo
     model_text: '[run_query(sql="SELECT a, SELECT b"), get_time(timezone="EST")]'
     tools:
@@ -102,7 +202,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_12
+      dynamo:
         calls:
         - name: run_query
           arguments:
@@ -111,23 +211,131 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_12
-      sglang: *d_12
-  PARSER.batch.13:
-    description: Unknown tool name absent from supplied tools
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a, SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+  PARSER.batch.12.b:
+    description: Multi-call response with structural delimiters inside one argument string value
+    ref: SGLang/LightSeek delimiter-state audit
+    model_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket ]"), get_time(timezone="EST")]'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+  PARSER.batch.13.a:
+    description: Unknown-only call under default behavior
     ref: originated from https://github.com/sgl-project/sglang/blob/612785ffdcaf35552f1ed433a981d596ca9fe900/test/registered/unit/function_call/test_function_call_parser.py#L3147
     model_text: '[unknown_tool(location="NYC")]'
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &d_13
+      dynamo:
         calls:
         - name: unknown_tool
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_13
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
         calls: []
+        normal_text: ''
+        reason: SGLang PythonicDetector drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls in one response
+    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    model_text: '[get_weather(location="NYC"), unknown_tool(location="LA")]'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
         reason: SGLang PythonicDetector drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -94,8 +94,8 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11.a:
-    description: Call separator character inside one argument string value
+  PARSER.batch.30.a:
+    description: Pythonic call separator `,` inside one argument string value
     ref: dynamo
     model_text: '[run_query(sql="SELECT a, SELECT b")]'
     tools:
@@ -124,8 +124,8 @@ cases:
           arguments:
             sql: SELECT a, SELECT b
         normal_text: ''
-  PARSER.batch.11.b:
-    description: Structural delimiter inside one argument string value
+  PARSER.batch.30.b:
+    description: Pythonic/list structural delimiters `}` and `]` inside one argument string value
     ref: dynamo
     model_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket ]")]'
     tools:
@@ -154,8 +154,8 @@ cases:
           arguments:
             sql: SELECT value WHERE note has brace } and bracket ]
         normal_text: ''
-  PARSER.batch.11.c:
-    description: Tool-call marker text inside one argument string value
+  PARSER.batch.30.c:
+    description: Tool-call marker-looking `[get_time ...]` text inside one argument string value
     ref: dynamo
     model_text: '[run_query(sql="literal [get_time marker] stays text")]'
     tools:
@@ -184,8 +184,8 @@ cases:
           arguments:
             sql: literal [get_time marker] stays text
         normal_text: ''
-  PARSER.batch.12.a:
-    description: Multi-call response with a separator character inside one argument string value
+  PARSER.batch.31.a:
+    description: Multi-call Pythonic list with call separator `,` inside the first argument string
     ref: dynamo
     model_text: '[run_query(sql="SELECT a, SELECT b"), get_time(timezone="EST")]'
     tools:
@@ -229,7 +229,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-  PARSER.batch.12.b:
+  PARSER.batch.31.b:
     description: Multi-call response with structural delimiters inside one argument string value
     ref: dynamo
     model_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket ]"), get_time(timezone="EST")]'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -126,7 +126,7 @@ cases:
         normal_text: ''
   PARSER.batch.11.b:
     description: Structural delimiter inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket ]")]'
     tools:
     - name: run_query
@@ -156,8 +156,8 @@ cases:
         normal_text: ''
   PARSER.batch.11.c:
     description: Tool-call marker text inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
-    model_text: '[run_query(sql="literal [get_time()] stays text")]'
+    ref: dynamo
+    model_text: '[run_query(sql="literal [get_time marker] stays text")]'
     tools:
     - name: run_query
       parameters:
@@ -170,19 +170,19 @@ cases:
         calls:
         - name: run_query
           arguments:
-            sql: literal [get_time()] stays text
+            sql: literal [get_time marker] stays text
         normal_text: ''
       vllm:
         calls:
         - name: run_query
           arguments:
-            sql: literal [get_time()] stays text
+            sql: literal [get_time marker] stays text
         normal_text: ''
       sglang:
         calls:
         - name: run_query
           arguments:
-            sql: literal [get_time()] stays text
+            sql: literal [get_time marker] stays text
         normal_text: ''
   PARSER.batch.12.a:
     description: Multi-call response with a separator character inside one argument string value
@@ -231,7 +231,7 @@ cases:
         normal_text: ''
   PARSER.batch.12.b:
     description: Multi-call response with structural delimiters inside one argument string value
-    ref: SGLang/LightSeek delimiter-state audit
+    ref: dynamo
     model_text: '[run_query(sql="SELECT value WHERE note has brace } and bracket ]"), get_time(timezone="EST")]'
     tools:
     - name: run_query
@@ -304,7 +304,7 @@ cases:
         reason: SGLang PythonicDetector drops unknown tool names by default unless SGLANG_FORWARD_UNKNOWN_TOOLS is enabled.
   PARSER.batch.13.c:
     description: Mixed known and unknown calls in one response
-    ref: SGLang TestHunyuanDetectorDetectAndParse.test_mixed_known_and_unknown_tools
+    ref: dynamo
     model_text: '[get_weather(location="NYC"), unknown_tool(location="LA")]'
     tools:
     - name: get_weather

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
@@ -113,7 +113,7 @@ cases:
         normal_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
   PARSER.batch.7.e:
     description: Large / deep JSON-edge argument payload
-    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    ref: dynamo
     model_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
       3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
     tools:

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
@@ -111,3 +111,43 @@ cases:
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge argument payload
+    ref: 'SGLang/LightSeek audit: large payload, nested JSON, null, and empty-object argument coverage'
+    model_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1, 2,
+      3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          payload:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            payload:
+              regions:
+              - name: west
+                scores:
+                - 1
+                - 2
+                - 3
+              - name: east
+                scores:
+                - 4
+                - 5
+                - 6
+              flags:
+                enabled: true
+                retry: null
+              empty: {}
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
+          2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -101,14 +101,14 @@ cases:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
           "get_weather", "arguments": {"location": "LA"}}</tool_call>'
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. qwen25 uses a <tool_call> envelope around a JSON object rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to qwen25 because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. qwen25 uses a <tool_call> envelope around a JSON object rather than delimiter-splitting multiple calls with an in-band separator, so generic JSON string escaping remains covered by PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to qwen25 because it wraps each JSON object in <tool_call>, not a delimiter-separated call body.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -133,3 +133,7 @@ cases:
         calls: []
         normal_text: '<tool_call>{"name": "unknown_tool", "arguments": {"location": "NYC"}}</tool_call>'
         reason: SGLang treats the unknown qwen25 tool call as ordinary content rather than forwarding it by default.
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to qwen25 because vLLM has no peer parser and SGLang treats this family as ordinary content.

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -40,18 +40,45 @@ cases:
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
       sglang: *id002
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id003
+      dynamo:
         calls: []
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *id003
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
@@ -78,3 +78,6 @@ cases:
     description: Nested-arguments test 7.d — not yet authored for this family
     reason: |-
       Nested-arguments test 7.d not yet authored for qwen3_coder; see 7.a / 7.b for simpler argument shapes.
+  PARSER.batch.7.e:
+    description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
+    reason: Large/deep JSON-edge payload test 7.e not yet authored for qwen3_coder; existing batch.7 coverage remains in 7.a-d.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -43,17 +43,47 @@ cases:
         normal_text: Hello, how can I help you today?
       vllm: *id003
       sglang: *id003
-  PARSER.batch.9:
-    description: Empty input
+  PARSER.batch.9.a:
+    description: Empty model text
     model_text: ''
     tools:
-    - *id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
     expected:
-      dynamo: &id004
+      dynamo:
         calls: []
         normal_text: ''
-      vllm: *id004
-      sglang: *id004
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+  PARSER.batch.9.b:
+    description: Blank / whitespace-only model text
+    ref: dynamo
+    model_text: '   '
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '   '
+      vllm:
+        calls: []
+        normal_text: '   '
+      sglang:
+        calls: []
+        normal_text: '   '
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -115,14 +115,14 @@ cases:
         normal_text: ''
       vllm: *id005
       sglang: *id005
-  PARSER.batch.11:
-    description: Separator-character case — n/a for this family's syntax
+  PARSER.batch.30:
+    description: Separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. qwen3_coder uses XML-ish function/parameter tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b.
-  PARSER.batch.12:
-    description: Multi-call separator-character case — n/a for this family's syntax
+      This case is not applicable to qwen3_coder because it uses XML-ish function/parameter tags, not delimiter-separated call bodies.
+  PARSER.batch.31:
+    description: Multi-call separator-character case not applicable
     reason: |-
-      PARSER.batch.11 targets delimiter-separated parser formats. qwen3_coder uses XML-ish function/parameter tags rather than delimiter-splitting call bodies, so generic string-value coverage remains in PARSER.batch.7.b. PARSER.batch.12 is the multi-call version of the same separator-state check, so the same applicability rule applies.
+      This case is not applicable to qwen3_coder because it uses XML-ish function/parameter tags, not delimiter-separated call bodies.
   PARSER.batch.13:
     description: Unknown tool name absent from supplied tools
     ref: dynamo
@@ -158,3 +158,7 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+  PARSER.batch.13.c:
+    description: Mixed known and unknown calls not applicable
+    reason: |-
+      This case is not applicable to qwen3_coder because there is no peer mixed known/unknown Qwen 3 Coder parser case to align against.

--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -51,6 +51,7 @@ PARITY.{md,html} are for local viewing only; don't check them in.
 from __future__ import annotations
 
 import argparse
+import copy
 import datetime
 import html as html_lib
 import json
@@ -294,15 +295,42 @@ TOP_N_FAMILIES = [
 ]
 
 SUB_CASE_GROUPS = [
-    ("Core", ("1", "3", "9", "10", "13")),
-    ("Multi-call", ("2.a", "2.b", "2.c", "2.d", "12")),
+    ("Core", ("1", "3", "9", "9.a", "9.b")),
+    ("Multi-call", ("2.a", "2.b", "2.c", "2.d", "10")),
     (
         "Malformed / recovery",
         ("4.a", "4.b", "4.c", "4.d", "4.e", "5.a", "5.b", "5.c", "5.d", "5.e"),
     ),
-    ("Args", ("6.a", "6.b", "6.c", "7.a", "7.b", "7.c", "7.d", "11")),
+    (
+        "Args",
+        (
+            "6.a",
+            "6.b",
+            "6.c",
+            "7.a",
+            "7.b",
+            "7.c",
+            "7.d",
+            "7.e",
+        ),
+    ),
     ("Text interleaving", ("8.a", "8.b", "8.c", "8.d")),
+    ("Unknown tools", ("13", "13.a", "13.c")),
+    (
+        "String contents",
+        ("30", "30.a", "30.b", "30.c", "31", "31.a", "31.b"),
+    ),
 ]
+
+SPLIT_PARENT_SUBCASES = {
+    # Once a taxonomy bucket has leaf cases, the matrix should render only the
+    # leaves. Existing parent fixtures still carry useful expectations/reasons
+    # for parser families that have not been rewritten to leaf IDs yet.
+    "9": ("9.a",),
+    "30": ("30.a", "30.b", "30.c"),
+    "31": ("31.a", "31.b"),
+    "13": ("13.a",),
+}
 
 _SUB_CASE_DISPLAY_ORDER = {
     sub: (group_idx, sub_idx)
@@ -343,6 +371,46 @@ def _subcase_band_class(sub: str) -> str:
 def _discover_sub_cases(cases: dict) -> list[str]:
     """Union of sub-case IDs across all loaded fixtures, in stable order."""
     return sorted({sub for _fam, sub in cases.keys()}, key=_sub_sort_key)
+
+
+def _normalize_split_parent_cases(cases: dict) -> dict:
+    """Render split taxonomy buckets as leaf cases only.
+
+    Some older fixture files still define parent buckets such as
+    `PARSER.batch.30`, while newer files define leaf buckets such as
+    `PARSER.batch.30.a`. For display, parent+leaf duplication is confusing:
+    once any leaf exists for a parent bucket, the chart should show only the
+    leaf columns. Parent entries are copied into missing leaf cells so their
+    existing expectations or n/a reasons remain visible until the YAML itself
+    is migrated.
+    """
+    all_subs = {sub for _fam, sub in cases.keys()}
+    active_split_parents = {
+        parent
+        for parent, children in SPLIT_PARENT_SUBCASES.items()
+        if any(child in all_subs for child in children)
+    }
+    if not active_split_parents:
+        return cases
+
+    normalized = dict(cases)
+    families = {fam for fam, _sub in cases.keys()}
+    for family in families:
+        for parent in active_split_parents:
+            parent_key = (family, parent)
+            parent_case = normalized.get(parent_key)
+            if parent_case is None:
+                continue
+            for child in SPLIT_PARENT_SUBCASES[parent]:
+                child_key = (family, child)
+                if child_key in normalized:
+                    continue
+                child_case = copy.deepcopy(parent_case)
+                child_case["__case_id"] = f"PARSER.batch.{child}"
+                child_case["__synthetic_from_case_id"] = parent_case.get("__case_id")
+                normalized[child_key] = child_case
+            del normalized[parent_key]
+    return normalized
 
 
 def _derive_no_peer_sets(cases: dict) -> tuple[set[str], set[str]]:
@@ -408,7 +476,7 @@ def load_all_cases() -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
             case["__fixture_path"] = rel
             case["__case_id"] = cid
             cases[(family, sub)] = case
-    return cases, labels
+    return _normalize_split_parent_cases(cases), labels
 
 
 def _build_display_groups(


### PR DESCRIPTION
#### Overview:

This PR expands `PARSER.batch.*` parity fixtures and charting based on SGLang/vLLM coverage; it does not change parser implementation behavior.

#### Details:

- **How is this fixed?** Add fixture-only `PARSER.batch.*` variants and chart generation support; no parser implementation code is changed.
- Added string-content cases (`30.a`-`31.b`).
- Moved delimiter/string-content coverage from `PARSER.batch.11` / `PARSER.batch.12` to `PARSER.batch.30` / `PARSER.batch.31`.
- Added unknown-tool cases (`13.a`, `13.c`).

#### Verification:

Generated `tests/parity/parser/PARITY.html`; `python3 -m pytest tests/parity/parser/test_parity_parser.py --collect-only -q -o filterwarnings= --basetemp=/tmp/pytest_temp` collected 2049 tests; pre-commit passed on commit `80f060cacb7e`.

#### Related Issues:

Relates to [DIS-1927](https://linear.app/nvidia/issue/DIS-1927/add-sglang-parser-test-coverage-to-fill-more-gaps) — Add SGLang parser test coverage to fill more gaps.

<!-- parser-parity-chart-start -->
#### Parser Parity Chart:

Generated from `tests/parity/parser/generate_parity_chart.py` at PR head `80f060cacb7e`. Showing only newly added parser-case columns.

| model | parser | 13.a | 13.c | 30.a | 30.b | 30.c | 31.a | 31.b |
| --- | --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
| **Top-N models** |  |  |  |  |  |  |  |  |
| DeepSeek V4 | deepseek_v4§ | = | n/a | n/a | n/a | n/a | n/a | n/a |
| Gemma 4 | gemma4 | = | = | = | = | = | = | = |
| GLM 5.1 | glm47 | V | n/a | n/a | n/a | n/a | n/a | n/a |
| gpt-oss | harmony | S | n/a | n/a | n/a | n/a | n/a | n/a |
| Kimi K2.6 | kimi_k2 | = | n/a | n/a | n/a | n/a | n/a | n/a |
| MiniMax 2.7 | minimax_m2 | V | n/a | n/a | n/a | n/a | n/a | n/a |
| Qwen 3 Coder | qwen3_coder | = | n/a | n/a | n/a | n/a | n/a | n/a |
| **Others** |  |  |  |  |  |  |  |  |
| AI21 Jamba | jamba§ | = | = | = | = | = | = | = |
| DeepSeek V3 | deepseek_v3 | S | n/a | n/a | n/a | n/a | n/a | n/a |
| DeepSeek V3.1 | deepseek_v3_1 | S | n/a | n/a | n/a | n/a | n/a | n/a |
| DeepSeek V3.2 | deepseek_v3_2 | S | n/a | n/a | n/a | n/a | n/a | n/a |
| Hermes-3 / Llama variants | hermes | S | S | n/a | n/a | n/a | n/a | n/a |
| Llama 3 (JSON fmt) | llama3_json | S | S | = | = | = | = | = |
| Llama 4 (pythonic fmt) | pythonic | S | S | = | = | = | = | = |
| Mistral series | mistral | S | S | S | S? | S? | S | S? |
| Nemotron (DeciLM) | nemotron_deci†§ | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| Nemotron Nano | nemotron_nano†§ | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| Phi-4 | phi4§ | = | = | = | V | V | = | V |
| Qwen 2.5 | qwen25† | S | n/a | n/a | n/a | n/a | n/a | n/a |

**Legend:** `=` full parity (Dynamo, vLLM, and SGLang produce the same results) · `V`/`S` divergence (V = vLLM, S = SGLang; intentional, has `reason:`) · `?` research-needed suffix (e.g. V?, S? — diverges with no `reason:` yet) · `↯` Dynamo leaks tool call markup into `normal_text` (`expected.dynamo.reason:` carries the explanation) · `!` expected-error suffix (e.g. V!, S! — engine crashes by design) · `n/a` not applicable · `—` missing fixture coverage · `†` (parser column) = no vLLM peer parser for this family · `§` (parser column) = no SGLang peer parser for this family.
<!-- parser-parity-chart-end -->
#### Where should the reviewer start?

`lib/parsers/PARSER_CASES.md`, then `tests/parity/parser/generate_parity_chart.py`, then `tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml`

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Expanded test coverage** for tool-call parser behavior across multiple model families, including new test cases for large/complex JSON payloads, edge cases with delimiters in arguments, and comprehensive handling of empty/whitespace input scenarios.
* **Refined test taxonomy** with more granular sub-cases to improve clarity and specificity of parser test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9620)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->










