### PR TITLE
fix: DGDR does not propagate environment variables to generated DGD worker pods

### DIFF
--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -754,11 +754,12 @@ def _deep_merge_overrides(
 
     Rules:
     - Dicts are merged recursively; missing intermediate keys are created.
-    - ``spec.services.<name>`` that does not exist in *target* is skipped
-      with a warning (all nested overrides under that service are dropped).
-    - Only ``spec.services.<worker>.extraPodSpec.mainContainer.args`` is
-      *appended* to the existing list (preserving profiler-generated CLI
-      args).  ``args`` at any other path is replaced normally.
+    - `spec.services.<name>` that does not exist in *target* is skipped
+      with a warning.
+    - Only `spec.services.<worker>.extraPodSpec.mainContainer.args` is appended
+      to preserve profiler-generated CLI args.
+    - Environment variables are merged intelligently: user overrides replace
+      injected env vars but log a warning if a name conflict occurs.
     - All other leaf values replace the target value.
     """
     for key, value in overrides.items():
@@ -779,17 +780,62 @@ def _deep_merge_overrides(
                 )
                 continue
 
-        if isinstance(value, dict) and isinstance(target.get(key), dict):
-            _deep_merge_overrides(target[key], value, current_path)
-        elif isinstance(value, dict) and key not in target:
-            target[key] = copy.deepcopy(value)
+        # Recurse for nested dicts
+        if isinstance(value, dict):
+            existing = target.get(key)
+
+            if isinstance(existing, dict):
+                _deep_merge_overrides(existing, value, current_path)
+            else:
+                target[key] = copy.deepcopy(value)
+
+        # Append worker CLI args instead of replacing
         elif (
             key == "args"
             and isinstance(value, list)
             and _is_worker_main_container_args(current_path)
         ):
             existing = target.get(key) or []
-            target[key] = list(existing) + list(value)
+            target[key] = list(existing) + copy.deepcopy(value)
+
+        # Merge env vars by env name. User overrides take precedence over profiler-injected envs.
+        elif (
+            key == "env"
+            and isinstance(value, list)
+            and isinstance(target.get(key), list)
+        ):
+            existing = target.get(key, [])
+            merged: dict[str, dict] = {}
+
+            for env in existing:
+                env_dict = _envvar_to_dict(env)
+                env_name = env_dict.get("name")
+
+                if env_name:
+                    merged[env_name] = env_dict
+
+            for env in value:
+                env_dict = _envvar_to_dict(env)
+                env_name = env_dict.get("name")
+
+                if not env_name:
+                    logger.warning(
+                        "Skipping env override without a valid 'name': %r",
+                        env,
+                    )
+                    continue
+
+                if env_name in merged:
+                    logger.warning(
+                        "Override for env var '%s' replaces the existing value.",
+                        env_name,
+                    )
+
+                merged[env_name] = env_dict
+
+            target[key] = list(merged.values())
+
+        # Replace all other leaf values
         else:
             target[key] = (
                 copy.deepcopy(value) if isinstance(value, (dict, list)) else value

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -22,6 +22,8 @@ from typing import Any, Optional
 import numpy as np
 import yaml
 
+from copy import deepcopy
+from typing import Any, Optional
 from dynamo.common.utils.paths import get_workspace_dir
 from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
 from dynamo.planner.config.backend_components import (
@@ -118,6 +120,20 @@ def assemble_final_config(
     else:
         base = dgd_config
 
+    # --- Normalize services dict/list ---
+    services_dict, services_list = _normalize_services(base)
+
+    # --- Inject global envs into all containers ---
+    _inject_global_envs(
+        services_list,
+        dgdr.envs or [],
+    )
+
+    _inject_worker_envs(
+        services_dict,
+        dgdr.workerEnvs or [],
+    )
+                        
     # Step 2: for vLLM deployments, turn on the per-worker self-benchmark so
     # the get_perf_metrics endpoint is available to the planner. Mocker
     # workers don't use DYN_BENCHMARK_MODE, so skip when mocker is active.
@@ -620,3 +636,120 @@ def _load_profiling_data(output_dir: str) -> dict:
         pass
 
     return result
+
+
+def _envvar_to_dict(env: Any) -> dict:
+    """Convert a Kubernetes EnvVar-like object into a plain dict.
+
+    Supports:
+    - kubernetes.client.V1EnvVar
+    - pydantic/dataclass objects
+    - plain dicts
+
+    Preserves:
+    - value
+    - valueFrom
+    """
+    if isinstance(env, dict):
+        return deepcopy(env)
+
+    env_dict = {"name": env.name}
+
+    value = getattr(env, "value", None)
+    if value is not None:
+        env_dict["value"] = str(value)
+
+    value_from = (
+        getattr(env, "valueFrom", None)
+        or getattr(env, "value_from", None)
+    )
+
+    if value_from is not None:
+        # Preserve the original Kubernetes structure
+        if hasattr(value_from, "to_dict"):
+            env_dict["valueFrom"] = value_from.to_dict()
+        elif isinstance(value_from, dict):
+            env_dict["valueFrom"] = deepcopy(value_from)
+        else:
+            env_dict["valueFrom"] = deepcopy(vars(value_from))
+
+    return env_dict
+
+
+def _append_envs_or_override(
+    container_env: list[dict],
+    envs: list[Any],
+) -> None:
+    env_map = {e.get("name"): e for e in container_env if isinstance(e, dict)}
+
+    for env in envs:
+        env_dict = _envvar_to_dict(env)
+        name = env_dict["name"]
+
+        # override instead of skip
+        env_map[name] = env_dict
+
+    container_env[:] = list(env_map.values())
+
+
+def _normalize_services(base: dict) -> tuple[dict[str, dict], list[dict]]:
+    """Normalize DGD services to both dict and list forms."""
+    services = base.get("spec", {}).get("services", {})
+
+    if isinstance(services, dict):
+        return services, list(services.values())
+
+    services_dict = {f"svc_{i}": s for i, s in enumerate(services)}
+    return services_dict, services
+
+
+def _inject_global_envs(
+    services_list: list[dict],
+    envs: list[Any],
+) -> None:
+    """Inject envs into all containers across all services."""
+    if not envs:
+        return
+
+    for svc_spec in services_list:
+        containers = svc_spec.get("containers", [])
+
+        for container in _iter_service_containers(svc_spec):
+            container_env = container.setdefault("env", [])
+            _append_envs_or_override(container_env, envs)
+
+
+def _inject_worker_envs(
+    services_dict: dict[str, dict],
+    worker_envs: list[Any],
+) -> None:
+    """Inject envs only into worker containers."""
+    if not worker_envs:
+        return
+
+    worker_names = (
+        set(_vllm_worker_roles().keys())
+        | set(_mocker_worker_names())
+    )
+
+    for svc_name, svc_spec in services_dict.items():
+        if svc_name not in worker_names:
+            continue
+
+        for container in _iter_service_containers(svc_spec):
+            container_env = container.setdefault("env", [])
+            _append_envs_or_override(container_env, worker_envs)
+
+
+def _iter_service_containers(svc_spec: dict):
+    containers = svc_spec.get("containers", [])
+    for c in containers:
+        yield c
+
+    main_container = (
+        svc_spec.get("extraPodSpec", {})
+        .get("mainContainer")
+    )
+
+    if main_container:
+        yield main_container

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -287,6 +287,14 @@ class DynamoGraphDeploymentRequestSpec(BaseModel):
         default=True,
         description="AutoApply indicates whether to automatically create a DynamoGraphDeployment after profiling completes. If false, the generated spec is stored in status for manual review and application.",
     )
+    envs: Optional[List[corev1.EnvVar]] = Field(
+        default=None,
+        description="Envs are global environment variables propagated to all containers."
+    )
+    workerEnvs: Optional[List[corev1.EnvVar]] = Field(
+        default=None,
+        description="WorkerEnvs are environment variables propagated only to worker containers."
+    )
 
 
 class ParetoConfig(BaseModel):

--- a/components/src/dynamo/profiler/utils/dgdr_validate.py
+++ b/components/src/dynamo/profiler/utils/dgdr_validate.py
@@ -26,7 +26,7 @@ code can access them without ``None`` checks.
 from __future__ import annotations
 
 import logging
-
+from collections.abc import Sequence
 from dynamo.planner.config.planner_config import PlannerPreDeploymentSweepMode
 from dynamo.profiler.utils.defaults import SearchStrategy
 from dynamo.profiler.utils.dgdr_v1beta1_types import (
@@ -35,7 +35,7 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import (
     WorkloadSpec,
 )
 from dynamo.profiler.utils.profile_common import is_planner_enabled
-
+from typing import Optional
 logger = logging.getLogger(__name__)
 
 
@@ -64,13 +64,54 @@ def valid_dgdr_spec(
     _validate_workload(dgdr.workload)
     _validate_sla(dgdr.sla)
     _validate_parallelization_sweeping_mode(dgdr)
+    _validate_envs(dgdr.envs)
+    _validate_envs(dgdr.workerEnvs)
     return dgdr
 
 
 # ---------------------------------------------------------------------------
-# Internal validators
+# Internal validator functions for different aspects of the spec.  Each should raise ValueError with a clear message if validation fails.
 # ---------------------------------------------------------------------------
 
+def _validate_envs(envs: Optional[Sequence]) -> None:
+    """Validate Kubernetes-style environment variables."""
+
+    if not envs:
+        return
+
+    seen = set()
+
+    for env in envs:
+        if not getattr(env, "name", None):
+            raise ValueError(
+                f"Environment variable must have a non-empty name (got {env})"
+            )
+
+        if env.name in seen:
+            raise ValueError(
+                f"Duplicate environment variable '{env.name}'"
+            )
+
+        seen.add(env.name)
+
+        has_value = getattr(env, "value", None) is not None
+
+        has_value_from = (
+            getattr(env, "valueFrom", None) is not None
+            or getattr(env, "value_from", None) is not None
+        )
+
+        if has_value and has_value_from:
+            raise ValueError(
+                f"Environment variable '{env.name}' cannot define both "
+                "'value' and 'valueFrom'"
+            )
+
+        if not has_value and not has_value_from:
+            raise ValueError(
+                f"Environment variable '{env.name}' must define either "
+                "'value' or 'valueFrom'"
+            )
 
 def _validate_required_fields(dgdr: DynamoGraphDeploymentRequestSpec) -> None:
     """Check fields the profiler treats as required."""
@@ -90,6 +131,11 @@ def _validate_required_fields(dgdr: DynamoGraphDeploymentRequestSpec) -> None:
     if dgdr.sla is None:
         dgdr.sla = SLASpec()
 
+    # Normalize env lists
+    if dgdr.envs is None:
+        dgdr.envs = []
+    if dgdr.workerEnvs is None:
+        dgdr.workerEnvs = []
 
 def _validate_workload(workload: WorkloadSpec) -> None:
     """Concurrency and requestRate are mutually exclusive."""

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -19,6 +19,7 @@ package v1beta1
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -487,6 +488,14 @@ type DynamoGraphDeploymentRequestSpec struct {
 	// +optional
 	// +kubebuilder:default=true
 	AutoApply *bool `json:"autoApply,omitempty"`
+
+	// Envs are global environment variables propagated to all containers.
+	// +optional
+	Envs []corev1.EnvVar `json:"envs,omitempty"`
+
+	// WorkerEnvs are environment variables propagated only to worker containers.
+	// +optional
+	WorkerEnvs []corev1.EnvVar `json:"workerEnvs,omitempty"`
 }
 
 // ParetoConfig represents a single Pareto-optimal deployment configuration


### PR DESCRIPTION


#### Overview:

This PR fixes a gap in DGDR → DGD propagation where environment variables defined in the DGDR spec were not being applied to generated worker pods.

With this change, DGDR now supports first-class environment variable injection into both:
- all services (global envs)
- worker-only services (worker envs)

It also improves override behavior so user-supplied DGD overrides correctly replace profiler-injected environment variables.

**Fixes:** DGDR does not propagate environment variables to generated DGD worker pods - [6794](https://github.com/ai-dynamo/dynamo/issues/6794)

#### Details:

### 1. `dgd_generation.py`

Introduces full environment variable propagation during DGD assembly.

#### New functionality

- `dgdr.envs`
  - Injected into **all containers** across all services
- `dgdr.workerEnvs`
  - Injected **only into worker services**
  - Applies to:
    - vLLM workers
    - mocker workers

#### Precedence rules

Environment variables are now resolved with the following priority:

1. `workerEnvs` (highest priority for workers)
2. `envs` (global DGDR envs)
3. profiler-injected envs (lowest priority unless overridden explicitly)

#### Behavior improvements

- Env variables are merged by `name` instead of appended blindly
- Duplicate env names are overridden deterministically
- Supports both container formats:
  - `containers[]`
  - `extraPodSpec.mainContainer`

#### New helpers added

- `_envvar_to_dict`
- `_append_envs_or_override`
- `_inject_global_envs`
- `_inject_worker_envs`
- `_iter_service_containers`
- `_normalize_services`

---

### 2. `protocol.py`

Improves deep merge override semantics for `env` fields.

#### Before
- Env vars could be duplicated or ignored depending on structure
- No consistent name-based merge behavior

#### After

- Env vars are merged by `name`
- Overrides replace existing values deterministically
- Supports multiple env representations:
  - dict-based envs
  - Kubernetes `V1EnvVar`
  - pydantic/dataclass objects

#### Preserved fields
- `value`
- `valueFrom`

---

### 3. `dgdr_validate.py`

Adds validation for new DGDR fields:

- `envs []corev1.EnvVar`
- `workerEnvs []corev1.EnvVar`

Ensures both fields conform to Kubernetes `EnvVar` schema before planning/profiling begins.

---

### 4. `dynamographdeploymentrequest_types.go`

Extends the DGDR API spec:

```go
type DynamoGraphDeploymentRequestSpec struct {
    ...
    Envs        []corev1.EnvVar `json:"envs,omitempty"`
    WorkerEnvs  []corev1.EnvVar `json:"workerEnvs,omitempty"`
}

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global environment variables configuration (`envs`) applicable to all containers.
  * Added worker-specific environment variables configuration (`workerEnvs`) for worker containers only.

* **Improvements**
  * Enhanced override deep-merge logic with structured environment variable handling, deduplication by name, and conflict resolution.
  * Added validation for environment variable entries to enforce Kubernetes-style semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->