### PR TITLE
feat(planner): show recommended replicas in reports and update docs

### DIFF
--- a/components/src/dynamo/planner/monitoring/diagnostics_recorder.py
+++ b/components/src/dynamo/planner/monitoring/diagnostics_recorder.py
@@ -282,6 +282,32 @@ class DiagnosticsRecorder:
             row=1,
             col=1,
         )
+        recommended_prefill = _vals("scale_to_prefill")
+        if any(v is not None for v in recommended_prefill):
+            fig.add_trace(
+                go.Scatter(
+                    x=labels,
+                    y=recommended_prefill,
+                    name="Recommended Prefill Replicas",
+                    mode="markers",
+                    marker=dict(symbol="diamond", size=10),
+                ),
+                row=1,
+                col=1,
+            )
+        recommended_decode = _vals("scale_to_decode")
+        if any(v is not None for v in recommended_decode):
+            fig.add_trace(
+                go.Scatter(
+                    x=labels,
+                    y=recommended_decode,
+                    name="Recommended Decode Replicas",
+                    mode="markers",
+                    marker=dict(symbol="diamond", size=10),
+                ),
+                row=1,
+                col=1,
+            )
         tp_lower_p = _vals("throughput_lower_bound_prefill")
         if any(v is not None and v > 1 for v in tp_lower_p):
             fig.add_trace(

--- a/components/src/dynamo/planner/tests/unit/test_diagnostics_recorder.py
+++ b/components/src/dynamo/planner/tests/unit/test_diagnostics_recorder.py
@@ -266,6 +266,8 @@ class TestDiagnosticsRecorder:
             assert len(content) > 1000
             assert "plotly" in content.lower()
             assert "Replica Counts" in content
+            assert "Recommended Prefill Replicas" in content
+            assert "Recommended Decode Replicas" in content
             assert "Observed TTFT vs SLA" in content
             assert "Observed ITL vs SLA" in content
             assert "Estimated TTFT vs SLA" in content
@@ -375,6 +377,72 @@ class TestDiagnosticsRecorder:
             assert filepath is not None
             log_path = os.path.splitext(filepath)[0] + ".log.jsonl.gz"
             assert not os.path.exists(log_path)
+
+    def test_report_plots_recommended_replica_events(self, monkeypatch):
+        from plotly.graph_objects import Figure
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cfg = _make_config(tmp_dir)
+            recorder = DiagnosticsRecorder(config=cfg)
+
+            ticks = [
+                (
+                    TickInput(
+                        now_s=1000.0,
+                        worker_counts=WorkerCounts(
+                            ready_num_prefill=1, ready_num_decode=1
+                        ),
+                    ),
+                    PlannerEffects(diagnostics=TickDiagnostics()),
+                ),
+                (
+                    TickInput(
+                        now_s=1060.0,
+                        worker_counts=WorkerCounts(
+                            ready_num_prefill=1, ready_num_decode=1
+                        ),
+                    ),
+                    PlannerEffects(
+                        scale_to=ScalingDecision(num_prefill=3, num_decode=4),
+                        diagnostics=TickDiagnostics(),
+                    ),
+                ),
+                (
+                    TickInput(
+                        now_s=1120.0,
+                        worker_counts=WorkerCounts(
+                            ready_num_prefill=1, ready_num_decode=1
+                        ),
+                    ),
+                    PlannerEffects(diagnostics=TickDiagnostics()),
+                ),
+            ]
+
+            observed = Metrics(ttft=100.0, itl=10.0, num_req=60, isl=800, osl=120)
+            for tick_input, effects in ticks:
+                recorder.record(tick_input, effects, observed, gpu_hours=1.0)
+
+            traces = []
+            original_add_trace = Figure.add_trace
+
+            def capture_trace(self, trace, *args, **kwargs):
+                traces.append(trace)
+                return original_add_trace(self, trace, *args, **kwargs)
+
+            monkeypatch.setattr(Figure, "add_trace", capture_trace)
+            recorder._build_report_html(list(recorder._snapshots))
+
+            prefill_trace = next(
+                t for t in traces if t.name == "Recommended Prefill Replicas"
+            )
+            decode_trace = next(
+                t for t in traces if t.name == "Recommended Decode Replicas"
+            )
+
+            assert list(prefill_trace.y) == [None, 3, None]
+            assert list(decode_trace.y) == [None, 4, None]
+            assert prefill_trace.mode == "markers"
+            assert decode_trace.mode == "markers"
 
     def test_generate_report_clears_snapshots(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -159,7 +159,7 @@ Load-based scaling has the following known limitations. Throughput-based scaling
 | `--min-endpoint` | `1` | Minimum replicas per worker type |
 | `--decode-engine-num-gpu` | `1` | GPUs per decode engine |
 | `--prefill-engine-num-gpu` | `1` | GPUs per prefill engine |
-| `--no-operation` | `false` | Observation mode (no actual scaling) |
+| `advisory` | `false` | Suggestion-only mode. The Planner computes and reports recommended replica counts, but does not execute scaling actions or change the deployment. |
 | **Throughput-based scaling** | | |
 | `--enable-throughput-scaling` | `true` | Enable throughput-based scaling |
 | `--adjustment-interval` | `180` | Seconds between throughput-based scaling decisions |
@@ -229,9 +229,15 @@ The throughput planner uses request count, ISL, OSL, and optional KV hit rate as
 
 FPM observes engine-side scheduled and queued work. It does not include requests still queued in the `LocalRouter` before engine assignment.
 
-Core gauges on the planner port include replica counts (`dynamo_planner_num_prefill_replicas`, `dynamo_planner_num_decode_replicas`), observed traffic (`dynamo_planner_observed_*`), replica decisions (`dynamo_planner_predicted_num_prefill_replicas`, `dynamo_planner_predicted_num_decode_replicas`), and cumulative `dynamo_planner_gpu_hours`.
+Core gauges on the planner port include replica counts (`dynamo_planner_num_prefill_replicas`, `dynamo_planner_num_decode_replicas`), observed traffic (`dynamo_planner_observed_*`), replica recommendations (`dynamo_planner_predicted_num_prefill_replicas`, `dynamo_planner_predicted_num_decode_replicas`), and cumulative `dynamo_planner_gpu_hours`.
 
 Throughput prediction gauges `dynamo_planner_predicted_requests_per_second`, `dynamo_planner_predicted_input_sequence_tokens`, and `dynamo_planner_predicted_output_sequence_tokens` are wired from throughput-scaling traffic prediction and exposed alongside observed sequence-length metrics.
+
+### Advisory mode
+
+Set `advisory: true` to run the local Planner in suggestion-only mode. This is recommended when you are evaluating a new Planner configuration, validating SLA targets, or reviewing how the Planner would react to production traffic before allowing it to scale workers.
+
+In advisory mode, the Planner still observes traffic and FPM data, computes recommended prefill and decode replica counts, logs recommendation summaries, exports predicted replica metrics, and includes recommendations in diagnostics reports. The recommendations are not applied as scaling decisions: the Planner does not execute scaling actions, send replica changes to Kubernetes or GlobalPlanner, or mutate the deployment.
 
 #### Diagnostics metrics
 
@@ -252,4 +258,4 @@ Configure this in `PlannerConfig` (or the equivalent YAML / constructor wiring y
 - `report_output_dir`: directory where HTML files are written (default `./planner_reports`).
 - `live_dashboard_port`: port for a real-time HTTP dashboard (default `8080`). Set to `0` to disable. An aiohttp server starts on the given port and serves the current accumulated snapshot data as an interactive Plotly report at `http://<host>:<port>/`. Unlike periodic reports, the live dashboard does **not** clear snapshots — it always shows all data accumulated since the last periodic report (or since startup if periodic reports are disabled).
 
-Reports aggregate per-tick snapshots and use `TickInput.now_s` for timestamps, so they behave the same in live runs (wall clock) and in **replay** with a simulated clock. Typical charts cover worker counts, observed versus estimated latencies versus SLA targets, request rate, engine capacity, scaling decision timelines, and input/output sequence lengths.
+Reports aggregate per-tick snapshots and use `TickInput.now_s` for timestamps, so they behave the same in live runs (wall clock) and in **replay** with a simulated clock. Typical charts cover worker counts, recommended replica counts, observed versus estimated latencies versus SLA targets, request rate, engine capacity, scaling decision timelines, and input/output sequence lengths. In the Replica Counts plot, actual replicas are shown as lines and the Planner's recommended prefill and decode replica counts are shown as discrete markers at the ticks where recommendations were produced. This is especially useful with `advisory: true` because those recommendations are suggestions only.

--- a/docs/components/planner/planner-guide.md
+++ b/docs/components/planner/planner-guide.md
@@ -47,6 +47,16 @@ features:
     backend: vllm
 ```
 
+To evaluate Planner behavior without changing replica counts, turn on advisory mode:
+
+```yaml
+features:
+  planner:
+    advisory: true
+```
+
+Advisory mode is suggestion-only. The Planner computes recommended replica counts, logs them, exports them as diagnostics, and shows them in HTML reports. The recommendations are not applied as scaling decisions: the Planner does not execute scaling actions or change the deployment.
+
 ### Optimization Target
 
 | Field | Type | Default | Description |
@@ -102,6 +112,7 @@ When throughput-based scaling is enabled, the planner needs engine performance d
 | `backend` | string | `vllm` | Backend: `vllm`, `sglang`, `trtllm`, or `mocker`. |
 | `environment` | string | `kubernetes` | Runtime environment: `kubernetes`, `virtual`, or `global-planner`. |
 | `namespace` | string | env `DYN_NAMESPACE` | Kubernetes namespace for the deployment. |
+| `advisory` | bool | `false` | Suggestion-only mode. Compute, log, export, and report recommended replica counts without executing scaling actions or changing the deployment. |
 
 ### Traffic Prediction Settings
 
@@ -129,7 +140,9 @@ When throughput-based scaling is enabled, the planner needs engine performance d
 | `report_output_dir` | string | `./planner_reports` | Directory for HTML diagnostics reports. |
 | `live_dashboard_port` | int | `8080` | Port for the live diagnostics dashboard HTTP server. Set to `0` to disable. When enabled, visit `http://host:port/` to view a real-time Plotly report of accumulated snapshots. |
 
-The same diagnostic signals surfaced in these reports are also exported as Prometheus metrics under the `dynamo_planner_*` prefix—for example estimated TTFT/ITL (`dynamo_planner_estimated_ttft_ms`, `dynamo_planner_estimated_itl_ms`), per-engine capacity and FPM queue depths, and load/throughput scaling decision enums.
+The same diagnostic signals surfaced in these reports are also exported as Prometheus metrics under the `dynamo_planner_*` prefix—for example estimated TTFT/ITL (`dynamo_planner_estimated_ttft_ms`, `dynamo_planner_estimated_itl_ms`), recommended replica counts (`dynamo_planner_predicted_num_prefill_replicas`, `dynamo_planner_predicted_num_decode_replicas`), per-engine capacity and FPM queue depths, and load/throughput scaling decision enums.
+
+The Replica Counts plot overlays actual prefill/decode replicas with discrete recommendation markers for the Planner's recommended prefill/decode replicas. When `advisory: true`, these recommended counts are suggestions only; the Planner records what it would do without applying the change.
 
 ## Integration with Profiler
 


### PR DESCRIPTION
## Summary
- add recommended prefill/decode replica markers to the Planner HTML diagnostics Replica Counts plot
- document local Planner advisory mode as suggestion-only and recommend it for evaluating configs without scaling
- add trace-level test coverage for recommendation marker values and no-decision gaps

## Review
- ran an agentic follow-up review on the tracked diff; initial sparse-line concern was addressed by switching recommendations to marker-only events and documenting that behavior

## Tests
- .venv/bin/python -m pytest components/src/dynamo/planner/tests/unit/test_diagnostics_recorder.py
- .venv/bin/ruff format --check components/src/dynamo/planner/monitoring/diagnostics_recorder.py components/src/dynamo/planner/tests/unit/test_diagnostics_recorder.py
- .venv/bin/ruff check components/src/dynamo/planner/monitoring/diagnostics_recorder.py components/src/dynamo/planner/tests/unit/test_diagnostics_recorder.py
- NODE_OPTIONS=--experimental-global-webcrypto fern check
- NODE_OPTIONS=--experimental-global-webcrypto fern docs broken-links (reports existing unrelated broken links outside planner docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replica Counts charts now overlay recommended prefill and decode replica markers
  * Advisory mode configuration added for suggestion-only scaling operations

* **Documentation**
  * Updated configuration reference with advisory mode settings
  * Enhanced diagnostics documentation for replica visualization and advisory mode

* **Tests**
  * Added test coverage for recommended replica markers in diagnostics reports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->