### PR TITLE
fix(vllm): backport get_kv_cache_group_metadata to vllm 0.20.1

### DIFF
--- a/container/deps/vllm/patches/v0.20.1/0002-pr40984-backport-get-kv-cache-group-metadata.patch
+++ b/container/deps/vllm/patches/v0.20.1/0002-pr40984-backport-get-kv-cache-group-metadata.patch
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+
+From bcb9c133bafed161b3f4d0ea391c985465429680 Mon Sep 17 00:00:00 2001
+From: PeaBrane <yanrpei@gmail.com>
+Date: Wed, 7 May 2026 00:00:00 +0000
+Subject: [PATCH] feat(kv-events): backport get_kv_cache_group_metadata to
+ EngineCore (#40984)
+
+Backport of get_kv_cache_group_metadata from vllm main (PR #40984).
+In vllm 0.20.1 this method is absent from EngineCore, so Dynamo's
+call_utility_async("get_kv_cache_group_metadata") fails with an
+AttributeError in EngineCoreProc.  Dynamo uses this method to select the
+correct KV-event block size for models with multiple KV cache groups
+(e.g. hybrid MLA+Mamba models).  The backport inlines the isinstance
+logic because get_kv_cache_spec_kind() was also introduced after 0.20.1.
+
+Signed-off-by: PeaBrane <yanrpei@gmail.com>
+---
+ vllm/v1/engine/core.py | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
+--- a/vllm/v1/engine/core.py
++++ b/vllm/v1/engine/core.py
+@@ -793,11 +793,43 @@
+         self,
+         notification_type: EEPNotificationType,
+         vllm_config: VllmConfig | None = None,
+     ):
+         raise NotImplementedError
+
++    def get_kv_cache_group_metadata(self) -> list[dict[str, int | str | None]]:
++        """Return msgspec-serializable metadata for scheduler KV cache groups."""
++        from vllm.v1.kv_cache_interface import (  # noqa: PLC0415
++            FullAttentionSpec,
++            MLAAttentionSpec,
++            SinkFullAttentionSpec,
++        )
++        kv_cache_config = getattr(self.scheduler, "kv_cache_config", None)
++        if kv_cache_config is None:
++            return []
++
++        metadata: list[dict[str, int | str | None]] = []
++        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
++            spec = group.kv_cache_spec
++            # Check subclasses before their parent: both MLAAttentionSpec and
++            # SinkFullAttentionSpec inherit from FullAttentionSpec.
++            if isinstance(spec, SinkFullAttentionSpec):
++                kind = "sink_full_attention"
++            elif isinstance(spec, MLAAttentionSpec):
++                kind = "mla_attention"
++            elif isinstance(spec, FullAttentionSpec):
++                kind = "full_attention"
++            else:
++                kind = type(spec).__name__.lower()
++            metadata.append({
++                "group_idx": group_idx,
++                "kind": kind,
++                "block_size": spec.block_size,
++                "sliding_window": getattr(spec, "sliding_window", None),
++            })
++        return metadata
++
+
+ class EngineShutdownState(IntEnum):
+     RUNNING = 0
+     REQUESTED = 1
+     SHUTTING_DOWN = 2
+--
+2.43.0

--- a/container/deps/vllm/patches/v0.20.1/0002-pr40984-backport-get-kv-cache-group-metadata.patch
+++ b/container/deps/vllm/patches/v0.20.1/0002-pr40984-backport-get-kv-cache-group-metadata.patch
@@ -18,13 +18,13 @@ logic because get_kv_cache_spec_kind() was also introduced after 0.20.1.
 
 Signed-off-by: PeaBrane <yanrpei@gmail.com>
 ---
- vllm/v1/engine/core.py | 32 ++++++++++++++++++++++++++++++++
- 1 file changed, 32 insertions(+)
+ vllm/v1/engine/core.py | 59 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
 
 diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
 --- a/vllm/v1/engine/core.py
 +++ b/vllm/v1/engine/core.py
-@@ -793,11 +793,43 @@
+@@ -793,11 +793,70 @@
          self,
          notification_type: EEPNotificationType,
          vllm_config: VllmConfig | None = None,
@@ -34,10 +34,47 @@ diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
 +    def get_kv_cache_group_metadata(self) -> list[dict[str, int | str | None]]:
 +        """Return msgspec-serializable metadata for scheduler KV cache groups."""
 +        from vllm.v1.kv_cache_interface import (  # noqa: PLC0415
++            ChunkedLocalAttentionSpec,
++            CrossAttentionSpec,
++            EncoderOnlyAttentionSpec,
 +            FullAttentionSpec,
 +            MLAAttentionSpec,
++            MambaSpec,
 +            SinkFullAttentionSpec,
++            SlidingWindowMLASpec,
++            SlidingWindowSpec,
++            UniformTypeKVCacheSpecs,
 +        )
++
++        def _spec_kind(spec) -> str:
++            # UniformTypeKVCacheSpecs wraps multiple specs; propagate the kind
++            # only when all inner specs agree, otherwise fall back to "unknown".
++            if isinstance(spec, UniformTypeKVCacheSpecs):
++                inner = {_spec_kind(s) for s in spec.kv_cache_specs.values()}
++                return next(iter(inner)) if len(inner) == 1 else "unknown"
++            # Keep subclass checks before base classes so specialized specs
++            # keep their more precise kind (mirrors get_kv_cache_spec_kind in
++            # vllm main, PR #40984).
++            if isinstance(spec, SlidingWindowMLASpec):
++                return "sliding_window_mla"
++            if isinstance(spec, MLAAttentionSpec):
++                return "mla_attention"
++            if isinstance(spec, SinkFullAttentionSpec):
++                return "sink_full_attention"
++            if isinstance(spec, FullAttentionSpec):
++                return "full_attention"
++            if isinstance(spec, ChunkedLocalAttentionSpec):
++                return "chunked_local_attention"
++            if isinstance(spec, SlidingWindowSpec):
++                return "sliding_window"
++            if isinstance(spec, MambaSpec):
++                return "mamba"
++            if isinstance(spec, EncoderOnlyAttentionSpec):
++                return "encoder_only_attention"
++            if isinstance(spec, CrossAttentionSpec):
++                return "cross_attention"
++            return "unknown"
++
 +        kv_cache_config = getattr(self.scheduler, "kv_cache_config", None)
 +        if kv_cache_config is None:
 +            return []
@@ -45,19 +82,9 @@ diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
 +        metadata: list[dict[str, int | str | None]] = []
 +        for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
 +            spec = group.kv_cache_spec
-+            # Check subclasses before their parent: both MLAAttentionSpec and
-+            # SinkFullAttentionSpec inherit from FullAttentionSpec.
-+            if isinstance(spec, SinkFullAttentionSpec):
-+                kind = "sink_full_attention"
-+            elif isinstance(spec, MLAAttentionSpec):
-+                kind = "mla_attention"
-+            elif isinstance(spec, FullAttentionSpec):
-+                kind = "full_attention"
-+            else:
-+                kind = type(spec).__name__.lower()
 +            metadata.append({
 +                "group_idx": group_idx,
-+                "kind": kind,
++                "kind": _spec_kind(spec),
 +                "block_size": spec.block_size,
 +                "sliding_window": getattr(spec, "sliding_window", None),
 +            })


### PR DESCRIPTION
## Summary

- In vllm 0.20.1 (our pinned version) `EngineCore.get_kv_cache_group_metadata` does not exist — it was added to vllm main in PR [#40984](https://github.com/vllm-project/vllm/pull/40984) after the 0.20.1 release.
- `configure_kv_event_block_size` calls this via `call_utility_async`, which dispatches to `EngineCoreProc`. Since the method is absent in 0.20.1, vllm logs an ERROR and dynamo falls back to the minimum block size across all KV cache groups — which can be wrong for models with multiple groups (e.g. hybrid MLA+Mamba).
- Adds a vendored patch using the project's existing mechanism in `install_vllm.sh` (same directory as the existing `0001-pr40932` patch). The backport inlines `isinstance`-based kind detection because `get_kv_cache_spec_kind()` was also introduced post-0.20.1.

Fixes #9560

## Test plan

- [ ] Container build applies both patches cleanly (`--forward` skips already-applied hunks, so re-runs are safe)
- [ ] `call_utility_async("get_kv_cache_group_metadata")` succeeds and the correct KV-event block size is selected for standard and MLA models
- [ ] No regression on existing vllm worker tests
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New method enables retrieval of KV cache group metadata for improved visibility into cache configuration and monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->