### PR TITLE
test(serve): bump test_sample_deployment pytest-timeout to 600s (OPS-5850)

### DIFF
--- a/tests/serve/test_sample.py
+++ b/tests/serve/test_sample.py
@@ -28,7 +28,9 @@ sample_configs = {
         script_args=["--model-name", "Qwen/Qwen3-0.6B"],
         marks=[
             pytest.mark.gpu_0,
-            pytest.mark.timeout(300),
+            # 300s left only ~60s of test budget after #9421 preflight + xdist stagger
+            # on slower runners (efa, gw16+); match EngineConfig.timeout (600s). OPS-5850.
+            pytest.mark.timeout(600),
             pytest.mark.pre_merge,
             pytest.mark.unified,
             pytest.mark.vllm,


### PR DESCRIPTION
## Summary
`tests/serve/test_sample.py::test_sample_deployment[aggregated]` carries `pytest.mark.timeout(300)`, but recent harness additions push the budget past 300s on slower runners:

- #9421 added per-test endpoint readiness preflight (extra setup time).
- #9036 added in-process query retry for flaky payloads (extra per-request time).
- xdist stagger on high worker IDs (gw16+) can consume up to ~240s before the test even starts.
- The test then runs 6 serial chat/completion requests at ~10s each = ~60s.

Per OPS-5850 diagnosis: `vllm-runtime-efa / CPU Test cuda12.9, amd64` was 0/26 (100% failing) over a stretch where this test was previously 715/715 green. The PR's #9616 CI also hit it on `vllm-runtime / Test cuda12.9, amd64` (timeout >300s waiting on the 3rd completions request).

`EngineConfig.timeout` already defaults to 600s ([tests/utils/engine_process.py:64](https://github.com/ai-dynamo/dynamo/blob/main/tests/utils/engine_process.py#L64)). Align the pytest-level wall-clock timeout so the harness budget matches the engine-startup budget.

## Test plan
- [ ] PR vllm-runtime tests pass (no regression on the well-conditioned runs)
- [ ] Post-merge \`vllm-runtime-efa / CPU Test\` returns to green
- [ ] Grafana pass-rate dashboard for \`test_sample_deployment[aggregated]\` trends back to historical 100%

Related: OPS-5424, OPS-6303, OPS-4842 (same test, separate alert tickets — should auto-resolve as the failure rate drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration parameters for backend service testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9624)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->