### PR TITLE
fix: Fix the workspace inherit

### DIFF
--- a/lib/backend-common/Cargo.toml
+++ b/lib/backend-common/Cargo.toml
@@ -20,7 +20,7 @@ testing = []
 
 [dependencies]
 dynamo-runtime = { workspace = true }
-dynamo-llm = { path = "../llm", version = "1.2.0", default-features = false }
+dynamo-llm = { path = "../llm", default-features = false }
 dynamo-protocols = { workspace = true }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
#### Overview:

 Removed the hard-coded version = "1.2.0" from the dynamo-llm dependency in lib/backend-common/Cargo.toml. Duplicating the version string locally instead of inheriting it also defeats the purpose of workspace-managed dependencies and creates drift risk the next time the version is bumped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configuration to use a local path reference instead of a version-pinned remote dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->