### PR TITLE
test(router): extend overload-503 wait 10s→30s for arm64 KV-event lag (OPS-5851)

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1170,7 +1170,11 @@ def _test_router_overload_503(
 
                     if not stop_event.is_set():
                         try:
-                            await asyncio.wait_for(stop_event.wait(), timeout=10)
+                            # OPS-5851: KV event propagation from the slow mocker
+                            # (speedup_ratio=0.01) to the router can take >10s on
+                            # arm64 / contended runners. Give the router time to
+                            # actually observe high utilization before asserting.
+                            await asyncio.wait_for(stop_event.wait(), timeout=30)
                         except asyncio.TimeoutError:
                             logger.error("Timed out waiting for overload 503")
                 finally:

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1073,7 +1073,9 @@ def test_mocker_two_kv_router(
 @pytest.mark.parametrize(
     "durable_kv_events", [False], ids=["nondurable"], indirect=True
 )  # Use NATS Core (local indexer)
-@pytest.mark.timeout(45)  # ~3x average (~13.10s), rounded up (when enabled)
+@pytest.mark.timeout(
+    90
+)  # OPS-5851: inner wait bumped from 10s→30s for arm64 KV-event lag
 def test_mocker_kv_router_overload_503(
     request,
     runtime_services_dynamic_ports,


### PR DESCRIPTION
## Summary
\`test_mocker_kv_router_overload_503[nondurable]\` flakes ~1% on arm64 sequential CPU. The failing-run log on #9616's PR CI (\`dynamo-runtime / test / sequential cuda12.9, arm64\`) tells the story:

\`\`\`
16:48:31.647 -> Request  0 accepted
16:48:36.594 -> Request 49 accepted     # 5s loop, 50 reqs × 0.1s stagger
16:48:46.692 -> ERROR: Timed out waiting for overload 503
Results: 50 succeeded, 0 rejected, 0 other
\`\`\`

All 50 streaming requests got HTTP 200; the router never crossed the 0.2 active-decode-blocks busy threshold inside the 10s wait window. The mocker runs with \`speedup_ratio=0.01\` (100× slower than real), so block allocation and KV-metrics publication ([lib/llm/src/mocker.rs:638-657](https://github.com/ai-dynamo/dynamo/blob/main/lib/llm/src/mocker.rs#L638-L657) → NATS Core → router's \`worker_monitor\`) lag the acceptance rate. On arm64 / contended runners that lag exceeds the 10s budget.

## Change
- \`tests/router/common.py:1173\` — \`asyncio.wait_for(stop_event.wait(), timeout=10)\` → \`timeout=30\`.
- \`tests/router/test_router_e2e_with_mockers.py:1076\` — \`@pytest.mark.timeout(45)\` → \`@pytest.mark.timeout(90)\` to fit the new wait.

Test semantics are unchanged. If the router actually fails to throttle, the assertion still fires; we're only accommodating slower event propagation on slow runners. Worst-case test wall time goes from ~28s → ~48s, still well under the new 90s pytest budget.

Linked tickets (OPS-5316, OPS-5851, OPS-5885) should auto-resolve as the flake rate drops. The architectural fix in DGH-758 (Request Rejection Refactoring) is the long-term solution; this PR is the short-term unflake.

## Test plan
- [ ] PR \`dynamo-runtime / test / sequential cuda12.9, arm64\` job passes
- [ ] Grafana 7-day pass-rate for \`test_mocker_kv_router_overload_503[nondurable]\` trends back to 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased test timeouts in router overload tests to reduce flakiness and improve test reliability in environments with delayed event propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9625)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->