### PR TITLE
chore: document SGLang qwen3_coder divergences and fix tool-schema wrapper

### DIFF
--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
@@ -36,6 +36,12 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: |-
+          SGLang consumes the <tool_call>...</tool_call> wrapper into the parsed
+          region (normal_text=text[:start_idx_of_<tool_call>]) before scanning for
+          <function=...> bodies; when no body is found it emits zero calls and an
+          empty normal_text. Dynamo/vLLM preserve the unrecognized wrapper as
+          normal_text per impl-defined recovery contract (see PARSER_CASES.md).
   PARSER.batch.4.d:
     description: Missing </parameter> closing tag
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L729

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
@@ -66,6 +66,13 @@ cases:
           </parameter>
           </function>
           </tool_call>
+        reason: |-
+          SGLang's qwen3_coder detector gates parsing on the opening
+          <tool_call> sentinel (`if tool_call_start_token not in text: return
+          normal_text=text`); a bare </tool_call> close with a valid <function>
+          body short-circuits to zero calls and the full text as normal_text.
+          Dynamo/vLLM tolerate the missing open and extract the <function> body
+          per impl-defined recovery contract (see PARSER_CASES.md).
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -124,6 +131,11 @@ cases:
             location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: |-
+          SGLang's non-streaming path uses `re.compile(r"<tool_call>(.*?)</tool_call>")`
+          which requires a matching </tool_call> close; an unterminated trailing
+          <tool_call> (even with a complete <function> body) is silently dropped.
+          Dynamo/vLLM recover the trailing call and emit it.
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -161,3 +173,8 @@ cases:
             location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: |-
+          Same root cause as 5.d: SGLang's `<tool_call>(.*?)</tool_call>` regex
+          requires the closing sentinel, so the trailing call truncated mid-arg
+          value is dropped. Dynamo/vLLM recover the partial value
+          (location='New York') and emit the call.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
@@ -42,14 +42,7 @@ cases:
             passengers: 2
         normal_text: ''
       vllm: *id001
-      sglang:
-        calls:
-        - name: book_flight
-          arguments:
-            destination: Paris
-            passengers: '2'
-            first_class: 'true'
-        normal_text: ''
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode in parameter value
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -121,11 +121,12 @@ def _build_tools(tools: list[dict[str, Any]] | None) -> list[Any] | None:
         return None
     return [
         SimpleNamespace(
+            type="function",
             function=SimpleNamespace(
                 name=(t["function"] if "function" in t else t)["name"],
                 parameters=(t["function"] if "function" in t else t).get("parameters"),
                 strict=False,
-            )
+            ),
         )
         for t in tools
     ]


### PR DESCRIPTION

The qwen3_coder row in the parity chart had 5 `S?` (research-needed) cells because the SGLang divergences lacked `reason:` fields. Four are legitimate SGLang behaviors that now carry explanations; the fifth (7.a) was actually a parity harness bug.

Harness fix:
- `tests/parity/parser/sglang.py:_build_tools` did not set `type="function"` on the wrapped SimpleNamespace. SGLang's qwen3_coder `_get_arguments_config` iterates tools and skips any without `config.type == "function"`, so the schema lookup always failed and `_convert_param_value` never coerced typed primitives (passengers/first_class surfaced as raw strings). Add `type="function"` so the wrapper matches the OpenAI Tool[] shape SGLang expects.

Fixture updates (qwen3_coder/PARSER.batch.{4,5,7}.yaml):
- 7.a: SGLang now coerces types correctly; collapse `expected.sglang` to anchor on dynamo (parity).
- 4.a: SGLang strips `<tool_call>` and everything after into `normal_text=''` even when no `<function>` body is found; Dynamo/vLLM preserve the unrecognized wrapper as normal_text.
- 5.b: SGLang's detector short-circuits when the opening `<tool_call>` sentinel is missing, returning the full text as normal_text and zero calls.
- 5.d / 5.e: SGLang's `<tool_call>(.*?)</tool_call>` non-streaming regex requires a matching close, so an unterminated trailing call (complete body or mid-arg-value) is silently dropped.

Verified by running SGLang's Qwen3CoderDetector against each fixture's `model_text`; outputs match the new `expected.sglang` blocks.

After
<img width="1655" height="55" alt="image" src="https://github.com/user-attachments/assets/b2ae08bf-6461-408e-9acc-ba2a59a7a9a8" />

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced parity testing to validate tool call parsing behavior across implementations, including edge cases with malformed or incomplete tool wrappers
  * Updated test fixtures to document expected outcomes for truncated or unmatched tool call markers
  * Improved consistency verification between SGLang and alternative implementations

* **Chores**
  * Refined tool configuration structure in parsing pipeline

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->