### PR TITLE
feat(mocker): add Mooncake delta replay

### DIFF
--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1107,11 +1107,14 @@ fn parse_trace_file_format(
 ) -> PyResult<dynamo_mocker::loadgen::TraceFileFormat> {
     match trace_format {
         "mooncake" => Ok(dynamo_mocker::loadgen::TraceFileFormat::Mooncake),
+        "mooncake-delta" | "mooncake_delta" => {
+            Ok(dynamo_mocker::loadgen::TraceFileFormat::MooncakeDelta)
+        }
         "applied_compute_agentic" => {
             Ok(dynamo_mocker::loadgen::TraceFileFormat::AppliedComputeAgentic)
         }
         other => Err(PyException::new_err(format!(
-            "trace_format must be either 'mooncake' or 'applied_compute_agentic', got '{}'",
+            "trace_format must be 'mooncake', 'mooncake-delta', or 'applied_compute_agentic', got '{}'",
             other
         ))),
     }

--- a/lib/bindings/python/src/dynamo/replay/main.py
+++ b/lib/bindings/python/src/dynamo/replay/main.py
@@ -420,9 +420,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--arrival-speedup-ratio", type=float, default=1.0)
     parser.add_argument(
         "--trace-format",
-        choices=("mooncake", "applied_compute_agentic"),
+        choices=("mooncake", "mooncake-delta", "applied_compute_agentic"),
         default="mooncake",
-        help="format of trace_file when replaying from a file",
+        help=(
+            "format of trace_file when replaying from a file; mooncake-delta "
+            "accumulates per-session input deltas into cumulative prompts and "
+            "can use substantially more memory than mooncake"
+        ),
     )
     parser.add_argument(
         "--trace-block-size",

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -4,7 +4,10 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
+use dynamo_kv_router::protocols::{
+    BlockHashOptions, compute_block_hash_for_seq, compute_seq_hash_for_block,
+};
 use rustc_hash::FxHashMap;
 use uuid::Uuid;
 
@@ -17,10 +20,17 @@ enum DriverMode {
     Concurrency,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptMode {
+    Full,
+    DeltaCumulative,
+}
+
 #[derive(Debug)]
 struct SessionRuntime {
     session_id: String,
     turns: Vec<TurnRuntime>,
+    cumulative_tokens: Vec<u32>,
     next_turn_index: usize,
     next_ready_at_ms: Option<f64>,
     in_flight: Option<Uuid>,
@@ -31,7 +41,7 @@ struct TurnRuntime {
     tokens: Vec<u32>,
     max_output_tokens: usize,
     delay_after_previous_ms: f64,
-    replay_hashes: ReplayRequestHashes,
+    replay_hashes: Option<ReplayRequestHashes>,
 }
 
 #[derive(Debug)]
@@ -76,22 +86,79 @@ impl PartialOrd for ReadySession {
 #[derive(Debug)]
 pub struct WorkloadDriver {
     mode: DriverMode,
+    prompt_mode: PromptMode,
+    engine_block_size: u32,
     sessions: Vec<SessionRuntime>,
     in_flight: FxHashMap<Uuid, InFlightTurn>,
     ready_sessions: BinaryHeap<ReadySession>,
     max_in_flight: Option<usize>,
 }
 
+fn replay_hashes_from_tokens(tokens: &[u32], engine_block_size: u32) -> ReplayRequestHashes {
+    let local_block_hashes =
+        compute_block_hash_for_seq(tokens, engine_block_size, BlockHashOptions::default());
+    let sequence_hashes = compute_seq_hash_for_block(&local_block_hashes);
+
+    ReplayRequestHashes {
+        local_block_hashes,
+        sequence_hashes,
+    }
+}
+
 impl WorkloadDriver {
     pub(crate) fn new_trace(trace: Trace, engine_block_size: usize) -> Result<Self> {
-        Self::new(trace, engine_block_size, DriverMode::Trace)
+        Self::new(
+            trace,
+            engine_block_size,
+            DriverMode::Trace,
+            PromptMode::Full,
+        )
+    }
+
+    pub(crate) fn new_trace_accumulating_deltas(
+        trace: Trace,
+        engine_block_size: usize,
+    ) -> Result<Self> {
+        Self::new(
+            trace,
+            engine_block_size,
+            DriverMode::Trace,
+            PromptMode::DeltaCumulative,
+        )
     }
 
     pub(crate) fn new_concurrency(trace: Trace, engine_block_size: usize) -> Result<Self> {
-        Self::new(trace, engine_block_size, DriverMode::Concurrency)
+        Self::new(
+            trace,
+            engine_block_size,
+            DriverMode::Concurrency,
+            PromptMode::Full,
+        )
     }
 
-    fn new(trace: Trace, engine_block_size: usize, mode: DriverMode) -> Result<Self> {
+    pub(crate) fn new_concurrency_accumulating_deltas(
+        trace: Trace,
+        engine_block_size: usize,
+    ) -> Result<Self> {
+        Self::new(
+            trace,
+            engine_block_size,
+            DriverMode::Concurrency,
+            PromptMode::DeltaCumulative,
+        )
+    }
+
+    fn new(
+        trace: Trace,
+        engine_block_size: usize,
+        mode: DriverMode,
+        prompt_mode: PromptMode,
+    ) -> Result<Self> {
+        if engine_block_size == 0 {
+            bail!("engine_block_size must be greater than 0");
+        }
+        let engine_block_size_u32 =
+            u32::try_from(engine_block_size).context("engine_block_size does not fit in u32")?;
         let trace_block_size = trace.block_size;
         let sessions: Vec<SessionRuntime> = trace
             .sessions
@@ -105,18 +172,28 @@ impl WorkloadDriver {
                     .turns
                     .into_iter()
                     .map(|turn| -> Result<TurnRuntime> {
+                        let replay_hashes = if prompt_mode == PromptMode::Full {
+                            Some(turn.to_replay_hashes(trace_block_size, engine_block_size)?)
+                        } else {
+                            None
+                        };
                         Ok(TurnRuntime {
                             tokens: turn.synthesize_tokens(trace_block_size)?,
                             max_output_tokens: turn.max_output_tokens,
                             delay_after_previous_ms: turn.delay_after_previous_ms,
-                            replay_hashes: turn
-                                .to_replay_hashes(trace_block_size, engine_block_size)?,
+                            replay_hashes,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?;
+                let cumulative_capacity = if prompt_mode == PromptMode::DeltaCumulative {
+                    turns.iter().map(|turn| turn.tokens.len()).sum()
+                } else {
+                    0
+                };
                 Ok(SessionRuntime {
                     session_id: session.session_id,
                     turns,
+                    cumulative_tokens: Vec::with_capacity(cumulative_capacity),
                     next_turn_index: 0,
                     next_ready_at_ms,
                     in_flight: None,
@@ -138,6 +215,8 @@ impl WorkloadDriver {
 
         Ok(Self {
             mode,
+            prompt_mode,
+            engine_block_size: engine_block_size_u32,
             sessions,
             in_flight: FxHashMap::default(),
             ready_sessions,
@@ -213,8 +292,24 @@ impl WorkloadDriver {
                 DriverMode::Trace => Some(scheduled_ready_at_ms),
                 DriverMode::Concurrency => None,
             };
+            let (request_tokens, replay_hashes) = match self.prompt_mode {
+                PromptMode::Full => (
+                    turn.tokens.clone(),
+                    turn.replay_hashes
+                        .as_ref()
+                        .expect("full-prompt workload turns precompute replay hashes")
+                        .clone(),
+                ),
+                PromptMode::DeltaCumulative => {
+                    session.cumulative_tokens.extend_from_slice(&turn.tokens);
+                    let request_tokens = session.cumulative_tokens.clone();
+                    let replay_hashes =
+                        replay_hashes_from_tokens(&request_tokens, self.engine_block_size);
+                    (request_tokens, replay_hashes)
+                }
+            };
             let request = DirectRequest {
-                tokens: turn.tokens.clone(),
+                tokens: request_tokens,
                 max_output_tokens: turn.max_output_tokens,
                 uuid: Some(request_uuid),
                 dp_rank: 0,
@@ -234,7 +329,7 @@ impl WorkloadDriver {
                 session_id: session.session_id.clone(),
                 turn_index,
                 scheduled_ready_at_ms,
-                replay_hashes: Some(turn.replay_hashes.clone()),
+                replay_hashes: Some(replay_hashes),
                 request,
             });
         }
@@ -467,6 +562,44 @@ mod tests {
         assert!(
             driver.is_drained(),
             "is_drained must become true so run_workload can exit"
+        );
+    }
+
+    #[test]
+    fn accumulating_delta_mode_emits_cumulative_input_tokens() {
+        let trace = Trace {
+            block_size: 4,
+            sessions: vec![SessionTrace {
+                session_id: "a".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![
+                    TurnTrace {
+                        input_length: 6,
+                        max_output_tokens: 1,
+                        hash_ids: vec![10, 11],
+                        delay_after_previous_ms: 0.0,
+                    },
+                    TurnTrace {
+                        input_length: 3,
+                        max_output_tokens: 1,
+                        hash_ids: vec![12],
+                        delay_after_previous_ms: 5.0,
+                    },
+                ],
+            }],
+        };
+        let mut driver = WorkloadDriver::new_concurrency_accumulating_deltas(trace, 4).unwrap();
+
+        let first = driver.pop_ready(0.0, usize::MAX);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].request.tokens, vec![10, 10, 10, 10, 11, 11]);
+        driver.on_complete(first[0].request_uuid, 10.0).unwrap();
+
+        let second = driver.pop_ready(15.0, usize::MAX);
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            second[0].request.tokens,
+            vec![10, 10, 10, 10, 11, 11, 12, 12, 12]
         );
     }
 }

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -799,12 +799,28 @@ impl Trace {
         WorkloadDriver::new_trace(self, engine_block_size)
     }
 
+    pub fn into_delta_accumulating_trace_driver_with_block_size(
+        self,
+        engine_block_size: usize,
+    ) -> Result<WorkloadDriver> {
+        self.validate_for_trace_mode()?;
+        WorkloadDriver::new_trace_accumulating_deltas(self, engine_block_size)
+    }
+
     pub fn into_concurrency_driver_with_block_size(
         self,
         engine_block_size: usize,
     ) -> Result<WorkloadDriver> {
         self.validate_for_concurrency_mode()?;
         WorkloadDriver::new_concurrency(self, engine_block_size)
+    }
+
+    pub fn into_delta_accumulating_concurrency_driver_with_block_size(
+        self,
+        engine_block_size: usize,
+    ) -> Result<WorkloadDriver> {
+        self.validate_for_concurrency_mode()?;
+        WorkloadDriver::new_concurrency_accumulating_deltas(self, engine_block_size)
     }
 
     fn validate(&self, allow_missing_first_timestamp: bool) -> Result<()> {

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -17,6 +17,12 @@ pub struct Trace {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TraceFileFormat {
     Mooncake,
+    /// Mooncake-shaped rows where follow-up turns contain input deltas.
+    /// Offline replay accumulates those deltas per session in token space before
+    /// computing engine block hashes. Use this only for delta traces: it expands
+    /// compact session deltas into cumulative prompts and can use much more
+    /// memory than `Mooncake`.
+    MooncakeDelta,
     AppliedComputeAgentic,
 }
 

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -27,7 +27,9 @@ fn load_trace_from_file(
     trace_num_prefix_groups: usize,
 ) -> Result<Trace> {
     match trace_format {
-        TraceFileFormat::Mooncake => Trace::from_mooncake(trace_path, trace_block_size),
+        TraceFileFormat::Mooncake | TraceFileFormat::MooncakeDelta => {
+            Trace::from_mooncake(trace_path, trace_block_size)
+        }
         TraceFileFormat::AppliedComputeAgentic => Trace::from_applied_compute_agentic(
             trace_path,
             trace_block_size,
@@ -37,11 +39,19 @@ fn load_trace_from_file(
     }
 }
 
+fn trace_accumulates_session_deltas(trace_format: TraceFileFormat) -> bool {
+    trace_format == TraceFileFormat::MooncakeDelta
+}
+
 fn single_turn_mooncake_requests(
     trace_format: TraceFileFormat,
     trace: &Trace,
 ) -> Result<Option<Vec<DirectRequest>>> {
-    if trace_format == TraceFileFormat::Mooncake && trace.is_single_turn() {
+    if matches!(
+        trace_format,
+        TraceFileFormat::Mooncake | TraceFileFormat::MooncakeDelta
+    ) && trace.is_single_turn()
+    {
         // The timestamped request path expects every request to carry an
         // arrival timestamp; without this guard a trace missing
         // `first_arrival_timestamp_ms` would panic in
@@ -146,6 +156,15 @@ pub fn simulate_trace_file_with_router_mode_and_format(
             1.0,
             router_mode,
         )?
+    } else if trace_accumulates_session_deltas(trace_format) {
+        crate::replay::offline::simulate_trace_workload_accumulating_deltas(
+            args,
+            router_config,
+            prefill_load_estimator,
+            trace,
+            num_workers,
+            router_mode,
+        )?
     } else {
         crate::replay::offline::simulate_trace_workload(
             args,
@@ -201,6 +220,9 @@ pub fn simulate_trace_file_disagg_with_router_mode_and_format(
         bail!(
             "applied_compute_agentic trace format requires replay_concurrency because source traces do not contain first-turn timestamps"
         );
+    }
+    if trace_accumulates_session_deltas(trace_format) {
+        bail!("mooncake-delta trace format is not supported for disaggregated replay");
     }
     let trace = load_trace_from_file(
         trace_path,
@@ -297,6 +319,9 @@ pub fn simulate_trace_live_file_with_router_mode_and_format(
         bail!(
             "applied_compute_agentic trace format requires replay_concurrency because source traces do not contain first-turn timestamps"
         );
+    }
+    if trace_accumulates_session_deltas(trace_format) {
+        bail!("mooncake-delta trace format is not supported for online replay");
     }
     let trace = load_trace_from_file(
         trace_path,
@@ -509,15 +534,27 @@ pub fn simulate_concurrency_file_with_router_mode_and_format(
         trace_shared_prefix_ratio,
         trace_num_prefix_groups,
     )?;
-    let report = simulate_concurrency_workload_with_router_mode(
-        args,
-        router_config,
-        prefill_load_estimator,
-        trace,
-        max_in_flight,
-        num_workers,
-        router_mode,
-    )?;
+    let report = if trace_accumulates_session_deltas(trace_format) {
+        crate::replay::offline::simulate_concurrency_workload_accumulating_deltas(
+            args,
+            router_config,
+            prefill_load_estimator,
+            trace,
+            max_in_flight,
+            num_workers,
+            router_mode,
+        )?
+    } else {
+        simulate_concurrency_workload_with_router_mode(
+            args,
+            router_config,
+            prefill_load_estimator,
+            trace,
+            max_in_flight,
+            num_workers,
+            router_mode,
+        )?
+    };
     Ok(report)
 }
 
@@ -559,6 +596,9 @@ pub fn simulate_concurrency_file_disagg_with_router_mode_and_format(
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_concurrency_args(&config, max_in_flight, router_mode)?;
+    if trace_accumulates_session_deltas(trace_format) {
+        bail!("mooncake-delta trace format is not supported for disaggregated replay");
+    }
     let trace = load_trace_from_file(
         trace_path,
         trace_block_size,
@@ -638,6 +678,9 @@ pub fn simulate_concurrency_live_file_with_router_mode_and_format(
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_online_concurrency_args(&args, num_workers, max_in_flight)?;
+    if trace_accumulates_session_deltas(trace_format) {
+        bail!("mooncake-delta trace format is not supported for online replay");
+    }
     let trace = load_trace_from_file(
         trace_path,
         trace_block_size,

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -173,8 +173,47 @@ pub(crate) fn simulate_trace_workload(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    simulate_trace_workload_with_delta_mode(
+        args,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        num_workers,
+        router_mode,
+        false,
+    )
+}
+
+pub(crate) fn simulate_trace_workload_accumulating_deltas(
+    args: MockEngineArgs,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    num_workers: usize,
+    router_mode: ReplayRouterMode,
+) -> Result<TraceSimulationReport> {
+    simulate_trace_workload_with_delta_mode(
+        args,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        num_workers,
+        router_mode,
+        true,
+    )
+}
+
+fn simulate_trace_workload_with_delta_mode(
+    args: MockEngineArgs,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    num_workers: usize,
+    router_mode: ReplayRouterMode,
+    accumulate_session_deltas: bool,
+) -> Result<TraceSimulationReport> {
     if num_workers == 1 && args.engine_type == EngineType::Vllm {
-        simulate_trace_workload_single(args, trace)
+        simulate_trace_workload_single(args, trace, accumulate_session_deltas)
     } else {
         simulate_trace_workload_multi(
             args,
@@ -183,6 +222,7 @@ pub(crate) fn simulate_trace_workload(
             trace,
             num_workers,
             router_mode,
+            accumulate_session_deltas,
         )
     }
 }
@@ -196,8 +236,52 @@ pub(crate) fn simulate_concurrency_workload(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    simulate_concurrency_workload_with_delta_mode(
+        args,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        max_in_flight,
+        num_workers,
+        router_mode,
+        false,
+    )
+}
+
+pub(crate) fn simulate_concurrency_workload_accumulating_deltas(
+    args: MockEngineArgs,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    max_in_flight: usize,
+    num_workers: usize,
+    router_mode: ReplayRouterMode,
+) -> Result<TraceSimulationReport> {
+    simulate_concurrency_workload_with_delta_mode(
+        args,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        max_in_flight,
+        num_workers,
+        router_mode,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn simulate_concurrency_workload_with_delta_mode(
+    args: MockEngineArgs,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    max_in_flight: usize,
+    num_workers: usize,
+    router_mode: ReplayRouterMode,
+    accumulate_session_deltas: bool,
+) -> Result<TraceSimulationReport> {
     if num_workers == 1 && args.engine_type == EngineType::Vllm {
-        simulate_concurrency_workload_single(args, trace, max_in_flight)
+        simulate_concurrency_workload_single(args, trace, max_in_flight, accumulate_session_deltas)
     } else {
         simulate_concurrency_workload_multi(
             args,
@@ -207,6 +291,7 @@ pub(crate) fn simulate_concurrency_workload(
             max_in_flight,
             num_workers,
             router_mode,
+            accumulate_session_deltas,
         )
     }
 }
@@ -330,16 +415,17 @@ pub(crate) fn simulate_concurrency_single(
 pub(crate) fn simulate_trace_workload_single(
     args: MockEngineArgs,
     trace: Trace,
+    accumulate_session_deltas: bool,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
     let engine_block_size = args.block_size;
-    let collector = SingleRuntime::new_workload(
-        args,
-        trace.into_trace_driver_with_block_size(engine_block_size)?,
-        SingleReplayMode::Trace,
-    )
-    .run()?;
+    let driver = if accumulate_session_deltas {
+        trace.into_delta_accumulating_trace_driver_with_block_size(engine_block_size)?
+    } else {
+        trace.into_trace_driver_with_block_size(engine_block_size)?
+    };
+    let collector = SingleRuntime::new_workload(args, driver, SingleReplayMode::Trace).run()?;
     Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
@@ -347,13 +433,19 @@ pub(crate) fn simulate_concurrency_workload_single(
     args: MockEngineArgs,
     trace: Trace,
     max_in_flight: usize,
+    accumulate_session_deltas: bool,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
     let engine_block_size = args.block_size;
+    let driver = if accumulate_session_deltas {
+        trace.into_delta_accumulating_concurrency_driver_with_block_size(engine_block_size)?
+    } else {
+        trace.into_concurrency_driver_with_block_size(engine_block_size)?
+    };
     let collector = SingleRuntime::new_workload(
         args,
-        trace.into_concurrency_driver_with_block_size(engine_block_size)?,
+        driver,
         SingleReplayMode::Concurrency { max_in_flight },
     )
     .run()?;
@@ -417,14 +509,20 @@ pub(crate) fn simulate_trace_workload_multi(
     trace: Trace,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    accumulate_session_deltas: bool,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
+    let driver = if accumulate_session_deltas {
+        trace.into_delta_accumulating_trace_driver_with_block_size(args.block_size)?
+    } else {
+        trace.into_trace_driver_with_block_size(args.block_size)?
+    };
     let (collector, _) = AggRuntime::new_workload(
         &args,
         router_config,
         prefill_load_estimator,
-        trace.into_trace_driver_with_block_size(args.block_size)?,
+        driver,
         num_workers,
         AggReplayMode::Trace,
         router_mode,
@@ -433,6 +531,7 @@ pub(crate) fn simulate_trace_workload_multi(
     Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn simulate_concurrency_workload_multi(
     args: MockEngineArgs,
     router_config: Option<KvRouterConfig>,
@@ -441,14 +540,20 @@ pub(crate) fn simulate_concurrency_workload_multi(
     max_in_flight: usize,
     num_workers: usize,
     router_mode: ReplayRouterMode,
+    accumulate_session_deltas: bool,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
+    let driver = if accumulate_session_deltas {
+        trace.into_delta_accumulating_concurrency_driver_with_block_size(args.block_size)?
+    } else {
+        trace.into_concurrency_driver_with_block_size(args.block_size)?
+    };
     let (collector, _) = AggRuntime::new_workload(
         &args,
         router_config,
         prefill_load_estimator,
-        trace.into_concurrency_driver_with_block_size(args.block_size)?,
+        driver,
         num_workers,
         AggReplayMode::Concurrency { max_in_flight },
         router_mode,

--- a/lib/mocker/src/replay/offline/mod.rs
+++ b/lib/mocker/src/replay/offline/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod state;
 
 pub(crate) use entrypoints::{
     generate_trace_worker_artifacts, simulate_concurrency, simulate_concurrency_disagg,
-    simulate_concurrency_workload, simulate_concurrency_workload_disagg, simulate_trace,
-    simulate_trace_disagg, simulate_trace_workload, simulate_trace_workload_disagg,
+    simulate_concurrency_workload, simulate_concurrency_workload_accumulating_deltas,
+    simulate_concurrency_workload_disagg, simulate_trace, simulate_trace_disagg,
+    simulate_trace_workload, simulate_trace_workload_accumulating_deltas,
+    simulate_trace_workload_disagg,
 };


### PR DESCRIPTION
Adds an explicit mooncake-delta trace format for offline replay so session input deltas are accumulated into cumulative prompts before engine block hashes are recomputed. Keeps existing mooncake replay behavior unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Mooncake Delta trace format with delta-accumulating replay mode, enabling efficient per-session token accumulation for trace and concurrency workload simulations.
  * Expanded CLI `--trace-format` argument to recognize `mooncake-delta` and `mooncake_delta` format aliases.
  * Added new replay entrypoints for offline trace and concurrency simulations with delta-accumulating behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->