### PR TITLE
test: reskip online replay smoke

### DIFF
--- a/lib/bindings/python/tests/replay/test_replay_smoke.py
+++ b/lib/bindings/python/tests/replay/test_replay_smoke.py
@@ -23,10 +23,18 @@ from .replay_utils import (
 
 pytestmark = [
     pytest.mark.gpu_0,
+    pytest.mark.parallel,
     pytest.mark.pre_merge,
     pytest.mark.unit,
     pytest.mark.timeout(120),
 ]
+
+
+@pytest.fixture(autouse=True)
+def _skip_online(request):
+    callspec = getattr(request.node, "callspec", None)
+    if callspec and callspec.params.get("replay_mode") == "online":
+        pytest.skip("intermittent hang in online replay mode (#9548)")
 
 
 @pytest.mark.parametrize("engine_type", ["vllm", "sglang"])


### PR DESCRIPTION
Reskips online replay smoke parametrizations due to the intermittent hang and restores the replay smoke module to the parallel test lane.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled parallel test execution support for improved test performance
  * Added automatic skipping of tests prone to intermittent failures in online mode to improve test reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->