### PR TITLE
ci(nightly): harden nightly releases — approval gate + `-nightly` ECR tags

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: ''
+      image_tag_suffix:
+        description: 'Suffix appended to the SHA-keyed image tag (e.g. "-nightly"). Empty = no suffix.'
+        required: false
+        type: string
+        default: ''
       cpu_parallel_test_markers:
         required: true
         type: string
@@ -83,6 +88,7 @@ jobs:
       build_timeout_minutes: ${{ inputs.build_timeout_minutes }}
       dev_version_suffix: ${{ inputs.dev_version_suffix }}
       source_ref: ${{ inputs.source_ref }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix }}
     secrets: inherit
 
   # rust-gpu-checks + mypy run inside the built images because they depend on
@@ -92,7 +98,7 @@ jobs:
     needs: image
     runs-on: prod-tester-amd-gpu-v2
     container:
-      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ inputs.cuda_version != '' && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || startsWith(inputs.cuda_version, '13.') && '13' || inputs.cuda_version) || '' }}-test
+      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ inputs.cuda_version != '' && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || startsWith(inputs.cuda_version, '13.') && '13' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:
         # The image creates user 'dynamo' at uid 1000, but the ARC k8s runner
         # executes the job pod as uid 1001 (runner's uid). Overriding HOME and
@@ -141,7 +147,7 @@ jobs:
     needs: image
     runs-on: prod-tester-amd-v2
     container:
-      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ inputs.cuda_version != '' && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || startsWith(inputs.cuda_version, '13.') && '13' || inputs.cuda_version) || '' }}-test
+      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ inputs.cuda_version != '' && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || startsWith(inputs.cuda_version, '13.') && '13' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:
         # The image creates user 'dynamo' at uid 1000, but the ARC k8s runner
         # executes the job pod as uid 1001 (runner's uid). Overriding HOME and
@@ -189,6 +195,7 @@ jobs:
       cpu_parallel_mode: 'none'
       run_gpu_tests: false
       source_ref: ${{ inputs.source_ref }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix }}
     secrets: inherit
 
   sequential:
@@ -209,6 +216,7 @@ jobs:
       cpu_parallel_mode: 'none'
       run_gpu_tests: false
       source_ref: ${{ inputs.source_ref }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix }}
     secrets: inherit
 
   gpu:
@@ -228,4 +236,5 @@ jobs:
       gpu_test_markers: ${{ inputs.gpu_test_markers }}
       gpu_test_timeout_minutes: 30
       source_ref: ${{ inputs.source_ref }}
+      image_tag_suffix: ${{ inputs.image_tag_suffix }}
     secrets: inherit

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -182,6 +182,7 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       build_timeout_minutes: 120
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   sglang-build:
@@ -196,6 +197,7 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       build_timeout_minutes: 120
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   trtllm-build:
@@ -210,6 +212,7 @@ jobs:
       builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
       build_timeout_minutes: 120
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   # ============================================================================
@@ -238,6 +241,7 @@ jobs:
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -257,6 +261,7 @@ jobs:
       gpu_test_markers: vllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   sglang-test:
@@ -282,6 +287,7 @@ jobs:
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   sglang-multi-gpu-test:
@@ -301,6 +307,7 @@ jobs:
       gpu_test_markers: sglang and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   trtllm-test:
@@ -326,6 +333,7 @@ jobs:
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   trtllm-multi-gpu-test:
@@ -345,6 +353,7 @@ jobs:
       gpu_test_markers: trtllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   # ============================================================================
@@ -368,6 +377,7 @@ jobs:
       gpu_test_markers: 'pre_merge and none and gpu_1'
       dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -146,6 +146,27 @@ jobs:
           esac
 
   # ============================================================================
+  # MANUAL RELEASE APPROVAL GATE
+  # ============================================================================
+  # Manual workflow_dispatch that would publish (release=true) must be approved
+  # by a reviewer of the `manual-release-approval` environment before the
+  # `release` job runs release.yml. Scheduled runs skip this job; the `release`
+  # job below accepts `skipped` as success.
+  manual-release-approval:
+    name: Manual release approval gate
+    needs: [compute-release-mode]
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.compute-release-mode.outputs.release == 'true' }}
+    runs-on: prod-default-small-v2
+    environment: manual-release-approval
+    permissions:
+      contents: read
+    steps:
+      - name: Record approval
+        run: |
+          echo "Manual nightly release approved by ${{ github.actor }}"
+          echo "Run: ${{ github.run_id }} attempt ${{ github.run_attempt }}"
+
+  # ============================================================================
   # BUILD JOBS
   # ============================================================================
 
@@ -432,6 +453,7 @@ jobs:
     needs:
       - resolve-source-sha
       - compute-release-mode
+      - manual-release-approval
       - vllm-test
       - vllm-multi-gpu-test
       - sglang-test
@@ -441,7 +463,12 @@ jobs:
       - dynamo-pipeline
       - rust-tests
     # Framework (vllm/sglang/trtllm) and rust tests do not block publishing.
-    if: ${{ !cancelled() && needs.compute-release-mode.outputs.release == 'true' }}
+    # The manual-release-approval gate is `skipped` on cron and `success` after
+    # reviewer approval on workflow_dispatch — both are accepted here.
+    if: ${{ !cancelled()
+        && needs.compute-release-mode.outputs.release == 'true'
+        && (needs.manual-release-approval.result == 'success'
+            || needs.manual-release-approval.result == 'skipped') }}
     uses: ./.github/workflows/release.yml
     with:
       commit_sha: ${{ needs.resolve-source-sha.outputs.source_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,10 +251,19 @@ jobs:
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
           ECR_HOSTNAME="${ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
 
+          # Nightly builds push ECR tags with a `-nightly` suffix so a missing
+          # or failed nightly build can't fall through to the post-merge image
+          # at the same SHA (which carries stable, non-dev wheel versions).
+          NIGHTLY_TAG_SUFFIX=""
+          if [ "${NIGHTLY}" = "true" ]; then
+            NIGHTLY_TAG_SUFFIX="-nightly"
+          fi
+
           echo "========================================"
           echo "Copying images from ECR to NGC (registry-to-registry)"
           echo "Source commit SHA: ${COMMIT_SHA}"
           echo "NGC Version Tag: ${NGC_VERSION_TAG}"
+          echo "Nightly tag suffix: '${NIGHTLY_TAG_SUFFIX}'"
           echo "========================================"
 
           copy_image() {
@@ -279,7 +288,7 @@ jobs:
           CUDA12_FRAMEWORKS=("vllm" "sglang")
           for FRAMEWORK in "${CUDA12_FRAMEWORKS[@]}"; do
             NGC_NAME="${FRAMEWORK}-runtime"
-            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-${FRAMEWORK}-runtime-cuda12"
+            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-${FRAMEWORK}-runtime-cuda12${NIGHTLY_TAG_SUFFIX}"
             TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/${NGC_NAME}:${NGC_VERSION_TAG}"
             copy_image "${SOURCE}" "${TARGET}" "${NGC_NAME}:${NGC_VERSION_TAG}"
           done
@@ -295,7 +304,7 @@ jobs:
               NGC_NAME="${FRAMEWORK}-runtime"
             fi
 
-            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-${FRAMEWORK}-runtime-cuda13"
+            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-${FRAMEWORK}-runtime-cuda13${NIGHTLY_TAG_SUFFIX}"
             TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/${NGC_NAME}:${NGC_VERSION_TAG}-cuda13"
             copy_image "${SOURCE}" "${TARGET}" "${NGC_NAME}:${NGC_VERSION_TAG}-cuda13"
           done
@@ -521,7 +530,13 @@ jobs:
 
           ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
           ECR_HOSTNAME="${ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          ECR_IMAGE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-dynamo-runtime-cuda12"
+          # Nightly pushes to <sha>-dynamo-runtime-cuda12-nightly so a failed
+          # nightly build cannot fall through to the stable post-merge image.
+          NIGHTLY_TAG_SUFFIX=""
+          if [ "${NIGHTLY}" = "true" ]; then
+            NIGHTLY_TAG_SUFFIX="-nightly"
+          fi
+          ECR_IMAGE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-dynamo-runtime-cuda12${NIGHTLY_TAG_SUFFIX}"
 
           STAGE="${RUNNER_TEMP}/wheels"
           mkdir -p "${STAGE}/amd64" "${STAGE}/arm64"

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -92,6 +92,11 @@ on:
         required: false
         type: string
         default: ''
+      image_tag_suffix:
+        description: 'Suffix appended to the SHA-keyed image tag (e.g. "-nightly"). Empty = no suffix.'
+        required: false
+        type: string
+        default: ''
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -159,8 +164,9 @@ jobs:
             TAG_BUILDER+="-cuda${CUDA_MAJOR}"
           fi
           SOURCE_SHA=${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
-          IMAGE_TAG=${SOURCE_SHA}-${TAG_BUILDER}
-          TEST_IMAGE_TAG=${SOURCE_SHA}-${TAG_BUILDER}-test
+          IMAGE_TAG_SUFFIX='${{ inputs.image_tag_suffix }}'
+          IMAGE_TAG=${SOURCE_SHA}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}
+          TEST_IMAGE_TAG=${SOURCE_SHA}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}-test
 
           IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${IMAGE_TAG}"
           TEST_IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com/ai-dynamo/dynamo:${TEST_IMAGE_TAG}"

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -88,6 +88,11 @@ on:
         required: false
         type: string
         default: ''
+      image_tag_suffix:
+        description: 'Suffix appended to the SHA-keyed image tag (e.g. "-nightly"). Empty = no suffix.'
+        required: false
+        type: string
+        default: ''
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -112,7 +117,7 @@ jobs:
     name: ${{ inputs.test_type }} ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}, ${{ matrix.platform }}
     runs-on: ${{ matrix.platform == 'amd64' && inputs.amd_runner || 'prod-tester-arm-v2' }}
     container:
-      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ inputs.target_tag_plain }}${{ matrix.cuda_version != '' && format('-cuda{0}', startsWith(matrix.cuda_version, '12.') && '12' || startsWith(matrix.cuda_version, '13.') && '13' || matrix.cuda_version) || '' }}-test
+      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ inputs.target_tag_plain }}${{ matrix.cuda_version != '' && format('-cuda{0}', startsWith(matrix.cuda_version, '12.') && '12' || startsWith(matrix.cuda_version, '13.') && '13' || matrix.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
       env:
         # The image creates user 'dynamo' at uid 1000, but the ARC k8s runner
         # executes the job pod as uid 1001 (runner's uid). Overriding HOME and


### PR DESCRIPTION
## Background

Two related failure modes in the nightly release pipeline (`.github/workflows/nightly-ci.yml`) put PyPI / Artifactory at risk of receiving the wrong artifact.

### Failure mode 1 — manual `workflow_dispatch` silently publishes

The nightly pipeline supports two triggers:
- `schedule:` cron at 08:00 UTC daily (the intended release path).
- `workflow_dispatch:` manual trigger (documented as being "for testing").

Both events feed `compute-release-mode`, whose manual `release` input defaults to **`true`**. Nothing downstream distinguished a human-initiated run from the scheduled nightly, so clicking **Run workflow** in the Actions UI fired the full release path: NGC image copy, JFrog wheel staging, and the downstream GitLab pipeline that publishes to PyPI. A recent manual dispatch did exactly that and resulted in an unintended PyPI release.

### Failure mode 2 — failed nightly build falls through to the post-merge image

post-merge CI and nightly CI both push ECR images keyed by commit SHA — `<sha>-vllm-runtime-cuda12`, `<sha>-dynamo-runtime-cuda12`, etc. They share the **same** tag namespace.

The nightly pipeline computes a `.devYYYYMMDD` PEP-440 dev suffix in `compute-dev-version` and propagates it to `apply_dev_version.py`, which rewrites `pyproject.toml` / `Cargo.toml` on the runner *before* `docker buildx`. Critically, this suffix only affects **image contents**, never the **tag**. Same SHA, same tag — only the wheels inside differ.

If post-merge CI on commit `<sha>` already pushed `<sha>-dynamo-runtime-cuda12` (containing stable `1.1.0` wheels), and the nightly build for `<sha>` later **fails** before re-pushing, the post-merge image stays put. `release.yml`'s `release` job uses `!cancelled()`, which does *not* skip on `failure` of the `dynamo-pipeline` build job. So `stage-wheels-artifactory` runs anyway, finds the post-merge tag, extracts stable-versioned wheels, and the GitLab pipeline ships them to PyPI as if they were nightlies.

## What this PR does

Two independent, layered hardening changes against the failure modes above.

---

### Change 1 — Manual release approval gate (commit 1)

Adds a required-reviewer gate that **only** applies to manual `workflow_dispatch` runs. The daily cron continues to run untouched.

#### New `manual-release-approval` job in `nightly-ci.yml`

```yaml
manual-release-approval:
  name: Manual release approval gate
  needs: [compute-release-mode]
  if: ${{ github.event_name == 'workflow_dispatch'
       && needs.compute-release-mode.outputs.release == 'true' }}
  runs-on: prod-default-small-v2
  environment: manual-release-approval
  permissions:
    contents: read
  steps:
    - name: Record approval
      run: |
        echo "Manual nightly release approved by ${{ github.actor }}"
        echo "Run: ${{ github.run_id }} attempt ${{ github.run_attempt }}"
```

The job does no privileged work — it exists solely to materialize the GitHub environment-protection approval prompt. The actual publishing jobs in `release.yml` continue to target the existing `automated-release` environment, unchanged.

`if:` truth table:

| Event | `release` input | Gate runs? | Outcome |
|---|---|---|---|
| `schedule` (cron) | n/a | No (first clause false) | `Skipped` |
| `workflow_dispatch` | `true` (default or explicit) | **Yes** | `Waiting` → `success` after approval, `failure` if rejected |
| `workflow_dispatch` | `false` (tests-only) | No (second clause false) | `Skipped` |

#### `release` job wired to the gate

The existing `release` job that calls `release.yml` now lists `manual-release-approval` in its `needs:` and updates its `if:` to accept both `success` and `skipped`:

```yaml
if: ${{ !cancelled()
    && needs.compute-release-mode.outputs.release == 'true'
    && (needs.manual-release-approval.result == 'success'
        || needs.manual-release-approval.result == 'skipped') }}
```

- `!cancelled()` is preserved — framework/rust test failures still don't block publishing, matching prior intent.
- The existing `release == 'true'` short-circuit is preserved, so manual `release=false` runs still bypass `release.yml` entirely.
- `success || skipped` lets cron (gate skipped) and approved-manual (gate success) both proceed; rejected-manual lands as `failure` and the release job is skipped.

#### Why a new environment instead of reusing `automated-release`

The three publishing jobs in `release.yml` (`release-publish`, `stage-wheels-artifactory`, `trigger-gitlab-release-pipeline`) already target `automated-release`. Adding required reviewers there would **also block the daily cron** — defeating the goal. GitHub Actions environments don't support per-event-type reviewer policies, so the cleanest pattern is a dedicated gate environment used only by a manual-only job.

---

### Change 2 — `-nightly` suffix on nightly ECR tags (commit 2)

Adds an optional `image_tag_suffix` input to the build / test / pipeline reusable workflows, and has nightly pass `'-nightly'`. Post-merge callers don't pass it, so their tags are untouched.

#### Tag layout after this change

| Pipeline | Image tag in ECR |
|---|---|
| post-merge CI | `<sha>-vllm-runtime-cuda12`, `<sha>-dynamo-runtime-cuda12`, … |
| nightly CI | `<sha>-vllm-runtime-cuda12-nightly`, `<sha>-dynamo-runtime-cuda12-nightly`, … |

These are now distinct objects in ECR. Nightly publishing reads from the `-nightly` namespace; failed nightly builds leave nothing for downstream jobs to fall through onto.

#### Code changes per file

**`shared-build-image.yml`** — new input `image_tag_suffix` (default `''`). Appended in `calculate-target-tag`:
```bash
IMAGE_TAG=${SOURCE_SHA}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}
TEST_IMAGE_TAG=${SOURCE_SHA}-${TAG_BUILDER}${IMAGE_TAG_SUFFIX}-test
```

**`shared-test.yml`** — new input `image_tag_suffix`. Appended in the `container.image` path before `-test`.

**`dynamo-pipeline.yml`** — new input passthrough. Forwarded to the nested `shared-build-image` call and to the three nested `shared-test` calls (`parallel`, `sequential`, `gpu`). Two inline `container.image` paths (`rust-gpu`, `mypy`) updated to include the suffix.

**`nightly-ci.yml`** — passes `image_tag_suffix: '-nightly'` to every nightly call: three framework builds, six framework test jobs, and `dynamo-pipeline`.

**`release.yml`** — `release-publish` and `stage-wheels-artifactory` now conditionally suffix their ECR **source** tags:
```bash
NIGHTLY_TAG_SUFFIX=""
if [ "${NIGHTLY}" = "true" ]; then
  NIGHTLY_TAG_SUFFIX="-nightly"
fi
SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-${FRAMEWORK}-runtime-cuda12${NIGHTLY_TAG_SUFFIX}"
```
The NGC **target** tags (already `nightly-${DATE_UTC}-${SHORT_SHA}` per `release.yml:140`) are unchanged. Non-nightly release-branch dispatches keep reading the unsuffixed tags exactly as today.

#### Why this design

- **Additive, opt-in.** Default `image_tag_suffix: ''` means post-merge-ci.yml, release-branch dispatches, and every other caller behave identically to today.
- **Fail-loud, not fail-stale.** If nightly build for `<sha>` fails, NGC copy and wheel extract look for tags that don't exist; the release job fails cleanly instead of publishing post-merge content.
- **Single source of truth.** Reuses the existing `inputs.nightly` plumbing in `release.yml` rather than adding a parallel switch.

---

## Required follow-up in repo settings (not in this PR)

Before merging, the `manual-release-approval` GitHub environment must exist with required reviewers configured, otherwise manual dispatch runs will fail with "environment not found":

1. Settings → Environments → **New environment** → name `manual-release-approval`.
2. **Required reviewers**: release managers / whoever should be authorized to approve a manual nightly publish.
3. **Deployment branches**: restrict to `main` (matches the existing `release.yml` `nightly=true` branch check at lines 85–89).
4. No secrets needed.

After the environment is configured, the merge order doesn't matter for the cron path — the gate is skipped on schedule events regardless.

## Test plan

### Approval gate
- [ ] Create the `manual-release-approval` environment in repo settings with required reviewers + `main`-only branch policy.
- [ ] `gh api repos/ai-dynamo/dynamo/environments/manual-release-approval` returns 200.
- [ ] **Cron path** — verify the next scheduled run shows `manual-release-approval` as `Skipped` and `release` runs end-to-end.
- [ ] **Manual + release=true** — `gh workflow run nightly-ci.yml --ref main -f release=true`. Confirm the run pauses on the gate; a non-reviewer cannot approve; after a reviewer approves, `release` proceeds.
- [ ] **Manual + release=true, rejected** — confirm `release` is `Skipped` and no NGC/Artifactory/GitLab publish happens.
- [ ] **Manual + release=false** — `gh workflow run nightly-ci.yml --ref main -f release=false`. Confirm `manual-release-approval` is `Skipped` and `release` is also `Skipped` via the existing short-circuit.

### `-nightly` tag suffix
- [ ] **Build inspection** — after the next nightly run, list ECR tags for the resolved SHA. Confirm `<sha>-vllm-runtime-cuda12-nightly`, `<sha>-sglang-runtime-cuda12-nightly`, `<sha>-trtllm-runtime-cuda13-nightly`, `<sha>-dynamo-runtime-cuda12-nightly` all exist, alongside the prior post-merge non-suffixed tags.
- [ ] **release-publish log** — `crane copy` source lines should end in `-cuda12-nightly` / `-cuda13-nightly`; NGC target tags unchanged.
- [ ] **stage-wheels-artifactory log** — `ECR_IMAGE` line ends in `-cuda12-nightly`; extracted wheels carry `.dev<DATE>` in filenames.
- [ ] **Failure-mode regression test** — on a feature branch, deliberately break the dynamo build step (e.g. add `exit 1` after `Apply nightly dev version`). Dispatch nightly. Confirm `stage-wheels-artifactory` fails with `manifest unknown` from crane, instead of silently extracting stable wheels.
- [ ] **Post-merge regression check** — observe the next post-merge CI run on `main`. Confirm tags pushed are `<sha>-...-cuda12` (no `-nightly`) and that any release-branch dispatch off those tags still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
