### PR TITLE
docs(tool-calling): add troubleshooting guide using logprobs

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -166,6 +166,8 @@ navigation:
             path: tool-calling/dynamo.md
           - page: Tool Call Parsing (Engine Fallback)
             path: tool-calling/engine-fallback.md
+          - page: Troubleshooting Tool Calls
+            path: tool-calling/troubleshooting.md
       - section: Reasoning
         slug: reasoning
         path: reasoning/README.md

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -25,17 +25,15 @@ registry does not list a parser for your model.
 
 ## Troubleshooting
 
-If a tool call comes back wrong -- `tool_calls` is `null`, the arguments are
-malformed, or raw `<tool_call>` markers appear in `message.content` -- add
-`logprobs: true` to a single repro request to inspect the raw model output
-independent of any parser. See
-[Troubleshooting Tool Calls](troubleshooting.md).
+If a tool call comes back wrong, add `logprobs: true` to a single repro
+request and share the response. See
+[Troubleshooting Tool Calls](troubleshooting.md) for what to capture and
+include when reporting an issue.
 
 ## See Also
 
-- [Troubleshooting Tool Calls](troubleshooting.md) -- use `logprobs` to
-  localize tool-call issues to the model, the parser configuration, or the
-  parser itself.
+- [Troubleshooting Tool Calls](troubleshooting.md) -- capture raw model
+  output with `logprobs` so tool-call issues can be localized.
 - [Reasoning](../reasoning/README.md) -- separate `reasoning_content` from
   assistant content for chain-of-thought models. Several models need both a
   tool-call parser and a reasoning parser configured together.

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -23,8 +23,19 @@ parser lives in Dynamo's own registry or in the upstream engine (vLLM, SGLang).
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.
 
+## Troubleshooting
+
+If a tool call comes back wrong -- `tool_calls` is `null`, the arguments are
+malformed, or raw `<tool_call>` markers appear in `message.content` -- add
+`logprobs: true` to a single repro request to inspect the raw model output
+independent of any parser. See
+[Troubleshooting Tool Calls](troubleshooting.md).
+
 ## See Also
 
+- [Troubleshooting Tool Calls](troubleshooting.md) -- use `logprobs` to
+  localize tool-call issues to the model, the parser configuration, or the
+  parser itself.
 - [Reasoning](../reasoning/README.md) -- separate `reasoning_content` from
   assistant content for chain-of-thought models. Several models need both a
   tool-call parser and a reasoning parser configured together.

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -152,8 +152,7 @@ OpenAI-compatible `tool_calls` entries on the response:
 ```
 
 > [!TIP]
-> If `tool_calls` is `null`, the arguments look malformed, or raw
-> `<tool_call>` markers appear in `message.content`, add
-> `"logprobs": true` to a single repro request to see the raw model output
-> and localize the issue. See
-> [Troubleshooting Tool Calls](troubleshooting.md).
+> If a tool call comes back wrong, add `"logprobs": true` to a single repro
+> request and share the response. See
+> [Troubleshooting Tool Calls](troubleshooting.md) for what to capture and
+> include when reporting an issue.

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -150,3 +150,10 @@ OpenAI-compatible `tool_calls` entries on the response:
   ...
 }
 ```
+
+> [!TIP]
+> If `tool_calls` is `null`, the arguments look malformed, or raw
+> `<tool_call>` markers appear in `message.content`, add
+> `"logprobs": true` to a single repro request to see the raw model output
+> and localize the issue. See
+> [Troubleshooting Tool Calls](troubleshooting.md).

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -46,8 +46,16 @@ python -m dynamo.sglang ...
 python -m dynamo.frontend --dyn-chat-processor sglang --tool-call-parser kimi_k2
 ```
 
+> [!TIP]
+> If `tool_calls` is `null`, the arguments look malformed, or raw
+> `<tool_call>` markers appear in `message.content`, add
+> `"logprobs": true` to a single repro request to see the raw model output
+> and localize the issue. See
+> [Troubleshooting Tool Calls](troubleshooting.md).
+
 ## See Also
 
+- [Troubleshooting Tool Calls](troubleshooting.md) -- use `logprobs` to localize tool-call issues to the model, the parser configuration, or the parser itself
 - [Tool Call Parsing (Dynamo)](dynamo.md) -- Dynamo-native parsers and request examples
 - [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md) -- Equivalent fallback for reasoning
 - [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md) -- vLLM chat-processor details

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -47,15 +47,14 @@ python -m dynamo.frontend --dyn-chat-processor sglang --tool-call-parser kimi_k2
 ```
 
 > [!TIP]
-> If `tool_calls` is `null`, the arguments look malformed, or raw
-> `<tool_call>` markers appear in `message.content`, add
-> `"logprobs": true` to a single repro request to see the raw model output
-> and localize the issue. See
-> [Troubleshooting Tool Calls](troubleshooting.md).
+> If a tool call comes back wrong, add `"logprobs": true` to a single repro
+> request and share the response. See
+> [Troubleshooting Tool Calls](troubleshooting.md) for what to capture and
+> include when reporting an issue.
 
 ## See Also
 
-- [Troubleshooting Tool Calls](troubleshooting.md) -- use `logprobs` to localize tool-call issues to the model, the parser configuration, or the parser itself
+- [Troubleshooting Tool Calls](troubleshooting.md) -- capture raw model output with `logprobs` so tool-call issues can be localized
 - [Tool Call Parsing (Dynamo)](dynamo.md) -- Dynamo-native parsers and request examples
 - [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md) -- Equivalent fallback for reasoning
 - [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md) -- vLLM chat-processor details

--- a/docs/tool-calling/troubleshooting.md
+++ b/docs/tool-calling/troubleshooting.md
@@ -24,13 +24,20 @@ diagnostic info.
 > (`harmony`, `kimi_k2`, `kimi_k25`, `gemma4`), the recipe recovers only
 > the assistant-content channel; the reasoning channel is not surfaced in
 > `logprobs.content`.
+>
+> If the worker is the SGLang backend, `logprobs: true` is rejected by
+> default because SGLang's tokenizer manager detokenizes top-k tokens
+> serially, causing latency degradation. Launch the worker with
+> `DYN_SGL_ALLOW_TOP_LOGPROBS=1` set in the environment to opt in for the
+> duration of the repro request, then unset it afterward. Tracked at
+> [sgl-project/sglang#24447](https://github.com/sgl-project/sglang/pull/24447).
 
 ## The request
 
 Add `"logprobs": true` to your failing request:
 
 ```bash
-curl -s http://localhost:8080/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "Qwen/Qwen2.5-7B-Instruct",

--- a/docs/tool-calling/troubleshooting.md
+++ b/docs/tool-calling/troubleshooting.md
@@ -2,85 +2,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Troubleshooting Tool Calls
-subtitle: Inspect raw model output with logprobs to localize tool-call issues
+subtitle: Capture raw model output with logprobs so issues can be localized
 ---
 
-When a tool call comes back wrong -- `tool_calls` is `null` when you expected
-a function call, the arguments are malformed, or raw `<tool_call>` markers
-appear inside `message.content` -- the request and response alone cannot tell
-you whether the model produced bad text or a downstream parser mangled good
-text. This page shows how to add `logprobs` to a single repro request so you
-can see exactly what the engine emitted, independent of the parser.
+When a tool call comes back wrong (`tool_calls` is `null`, the arguments
+look malformed, raw `<tool_call>` markers appear in `message.content`, or
+`finish_reason` is `"stop"` when you expected `"tool_calls"`), the request
+and response alone usually do not say *where* the bug is. The model and the
+parser produce indistinguishable failures from the response side.
 
-For the happy-path setup and parser names, see
-[Tool Call Parsing (Dynamo)](dynamo.md) and
-[Tool Call Parsing (Engine Fallback)](engine-fallback.md).
+Adding `"logprobs": true` to a single repro request makes the engine's raw
+token output visible in the response. That is enough for someone on the
+Dynamo team to identify whether the issue is in the model, the parser
+configuration, or the parser itself. This page shows the field to add and
+what the response will look like, so you can capture and share useful
+diagnostic info.
 
 > [!NOTE]
-> **Scope.** This recipe applies to non-streaming requests against Dynamo's
-> OpenAI `/v1/chat/completions` endpoint. Streaming responses, the Responses
-> API, the Anthropic-API mode (`--enable-anthropic-api`), and the kserve gRPC
-> frontend serialize logprobs differently and are not covered.
->
-> For multi-channel reasoning models (`harmony`, `kimi_k2`, `kimi_k25`,
-> `gemma4`), the recipe recovers only the assistant-content channel. The
-> reasoning-content channel is not surfaced in `logprobs.content` because the
-> OpenAI schema has no equivalent `reasoning_logprobs` field. If the model
-> emits a tool call on a reasoning channel, the reconstructed stream will
-> look truncated even when the model is fine.
+> Recipe applies to non-streaming requests against Dynamo's OpenAI
+> `/v1/chat/completions` endpoint. For multi-channel reasoning models
+> (`harmony`, `kimi_k2`, `kimi_k25`, `gemma4`), the recipe recovers only
+> the assistant-content channel; the reasoning channel is not surfaced in
+> `logprobs.content`.
 
-## When to use this page
+## The request
 
-Re-run the failing request with `logprobs` enabled when any of these are true:
-
-- `message.tool_calls[].function.arguments` is malformed JSON or omits
-  expected fields.
-- `message.content` contains raw `<tool_call>...</tool_call>` markers (or the
-  family-equivalent wrapper) instead of being `null`.
-- `finish_reason` is `"stop"` when you expected `"tool_calls"`.
-- A customer has shared only the request and response and you need to triage
-  remotely without standing up their model.
-
-## The technique
-
-Add one field to the request:
-
-```json
-{
-  "logprobs": true
-}
-```
-
-This makes the server include `choices[0].logprobs.content` in the response:
-an array with one entry per generated token, each carrying the surface-form
-`token` string and a `bytes` array (the exact UTF-8 sequence). Concatenating
-those bytes reconstructs the raw output stream verbatim, before any
-tool-call parser touched it.
-
-The flag is intended to be observationally equivalent: on the same prompt
-and sampling parameters, `finish_reason`, `content`, and `tool_calls` should
-not change. In practice some backends take slightly different sampling
-paths under `logprobs=true` (vLLM routes through a separate SamplingParams
-branch; SGLang can disable certain CUDA-graph fast paths). If you suspect
-logprobs is perturbing the bug itself, capture one request with and one
-without, diff the non-logprobs fields, and check `usage`.
-
-Added cost is response size, roughly 50-100 bytes per generated token, so
-this is intended for one-off debug requests, not production traffic.
-
-Edge case: at end-of-stream when Dynamo's parser jail drains undecided
-bytes, the trailing tokens may have `logprobs: null` even when requested.
-If the final entry of `logprobs.content` is missing, the wrapper-marker
-close (for example, `</tool_call>`) may have been emitted past the jail
-flush point. Read the captured tokens up to that point as still
-authoritative.
-
-## Worked example
-
-This uses the same Qwen2.5 / `get_weather` setup as the
-[Dynamo parser example](dynamo.md#examples), with `logprobs` added.
-
-### Request
+Add `"logprobs": true` to your failing request:
 
 ```bash
 curl -s http://localhost:8080/v1/chat/completions \
@@ -110,7 +57,11 @@ curl -s http://localhost:8080/v1/chat/completions \
   }'
 ```
 
-### Response
+## The response
+
+You will get back the usual fields (`message.tool_calls`, `message.content`,
+`finish_reason`) plus a new `choices[0].logprobs.content` field carrying the
+engine's raw token stream:
 
 ```json
 {
@@ -133,10 +84,6 @@ curl -s http://localhost:8080/v1/chat/completions \
         {"token": "\n", "bytes": [10]},
         {"token": "{\"", "bytes": [123, 34]},
         {"token": "name", "bytes": [110, 97, 109, 101]},
-        {"token": "\":", "bytes": [34, 58]},
-        {"token": " \"get", "bytes": [32, 34, 103, 101, 116]},
-        {"token": "_weather", "bytes": [95, 119, 101, 97, 116, 104, 101, 114]},
-        {"token": "\",", "bytes": [34, 44]},
         "...",
         {"token": "</tool_call>", "bytes": [60, 47, 116, 111, 111, 108, 95, 99, 97, 108, 108, 62]}
       ]
@@ -145,162 +92,36 @@ curl -s http://localhost:8080/v1/chat/completions \
 }
 ```
 
-### Reconstruct the raw stream
+Each entry in `logprobs.content` is one generated token with its exact UTF-8
+`bytes`. Concatenating those bytes in order reconstructs the raw model
+output, before any tool-call parser touched it. That is the key piece for
+triage: it tells us what the model actually produced, separately from what
+the parser made of it.
 
-```python
-import json
+## What to include when reporting an issue
 
-response = json.load(open("response.json"))
-entries = response["choices"][0]["logprobs"]["content"]
+Share these four things in the bug report or issue thread:
 
-# Sanity check: confirm the backend populates `bytes`. If it's null or
-# empty, the backend version does not surface byte-level logprobs; fall
-# back to the `token` field (lossy for non-ASCII).
-assert entries[0].get("bytes"), "backend did not populate logprobs.bytes"
+1. **The full request body** (model name, messages, tools, sampling params,
+   and `logprobs: true`).
+2. **The full response body.** Do not truncate `logprobs.content` -- the
+   per-token entries are the part that matters.
+3. **The Dynamo version and the backend** (vLLM, SGLang, TRT-LLM, including
+   versions if known).
+4. **The worker launch command**, especially the `--dyn-tool-call-parser`
+   value if set.
 
-raw_bytes = b"".join(bytes(e["bytes"]) for e in entries)
-print(raw_bytes.decode("utf-8"))
-```
-
-Output:
-
-```
-<tool_call>
-{"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}
-</tool_call>
-```
-
-That string is the model's exact output -- bytes that the engine produced
-before any tool-call parser stripped wrapper tokens or lifted JSON into
-`message.tool_calls`. Compare it to the rendered `message.content` and
-`message.tool_calls` to localize where things diverged.
-
-## Before the ladder: quick pre-checks
-
-Three classes of failure look like model or parser bugs but are not. Rule
-them out first:
-
-1. **Truncation.** If `finish_reason == "length"`, the model hit
-   `max_tokens` or the context window mid-generation. The raw stream
-   looking "garbled" is just incomplete output. Raise `max_tokens` or
-   shorten the prompt and re-run.
-
-2. **`tool_choice="required"` with a wrapped format.** When
-   `tool_choice="required"`, Dynamo's preprocessor expects bare JSON, not
-   `<tool_call>`-wrapped JSON. If the model emits wrapper markers anyway,
-   parsing fails because the contract differs, not because the parser is
-   broken. Set `tool_choice="auto"` if the model is trained to wrap.
-
-3. **Hallucinated tool name.** If `tool_calls[].function.name` is populated
-   but does not match any name in your request's `tools[]`, the model
-   invented a function. That is a prompt or model issue, not a parser
-   issue. Lower temperature, add few-shot examples, or constrain the model
-   upstream.
-
-If none of these apply, work the ladder below.
-
-## Diagnostic ladder
-
-Once you have the raw stream from `logprobs.content` and the parsed view from
-`message.*`, work the three checks in order:
-
-### 1. Does the detokenized stream itself look garbled?
-
-If the raw bytes are nonsense -- truncated mid-token, off-grammar, or wrong
-language -- the issue is upstream of any parser. The model produced bad
-tokens.
-
-- **Likely causes:** prompt formatting (missing chat template), sampling
-  parameters (temperature too high, top_p too low, repetition penalty
-  fighting the JSON syntax), checkpoint version mismatch, custom Jinja
-  template not rendering tool definitions correctly.
-- **Where to fix:** request side. Check the worker's `--custom-jinja-template`
-  if you set one, drop temperature toward 0 for a deterministic repro, and
-  verify the prompt rendering matches the model card.
-
-### 2. Is the raw stream well-formed but `message.content` still has wrapper markers?
-
-If `logprobs.content` decodes to a valid `<tool_call>...</tool_call>` (or
-family-equivalent) block, but `message.content` contains those wrapper
-markers as literal text and `message.tool_calls` is `null` or absent, no
-parser is engaged.
-
-- **Likely causes:** worker started without `--dyn-tool-call-parser`, or
-  the wrong parser name for the model family.
-- **Known trap:** if you are using engine fallback
-  (`--dyn-chat-processor vllm` or `sglang`) AND disaggregated serving, the
-  engine-fallback parser is silently not engaged. See the warning in
-  [Tool Call Parsing (Engine Fallback)](engine-fallback.md). Do not proceed
-  to step 3 in that case.
-- **Where to fix:** restart the worker with the right parser:
-
-  ```bash
-  python -m dynamo.<backend> --model <name> \
-    --dyn-tool-call-parser <family>
-  ```
-
-  See the parser-name table in
-  [Tool Call Parsing (Dynamo)](dynamo.md#supported-tool-call-parsers).
-
-### 3. Is the raw stream well-formed but `tool_calls.arguments` is mangled?
-
-If `logprobs.content` decodes to a clean JSON object inside the wrapper but
-`message.tool_calls[].function.arguments` differs from it -- fields dropped,
-escapes wrong, sibling keys merged -- a parser ran and produced the wrong
-output.
-
-- **Likely causes:** parser bug specific to this model family, or a parser
-  configured against the wrong family.
-- **Where to localize:** diff the JSON visible in `logprobs.content` against
-  `tool_calls[].function.arguments` character by character. The diff shows
-  exactly what the parser dropped or rewrote.
-- **Where to report:** open an issue with both blobs side by side. The Dynamo
-  parser source lives at `lib/parsers/src/tool_calling/<family>/` and the
-  cross-impl parity harness at
-  [tests/parity/README.md](../../tests/parity/README.md) records the
-  contract.
-
-## Pipeline view
-
-The recipe works because each stage in the response pipeline has its own
-observable in the response, and `logprobs.content` sits **upstream** of the
-parser:
-
-```
-model emits tokens
-      |
-      v
-logprobs.content   <-- ground truth
-                       (parser does not touch this)
-      |
-      v
-tool-call parser
-(consumes wrapper markers,
- extracts JSON into tool_calls)
-      |
-      v
-message.content    <-- what parser left in text
-                       (null/empty if parsed,
-                        raw markers if no parser engaged)
-message.tool_calls <-- what parser extracted as structure
-                       (populated if parsed,
-                        null/absent if no parser engaged)
-finish_reason      <-- "tool_calls" iff extraction succeeded
-```
-
-Diffs between adjacent layers localize the bug to a single stage. The same
-recipe applies whether the parser lives in Dynamo's Rust preprocessor (the
-default), in the SGLang `FunctionCallParser`, or in vLLM's auto-tool-choice
-path -- `logprobs.content` is OpenAI-standard and sits upstream of all
-three.
+With those four pieces, the Dynamo team can usually localize the bug
+without standing up your model. The team will reconstruct the raw stream
+from the `bytes` arrays and compare it against `message.content` and
+`message.tool_calls` to decide whether the issue is in the model output,
+the parser configuration, or the parser logic.
 
 ## See also
 
 - [Tool Call Parsing (Dynamo)](dynamo.md) -- Dynamo-native parser names and
   request examples
-- [Tool Call Parsing (Engine Fallback)](engine-fallback.md) -- `--dyn-chat-processor`
-  fallback path to vLLM / SGLang parsers
+- [Tool Call Parsing (Engine Fallback)](engine-fallback.md) --
+  `--dyn-chat-processor` fallback path to vLLM and SGLang parsers
 - [Frontend Configuration Reference](../components/frontend/configuration.md)
-  -- Full CLI flag reference for the frontend and worker
-- [Cross-impl parity test suite](../../tests/parity/README.md) -- Where the
-  parser contract is recorded across Dynamo, vLLM, and SGLang
+  -- full CLI flag reference for the frontend and worker

--- a/docs/tool-calling/troubleshooting.md
+++ b/docs/tool-calling/troubleshooting.md
@@ -1,0 +1,306 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Troubleshooting Tool Calls
+subtitle: Inspect raw model output with logprobs to localize tool-call issues
+---
+
+When a tool call comes back wrong -- `tool_calls` is `null` when you expected
+a function call, the arguments are malformed, or raw `<tool_call>` markers
+appear inside `message.content` -- the request and response alone cannot tell
+you whether the model produced bad text or a downstream parser mangled good
+text. This page shows how to add `logprobs` to a single repro request so you
+can see exactly what the engine emitted, independent of the parser.
+
+For the happy-path setup and parser names, see
+[Tool Call Parsing (Dynamo)](dynamo.md) and
+[Tool Call Parsing (Engine Fallback)](engine-fallback.md).
+
+> [!NOTE]
+> **Scope.** This recipe applies to non-streaming requests against Dynamo's
+> OpenAI `/v1/chat/completions` endpoint. Streaming responses, the Responses
+> API, the Anthropic-API mode (`--enable-anthropic-api`), and the kserve gRPC
+> frontend serialize logprobs differently and are not covered.
+>
+> For multi-channel reasoning models (`harmony`, `kimi_k2`, `kimi_k25`,
+> `gemma4`), the recipe recovers only the assistant-content channel. The
+> reasoning-content channel is not surfaced in `logprobs.content` because the
+> OpenAI schema has no equivalent `reasoning_logprobs` field. If the model
+> emits a tool call on a reasoning channel, the reconstructed stream will
+> look truncated even when the model is fine.
+
+## When to use this page
+
+Re-run the failing request with `logprobs` enabled when any of these are true:
+
+- `message.tool_calls[].function.arguments` is malformed JSON or omits
+  expected fields.
+- `message.content` contains raw `<tool_call>...</tool_call>` markers (or the
+  family-equivalent wrapper) instead of being `null`.
+- `finish_reason` is `"stop"` when you expected `"tool_calls"`.
+- A customer has shared only the request and response and you need to triage
+  remotely without standing up their model.
+
+## The technique
+
+Add one field to the request:
+
+```json
+{
+  "logprobs": true
+}
+```
+
+This makes the server include `choices[0].logprobs.content` in the response:
+an array with one entry per generated token, each carrying the surface-form
+`token` string and a `bytes` array (the exact UTF-8 sequence). Concatenating
+those bytes reconstructs the raw output stream verbatim, before any
+tool-call parser touched it.
+
+The flag is intended to be observationally equivalent: on the same prompt
+and sampling parameters, `finish_reason`, `content`, and `tool_calls` should
+not change. In practice some backends take slightly different sampling
+paths under `logprobs=true` (vLLM routes through a separate SamplingParams
+branch; SGLang can disable certain CUDA-graph fast paths). If you suspect
+logprobs is perturbing the bug itself, capture one request with and one
+without, diff the non-logprobs fields, and check `usage`.
+
+Added cost is response size, roughly 50-100 bytes per generated token, so
+this is intended for one-off debug requests, not production traffic.
+
+Edge case: at end-of-stream when Dynamo's parser jail drains undecided
+bytes, the trailing tokens may have `logprobs: null` even when requested.
+If the final entry of `logprobs.content` is missing, the wrapper-marker
+close (for example, `</tool_call>`) may have been emitted past the jail
+flush point. Read the captured tokens up to that point as still
+authoritative.
+
+## Worked example
+
+This uses the same Qwen2.5 / `get_weather` setup as the
+[Dynamo parser example](dynamo.md#examples), with `logprobs` added.
+
+### Request
+
+```bash
+curl -s http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct",
+    "messages": [
+      {"role": "user", "content": "What is the weather in NYC?"}
+    ],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {"type": "string"},
+            "unit": {"enum": ["celsius", "fahrenheit"]}
+          },
+          "required": ["location"]
+        }
+      }
+    }],
+    "tool_choice": "auto",
+    "temperature": 0.0,
+    "logprobs": true
+  }'
+```
+
+### Response
+
+```json
+{
+  "choices": [{
+    "finish_reason": "tool_calls",
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "arguments": "{\"location\":\"New York, NY\",\"unit\":\"fahrenheit\"}"
+        }
+      }]
+    },
+    "logprobs": {
+      "content": [
+        {"token": "<tool_call>", "bytes": [60, 116, 111, 111, 108, 95, 99, 97, 108, 108, 62]},
+        {"token": "\n", "bytes": [10]},
+        {"token": "{\"", "bytes": [123, 34]},
+        {"token": "name", "bytes": [110, 97, 109, 101]},
+        {"token": "\":", "bytes": [34, 58]},
+        {"token": " \"get", "bytes": [32, 34, 103, 101, 116]},
+        {"token": "_weather", "bytes": [95, 119, 101, 97, 116, 104, 101, 114]},
+        {"token": "\",", "bytes": [34, 44]},
+        "...",
+        {"token": "</tool_call>", "bytes": [60, 47, 116, 111, 111, 108, 95, 99, 97, 108, 108, 62]}
+      ]
+    }
+  }]
+}
+```
+
+### Reconstruct the raw stream
+
+```python
+import json
+
+response = json.load(open("response.json"))
+entries = response["choices"][0]["logprobs"]["content"]
+
+# Sanity check: confirm the backend populates `bytes`. If it's null or
+# empty, the backend version does not surface byte-level logprobs; fall
+# back to the `token` field (lossy for non-ASCII).
+assert entries[0].get("bytes"), "backend did not populate logprobs.bytes"
+
+raw_bytes = b"".join(bytes(e["bytes"]) for e in entries)
+print(raw_bytes.decode("utf-8"))
+```
+
+Output:
+
+```
+<tool_call>
+{"name": "get_weather", "arguments": {"location": "New York, NY", "unit": "fahrenheit"}}
+</tool_call>
+```
+
+That string is the model's exact output -- bytes that the engine produced
+before any tool-call parser stripped wrapper tokens or lifted JSON into
+`message.tool_calls`. Compare it to the rendered `message.content` and
+`message.tool_calls` to localize where things diverged.
+
+## Before the ladder: quick pre-checks
+
+Three classes of failure look like model or parser bugs but are not. Rule
+them out first:
+
+1. **Truncation.** If `finish_reason == "length"`, the model hit
+   `max_tokens` or the context window mid-generation. The raw stream
+   looking "garbled" is just incomplete output. Raise `max_tokens` or
+   shorten the prompt and re-run.
+
+2. **`tool_choice="required"` with a wrapped format.** When
+   `tool_choice="required"`, Dynamo's preprocessor expects bare JSON, not
+   `<tool_call>`-wrapped JSON. If the model emits wrapper markers anyway,
+   parsing fails because the contract differs, not because the parser is
+   broken. Set `tool_choice="auto"` if the model is trained to wrap.
+
+3. **Hallucinated tool name.** If `tool_calls[].function.name` is populated
+   but does not match any name in your request's `tools[]`, the model
+   invented a function. That is a prompt or model issue, not a parser
+   issue. Lower temperature, add few-shot examples, or constrain the model
+   upstream.
+
+If none of these apply, work the ladder below.
+
+## Diagnostic ladder
+
+Once you have the raw stream from `logprobs.content` and the parsed view from
+`message.*`, work the three checks in order:
+
+### 1. Does the detokenized stream itself look garbled?
+
+If the raw bytes are nonsense -- truncated mid-token, off-grammar, or wrong
+language -- the issue is upstream of any parser. The model produced bad
+tokens.
+
+- **Likely causes:** prompt formatting (missing chat template), sampling
+  parameters (temperature too high, top_p too low, repetition penalty
+  fighting the JSON syntax), checkpoint version mismatch, custom Jinja
+  template not rendering tool definitions correctly.
+- **Where to fix:** request side. Check the worker's `--custom-jinja-template`
+  if you set one, drop temperature toward 0 for a deterministic repro, and
+  verify the prompt rendering matches the model card.
+
+### 2. Is the raw stream well-formed but `message.content` still has wrapper markers?
+
+If `logprobs.content` decodes to a valid `<tool_call>...</tool_call>` (or
+family-equivalent) block, but `message.content` contains those wrapper
+markers as literal text and `message.tool_calls` is `null` or absent, no
+parser is engaged.
+
+- **Likely causes:** worker started without `--dyn-tool-call-parser`, or
+  the wrong parser name for the model family.
+- **Known trap:** if you are using engine fallback
+  (`--dyn-chat-processor vllm` or `sglang`) AND disaggregated serving, the
+  engine-fallback parser is silently not engaged. See the warning in
+  [Tool Call Parsing (Engine Fallback)](engine-fallback.md). Do not proceed
+  to step 3 in that case.
+- **Where to fix:** restart the worker with the right parser:
+
+  ```bash
+  python -m dynamo.<backend> --model <name> \
+    --dyn-tool-call-parser <family>
+  ```
+
+  See the parser-name table in
+  [Tool Call Parsing (Dynamo)](dynamo.md#supported-tool-call-parsers).
+
+### 3. Is the raw stream well-formed but `tool_calls.arguments` is mangled?
+
+If `logprobs.content` decodes to a clean JSON object inside the wrapper but
+`message.tool_calls[].function.arguments` differs from it -- fields dropped,
+escapes wrong, sibling keys merged -- a parser ran and produced the wrong
+output.
+
+- **Likely causes:** parser bug specific to this model family, or a parser
+  configured against the wrong family.
+- **Where to localize:** diff the JSON visible in `logprobs.content` against
+  `tool_calls[].function.arguments` character by character. The diff shows
+  exactly what the parser dropped or rewrote.
+- **Where to report:** open an issue with both blobs side by side. The Dynamo
+  parser source lives at `lib/parsers/src/tool_calling/<family>/` and the
+  cross-impl parity harness at
+  [tests/parity/README.md](../../tests/parity/README.md) records the
+  contract.
+
+## Pipeline view
+
+The recipe works because each stage in the response pipeline has its own
+observable in the response, and `logprobs.content` sits **upstream** of the
+parser:
+
+```
+model emits tokens
+      |
+      v
+logprobs.content   <-- ground truth
+                       (parser does not touch this)
+      |
+      v
+tool-call parser
+(consumes wrapper markers,
+ extracts JSON into tool_calls)
+      |
+      v
+message.content    <-- what parser left in text
+                       (null/empty if parsed,
+                        raw markers if no parser engaged)
+message.tool_calls <-- what parser extracted as structure
+                       (populated if parsed,
+                        null/absent if no parser engaged)
+finish_reason      <-- "tool_calls" iff extraction succeeded
+```
+
+Diffs between adjacent layers localize the bug to a single stage. The same
+recipe applies whether the parser lives in Dynamo's Rust preprocessor (the
+default), in the SGLang `FunctionCallParser`, or in vLLM's auto-tool-choice
+path -- `logprobs.content` is OpenAI-standard and sits upstream of all
+three.
+
+## See also
+
+- [Tool Call Parsing (Dynamo)](dynamo.md) -- Dynamo-native parser names and
+  request examples
+- [Tool Call Parsing (Engine Fallback)](engine-fallback.md) -- `--dyn-chat-processor`
+  fallback path to vLLM / SGLang parsers
+- [Frontend Configuration Reference](../components/frontend/configuration.md)
+  -- Full CLI flag reference for the frontend and worker
+- [Cross-impl parity test suite](../../tests/parity/README.md) -- Where the
+  parser contract is recorded across Dynamo, vLLM, and SGLang

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -4,16 +4,15 @@ Shared test infrastructure for diffing parser / preprocess / postprocess
 behavior across Dynamo, vLLM, and SGLang. Today only the parser stage
 is populated (`parser/`); other stages slot in as siblings as they land.
 
-> **Diagnosing customer-reported tool-call issues?** Before stepping into the
-> parity harness, point customers (or yourself) at
+> **Triaging a tool-call issue from a user?** Before stepping into the
+> parity harness, point them at
 > [docs/tool-calling/troubleshooting.md](../../docs/tool-calling/troubleshooting.md).
-> That page shows how to add `logprobs: true` to a single request,
-> reconstruct the raw stream from `bytes`, and localize the failure to one
-> of three causes: the
+> That page asks users to re-run with `logprobs: true` and share the
+> response, which carries the engine's raw token stream. With that captured
+> output, the failure usually localizes to one of three causes: the
 > **model** emitted bad tokens, the **parser was not configured**
 > (`--dyn-tool-call-parser` missing or wrong family), or the **parser** ran
-> and produced the wrong output. Only the third class lands here -- the
-> other two are resolved without touching parser source.
+> and produced the wrong output. Only the third class lands here.
 
 ## Layout
 

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -4,6 +4,17 @@ Shared test infrastructure for diffing parser / preprocess / postprocess
 behavior across Dynamo, vLLM, and SGLang. Today only the parser stage
 is populated (`parser/`); other stages slot in as siblings as they land.
 
+> **Diagnosing customer-reported tool-call issues?** Before stepping into the
+> parity harness, point customers (or yourself) at
+> [docs/tool-calling/troubleshooting.md](../../docs/tool-calling/troubleshooting.md).
+> That page shows how to add `logprobs: true` to a single request,
+> reconstruct the raw stream from `bytes`, and localize the failure to one
+> of three causes: the
+> **model** emitted bad tokens, the **parser was not configured**
+> (`--dyn-tool-call-parser` missing or wrong family), or the **parser** ran
+> and produced the wrong output. Only the third class lands here -- the
+> other two are resolved without touching parser source.
+
 ## Layout
 
 ```


### PR DESCRIPTION
#### Why

Tool-call bug reports usually arrive as a request and a response, and that's
not enough information to triage. If `tool_calls` is null or the arguments
look wrong, we can't tell whether the model produced bad text or a parser
downstream of it mangled good text. Both look identical from the response
side.

The fix is asking the customer to re-run with `logprobs: true`. That gives
us a parser-independent view of the raw model output, which is enough to
localize the bug to one of three places: the model, the parser
configuration, or the parser itself. Without this page, that triage path
lives in tribal knowledge and customers don't know to ask for it.

#### What

New page at `docs/tool-calling/troubleshooting.md` with the recipe, a worked
Qwen2.5 example, and a three-step diagnostic ladder. Cross-linked from the
two existing parser docs (`dynamo.md`, `engine-fallback.md`) and the
tool-calling landing page. Added to the docs sidebar in `docs/index.yml`.
Also added a short signpost at the top of `tests/parity/README.md` so devs
hitting the parity harness know to redirect customers to self-diagnose
first.

#### Test Plan

Ran the recipe against `dynamo.frontend` + `dynamo.vllm` serving
Qwen2.5-7B-Instruct, with and without `--dyn-tool-call-parser`. Confirmed
the raw stream reconstructed from `logprobs.content` bytes matches what the
diagnostic ladder predicts in both cases. The example in the doc is real
captured output, not invented.

#### Related Issues

None.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for resolving tool-calling issues with diagnostic techniques to identify root causes
  * Expanded tool-calling documentation with guidance on inspecting model behavior and differentiating upstream token problems from parser configuration or output issues
  * Added cross-references and updated navigation to help users locate troubleshooting resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->