### PR TITLE
fix(parsers): drop trailing text after glm47 tool-call wrapper

### DIFF
--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -130,8 +130,13 @@ fn extract_tool_calls(
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
 
-            // Add text before tool call to normal parts
-            normal_parts.push(&text[cursor..abs_start]);
+            // Only surface normal text that precedes the first parsed call.
+            // Text after any </tool_call> is not response content; matches the
+            // convention ported into the generic XML parser by PR #9350 and
+            // vLLM's glm47_moe_tool_parser.
+            if calls.is_empty() {
+                normal_parts.push(&text[cursor..abs_start]);
+            }
 
             // Find the corresponding end token
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
@@ -211,12 +216,19 @@ fn extract_tool_calls(
             }
         } else {
             // No more tool calls
-            normal_parts.push(&text[cursor..]);
+            if calls.is_empty() {
+                normal_parts.push(&text[cursor..]);
+            }
             break;
         }
     }
 
-    let normal_text = normal_parts.join("").trim().to_string();
+    let normal_text = normal_parts.join("");
+    let normal_text = if calls.is_empty() {
+        normal_text.trim().to_string()
+    } else {
+        normal_text
+    };
     Ok((normal_text, calls))
 }
 
@@ -486,7 +498,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(
             normal_text,
-            Some("I'll check the weather for you.".to_string())
+            Some("I'll check the weather for you. ".to_string())
         );
     }
 

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
@@ -52,8 +52,9 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Checking:  Done.'
-      vllm:
+        normal_text: 'Checking: '
+      vllm: *id004
+      sglang:
         calls:
         - name: get_weather
           arguments:
@@ -61,9 +62,8 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Checking: '
-        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — trailing prose after the last </tool_call> is dropped; Dynamo and SGLang preserve it
-      sglang: *id004
+        normal_text: 'Checking:  Done.'
+        reason: SGLang glm47 preserves trailing prose after the last </tool_call>; Dynamo and vLLM drop it
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
@@ -22,15 +22,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.
-      vllm:
+        normal_text: 'I will check the weather. '
+      vllm: *id001
+      sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
-        reason: vLLM glm47 keeps trailing whitespace before the first <tool_call>; Dynamo and SGLang both trim it
-      sglang: *id001
+        normal_text: I will check the weather.
+        reason: SGLang glm47 trims trailing whitespace before the first <tool_call>; Dynamo and vLLM keep it verbatim
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -44,15 +44,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: Let me know if you need more.
-      vllm:
+        normal_text: ''
+      vllm: *id003
+      sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: ''
-        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — content after the last </tool_call> is dropped; Dynamo and SGLang both preserve it
-      sglang: *id003
+        normal_text: Let me know if you need more.
+        reason: SGLang glm47 preserves trailing normal_text after the last </tool_call>; Dynamo and vLLM drop it
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -66,15 +66,15 @@ cases:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.  Let me know if you need more.
-      vllm:
+        normal_text: 'I will check the weather. '
+      vllm: *id004
+      sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: 'I will check the weather. '
-        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — content after the </tool_call> is dropped; Dynamo and SGLang both concatenate the prefix and the trailing prose
-      sglang: *id004
+        normal_text: 'I will check the weather.  Let me know if you need more.'
+        reason: SGLang glm47 concatenates the prefix and trailing prose; Dynamo and vLLM drop the post-wrapper text
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -91,8 +91,9 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: I will check the weather.  Then check LA weather.
-      vllm:
+        normal_text: 'I will check the weather. '
+      vllm: *id005
+      sglang:
         calls:
         - name: get_weather
           arguments:
@@ -100,6 +101,5 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: 'I will check the weather. '
-        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — prose between successive calls is dropped; Dynamo and SGLang concatenate all non-tool-call segments
-      sglang: *id005
+        normal_text: 'I will check the weather.  Then check LA weather.'
+        reason: SGLang glm47 concatenates inter-call narration and trailing prose; Dynamo and vLLM only emit the prefix before the first <tool_call>


### PR DESCRIPTION
#### Overview:

GLM-4.7's parser was surfacing every chunk of non-tool-call text in the model output as normal_text, including content after the closing `</tool_call>`. vLLM's `glm4_moe_tool_parser` only emits text that precedes the first `<tool_call>`; everything after the last wrapper close is dropped. PR #9350 already ported this prefix-only convention into the generic XML parser (qwen3_coder, minimax_m2, nemotron_nano), and #9411 / #9524 followed for gemma4 and DeepSeek v4. GLM-4.7 has its own parser file and wasn't covered.

In production we saw the consequence on a truncated parallel-call response: the model emitted two `<tool_call>` blocks with the second one cut mid-arg, the EOF recovery path returned a tool_call with empty args, and downstream tag-stripping turned the raw second block into `get_weatherlocationNew York` text in `message.content`. PR #9355 fixed the empty-args side. This PR is the text-handling counterpart: post-wrapper prose is dropped at the parser layer so wire markup can't leak through to content even when truncation or other failures happen later.

#### Details:

- `glm47_parser.rs` `extract_tool_calls()`:
  - Three `normal_parts.push(...)` sites now gated on `calls.is_empty()` so text after the first parsed call is dropped. Matches the pattern in `xml/parser.rs` from #9350.
  - Final `normal_parts.join("")` no longer trims when calls were extracted. Pre-wrapper whitespace (e.g. the trailing space in `"I will check the weather. "`) is preserved verbatim so the prefix is byte-identical to what vLLM emits.

- Fixture updates collapse `batch.8.a/b/c/d` and `batch.2.c` onto a shared dynamo+vllm anchor. SGLang 0.5.11 still preserves the post-wrapper prose, so each case keeps an explicit `sglang:` block with a `reason:` string describing the remaining divergence.

#### Before / After:

Repro: model emits parallel calls with the last one truncated mid-arg-value (max_tokens cut). This is the curl case from DYN-3019.

Model wire output:
```
I'll start by fetching the weather for both Boston and New York at the same time!
<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call>
<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
```

Before (pre-#9355 + pre-this PR):
```
tool_calls: [
  {name: get_weather, arguments: {location: "Boston"}},
  {name: get_weather, arguments: {}}     # ghost call from EOF recovery
]
content: "I'll start by fetching the weather for both Boston and New York at the same time!get_weatherlocationNew York"
                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                                                            raw 2nd block, tags stripped
```

After #9355 alone (EOF recovery disabled, but raw block still preserved):
```
tool_calls: [{name: get_weather, arguments: {location: "Boston"}}]
content: "I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York"
```

After this PR:
```
tool_calls: [{name: get_weather, arguments: {location: "Boston"}}]
content: "I'll start by fetching the weather for both Boston and New York at the same time!"
```

#### Cross-impl behavior:

For each batch.8 sub-case and batch.2.c, the model_text is the same; the table is the parsed `normal_text` per impl.

`PARSER.batch.8.a` (text before only):
```
dynamo:  "I will check the weather. "
vllm:    "I will check the weather. "    (anchor)
sglang:  "I will check the weather."     (sglang trims trailing space)
```

`PARSER.batch.8.b` (text after only):
```
dynamo:  ""
vllm:    ""                              (anchor)
sglang:  "Let me know if you need more." (sglang preserves post-wrapper)
```

`PARSER.batch.8.c` (sandwich):
```
dynamo:  "I will check the weather. "
vllm:    "I will check the weather. "                              (anchor)
sglang:  "I will check the weather.  Let me know if you need more."
```

`PARSER.batch.8.d` (between two calls):
```
dynamo:  "I will check the weather. "
vllm:    "I will check the weather. "                  (anchor)
sglang:  "I will check the weather.  Then check LA weather."
```

`PARSER.batch.2.c` (parallel calls with surrounding prose):
```
dynamo:  "Checking: "
vllm:    "Checking: "                  (anchor)
sglang:  "Checking:  Done."
```

Dynamo is byte-identical to vLLM on all five cases. SGLang diverges on each one with a recorded `reason:` string in the fixture.

#### Verification:

- `cargo test -p dynamo-parsers --lib glm47`: 25/25 pass
- `cargo test -p dynamo-parsers --lib`: 513 pass, 4 ignored
- `cargo clippy -p dynamo-parsers --lib --tests -- -D warnings`: clean
- M2 parity harness against vLLM 0.20.1 (CI container): 44 pass, 12 n/a-stub skips
- M2 parity harness against SGLang 0.5.11 (CI container): 22 pass, 6 n/a-stub skips

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/xml/glm47_parser.rs` `extract_tool_calls()`, then `tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml` for the dynamo/vllm/sglang shape per case.

#### Related Issues:

Relates to [DYN-3019](https://linear.app/nvidia/issue/DYN-3019/fix-known-glm-551-parser-issues).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined tool calling parser to adjust how narrative text surrounding tool calls is handled. Updated text collection behavior when multiple tool calls are present for more consistent results across parsing backends.

* **Tests**
  * Updated parser test fixtures to reflect refined tool calling behavior and expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9629)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->