### PR TITLE
docs: bump SGLang references to 0.5.11 on main (#9546)

### DIFF
--- a/docs/backends/sglang/agents.md
+++ b/docs/backends/sglang/agents.md
@@ -175,7 +175,7 @@ Session control is request-driven. The router's `AgentController` (session lifec
 > Session control is currently supported only on the SGLang backend. vLLM and TensorRT-LLM do not yet expose the streaming session API.
 
 > [!IMPORTANT]
-> Streaming sessions require SGLang changes from [sgl-project/sglang#21875](https://github.com/sgl-project/sglang/pull/21875) (session-aware cache, race condition fixes, session metrics). This is merged to SGLang main but not yet in a release. Until a version after `0.5.10.post1` is published, build SGLang from source (`pip install -e "python"` from the SGLang repo).
+> Streaming sessions require SGLang `0.5.11` or later, which includes changes from [sgl-project/sglang#21875](https://github.com/sgl-project/sglang/pull/21875) (session-aware cache, race condition fixes, session metrics).
 
 **SGLang worker:**
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.10.post1` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.11` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.1** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |

--- a/recipes/glm-5-nvfp4/Dockerfile
+++ b/recipes/glm-5-nvfp4/Dockerfile
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# TODO: bump to lmsysorg/sglang:v0.5.11-cu130
 ARG BASE_IMAGE="lmsysorg/sglang:v0.5.10.post1-cu130"
 ARG ARCH=arm64
 ARG DYNAMO_COMMIT="main"


### PR DESCRIPTION
Cherry-pick of #9546 to release/1.2.0.

release/1.2.0 already runs SGLang v0.5.11 at the container level (carried via #9230). This brings the doc + recipe references in line so the rendered docs site stays consistent between main and the release branch.

Files:
- `docs/backends/sglang/agents.md` — rewords the streaming-sessions note now that sgl#21875 is in a released SGLang tag.
- `docs/reference/support-matrix.md` — updates the "main (ToT)" row to 0.5.11.
- `recipes/glm-5-nvfp4/Dockerfile` — adds a TODO to bump base image to v0.5.11-cu130 (base pin unchanged).

No code changes; no test impact.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->