### PR TITLE
fix(runtime): preserve busy state during reconciliation

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -804,7 +804,7 @@ impl ModelWatcher {
             // worker TTFT/ITL cleanup). The thresholds control busy detection behavior only.
             //
             // IMPORTANT: When KV routing is active, the monitor must use the KvRouter's Client
-            // so that busy-state updates (via update_free_instances) are visible to the
+            // so that busy-state updates (via set_busy_instances) are visible to the
             // PushRouter, which also uses the KvRouter's Client (see common.rs:258-263).
             // Using a different Client instance would cause the PushRouter to never see
             // busy workers, since each Client::new() creates independent ArcSwap state.

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -677,7 +677,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                         // Only update if busy_instances has changed
                         if busy_instances != previous_busy_instances {
                             let total_workers = client.instance_ids().len();
-                            client.update_free_instances(&busy_instances);
+                            client.set_busy_instances(&busy_instances);
                             let free_workers = client.instance_ids_free().len();
                             tracing::debug!(
                                 busy_instances = ?busy_instances,

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -156,7 +156,7 @@ pub struct Client {
     // These are the instance source ids less those reported as down from sending rpc
     instance_avail: Arc<ArcSwap<Vec<u64>>>,
     // These are the instance ids reported as busy (above threshold)
-    instance_busy: Arc<StdMutex<HashSet<u64>>>,
+    instance_busy: Arc<ArcSwap<HashSet<u64>>>,
     // Watch sender for available instance IDs (for sending updates)
     instance_avail_tx: Arc<tokio::sync::watch::Sender<Vec<u64>>>,
     // Watch receiver for available instance IDs (for cloning to external subscribers)
@@ -202,7 +202,7 @@ impl Client {
             endpoint_discovery_source,
             instance_source: instance_source.clone(),
             instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
-            instance_busy: Arc::new(StdMutex::new(HashSet::new())),
+            instance_busy: Arc::new(ArcSwap::from_pointee(HashSet::new())),
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
             reconcile_interval,
@@ -226,7 +226,7 @@ impl Client {
 
     pub fn instance_ids_free(&self) -> Vec<u64> {
         let instance_ids = self.instance_ids();
-        let busy_ids = self.instance_busy.lock().unwrap();
+        let busy_ids = self.instance_busy.load();
 
         instance_ids
             .into_iter()
@@ -291,9 +291,9 @@ impl Client {
 
     /// Update the set of free instances based on busy instance IDs
     pub fn update_free_instances(&self, busy_instance_ids: &[u64]) {
-        let mut busy_ids = self.instance_busy.lock().unwrap();
-        busy_ids.clear();
-        busy_ids.extend(busy_instance_ids.iter().copied());
+        self.instance_busy.store(Arc::new(
+            busy_instance_ids.iter().copied().collect::<HashSet<_>>(),
+        ));
     }
 
     /// Monitor the key-value instance source and update instance_avail.

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -234,6 +234,32 @@ impl Client {
             .collect()
     }
 
+    pub fn instance_count(&self) -> usize {
+        self.instance_source.borrow().len()
+    }
+
+    pub fn busy_instance_count(&self) -> usize {
+        self.instance_busy.load().len()
+    }
+
+    pub fn all_instances_busy(&self) -> bool {
+        let busy_ids = self.instance_busy.load();
+        if busy_ids.is_empty() {
+            return false;
+        }
+
+        let instances = self.instance_source.borrow();
+        let mut saw_instance = false;
+        for instance in instances.iter() {
+            saw_instance = true;
+            if !busy_ids.contains(&instance.id()) {
+                return false;
+            }
+        }
+
+        saw_instance
+    }
+
     /// Get a watcher for available instance IDs
     pub fn instance_avail_watcher(&self) -> tokio::sync::watch::Receiver<Vec<u64>> {
         self.instance_avail_rx.clone()

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -234,14 +234,6 @@ impl Client {
             .collect()
     }
 
-    pub fn instance_count(&self) -> usize {
-        self.instance_source.borrow().len()
-    }
-
-    pub fn busy_instance_count(&self) -> usize {
-        self.instance_busy.load().len()
-    }
-
     pub fn all_instances_busy(&self) -> bool {
         let busy_ids = self.instance_busy.load();
         if busy_ids.is_empty() {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -289,8 +289,8 @@ impl Client {
         tracing::debug!("inhibiting instance {instance_id}");
     }
 
-    /// Update the set of free instances based on busy instance IDs
-    pub fn update_free_instances(&self, busy_instance_ids: &[u64]) {
+    /// Replace the set of busy instances reported by the worker monitor.
+    pub fn set_busy_instances(&self, busy_instance_ids: &[u64]) {
         self.instance_busy.store(Arc::new(
             busy_instance_ids.iter().copied().collect::<HashSet<_>>(),
         ));
@@ -556,7 +556,7 @@ mod tests {
             "worker should be free after initial discovery reconciliation"
         );
 
-        client.update_free_instances(&[worker_id]);
+        client.set_busy_instances(&[worker_id]);
         assert!(
             client.instance_ids_free().is_empty(),
             "worker should be busy before periodic reconciliation"
@@ -590,7 +590,7 @@ mod tests {
         let client = Client::with_reconcile_interval(endpoint.clone(), TEST_RECONCILE_INTERVAL)
             .await
             .unwrap();
-        client.update_free_instances(&[worker_id]);
+        client.set_busy_instances(&[worker_id]);
 
         endpoint.register_endpoint_instance().await.unwrap();
         let instances = client.wait_for_instances().await.unwrap();

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -108,6 +108,20 @@ pub(crate) async fn get_or_create_routing_occupancy_state(
 /// Default interval for periodic reconciliation of instance_avail with instance_source
 const DEFAULT_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 
+fn reconcile_free_instance_ids(
+    instance_ids: &[u64],
+    known_instance_ids: &HashSet<u64>,
+    previous_free_ids: &[u64],
+) -> Vec<u64> {
+    let previous_free_ids = previous_free_ids.iter().copied().collect::<HashSet<_>>();
+
+    instance_ids
+        .iter()
+        .copied()
+        .filter(|id| previous_free_ids.contains(id) || !known_instance_ids.contains(id))
+        .collect()
+}
+
 /// Shared endpoint discovery state for a single endpoint query.
 ///
 /// This wraps both the coalesced instance snapshot used for routing decisions
@@ -306,6 +320,11 @@ impl Client {
         let endpoint_id = self.endpoint.id();
         tokio::task::spawn(async move {
             let mut rx = client.instance_source.as_ref().clone();
+            let mut known_instance_ids = rx
+                .borrow()
+                .iter()
+                .map(|instance| instance.id())
+                .collect::<HashSet<_>>();
             while !cancel_token.is_cancelled() {
                 let instance_ids: Vec<u64> = rx
                     .borrow_and_update()
@@ -313,9 +332,15 @@ impl Client {
                     .map(|instance| instance.id())
                     .collect();
 
-                // TODO: this resets both tracked available and free instances
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
-                client.instance_free.store(Arc::new(instance_ids.clone()));
+                client.instance_free.rcu(|previous_free_ids| {
+                    Arc::new(reconcile_free_instance_ids(
+                        &instance_ids,
+                        &known_instance_ids,
+                        previous_free_ids,
+                    ))
+                });
+                known_instance_ids = instance_ids.iter().copied().collect();
 
                 // Clean up stale occupancy counters for instances that no longer exist.
                 let registry = client.endpoint.drt().routing_occupancy_states();
@@ -521,6 +546,25 @@ mod tests {
         assert!(avail.contains(&3), "Instance 3 should still be available");
 
         rt.shutdown();
+    }
+
+    #[test]
+    fn test_reconcile_free_instance_ids_preserves_existing_busy_state() {
+        let known_instance_ids = std::collections::HashSet::from([1_u64, 2, 3]);
+
+        assert_eq!(
+            reconcile_free_instance_ids(&[1, 2, 3, 4], &known_instance_ids, &[1, 3]),
+            vec![1, 3, 4],
+            "existing busy workers stay busy while new workers become free"
+        );
+
+        let known_instance_ids = std::collections::HashSet::from([1_u64, 2, 3, 4]);
+
+        assert_eq!(
+            reconcile_free_instance_ids(&[2, 3, 4], &known_instance_ids, &[1, 3, 4]),
+            vec![3, 4],
+            "removed workers are dropped without freeing existing busy workers"
+        );
     }
 
     /// Test that instance_avail_watcher receives updates when instances change.

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -201,7 +201,7 @@ impl Client {
             endpoint: endpoint.clone(),
             endpoint_discovery_source,
             instance_source: instance_source.clone(),
-            instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
+            instance_avail: Arc::new(ArcSwap::from_pointee(initial_ids.clone())),
             instance_busy: Arc::new(ArcSwap::from_pointee(HashSet::new())),
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -108,20 +108,6 @@ pub(crate) async fn get_or_create_routing_occupancy_state(
 /// Default interval for periodic reconciliation of instance_avail with instance_source
 const DEFAULT_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 
-fn reconcile_free_instance_ids(
-    instance_ids: &[u64],
-    known_instance_ids: &HashSet<u64>,
-    previous_free_ids: &[u64],
-) -> Vec<u64> {
-    let previous_free_ids = previous_free_ids.iter().copied().collect::<HashSet<_>>();
-
-    instance_ids
-        .iter()
-        .copied()
-        .filter(|id| previous_free_ids.contains(id) || !known_instance_ids.contains(id))
-        .collect()
-}
-
 /// Shared endpoint discovery state for a single endpoint query.
 ///
 /// This wraps both the coalesced instance snapshot used for routing decisions
@@ -318,13 +304,14 @@ impl Client {
         let cancel_token = self.endpoint.drt().primary_token();
         let client = self.clone();
         let endpoint_id = self.endpoint.id();
+        let mut known_instance_ids = self
+            .instance_source
+            .borrow()
+            .iter()
+            .map(|instance| instance.id())
+            .collect::<HashSet<_>>();
         tokio::task::spawn(async move {
             let mut rx = client.instance_source.as_ref().clone();
-            let mut known_instance_ids = rx
-                .borrow()
-                .iter()
-                .map(|instance| instance.id())
-                .collect::<HashSet<_>>();
             while !cancel_token.is_cancelled() {
                 let instance_ids: Vec<u64> = rx
                     .borrow_and_update()
@@ -334,11 +321,16 @@ impl Client {
 
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
                 client.instance_free.rcu(|previous_free_ids| {
-                    Arc::new(reconcile_free_instance_ids(
-                        &instance_ids,
-                        &known_instance_ids,
-                        previous_free_ids,
-                    ))
+                    let previous_free_ids =
+                        previous_free_ids.iter().copied().collect::<HashSet<_>>();
+                    let free_ids = instance_ids
+                        .iter()
+                        .copied()
+                        .filter(|id| {
+                            previous_free_ids.contains(id) || !known_instance_ids.contains(id)
+                        })
+                        .collect();
+                    Arc::new(free_ids)
                 });
                 known_instance_ids = instance_ids.iter().copied().collect();
 
@@ -548,23 +540,52 @@ mod tests {
         rt.shutdown();
     }
 
-    #[test]
-    fn test_reconcile_free_instance_ids_preserves_existing_busy_state() {
-        let known_instance_ids = std::collections::HashSet::from([1_u64, 2, 3]);
+    #[tokio::test]
+    async fn test_instance_reconciliation_preserves_busy_existing_instances() {
+        const TEST_RECONCILE_INTERVAL: Duration = Duration::from_millis(50);
 
-        assert_eq!(
-            reconcile_free_instance_ids(&[1, 2, 3, 4], &known_instance_ids, &[1, 3]),
-            vec![1, 3, 4],
-            "existing busy workers stay busy while new workers become free"
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt
+            .namespace("test_busy_reconciliation".to_string())
+            .unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        let client = Client::with_reconcile_interval(endpoint.clone(), TEST_RECONCILE_INTERVAL)
+            .await
+            .unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let instances = client.wait_for_instances().await.unwrap();
+        let worker_id = instances[0].id();
+
+        for _ in 0..10 {
+            if client.instance_ids_free().contains(&worker_id) {
+                break;
+            }
+            tokio::time::sleep(TEST_RECONCILE_INTERVAL).await;
+        }
+        assert!(
+            client.instance_ids_free().contains(&worker_id),
+            "worker should be free after initial discovery reconciliation"
         );
 
-        let known_instance_ids = std::collections::HashSet::from([1_u64, 2, 3, 4]);
-
-        assert_eq!(
-            reconcile_free_instance_ids(&[2, 3, 4], &known_instance_ids, &[1, 3, 4]),
-            vec![3, 4],
-            "removed workers are dropped without freeing existing busy workers"
+        client.update_free_instances(&[worker_id]);
+        assert!(
+            client.instance_ids_free().is_empty(),
+            "worker should be busy before periodic reconciliation"
         );
+
+        tokio::time::sleep(TEST_RECONCILE_INTERVAL + Duration::from_millis(50)).await;
+
+        assert!(
+            client.instance_ids_free().is_empty(),
+            "periodic reconciliation should not mark an existing busy worker free"
+        );
+
+        rt.shutdown();
     }
 
     /// Test that instance_avail_watcher receives updates when instances change.

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -157,6 +157,8 @@ pub struct Client {
     instance_avail: Arc<ArcSwap<Vec<u64>>>,
     // These are the instance source ids less those reported as busy (above threshold)
     instance_free: Arc<ArcSwap<Vec<u64>>>,
+    // These are the instance ids reported as busy (above threshold)
+    instance_busy: Arc<StdMutex<HashSet<u64>>>,
     // Watch sender for available instance IDs (for sending updates)
     instance_avail_tx: Arc<tokio::sync::watch::Sender<Vec<u64>>>,
     // Watch receiver for available instance IDs (for cloning to external subscribers)
@@ -203,6 +205,7 @@ impl Client {
             instance_source: instance_source.clone(),
             instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
             instance_free: Arc::new(ArcSwap::from(Arc::new(initial_ids))),
+            instance_busy: Arc::new(StdMutex::new(HashSet::new())),
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
             reconcile_interval,
@@ -285,10 +288,14 @@ impl Client {
 
     /// Update the set of free instances based on busy instance IDs
     pub fn update_free_instances(&self, busy_instance_ids: &[u64]) {
-        let all_instance_ids = self.instance_ids();
-        let free_ids: Vec<u64> = all_instance_ids
+        let mut busy_ids = self.instance_busy.lock().unwrap();
+        busy_ids.clear();
+        busy_ids.extend(busy_instance_ids.iter().copied());
+
+        let free_ids = self
+            .instance_ids()
             .into_iter()
-            .filter(|id| !busy_instance_ids.contains(id))
+            .filter(|id| !busy_ids.contains(id))
             .collect();
         self.instance_free.store(Arc::new(free_ids));
     }
@@ -304,12 +311,6 @@ impl Client {
         let cancel_token = self.endpoint.drt().primary_token();
         let client = self.clone();
         let endpoint_id = self.endpoint.id();
-        let mut known_instance_ids = self
-            .instance_source
-            .borrow()
-            .iter()
-            .map(|instance| instance.id())
-            .collect::<HashSet<_>>();
         tokio::task::spawn(async move {
             let mut rx = client.instance_source.as_ref().clone();
             while !cancel_token.is_cancelled() {
@@ -320,19 +321,15 @@ impl Client {
                     .collect();
 
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
-                client.instance_free.rcu(|previous_free_ids| {
-                    let previous_free_ids =
-                        previous_free_ids.iter().copied().collect::<HashSet<_>>();
+                {
+                    let busy_ids = client.instance_busy.lock().unwrap();
                     let free_ids = instance_ids
                         .iter()
                         .copied()
-                        .filter(|id| {
-                            previous_free_ids.contains(id) || !known_instance_ids.contains(id)
-                        })
+                        .filter(|id| !busy_ids.contains(id))
                         .collect();
-                    Arc::new(free_ids)
-                });
-                known_instance_ids = instance_ids.iter().copied().collect();
+                    client.instance_free.store(Arc::new(free_ids));
+                }
 
                 // Clean up stale occupancy counters for instances that no longer exist.
                 let registry = client.endpoint.drt().routing_occupancy_states();
@@ -583,6 +580,40 @@ mod tests {
         assert!(
             client.instance_ids_free().is_empty(),
             "periodic reconciliation should not mark an existing busy worker free"
+        );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_instance_reconciliation_preserves_busy_new_instances() {
+        const TEST_RECONCILE_INTERVAL: Duration = Duration::from_millis(50);
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let worker_id = drt.connection_id();
+        let ns = drt
+            .namespace("test_new_busy_reconciliation".to_string())
+            .unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        let client = Client::with_reconcile_interval(endpoint.clone(), TEST_RECONCILE_INTERVAL)
+            .await
+            .unwrap();
+        client.update_free_instances(&[worker_id]);
+
+        endpoint.register_endpoint_instance().await.unwrap();
+        let instances = client.wait_for_instances().await.unwrap();
+        assert_eq!(instances[0].id(), worker_id);
+
+        tokio::time::sleep(TEST_RECONCILE_INTERVAL + Duration::from_millis(50)).await;
+
+        assert!(
+            client.instance_ids_free().is_empty(),
+            "discovery reconciliation should not mark a newly discovered busy worker free"
         );
 
         rt.shutdown();

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -234,32 +234,6 @@ impl Client {
             .collect()
     }
 
-    pub fn instance_count(&self) -> usize {
-        self.instance_source.borrow().len()
-    }
-
-    pub fn busy_instance_count(&self) -> usize {
-        self.instance_busy.load().len()
-    }
-
-    pub fn all_instances_busy(&self) -> bool {
-        let busy_ids = self.instance_busy.load();
-        if busy_ids.is_empty() {
-            return false;
-        }
-
-        let instances = self.instance_source.borrow();
-        let mut saw_instance = false;
-        for instance in instances.iter() {
-            saw_instance = true;
-            if !busy_ids.contains(&instance.id()) {
-                return false;
-            }
-        }
-
-        saw_instance
-    }
-
     /// Get a watcher for available instance IDs
     pub fn instance_avail_watcher(&self) -> tokio::sync::watch::Receiver<Vec<u64>> {
         self.instance_avail_rx.clone()

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -155,8 +155,6 @@ pub struct Client {
     pub instance_source: Arc<tokio::sync::watch::Receiver<Vec<Instance>>>,
     // These are the instance source ids less those reported as down from sending rpc
     instance_avail: Arc<ArcSwap<Vec<u64>>>,
-    // These are the instance source ids less those reported as busy (above threshold)
-    instance_free: Arc<ArcSwap<Vec<u64>>>,
     // These are the instance ids reported as busy (above threshold)
     instance_busy: Arc<StdMutex<HashSet<u64>>>,
     // Watch sender for available instance IDs (for sending updates)
@@ -204,7 +202,6 @@ impl Client {
             endpoint_discovery_source,
             instance_source: instance_source.clone(),
             instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
-            instance_free: Arc::new(ArcSwap::from(Arc::new(initial_ids))),
             instance_busy: Arc::new(StdMutex::new(HashSet::new())),
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
@@ -227,8 +224,14 @@ impl Client {
         self.instance_avail.load()
     }
 
-    pub fn instance_ids_free(&self) -> arc_swap::Guard<Arc<Vec<u64>>> {
-        self.instance_free.load()
+    pub fn instance_ids_free(&self) -> Vec<u64> {
+        let instance_ids = self.instance_ids();
+        let busy_ids = self.instance_busy.lock().unwrap();
+
+        instance_ids
+            .into_iter()
+            .filter(|id| !busy_ids.contains(id))
+            .collect()
     }
 
     /// Get a watcher for available instance IDs
@@ -291,13 +294,6 @@ impl Client {
         let mut busy_ids = self.instance_busy.lock().unwrap();
         busy_ids.clear();
         busy_ids.extend(busy_instance_ids.iter().copied());
-
-        let free_ids = self
-            .instance_ids()
-            .into_iter()
-            .filter(|id| !busy_ids.contains(id))
-            .collect();
-        self.instance_free.store(Arc::new(free_ids));
     }
 
     /// Monitor the key-value instance source and update instance_avail.
@@ -321,15 +317,6 @@ impl Client {
                     .collect();
 
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
-                {
-                    let busy_ids = client.instance_busy.lock().unwrap();
-                    let free_ids = instance_ids
-                        .iter()
-                        .copied()
-                        .filter(|id| !busy_ids.contains(id))
-                        .collect();
-                    client.instance_free.store(Arc::new(free_ids));
-                }
 
                 // Clean up stale occupancy counters for instances that no longer exist.
                 let registry = client.endpoint.drt().routing_occupancy_states();
@@ -586,7 +573,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_instance_reconciliation_preserves_busy_new_instances() {
+    async fn test_instance_ids_free_excludes_busy_new_instances() {
         const TEST_RECONCILE_INTERVAL: Duration = Duration::from_millis(50);
 
         let rt = Runtime::from_current().unwrap();
@@ -608,12 +595,16 @@ mod tests {
         endpoint.register_endpoint_instance().await.unwrap();
         let instances = client.wait_for_instances().await.unwrap();
         assert_eq!(instances[0].id(), worker_id);
+        assert!(
+            client.instance_ids_free().is_empty(),
+            "newly discovered busy worker should not be free"
+        );
 
         tokio::time::sleep(TEST_RECONCILE_INTERVAL + Duration::from_millis(50)).await;
 
         assert!(
             client.instance_ids_free().is_empty(),
-            "discovery reconciliation should not mark a newly discovered busy worker free"
+            "discovery reconciliation should not affect recomputed free workers"
         );
 
         rt.shutdown();

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -234,6 +234,14 @@ impl Client {
             .collect()
     }
 
+    pub fn instance_count(&self) -> usize {
+        self.instance_source.borrow().len()
+    }
+
+    pub fn busy_instance_count(&self) -> usize {
+        self.instance_busy.load().len()
+    }
+
     pub fn all_instances_busy(&self) -> bool {
         let busy_ids = self.instance_busy.load();
         if busy_ids.is_empty() {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -107,7 +107,7 @@ impl Drop for OccupancyPermit {
 #[async_trait]
 pub trait WorkerLoadMonitor: Send + Sync {
     /// Start background monitoring of worker load.
-    /// This should spawn background tasks that update the client's free instances.
+    /// This should spawn background tasks that update the client's busy instances.
     async fn start_monitoring(&self) -> anyhow::Result<()>;
 }
 
@@ -446,7 +446,7 @@ where
     /// Create a new PushRouter with an optional worker load monitor.
     ///
     /// The rejection path is gated by `fault_detection_enabled` (true here);
-    /// busy detection itself is driven by the monitor via `client.update_free_instances(...)`.
+    /// busy detection itself is driven by the monitor via `client.set_busy_instances(...)`.
     /// If no thresholds are configured on the monitor (or no monitor is provided),
     /// `client.instance_ids_free()` returns all instances and the gate never rejects.
     pub async fn from_client_with_monitor(

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -448,7 +448,7 @@ where
     /// The rejection path is gated by `fault_detection_enabled` (true here);
     /// busy detection itself is driven by the monitor via `client.set_busy_instances(...)`.
     /// If no thresholds are configured on the monitor (or no monitor is provided),
-    /// `client.instance_ids_free()` returns all instances and the gate never rejects.
+    /// `client.all_instances_busy()` returns false and the gate never rejects.
     pub async fn from_client_with_monitor(
         client: Client,
         router_mode: RouterMode,
@@ -808,36 +808,33 @@ where
 
         // Check if all workers are busy (when fault detection is enabled).
         if self.fault_detection_enabled {
-            let free_instances = self.client.instance_ids_free();
+            let all_instances_busy = self.client.all_instances_busy();
             if tracing::enabled!(tracing::Level::DEBUG) {
                 tracing::debug!(
                     request_id = %request_id,
                     instance_id,
                     router_mode = ?self.router_mode,
-                    free_workers = free_instances.len(),
-                    total_workers = self.client.instance_ids().len(),
+                    busy_workers = self.client.busy_instance_count(),
+                    total_workers = self.client.instance_count(),
+                    all_instances_busy,
                     "checked worker busy state"
                 );
             }
-            if free_instances.is_empty() {
-                // Check if we actually have any instances at all
-                let all_instances = self.client.instance_ids();
-                if !all_instances.is_empty() {
-                    tracing::warn!(
-                        instance_id,
-                        total_workers = all_instances.len(),
-                        "Rejecting request: all workers are busy"
-                    );
-                    let cause = PipelineError::ServiceOverloaded(
-                        "All workers are busy, please retry later".to_string(),
-                    );
-                    return Err(DynamoError::builder()
-                        .error_type(ErrorType::ResourceExhausted)
-                        .message("All workers are busy, please retry later")
-                        .cause(cause)
-                        .build()
-                        .into());
-                }
+            if all_instances_busy {
+                tracing::warn!(
+                    instance_id,
+                    total_workers = self.client.instance_count(),
+                    "Rejecting request: all workers are busy"
+                );
+                let cause = PipelineError::ServiceOverloaded(
+                    "All workers are busy, please retry later".to_string(),
+                );
+                return Err(DynamoError::builder()
+                    .error_type(ErrorType::ResourceExhausted)
+                    .message("All workers are busy, please retry later")
+                    .cause(cause)
+                    .build()
+                    .into());
             }
         }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -814,8 +814,7 @@ where
                     request_id = %request_id,
                     instance_id,
                     router_mode = ?self.router_mode,
-                    busy_workers = self.client.busy_instance_count(),
-                    total_workers = self.client.instance_count(),
+                    total_workers = self.client.instance_source.borrow().len(),
                     all_instances_busy,
                     "checked worker busy state"
                 );
@@ -823,7 +822,7 @@ where
             if all_instances_busy {
                 tracing::warn!(
                     instance_id,
-                    total_workers = self.client.instance_count(),
+                    total_workers = self.client.instance_source.borrow().len(),
                     "Rejecting request: all workers are busy"
                 );
                 let cause = PipelineError::ServiceOverloaded(

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -814,7 +814,8 @@ where
                     request_id = %request_id,
                     instance_id,
                     router_mode = ?self.router_mode,
-                    total_workers = self.client.instance_source.borrow().len(),
+                    busy_workers = self.client.busy_instance_count(),
+                    total_workers = self.client.instance_count(),
                     all_instances_busy,
                     "checked worker busy state"
                 );
@@ -822,7 +823,7 @@ where
             if all_instances_busy {
                 tracing::warn!(
                     instance_id,
-                    total_workers = self.client.instance_source.borrow().len(),
+                    total_workers = self.client.instance_count(),
                     "Rejecting request: all workers are busy"
                 );
                 let cause = PipelineError::ServiceOverloaded(

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -448,7 +448,7 @@ where
     /// The rejection path is gated by `fault_detection_enabled` (true here);
     /// busy detection itself is driven by the monitor via `client.set_busy_instances(...)`.
     /// If no thresholds are configured on the monitor (or no monitor is provided),
-    /// `client.all_instances_busy()` returns false and the gate never rejects.
+    /// `client.instance_ids_free()` returns all instances and the gate never rejects.
     pub async fn from_client_with_monitor(
         client: Client,
         router_mode: RouterMode,
@@ -808,33 +808,36 @@ where
 
         // Check if all workers are busy (when fault detection is enabled).
         if self.fault_detection_enabled {
-            let all_instances_busy = self.client.all_instances_busy();
+            let free_instances = self.client.instance_ids_free();
             if tracing::enabled!(tracing::Level::DEBUG) {
                 tracing::debug!(
                     request_id = %request_id,
                     instance_id,
                     router_mode = ?self.router_mode,
-                    busy_workers = self.client.busy_instance_count(),
-                    total_workers = self.client.instance_count(),
-                    all_instances_busy,
+                    free_workers = free_instances.len(),
+                    total_workers = self.client.instance_ids().len(),
                     "checked worker busy state"
                 );
             }
-            if all_instances_busy {
-                tracing::warn!(
-                    instance_id,
-                    total_workers = self.client.instance_count(),
-                    "Rejecting request: all workers are busy"
-                );
-                let cause = PipelineError::ServiceOverloaded(
-                    "All workers are busy, please retry later".to_string(),
-                );
-                return Err(DynamoError::builder()
-                    .error_type(ErrorType::ResourceExhausted)
-                    .message("All workers are busy, please retry later")
-                    .cause(cause)
-                    .build()
-                    .into());
+            if free_instances.is_empty() {
+                // Check if we actually have any instances at all
+                let all_instances = self.client.instance_ids();
+                if !all_instances.is_empty() {
+                    tracing::warn!(
+                        instance_id,
+                        total_workers = all_instances.len(),
+                        "Rejecting request: all workers are busy"
+                    );
+                    let cause = PipelineError::ServiceOverloaded(
+                        "All workers are busy, please retry later".to_string(),
+                    );
+                    return Err(DynamoError::builder()
+                        .error_type(ErrorType::ResourceExhausted)
+                        .message("All workers are busy, please retry later")
+                        .cause(cause)
+                        .build()
+                        .into());
+                }
             }
         }
 


### PR DESCRIPTION
Preserve existing busy-state filtering when discovery reconciliation refreshes client instances. New workers are added as free and removed workers are dropped without clobbering busy workers.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of instance state management by ensuring previously available instances are correctly tracked and unavailable ones are properly removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9631)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->