### PR TITLE
docs: use planner image for profiler docs

### DIFF
--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -253,7 +253,7 @@ class DynamoGraphDeploymentRequestSpec(BaseModel):
     )
     image: Optional[str] = Field(
         default=None,
-        description='Image is the container image reference for the profiling job (frontend image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1".',
+        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".',
     )
     modelCache: Optional[ModelCacheSpec] = Field(
         default=None,

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -253,7 +253,7 @@ class DynamoGraphDeploymentRequestSpec(BaseModel):
     )
     image: Optional[str] = Field(
         default=None,
-        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1". For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.',
+        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1". For Dynamo < 1.1.0, use dynamo-frontend.',
     )
     modelCache: Optional[ModelCacheSpec] = Field(
         default=None,

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -253,7 +253,7 @@ class DynamoGraphDeploymentRequestSpec(BaseModel):
     )
     image: Optional[str] = Field(
         default=None,
-        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".',
+        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1". For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.',
     )
     modelCache: Optional[ModelCacheSpec] = Field(
         default=None,

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -80,7 +80,7 @@ def derive_backend_image(profiler_image: str, backend: str) -> str:
     Examples::
 
         derive_backend_image(
-            "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1", "vllm"
+            "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1", "vllm"
         )
         # → "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
 

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -684,8 +684,8 @@ spec:
                   type: object
                 image:
                   description: |-
-                    Image is the container image reference for the profiling job (frontend image).
-                    Example: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1".
+                    Image is the container image reference for the profiling job (planner image).
+                    Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
                   type: string
                 model:
                   description: |-

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -686,6 +686,7 @@ spec:
                   description: |-
                     Image is the container image reference for the profiling job (planner image).
                     Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
+                    For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.
                   type: string
                 model:
                   description: |-

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -686,7 +686,7 @@ spec:
                   description: |-
                     Image is the container image reference for the profiling job (planner image).
                     Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
-                    For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.
+                    For Dynamo < 1.1.0, use dynamo-frontend.
                   type: string
                 model:
                   description: |-

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -445,6 +445,7 @@ type DynamoGraphDeploymentRequestSpec struct {
 
 	// Image is the container image reference for the profiling job (planner image).
 	// Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
+	// For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.
 	// +optional
 	Image string `json:"image,omitempty"`
 

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -445,7 +445,7 @@ type DynamoGraphDeploymentRequestSpec struct {
 
 	// Image is the container image reference for the profiling job (planner image).
 	// Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
-	// For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.
+	// For Dynamo < 1.1.0, use dynamo-frontend.
 	// +optional
 	Image string `json:"image,omitempty"`
 

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -443,8 +443,8 @@ type DynamoGraphDeploymentRequestSpec struct {
 	// +kubebuilder:validation:Enum=auto;sglang;trtllm;vllm
 	Backend BackendType `json:"backend,omitempty"`
 
-	// Image is the container image reference for the profiling job (frontend image).
-	// Example: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1".
+	// Image is the container image reference for the profiling job (planner image).
+	// Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
 	// +optional
 	Image string `json:"image,omitempty"`
 

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -684,8 +684,8 @@ spec:
                   type: object
                 image:
                   description: |-
-                    Image is the container image reference for the profiling job (frontend image).
-                    Example: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1".
+                    Image is the container image reference for the profiling job (planner image).
+                    Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
                   type: string
                 model:
                   description: |-

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -686,6 +686,7 @@ spec:
                   description: |-
                     Image is the container image reference for the profiling job (planner image).
                     Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
+                    For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.
                   type: string
                 model:
                   description: |-

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -686,7 +686,7 @@ spec:
                   description: |-
                     Image is the container image reference for the profiling job (planner image).
                     Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".
-                    For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag.
+                    For Dynamo < 1.1.0, use dynamo-frontend.
                   type: string
                 model:
                   description: |-

--- a/docs/components/planner/global-planner.md
+++ b/docs/components/planner/global-planner.md
@@ -182,7 +182,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
-  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:<tag>  # dynamo-frontend for Dynamo < 1.1.0
+  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1  # dynamo-frontend for Dynamo < 1.1.0
   workload:
     isl: 2048
     osl: 256

--- a/docs/components/planner/global-planner.md
+++ b/docs/components/planner/global-planner.md
@@ -182,6 +182,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:<tag>
   workload:
     isl: 2048

--- a/docs/components/planner/global-planner.md
+++ b/docs/components/planner/global-planner.md
@@ -182,8 +182,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:<tag>
+  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:<tag>  # dynamo-frontend for Dynamo < 1.1.0
   workload:
     isl: 2048
     osl: 256

--- a/docs/components/planner/global-planner.md
+++ b/docs/components/planner/global-planner.md
@@ -182,7 +182,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
-  image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:<tag>
+  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:<tag>
   workload:
     isl: 2048
     osl: 256

--- a/docs/components/planner/planner-examples.md
+++ b/docs/components/planner/planner-examples.md
@@ -20,6 +20,7 @@ metadata:
 spec:
   model: Qwen/Qwen3-32B
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -42,6 +43,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -67,6 +69,7 @@ metadata:
 spec:
   model: deepseek-ai/DeepSeek-R1
   backend: sglang
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -99,6 +102,7 @@ metadata:
 spec:
   model: deepseek-ai/DeepSeek-R1
   backend: sglang
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -139,6 +143,7 @@ spec:
     mocker:
       enabled: true  # Deploy mocker instead of real backend
 
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 

--- a/docs/components/planner/planner-examples.md
+++ b/docs/components/planner/planner-examples.md
@@ -20,8 +20,7 @@ metadata:
 spec:
   model: Qwen/Qwen3-32B
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 Deploy:
@@ -43,8 +42,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 Deploy:
@@ -69,8 +67,7 @@ metadata:
 spec:
   model: deepseek-ai/DeepSeek-R1
   backend: sglang
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 Deploy:
@@ -102,8 +99,7 @@ metadata:
 spec:
   model: deepseek-ai/DeepSeek-R1
   backend: sglang
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 The profiler uses the DGD config from the ConfigMap as a **base template**, then optimizes it based on your SLA targets. The controller automatically injects `spec.model` and `spec.backend` into the final configuration.
@@ -143,8 +139,7 @@ spec:
     mocker:
       enabled: true  # Deploy mocker instead of real backend
 
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 Profiling runs against the real backend (via GPUs or AIC). The mocker deployment then uses profiling data to simulate realistic timing.

--- a/docs/components/planner/planner-examples.md
+++ b/docs/components/planner/planner-examples.md
@@ -20,7 +20,7 @@ metadata:
 spec:
   model: Qwen/Qwen3-32B
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 Deploy:
@@ -42,7 +42,7 @@ metadata:
 spec:
   model: meta-llama/Llama-3.3-70B-Instruct
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 Deploy:
@@ -67,7 +67,7 @@ metadata:
 spec:
   model: deepseek-ai/DeepSeek-R1
   backend: sglang
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 Deploy:
@@ -99,7 +99,7 @@ metadata:
 spec:
   model: deepseek-ai/DeepSeek-R1
   backend: sglang
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 The profiler uses the DGD config from the ConfigMap as a **base template**, then optimizes it based on your SLA targets. The controller automatically injects `spec.model` and `spec.backend` into the final configuration.
@@ -139,7 +139,7 @@ spec:
     mocker:
       enabled: true  # Deploy mocker instead of real backend
 
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 Profiling runs against the real backend (via GPUs or AIC). The mocker deployment then uses profiling data to simulate realistic timing.

--- a/docs/components/profiler/README.md
+++ b/docs/components/profiler/README.md
@@ -37,7 +37,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   workload:
     isl: 3000      # Average input sequence length

--- a/docs/components/profiler/README.md
+++ b/docs/components/profiler/README.md
@@ -37,8 +37,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 
   workload:
     isl: 3000      # Average input sequence length

--- a/docs/components/profiler/README.md
+++ b/docs/components/profiler/README.md
@@ -37,6 +37,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   workload:

--- a/docs/components/profiler/profiler-examples.md
+++ b/docs/components/profiler/profiler-examples.md
@@ -19,8 +19,7 @@ metadata:
   name: qwen-0-6b
 spec:
   model: "Qwen/Qwen3-0.6B"
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 ### Dense Model: Thorough
@@ -35,8 +34,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
   searchStrategy: thorough
 ```
 
@@ -57,8 +55,7 @@ metadata:
 spec:
   model: "deepseek-ai/DeepSeek-R1"
   backend: sglang
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 
   hardware:
     numGpusPerNode: 8
@@ -88,8 +85,7 @@ metadata:
   name: llama-private
 spec:
   model: "meta-llama/Llama-3.1-8B-Instruct"
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 
   overrides:
     profilingJob:
@@ -120,8 +116,7 @@ metadata:
   name: low-latency-dense
 spec:
   model: "Qwen/Qwen3-0.6B"
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 
   sla:
     ttft: 500      # Time To First Token target in milliseconds
@@ -155,8 +150,7 @@ metadata:
   name: dense-with-tolerations
 spec:
   model: "Qwen/Qwen3-0.6B"
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 
   overrides:
     profilingJob:

--- a/docs/components/profiler/profiler-examples.md
+++ b/docs/components/profiler/profiler-examples.md
@@ -19,6 +19,7 @@ metadata:
   name: qwen-0-6b
 spec:
   model: "Qwen/Qwen3-0.6B"
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -34,6 +35,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
   searchStrategy: thorough
 ```
@@ -55,6 +57,7 @@ metadata:
 spec:
   model: "deepseek-ai/DeepSeek-R1"
   backend: sglang
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   hardware:
@@ -85,6 +88,7 @@ metadata:
   name: llama-private
 spec:
   model: "meta-llama/Llama-3.1-8B-Instruct"
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   overrides:
@@ -116,6 +120,7 @@ metadata:
   name: low-latency-dense
 spec:
   model: "Qwen/Qwen3-0.6B"
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   sla:
@@ -150,6 +155,7 @@ metadata:
   name: dense-with-tolerations
 spec:
   model: "Qwen/Qwen3-0.6B"
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   overrides:

--- a/docs/components/profiler/profiler-examples.md
+++ b/docs/components/profiler/profiler-examples.md
@@ -19,7 +19,7 @@ metadata:
   name: qwen-0-6b
 spec:
   model: "Qwen/Qwen3-0.6B"
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 ### Dense Model: Thorough
@@ -34,7 +34,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
   searchStrategy: thorough
 ```
 
@@ -55,7 +55,7 @@ metadata:
 spec:
   model: "deepseek-ai/DeepSeek-R1"
   backend: sglang
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   hardware:
     numGpusPerNode: 8
@@ -85,7 +85,7 @@ metadata:
   name: llama-private
 spec:
   model: "meta-llama/Llama-3.1-8B-Instruct"
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   overrides:
     profilingJob:
@@ -116,7 +116,7 @@ metadata:
   name: low-latency-dense
 spec:
   model: "Qwen/Qwen3-0.6B"
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   sla:
     ttft: 500      # Time To First Token target in milliseconds
@@ -150,7 +150,7 @@ metadata:
   name: dense-with-tolerations
 spec:
   model: "Qwen/Qwen3-0.6B"
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   overrides:
     profilingJob:

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -198,7 +198,7 @@ Each DGDR requires a container image for profiling and deployment:
 
 ```yaml
 spec:
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 #### Quick Start: Deploy with DGDR
@@ -215,7 +215,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 **Step 2: Apply the DGDR**
@@ -372,7 +372,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   searchStrategy: rapid  # or thorough
   autoApply: true

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -198,8 +198,7 @@ Each DGDR requires a container image for profiling and deployment:
 
 ```yaml
 spec:
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 #### Quick Start: Deploy with DGDR
@@ -216,8 +215,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 **Step 2: Apply the DGDR**
@@ -374,8 +372,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 
   searchStrategy: rapid  # or thorough
   autoApply: true

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -198,6 +198,7 @@ Each DGDR requires a container image for profiling and deployment:
 
 ```yaml
 spec:
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -215,6 +216,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -372,6 +374,7 @@ metadata:
 spec:
   model: "Qwen/Qwen3-0.6B"
   backend: vllm
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 
   searchStrategy: rapid  # or thorough

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -91,8 +91,7 @@ metadata:
 spec:
   model: Qwen/Qwen3-0.6B
   backend: auto
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 ```bash

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -91,7 +91,8 @@ metadata:
 spec:
   model: Qwen/Qwen3-0.6B
   backend: auto
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.2"
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 ```bash

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -1894,7 +1894,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `model` _string_ | Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b").<br />Can be a HuggingFace ID or a private model name. |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `backend` _[BackendType](#backendtype)_ | Backend specifies the inference backend to use for profiling and deployment. | auto | Enum: [auto sglang trtllm vllm] <br />Optional: \{\} <br /> |
-| `image` _string_ | Image is the container image reference for the profiling job (frontend image).<br />Example: "nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.1.1". |  | Optional: \{\} <br /> |
+| `image` _string_ | Image is the container image reference for the profiling job (planner image).<br />Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1". |  | Optional: \{\} <br /> |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | ModelCache provides optional PVC configuration for pre-downloaded model weights.<br />When provided, weights are loaded from the PVC instead of downloading from HuggingFace. |  | Optional: \{\} <br /> |
 | `hardware` _[HardwareSpec](#hardwarespec)_ | Hardware describes the hardware resources available for profiling and deployment.<br />Typically auto-filled by the operator from cluster discovery. |  | Optional: \{\} <br /> |
 | `workload` _[WorkloadSpec](#workloadspec)_ | Workload defines the expected workload characteristics for SLA-based profiling. |  | Optional: \{\} <br /> |

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -1894,7 +1894,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `model` _string_ | Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b").<br />Can be a HuggingFace ID or a private model name. |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `backend` _[BackendType](#backendtype)_ | Backend specifies the inference backend to use for profiling and deployment. | auto | Enum: [auto sglang trtllm vllm] <br />Optional: \{\} <br /> |
-| `image` _string_ | Image is the container image reference for the profiling job (planner image).<br />Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1". |  | Optional: \{\} <br /> |
+| `image` _string_ | Image is the container image reference for the profiling job (planner image).<br />Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".<br />For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag. |  | Optional: \{\} <br /> |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | ModelCache provides optional PVC configuration for pre-downloaded model weights.<br />When provided, weights are loaded from the PVC instead of downloading from HuggingFace. |  | Optional: \{\} <br /> |
 | `hardware` _[HardwareSpec](#hardwarespec)_ | Hardware describes the hardware resources available for profiling and deployment.<br />Typically auto-filled by the operator from cluster discovery. |  | Optional: \{\} <br /> |
 | `workload` _[WorkloadSpec](#workloadspec)_ | Workload defines the expected workload characteristics for SLA-based profiling. |  | Optional: \{\} <br /> |

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -1894,7 +1894,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `model` _string_ | Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b").<br />Can be a HuggingFace ID or a private model name. |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `backend` _[BackendType](#backendtype)_ | Backend specifies the inference backend to use for profiling and deployment. | auto | Enum: [auto sglang trtllm vllm] <br />Optional: \{\} <br /> |
-| `image` _string_ | Image is the container image reference for the profiling job (planner image).<br />Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".<br />For Dynamo versions before 1.1.0, use dynamo-frontend with the same tag. |  | Optional: \{\} <br /> |
+| `image` _string_ | Image is the container image reference for the profiling job (planner image).<br />Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1".<br />For Dynamo < 1.1.0, use dynamo-frontend. |  | Optional: \{\} <br /> |
 | `modelCache` _[ModelCacheSpec](#modelcachespec)_ | ModelCache provides optional PVC configuration for pre-downloaded model weights.<br />When provided, weights are loaded from the PVC instead of downloading from HuggingFace. |  | Optional: \{\} <br /> |
 | `hardware` _[HardwareSpec](#hardwarespec)_ | Hardware describes the hardware resources available for profiling and deployment.<br />Typically auto-filled by the operator from cluster discovery. |  | Optional: \{\} <br /> |
 | `workload` _[WorkloadSpec](#workloadspec)_ | Workload defines the expected workload characteristics for SLA-based profiling. |  | Optional: \{\} <br /> |

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -42,7 +42,7 @@ metadata:
   name: my-model
 spec:
   model: Qwen/Qwen3-0.6B
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.0.0"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
 ### Field Reference

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -42,8 +42,7 @@ metadata:
   name: my-model
 spec:
   model: Qwen/Qwen3-0.6B
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
 ### Field Reference
@@ -95,8 +94,7 @@ metadata:
 spec:
   model: Qwen/Qwen3-30B-A3B
   backend: sglang
-  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
-  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"  # dynamo-frontend for Dynamo < 1.1.0
   overrides:
     dgd:
       apiVersion: nvidia.com/v1alpha1

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -42,6 +42,7 @@ metadata:
   name: my-model
 spec:
   model: Qwen/Qwen3-0.6B
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
 ```
 
@@ -94,6 +95,7 @@ metadata:
 spec:
   model: Qwen/Qwen3-30B-A3B
   backend: sglang
+  # For Dynamo < 1.1.0, use dynamo-frontend with the same tag.
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
   overrides:
     dgd:


### PR DESCRIPTION
## Summary
- Source: [DGDR Revamp Plan for VDR Feedback](https://docs.google.com/document/d/1yLit0PKTVf4VBFOxtq_UVCnF4ivyxJETskcRnUNidP0/edit?tab=t.0), which calls out that v1beta1 API docs and CRD descriptions still describe DGDR `spec.image` as the profiler frontend image while the defaulting webhook now uses `dynamo-planner`.
- Update DGDR `spec.image` API, CRD, API reference, and generated Python schema wording with the minimal change from `(frontend image)` to `(planner image)`.
- Replace stale DGDR/profiler/planner examples that used `dynamo-frontend:1.1.1` as the profiling-job image with `dynamo-planner:1.1.1`.
- Refresh the profiler image-derivation docstring example to match the current image convention.

## Context
- Part of the broader DGDR deployability cleanup tracked by #8469, which collects DGDR profiling/deployment reliability gaps surfaced by VDR and QA.
- Supports the DGDR/Kubernetes docs cleanup tracked by #8658 by removing an avoidable golden-path trust-breaker from public docs and generated API references.
- Related historical image context: #6526 documented the older profiler-image assumption around `dynamo-frontend` and backend image derivation; this PR updates docs to match the current planner-image behavior.

## Testing
- `make -C deploy/operator manifests generate-api-docs`
- `make -C deploy/operator generate-pydantic`
- `git diff --check`
- `NPM_CONFIG_CACHE=/private/tmp/npm-cache npx --yes fern-api@4.66.1 docs broken-links`
- `NPM_CONFIG_CACHE=/private/tmp/npm-cache npx --yes fern-api@4.66.1 check`

## Prompt Trail
- Reviewed the remaining trust-breaker cleanup list and identified stale DGDR `spec.image` docs as the next narrow task.
- Confirmed current releases use the `dynamo-planner` image for DGDR profiling jobs.
- Verified the planner image contains profiler code and dependencies in `container/templates/planner.Dockerfile`.
- Kept generated CRD/API docs derived from the Go API comment instead of editing generated output directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment examples and configuration guidance to reference the correct container image (`dynamo-planner`) across profiler and planner component documentation and Kubernetes API references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
