### PR TITLE
fix(ci): parallelize vLLM gpu_1 leftovers

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_engine.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine.py
@@ -19,23 +19,43 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import os
+from collections.abc import Mapping
 from typing import cast
 
 import pytest
 import pytest_asyncio
 
+from tests.utils.gpu_args import build_gpu_mem_args
+
 MODEL_ID = "Qwen/Qwen3-0.6B"
-_BASE_ARGV = [
-    "--model",
-    MODEL_ID,
-    "--gpu-memory-utilization",
-    "0.3",
-    "--max-model-len",
-    "1024",
-    "--max-num-seqs",
-    "4",
-    "--enforce-eager",
-]
+
+
+def _env_with_requested_kv_bytes(request: pytest.FixtureRequest) -> dict[str, str]:
+    env = os.environ.copy()
+    if "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" not in env:
+        kv_mark = request.node.get_closest_marker("requested_vllm_kv_cache_bytes")
+        if kv_mark:
+            env["_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES"] = str(int(kv_mark.args[0]))
+    return env
+
+
+def _base_argv(env: Mapping[str, str]) -> list[str]:
+    gpu_mem_args = build_gpu_mem_args("build_vllm_gpu_mem_args", env=env)
+    if not gpu_mem_args:
+        gpu_mem_args = ["--gpu-memory-utilization", "0.3"]
+
+    return [
+        "--model",
+        MODEL_ID,
+        *gpu_mem_args,
+        "--max-model-len",
+        "1024",
+        "--max-num-seqs",
+        "4",
+        "--enforce-eager",
+    ]
+
 
 pytestmark = [
     pytest.mark.asyncio(loop_scope="module"),
@@ -43,7 +63,6 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.unified,
     pytest.mark.gpu_1,
-    pytest.mark.pre_merge,
     pytest.mark.timeout(300),
     pytest.mark.skipif(
         importlib.util.find_spec("vllm") is None,
@@ -69,14 +88,16 @@ class _FakeContext:
         await asyncio.Event().wait()
 
 
-@pytest_asyncio.fixture(scope="module", loop_scope="module")
-async def started_engine():
+@pytest_asyncio.fixture(loop_scope="module")
+async def started_engine(request):
     # Use vLLM's default spawn for the EngineCore subprocess (set by
     # VllmLLMEngine.start). Fork would inherit pytest's filterwarnings=error
     # and crash the child on transitive flashinfer DeprecationWarnings.
     from dynamo.vllm.llm_engine import VllmLLMEngine
 
-    engine, _ = await VllmLLMEngine.from_args(_BASE_ARGV)
+    engine, _ = await VllmLLMEngine.from_args(
+        _base_argv(_env_with_requested_kv_bytes(request))
+    )
     try:
         # Worker_id 0 is fine for tests — the engine doesn't use it.
         engine_config = await engine.start(0)
@@ -85,7 +106,28 @@ async def started_engine():
         await engine.cleanup()
 
 
-async def test_start_populates_registration_metadata(started_engine):
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(3.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
+@pytest.mark.timeout(900)
+async def test_vllm_engine_all(request, started_engine):
+    """Run the real-engine VllmLLMEngine checks under one profiled startup."""
+    await _check_start_populates_registration_metadata(started_engine)
+    await _check_generate_streams_chunks_with_coherent_final_usage(started_engine)
+    await _check_abort_and_cleanup_are_safe_before_start(request)
+    await _check_abort_unknown_request_on_running_engine(started_engine)
+    await _check_from_args_propagates_disaggregation_mode_to_worker_config(
+        request, "agg", "AGGREGATED"
+    )
+    await _check_from_args_propagates_disaggregation_mode_to_worker_config(
+        request, "prefill", "PREFILL"
+    )
+    await _check_from_args_propagates_disaggregation_mode_to_worker_config(
+        request, "decode", "DECODE"
+    )
+
+
+async def _check_start_populates_registration_metadata(started_engine):
     """``start`` must surface non-None values for the fields the Rust
     registration path reads — if any of them come back None, the model
     appears in /v1/models but fails to actually serve."""
@@ -97,7 +139,7 @@ async def test_start_populates_registration_metadata(started_engine):
     assert cfg.max_num_batched_tokens and cfg.max_num_batched_tokens > 0
 
 
-async def test_generate_streams_chunks_with_coherent_final_usage(started_engine):
+async def _check_generate_streams_chunks_with_coherent_final_usage(started_engine):
     """Every chunk must carry ``token_ids``; the final chunk must also carry
     ``finish_reason`` and a ``completion_usage`` whose totals add up."""
     engine, _ = started_engine
@@ -124,35 +166,29 @@ async def test_generate_streams_chunks_with_coherent_final_usage(started_engine)
     assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
 
 
-async def test_abort_and_cleanup_are_safe_before_start():
+async def _check_abort_and_cleanup_are_safe_before_start(request):
     """Worker may call ``abort`` / ``cleanup`` on any failure path.  Neither
     must raise on a just-constructed engine, and ``cleanup`` must be
     idempotent."""
     from dynamo.vllm.llm_engine import VllmLLMEngine
 
-    engine, _ = await VllmLLMEngine.from_args(_BASE_ARGV)
+    engine, _ = await VllmLLMEngine.from_args(
+        _base_argv(_env_with_requested_kv_bytes(request))
+    )
     await engine.abort(cast(object, _FakeContext()))  # type: ignore[arg-type]
     await engine.cleanup()
     await engine.cleanup()
 
 
-async def test_abort_unknown_request_on_running_engine(started_engine):
+async def _check_abort_unknown_request_on_running_engine(started_engine):
     """vLLM's ``AsyncLLM.abort`` is a best-effort lookup.  Aborting a request
     id the engine has never seen must not raise."""
     engine, _ = started_engine
     await engine.abort(cast(object, _FakeContext("never-submitted")))  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize(
-    "mode_arg, expected",
-    [
-        ("agg", "AGGREGATED"),
-        ("prefill", "PREFILL"),
-        ("decode", "DECODE"),
-    ],
-)
-async def test_from_args_propagates_disaggregation_mode_to_worker_config(
-    mode_arg, expected
+async def _check_from_args_propagates_disaggregation_mode_to_worker_config(
+    request, mode_arg, expected
 ):
     """``--disaggregation-mode`` must flow from CLI through to the
     ``WorkerConfig`` the unified Worker sees, and onto the engine instance
@@ -171,7 +207,12 @@ async def test_from_args_propagates_disaggregation_mode_to_worker_config(
         ]
 
     engine, worker_config = await VllmLLMEngine.from_args(
-        [*_BASE_ARGV, "--disaggregation-mode", mode_arg, *extra_args]
+        [
+            *_base_argv(_env_with_requested_kv_bytes(request)),
+            "--disaggregation-mode",
+            mode_arg,
+            *extra_args,
+        ]
     )
     try:
         expected_mode = getattr(DisaggregationMode, expected)

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -40,6 +40,7 @@ pytestmark = [
     # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
     # runners with "Failed to infer device type" even for mock tests.
     pytest.mark.gpu_1,
+    pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -37,6 +37,7 @@ JINJA_TEMPLATE_PATH = str(
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
     # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
     # runners with "Failed to infer device type" even for mock tests.
     pytest.mark.gpu_1,

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -14,6 +14,7 @@ from dynamo.vllm.worker_factory import EngineSetupResult, WorkerFactory
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
     # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
     # runners with "Failed to infer device type" even for mock tests.
     pytest.mark.gpu_1,

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -17,6 +17,7 @@ pytestmark = [
     # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
     # runners with "Failed to infer device type" even for mock tests.
     pytest.mark.gpu_1,
+    pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
 

--- a/tests/frontend/test_vllm_prepost_integration.py
+++ b/tests/frontend/test_vllm_prepost_integration.py
@@ -47,6 +47,7 @@ pytestmark = [
     # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
     # runners with "Failed to infer device type" even for mock tests.
     pytest.mark.gpu_1,
+    pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
     pytest.mark.integration,
     pytest.mark.parallel,

--- a/tests/kvbm_integration/common.py
+++ b/tests/kvbm_integration/common.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional, Tuple
 import pytest
 import requests
 
+from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.port_utils import allocate_port, deallocate_port
 
 # ============================================================================
@@ -573,13 +574,31 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
         f"NATS: {nats_process.port}, etcd: {etcd_process.port}"
     )
 
+    # Set up environment
+    # Note: NATS_SERVER and ETCD_ENDPOINTS are already set by
+    # runtime_services_dynamic_ports fixture.
+    env = os.environ.copy()
+    env.update(
+        {
+            "RUST_BACKTRACE": "1",
+            "VLLM_SERVER_DEV_MODE": "1",
+            "DYN_LOG": "debug",
+            "DYN_KVBM_METRICS": "true",
+            "DYN_KVBM_METRICS_PORT": str(metrics_port),
+            "DYN_KVBM_LEADER_ZMQ_PUB_PORT": str(zmq_pub_port),
+            "DYN_KVBM_LEADER_ZMQ_ACK_PORT": str(zmq_ack_port),
+            # DynamoConnector uses NATS_SERVER and ETCD_ENDPOINTS from the env.
+        }
+    )
+
+    if "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" not in env:
+        kv_mark = request.node.get_closest_marker("requested_vllm_kv_cache_bytes")
+        if kv_mark:
+            env["_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES"] = str(int(kv_mark.args[0]))
+
+    gpu_mem_args = build_gpu_mem_args("build_vllm_gpu_mem_args", env=env)
+
     # Build vLLM command
-    # TODO: For parallel execution on single GPU with pytest-xdist, add dynamic GPU memory allocation:
-    #   1. Detect parallel execution: worker_count = os.environ.get("PYTEST_XDIST_WORKER_COUNT")
-    #   2. Calculate fraction: gpu_memory_fraction = 0.85 / int(worker_count) if worker_count else 0.9
-    #   3. Add to command: "--gpu-memory-utilization", str(gpu_memory_fraction)
-    #   Example: 2 workers → 42.5% each, 3 workers → 28.3% each
-    #   Trade-off: Smaller GPU memory per worker = smaller KV cache = more CPU offloads
     command = [
         "vllm",
         "serve",
@@ -592,6 +611,7 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
         model,
         "--max-model-len",
         str(max_model_len),
+        *gpu_mem_args,
     ]
 
     # GPU blocks override
@@ -603,23 +623,6 @@ def llm_server_kvbm(request, runtime_services_dynamic_ports):
         command.extend(
             ["--max-num-batched-tokens", str(params["max_num_batched_tokens"])]
         )
-
-    # Set up environment
-    # Note: NATS_SERVER and ETCD_ENDPOINTS are already set by runtime_services_dynamic_ports fixture
-    env = os.environ.copy()
-    env.update(
-        {
-            "RUST_BACKTRACE": "1",
-            "VLLM_SERVER_DEV_MODE": "1",
-            "DYN_LOG": "debug",
-            "DYN_KVBM_METRICS": "true",
-            "DYN_KVBM_METRICS_PORT": str(metrics_port),
-            "DYN_KVBM_LEADER_ZMQ_PUB_PORT": str(zmq_pub_port),
-            "DYN_KVBM_LEADER_ZMQ_ACK_PORT": str(zmq_ack_port),
-            # DynamoConnector will use NATS_SERVER and ETCD_ENDPOINTS from environment
-            # (already set by runtime_services_dynamic_ports fixture)
-        }
-    )
 
     # CPU cache blocks override via env
     if cpu_blocks is not None:

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -118,6 +118,8 @@ def tester(llm_server_kvbm):  # noqa: F811
     ],
     indirect=True,
 )
+@pytest.mark.profiled_vram_gib(3.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
 @pytest.mark.timeout(140)  # 4x measured (~34s), rounded up
 def test_chunked_prefill_offload(tester, llm_server_kvbm):  # noqa: F811
     """

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -114,6 +114,8 @@ def tester(llm_server_kvbm):  # noqa: F811
 
 # Tests
 @pytest.mark.parametrize("llm_server_kvbm", [{"model": KVBM_TEST_MODEL}], indirect=True)
+@pytest.mark.profiled_vram_gib(3.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
 @pytest.mark.timeout(170)  # 4x measured (~41s), rounded up
 def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     """
@@ -181,6 +183,8 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
     indirect=True,
 )
+@pytest.mark.profiled_vram_gib(3.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
 @pytest.mark.timeout(170)  # 4x measured (~42s), rounded up
 def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     """
@@ -256,6 +260,8 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     [{"cpu_blocks": 200, "gpu_blocks": 20, "model": KVBM_TEST_MODEL}],
     indirect=True,
 )
+@pytest.mark.profiled_vram_gib(3.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
 @pytest.mark.timeout(160)  # 4x measured (~39s), rounded up
 def test_onboarding_determinism(tester, llm_server_kvbm):  # noqa: F811
     """

--- a/tests/mm_router/test_vllm_mm_router_e2e.py
+++ b/tests/mm_router/test_vllm_mm_router_e2e.py
@@ -40,15 +40,11 @@ THREE_IMAGE_TOTAL_BLOCKS_RANGE = (180, 340)
 SINGLE_IMAGE_TOTAL_BLOCKS_RANGE = (60, 160)
 
 pytestmark = [
-    pytest.mark.pre_merge,  # all tests take <1 min to run finish on RTX 6000
     pytest.mark.e2e,
     pytest.mark.vllm,
     pytest.mark.multimodal,
     pytest.mark.gpu_1,
     pytest.mark.model(VLLM_MM_MODEL),
-    pytest.mark.requested_vllm_kv_cache_bytes(
-        1_719_075_000
-    ),  # KV cache cap (2x safety over min=859_537_408)
 ]
 
 _COLORS = [
@@ -303,8 +299,45 @@ def _send_request_get_overlap(
     return overlap, total, segment
 
 
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(7.6)
+@pytest.mark.requested_vllm_kv_cache_bytes(
+    1_719_075_000
+)  # KV cache cap (2x safety over min=859_537_408)
+@pytest.mark.timeout(1800)
+def test_vllm_mm_overlap_all(
+    start_vllm_mm_services, predownload_models, http_image_server
+):
+    """Run all MM overlap scenarios under one profiled worker startup.
+
+    GPU-parallel CI runs each selected test id in its own pytest subprocess.
+    Keeping the individual scenario tests out of pre_merge avoids paying vLLM
+    startup for each scenario while preserving them for manual development runs.
+    """
+    _check_text_only_overlap_repeated_prompt(start_vllm_mm_services, predownload_models)
+    _check_repeated_three_images(start_vllm_mm_services, predownload_models)
+    _check_repeated_single_image(start_vllm_mm_services, predownload_models)
+    _check_repeated_two_identical_images(start_vllm_mm_services, predownload_models)
+    _check_staircase_single_to_double_to_triple_identical_image(
+        start_vllm_mm_services, predownload_models
+    )
+    _check_diff_images_less_than_same(start_vllm_mm_services, predownload_models)
+    _check_same_images_different_prompt_less_than_same_prompt(
+        start_vllm_mm_services, predownload_models
+    )
+    _check_swapped_order_less_than_same_order(
+        start_vllm_mm_services, predownload_models
+    )
+    _check_repeated_http_images(
+        start_vllm_mm_services, predownload_models, http_image_server
+    )
+    _check_http_vs_data_uri_same_image(
+        start_vllm_mm_services, predownload_models, http_image_server
+    )
+
+
 @pytest.mark.timeout(300)
-def test_vllm_text_only_overlap_repeated_prompt(
+def _check_text_only_overlap_repeated_prompt(
     start_vllm_mm_services, predownload_models
 ):
     """Text-only routing should increase overlap on repeat and then stabilize."""
@@ -349,9 +382,7 @@ def test_vllm_text_only_overlap_repeated_prompt(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_repeated_three_images(
-    start_vllm_mm_services, predownload_models
-):
+def _check_repeated_three_images(start_vllm_mm_services, predownload_models):
     """For repeated same 3-image request: low first overlap, then increase, then stable."""
     frontend_port, router_proc = start_vllm_mm_services
 
@@ -389,9 +420,7 @@ def test_vllm_mm_overlap_repeated_three_images(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_repeated_single_image(
-    start_vllm_mm_services, predownload_models
-):
+def _check_repeated_single_image(start_vllm_mm_services, predownload_models):
     """For repeated same single-image request: low first overlap, then increase, then stable."""
     frontend_port, router_proc = start_vllm_mm_services
 
@@ -429,9 +458,7 @@ def test_vllm_mm_overlap_repeated_single_image(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_repeated_two_identical_images(
-    start_vllm_mm_services, predownload_models
-):
+def _check_repeated_two_identical_images(start_vllm_mm_services, predownload_models):
     """For repeated same two-identical-image request: low first overlap, then increase, then stable."""
     frontend_port, router_proc = start_vllm_mm_services
 
@@ -465,7 +492,7 @@ def test_vllm_mm_overlap_repeated_two_identical_images(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_staircase_single_to_double_to_triple_identical_image(
+def _check_staircase_single_to_double_to_triple_identical_image(
     start_vllm_mm_services, predownload_models
 ):
     """Single->double->triple identical image requests follow prefix-overlap semantics."""
@@ -520,9 +547,7 @@ def test_vllm_mm_overlap_staircase_single_to_double_to_triple_identical_image(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_diff_images_less_than_same(
-    start_vllm_mm_services, predownload_models
-):
+def _check_diff_images_less_than_same(start_vllm_mm_services, predownload_models):
     """Different images should produce lower overlap than repeated identical images."""
     frontend_port, router_proc = start_vllm_mm_services
     baseline_payload = _build_payload(
@@ -574,7 +599,7 @@ def test_vllm_mm_overlap_diff_images_less_than_same(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_same_images_different_prompt_less_than_same_prompt(
+def _check_same_images_different_prompt_less_than_same_prompt(
     start_vllm_mm_services, predownload_models
 ):
     """Same images but different prompt should produce lower overlap than repeated same prompt."""
@@ -634,7 +659,7 @@ def test_vllm_mm_overlap_same_images_different_prompt_less_than_same_prompt(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_swapped_order_less_than_same_order(
+def _check_swapped_order_less_than_same_order(
     start_vllm_mm_services, predownload_models
 ):
     """Swapping order of three distinct images should result in near-zero overlap."""
@@ -728,7 +753,7 @@ def http_image_server() -> Generator[list[str], None, None]:
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_repeated_http_images(
+def _check_repeated_http_images(
     start_vllm_mm_services, predownload_models, http_image_server
 ):
     """For repeated same 3-HTTP-image request: low first overlap, then increase, then stable."""
@@ -769,7 +794,7 @@ def test_vllm_mm_overlap_repeated_http_images(
 
 
 @pytest.mark.timeout(600)
-def test_vllm_mm_overlap_http_vs_data_uri_same_image(
+def _check_http_vs_data_uri_same_image(
     start_vllm_mm_services, predownload_models, http_image_server
 ):
     """HTTP URL and data URI for the same image should produce identical KV cache hashes."""

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -307,9 +307,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
-                # TODO: re-enable GPU-parallel scheduling with
-                # profiled_vram_gib=12.0 once this has a bounded --kv-bytes profile.
                 timeout_s=300,
+                profiled_vram_gib=12.0,
+                requested_vllm_kv_cache_bytes=922_354_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
         },

--- a/tests/test_predownload_models.py
+++ b/tests/test_predownload_models.py
@@ -27,6 +27,7 @@ import pytest
                 pytest.mark.core,
                 pytest.mark.e2e,
                 pytest.mark.gpu_1,
+                pytest.mark.profiled_vram_gib(0),
             ],
         ),
         pytest.param(

--- a/tests/utils/gpu_args.py
+++ b/tests/utils/gpu_args.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 
 import shlex
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 
-def build_gpu_mem_args(function_name: str) -> list[str]:
+def build_gpu_mem_args(
+    function_name: str, env: Mapping[str, str] | None = None
+) -> list[str]:
     """Call a backend memory-args function from examples/common/gpu_utils.sh."""
     repo_root = Path(__file__).resolve().parents[2]
     gpu_utils = repo_root / "examples" / "common" / "gpu_utils.sh"
@@ -19,6 +22,7 @@ def build_gpu_mem_args(function_name: str) -> list[str]:
         ["bash", "-lc", cmd],
         check=True,
         capture_output=True,
+        env=env,
         text=True,
     )
     return shlex.split(result.stdout.strip())

--- a/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
+++ b/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
@@ -65,6 +65,7 @@ import pytest
 
 from tests.utils.client import send_request
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
@@ -163,6 +164,16 @@ class _DynamoBenchmarkWorker(ManagedProcess):
         # --benchmark-mode and so doesn't auto-inject InstrumentedScheduler.
         self.fpm_port = allocate_port(20380)
 
+        env = os.environ.copy()
+        if "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" not in env:
+            kv_mark = request.node.get_closest_marker("requested_vllm_kv_cache_bytes")
+            if kv_mark:
+                env["_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES"] = str(int(kv_mark.args[0]))
+
+        gpu_mem_args = build_gpu_mem_args("build_vllm_gpu_mem_args", env=env)
+        if not gpu_mem_args:
+            gpu_mem_args = ["--gpu-memory-utilization", _GPU_MEMORY_UTILIZATION]
+
         command = [
             "python3",
             "-m",
@@ -170,8 +181,7 @@ class _DynamoBenchmarkWorker(ManagedProcess):
             "--model",
             FAULT_TOLERANCE_MODEL_NAME,
             "--enforce-eager",
-            "--gpu-memory-utilization",
-            _GPU_MEMORY_UTILIZATION,
+            *gpu_mem_args,
             "--max-model-len",
             _MAX_MODEL_LEN,
             # Benchmark flags
@@ -225,7 +235,6 @@ class _DynamoBenchmarkWorker(ManagedProcess):
                 (f"http://localhost:{frontend_port}/health", check_health_generate),
             ]
 
-        env = os.environ.copy()
         env["DYN_LOG"] = "info"
         # Match cancellation tests' config to avoid CI flake from
         # canary health checks during startup.
@@ -338,6 +347,8 @@ def _send_chat_completion(frontend_port: int) -> str:
 
 
 @pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(3.8)
+@pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
 @pytest.mark.timeout(600)
 def test_self_benchmark_agg_serves_after_bench(
     request, runtime_services_dynamic_ports, predownload_models, tmp_path


### PR DESCRIPTION
#### Overview:

Move the remaining non-skipped `pre_merge and vllm and gpu_1 and not profiled_vram_gib` tests out of the sequential GPU fallback and into the GPU-parallel pool.

This should remove the ~30 minute pre-merge vLLM `gpu_1` sequential tail caused by unprofiled leftovers.

#### Details:

- Converts `test_vllm_engine.py` into one profiled umbrella test so engine startup is amortized across scenarios.
- Keeps the MM-router umbrella pattern so CI schedules 3 fixture-param tests instead of 30 scenario tests.
- Adds profiled VRAM/KV markers to KVBM leftovers, Gemma multimodal serve topology, and the self-benchmark leftover.
- Updates vLLM/KVBM/self-benchmark launch paths to honor `requested_vllm_kv_cache_bytes` via `build_gpu_mem_args`.
- Adds `profiled_vram_gib(0)` to vLLM tests that require the vLLM environment but should not consume GPU-parallel VRAM budget.
- Preserves main's new `core` marker on the vLLM GPU1 predownload param while keeping it out of the sequential fallback.

Validation run:
- Marker report: `55` checked, `6` mypy skipped, `0` missing marker sets.
- dlcluster A100x2 CI-style run:
  `python3 -m pytest -o cache_dir=/tmp/pytest-cache --max-vram-gib=24 -n 2 -m "pre_merge and vllm and gpu_1" ...`
  completed with SLURM exit `0:0` in `00:15:22`.
- Leftover query for `pre_merge and vllm and gpu_1 and not profiled_vram_gib` collected no unintended leftovers in the vLLM GPU test container.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/tests/test_vllm_engine.py`
- `tests/mm_router/test_vllm_mm_router_e2e.py`
- `tests/kvbm_integration/common.py`
- `tests/kvbm_integration/test_kvbm.py`
- `tests/kvbm_integration/test_chunked_prefill.py`
- `tests/serve/multimodal_profiles/vllm.py`
- `tests/vllm_self_benchmark/test_self_benchmark_gpu.py`
- `tests/utils/gpu_args.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes #9508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test orchestration to consolidate multiple integration checks into single orchestrated test functions with sequential execution.
  * Enhanced GPU memory and KV-cache profiling configuration with new pytest markers for VRAM allocation and cache sizing.
  * Improved dynamic GPU memory argument handling in test utilities for flexible resource configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9634)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->