### PR TITLE
docs: remove stale DGDR sample references

### DIFF
--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -112,11 +112,9 @@ features:
     pre_deployment_sweeping_mode: rapid
 ```
 
-The fastest path to SLA-based scaling is through a DynamoGraphDeploymentRequest, which automatically profiles your model:
-
-```bash
-kubectl apply -f components/src/dynamo/profiler/deploy/profile_sla_aic_dgdr.yaml -n $NAMESPACE
-```
+The fastest path to SLA-based scaling is through a DynamoGraphDeploymentRequest,
+which automatically profiles your model. See [Planner Examples](planner-examples.md)
+for copyable DGDR manifests.
 
 See [Planner Guide](planner-guide.md) for the full workflow.
 

--- a/docs/components/planner/planner-examples.md
+++ b/docs/components/planner/planner-examples.md
@@ -26,7 +26,8 @@ spec:
 Deploy:
 ```bash
 export NAMESPACE=your-namespace
-kubectl apply -f components/src/dynamo/profiler/deploy/profile_sla_aic_dgdr.yaml -n $NAMESPACE
+# Save the manifest above as sla-aic.yaml first.
+kubectl apply -f sla-aic.yaml -n $NAMESPACE
 ```
 
 ### Online Profiling (Real Measurements)
@@ -46,13 +47,9 @@ spec:
 
 Deploy:
 ```bash
-kubectl apply -f components/src/dynamo/profiler/deploy/profile_sla_dgdr.yaml -n $NAMESPACE
+# Save the manifest above as sla-online.yaml first.
+kubectl apply -f sla-online.yaml -n $NAMESPACE
 ```
-
-Available sample DGDRs in `components/src/dynamo/profiler/deploy/`:
-- **`profile_sla_dgdr.yaml`**: Standard online profiling for dense models
-- **`profile_sla_aic_dgdr.yaml`**: Fast offline profiling using AI Configurator
-- **`profile_sla_moe_dgdr.yaml`**: Online profiling for MoE models (SGLang)
 
 > **Note**: Starting with Dynamo 1.0.0 (DGDR API version v1beta1), DGDR fields use structured spec fields (e.g., `spec.workload`, `spec.sla`, `spec.hardware`) instead of the nested `profilingConfig.config` blob used in v1alpha1.
 
@@ -75,7 +72,8 @@ spec:
 
 Deploy:
 ```bash
-kubectl apply -f components/src/dynamo/profiler/deploy/profile_sla_moe_dgdr.yaml -n $NAMESPACE
+# Save the manifest above as sla-moe.yaml first.
+kubectl apply -f sla-moe.yaml -n $NAMESPACE
 ```
 
 ### Using Existing DGD Configs (Custom Setups)

--- a/fern/components/profiler/profiler_guide.md
+++ b/fern/components/profiler/profiler_guide.md
@@ -50,13 +50,8 @@ The profiler sweeps over the following parallelization mappings for prefill and 
 
 ### Kubernetes Deployment (DGDR)
 
-The recommended deployment method is through DGDRs. Sample configurations are provided in `benchmarks/profiler/deploy/`:
-
-| Sample | Description |
-|--------|-------------|
-| `profile_sla_dgdr.yaml` | Standard online profiling with AIPerf |
-| `profile_sla_aic_dgdr.yaml` | Fast offline profiling with AI Configurator |
-| `profile_sla_moe_dgdr.yaml` | MoE model profiling (SGLang) |
+The recommended deployment method is through DGDRs. For copyable manifests, see the
+profiler and planner examples in the current documentation.
 
 #### Container Images
 


### PR DESCRIPTION
## Summary
- Remove stale references to deleted `profile_sla_*_dgdr.yaml` profiler deployment samples.
- Replace dead `components/src/dynamo/profiler/deploy/` apply commands with local filenames saved from the inline examples.
- Remove the stale Fern sample table that pointed at `benchmarks/profiler/deploy/`.

## Testing
- `git diff --check`
- `rg -n 'profile_sla_.*_dgdr\\.yaml|components/src/dynamo/profiler/deploy|benchmarks/profiler/deploy' docs fern components deploy examples recipes`\n\n## Prompt Trail\n- User asked to continue the DGDR docs cleanup task list and identify item 3.\n- We identified item 3 as stale references to deleted profiler DGDR sample manifests.\n- User asked to fix the stale references, so the dead paths were replaced with self-contained inline-manifest instructions.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified SLA-Based Scaling guidance with cross-references to deployment examples
  * Updated Kubernetes deployment instructions with improved local file workflow
  * Enhanced profiler documentation with consolidated example references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->