### PR TITLE
feat(RL): add worker discovery endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "dynamo-parsers",
  "dynamo-protocols",
  "dynamo-renderer",
+ "dynamo-rl",
  "dynamo-runtime",
  "dynamo-tokenizers",
  "dynamo-tokens",
@@ -2725,6 +2726,20 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "dynamo-rl"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.4",
+ "dynamo-runtime",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 [workspace]
 members = [
     "lib/llm",
+    "lib/rl",
     "lib/runtime",
     "lib/tokenizers",
     "lib/renderer",
@@ -45,6 +46,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 # Local crates
 dynamo-runtime = { path = "lib/runtime", version = "1.3.0" }
 dynamo-llm = { path = "lib/llm", version = "1.3.0" }
+dynamo-rl = { path = "lib/rl", version = "1.3.0" }
 dynamo-tokenizers = { path = "lib/tokenizers", version = "1.3.0" }
 dynamo-renderer = { path = "lib/renderer", version = "1.3.0" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "dynamo-parsers",
  "dynamo-protocols",
  "dynamo-renderer",
+ "dynamo-rl",
  "dynamo-runtime",
  "dynamo-tokenizers",
  "dynamo-tokens",
@@ -1731,6 +1732,20 @@ dependencies = [
  "minijinja-contrib",
  "serde",
  "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "dynamo-rl"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "dynamo-runtime",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "dynamo-parsers",
  "dynamo-protocols",
  "dynamo-renderer",
+ "dynamo-rl",
  "dynamo-runtime",
  "dynamo-tokenizers",
  "dynamo-tokens",
@@ -2360,6 +2361,20 @@ dependencies = [
  "minijinja-contrib",
  "serde",
  "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "dynamo-rl"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "dynamo-runtime",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
  "tracing",
 ]
 

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -61,6 +61,7 @@ required-features = ["agent-trace-bench"]
 dynamo-kv-router = { workspace = true, features = ["metrics", "runtime-protocols"] }
 dynamo-memory = { workspace = true }
 dynamo-mocker = { workspace = true }
+dynamo-rl = { workspace = true }
 dynamo-runtime = { workspace = true }
 dynamo-tokenizers = { workspace = true }
 dynamo-renderer = { workspace = true }

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -63,6 +63,8 @@ pub async fn run(
     // with the instance_id as the router_id label.
     http_service_builder =
         http_service_builder.drt_discovery(Some(distributed_runtime.discovery()));
+    http_service_builder =
+        http_service_builder.runtime(Some(Arc::new(distributed_runtime.clone())));
 
     let http_service = match engine_config {
         EngineConfig::Dynamic {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -79,6 +79,14 @@ const VALIDATION_PREFIX: &str = "Validation: ";
 
 use super::error::SanitizedError;
 
+pub(super) fn rl_router(
+    drt: Arc<dynamo_runtime::DistributedRuntime>,
+) -> anyhow::Result<axum::Router> {
+    let config = dynamo_rl::RlDiscoveryConfig::from_env(drt);
+    let state = dynamo_rl::RlDiscoveryState::new(config);
+    Ok(dynamo_rl::rl_router(state))
+}
+
 // Default axum max body limit without configuring is 2MB: https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html
 /// Default body limit in bytes (45MB) to support 500k+ token payloads.
 /// Can be configured at runtime using the DYN_HTTP_BODY_LIMIT_MB environment variable.

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -25,6 +25,7 @@ use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
 use derive_builder::Builder;
+use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::config::env_is_truthy;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::discovery::Discovery;
@@ -215,6 +216,9 @@ pub struct HttpService {
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
     route_docs: Vec<RouteDoc>,
+    /// RL worker discovery router, served on a dedicated port when enabled.
+    rl_router: Option<axum::Router>,
+    rl_port: u16,
 }
 
 #[derive(Clone, Builder)]
@@ -270,6 +274,25 @@ pub struct HttpServiceConfig {
     /// are registered using discovery.instance_id() and exposed on /metrics.
     #[builder(default = "None")]
     drt_discovery: Option<Arc<dyn Discovery>>,
+
+    /// When true, serve the RL worker discovery API on `rl_port`.
+    #[builder(default = "false")]
+    enable_rl: bool,
+
+    /// Port for the RL worker discovery listener. Defaults to `DYN_RL_PORT` or 8001.
+    #[builder(default = "default_rl_port()")]
+    rl_port: u16,
+
+    /// Distributed runtime used by the RL worker discovery API.
+    #[builder(default = "None")]
+    runtime: Option<Arc<DistributedRuntime>>,
+}
+
+fn default_rl_port() -> u16 {
+    std::env::var("DYN_RL_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8001)
 }
 
 impl HttpService {
@@ -378,6 +401,8 @@ impl HttpService {
                 .handle(handle.clone())
                 .serve(router.into_make_service());
 
+            self.spawn_rl_listener_if_configured(&cancel_token);
+
             // Spawn canary after all fallible startup so it won't leak on early errors
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
 
@@ -426,6 +451,8 @@ impl HttpService {
                 }
             };
 
+            self.spawn_rl_listener_if_configured(&cancel_token);
+
             // Spawn canary after all fallible startup so it won't leak on early errors
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
 
@@ -445,6 +472,39 @@ impl HttpService {
         }
 
         Ok(())
+    }
+
+    fn spawn_rl_listener_if_configured(&self, cancel_token: &CancellationToken) {
+        let Some(rl_router) = self.rl_router.clone() else {
+            return;
+        };
+        let rl_addr = format!("{}:{}", self.host, self.rl_port);
+        let rl_cancel = cancel_token.child_token();
+        tokio::spawn(async move {
+            match tokio::net::TcpListener::bind(&rl_addr).await {
+                Ok(listener) => {
+                    tracing::info!(
+                        address = %rl_addr,
+                        "RL worker discovery listener started"
+                    );
+                    if let Err(e) = axum::serve(listener, rl_router)
+                        .with_graceful_shutdown(async move {
+                            rl_cancel.cancelled_owned().await;
+                        })
+                        .await
+                    {
+                        tracing::error!("RL worker discovery listener error: {e}");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        address = %rl_addr,
+                        error = %e,
+                        "Failed to bind RL worker discovery listener"
+                    );
+                }
+            }
+        });
     }
 
     /// Documentation of exposed HTTP endpoints
@@ -631,6 +691,30 @@ impl HttpServiceConfigBuilder {
         // Echo x-request-id from request to response headers for client correlation
         let router = router.layer(axum::middleware::from_fn(echo_request_id_header));
 
+        let enable_rl_router = config.enable_rl || env_is_truthy("DYN_ENABLE_RL");
+        let rl_router = if enable_rl_router {
+            let Some(drt) = config.runtime.as_ref() else {
+                return Err(anyhow::anyhow!(
+                    "RL worker discovery was requested (DYN_ENABLE_RL=true \
+                     or enable_rl) but HttpServiceConfig.runtime is not set."
+                ));
+            };
+            let router = super::openai::rl_router(drt.clone())?;
+            tracing::info!(
+                rl_port = config.rl_port,
+                "RL worker discovery enabled at /v1/rl/workers"
+            );
+            Some(
+                router.layer(
+                    TraceLayer::new_for_http()
+                        .make_span_with(make_system_request_span)
+                        .on_response(on_response),
+                ),
+            )
+        } else {
+            None
+        };
+
         Ok(HttpService {
             state,
             router,
@@ -640,6 +724,8 @@ impl HttpServiceConfigBuilder {
             tls_cert_path: config.tls_cert_path,
             tls_key_path: config.tls_key_path,
             route_docs: all_docs,
+            rl_router,
+            rl_port: config.rl_port,
         })
     }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -401,7 +401,7 @@ impl HttpService {
                 .handle(handle.clone())
                 .serve(router.into_make_service());
 
-            self.spawn_rl_listener_if_configured(&cancel_token);
+            self.spawn_rl_listener_if_configured(&cancel_token).await?;
 
             // Spawn canary after all fallible startup so it won't leak on early errors
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
@@ -451,7 +451,7 @@ impl HttpService {
                 }
             };
 
-            self.spawn_rl_listener_if_configured(&cancel_token);
+            self.spawn_rl_listener_if_configured(&cancel_token).await?;
 
             // Spawn canary after all fallible startup so it won't leak on early errors
             tokio::spawn(tokio_metrics_and_canary_loop(cancel_token.clone()));
@@ -474,37 +474,41 @@ impl HttpService {
         Ok(())
     }
 
-    fn spawn_rl_listener_if_configured(&self, cancel_token: &CancellationToken) {
+    async fn spawn_rl_listener_if_configured(
+        &self,
+        cancel_token: &CancellationToken,
+    ) -> Result<()> {
         let Some(rl_router) = self.rl_router.clone() else {
-            return;
+            return Ok(());
         };
         let rl_addr = format!("{}:{}", self.host, self.rl_port);
+        // Bind eagerly and fail fast: when RL discovery is enabled, a bind failure
+        // should abort service startup rather than silently leave RL discovery
+        // unavailable while the main HTTP service keeps running.
+        let listener = tokio::net::TcpListener::bind(&rl_addr).await.map_err(|e| {
+            tracing::error!(
+                address = %rl_addr,
+                error = %e,
+                "Failed to bind RL worker discovery listener"
+            );
+            anyhow::anyhow!("Failed to bind RL worker discovery listener on {rl_addr}: {e}")
+        })?;
+        tracing::info!(
+            address = %rl_addr,
+            "RL worker discovery listener started"
+        );
         let rl_cancel = cancel_token.child_token();
         tokio::spawn(async move {
-            match tokio::net::TcpListener::bind(&rl_addr).await {
-                Ok(listener) => {
-                    tracing::info!(
-                        address = %rl_addr,
-                        "RL worker discovery listener started"
-                    );
-                    if let Err(e) = axum::serve(listener, rl_router)
-                        .with_graceful_shutdown(async move {
-                            rl_cancel.cancelled_owned().await;
-                        })
-                        .await
-                    {
-                        tracing::error!("RL worker discovery listener error: {e}");
-                    }
-                }
-                Err(e) => {
-                    tracing::error!(
-                        address = %rl_addr,
-                        error = %e,
-                        "Failed to bind RL worker discovery listener"
-                    );
-                }
+            if let Err(e) = axum::serve(listener, rl_router)
+                .with_graceful_shutdown(async move {
+                    rl_cancel.cancelled_owned().await;
+                })
+                .await
+            {
+                tracing::error!("RL worker discovery listener error: {e}");
             }
         });
+        Ok(())
     }
 
     /// Documentation of exposed HTTP endpoints

--- a/lib/rl/Cargo.toml
+++ b/lib/rl/Cargo.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-rl"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Dynamo RL worker discovery API"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+dynamo-runtime = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dynamo RL worker discovery surface.
+//!
+//! Workers that run with `DYN_ENABLE_RL` / `--enable-rl` register an `rl`
+//! request-plane endpoint:
+//!
+//! ```text
+//! dyn://<namespace>.<component>.rl
+//! ```
+//!
+//! This crate exposes a read-only frontend route. The frontend discovers live
+//! `rl` endpoint instances from Dynamo discovery, then asks each worker for its
+//! available RL admin routes with `{"method": "routes"}` over the request
+//! plane. It does not expose a frontend fan-out method endpoint.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
+use dynamo_runtime::{
+    DistributedRuntime,
+    component::{Client, Instance, TransportType},
+    discovery::{DiscoveryInstance, DiscoveryQuery},
+    pipeline::{
+        SingleIn,
+        network::egress::push_router::{PushRouter, RouterMode},
+    },
+    protocols::annotated::Annotated,
+};
+use futures::{StreamExt, future::join_all};
+
+const DEFAULT_NAMESPACE: &str = "dynamo";
+const DEFAULT_RL_ENDPOINT: &str = "rl";
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+type ModelKey = (String, String, u64);
+
+#[derive(Clone)]
+pub struct RlDiscoveryConfig {
+    pub runtime: Arc<DistributedRuntime>,
+    pub namespace: String,
+    pub rl_endpoint: String,
+    pub component_filter: Option<Vec<String>>,
+    pub request_timeout: Duration,
+}
+
+impl RlDiscoveryConfig {
+    pub fn from_env(runtime: Arc<DistributedRuntime>) -> Self {
+        let namespace = std::env::var("DYN_NAMESPACE").unwrap_or_else(|_| DEFAULT_NAMESPACE.into());
+        let rl_endpoint =
+            std::env::var("DYN_RL_ENDPOINT").unwrap_or_else(|_| DEFAULT_RL_ENDPOINT.into());
+        let component_filter = parse_csv_env("DYN_RL_COMPONENTS")
+            .or_else(|| std::env::var("DYN_RL_COMPONENT").ok().map(|c| vec![c]));
+        let request_timeout = std::env::var("DYN_RL_REQUEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS));
+
+        Self {
+            runtime,
+            namespace,
+            rl_endpoint,
+            component_filter,
+            request_timeout,
+        }
+    }
+}
+
+fn parse_csv_env(name: &str) -> Option<Vec<String>> {
+    let values = std::env::var(name).ok()?;
+    let parsed = values
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    (!parsed.is_empty()).then_some(parsed)
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RlWorkerInfo {
+    pub namespace: String,
+    pub component: String,
+    pub endpoint: String,
+    pub instance_id: u64,
+    pub transport: TransportType,
+    pub request_plane_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub routes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RlWorkersResponse {
+    pub namespace: String,
+    pub workers: Vec<RlWorkerInfo>,
+}
+
+#[derive(Clone)]
+pub struct RlDiscoveryState {
+    config: Arc<RlDiscoveryConfig>,
+}
+
+impl RlDiscoveryState {
+    pub fn new(config: RlDiscoveryConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+pub fn rl_router(state: RlDiscoveryState) -> Router {
+    Router::new()
+        .route("/v1/rl/workers", get(workers_handler))
+        .with_state(state)
+}
+
+async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResponse {
+    match list_workers(&state.config).await {
+        Ok(workers) => Json(RlWorkersResponse {
+            namespace: state.config.namespace.clone(),
+            workers,
+        })
+        .into_response(),
+        Err(err) => {
+            tracing::error!("failed to list RL workers: {err}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "discovery_failed",
+                    "message": err.to_string(),
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn list_workers(config: &RlDiscoveryConfig) -> anyhow::Result<Vec<RlWorkerInfo>> {
+    let endpoint_instances = config
+        .runtime
+        .discovery()
+        .list(DiscoveryQuery::NamespacedEndpoints {
+            namespace: config.namespace.clone(),
+        })
+        .await?;
+
+    let model_instances = config
+        .runtime
+        .discovery()
+        .list(DiscoveryQuery::NamespacedModels {
+            namespace: config.namespace.clone(),
+        })
+        .await
+        .unwrap_or_default();
+
+    let models = model_map(model_instances);
+    let rl_endpoints = endpoint_instances
+        .into_iter()
+        .filter_map(|instance| match instance {
+            DiscoveryInstance::Endpoint(endpoint) => Some(endpoint),
+            _ => None,
+        })
+        .filter(|endpoint| endpoint.endpoint == config.rl_endpoint)
+        .filter(|endpoint| {
+            config
+                .component_filter
+                .as_ref()
+                .map(|components| components.iter().any(|c| c == &endpoint.component))
+                .unwrap_or(true)
+        })
+        .collect::<Vec<_>>();
+
+    let mut workers = join_all(rl_endpoints.into_iter().map(|endpoint| {
+        let runtime = config.runtime.clone();
+        let timeout = config.request_timeout;
+        let model = models
+            .get(&(
+                endpoint.namespace.clone(),
+                endpoint.component.clone(),
+                endpoint.instance_id,
+            ))
+            .cloned();
+        async move { describe_worker(runtime, endpoint, model, timeout).await }
+    }))
+    .await;
+
+    workers.sort_by(|a, b| {
+        (&a.namespace, &a.component, &a.endpoint, a.instance_id).cmp(&(
+            &b.namespace,
+            &b.component,
+            &b.endpoint,
+            b.instance_id,
+        ))
+    });
+
+    workers.dedup_by(|a, b| {
+        a.namespace == b.namespace
+            && a.component == b.component
+            && a.endpoint == b.endpoint
+            && a.instance_id == b.instance_id
+    });
+
+    Ok(workers)
+}
+
+async fn describe_worker(
+    runtime: Arc<DistributedRuntime>,
+    endpoint: Instance,
+    model: Option<String>,
+    timeout: Duration,
+) -> RlWorkerInfo {
+    match call_worker_routes(&runtime, &endpoint, timeout).await {
+        Ok(routes) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
+        Err(err) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
+    }
+}
+
+#[derive(Debug, Default)]
+struct WorkerRoutes {
+    routes: Vec<String>,
+    system_url: Option<String>,
+}
+
+async fn call_worker_routes(
+    runtime: &Arc<DistributedRuntime>,
+    target: &Instance,
+    timeout: Duration,
+) -> anyhow::Result<WorkerRoutes> {
+    let endpoint = runtime
+        .namespace(&target.namespace)?
+        .component(&target.component)?
+        .endpoint(target.endpoint.clone());
+
+    let client = endpoint.client().await?;
+    wait_for_client_targets(&client, &[target.instance_id], Duration::from_secs(5)).await;
+
+    let router = PushRouter::<serde_json::Value, Annotated<serde_json::Value>>::from_client(
+        client,
+        RouterMode::Direct,
+    )
+    .await?;
+
+    let request_value = serde_json::json!({
+        "method": "routes",
+    });
+    let instance_id = target.instance_id;
+
+    let dispatch = async {
+        let request = SingleIn::new(request_value);
+        let mut stream = router.direct(request, instance_id).await?;
+
+        while let Some(chunk) = stream.next().await {
+            if let Some(data) = chunk.data {
+                return parse_worker_routes(data);
+            }
+            if let Some(err) = chunk.error {
+                anyhow::bail!(err.to_string());
+            }
+        }
+
+        anyhow::bail!("empty routes response from worker");
+    };
+
+    tokio::time::timeout(timeout, dispatch)
+        .await
+        .map_err(|_| anyhow::anyhow!("routes request timed out after {}s", timeout.as_secs()))?
+}
+
+async fn wait_for_client_targets(client: &Client, target_ids: &[u64], timeout: Duration) {
+    let wait = async {
+        loop {
+            let ids = client.instance_ids();
+            if target_ids.iter().all(|id| ids.contains(id)) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    };
+    let _ = tokio::time::timeout(timeout, wait).await;
+}
+
+fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes> {
+    if value
+        .get("status")
+        .and_then(|status| status.as_str())
+        .is_some_and(|status| status == "error")
+    {
+        anyhow::bail!(
+            "{}",
+            value
+                .get("message")
+                .and_then(|message| message.as_str())
+                .unwrap_or("worker routes request failed")
+        );
+    }
+
+    let routes = value
+        .get("routes")
+        .and_then(|routes| routes.as_array())
+        .ok_or_else(|| anyhow::anyhow!("worker routes response missing 'routes' array"))?
+        .iter()
+        .filter_map(|route| route.as_str().map(ToString::to_string))
+        .collect::<Vec<_>>();
+
+    let system_url = value
+        .get("system_url")
+        .and_then(|url| url.as_str())
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToString::to_string);
+
+    Ok(WorkerRoutes { routes, system_url })
+}
+
+fn worker_info(
+    endpoint: Instance,
+    model: Option<String>,
+    mut routes: Vec<String>,
+    system_url: Option<String>,
+    error: Option<String>,
+) -> RlWorkerInfo {
+    routes.sort();
+    routes.dedup();
+
+    RlWorkerInfo {
+        request_plane_url: request_plane_url(&endpoint),
+        namespace: endpoint.namespace,
+        component: endpoint.component,
+        endpoint: endpoint.endpoint,
+        instance_id: endpoint.instance_id,
+        transport: endpoint.transport,
+        system_url,
+        model,
+        routes,
+        error,
+    }
+}
+
+fn request_plane_url(endpoint: &Instance) -> String {
+    format!(
+        "dyn://{}.{}.{}",
+        endpoint.namespace, endpoint.component, endpoint.endpoint
+    )
+}
+
+fn model_map(instances: Vec<DiscoveryInstance>) -> HashMap<ModelKey, String> {
+    instances
+        .into_iter()
+        .filter_map(|instance| match instance {
+            DiscoveryInstance::Model {
+                namespace,
+                component,
+                endpoint: _,
+                instance_id,
+                card_json,
+                model_suffix,
+            } if model_suffix.as_ref().is_none_or(|suffix| suffix.is_empty()) => {
+                let model = card_json
+                    .get("display_name")
+                    .and_then(|value| value.as_str())
+                    .map(ToString::to_string);
+                model.map(|name| ((namespace, component, instance_id), name))
+            }
+            _ => None,
+        })
+        .collect()
+}

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -15,7 +15,11 @@
 //! available RL admin routes with `{"method": "routes"}` over the request
 //! plane. It does not expose a frontend fan-out method endpoint.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
 use dynamo_runtime::{
@@ -33,6 +37,9 @@ use futures::{StreamExt, future::join_all};
 const DEFAULT_NAMESPACE: &str = "dynamo";
 const DEFAULT_RL_ENDPOINT: &str = "rl";
 const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+/// Global cap on concurrent per-worker probes (across all in-flight discovery
+/// requests), so a large fleet or many concurrent callers can't fan out without bound.
+const DEFAULT_MAX_CONCURRENT_PROBES: usize = 32;
 
 type ModelKey = (String, String, u64);
 
@@ -43,6 +50,7 @@ pub struct RlDiscoveryConfig {
     pub rl_endpoint: String,
     pub component_filter: Option<Vec<String>>,
     pub request_timeout: Duration,
+    pub max_concurrent_probes: usize,
 }
 
 impl RlDiscoveryConfig {
@@ -57,6 +65,11 @@ impl RlDiscoveryConfig {
             .and_then(|value| value.parse::<u64>().ok())
             .map(Duration::from_secs)
             .unwrap_or_else(|| Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS));
+        let max_concurrent_probes = std::env::var("DYN_RL_MAX_CONCURRENT_PROBES")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_MAX_CONCURRENT_PROBES);
 
         Self {
             runtime,
@@ -64,6 +77,7 @@ impl RlDiscoveryConfig {
             rl_endpoint,
             component_filter,
             request_timeout,
+            max_concurrent_probes,
         }
     }
 }
@@ -112,13 +126,18 @@ pub struct RlDiscoveryState {
     /// Drop cleanup, so building one per request would leak a task per (request*worker).
     /// Cache and reuse one client per endpoint instead.
     clients: Arc<tokio::sync::Mutex<HashMap<EndpointKey, Client>>>,
+    /// Caps concurrent per-worker probes across all in-flight discovery requests,
+    /// so a large fleet (or many concurrent callers) can't fan out without bound.
+    probe_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
 impl RlDiscoveryState {
     pub fn new(config: RlDiscoveryConfig) -> Self {
+        let permits = config.max_concurrent_probes.max(1);
         Self {
             config: Arc::new(config),
             clients: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            probe_semaphore: Arc::new(tokio::sync::Semaphore::new(permits)),
         }
     }
 
@@ -150,6 +169,14 @@ impl RlDiscoveryState {
             .await?;
         guard.insert(key, client.clone());
         Ok(client)
+    }
+
+    /// Drop cached clients for endpoints no longer present, so the cache can't grow
+    /// without bound under endpoint/component churn. Stable components (the common
+    /// case) are always in `live`, so this is a no-op for them.
+    async fn retain_endpoints(&self, live: &HashSet<EndpointKey>) {
+        let mut guard = self.clients.lock().await;
+        guard.retain(|key, _| live.contains(key));
     }
 }
 
@@ -216,6 +243,21 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         })
         .collect::<Vec<_>>();
 
+    // Bound the client cache (N2): drop clients for endpoints that are no longer
+    // present. Live endpoints are retained, so the fan-out below still reuses their
+    // cached clients rather than recreating them.
+    let live_endpoints: HashSet<EndpointKey> = rl_endpoints
+        .iter()
+        .map(|endpoint| {
+            (
+                endpoint.namespace.clone(),
+                endpoint.component.clone(),
+                endpoint.endpoint.clone(),
+            )
+        })
+        .collect();
+    state.retain_endpoints(&live_endpoints).await;
+
     let mut workers = join_all(rl_endpoints.into_iter().map(|endpoint| {
         let state = state.clone();
         let timeout = config.request_timeout;
@@ -255,6 +297,21 @@ async fn describe_worker(
     model: Option<String>,
     timeout: Duration,
 ) -> RlWorkerInfo {
+    // Bound global probe concurrency (N1): acquire a permit before doing any work.
+    // The wait is intentionally outside the per-worker timeout below, so time spent
+    // queued for a permit does not consume the probe's own deadline.
+    let _permit = match state.probe_semaphore.acquire().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            return worker_info(
+                endpoint,
+                model,
+                Vec::new(),
+                None,
+                Some("rl discovery is shutting down".to_string()),
+            );
+        }
+    };
     // Single end-to-end deadline for the whole per-worker probe (client lookup +
     // readiness wait + routes RPC), so total discovery latency stays bounded by
     // request_timeout instead of summing several independent timeouts.

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -174,6 +174,12 @@ impl RlDiscoveryState {
     /// Drop cached clients for endpoints no longer present, so the cache can't grow
     /// without bound under endpoint/component churn. Stable components (the common
     /// case) are always in `live`, so this is a no-op for them.
+    ///
+    /// Note: dropping a `Client` frees its cache slot but does not stop the
+    /// runtime-lived instance-monitor task it spawned — the `dynamo-runtime` `Client`
+    /// has no per-client cancellation/`Drop`. For RL discovery the live endpoint set is
+    /// small and stable, so this is bounded in practice; fully reclaiming the monitor
+    /// task on drop is a runtime `Client` lifecycle change tracked outside this crate.
     async fn retain_endpoints(&self, live: &HashSet<EndpointKey>) {
         let mut guard = self.clients.lock().await;
         guard.retain(|key, _| live.contains(key));
@@ -297,25 +303,18 @@ async fn describe_worker(
     model: Option<String>,
     timeout: Duration,
 ) -> RlWorkerInfo {
-    // Bound global probe concurrency (N1): acquire a permit before doing any work.
-    // The wait is intentionally outside the per-worker timeout below, so time spent
-    // queued for a permit does not consume the probe's own deadline.
-    let _permit = match state.probe_semaphore.acquire().await {
-        Ok(permit) => permit,
-        Err(_) => {
-            return worker_info(
-                endpoint,
-                model,
-                Vec::new(),
-                None,
-                Some("rl discovery is shutting down".to_string()),
-            );
-        }
+    // Bound the whole per-worker probe — INCLUDING the wait for a global concurrency
+    // permit (N1) — by request_timeout, so neither a slow worker nor a saturated
+    // semaphore can make per-worker latency unbounded (true end-to-end deadline, F2).
+    let probe = async {
+        let _permit = state
+            .probe_semaphore
+            .acquire()
+            .await
+            .map_err(|_| anyhow::anyhow!("rl discovery is shutting down"))?;
+        call_worker_routes(state, &endpoint, timeout).await
     };
-    // Single end-to-end deadline for the whole per-worker probe (client lookup +
-    // readiness wait + routes RPC), so total discovery latency stays bounded by
-    // request_timeout instead of summing several independent timeouts.
-    match tokio::time::timeout(timeout, call_worker_routes(state, &endpoint, timeout)).await {
+    match tokio::time::timeout(timeout, probe).await {
         Ok(Ok(routes)) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
         Ok(Err(err)) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
         Err(_) => worker_info(

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -239,7 +239,10 @@ async fn call_worker_routes(
         .endpoint(target.endpoint.clone());
 
     let client = endpoint.client().await?;
-    wait_for_client_targets(&client, &[target.instance_id], Duration::from_secs(5)).await;
+    // Bound the readiness wait by the configured request timeout (capped at 5s so a
+    // large request_timeout doesn't block discovery on a single slow-to-register worker).
+    let readiness_timeout = timeout.min(Duration::from_secs(5));
+    wait_for_client_targets(&client, &[target.instance_id], readiness_timeout).await?;
 
     let router = PushRouter::<serde_json::Value, Annotated<serde_json::Value>>::from_client(
         client,
@@ -273,7 +276,11 @@ async fn call_worker_routes(
         .map_err(|_| anyhow::anyhow!("routes request timed out after {}s", timeout.as_secs()))?
 }
 
-async fn wait_for_client_targets(client: &Client, target_ids: &[u64], timeout: Duration) {
+async fn wait_for_client_targets(
+    client: &Client,
+    target_ids: &[u64],
+    timeout: Duration,
+) -> anyhow::Result<()> {
     let wait = async {
         loop {
             let ids = client.instance_ids();
@@ -283,7 +290,12 @@ async fn wait_for_client_targets(client: &Client, target_ids: &[u64], timeout: D
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
     };
-    let _ = tokio::time::timeout(timeout, wait).await;
+    tokio::time::timeout(timeout, wait).await.map_err(|_| {
+        anyhow::anyhow!(
+            "timed out after {}s waiting for worker instance(s) to become discoverable",
+            timeout.as_secs()
+        )
+    })
 }
 
 fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes> {

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -102,16 +102,54 @@ pub struct RlWorkersResponse {
     pub workers: Vec<RlWorkerInfo>,
 }
 
+type EndpointKey = (String, String, String);
+
 #[derive(Clone)]
 pub struct RlDiscoveryState {
     config: Arc<RlDiscoveryConfig>,
+    /// Cache of request-plane clients keyed by (namespace, component, endpoint).
+    /// A `Client` spawns a runtime-lived instance-monitor task and has no per-client
+    /// Drop cleanup, so building one per request would leak a task per (request*worker).
+    /// Cache and reuse one client per endpoint instead.
+    clients: Arc<tokio::sync::Mutex<HashMap<EndpointKey, Client>>>,
 }
 
 impl RlDiscoveryState {
     pub fn new(config: RlDiscoveryConfig) -> Self {
         Self {
             config: Arc::new(config),
+            clients: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Get (or lazily create and cache) the request-plane client for an endpoint.
+    /// The lock is held across creation so concurrent fan-out for the same endpoint
+    /// creates exactly one client (cloning a `Client` shares its monitor task).
+    async fn client_for(
+        &self,
+        namespace: &str,
+        component: &str,
+        endpoint: &str,
+    ) -> anyhow::Result<Client> {
+        let key = (
+            namespace.to_string(),
+            component.to_string(),
+            endpoint.to_string(),
+        );
+        let mut guard = self.clients.lock().await;
+        if let Some(client) = guard.get(&key) {
+            return Ok(client.clone());
+        }
+        let client = self
+            .config
+            .runtime
+            .namespace(namespace)?
+            .component(component)?
+            .endpoint(endpoint.to_string())
+            .client()
+            .await?;
+        guard.insert(key, client.clone());
+        Ok(client)
     }
 }
 
@@ -122,7 +160,7 @@ pub fn rl_router(state: RlDiscoveryState) -> Router {
 }
 
 async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResponse {
-    match list_workers(&state.config).await {
+    match list_workers(&state).await {
         Ok(workers) => Json(RlWorkersResponse {
             namespace: state.config.namespace.clone(),
             workers,
@@ -142,7 +180,8 @@ async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResp
     }
 }
 
-async fn list_workers(config: &RlDiscoveryConfig) -> anyhow::Result<Vec<RlWorkerInfo>> {
+async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerInfo>> {
+    let config = &state.config;
     let endpoint_instances = config
         .runtime
         .discovery()
@@ -178,7 +217,7 @@ async fn list_workers(config: &RlDiscoveryConfig) -> anyhow::Result<Vec<RlWorker
         .collect::<Vec<_>>();
 
     let mut workers = join_all(rl_endpoints.into_iter().map(|endpoint| {
-        let runtime = config.runtime.clone();
+        let state = state.clone();
         let timeout = config.request_timeout;
         let model = models
             .get(&(
@@ -187,7 +226,7 @@ async fn list_workers(config: &RlDiscoveryConfig) -> anyhow::Result<Vec<RlWorker
                 endpoint.instance_id,
             ))
             .cloned();
-        async move { describe_worker(runtime, endpoint, model, timeout).await }
+        async move { describe_worker(&state, endpoint, model, timeout).await }
     }))
     .await;
 
@@ -211,14 +250,27 @@ async fn list_workers(config: &RlDiscoveryConfig) -> anyhow::Result<Vec<RlWorker
 }
 
 async fn describe_worker(
-    runtime: Arc<DistributedRuntime>,
+    state: &RlDiscoveryState,
     endpoint: Instance,
     model: Option<String>,
     timeout: Duration,
 ) -> RlWorkerInfo {
-    match call_worker_routes(&runtime, &endpoint, timeout).await {
-        Ok(routes) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
-        Err(err) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
+    // Single end-to-end deadline for the whole per-worker probe (client lookup +
+    // readiness wait + routes RPC), so total discovery latency stays bounded by
+    // request_timeout instead of summing several independent timeouts.
+    match tokio::time::timeout(timeout, call_worker_routes(state, &endpoint, timeout)).await {
+        Ok(Ok(routes)) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
+        Ok(Err(err)) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
+        Err(_) => worker_info(
+            endpoint,
+            model,
+            Vec::new(),
+            None,
+            Some(format!(
+                "worker discovery timed out after {}s",
+                timeout.as_secs()
+            )),
+        ),
     }
 }
 
@@ -229,18 +281,19 @@ struct WorkerRoutes {
 }
 
 async fn call_worker_routes(
-    runtime: &Arc<DistributedRuntime>,
+    state: &RlDiscoveryState,
     target: &Instance,
     timeout: Duration,
 ) -> anyhow::Result<WorkerRoutes> {
-    let endpoint = runtime
-        .namespace(&target.namespace)?
-        .component(&target.component)?
-        .endpoint(target.endpoint.clone());
+    // Reuse a cached client per endpoint instead of constructing one per worker/request
+    // (a fresh client leaks a runtime-lived monitor task — see RlDiscoveryState::client_for).
+    let client = state
+        .client_for(&target.namespace, &target.component, &target.endpoint)
+        .await?;
 
-    let client = endpoint.client().await?;
-    // Bound the readiness wait by the configured request timeout (capped at 5s so a
-    // large request_timeout doesn't block discovery on a single slow-to-register worker).
+    // Bound the readiness wait by the configured request timeout (capped at 5s so a large
+    // request_timeout doesn't block discovery on a single slow-to-register worker). The
+    // caller (describe_worker) also enforces the overall request_timeout deadline.
     let readiness_timeout = timeout.min(Duration::from_secs(5));
     wait_for_client_targets(&client, &[target.instance_id], readiness_timeout).await?;
 
@@ -255,25 +308,19 @@ async fn call_worker_routes(
     });
     let instance_id = target.instance_id;
 
-    let dispatch = async {
-        let request = SingleIn::new(request_value);
-        let mut stream = router.direct(request, instance_id).await?;
+    let request = SingleIn::new(request_value);
+    let mut stream = router.direct(request, instance_id).await?;
 
-        while let Some(chunk) = stream.next().await {
-            if let Some(data) = chunk.data {
-                return parse_worker_routes(data);
-            }
-            if let Some(err) = chunk.error {
-                anyhow::bail!(err.to_string());
-            }
+    while let Some(chunk) = stream.next().await {
+        if let Some(data) = chunk.data {
+            return parse_worker_routes(data);
         }
+        if let Some(err) = chunk.error {
+            anyhow::bail!(err.to_string());
+        }
+    }
 
-        anyhow::bail!("empty routes response from worker");
-    };
-
-    tokio::time::timeout(timeout, dispatch)
-        .await
-        .map_err(|_| anyhow::anyhow!("routes request timed out after {}s", timeout.as_secs()))?
+    anyhow::bail!("empty routes response from worker")
 }
 
 async fn wait_for_client_targets(
@@ -313,13 +360,22 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
         );
     }
 
-    let routes = value
+    let routes_array = value
         .get("routes")
         .and_then(|routes| routes.as_array())
-        .ok_or_else(|| anyhow::anyhow!("worker routes response missing 'routes' array"))?
-        .iter()
-        .filter_map(|route| route.as_str().map(ToString::to_string))
-        .collect::<Vec<_>>();
+        .ok_or_else(|| anyhow::anyhow!("worker routes response missing 'routes' array"))?;
+    let mut routes = Vec::with_capacity(routes_array.len());
+    for route in routes_array {
+        // Surface a protocol error for malformed entries instead of silently dropping
+        // them (which would report a truncated capability list as success).
+        let name = route.as_str().ok_or_else(|| {
+            anyhow::anyhow!("worker routes response contains a non-string route entry")
+        })?;
+        if name.is_empty() {
+            anyhow::bail!("worker routes response contains an empty route entry");
+        }
+        routes.push(name.to_string());
+    }
 
     let system_url = value
         .get("system_url")
@@ -363,24 +419,168 @@ fn request_plane_url(endpoint: &Instance) -> String {
 }
 
 fn model_map(instances: Vec<DiscoveryInstance>) -> HashMap<ModelKey, String> {
-    instances
+    // A worker registers its model under its serving endpoint (e.g. "generate"), not the
+    // "rl" endpoint, so association is by (namespace, component, instance_id) and intentionally
+    // ignores the model's own endpoint. If one instance advertises multiple distinct base
+    // models we cannot pick one safely, so omit it rather than report an arbitrary/wrong model.
+    let mut by_key: HashMap<ModelKey, std::collections::BTreeSet<String>> = HashMap::new();
+    for instance in instances {
+        if let DiscoveryInstance::Model {
+            namespace,
+            component,
+            endpoint: _,
+            instance_id,
+            card_json,
+            model_suffix,
+        } = instance
+            && model_suffix.as_ref().is_none_or(|suffix| suffix.is_empty())
+            && let Some(name) = card_json
+                .get("display_name")
+                .and_then(|value| value.as_str())
+        {
+            by_key
+                .entry((namespace, component, instance_id))
+                .or_default()
+                .insert(name.to_string());
+        }
+    }
+    by_key
         .into_iter()
-        .filter_map(|instance| match instance {
-            DiscoveryInstance::Model {
-                namespace,
-                component,
-                endpoint: _,
-                instance_id,
-                card_json,
-                model_suffix,
-            } if model_suffix.as_ref().is_none_or(|suffix| suffix.is_empty()) => {
-                let model = card_json
-                    .get("display_name")
-                    .and_then(|value| value.as_str())
-                    .map(ToString::to_string);
-                model.map(|name| ((namespace, component, instance_id), name))
-            }
+        .filter_map(|(key, names)| match names.len() {
+            1 => names.into_iter().next().map(|name| (key, name)),
             _ => None,
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn model_instance(
+        namespace: &str,
+        component: &str,
+        endpoint: &str,
+        instance_id: u64,
+        display_name: &str,
+        model_suffix: Option<&str>,
+    ) -> DiscoveryInstance {
+        DiscoveryInstance::Model {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            endpoint: endpoint.to_string(),
+            instance_id,
+            card_json: json!({ "display_name": display_name }),
+            model_suffix: model_suffix.map(ToString::to_string),
+        }
+    }
+
+    #[test]
+    fn parse_worker_routes_accepts_valid_payload() {
+        let parsed = parse_worker_routes(json!({
+            "routes": ["pause_generation", "resume_generation"],
+            "system_url": "  http://worker:8080  ",
+        }))
+        .expect("valid payload");
+        let routes: Vec<&str> = parsed.routes.iter().map(String::as_str).collect();
+        assert_eq!(routes, ["pause_generation", "resume_generation"]);
+        // system_url is trimmed.
+        assert_eq!(parsed.system_url.as_deref(), Some("http://worker:8080"));
+    }
+
+    #[test]
+    fn parse_worker_routes_blank_system_url_is_none() {
+        let parsed = parse_worker_routes(json!({ "routes": [], "system_url": "   " }))
+            .expect("valid payload");
+        assert!(parsed.routes.is_empty());
+        assert!(parsed.system_url.is_none());
+    }
+
+    #[test]
+    fn parse_worker_routes_requires_routes_array() {
+        let err = parse_worker_routes(json!({ "system_url": "http://x" })).unwrap_err();
+        assert!(err.to_string().contains("missing 'routes' array"));
+    }
+
+    #[test]
+    fn parse_worker_routes_rejects_non_string_entry() {
+        // Must surface a protocol error, not silently drop the bad entry (finding F4).
+        let err = parse_worker_routes(json!({ "routes": ["pause", 7] })).unwrap_err();
+        assert!(err.to_string().contains("non-string route entry"));
+    }
+
+    #[test]
+    fn parse_worker_routes_rejects_empty_entry() {
+        let err = parse_worker_routes(json!({ "routes": ["pause", ""] })).unwrap_err();
+        assert!(err.to_string().contains("empty route entry"));
+    }
+
+    #[test]
+    fn parse_worker_routes_propagates_worker_error_status() {
+        let err = parse_worker_routes(json!({ "status": "error", "message": "engine is dead" }))
+            .unwrap_err();
+        assert!(err.to_string().contains("engine is dead"));
+    }
+
+    #[test]
+    fn model_map_associates_single_model_ignoring_endpoint() {
+        let map = model_map(vec![model_instance(
+            "dynamo",
+            "backend",
+            "generate",
+            1,
+            "Qwen/Qwen3-0.6B",
+            None,
+        )]);
+        assert_eq!(
+            map.get(&("dynamo".to_string(), "backend".to_string(), 1u64))
+                .map(String::as_str),
+            Some("Qwen/Qwen3-0.6B")
+        );
+    }
+
+    #[test]
+    fn model_map_omits_instance_with_conflicting_models() {
+        // One instance advertising two distinct base models must be omitted, not
+        // arbitrarily resolved to one of them (finding F5).
+        let map = model_map(vec![
+            model_instance("dynamo", "backend", "generate", 1, "Qwen/Qwen3-0.6B", None),
+            model_instance(
+                "dynamo",
+                "backend",
+                "embed",
+                1,
+                "Qwen/Qwen3-Embedding-4B",
+                None,
+            ),
+        ]);
+        assert!(!map.contains_key(&("dynamo".to_string(), "backend".to_string(), 1u64)));
+    }
+
+    #[test]
+    fn model_map_dedupes_identical_model_across_endpoints() {
+        let map = model_map(vec![
+            model_instance("dynamo", "backend", "generate", 1, "Qwen/Qwen3-0.6B", None),
+            model_instance("dynamo", "backend", "rl", 1, "Qwen/Qwen3-0.6B", None),
+        ]);
+        assert_eq!(
+            map.get(&("dynamo".to_string(), "backend".to_string(), 1u64))
+                .map(String::as_str),
+            Some("Qwen/Qwen3-0.6B")
+        );
+    }
+
+    #[test]
+    fn model_map_skips_lora_suffix_entries() {
+        let map = model_map(vec![model_instance(
+            "dynamo",
+            "backend",
+            "generate",
+            1,
+            "adapter",
+            Some("lora-1"),
+        )]);
+        assert!(map.is_empty());
+    }
 }

--- a/tests/rl/__init__.py
+++ b/tests/rl/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/rl/test_worker_discovery.py
+++ b/tests/rl/test_worker_discovery.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke coverage for Dynamo RL worker discovery and direct admin routes."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from typing import Any, Generator
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+import requests
+
+from tests.utils.constants import QWEN
+from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
+from tests.utils.payloads import check_models_api
+from tests.utils.port_utils import ServicePorts, allocate_port, deallocate_port
+
+TEST_MODEL = QWEN
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.e2e,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_1,
+    pytest.mark.model(TEST_MODEL),
+]
+
+
+def _check_ready(response: requests.Response) -> bool:
+    try:
+        return (response.json() or {}).get("status") == "ready"
+    except ValueError:
+        return False
+
+
+def _check_model_registered(response: requests.Response) -> bool:
+    if not check_models_api(response):
+        return False
+    data = response.json()
+    return any(model.get("id") == TEST_MODEL for model in data.get("data", []))
+
+
+def _status_is_ok(payload: dict[str, Any]) -> bool:
+    return payload.get("status") in {"ok", "success"}
+
+
+def _post_json(
+    url: str, payload: dict[str, Any], *, timeout: int = 60
+) -> dict[str, Any]:
+    response = requests.post(url, json=payload, timeout=timeout)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert isinstance(data, dict), data
+    return data
+
+
+def _http_status(url: str) -> int:
+    try:
+        return requests.get(url, timeout=10).status_code
+    except requests.RequestException:
+        return 0
+
+
+def _normalize_local_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.hostname not in {"0.0.0.0", "::"}:
+        return url.rstrip("/")
+
+    netloc = "localhost"
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc)).rstrip("/")
+
+
+def _process_env(**extra: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("HF_HUB_OFFLINE", "1")
+    env.setdefault("TRANSFORMERS_OFFLINE", "1")
+    env["DYN_LOG"] = "debug"
+    env["DYN_NAMESPACE"] = "dynamo"
+    env.update(extra)
+    return env
+
+
+def _prepare_log_dir(request: pytest.FixtureRequest, suffix: str) -> str:
+    log_dir = f"{request.node.name}_{suffix}"
+    shutil.rmtree(log_dir, ignore_errors=True)
+    return log_dir
+
+
+class RLVllmWorkerProcess(ManagedProcess):
+    def __init__(
+        self,
+        request: pytest.FixtureRequest,
+        *,
+        frontend_port: int,
+        system_port: int,
+    ):
+        env = _process_env(
+            DYN_ENABLE_RL="true",
+            DYN_SYSTEM_PORT=str(system_port),
+            DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS='["generate"]',
+        )
+
+        super().__init__(
+            command=[
+                "python3",
+                "-m",
+                "dynamo.vllm",
+                "--model",
+                TEST_MODEL,
+                "--enforce-eager",
+                "--max-model-len",
+                "2048",
+                "--max-num-seqs",
+                "2",
+                "--enable-rl",
+                "--worker-extension-cls",
+                "tests.rl.weight_update_worker.DynamoRLTestWorkerExtension",
+            ],
+            env=env,
+            health_check_urls=[
+                (f"http://localhost:{system_port}/health", _check_ready),
+                (
+                    f"http://localhost:{frontend_port}/v1/models",
+                    _check_model_registered,
+                ),
+            ],
+            timeout=600,
+            display_output=True,
+            terminate_all_matching_process_names=False,
+            straggler_commands=["-m dynamo.vllm"],
+            log_dir=_prepare_log_dir(request, "rl-vllm-worker"),
+            display_name="rl-vllm-worker",
+        )
+
+
+@pytest.fixture(scope="function")
+def rl_discovery_port() -> Generator[int, None, None]:
+    port = allocate_port(8001)
+    try:
+        yield port
+    finally:
+        deallocate_port(port)
+
+
+@pytest.fixture(scope="function")
+def start_rl_services(
+    request: pytest.FixtureRequest,
+    runtime_services_dynamic_ports: object,
+    dynamo_dynamic_ports: ServicePorts,
+    rl_discovery_port: int,
+    predownload_models: object,
+) -> Generator[tuple[int, int, int], None, None]:
+    _ = runtime_services_dynamic_ports, predownload_models
+    frontend_port = dynamo_dynamic_ports.frontend_port
+    system_port = dynamo_dynamic_ports.system_ports[0]
+
+    with DynamoFrontendProcess(
+        request,
+        frontend_port=frontend_port,
+        extra_env=_process_env(
+            DYN_ENABLE_RL="true",
+            DYN_RL_PORT=str(rl_discovery_port),
+        ),
+        terminate_all_matching_process_names=False,
+        display_name="rl-frontend",
+    ):
+        with RLVllmWorkerProcess(
+            request,
+            frontend_port=frontend_port,
+            system_port=system_port,
+        ):
+            yield frontend_port, rl_discovery_port, system_port
+
+
+def _wait_for_discovered_worker(
+    *, rl_port: int, timeout_s: int = 180
+) -> tuple[dict[str, Any], str]:
+    deadline = time.monotonic() + timeout_s
+    last_response = ""
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(
+                f"http://localhost:{rl_port}/v1/rl/workers",
+                timeout=10,
+            )
+            last_response = response.text
+            if response.status_code == 200:
+                data = response.json()
+                for worker in data.get("workers", []):
+                    system_url = worker.get("system_url")
+                    if system_url:
+                        return worker, _normalize_local_url(system_url)
+        except requests.RequestException as exc:
+            last_response = str(exc)
+        time.sleep(3)
+
+    raise AssertionError(
+        "Timed out waiting for an RL worker with system_url from "
+        f"/v1/rl/workers. Last response: {last_response}"
+    )
+
+
+@pytest.mark.timeout(900)
+def test_rl_worker_discovery_and_engine_admin_routes(
+    start_rl_services, tmp_path
+) -> None:
+    frontend_port, rl_port, _system_port = start_rl_services
+    worker, admin_url = _wait_for_discovered_worker(rl_port=rl_port)
+
+    assert worker["endpoint"] == "rl"
+    assert worker["request_plane_url"] == "dyn://dynamo.backend.rl"
+    assert worker["system_url"]
+    assert worker.get("model") == TEST_MODEL
+
+    routes = set(worker.get("routes", []))
+    assert {
+        "liveness_probe",
+        "pause_generation",
+        "resume_generation",
+        "get_weight_version",
+        "update_weights_from_disk",
+        "update_weights_from_distributed",
+        "init_weights_update_group",
+        "destroy_weights_update_group",
+    }.issubset(routes)
+    assert "load_lora" not in routes
+    assert "unload_lora" not in routes
+
+    assert _http_status(f"http://localhost:{rl_port}/v1/rl/engine") in {404, 405}
+    assert _http_status(f"http://localhost:{rl_port}/v1/rl/engines") in {404, 405}
+    assert _http_status(f"http://localhost:{frontend_port}/v1/rl/workers") in {
+        404,
+        405,
+    }
+
+    liveness = _post_json(f"{admin_url}/engine/liveness_probe", {})
+    assert _status_is_ok(liveness)
+
+    pause = _post_json(
+        f"{admin_url}/engine/pause_generation",
+        {"mode": "keep", "clear_cache": False},
+    )
+    assert _status_is_ok(pause)
+
+    update = _post_json(
+        f"{admin_url}/engine/update_weights_from_disk",
+        {
+            "model_path": str(tmp_path),
+            "weight_version": "smoke_v1",
+            "engine_rpc": "update_weights_from_path",
+        },
+        timeout=300,
+    )
+    assert _status_is_ok(update)
+
+    version = _post_json(f"{admin_url}/engine/get_weight_version", {})
+    assert version.get("version", version.get("weight_version")) == "smoke_v1"
+
+    resume = _post_json(f"{admin_url}/engine/resume_generation", {})
+    assert _status_is_ok(resume)
+
+    inference = requests.post(
+        f"http://localhost:{frontend_port}/v1/chat/completions",
+        json={
+            "model": TEST_MODEL,
+            "messages": [{"role": "user", "content": "Say: hello"}],
+            "max_tokens": 8,
+            "stream": False,
+            "nvext": {"extra_fields": ["engine_data"]},
+        },
+        timeout=60,
+    )
+    assert inference.status_code == 200, inference.text
+    assert inference.json().get("choices")

--- a/tests/rl/test_worker_discovery.py
+++ b/tests/rl/test_worker_discovery.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import time
 from typing import Any, Generator
 from urllib.parse import urlparse, urlunparse
@@ -22,12 +21,17 @@ from tests.utils.port_utils import ServicePorts, allocate_port, deallocate_port
 TEST_MODEL = QWEN
 
 pytestmark = [
-    pytest.mark.pre_merge,
+    # Heavy e2e (model startup + admin flows, timeout 900s): keep out of pre-merge gating.
+    pytest.mark.post_merge,
     pytest.mark.e2e,
     pytest.mark.vllm,
     pytest.mark.core,
     pytest.mark.gpu_1,
     pytest.mark.model(TEST_MODEL),
+    # VRAM/KV budget so CI schedulers can place this model-loading test.
+    # Mirrors the vLLM Qwen3-0.6B e2e values in tests/router/test_router_e2e_with_vllm.py.
+    pytest.mark.profiled_vram_gib(6.9),
+    pytest.mark.requested_vllm_kv_cache_bytes(331_801_000),
 ]
 
 
@@ -88,9 +92,12 @@ def _process_env(**extra: str) -> dict[str, str]:
 
 
 def _prepare_log_dir(request: pytest.FixtureRequest, suffix: str) -> str:
-    log_dir = f"{request.node.name}_{suffix}"
-    shutil.rmtree(log_dir, ignore_errors=True)
-    return log_dir
+    # Use pytest's per-test temp dir instead of a repo-relative path so process logs
+    # never land in the repo tree and never collide across parallel runs.
+    tmp_path = request.getfixturevalue("tmp_path")
+    log_dir = tmp_path / suffix
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return str(log_dir)
 
 
 class RLVllmWorkerProcess(ManagedProcess):

--- a/tests/rl/weight_update_worker.py
+++ b/tests/rl/weight_update_worker.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamo-local vLLM worker extension used by RL discovery tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_worker import Worker
+else:
+    Worker = object
+
+
+class DynamoRLTestWorkerExtension(Worker):
+    """Minimal extension for exercising RL admin collective RPC plumbing.
+
+    Production RL integrations can provide real filesystem or NCCL weight loading.
+    The Dynamo pytest suite only needs to verify that the worker admin route reaches
+    a vLLM worker extension without depending on an external RL framework package.
+    """
+
+    def init_broadcaster(self, **_: object) -> None:
+        return None
+
+    def destroy_broadcaster(self, **_: object) -> None:
+        return None
+
+    def liveness_probe(self) -> None:
+        return None
+
+    def update_weights_from_path(self, weight_path: str) -> None:
+        assert weight_path
+        return None

--- a/tests/rl/weight_update_worker.py
+++ b/tests/rl/weight_update_worker.py
@@ -31,5 +31,6 @@ class DynamoRLTestWorkerExtension(Worker):
         return None
 
     def update_weights_from_path(self, weight_path: str) -> None:
-        assert weight_path
+        if not weight_path:
+            raise ValueError("weight_path must be a non-empty string")
         return None


### PR DESCRIPTION
## Overview

Adds the frontend worker discovery surface for RL frameworks. This is stacked on the worker-side RL admin routes PR and exposes only `GET /v1/rl/workers`; admin execution remains direct-to-worker through `workers[*].system_url` and `/engine/<route>`.

## Changes

- Add the `dynamo-rl` crate with read-only `GET /v1/rl/workers`.
- Discover live `dyn://<namespace>.<component>.rl` instances and query them with `{"method":"routes"}`.
- Wire the frontend dedicated RL discovery listener through `DYN_ENABLE_RL=true` and `DYN_RL_PORT` defaulting to `8001`.
- Add focused vLLM E2E pytest coverage for discovery plus direct worker `/engine/*` admin calls.

## Validation

- `cargo check -p dynamo-rl`
- `cargo check -p dynamo-llm`
- `.venv/bin/python -m pytest tests/rl/test_worker_discovery.py::test_rl_worker_discovery_and_engine_admin_routes -q`
- Prime-rl full-weight filesystem E2E passed in `/home/biswaranjanp/dev/rl/work/bis-dev/may-18/fullweight-fs-e2e-simple`

## Notes
supersedes https://github.com/ai-dynamo/dynamo/pull/9382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RL worker discovery API enabling discovery of live worker instances via `/v1/rl/workers` endpoint
  * HTTP service now supports configurable RL discovery listener on a separate port
  * Worker metadata includes routes, component information, and optional model names

* **Tests**
  * Added end-to-end tests for RL worker discovery and engine admin routes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->