### PR TITLE
test(parsers): add streaming parser YAML fixtures

### DIFF
--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.1.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+model_label: DeepSeek V3
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"}
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜tool▁calls▁begin｜>
+    - delta_text: <｜tool▁call▁begin｜>function<｜tool▁sep｜>
+    - delta_text: |
+        get_weather
+        ```json
+    - delta_text: '{"location": "NYC"}'
+    - delta_text: |2-
+
+        ```
+    - delta_text: <｜tool▁call▁end｜>
+    - delta_text: <｜tool▁calls▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.2.yaml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+model_label: DeepSeek V3
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <｜tool▁ca
+    - delta_text: lls▁beg
+    - delta_text: in｜><｜tool▁ca
+    - delta_text: ll▁be
+    - delta_text: gin｜>function<｜to
+    - delta_text: ol▁
+    - delta_text: sep｜>get_
+    - delta_text: weather
+    - delta_text: |2-
+
+        ```json
+        {"lo
+    - delta_text: catio
+    - delta_text: |-
+        n": "NYC"}
+        ```<｜t
+    - delta_text: ool
+    - delta_text: ▁call▁end
+    - delta_text: ｜><｜too
+    - delta_text: l▁call▁begin｜
+    - delta_text: '>func'
+    - delta_text: tion<｜tool▁sep｜>g
+    - delta_text: et_
+    - delta_text: |-
+        time
+        ```j
+    - delta_text: |-
+        son
+        {"t
+    - delta_text: 'imezone": "ES'
+    - delta_text: |-
+        T"}
+        `
+    - delta_text: '``<｜tool▁call▁end'
+    - delta_text: ｜><
+    - delta_text: ｜tool▁cal
+    - delta_text: ls▁end｜
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          json
+          {"location": "NYC"}
+          <｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+          json
+          {"timezone": "EST"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+          ```json
+          {"timezone": "EST"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.3.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+model_label: DeepSeek V3
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜
+    - delta_text: too
+    - delta_text: l▁cal
+    - delta_text: ls▁begin｜><
+    - delta_text: ｜tool▁call▁begin｜>f
+    - delta_text: un
+    - delta_text: cti
+    - delta_text: on<｜t
+    - delta_text: ool▁sep｜>ge
+    - delta_text: |-
+        t_weather
+        ```json
+        {
+    - delta_text: '"l'
+    - delta_text: oca
+    - delta_text: tion"
+    - delta_text: |-
+        : "NYC"}
+        ``
+    - delta_text: '`<｜tool▁call▁end｜><'
+    - delta_text: ｜t
+    - delta_text: ool
+    - delta_text: ▁call
+    - delta_text: s▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          json
+          {"location": "NYC"}
+          ```<｜tool▁calls▁end｜>
+      vllm:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.stream.4.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+model_label: DeepSeek V3
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"}
+        ```
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *id001
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>fun
+    - delta_text: |-
+        ction<｜tool▁sep｜>get_weather
+        ```json
+        {"loc
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id002
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"loc
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm: *id002

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.1.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+model_label: DeepSeek V3.1
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜tool▁calls▁begin｜>
+    - delta_text: <｜tool▁call▁begin｜>
+    - delta_text: get_weather
+    - delta_text: <｜tool▁sep｜>
+    - delta_text: '{"location":"NYC"}'
+    - delta_text: <｜tool▁call▁end｜>
+    - delta_text: <｜tool▁calls▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.2.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+model_label: DeepSeek V3.1
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <｜tool▁ca
+    - delta_text: lls▁beg
+    - delta_text: in｜><｜tool▁ca
+    - delta_text: ll▁be
+    - delta_text: gin｜>get_weather<
+    - delta_text: ｜to
+    - delta_text: ol▁sep｜>{
+    - delta_text: '"locati'
+    - delta_text: on":"NYC"}<｜t
+    - delta_text: ool▁c
+    - delta_text: all▁end｜><｜tool▁c
+    - delta_text: all
+    - delta_text: ▁begin｜>g
+    - delta_text: et_time
+    - delta_text: <｜tool▁sep｜>{
+    - delta_text: '"time'
+    - delta_text: zone":"EST"}<｜too
+    - delta_text: l▁c
+    - delta_text: all▁end｜>
+    - delta_text: <｜tool▁
+    - delta_text: calls▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.3.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+model_label: DeepSeek V3.1
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜
+    - delta_text: too
+    - delta_text: l▁cal
+    - delta_text: ls▁begin｜><
+    - delta_text: ｜tool▁call▁begin｜>g
+    - delta_text: et
+    - delta_text: _we
+    - delta_text: ather
+    - delta_text: <｜tool▁sep｜
+    - delta_text: '>{"location":"NYC"}'
+    - delta_text: <｜
+    - delta_text: too
+    - delta_text: l▁cal
+    - delta_text: l▁end｜><｜to
+    - delta_text: ol▁calls▁end｜>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.stream.4.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+model_label: DeepSeek V3.1
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *id001
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: <｜tool▁calls▁begin｜><｜tool▁call▁b
+    - delta_text: egin｜>get_weather<｜tool▁sep｜>{"loc
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id002
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: '{"loc'
+        normal_text: ''
+      vllm: *id002

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.1.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+model_label: DeepSeek V3.2
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |-
+        <｜DSML｜function_calls>
+        <｜DSML｜invoke name="get_weather">
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜function_calls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |
+        <｜DSML｜function_calls>
+    - delta_text: |
+        <｜DSML｜invoke name="get_weather">
+    - delta_text: <｜DSML｜parameter name="location" string="true">
+    - delta_text: NYC
+    - delta_text: |
+        </｜DSML｜parameter>
+    - delta_text: |
+        </｜DSML｜invoke>
+    - delta_text: </｜DSML｜function_calls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.2.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+model_label: DeepSeek V3.2
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <｜DSML｜fu
+    - delta_text: nction_
+    - delta_text: |-
+        calls>
+        <｜DSML
+    - delta_text: ｜invo
+    - delta_text: ke name="get_weat
+    - delta_text: her
+    - delta_text: |-
+        ">
+        <｜DSML
+    - delta_text: ｜parame
+    - delta_text: ter name="loc
+    - delta_text: ation
+    - delta_text: '" string="true">N'
+    - delta_text: YC<
+    - delta_text: /｜DSML｜pa
+    - delta_text: rameter
+    - delta_text: |-
+        >
+        </｜DSML｜inv
+    - delta_text: |
+        oke>
+    - delta_text: <｜DSML｜invoke nam
+    - delta_text: e="
+    - delta_text: get_time"
+    - delta_text: |-
+        >
+        <｜DSM
+    - delta_text: L｜parameter n
+    - delta_text: ame="
+    - delta_text: timezone" string=
+    - delta_text: '"tr'
+    - delta_text: ue">EST</
+    - delta_text: ｜DSML｜p
+    - delta_text: |-
+        arameter>
+        </｜
+    - delta_text: DSML｜
+    - delta_text: |-
+        invoke>
+        </｜DSML｜f
+    - delta_text: unc
+    - delta_text: tion_call
+    - delta_text: s>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.3.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+model_label: DeepSeek V3.2
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜
+    - delta_text: DSM
+    - delta_text: L｜fun
+    - delta_text: ction_calls
+    - delta_text: |-
+        >
+        <｜DSML｜invoke nam
+    - delta_text: e=
+    - delta_text: '"ge'
+    - delta_text: t_wea
+    - delta_text: |-
+        ther">
+        <｜DS
+    - delta_text: ML｜parameter name="
+    - delta_text: lo
+    - delta_text: cat
+    - delta_text: 'ion" '
+    - delta_text: string="tru
+    - delta_text: e">NYC</｜DSML｜param
+    - delta_text: et
+    - delta_text: er>
+    - delta_text: |2-
+
+        </｜D
+    - delta_text: SML｜invoke>
+    - delta_text: |2-
+
+        </｜DSML｜function_c
+    - delta_text: al
+    - delta_text: ls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.stream.4.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+model_label: DeepSeek V3.2
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: |-
+        <｜DSML｜function_calls>
+        <｜DSML｜invoke name="get_weather">
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+        </｜DSML｜invoke>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: |-
+        <｜DSML｜function_calls>
+        <｜DSML｜invoke name="get_weathe
+    - delta_text: |-
+        r">
+        <｜DSML｜parameter name="location" string="true">NY
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm: *id001

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.1.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+model_label: DeepSeek V4
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |-
+        <｜DSML｜tool_calls>
+        <｜DSML｜invoke name="get_weather">
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜tool_calls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |
+        <｜DSML｜tool_calls>
+    - delta_text: |
+        <｜DSML｜invoke name="get_weather">
+    - delta_text: <｜DSML｜parameter name="location" string="true">
+    - delta_text: NYC
+    - delta_text: |
+        </｜DSML｜parameter>
+    - delta_text: |
+        </｜DSML｜invoke>
+    - delta_text: </｜DSML｜tool_calls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *id003

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.2.yaml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+model_label: DeepSeek V4
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <｜DSML｜to
+    - delta_text: ol_call
+    - delta_text: |-
+        s>
+        <｜DSML｜inv
+    - delta_text: oke n
+    - delta_text: ame="get_weather"
+    - delta_text: |-
+        >
+        <
+    - delta_text: ｜DSML｜par
+    - delta_text: 'ameter '
+    - delta_text: name="locatio
+    - delta_text: n" st
+    - delta_text: ring="true">NYC</
+    - delta_text: ｜DS
+    - delta_text: ML｜parame
+    - delta_text: |-
+        ter>
+        </
+    - delta_text: ｜DSML｜invoke>
+    - delta_text: |2-
+
+        <｜DS
+    - delta_text: ML｜invoke name="g
+    - delta_text: et_
+    - delta_text: |-
+        time">
+        <｜
+    - delta_text: DSML｜pa
+    - delta_text: rameter name=
+    - delta_text: '"time'
+    - delta_text: zone" string="tru
+    - delta_text: e">
+    - delta_text: EST</｜DSM
+    - delta_text: L｜param
+    - delta_text: |-
+        eter>
+        </｜DSML
+    - delta_text: ｜invo
+    - delta_text: |-
+        ke>
+        </｜DSML｜tool_
+    - delta_text: cal
+    - delta_text: ls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *id001

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.3.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+model_label: DeepSeek V4
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <｜
+    - delta_text: DSM
+    - delta_text: L｜too
+    - delta_text: |-
+        l_calls>
+        <｜
+    - delta_text: DSML｜invoke name="g
+    - delta_text: et
+    - delta_text: _we
+    - delta_text: ather
+    - delta_text: |-
+        ">
+        <｜DSML｜p
+    - delta_text: arameter name="loca
+    - delta_text: ti
+    - delta_text: on"
+    - delta_text: ' stri'
+    - delta_text: ng="true">N
+    - delta_text: YC</｜DSML｜parameter
+    - delta_text: |
+        >
+    - delta_text: </｜
+    - delta_text: DSML｜
+    - delta_text: |-
+        invoke>
+        </｜
+    - delta_text: DSML｜tool_calls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *id001

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.stream.4.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+model_label: DeepSeek V4
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: |-
+        <｜DSML｜tool_calls>
+        <｜DSML｜invoke name="get_weather">
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+        </｜DSML｜invoke>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: |-
+        <｜DSML｜tool_calls>
+        <｜DSML｜invoke name="get_weather"
+    - delta_text: |-
+        >
+        <｜DSML｜parameter name="location" string="true">NY
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *id001

--- a/tests/parity/parser/fixtures/gemma4/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.stream.1.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+model_label: Gemma 4
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: ''
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|tool_call>
+    - delta_text: 'call:'
+    - delta_text: get_weather
+    - delta_text: '{location:'
+    - delta_text: <|"|>
+    - delta_text: NYC
+    - delta_text: <|"|>}
+    - delta_text: <tool_call|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/gemma4/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.stream.2.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+model_label: Gemma 4
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <|tool_ca
+    - delta_text: ll>call
+    - delta_text: :get_weather{
+    - delta_text: locat
+    - delta_text: ion:<|"|>NYC<|"|>
+    - delta_text: '}<t'
+    - delta_text: ool_call|
+    - delta_text: '><|tool'
+    - delta_text: _call>call:ge
+    - delta_text: t_tim
+    - delta_text: e{timezone:<|"|>E
+    - delta_text: ST<
+    - delta_text: '|"|>}<too'
+    - delta_text: l_call|
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/gemma4/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.stream.3.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+model_label: Gemma 4
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|
+    - delta_text: too
+    - delta_text: l_cal
+    - delta_text: l>call:get_
+    - delta_text: weather{location:<|
+    - delta_text: '"|'
+    - delta_text: '>NY'
+    - delta_text: C<|"|
+    - delta_text: '>}<tool_cal'
+    - delta_text: l|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/gemma4/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.stream.4.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+model_label: Gemma 4
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "NYC'
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: <|tool_call>call:get_w
+    - delta_text: eather{location:<|"|>N
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "N'
+        normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.stream.1.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+model_label: GLM 5.1
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <tool_call>
+    - delta_text: get_weather
+    - delta_text: <arg_key>location</arg_key>
+    - delta_text: <arg_value>
+    - delta_text: NYC
+    - delta_text: </arg_value>
+    - delta_text: </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/glm47/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.stream.2.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+model_label: GLM 5.1
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <tool_cal
+    - delta_text: l>get_w
+    - delta_text: eather<arg_ke
+    - delta_text: y>loc
+    - delta_text: ation</arg_key><a
+    - delta_text: rg_
+    - delta_text: value>NYC
+    - delta_text: </arg_v
+    - delta_text: alue></tool_c
+    - delta_text: all><
+    - delta_text: tool_call>get_tim
+    - delta_text: e<a
+    - delta_text: rg_key>ti
+    - delta_text: mezone<
+    - delta_text: /arg_key><arg
+    - delta_text: _valu
+    - delta_text: e>EST</arg_value>
+    - delta_text: </t
+    - delta_text: ool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/glm47/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.stream.3.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+model_label: GLM 5.1
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <t
+    - delta_text: ool
+    - delta_text: _call
+    - delta_text: '>get_weathe'
+    - delta_text: r<arg_key>location<
+    - delta_text: /a
+    - delta_text: rg_
+    - delta_text: key><
+    - delta_text: arg_value>N
+    - delta_text: YC</arg_value></too
+    - delta_text: l_
+    - delta_text: cal
+    - delta_text: l>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/glm47/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.stream.4.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+model_label: GLM 5.1
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "NYC"'
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "NYC"'
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: <tool_call>get_weather<arg_key
+    - delta_text: '>location</arg_key><arg_value>N'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "N'
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "N'
+        normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.stream.1.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+model_label: gpt-oss
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|channel|>commentary to=functions.
+    - delta_text: get_weather
+    - delta_text: ' <|constrain|>json'
+    - delta_text: <|message|>
+    - delta_text: '{"location":"NYC"}'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls: []
+        normal_text: ''
+      sglang: *id003
+      vllm:
+        unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks

--- a/tests/parity/parser/fixtures/harmony/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.stream.2.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+model_label: gpt-oss
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <|start|>
+    - delta_text: assista
+    - delta_text: nt<|channel|>
+    - delta_text: comme
+    - delta_text: ntary to=function
+    - delta_text: s.g
+    - delta_text: et_weathe
+    - delta_text: r <|con
+    - delta_text: strain|>json<
+    - delta_text: '|mess'
+    - delta_text: 'age|>{"location":'
+    - delta_text: '"NY'
+    - delta_text: C"}<|call
+    - delta_text: '|><|sta'
+    - delta_text: rt|>assistant
+    - delta_text: <|cha
+    - delta_text: 'nnel|>commentary '
+    - delta_text: to=
+    - delta_text: functions
+    - delta_text: .get_ti
+    - delta_text: me <|constrai
+    - delta_text: n|>js
+    - delta_text: on<|message|>{"ti
+    - delta_text: mez
+    - delta_text: one":"EST
+    - delta_text: '"}<|cal'
+    - delta_text: l|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: rt|>assistant<|channel|>commentary to=functions.get_time <|constrain|>js
+      vllm:
+        unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks

--- a/tests/parity/parser/fixtures/harmony/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.stream.3.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+model_label: gpt-oss
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|
+    - delta_text: cha
+    - delta_text: nnel|
+    - delta_text: '>commentary'
+    - delta_text: ' to=functions.get_w'
+    - delta_text: ea
+    - delta_text: the
+    - delta_text: r <|c
+    - delta_text: onstrain|>j
+    - delta_text: son<|message|>{"loc
+    - delta_text: at
+    - delta_text: ion
+    - delta_text: '":"NY'
+    - delta_text: C"}<|call|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+      sglang:
+        calls: []
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>j
+      vllm:
+        unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks

--- a/tests/parity/parser/fixtures/harmony/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.stream.4.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+model_label: gpt-oss
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: <|start|>assistant<|channel|>commentary to=functi
+    - delta_text: ons.get_weather <|constrain|>json<|message|>{"loc
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id002
+        calls: []
+        normal_text: ''
+      sglang: *id002
+      vllm:
+        unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks

--- a/tests/parity/parser/fixtures/hermes/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.stream.1.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+model_label: Hermes-3 / Llama variants
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <tool_call>
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}'
+    - delta_text: </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/hermes/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.stream.2.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+model_label: Hermes-3 / Llama variants
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <tool_cal
+    - delta_text: l>{"nam
+    - delta_text: 'e": "get_weat'
+    - delta_text: her",
+    - delta_text: ' "arguments": {"l'
+    - delta_text: oca
+    - delta_text: 'tion": "N'
+    - delta_text: YC"}}</
+    - delta_text: tool_call><to
+    - delta_text: ol_ca
+    - delta_text: 'll>{"name": "get_'
+    - delta_text: tim
+    - delta_text: e", "argu
+    - delta_text: 'ments":'
+    - delta_text: ' {"timezone":'
+    - delta_text: ' "EST'
+    - delta_text: '"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/hermes/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.stream.3.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+model_label: Hermes-3 / Llama variants
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <t
+    - delta_text: ool
+    - delta_text: _call
+    - delta_text: '>{"name": "'
+    - delta_text: get_weather", "argu
+    - delta_text: me
+    - delta_text: nts
+    - delta_text: '": {"'
+    - delta_text: 'location": '
+    - delta_text: '"NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/hermes/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.stream.4.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+model_label: Hermes-3 / Llama variants
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_w'
+    - delta_text: 'eather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"loc'
+        normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.stream.1.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+model_label: AI21 Jamba
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <tool_calls>
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: </tool_calls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.stream.2.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+model_label: AI21 Jamba
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <tool_cal
+    - delta_text: ls>[{"n
+    - delta_text: 'ame": "get_we'
+    - delta_text: ather
+    - delta_text: '", "arguments": {'
+    - delta_text: '"lo'
+    - delta_text: 'cation": '
+    - delta_text: '"NYC"}}'
+    - delta_text: ', {"name": "g'
+    - delta_text: et_ti
+    - delta_text: 'me", "arguments":'
+    - delta_text: ' {"'
+    - delta_text: timezone"
+    - delta_text: ': "EST"'
+    - delta_text: '}}]</tool_cal'
+    - delta_text: ls>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments: '{"timezone": "EST"'
+        normal_text: <tool_cal

--- a/tests/parity/parser/fixtures/jamba/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.stream.3.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+model_label: AI21 Jamba
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <t
+    - delta_text: ool
+    - delta_text: _call
+    - delta_text: 's>[{"name":'
+    - delta_text: ' "get_weather", "ar'
+    - delta_text: gu
+    - delta_text: men
+    - delta_text: 'ts": '
+    - delta_text: '{"location"'
+    - delta_text: ': "NYC"}}]</tool_ca'
+    - delta_text: ll
+    - delta_text: s>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: <tool_call

--- a/tests/parity/parser/fixtures/jamba/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.stream.4.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+model_label: AI21 Jamba
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '<tool_calls>[{"name": "get_'
+    - delta_text: 'weather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.1.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+model_label: Kimi K2.6
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *id001
+      sglang: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|tool_calls_section_begin|>
+    - delta_text: <|tool_call_begin|>functions.
+    - delta_text: get_weather:0
+    - delta_text: <|tool_call_argument_begin|>
+    - delta_text: '{"location":"'
+    - delta_text: NYC
+    - delta_text: '"}'
+    - delta_text: <|tool_call_end|>
+    - delta_text: <|tool_calls_section_end|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id002
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: *id002
+      sglang: *id002

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.2.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+model_label: Kimi K2.6
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <|tool_ca
+    - delta_text: lls_sec
+    - delta_text: tion_begin|><
+    - delta_text: '|tool'
+    - delta_text: _call_begin|>func
+    - delta_text: tio
+    - delta_text: ns.get_we
+    - delta_text: ather:0
+    - delta_text: <|tool_call_a
+    - delta_text: rgume
+    - delta_text: nt_begin|>{"locat
+    - delta_text: ion
+    - delta_text: '":"NYC"}<'
+    - delta_text: '|tool_c'
+    - delta_text: all_end|><|to
+    - delta_text: ol_ca
+    - delta_text: ll_begin|>functio
+    - delta_text: ns.
+    - delta_text: 'get_time:'
+    - delta_text: 1<|tool
+    - delta_text: _call_argumen
+    - delta_text: t_beg
+    - delta_text: in|>{"timezone":"
+    - delta_text: EST
+    - delta_text: '"}<|tool_'
+    - delta_text: call_en
+    - delta_text: d|><|tool_cal
+    - delta_text: ls_se
+    - delta_text: ction_end|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
+      vllm: *id001

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.3.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+model_label: Kimi K2.6
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|
+    - delta_text: too
+    - delta_text: l_cal
+    - delta_text: ls_section_
+    - delta_text: begin|><|tool_call_
+    - delta_text: be
+    - delta_text: gin
+    - delta_text: '|>fun'
+    - delta_text: ctions.get_
+    - delta_text: weather:0<|tool_cal
+    - delta_text: l_
+    - delta_text: arg
+    - delta_text: ument
+    - delta_text: _begin|>{"l
+    - delta_text: ocation":"NYC"}<|to
+    - delta_text: ol
+    - delta_text: _ca
+    - delta_text: ll_en
+    - delta_text: d|><|tool_c
+    - delta_text: alls_section_end|>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+      vllm: *id001

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.stream.4.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+model_label: Kimi K2.6
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated before tool_call_end with complete JSON arguments
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: <|tool_calls_section_begin|>
+    - delta_text: <|tool_call_begin|>functions.Write:42
+    - delta_text: <|tool_call_argument_begin|>
+    - delta_text: '{"file_path":"/app/main.rs","content":"fn main() {}"}'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: Write
+      parameters:
+        type: object
+        properties:
+          file_path:
+            type: string
+          content:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls:
+        - name: Write
+          arguments:
+            file_path: /app/main.rs
+            content: fn main() {}
+        normal_text: ''
+      sglang:
+        calls:
+        - name: Write
+          arguments:
+            file_path: /app/main.rs
+            content: fn main() {}
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: <|tool_calls_section_begin|><|tool_call_begin|>func
+    - delta_text: tions.get_weather:0<|tool_call_argument_begin|>{"loc
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: '{"loc'
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"loc'
+        normal_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.stream.1.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+model_label: Llama 3 (JSON fmt)
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|python_tag|>
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.stream.2.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+model_label: Llama 3 (JSON fmt)
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <|python_
+    - delta_text: tag|>{"
+    - delta_text: 'name": "get_w'
+    - delta_text: eathe
+    - delta_text: 'r", "arguments": '
+    - delta_text: '{"l'
+    - delta_text: 'ocation":'
+    - delta_text: ' "NYC"}'
+    - delta_text: '};{"name": "g'
+    - delta_text: et_ti
+    - delta_text: 'me", "arguments":'
+    - delta_text: ' {"'
+    - delta_text: timezone"
+    - delta_text: ': "EST"'
+    - delta_text: '}}'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'et_time", "arguments": {"timezone": "EST"}}'
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: <|python_

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.stream.3.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+model_label: Llama 3 (JSON fmt)
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <|
+    - delta_text: pyt
+    - delta_text: hon_t
+    - delta_text: ag|>{"name"
+    - delta_text: ': "get_weather", "a'
+    - delta_text: rg
+    - delta_text: ume
+    - delta_text: 'nts":'
+    - delta_text: ' {"location'
+    - delta_text: '": "NYC"}}'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: <|python_t

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.stream.4.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+model_label: Llama 3 (JSON fmt)
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '<|python_tag|>{"name": "get_'
+    - delta_text: 'weather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.1.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+model_label: MiniMax 2.7
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |-
+        <minimax:tool_call>
+        <invoke name="get_weather">
+        <parameter name="location">NYC</parameter>
+        </invoke>
+        </minimax:tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |
+        <minimax:tool_call>
+    - delta_text: |
+        <invoke name="get_weather">
+    - delta_text: <parameter name="location">
+    - delta_text: NYC
+    - delta_text: |
+        </parameter>
+    - delta_text: |
+        </invoke>
+    - delta_text: </minimax:tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.2.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+model_label: MiniMax 2.7
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: '<minimax:'
+    - delta_text: tool_ca
+    - delta_text: |-
+        ll>
+        <invoke n
+    - delta_text: ame="
+    - delta_text: |-
+        get_weather">
+        <pa
+    - delta_text: ram
+    - delta_text: eter name
+    - delta_text: ="locat
+    - delta_text: ion">NYC</par
+    - delta_text: amete
+    - delta_text: |-
+        r>
+        </invoke>
+        <inv
+    - delta_text: oke
+    - delta_text: ' name="ge'
+    - delta_text: t_time"
+    - delta_text: ">\n<parameter "
+    - delta_text: name=
+    - delta_text: '"timezone">EST</p'
+    - delta_text: ara
+    - delta_text: |-
+        meter>
+        </
+    - delta_text: invoke>
+    - delta_text: |2-
+
+        </minimax:to
+    - delta_text: ol_ca
+    - delta_text: ll>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          <invoke name="get_time">
+          <parameter name="timezone">EST</parameter>
+          </invoke>
+          </minimax:tool_call>
+      vllm:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          <invoke name="get_time">
+          <parameter name="timezone">EST</parameter>
+          </invoke>
+          </minimax:tool_call>

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.3.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+model_label: MiniMax 2.7
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <m
+    - delta_text: ini
+    - delta_text: max:t
+    - delta_text: |-
+        ool_call>
+        <
+    - delta_text: invoke name="get_we
+    - delta_text: at
+    - delta_text: her
+    - delta_text: |-
+        ">
+        <p
+    - delta_text: arameter na
+    - delta_text: me="location">NYC</
+    - delta_text: pa
+    - delta_text: ram
+    - delta_text: eter>
+    - delta_text: |2
+
+        </invoke>
+    - delta_text: </minimax:tool_call
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          </minimax:tool_call>
+      vllm:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          </minimax:tool_call>

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.4.yaml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+model_label: MiniMax 2.7
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: |-
+        <minimax:tool_call>
+        <invoke name="get_weather">
+        <parameter name="location">NYC</parameter>
+        </invoke>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: |-
+        <minimax:tool_call>
+        <invoke name="get_
+    - delta_text: |-
+        weather">
+        <parameter name="location">NY
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NY
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.stream.1.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+model_label: Mistral series
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: ''
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '[TOOL_CALLS]'
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: '[/TOOL_CALLS]'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo: &id002
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: '[/TOOL_CALLS]'
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm: *id002

--- a/tests/parity/parser/fixtures/mistral/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.stream.2.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+model_label: Mistral series
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: '[TOOL_CAL'
+    - delta_text: LS][{"n
+    - delta_text: 'ame": "get_we'
+    - delta_text: ather
+    - delta_text: '", "arguments": {'
+    - delta_text: '"lo'
+    - delta_text: 'cation": '
+    - delta_text: '"NYC"}}'
+    - delta_text: ', {"name": "g'
+    - delta_text: et_ti
+    - delta_text: 'me", "arguments":'
+    - delta_text: ' {"'
+    - delta_text: timezone"
+    - delta_text: ': "EST"'
+    - delta_text: '}}][/TOOL_CAL'
+    - delta_text: LS]
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: '[/TOOL_CALLS]'
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: '[TOOL_CAL'

--- a/tests/parity/parser/fixtures/mistral/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.stream.3.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+model_label: Mistral series
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '[T'
+    - delta_text: OOL
+    - delta_text: _CALL
+    - delta_text: 'S][{"name":'
+    - delta_text: ' "get_weather", "ar'
+    - delta_text: gu
+    - delta_text: men
+    - delta_text: 'ts": '
+    - delta_text: '{"location"'
+    - delta_text: ': "NYC"}}][/TOOL_CA'
+    - delta_text: LL
+    - delta_text: S]
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: '[/TOOL_CALLS]'
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: '[TOOL_CALL'

--- a/tests/parity/parser/fixtures/mistral/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.stream.4.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+model_label: Mistral series
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm: *id001
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '[TOOL_CALLS][{"name": "get_'
+    - delta_text: 'weather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"loc'
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.1.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+model_label: Nemotron (DeciLM)
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <TOOLCALL>
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: </TOOLCALL>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.2.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+model_label: Nemotron (DeciLM)
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <TOOLCALL
+    - delta_text: '>[{"nam'
+    - delta_text: 'e": "get_weat'
+    - delta_text: her",
+    - delta_text: ' "arguments": {"l'
+    - delta_text: oca
+    - delta_text: 'tion": "N'
+    - delta_text: 'YC"}}, '
+    - delta_text: '{"name": "get'
+    - delta_text: _time
+    - delta_text: '", "arguments": {'
+    - delta_text: '"ti'
+    - delta_text: 'mezone": '
+    - delta_text: '"EST"}}'
+    - delta_text: ']</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.3.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+model_label: Nemotron (DeciLM)
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <T
+    - delta_text: OOL
+    - delta_text: CALL>
+    - delta_text: '[{"name": "'
+    - delta_text: get_weather", "argu
+    - delta_text: me
+    - delta_text: nts
+    - delta_text: '": {"'
+    - delta_text: 'location": '
+    - delta_text: '"NYC"}}]</TOOLCALL>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.stream.4.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+model_label: Nemotron (DeciLM)
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '<TOOLCALL>[{"name": "get_w'
+    - delta_text: 'eather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.1.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+model_label: Nemotron Nano
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |-
+        <tool_call>
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+        </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |
+        <tool_call>
+    - delta_text: |
+        <function=get_weather>
+    - delta_text: |
+        <parameter=location>
+    - delta_text: |
+        NYC
+    - delta_text: |
+        </parameter>
+    - delta_text: |
+        </function>
+    - delta_text: </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.2.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# `|2+` simply means a single newline ("\n"); see tests/parity/README.md for the full decode.
+
+family: nemotron_nano
+model_label: Nemotron Nano
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <tool_cal
+    - delta_text: |-
+        l>
+        <fun
+    - delta_text: ction=get_wea
+    - delta_text: ther>
+    - delta_text: |2-
+
+        <parameter=locat
+    - delta_text: ion
+    - delta_text: |-
+        >
+        NYC
+        </p
+    - delta_text: aramete
+    - delta_text: |-
+        r>
+        </function
+    - delta_text: |-
+        >
+        </t
+    - delta_text: |-
+        ool_call>
+        <tool_c
+    - delta_text: all
+    - delta_text: |-
+        >
+        <functi
+    - delta_text: on=get_
+    - delta_text: |-
+        time>
+        <parame
+    - delta_text: ter=t
+    - delta_text: |-
+        imezone>
+        EST
+        </pa
+    - delta_text: ram
+    - delta_text: |-
+        eter>
+        </f
+    - delta_text: unction
+    - delta_text: |-
+        >
+        </tool_call
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: |2+
+
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.3.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+model_label: Nemotron Nano
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <t
+    - delta_text: ool
+    - delta_text: _call
+    - delta_text: |-
+        >
+        <function
+    - delta_text: |-
+        =get_weather>
+        <para
+    - delta_text: me
+    - delta_text: ter
+    - delta_text: =loca
+    - delta_text: |-
+        tion>
+        NYC
+        <
+    - delta_text: |-
+        /parameter>
+        </funct
+    - delta_text: io
+    - delta_text: |
+        n>
+    - delta_text: </too
+    - delta_text: l_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.stream.4.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+model_label: Nemotron Nano
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: |-
+        <tool_call>
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: |-
+        <tool_call>
+        <function=get_wea
+    - delta_text: |-
+        ther>
+        <parameter=location>
+        NY
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'

--- a/tests/parity/parser/fixtures/phi4/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.stream.1.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+model_label: Phi-4
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+      vllm:
+        calls: []
+        normal_text: ''
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: functools
+    - delta_text: '[{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}]'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+      vllm:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.stream.2.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+model_label: Phi-4
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: functools
+    - delta_text: '[{"name'
+    - delta_text: '": "get_weath'
+    - delta_text: 'er", '
+    - delta_text: '"arguments": {"lo'
+    - delta_text: cat
+    - delta_text: 'ion": "NY'
+    - delta_text: C"}}, {
+    - delta_text: '"name": "get_'
+    - delta_text: time"
+    - delta_text: ', "arguments": {"'
+    - delta_text: tim
+    - delta_text: 'ezone": "'
+    - delta_text: EST"}}]
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+      vllm:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.stream.3.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+model_label: Phi-4
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: fu
+    - delta_text: nct
+    - delta_text: ools[
+    - delta_text: '{"name": "g'
+    - delta_text: et_weather", "argum
+    - delta_text: en
+    - delta_text: ts"
+    - delta_text: ': {"l'
+    - delta_text: 'ocation": "'
+    - delta_text: NYC"}}]
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+      vllm:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.stream.4.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+model_label: Phi-4
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+      vllm: *id001
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: 'functools[{"name": "get_we'
+    - delta_text: 'ather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id002
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+      vllm: *id002

--- a/tests/parity/parser/fixtures/pythonic/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.stream.1.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+model_label: Llama 4 (pythonic fmt)
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '[get_weather(location="NYC")]'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '['
+    - delta_text: get_weather
+    - delta_text: (location="
+    - delta_text: NYC
+    - delta_text: '")'
+    - delta_text: ']'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/pythonic/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.stream.2.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+model_label: Llama 4 (pythonic fmt)
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: '[get_weat'
+    - delta_text: her(loc
+    - delta_text: ation="NYC"),
+    - delta_text: ' get_'
+    - delta_text: time(timezone="ES
+    - delta_text: T")
+    - delta_text: ']'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/pythonic/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.stream.3.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+model_label: Llama 4 (pythonic fmt)
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '[g'
+    - delta_text: et_
+    - delta_text: weath
+    - delta_text: er(location
+    - delta_text: ="NYC")]
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm: *id001

--- a/tests/parity/parser/fixtures/pythonic/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.stream.4.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+model_label: Llama 4 (pythonic fmt)
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '[get_weather(location="NYC")'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '[get_weather(location="NYC")'
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '[get_weather'
+    - delta_text: (location="N
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls: []
+        normal_text: '[get_weather(location="N'
+      sglang:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: '{"location": "N'
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.stream.1.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+model_label: Qwen 2.5
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <tool_call>
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"arguments": {"location": "NYC"}}'
+    - delta_text: </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.stream.2.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+model_label: Qwen 2.5
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <tool_cal
+    - delta_text: l>{"nam
+    - delta_text: 'e": "get_weat'
+    - delta_text: her",
+    - delta_text: ' "arguments": {"l'
+    - delta_text: oca
+    - delta_text: 'tion": "N'
+    - delta_text: YC"}}</
+    - delta_text: tool_call><to
+    - delta_text: ol_ca
+    - delta_text: 'll>{"name": "get_'
+    - delta_text: tim
+    - delta_text: e", "argu
+    - delta_text: 'ments":'
+    - delta_text: ' {"timezone":'
+    - delta_text: ' "EST'
+    - delta_text: '"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'ol_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>'
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}<tool_call>{"name": "get_time",
+          "arguments": {"timezone": "EST"}}'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.stream.3.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+model_label: Qwen 2.5
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <t
+    - delta_text: ool
+    - delta_text: _call
+    - delta_text: '>{"name": "'
+    - delta_text: get_weather", "argu
+    - delta_text: me
+    - delta_text: nts
+    - delta_text: '": {"'
+    - delta_text: 'location": '
+    - delta_text: '"NYC"}}</tool_call>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.stream.4.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+model_label: Qwen 2.5
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: '<tool_call>{"name": "get_w'
+    - delta_text: 'eather", "arguments": {"loc'
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+      sglang: *id001
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.1.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+model_label: Qwen 3 Coder
+mode: stream
+cases:
+  PARSER.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |-
+        <tool_call>
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+        </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id002
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: ''
+  PARSER.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: |
+        <tool_call>
+    - delta_text: |
+        <function=get_weather>
+    - delta_text: |
+        <parameter=location>
+    - delta_text: |
+        NYC
+    - delta_text: |
+        </parameter>
+    - delta_text: |
+        </function>
+    - delta_text: </tool_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: *id002
+    expected:
+      dynamo: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id003
+      vllm: *id003

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.2.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# `|2+` simply means a single newline ("\n"); see tests/parity/README.md for the full decode.
+
+family: qwen3_coder
+model_label: Qwen 3 Coder
+mode: stream
+cases:
+  PARSER.stream.2:
+    description: Multiple tool calls split across multiple content chunks
+    ref: derived from PARSER.batch.2.a
+    chunks:
+    - delta_text: <tool_cal
+    - delta_text: |-
+        l>
+        <fun
+    - delta_text: ction=get_wea
+    - delta_text: ther>
+    - delta_text: |2-
+
+        <parameter=locat
+    - delta_text: ion
+    - delta_text: |-
+        >
+        NYC
+        </p
+    - delta_text: aramete
+    - delta_text: |-
+        r>
+        </function
+    - delta_text: |-
+        >
+        </t
+    - delta_text: |-
+        ool_call>
+        <tool_c
+    - delta_text: all
+    - delta_text: |-
+        >
+        <functi
+    - delta_text: on=get_
+    - delta_text: |-
+        time>
+        <parame
+    - delta_text: ter=t
+    - delta_text: |-
+        imezone>
+        EST
+        </pa
+    - delta_text: ram
+    - delta_text: |-
+        eter>
+        </f
+    - delta_text: unction
+    - delta_text: |-
+        >
+        </tool_call
+    - delta_text: '>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: |2+
+
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: |-
+          <tool_call>
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>
+          <tool_call>
+          <function=get_time>
+          <parameter=timezone>
+          EST
+          </parameter>
+          </function>
+          </tool_call>

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.3.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+model_label: Qwen 3 Coder
+mode: stream
+cases:
+  PARSER.stream.3:
+    description: Complete single tool call with a grammar token split across chunk boundaries
+    ref: derived from PARSER.batch.1
+    chunks:
+    - delta_text: <t
+    - delta_text: ool
+    - delta_text: _call
+    - delta_text: |-
+        >
+        <function
+    - delta_text: |-
+        =get_weather>
+        <para
+    - delta_text: me
+    - delta_text: ter
+    - delta_text: =loca
+    - delta_text: |-
+        tion>
+        NYC
+        <
+    - delta_text: |-
+        /parameter>
+        </funct
+    - delta_text: io
+    - delta_text: |
+        n>
+    - delta_text: </too
+    - delta_text: l_call>
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: |-
+          <tool_call>
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.4.yaml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+model_label: Qwen 3 Coder
+mode: stream
+cases:
+  PARSER.stream.4.a:
+    description: Truncated stream terminates after a complete in-flight tool-call body
+    ref: derived from PARSER.batch.5.a
+    chunks:
+    - delta_text: |-
+        <tool_call>
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo: &id001
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang: *id001
+      vllm:
+        calls: []
+        normal_text: ''
+  PARSER.stream.4.b:
+    description: Stream terminates mid-call body before the in-flight argument payload is complete
+    ref: derived from PARSER.batch.5.c
+    chunks:
+    - delta_text: |-
+        <tool_call>
+        <function=get_wea
+    - delta_text: |-
+        ther>
+        <parameter=location>
+        NY
+    - delta_text: ''
+      finish_reason: stop
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''
+      sglang:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -84,12 +84,17 @@ def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
       <family>/PARSER.<mode>.yaml       — legacy flat: holds 1, 2, ..., 10
       <family>/PARSER.<mode>.<n>.yaml   — per-top-level-case: holds n.a, n.b, ...
 
-    Both schemas are
+    The batch harness ignores stream fixtures; those are exercised by the
+    streaming harness layered on top of this fixture corpus.
+
+    Both batch schemas are
         {family: "...", mode: "batch", cases: {PARSER.batch.<id>: {...}, ...}}
     """
     out = []
     for fp in sorted(FIXTURES_ROOT.glob("*/PARSER.*.yaml")):
         doc = yaml.safe_load(fp.read_text())
+        if doc.get("mode", "batch") != "batch":
+            continue
         for case_id, case in doc["cases"].items():
             out.append((doc["family"], case_id, case))
     out.sort(key=lambda t: (t[0], *_case_sort_key(t[1])))


### PR DESCRIPTION
#### Overview:

This PR adds the streaming parser YAML fixture corpus first. It also keeps the existing batch parity test harness scoped to `mode: batch` so these stream fixtures stay data-only until stacked PR #9779 adds streaming execution.

#### Details:

- Adds 76 `PARSER.stream.{1..4}.yaml` fixture files under `tests/parity/parser/fixtures/*/`.
- Adds a batch-harness mode guard in `tests/parity/parser/test_parity_parser.py` so existing batch tests ignore `mode: stream` fixtures.
- No parser behavior change; Python/Rust streaming parity code remains in stacked PR #9779.

#### Verification:

- `python3 -m pytest tests/parity/parser/test_parity_parser.py -q -k PARSER.stream` deselects all stream fixtures under the batch harness.
- Loader check: `fixtures=683 stream_fixtures_loaded=0`.

#### Where should the reviewer start?

`tests/parity/parser/fixtures/` and the mode guard in `tests/parity/parser/test_parity_parser.py`.

#### Related Issues:

DIS-2068

/coderabbit profile chill