### PR TITLE
feat(RL): add vLLM Tokens-in-Tokens-Out and RL related response support

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -120,6 +120,22 @@ def parse_args(argv: list[str] | None = None) -> Config:
     return dynamo_config
 
 
+def configure_rl_logprobs_mode(config: Config) -> None:
+    if not config.enable_rl:
+        return
+
+    if config.engine_args.logprobs_mode == "raw_logprobs":
+        config.engine_args.logprobs_mode = "processed_logprobs"
+        logger.info("Defaulting logprobs_mode=processed_logprobs (--enable-rl active).")
+        return
+
+    if config.engine_args.logprobs_mode != "processed_logprobs":
+        raise ValueError(
+            "--enable-rl requires logprobs_mode=processed_logprobs; "
+            f"got {config.engine_args.logprobs_mode!r}."
+        )
+
+
 def cross_validate_config(
     dynamo_config: Config, engine_config: AsyncEngineArgs
 ) -> None:

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -102,6 +102,18 @@ class DynamoVllmArgGroup(ArgGroup):
             default=False,
             help="Enable multimodal processing. If not set, none of the multimodal components can be used.",
         )
+        # Select defaults used by RL-style token-in/token-out deployments.
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-rl",
+            env_var="DYN_ENABLE_RL",
+            default=False,
+            help=(
+                "Enable RL training support. Mirrors --enable-rl on the SGLang "
+                "backend and selects RL-friendly vLLM defaults for TITO and "
+                "per-token logprob parity."
+            ),
+        )
         add_argument(
             g,
             flag_name="--mm-prompt-template",
@@ -264,6 +276,8 @@ class DynamoVllmConfig(ConfigBase):
     multimodal_worker: bool
     multimodal_decode_worker: bool
     enable_multimodal: bool
+    # Enables RL-style token-in/token-out defaults.
+    enable_rl: bool = False
     mm_prompt_template: str
     frontend_decoding: bool
     embedding_transfer_mode: Union[

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -570,6 +570,9 @@ def _serialize_routed_experts(routed_experts: Any) -> Optional[Dict[str, Any]]:
     return {
         "data": base64.b85encode(tobytes()).decode("ascii"),
         "shape": [int(dim) for dim in shape],
+        # Encode dtype so the consumer decodes the raw bytes with the right
+        # element type instead of assuming int32.
+        "dtype": str(getattr(routed_experts, "dtype", "")),
     }
 
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -507,7 +507,21 @@ def _accumulate_engine_data(
         }
     )
     if logprob_accumulator:
-        engine_data["completion_logprobs"] = list(logprob_accumulator)
+        # completion_logprobs must stay positionally aligned 1:1 with
+        # completion_token_ids — the trainer indexes them together. A dropped or
+        # None logprob on any chunk shifts every later logprob onto the wrong
+        # token, so emit them only when the counts match; otherwise omit (a
+        # silently misaligned list corrupts the off-policy correction).
+        if len(logprob_accumulator) == len(token_accumulator):
+            engine_data["completion_logprobs"] = list(logprob_accumulator)
+        else:
+            logger.warning(
+                "Dropping completion_logprobs for output index %d: logprob "
+                "count %d != token count %d (misaligned)",
+                output_index,
+                len(logprob_accumulator),
+                len(token_accumulator),
+            )
     if request_prompt_token_ids:
         engine_data["prompt_token_ids"] = list(request_prompt_token_ids)
     tok["engine_data"] = engine_data

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -325,10 +325,220 @@ def _compute_mm_uuids(
     return {"image": uuids}
 
 
+# Helpers for nvext response fields requested through `nvext.extra_fields`.
+
+
+def _serialize_prompt_logprobs(
+    raw_prompt_logprobs: list,
+) -> list:
+    """Convert vLLM's ``RequestOutput.prompt_logprobs`` into the dict shape
+    expected by Dynamo's Rust ``PromptLogprobEntry`` (serde deserialization).
+
+    vLLM shape: ``list[dict[int, Logprob] | None]`` where ``Logprob`` has
+    ``.logprob``, ``.rank``, ``.decoded_token`` attributes.
+
+    Output shape: ``list[dict[str, {"logprob": float, ...}] | None]``.
+    Workers carry it under ``engine_data.prompt_logprobs`` so the Rust
+    postprocessor can surface it on ``NvExtResponse.prompt_logprobs`` without
+    changing the public ``LLMEngineOutput`` struct shape.
+
+    NOTE: token_id keys are emitted as **strings** (not ints) so that
+    pythonize → serde → JSON survives the worker→frontend transport. JSON
+    object keys are required to be strings; ``HashMap<u32, _>`` on the Rust
+    side deserializes string keys via ``u32::from_str``. Emitting int keys
+    here causes the chunk to be silently dropped on pythonize → JSON, which
+    surfaces as ``"Stream ended before generation completed"`` on the
+    frontend (worker emits cleanly, frontend never sees ``complete_final``).
+    """
+    result: list = []
+    for entry in raw_prompt_logprobs:
+        if entry is None:
+            result.append(None)
+        else:
+            converted: Dict[str, Dict[str, Any]] = {}
+            for token_id, logprob_obj in entry.items():
+                lp_dict: Dict[str, Any] = {
+                    "logprob": float(logprob_obj.logprob),
+                }
+                rank = getattr(logprob_obj, "rank", None)
+                if rank is not None:
+                    lp_dict["rank"] = int(rank)
+                decoded = getattr(logprob_obj, "decoded_token", None)
+                if decoded is not None:
+                    lp_dict["decoded_token"] = decoded
+                converted[str(int(token_id))] = lp_dict
+            result.append(converted)
+    return result
+
+
+def _attach_prompt_logprobs_engine_data(
+    tok: Dict[str, Any], prompt_logprobs: list
+) -> None:
+    engine_data = tok.setdefault("engine_data", {})
+    if isinstance(engine_data, dict):
+        engine_data["prompt_logprobs"] = prompt_logprobs
+
+
+def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
+    """Return True iff the request opted into the given nvext extra field.
+
+    Looks in two places (in order):
+      1. `request["nvext"]["extra_fields"]` — raw OpenAI request shape
+         (used by SGLang's handler; also covers any direct test injection).
+      2. `request["extra_args"]["nvext"]["extra_fields"]` — what the Rust
+         preprocessor stashes when building PreprocessedRequest from an
+         OpenAI request (PreprocessedRequest itself has no nvext field).
+    """
+    for source in (
+        request.get("nvext"),
+        (request.get("extra_args") or {}).get("nvext")
+        if isinstance(request.get("extra_args"), dict)
+        else None,
+    ):
+        if not isinstance(source, dict):
+            continue
+        extra_fields = source.get("extra_fields")
+        if isinstance(extra_fields, list) and field in extra_fields:
+            return True
+    return False
+
+
+def _apply_nvext_cache_salt(request: Dict[str, Any], prompt: Any) -> None:
+    extra_args = request.get("extra_args") or {}
+    nvext_args = extra_args.get("nvext") if isinstance(extra_args, dict) else None
+    if not isinstance(nvext_args, dict):
+        return
+
+    cache_salt = nvext_args.get("cache_salt")
+    if cache_salt is not None and isinstance(prompt, dict):
+        prompt["cache_salt"] = cache_salt
+
+
+def _prompt_token_ids_for_engine_data(
+    request: Dict[str, Any],
+    prompt: Any,
+) -> list[int]:
+    prompt_token_ids = (
+        prompt.get("prompt_token_ids")
+        if isinstance(prompt, dict)
+        else request.get("token_ids")
+    )
+    return list(prompt_token_ids or [])
+
+
+def _flatten_logprobs(
+    log_probs: Any,
+) -> Optional[list[float]]:
+    """Coerce a per-token logprob sequence into a flat list[float].
+
+    The backend's per-chunk `log_probs` field is one float per emitted
+    token (the logprob the engine sampled). Some upstream paths wrap it
+    in dicts or nested lists; this helper accepts:
+      - list[float]               -> returned as-is
+      - list[list[float]]         -> flattened
+      - list[dict{logprob: ...}]  -> .logprob extracted
+      - None                      -> None
+
+    Any element that isn't coercible to float is dropped silently rather
+    than poisoning the entire payload. The trainer treats missing
+    per-token logprobs as off-policy correction = 0 for that token, so a
+    partial list is preferable to a hard failure.
+    """
+    if log_probs is None:
+        return None
+    if not isinstance(log_probs, list):
+        return None
+    out: list[float] = []
+    pending = list(log_probs)
+    while pending:
+        item = pending.pop(0)
+        if isinstance(item, (int, float)):
+            out.append(float(item))
+        elif isinstance(item, list):
+            pending[0:0] = item
+        elif isinstance(item, dict) and "logprob" in item:
+            try:
+                out.append(float(item["logprob"]))
+            except (TypeError, ValueError):
+                continue
+    return out or None
+
+
+def _is_token_in_request(request: Dict[str, Any]) -> bool:
+    nvext = request.get("nvext")
+    if isinstance(nvext, dict) and nvext.get("token_data"):
+        return True
+
+    extra_args = request.get("extra_args") or {}
+    nvext_args = extra_args.get("nvext") if isinstance(extra_args, dict) else None
+    if not isinstance(nvext_args, dict):
+        return False
+
+    if nvext_args.get("token_in"):
+        return True
+
+    return False
+
+
+def _accumulate_engine_data(
+    tok: Dict[str, Any],
+    request_prompt_token_ids: Optional[list[int]],
+    accumulated_token_ids: dict[int, list[int]],
+    accumulated_log_probs: dict[int, list[float]],
+) -> None:
+    output_index = int(tok.get("index") or 0)
+    token_accumulator = accumulated_token_ids.setdefault(output_index, [])
+    logprob_accumulator = accumulated_log_probs.setdefault(output_index, [])
+
+    new_token_ids = tok.get("token_ids")
+    if isinstance(new_token_ids, list):
+        token_accumulator.extend(int(t) for t in new_token_ids)
+
+    flat_lp = _flatten_logprobs(tok.get("log_probs"))
+    if flat_lp:
+        logprob_accumulator.extend(flat_lp)
+
+    if tok.get("finish_reason") is None:
+        return
+
+    engine_data: Dict[str, Any] = dict(tok.get("engine_data") or {})
+    engine_data.update(
+        {
+            "completion_token_ids": list(token_accumulator),
+            "finished": True,
+        }
+    )
+    if logprob_accumulator:
+        engine_data["completion_logprobs"] = list(logprob_accumulator)
+    if request_prompt_token_ids:
+        engine_data["prompt_token_ids"] = list(request_prompt_token_ids)
+    tok["engine_data"] = engine_data
+
+
+def _serialize_routed_experts(routed_experts: Any) -> Optional[Dict[str, Any]]:
+    if routed_experts is None:
+        return None
+
+    shape = getattr(routed_experts, "shape", None)
+    tobytes = getattr(routed_experts, "tobytes", None)
+    if shape is None or not callable(tobytes):
+        logger.warning(
+            "Unable to serialize routed_experts of type %s",
+            type(routed_experts).__name__,
+        )
+        return None
+
+    return {
+        "data": base64.b85encode(tobytes()).decode("ascii"),
+        "shape": [int(dim) for dim in shape],
+    }
+
+
 def build_sampling_params(
     request: Dict[str, Any],
     default_sampling_params: Dict[str, Any],
     model_max_len: int | None = None,
+    enable_rl: bool = False,
 ) -> SamplingParams:
     """
     Build SamplingParams from a PreprocessedRequest (internal protocol format).
@@ -336,15 +546,33 @@ def build_sampling_params(
     Args:
         request: The PreprocessedRequest dict with 'sampling_options', 'stop_conditions',
                  and 'output_options'
-        default_sampling_params: Default sampling parameters to initialize with
+        default_sampling_params: Default sampling parameters from the model's
+            ``generation_config.json`` (vLLM ``ModelConfig.get_diff_sampling_param``).
+            Used for non-RL/chat clients that want the model's recommended
+            sampling defaults applied transparently.
 
     Returns:
         SamplingParams configured from the request
+
+    RL token-in requests use vLLM's default sampling values instead of model
+    `generation_config.json` sampling overrides. Ordinary token-data requests
+    keep generation_config defaults for Gateway/backward-compatible traffic.
+    Stop-token defaults from the model config are still applied later.
     """
-    sampling_params = SamplingParams(**default_sampling_params)
+    if enable_rl and _is_token_in_request(request):
+        # Use vLLM defaults without model generation_config overlays.
+        sampling_params = SamplingParams()
+    else:
+        sampling_params = SamplingParams(**default_sampling_params)
+    sampling_params.detokenize = False
 
     # Handle guided_decoding - convert to StructuredOutputsParams
-    sampling_options = request.get("sampling_options", {})
+    sampling_options = dict(request.get("sampling_options") or {})
+    extra_args = request.get("extra_args") or {}
+    if isinstance(extra_args, dict):
+        passthrough_sampling_options = extra_args.get("sampling_options")
+        if isinstance(passthrough_sampling_options, dict):
+            sampling_options.update(passthrough_sampling_options)
     guided_decoding = sampling_options.get("guided_decoding")
     if guided_decoding is not None and isinstance(guided_decoding, dict):
         sampling_params.structured_outputs = StructuredOutputsParams(
@@ -362,6 +590,9 @@ def build_sampling_params(
     for key, value in sampling_options.items():
         # Skip guided_decoding - already handled above
         if key == "guided_decoding":
+            continue
+        if key == "bad_words_token_ids" and value is not None:
+            sampling_params._bad_words_token_ids = value
             continue
         if value is not None and hasattr(sampling_params, key):
             setattr(sampling_params, key, value)
@@ -398,6 +629,10 @@ def build_sampling_params(
         sampling_params.logprobs = logprobs
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs
+
+        skip_special_tokens_value = output_options.get("skip_special_tokens")
+        if skip_special_tokens_value is not None:
+            sampling_params.skip_special_tokens = bool(skip_special_tokens_value)
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
@@ -2135,6 +2370,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             )
 
             total_output_tokens_by_index: dict[int, int] = {}
+            routed_experts_by_output: dict[int, Dict[str, Any]] = {}
             async for res in gen:
                 # res is vllm's RequestOutput
 
@@ -2179,6 +2415,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "index": output_idx,
                         "token_ids": token_ids,
                     }
+                    routed_experts = _serialize_routed_experts(
+                        getattr(output, "routed_experts", None)
+                    )
+                    if routed_experts is not None:
+                        routed_experts_by_output[output_idx] = routed_experts
 
                     # vLLM DELTA outputs already align token_ids/logprobs to this chunk.
                     tokenizer = getattr(self.engine_client, "tokenizer", None)
@@ -2199,6 +2440,17 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             embedding_sequence_length=embedding_sequence_length,
                             completion_token_counts=total_output_tokens_by_index,
                         )
+                        if res.prompt_logprobs is not None:
+                            _attach_prompt_logprobs_engine_data(
+                                out, _serialize_prompt_logprobs(res.prompt_logprobs)
+                            )
+                        routed_experts = routed_experts_by_output.get(output_idx)
+                        if routed_experts is not None:
+                            disaggregated_params = dict(
+                                out.get("disaggregated_params") or {}
+                            )
+                            disaggregated_params["routed_experts"] = routed_experts
+                            out["disaggregated_params"] = disaggregated_params
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "
@@ -2396,9 +2648,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             yield error
             return
 
+        _apply_nvext_cache_salt(request, prompt)
+
         # Build sampling params from request
         sampling_params = build_sampling_params(
-            request, self.default_sampling_params, self.model_max_len
+            request,
+            self.default_sampling_params,
+            self.model_max_len,
+            enable_rl=self.config.enable_rl,
         )
 
         if kv_params is not None:
@@ -2442,6 +2699,26 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             async with self._abort_monitor(
                 context, request_id, abort_guard=abort_guard
             ):
+                # nvext.engine_data opt-in: if the client requested
+                # `nvext.extra_fields=["engine_data"]`, we accumulate
+                # per-chunk token_ids and logprobs and attach them to the
+                # FINAL chunk (the one carrying `finish_reason`). The Rust
+                # frontend's response builder (delta.rs) gates emission via
+                # `NvExtResponseFieldSelection.engine_data` so this payload
+                # only reaches clients that asked for it.
+                want_engine_data = _nvext_extra_field_requested(request, "engine_data")
+                # Prompt token IDs the engine actually saw. Either the
+                # pre-tokenized `nvext.token_data` (TITO) or whatever the
+                # preprocessor produced from messages (MITO). We echo them
+                # back in engine_data so the client doesn't have to re-derive
+                # them from a request it might no longer hold.
+                request_prompt_token_ids = (
+                    _prompt_token_ids_for_engine_data(request, prompt)
+                    if want_engine_data
+                    else None
+                )
+                accumulated_token_ids: dict[int, list[int]] = {}
+                accumulated_log_probs: dict[int, list[float]] = {}
                 try:
                     async for tok in self.generate_tokens(
                         prompt,
@@ -2461,6 +2738,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                             tok["completion_usage"][
                                 "prompt_tokens_details"
                             ] = prefill_prompt_tokens_details
+
+                        if want_engine_data:
+                            _accumulate_engine_data(
+                                tok,
+                                request_prompt_token_ids,
+                                accumulated_token_ids,
+                                accumulated_log_probs,
+                            )
                         yield tok
                 except EngineDeadError as e:
                     logger.error(f"vLLM EngineDeadError: {e}")
@@ -2646,9 +2931,14 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             yield error
             return
 
+        _apply_nvext_cache_salt(request, prompt)
+
         # Build sampling params from request using shared utility
         sampling_params = build_sampling_params(
-            request, self.default_sampling_params, self.model_max_len
+            request,
+            self.default_sampling_params,
+            self.model_max_len,
+            enable_rl=self.config.enable_rl,
         )
 
         # One protocol instance per request; carries per-request state

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -515,14 +515,22 @@ def _accumulate_engine_data(
     if flat_lp:
         logprob_accumulator.extend(flat_lp)
 
-    if tok.get("finish_reason") is None:
+    finish_reason = tok.get("finish_reason")
+    if finish_reason is None:
         return
+
+    # An engine error is delivered as a finish_reason like "error: ..."; do not
+    # report it to the RL client as a clean finish (which would look like a
+    # successful empty completion).
+    finished = not (
+        isinstance(finish_reason, str) and finish_reason.startswith("error")
+    )
 
     engine_data: Dict[str, Any] = dict(tok.get("engine_data") or {})
     engine_data.update(
         {
             "completion_token_ids": list(token_accumulator),
-            "finished": True,
+            "finished": finished,
         }
     )
     if logprob_accumulator:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -15,7 +15,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Dict, Final, Generic, Optional, TypeVar
+from typing import Any, AsyncIterator, Dict, Final, Generic, Iterator, Optional, TypeVar
 
 import torch
 from vllm.config import ModelConfig, VllmConfig
@@ -379,39 +379,43 @@ def _attach_prompt_logprobs_engine_data(
         engine_data["prompt_logprobs"] = prompt_logprobs
 
 
-def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
-    """Return True iff the request opted into the given nvext extra field.
+def _iter_nvext_sources(request: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    """Yield each nvext dict on the request, in priority order:
 
-    Looks in two places (in order):
-      1. `request["nvext"]["extra_fields"]` — raw OpenAI request shape
-         (used by SGLang's handler; also covers any direct test injection).
-      2. `request["extra_args"]["nvext"]["extra_fields"]` — what the Rust
-         preprocessor stashes when building PreprocessedRequest from an
-         OpenAI request (PreprocessedRequest itself has no nvext field).
+      1. ``request["nvext"]``               — raw OpenAI shape (SGLang / tests).
+      2. ``request["extra_args"]["nvext"]`` — what the Rust preprocessor stashes
+         when building PreprocessedRequest from an OpenAI request
+         (PreprocessedRequest itself has no nvext field).
+
+    Centralizing this lookup keeps ``_nvext_extra_field_requested``,
+    ``_is_token_in_request`` and ``_apply_nvext_cache_salt`` consistent so an
+    nvext field is never honored by one helper but silently missed by another.
     """
+    extra_args = request.get("extra_args")
     for source in (
         request.get("nvext"),
-        (request.get("extra_args") or {}).get("nvext")
-        if isinstance(request.get("extra_args"), dict)
-        else None,
+        extra_args.get("nvext") if isinstance(extra_args, dict) else None,
     ):
-        if not isinstance(source, dict):
-            continue
-        extra_fields = source.get("extra_fields")
-        if isinstance(extra_fields, list) and field in extra_fields:
-            return True
-    return False
+        if isinstance(source, dict):
+            yield source
+
+
+def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
+    """Return True iff the request opted into the given nvext extra field."""
+    return any(
+        isinstance(source.get("extra_fields"), list) and field in source["extra_fields"]
+        for source in _iter_nvext_sources(request)
+    )
 
 
 def _apply_nvext_cache_salt(request: Dict[str, Any], prompt: Any) -> None:
-    extra_args = request.get("extra_args") or {}
-    nvext_args = extra_args.get("nvext") if isinstance(extra_args, dict) else None
-    if not isinstance(nvext_args, dict):
+    if not isinstance(prompt, dict):
         return
-
-    cache_salt = nvext_args.get("cache_salt")
-    if cache_salt is not None and isinstance(prompt, dict):
-        prompt["cache_salt"] = cache_salt
+    for source in _iter_nvext_sources(request):
+        cache_salt = source.get("cache_salt")
+        if cache_salt is not None:
+            prompt["cache_salt"] = cache_salt
+            return
 
 
 def _prompt_token_ids_for_engine_data(
@@ -465,19 +469,10 @@ def _flatten_logprobs(
 
 
 def _is_token_in_request(request: Dict[str, Any]) -> bool:
-    nvext = request.get("nvext")
-    if isinstance(nvext, dict) and nvext.get("token_data"):
-        return True
-
-    extra_args = request.get("extra_args") or {}
-    nvext_args = extra_args.get("nvext") if isinstance(extra_args, dict) else None
-    if not isinstance(nvext_args, dict):
-        return False
-
-    if nvext_args.get("token_in"):
-        return True
-
-    return False
+    return any(
+        source.get("token_data") or source.get("token_in")
+        for source in _iter_nvext_sources(request)
+    )
 
 
 def _accumulate_engine_data(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -643,17 +643,16 @@ def build_sampling_params(
             sampling_params.thinking_token_budget = value
 
     # Apply output_options (logprobs, prompt_logprobs, etc.)
-    logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(
-        request.get("output_options", {}) or {}
-    )
+    output_options = request.get("output_options", {}) or {}
+    logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
     if logprobs is not None:
         sampling_params.logprobs = logprobs
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs
 
-        skip_special_tokens_value = output_options.get("skip_special_tokens")
-        if skip_special_tokens_value is not None:
-            sampling_params.skip_special_tokens = bool(skip_special_tokens_value)
+    skip_special_tokens_value = output_options.get("skip_special_tokens")
+    if skip_special_tokens_value is not None:
+        sampling_params.skip_special_tokens = bool(skip_special_tokens_value)
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -606,7 +606,6 @@ def build_sampling_params(
         sampling_params = SamplingParams()
     else:
         sampling_params = SamplingParams(**default_sampling_params)
-    sampling_params.detokenize = False
 
     # Handle guided_decoding - convert to StructuredOutputsParams
     sampling_options = dict(request.get("sampling_options") or {})

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import inspect
 import logging
+import math
 import os
 
 # MM kwargs NIXL transfer (frontend → backend pre-rendered path)
@@ -329,6 +330,21 @@ def _compute_mm_uuids(
 # Helpers for nvext response fields requested through `nvext.extra_fields`.
 
 
+# Logprobs can be -inf (log of probability 0) for masked/disallowed tokens (e.g.
+# via bad_words_token_ids / allowed_token_ids) or full-vocab prompt logprobs.
+# JSON has no inf/nan, so pythonize -> serde_json rewrites them to `null`, which
+# then fails typed deserialization on the Rust side and SILENTLY DROPS the whole
+# logprobs payload. Clamp non-finite logprobs to a large finite-negative
+# sentinel so the value survives transport while still meaning "effectively
+# impossible".
+_MIN_FINITE_LOGPROB = -1e30
+
+
+def _finite_logprob(value: Any) -> float:
+    lp = float(value)
+    return lp if math.isfinite(lp) else _MIN_FINITE_LOGPROB
+
+
 def _serialize_prompt_logprobs(
     raw_prompt_logprobs: list,
 ) -> list:
@@ -359,7 +375,7 @@ def _serialize_prompt_logprobs(
             converted: Dict[str, Dict[str, Any]] = {}
             for token_id, logprob_obj in entry.items():
                 lp_dict: Dict[str, Any] = {
-                    "logprob": float(logprob_obj.logprob),
+                    "logprob": _finite_logprob(logprob_obj.logprob),
                 }
                 rank = getattr(logprob_obj, "rank", None)
                 if rank is not None:
@@ -459,13 +475,16 @@ def _flatten_logprobs(
     pending: deque = deque(log_probs)
     while pending:
         item = pending.popleft()
+        if isinstance(item, bool):
+            # bool is an int subclass; a True/False here is not a real logprob.
+            continue
         if isinstance(item, (int, float)):
-            out.append(float(item))
+            out.append(_finite_logprob(item))
         elif isinstance(item, list):
             pending.extendleft(reversed(item))
         elif isinstance(item, dict) and "logprob" in item:
             try:
-                out.append(float(item["logprob"]))
+                out.append(_finite_logprob(item["logprob"]))
             except (TypeError, ValueError):
                 continue
     return out or None

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2524,8 +2524,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             raw_routed_experts_by_output.get(output_idx)
                         )
                         if routed_experts is not None:
-                            disaggregated_params = dict(
-                                out.get("disaggregated_params") or {}
+                            existing = out.get("disaggregated_params")
+                            disaggregated_params: Dict[str, Any] = (
+                                dict(existing) if isinstance(existing, dict) else {}
                             )
                             disaggregated_params["routed_experts"] = routed_experts
                             out["disaggregated_params"] = disaggregated_params

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -14,6 +14,7 @@ import tempfile
 import threading
 import time
 from abc import ABC, abstractmethod
+from collections import deque
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, Final, Generic, Iterator, Optional, TypeVar
 
@@ -453,13 +454,15 @@ def _flatten_logprobs(
     if not isinstance(log_probs, list):
         return None
     out: list[float] = []
-    pending = list(log_probs)
+    # deque + popleft/extendleft avoids the O(n^2) of list.pop(0)/front-splice
+    # on long RL/TITO logprob payloads. reversed() keeps original token order.
+    pending: deque = deque(log_probs)
     while pending:
-        item = pending.pop(0)
+        item = pending.popleft()
         if isinstance(item, (int, float)):
             out.append(float(item))
         elif isinstance(item, list):
-            pending[0:0] = item
+            pending.extendleft(reversed(item))
         elif isinstance(item, dict) and "logprob" in item:
             try:
                 out.append(float(item["logprob"]))

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -679,9 +679,10 @@ def build_sampling_params(
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs
 
-    skip_special_tokens_value = output_options.get("skip_special_tokens")
-    if skip_special_tokens_value is not None:
-        sampling_params.skip_special_tokens = bool(skip_special_tokens_value)
+    # skip_special_tokens is intentionally NOT forwarded to vLLM here: this path
+    # forces detokenize=False (below), so vLLM never detokenizes and ignores it.
+    # Dynamo detokenizes in the Rust backend, which reads skip_special_tokens
+    # directly from the request output_options (lib/llm/src/backend.rs).
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2609,12 +2609,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # Firstly extract disaggregated params from prefill result if available
         prefill_result = request.get("prefill_result")
         if prefill_result and isinstance(prefill_result, dict):
-            kv_params = prefill_result.get("disaggregated_params", {}).get(
-                "kv_transfer_params"
-            )
-            embedding_params = prefill_result.get("disaggregated_params", {}).get(
-                "embedding_params"
-            )
+            # `disaggregated_params` may be explicitly None (prefill error path,
+            # or _build_disaggregated_params returning None when empty), so use
+            # `or {}` rather than a .get default — the default only applies when
+            # the key is absent, not when it is present-but-None.
+            disaggregated_params = prefill_result.get("disaggregated_params") or {}
+            kv_params = disaggregated_params.get("kv_transfer_params")
+            embedding_params = disaggregated_params.get("embedding_params")
             # Normalize embedding_params to None if it is an empty dict
             if not embedding_params:
                 embedding_params = None

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -374,6 +374,12 @@ def _serialize_prompt_logprobs(
         else:
             converted: Dict[str, Dict[str, Any]] = {}
             for token_id, logprob_obj in entry.items():
+                try:
+                    key = str(int(token_id))
+                except (TypeError, ValueError):
+                    # vLLM only emits int token-id keys; skip a non-int key
+                    # rather than aborting the whole prompt_logprobs payload.
+                    continue
                 lp_dict: Dict[str, Any] = {
                     "logprob": _finite_logprob(logprob_obj.logprob),
                 }
@@ -383,7 +389,7 @@ def _serialize_prompt_logprobs(
                 decoded = getattr(logprob_obj, "decoded_token", None)
                 if decoded is not None:
                     lp_dict["decoded_token"] = decoded
-                converted[str(int(token_id))] = lp_dict
+                converted[key] = lp_dict
             result.append(converted)
     return result
 
@@ -509,7 +515,13 @@ def _accumulate_engine_data(
 
     new_token_ids = tok.get("token_ids")
     if isinstance(new_token_ids, list):
-        token_accumulator.extend(int(t) for t in new_token_ids)
+        for t in new_token_ids:
+            try:
+                token_accumulator.append(int(t))
+            except (TypeError, ValueError):
+                # Defensive: a malformed token id should degrade (drop the
+                # token) rather than abort the whole generation stream.
+                continue
 
     flat_lp = _flatten_logprobs(tok.get("log_probs"))
     if flat_lp:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2392,8 +2392,20 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
             total_output_tokens_by_index: dict[int, int] = {}
             routed_experts_by_output: dict[int, Dict[str, Any]] = {}
+            # vLLM surfaces prompt_logprobs once (at end-of-prefill) and clears
+            # them on subsequent chunks, so the generation-finish chunk often
+            # carries None. Capture the first non-None payload and attach it to
+            # the final chunk instead of reading res.prompt_logprobs there.
+            prompt_logprobs_payload: Optional[list] = None
             async for res in gen:
                 # res is vllm's RequestOutput
+                if (
+                    prompt_logprobs_payload is None
+                    and getattr(res, "prompt_logprobs", None) is not None
+                ):
+                    prompt_logprobs_payload = _serialize_prompt_logprobs(
+                        res.prompt_logprobs
+                    )
 
                 if not res.outputs:
                     self._log_with_lora_context(
@@ -2461,9 +2473,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             embedding_sequence_length=embedding_sequence_length,
                             completion_token_counts=total_output_tokens_by_index,
                         )
-                        if res.prompt_logprobs is not None:
+                        if prompt_logprobs_payload is not None:
                             _attach_prompt_logprobs_engine_data(
-                                out, _serialize_prompt_logprobs(res.prompt_logprobs)
+                                out, prompt_logprobs_payload
                             )
                         routed_experts = routed_experts_by_output.get(output_idx)
                         if routed_experts is not None:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2420,7 +2420,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             )
 
             total_output_tokens_by_index: dict[int, int] = {}
-            routed_experts_by_output: dict[int, Dict[str, Any]] = {}
+            raw_routed_experts_by_output: dict[int, Any] = {}
             # vLLM surfaces prompt_logprobs once (at end-of-prefill) and clears
             # them on subsequent chunks, so the generation-finish chunk often
             # carries None. Capture the first non-None payload and attach it to
@@ -2477,11 +2477,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "index": output_idx,
                         "token_ids": token_ids,
                     }
-                    routed_experts = _serialize_routed_experts(
-                        getattr(output, "routed_experts", None)
-                    )
-                    if routed_experts is not None:
-                        routed_experts_by_output[output_idx] = routed_experts
+                    # Capture the raw routed_experts cheaply here; serialize it
+                    # only once on the final chunk (base85-encoding a tensor on
+                    # every streamed chunk would be wasted work, since only the
+                    # final value is emitted).
+                    raw_routed_experts = getattr(output, "routed_experts", None)
+                    if raw_routed_experts is not None:
+                        raw_routed_experts_by_output[output_idx] = raw_routed_experts
 
                     # vLLM DELTA outputs already align token_ids/logprobs to this chunk.
                     tokenizer = getattr(self.engine_client, "tokenizer", None)
@@ -2506,7 +2508,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             _attach_prompt_logprobs_engine_data(
                                 out, prompt_logprobs_payload
                             )
-                        routed_experts = routed_experts_by_output.get(output_idx)
+                        routed_experts = _serialize_routed_experts(
+                            raw_routed_experts_by_output.get(output_idx)
+                        )
                         if routed_experts is not None:
                             disaggregated_params = dict(
                                 out.get("disaggregated_params") or {}

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -590,6 +590,15 @@ def build_sampling_params(
         if key == "guided_decoding":
             continue
         if key == "bad_words_token_ids" and value is not None:
+            # vLLM has no public setter for token-id bad words; we write the
+            # private field directly. Guard so a vLLM upgrade that renames it
+            # fails loudly here instead of silently dropping the constraint.
+            if not hasattr(sampling_params, "_bad_words_token_ids"):
+                raise AttributeError(
+                    "vLLM SamplingParams._bad_words_token_ids missing; TITO "
+                    "bad_words_token_ids passthrough needs updating for this "
+                    "vLLM version"
+                )
             sampling_params._bad_words_token_ids = value
             continue
         if value is not None and hasattr(sampling_params, key):

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -47,7 +47,7 @@ from dynamo.common.backend.publisher import ComponentSnapshot, KvEventSource, Zm
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.llm import ModelInput
-from dynamo.vllm.args import parse_args
+from dynamo.vllm.args import configure_rl_logprobs_mode, parse_args
 from dynamo.vllm.cache_info import (
     configure_kv_event_block_size,
     get_configured_kv_event_block_size,
@@ -141,11 +141,13 @@ class VllmLLMEngine(LLMEngine):
         disaggregation_mode: DisaggregationMode,
         served_model_name: str,
         component: str,
+        enable_rl: bool = False,
     ):
         self.engine_args = engine_args
         self.disaggregation_mode = disaggregation_mode
         self._served_model_name = served_model_name
         self._component = component
+        self.enable_rl = enable_rl
         self.engine_client: AsyncLLM | None = None
         self._vllm_config: Any = None
         self._default_sampling_params: Any = None
@@ -178,6 +180,8 @@ class VllmLLMEngine(LLMEngine):
                 config.engine_args.served_model_name
             ) = config.model
 
+        configure_rl_logprobs_mode(config)
+
         # _resolve_disaggregation_mode() in DynamoVllmConfig has already
         # promoted the field to a DisaggregationMode enum; the field type
         # is still the input union, so narrow it here for mypy (cast
@@ -188,6 +192,7 @@ class VllmLLMEngine(LLMEngine):
             mode,
             served_model_name=config.served_model_name or config.model,
             component=config.component,
+            enable_rl=config.enable_rl,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -267,7 +272,10 @@ class VllmLLMEngine(LLMEngine):
 
         # TODO: remove dict() once build_sampling_params accepts GenerateRequest
         sampling_params = build_sampling_params(
-            dict(request), self._default_sampling_params, self._model_max_len
+            dict(request),
+            self._default_sampling_params,
+            self._model_max_len,
+            enable_rl=self.enable_rl,
         )
 
         # vLLM's KV transfer is internal to NixlConnector

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -303,9 +303,13 @@ class VllmLLMEngine(LLMEngine):
             sampling_params.min_tokens = 1
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             prefill_result = require_prefill_result(request, self.disaggregation_mode)
-            kv_params = prefill_result.get("disaggregated_params", {}).get(
-                "kv_transfer_params"
-            )
+            # `disaggregated_params` may be present-but-None (prefill error path
+            # / _build_disaggregated_params returning None), so use `or {}` — a
+            # .get default only applies when the key is absent. A None value then
+            # falls through to the kv_params ValueError below instead of raising
+            # AttributeError on None.get(...).
+            disaggregated_params = prefill_result.get("disaggregated_params") or {}
+            kv_params = disaggregated_params.get("kv_transfer_params")
             if kv_params is None:
                 raise ValueError(
                     "decode worker received prefill_result without "

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -44,7 +44,7 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs
-from .args import Config, _uses_dynamo_connector, parse_args
+from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import per_rank_kv_blocks
 from .constants import DisaggregationMode
@@ -115,6 +115,8 @@ async def worker() -> None:
     # or the HF name (e.g. "Qwen/Qwen3-0.6B"), depending on cmd line params.
     if not config.served_model_name:
         config.served_model_name = config.engine_args.served_model_name = config.model
+
+    configure_rl_logprobs_mode(config)
 
     # Download the model if necessary using modelexpress.
     # We want it on disk before we start vllm to avoid downloading from HuggingFace.

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -257,6 +257,7 @@ async def test_unified_llm_engine_passes_delta_chunks_and_counts_usage():
     engine._default_sampling_params = {}
     engine._model_max_len = None
     engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine.enable_rl = False
     engine._dp_range = None
 
     chunks = [

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -167,11 +167,17 @@ class TestTokenInSamplingDefaults:
         return build_sampling_params(req, {"top_p": 0.5}, enable_rl=enable_rl)
 
     def test_metadata_extra_fields_keep_generation_defaults(self):
-        sp = self._build({"nvext": {"extra_fields": ["timing", "worker_id"]}})
+        # enable_rl=True so the gate is ACTIVE: a metadata-only extra_fields
+        # request is not a token-in request, so generation defaults are kept.
+        sp = self._build(
+            {"nvext": {"extra_fields": ["timing", "worker_id"]}}, enable_rl=True
+        )
         assert sp.top_p == pytest.approx(0.5)
 
     def test_engine_data_extra_field_keeps_generation_defaults(self):
-        sp = self._build({"nvext": {"extra_fields": ["engine_data"]}})
+        # engine_data is a response opt-in, not a token-in marker; with RL on it
+        # must still keep generation defaults.
+        sp = self._build({"nvext": {"extra_fields": ["engine_data"]}}, enable_rl=True)
         assert sp.top_p == pytest.approx(0.5)
 
     def test_token_in_marker_skips_generation_defaults(self):

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -266,7 +266,9 @@ class TestEngineDataAccumulation:
 
 
 class TestSkipSpecialTokens:
-    """Verify skip_special_tokens from output_options flows to SamplingParams."""
+    """skip_special_tokens is handled by Dynamo's Rust backend (which reads it
+    from the request output_options), NOT forwarded to vLLM SamplingParams: the
+    internal token path forces detokenize=False, so vLLM never reads it."""
 
     @staticmethod
     def _build(output_options=None):
@@ -280,27 +282,21 @@ class TestSkipSpecialTokens:
         }
         return build_sampling_params(req, {})
 
-    def test_skip_special_tokens_true(self):
-        sp = self._build(output_options={"skip_special_tokens": True})
-        assert sp.skip_special_tokens is True
-
-    def test_skip_special_tokens_false(self):
+    def test_skip_special_tokens_not_forwarded(self):
+        # detokenize is forced off so vLLM ignores skip_special_tokens; it must
+        # be left at the vLLM default rather than overridden from output_options.
         sp = self._build(output_options={"skip_special_tokens": False})
-        assert sp.skip_special_tokens is False
+        assert sp.detokenize is False
+        assert sp.skip_special_tokens is True  # vLLM default, not overridden
 
-    def test_skip_special_tokens_absent(self):
-        """When not provided, build_sampling_params hardcodes detokenize=False
-        and SamplingParams default for skip_special_tokens should be unchanged."""
+    def test_detokenize_forced_off(self):
         sp = self._build(output_options={})
         assert sp.detokenize is False
 
     def test_prompt_logprobs_still_works(self):
-        """Regression: prompt_logprobs should still be wired alongside skip_special_tokens."""
-        sp = self._build(
-            output_options={"prompt_logprobs": 5, "skip_special_tokens": True}
-        )
+        """Regression: prompt_logprobs is still wired through output_options."""
+        sp = self._build(output_options={"prompt_logprobs": 5})
         assert sp.prompt_logprobs == 5
-        assert sp.skip_special_tokens is True
 
     def test_token_id_constraints(self):
         from dynamo.vllm.handlers import build_sampling_params

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -137,6 +137,17 @@ class TestCacheSaltWiring:
         assert prefill_prompt["cache_salt"] == "step_43"
         assert decode_prompt["cache_salt"] == "step_43"
 
+    def test_cache_salt_from_top_level_nvext(self):
+        """cache_salt under the raw request["nvext"] shape is also honored,
+        matching _nvext_extra_field_requested/_is_token_in_request (tzulingk)."""
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+
+        req = {"token_ids": [1, 2, 3], "nvext": {"cache_salt": "top_level"}}
+        prompt = {"prompt_token_ids": req["token_ids"]}
+        _apply_nvext_cache_salt(req, prompt)
+
+        assert prompt["cache_salt"] == "top_level"
+
 
 class TestTokenInSamplingDefaults:
     @staticmethod

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -308,4 +308,7 @@ class TestSkipSpecialTokens:
         sp = build_sampling_params(req, {})
         assert sp.allowed_token_ids == [10, 11]
         assert sp.bad_words_token_ids == [[12, 13]]
-        assert sp.detokenize is True
+        # The internal token path detokenizes downstream in Dynamo, so
+        # build_sampling_params forces detokenize=False even when the request
+        # asks for True.
+        assert sp.detokenize is False

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for vLLM token-in/token-out request handling."""
+
+from __future__ import annotations
+
+import importlib.util
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.skipif(
+        importlib.util.find_spec("vllm") is None,
+        reason="vllm not installed in this container",
+    ),
+]
+
+
+class TestSerializePromptLogprobs:
+    """Validate _serialize_prompt_logprobs against various vLLM outputs."""
+
+    @staticmethod
+    def _import():
+        from dynamo.vllm.handlers import _serialize_prompt_logprobs
+
+        return _serialize_prompt_logprobs
+
+    def test_none_entries_preserved(self):
+        fn = self._import()
+        raw = [None, None]
+        assert fn(raw) == [None, None]
+
+    def test_single_token_entry(self):
+        fn = self._import()
+        logprob = SimpleNamespace(logprob=-1.5, rank=1, decoded_token="hello")
+        raw = [{42: logprob}]
+        result = fn(raw)
+        assert len(result) == 1
+        entry = result[0]
+        assert "42" in entry
+        assert entry["42"]["logprob"] == pytest.approx(-1.5)
+        assert entry["42"]["rank"] == 1
+        assert entry["42"]["decoded_token"] == "hello"
+
+    def test_mixed_none_and_entries(self):
+        fn = self._import()
+        lp1 = SimpleNamespace(logprob=-0.1, rank=1, decoded_token="a")
+        lp2 = SimpleNamespace(logprob=-2.3, rank=5, decoded_token="b")
+        raw = [None, {10: lp1, 20: lp2}, None]
+        result = fn(raw)
+        assert result[0] is None
+        assert result[2] is None
+        assert set(result[1].keys()) == {"10", "20"}
+
+    def test_missing_optional_attributes(self):
+        """Logprob objects without rank/decoded_token should omit those keys."""
+        fn = self._import()
+        logprob = SimpleNamespace(logprob=-3.0)
+        raw = [{7: logprob}]
+        result = fn(raw)
+        assert result[0]["7"]["logprob"] == pytest.approx(-3.0)
+        assert "rank" not in result[0]["7"]
+        assert "decoded_token" not in result[0]["7"]
+
+    def test_empty_list(self):
+        fn = self._import()
+        assert fn([]) == []
+
+    def test_multiple_tokens_per_position(self):
+        fn = self._import()
+        lp_a = SimpleNamespace(logprob=-0.5, rank=1, decoded_token="x")
+        lp_b = SimpleNamespace(logprob=-1.2, rank=2, decoded_token="y")
+        lp_c = SimpleNamespace(logprob=-3.0, rank=3, decoded_token="z")
+        raw = [{100: lp_a, 200: lp_b, 300: lp_c}]
+        result = fn(raw)
+        assert len(result[0]) == 3
+
+
+class TestCacheSaltWiring:
+    """Verify cache_salt is extracted from extra_args and placed on the prompt."""
+
+    @staticmethod
+    def _build_token_mode_request(cache_salt=None, token_ids=None):
+        """Build a minimal TITO request dict mirroring the Rust preprocessor."""
+        req = {
+            "token_ids": token_ids or [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": {},
+        }
+        if cache_salt is not None:
+            req["extra_args"] = {"nvext": {"cache_salt": cache_salt}}
+        return req
+
+    def test_cache_salt_attached_to_prompt(self):
+        """When extra_args.nvext.cache_salt is set, the prompt dict gets it."""
+        from vllm.inputs import TokensPrompt
+
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+
+        req = self._build_token_mode_request(cache_salt="step_42")
+        prompt = TokensPrompt(prompt_token_ids=req["token_ids"])
+        _apply_nvext_cache_salt(req, prompt)
+
+        assert prompt.get("cache_salt") == "step_42"
+
+    def test_no_cache_salt_when_absent(self):
+        """When extra_args has no cache_salt, prompt should not gain the key."""
+        from vllm.inputs import TokensPrompt
+
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+
+        req = self._build_token_mode_request()
+        prompt = TokensPrompt(prompt_token_ids=req["token_ids"])
+        _apply_nvext_cache_salt(req, prompt)
+
+        assert "cache_salt" not in prompt
+
+    def test_prefill_and_decode_share_cache_salt_helper(self):
+        """Regression: disaggregated prefill and decode both salt prompt cache."""
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+
+        req = self._build_token_mode_request(cache_salt="step_43")
+        prefill_prompt = {"prompt_token_ids": req["token_ids"]}
+        decode_prompt = {"prompt_token_ids": req["token_ids"]}
+
+        _apply_nvext_cache_salt(req, prefill_prompt)
+        _apply_nvext_cache_salt(req, decode_prompt)
+
+        assert prefill_prompt["cache_salt"] == "step_43"
+        assert decode_prompt["cache_salt"] == "step_43"
+
+
+class TestTokenInSamplingDefaults:
+    @staticmethod
+    def _build(extra_args=None, enable_rl=False, nvext=None):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        req = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": {},
+        }
+        if extra_args is not None:
+            req["extra_args"] = extra_args
+        if nvext is not None:
+            req["nvext"] = nvext
+        return build_sampling_params(req, {"top_p": 0.5}, enable_rl=enable_rl)
+
+    def test_metadata_extra_fields_keep_generation_defaults(self):
+        sp = self._build({"nvext": {"extra_fields": ["timing", "worker_id"]}})
+        assert sp.top_p == pytest.approx(0.5)
+
+    def test_engine_data_extra_field_keeps_generation_defaults(self):
+        sp = self._build({"nvext": {"extra_fields": ["engine_data"]}})
+        assert sp.top_p == pytest.approx(0.5)
+
+    def test_token_in_marker_skips_generation_defaults(self):
+        sp = self._build({"nvext": {"token_in": True}}, enable_rl=True)
+        assert sp.top_p == pytest.approx(1.0)
+
+    def test_token_data_keeps_generation_defaults_when_rl_disabled(self):
+        sp = self._build(nvext={"token_data": [1, 2, 3]}, enable_rl=False)
+        assert sp.top_p == pytest.approx(0.5)
+
+    def test_token_data_skips_generation_defaults_when_rl_enabled(self):
+        sp = self._build(nvext={"token_data": [1, 2, 3]}, enable_rl=True)
+        assert sp.top_p == pytest.approx(1.0)
+
+
+class TestFlattenLogprobs:
+    def test_nested_lists_are_fully_flattened(self):
+        from dynamo.vllm.handlers import _flatten_logprobs
+
+        assert _flatten_logprobs(
+            [[{"logprob": -0.1}, {"logprob": -0.2}], [-0.3]]
+        ) == pytest.approx([-0.1, -0.2, -0.3])
+
+
+class TestEngineDataAccumulation:
+    def test_prompt_token_ids_come_from_built_prompt_when_available(self):
+        from dynamo.vllm.handlers import _prompt_token_ids_for_engine_data
+
+        request = {"token_ids": [1, 2, 3]}
+        prompt = {"prompt_token_ids": [1, 2, 99, 100]}
+
+        assert _prompt_token_ids_for_engine_data(request, prompt) == [1, 2, 99, 100]
+
+    def test_prompt_token_ids_fall_back_to_request_tokens(self):
+        from dynamo.vllm.handlers import _prompt_token_ids_for_engine_data
+
+        request = {"token_ids": [1, 2, 3]}
+
+        assert _prompt_token_ids_for_engine_data(request, "plain prompt") == [1, 2, 3]
+
+    def test_accumulates_per_output_index(self):
+        from dynamo.vllm.handlers import _accumulate_engine_data
+
+        token_ids: dict[int, list[int]] = {}
+        logprobs: dict[int, list[float]] = {}
+
+        _accumulate_engine_data(
+            {"index": 0, "token_ids": [10], "log_probs": [-0.1]},
+            [1, 2],
+            token_ids,
+            logprobs,
+        )
+        _accumulate_engine_data(
+            {"index": 1, "token_ids": [20], "log_probs": [-0.2]},
+            [1, 2],
+            token_ids,
+            logprobs,
+        )
+
+        final = {
+            "index": 0,
+            "token_ids": [11],
+            "log_probs": [-0.3],
+            "finish_reason": "stop",
+        }
+        _accumulate_engine_data(final, [1, 2], token_ids, logprobs)
+
+        assert final["engine_data"]["completion_token_ids"] == [10, 11]
+        assert final["engine_data"]["completion_logprobs"] == pytest.approx(
+            [-0.1, -0.3]
+        )
+        assert token_ids[1] == [20]
+
+    def test_engine_data_preserves_prompt_logprobs(self):
+        from dynamo.vllm.handlers import (
+            _accumulate_engine_data,
+            _attach_prompt_logprobs_engine_data,
+        )
+
+        final = {
+            "index": 0,
+            "token_ids": [11],
+            "finish_reason": "stop",
+        }
+        payload = [None, {"42": {"logprob": -0.5, "rank": 1}}]
+
+        _attach_prompt_logprobs_engine_data(final, payload)
+        _accumulate_engine_data(final, [1, 2], {}, {})
+
+        assert final["engine_data"]["prompt_logprobs"] == payload
+        assert final["engine_data"]["completion_token_ids"] == [11]
+
+
+class TestSkipSpecialTokens:
+    """Verify skip_special_tokens from output_options flows to SamplingParams."""
+
+    @staticmethod
+    def _build(output_options=None):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        req = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": output_options or {},
+        }
+        return build_sampling_params(req, {})
+
+    def test_skip_special_tokens_true(self):
+        sp = self._build(output_options={"skip_special_tokens": True})
+        assert sp.skip_special_tokens is True
+
+    def test_skip_special_tokens_false(self):
+        sp = self._build(output_options={"skip_special_tokens": False})
+        assert sp.skip_special_tokens is False
+
+    def test_skip_special_tokens_absent(self):
+        """When not provided, build_sampling_params hardcodes detokenize=False
+        and SamplingParams default for skip_special_tokens should be unchanged."""
+        sp = self._build(output_options={})
+        assert sp.detokenize is False
+
+    def test_prompt_logprobs_still_works(self):
+        """Regression: prompt_logprobs should still be wired alongside skip_special_tokens."""
+        sp = self._build(
+            output_options={"prompt_logprobs": 5, "skip_special_tokens": True}
+        )
+        assert sp.prompt_logprobs == 5
+        assert sp.skip_special_tokens is True
+
+    def test_token_id_constraints(self):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        req = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {
+                "allowed_token_ids": [10, 11],
+                "bad_words_token_ids": [[12, 13]],
+                "detokenize": True,
+            },
+            "stop_conditions": {},
+            "output_options": {},
+        }
+
+        sp = build_sampling_params(req, {})
+        assert sp.allowed_token_ids == [10, 11]
+        assert sp.bad_words_token_ids == [[12, 13]]
+        assert sp.detokenize is True

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -202,6 +202,57 @@ class TestFlattenLogprobs:
         ) == pytest.approx([-0.1, -0.2, -0.3])
 
 
+class TestNonFiniteLogprobs:
+    """Regression: -inf/nan logprobs (from bad_words/allowed_token_ids masking
+    or full-vocab prompt_logprobs) must be clamped to a finite sentinel. JSON
+    has no inf/nan, so pythonize -> serde_json would rewrite them to null and
+    the Rust typed deserialization would then silently drop the whole logprobs
+    payload."""
+
+    def test_finite_logprob_clamps_non_finite(self):
+        import math
+
+        from dynamo.vllm.handlers import _MIN_FINITE_LOGPROB, _finite_logprob
+
+        assert _finite_logprob(-0.5) == pytest.approx(-0.5)
+        assert _finite_logprob(0.0) == 0.0  # legitimate finite value preserved
+        assert _finite_logprob(float("-inf")) == _MIN_FINITE_LOGPROB
+        assert _finite_logprob(float("inf")) == _MIN_FINITE_LOGPROB
+        assert _finite_logprob(float("nan")) == _MIN_FINITE_LOGPROB
+        assert math.isfinite(_finite_logprob(float("-inf")))
+
+    def test_flatten_logprobs_clamps_inf_and_drops_bool(self):
+        from dynamo.vllm.handlers import _MIN_FINITE_LOGPROB, _flatten_logprobs
+
+        assert _flatten_logprobs([float("-inf"), -0.5, [{"logprob": float("nan")}]]) == [
+            _MIN_FINITE_LOGPROB,
+            pytest.approx(-0.5),
+            _MIN_FINITE_LOGPROB,
+        ]
+        # bool is an int subclass; drop it rather than coerce to 1.0/0.0.
+        assert _flatten_logprobs([True, -0.5, False]) == [pytest.approx(-0.5)]
+
+    def test_serialize_prompt_logprobs_clamps_inf(self):
+        from types import SimpleNamespace
+
+        from dynamo.vllm.handlers import _MIN_FINITE_LOGPROB, _serialize_prompt_logprobs
+
+        out = _serialize_prompt_logprobs([{7: SimpleNamespace(logprob=float("-inf"))}])
+        assert out[0]["7"]["logprob"] == _MIN_FINITE_LOGPROB
+
+    def test_sentinel_is_json_safe(self):
+        import json
+        import math
+
+        from dynamo.vllm.handlers import _MIN_FINITE_LOGPROB
+
+        assert math.isfinite(_MIN_FINITE_LOGPROB)
+        # Must serialize without becoming null (the whole point of the clamp).
+        assert json.loads(json.dumps({"logprob": _MIN_FINITE_LOGPROB})) == {
+            "logprob": _MIN_FINITE_LOGPROB
+        }
+
+
 class TestEngineDataAccumulation:
     def test_prompt_token_ids_come_from_built_prompt_when_available(self):
         from dynamo.vllm.handlers import _prompt_token_ids_for_engine_data

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -224,7 +224,9 @@ class TestNonFiniteLogprobs:
     def test_flatten_logprobs_clamps_inf_and_drops_bool(self):
         from dynamo.vllm.handlers import _MIN_FINITE_LOGPROB, _flatten_logprobs
 
-        assert _flatten_logprobs([float("-inf"), -0.5, [{"logprob": float("nan")}]]) == [
+        assert _flatten_logprobs(
+            [float("-inf"), -0.5, [{"logprob": float("nan")}]]
+        ) == [
             _MIN_FINITE_LOGPROB,
             pytest.approx(-0.5),
             _MIN_FINITE_LOGPROB,

--- a/components/src/dynamo/vllm/tests/test_vllm_trace_propagation.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_trace_propagation.py
@@ -59,6 +59,7 @@ def _make_engine(engine_client) -> VllmLLMEngine:
     engine._default_sampling_params = SimpleNamespace()
     engine._model_max_len = 1024
     engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine.enable_rl = False
     # `_dp_range=None` bypasses the router's DP-rank resolution branch.
     engine._dp_range = None
     return engine

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for vLLM backend components."""
 
+import asyncio
 import json
 import re
 import socket
@@ -19,6 +20,7 @@ from dynamo.vllm.args import (
     _is_routable,
     _uses_dynamo_connector,
     _uses_nixl_connector,
+    configure_rl_logprobs_mode,
     ensure_side_channel_host,
     get_host_ip,
     parse_args,
@@ -332,6 +334,120 @@ def test_headless_namespace_has_required_fields(mock_vllm_cli):
     # Core engine fields must survive the round-trip
     assert hasattr(ns, "model")
     assert hasattr(ns, "tensor_parallel_size")
+
+
+def test_rl_logprobs_force_converts_raw_mode():
+    config = SimpleNamespace(
+        enable_rl=True,
+        engine_args=SimpleNamespace(logprobs_mode="raw_logprobs"),
+    )
+
+    configure_rl_logprobs_mode(config)
+
+    assert config.engine_args.logprobs_mode == "processed_logprobs"
+
+
+def test_rl_logprobs_keeps_processed_mode():
+    config = SimpleNamespace(
+        enable_rl=True,
+        engine_args=SimpleNamespace(logprobs_mode="processed_logprobs"),
+    )
+
+    configure_rl_logprobs_mode(config)
+
+    assert config.engine_args.logprobs_mode == "processed_logprobs"
+
+
+def test_rl_logprobs_rejects_logits_modes():
+    config = SimpleNamespace(
+        enable_rl=True,
+        engine_args=SimpleNamespace(logprobs_mode="raw_logits"),
+    )
+
+    with pytest.raises(ValueError, match="processed_logprobs"):
+        configure_rl_logprobs_mode(config)
+
+
+def test_parse_args_does_not_track_logprobs_mode_presence(mock_vllm_cli):
+    mock_vllm_cli("--model", "Qwen/Qwen3-0.6B")
+    config = parse_args()
+    assert not hasattr(config, "logprobs_mode_explicitly_set")
+
+
+def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
+    from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+    from dynamo.vllm import llm_engine
+
+    config = SimpleNamespace(
+        enable_rl=True,
+        engine_args=SimpleNamespace(
+            logprobs_mode="raw_logprobs",
+            served_model_name=["Qwen/Qwen3-0.6B"],
+        ),
+        served_model_name="Qwen/Qwen3-0.6B",
+        model="Qwen/Qwen3-0.6B",
+        disaggregation_mode=CommonDisaggregationMode.AGGREGATED,
+        component="backend",
+    )
+    worker_config = object()
+
+    monkeypatch.setattr(llm_engine, "parse_args", lambda argv: config)
+    monkeypatch.setattr(
+        llm_engine.WorkerConfig,
+        "from_runtime_config",
+        lambda *args, **kwargs: worker_config,
+    )
+
+    async def run_from_args():
+        return await llm_engine.VllmLLMEngine.from_args(["--enable-rl"])
+
+    engine, result_worker_config = asyncio.run(run_from_args())
+
+    assert config.engine_args.logprobs_mode == "processed_logprobs"
+    assert engine.enable_rl is True
+    assert result_worker_config is worker_config
+
+
+def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
+    from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+    from dynamo.vllm import llm_engine
+
+    captured: dict[str, bool] = {}
+
+    def fake_build_sampling_params(
+        request, default_sampling_params, model_max_len=None, *, enable_rl=False
+    ):
+        captured["enable_rl"] = enable_rl
+        return SimpleNamespace(extra_args=None)
+
+    async def empty_generation():
+        if False:
+            yield None
+
+    def fake_generate(*args, **kwargs):
+        return empty_generation()
+
+    engine = llm_engine.VllmLLMEngine(
+        SimpleNamespace(),
+        CommonDisaggregationMode.AGGREGATED,
+        served_model_name="test-model",
+        component="backend",
+        enable_rl=True,
+    )
+    engine.engine_client = SimpleNamespace(generate=fake_generate)
+    engine._default_sampling_params = {}
+    engine._model_max_len = 4096
+
+    monkeypatch.setattr(llm_engine, "build_sampling_params", fake_build_sampling_params)
+
+    async def run_generate():
+        context = SimpleNamespace(id=lambda: "req", trace_headers=lambda: None)
+        async for _ in engine.generate({"token_ids": [1, 2, 3]}, context):
+            pass
+
+    asyncio.run(run_generate())
+
+    assert captured["enable_rl"] is True
 
 
 # --disaggregation-mode tests

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -8,10 +8,13 @@
 # Need to revisit the tests and update them to test the worker handlers.
 
 import asyncio
+import base64
 import json
 from collections import defaultdict
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 
@@ -278,6 +281,61 @@ class TestReasoningParserForwarding:
 
         assert chunks == []
         assert calls == {"called": True}
+
+    @pytest.mark.asyncio
+    async def test_generate_tokens_emits_routed_experts_on_final_chunk(self):
+        from vllm.sampling_params import SamplingParams
+
+        handler = _make_handler()
+        handler._extract_logprobs = MagicMock(return_value=(None, None))
+
+        routed_experts = np.array([[[1]], [[2]]], dtype=np.int32)
+
+        async def fake_generate(*args, **kwargs):
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[11],
+                        routed_experts=None,
+                        finish_reason=None,
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2],
+                prompt_logprobs=None,
+            )
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[11, 12],
+                        routed_experts=routed_experts,
+                        finish_reason="stop",
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2],
+                prompt_logprobs=None,
+            )
+
+        handler.engine_client = MagicMock()
+        handler.engine_client.generate = fake_generate
+
+        chunks = []
+        async for chunk in handler.generate_tokens(
+            PatchedTokensPrompt(prompt_token_ids=[1]),
+            SamplingParams(max_tokens=2),
+            "req-1",
+        ):
+            chunks.append(chunk)
+
+        assert [chunk["token_ids"] for chunk in chunks] == [[11], [12]]
+        assert "disaggregated_params" not in chunks[0]
+        routed = chunks[1]["disaggregated_params"]["routed_experts"]
+        assert routed["shape"] == [2, 1, 1]
+        decoded = np.frombuffer(base64.b85decode(routed["data"]), dtype=np.int32)
+        np.testing.assert_array_equal(decoded, routed_experts.reshape(-1))
 
 
 # ── Tests ────────────────────────────────────────────────────────────

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -337,7 +337,10 @@ class TestReasoningParserForwarding:
         assert "disaggregated_params" not in chunks[0]
         routed = chunks[1]["disaggregated_params"]["routed_experts"]
         assert routed["shape"] == [2, 1, 1]
-        decoded = np.frombuffer(base64.b85decode(routed["data"]), dtype=np.int32)
+        assert routed["dtype"] == "int32"
+        decoded = np.frombuffer(
+            base64.b85decode(routed["data"]), dtype=np.dtype(routed["dtype"])
+        )
         np.testing.assert_array_equal(decoded, routed_experts.reshape(-1))
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -305,11 +305,14 @@ class TestReasoningParserForwarding:
                 prompt_token_ids=[1, 2],
                 prompt_logprobs=None,
             )
+            # DELTA output_kind: each chunk carries only its own new token(s),
+            # and generate_tokens passes output.token_ids through verbatim — so
+            # the second chunk is the delta [12], not the cumulative [11, 12].
             yield SimpleNamespace(
                 outputs=[
                     SimpleNamespace(
                         index=0,
-                        token_ids=[11, 12],
+                        token_ids=[12],
                         routed_experts=routed_experts,
                         finish_reason="stop",
                         stop_reason=None,

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -965,6 +965,22 @@ impl DistributedRuntime {
         self.event_loop.clone()
     }
 
+    /// Return the local system status server URL if this runtime started one.
+    ///
+    /// Workers use this in their RL request-plane route descriptor so the
+    /// frontend does not need to derive worker system URLs from static env vars.
+    fn system_status_server_url(&self) -> Option<String> {
+        self.inner.system_status_server_info().map(|info| {
+            let socket_addr = info.socket_addr;
+            if socket_addr.ip().is_unspecified() {
+                let host = dynamo_runtime::utils::ip_resolver::local_ip_for_advertise();
+                format!("http://{host}:{}", socket_addr.port())
+            } else {
+                format!("http://{socket_addr}")
+            }
+        })
+    }
+
     /// Register an async Python callback for /engine/{route_name}
     ///
     /// Args:


### PR DESCRIPTION
## Summary
- add vLLM worker-side support for nvext Tokens-in-Tokens-Out requests
- forward RL/TITO flags through the vLLM CLI/runtime config
- preserve `nvext.cache_salt` on both decode and disaggregated prefill prompts
- expose requested `nvext.engine_data`, completion token IDs/logprobs, prompt logprobs, and related TITO parity fields
- add focused vLLM parity/unit coverage for cache salt, generation defaults, engine data, logprob flattening, and skip-special-token behavior

## Stack
- Base PR: #9649 (`bis/nvext-tito-rl`) with the Rust `lib/llm` protocol/preprocessor plumbing
- This PR is intentionally vLLM-only: `components/src/dynamo/vllm/*`

## Where To Review
- `components/src/dynamo/vllm/handlers.py`
- `components/src/dynamo/vllm/tests/test_vllm_tito_parity.py`
- `components/src/dynamo/vllm/args.py`
- `components/src/dynamo/vllm/backend_args.py`
- `components/src/dynamo/vllm/main.py`

## Local Tests
- `python -m py_compile components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/tests/test_vllm_tito_parity.py`
- `PYTHONPATH=components/src uv run --no-project --with pytest --with pytest-benchmark python -m pytest -c /dev/null components/src/dynamo/vllm/tests/test_vllm_tito_parity.py -q`
- `git diff --check`

## Notes
After #9649 lands, this PR can be retargeted to `main` or rebased so the diff remains limited to the vLLM files.

supersedes https://github.com/ai-dynamo/dynamo/pull/9382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `--enable-rl` configuration option for reinforcement learning-style defaults.
- Enhanced nvext request field support including cache_salt and engine_data accumulation.
- Added support for `bad_words_token_ids` and `skip_special_tokens` sampling parameters.
- Improved prompt logprobs serialization and accumulation in streaming responses.

**Tests**
- Added comprehensive test coverage for logprobs handling and configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->