### PR TITLE
docs/kubernetes: clarify DGDR GPU SKU values

### DIFF
--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -128,31 +128,22 @@ spec:
 
 ### SKU Format
 
-When providing hardware configuration manually, use lowercase underscore format:
+When providing hardware configuration manually, set `spec.hardware.gpuSku` to
+one of the canonical DGDR enum values. These values are lowercase and use
+underscores; marketing names and `nvidia-smi` product names are not accepted.
 
-| Correct | Incorrect |
-|---|---|
-| `h100_sxm` | `H100-SXM5-80GB` |
-| `h200_sxm` | `H200-SXM-141GB` |
-| `a100_sxm` | `A100-SXM4-80GB` |
-| `a30` | `A30` |
-| `l40s` | `L40S` |
+```yaml
+hardware:
+  gpuSku: h100_sxm
+```
 
-All supported values: `gb200_sxm`, `b200_sxm`, `h200_sxm`, `h100_sxm`,
+Supported `gpuSku` values: `gb200_sxm`, `b200_sxm`, `h200_sxm`, `h100_sxm`,
 `h100_pcie`, `a100_sxm`, `a100_pcie`, `a30`, `l40s`, `l40`, `l4`,
 `v100_sxm`, `v100_pcie`, `t4`, `mi200`, `mi300`.
 
 > [!NOTE]
 > Not all SKUs are supported by the AIC profiler for `rapid` mode. See
 > [AIC Support Matrix](model-deployment-guide.md#aic-support-matrix) for details.
-
-> [!IMPORTANT]
-> **PCIe variants not yet supported by profiler.** The CRD admits PCIe SKUs
-> (`h100_pcie`, `a100_pcie`, `v100_pcie`), but the profiler does not currently
-> ship training data for them. You can submit a DGDR with a PCIe value; the
-> operator will accept it but profiler-assisted sizing will fall back to
-> defaults. Profiler support for PCIe SKUs is tracked as an engineering
-> follow-up.
 
 ## Lifecycle
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -101,30 +101,37 @@ benchmarks with AIPerf. Takes 2–4 hours.
 
 ## AIC Support Matrix
 
-The rapid strategy relies on AIC performance models. AIC currently supports:
+The rapid strategy relies on AIC performance models. AIC rapid support by GPU
+SKU:
 
 ### GPU SKUs
 
-| Supported (rapid) | Not Yet Supported (use thorough) |
-|---|---|
-| H100 SXM | V100 (SXM/PCIe) |
-| H100 PCIe | T4 |
-| H200 SXM | MI200, MI300 |
-| A100 SXM |  |
-| A100 PCIe |  |
-| A30 |  |
-| B200 SXM |  |
-| GB200 SXM |  |
-| L40S |  |
-| L4 |  |
+| Hardware | Value | Rapid support |
+|---|---|---|
+| H100 SXM | `h100_sxm` | Supported |
+| H100 PCIe | `h100_pcie` | Supported |
+| H200 SXM | `h200_sxm` | Supported |
+| A100 SXM | `a100_sxm` | Supported |
+| A100 PCIe | `a100_pcie` | Supported |
+| A30 | `a30` | Supported |
+| B200 SXM | `b200_sxm` | Supported |
+| GB200 SXM | `gb200_sxm` | Supported |
+| L40S | `l40s` | Supported |
+| L40 | `l40` | Not yet supported; use `thorough` |
+| L4 | `l4` | Supported |
+| V100 SXM | `v100_sxm` | Not yet supported; use `thorough` |
+| V100 PCIe | `v100_pcie` | Not yet supported; use `thorough` |
+| T4 | `t4` | Not yet supported; use `thorough` |
+| MI200 | `mi200` | Not yet supported; use `thorough` |
+| MI300 | `mi300` | Not yet supported; use `thorough` |
 
 > [!NOTE]
 > Some rapid-mode SKUs use AIC estimate-only data until measured profiles are
 > available. Use `searchStrategy: thorough` when you need hardware-measured
 > profiling for an estimate-only or unsupported SKU.
 
-When specifying GPU SKUs manually, use lowercase underscore format (e.g.,
-`h100_sxm`, not `H100-SXM5-80GB`). See the
+When specifying GPU SKUs manually, set `spec.hardware.gpuSku` to one of the
+canonical lowercase underscore values above. See the
 [DGDR Reference — SKU Format](dgdr.md#sku-format) for the full list.
 
 ### Backends


### PR DESCRIPTION
Summary
- Replace the DGDR SKU format negative examples with a canonical `hardware.gpuSku` YAML example and the accepted enum list.
- Add a separate `Value` column to the AIC GPU SKU support matrix so users can copy the accepted DGDR values directly.
- Remove the stale PCIe-specific DGDR callout in favor of the support matrix link.

Validation
- `git diff --check -- docs/kubernetes/dgdr.md docs/kubernetes/model-deployment-guide.md`
- Commit hook passed for the staged docs change.

Prompt trail
- Asked whether the DGDR GPU SKU support/documentation gap was still open.
- Requested a PR to correct the documented SKU format.
- Narrowed the fix to removing misleading bad-format examples, keeping the canonical constants as source of truth, and adding an explicit value column to the AIC matrix.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved GPU SKU configuration guidance in Kubernetes deployment documentation with canonical enum values and clearer formatting
  * Enhanced AIC support matrix with comprehensive GPU SKU compatibility details, explicitly enumerating supported and unsupported SKUs and recommended fallback strategies for rapid search mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->