### PR TITLE
feat(planner): AIC closed-loop optimizer

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -116,6 +116,20 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     decode_engine_gpu_power_limit: int = 300  # watts per GPU, decode replicas
     power_agent_safe_default_watts: Optional[int] = None
 
+    # AIC optimizer (Phase 3+, disabled by default)
+    enable_aic_optimizer: bool = False
+    aic_reoptimize_interval: int = 300  # seconds between AIC sweeps
+    aic_drift_relative_threshold: float = 0.15  # fraction before re-sweep triggers
+    aic_drift_consecutive_ticks: int = 3  # ticks of sustained signal needed
+    # Cold-start values for per-component power coefficients (Phase 3+).
+    aic_initial_c_power_prefill: float = 1.0
+    aic_initial_c_power_decode: float = 1.0
+    aic_initial_c_power_agg: float = 1.0
+    aic_initial_c_ttft: float = 1.0
+    aic_initial_c_itl: float = 1.0
+    aic_max_consecutive_failures: int = 5
+    aic_throughput_regression_warn_threshold: float = 0.10
+
 
 class SubComponentType(str, Enum):
     PREFILL = "prefill"

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -283,6 +283,85 @@ class PlannerConfig(BaseModel):
         ),
     )
 
+    # --- AIC optimizer (Phase 3+) ---
+    enable_aic_optimizer: bool = Field(default=False)
+    aic_system: Optional[str] = Field(
+        default=None,
+        description="AIC system identifier (e.g. 'h200_sxm'). Falls back to aic_interpolation.system.",
+    )
+    aic_reoptimize_interval: int = Field(
+        default=SLAPlannerDefaults.aic_reoptimize_interval
+    )
+    aic_drift_relative_threshold: float = Field(
+        default=SLAPlannerDefaults.aic_drift_relative_threshold, ge=0.0
+    )
+    aic_drift_consecutive_ticks: int = Field(
+        default=SLAPlannerDefaults.aic_drift_consecutive_ticks, ge=1
+    )
+    aic_initial_c_power_prefill: float = Field(
+        default=SLAPlannerDefaults.aic_initial_c_power_prefill,
+        description="Cold-start c_power_p (disagg prefill side). H200 dense: ~1.05.",
+    )
+    aic_initial_c_power_decode: float = Field(
+        default=SLAPlannerDefaults.aic_initial_c_power_decode,
+        description="Cold-start c_power_d (disagg decode side). H200 dense: ~1.15.",
+    )
+    aic_initial_c_power_agg: float = Field(
+        default=SLAPlannerDefaults.aic_initial_c_power_agg,
+        description="Cold-start c_power_agg (aggregated mode only).",
+    )
+    aic_initial_c_ttft: float = Field(
+        default=SLAPlannerDefaults.aic_initial_c_ttft,
+        description="Cold-start c_ttft before live data arrives.",
+    )
+    aic_initial_c_itl: float = Field(
+        default=SLAPlannerDefaults.aic_initial_c_itl,
+        description="Cold-start c_itl before live data arrives.",
+    )
+    aic_max_consecutive_failures: int = Field(
+        default=SLAPlannerDefaults.aic_max_consecutive_failures, ge=1
+    )
+    aic_throughput_regression_warn_threshold: float = Field(
+        default=SLAPlannerDefaults.aic_throughput_regression_warn_threshold,
+        ge=0.0,
+        le=1.0,
+    )
+
+    # --- Frontend admission coupling (Phase 3+) ---
+    admission_mode: Literal["off", "inherit", "autoset"] = Field(
+        default="off",
+        description=(
+            "Frontend /busy_threshold coupling. 'off' never POSTs; 'inherit' "
+            "computes implied thresholds and emits Prometheus gauges only; "
+            "'autoset' POSTs implied thresholds after every config change."
+        ),
+    )
+    admission_safety_margin: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Multiplier applied to implied thresholds before POST in autoset mode. "
+            "Lower values shed earlier (more headroom for queueing variance)."
+        ),
+    )
+    frontend_http_port: int = Field(
+        default=8000,
+        ge=1,
+        le=65535,
+        description=(
+            "Legacy fallback port for /busy_threshold POST in autoset "
+            "admission mode. The planner now reads each frontend pod's "
+            "actual HTTP port from V1Pod.spec.containers[].ports[name=http] "
+            "(emitted by the operator since v1.x — see "
+            "deploy/operator/internal/consts/consts.go DynamoContainerPortName). "
+            "This config field is consulted only when the named port is "
+            "missing from the pod spec, which covers hand-rolled DGDs and "
+            "manifests authored before the operator's named-port standardization. "
+            "Default 8000 matches the operator's DynamoServicePort."
+        ),
+    )
+
     # Diagnostics report settings
     report_interval_hours: Optional[float] = Field(
         default=24.0,
@@ -356,6 +435,23 @@ class PlannerConfig(BaseModel):
                     "the Power Agent applies on a fresh GPU (no prior cap) when "
                     "annotation parsing fails. Recommended: ~70%% of SKU TDP "
                     "(e.g. 500W on H200 SXM)."
+                )
+
+        # AIC optimizer validation (Phase 3)
+        if self.enable_aic_optimizer:
+            if self.aic_interpolation is None:
+                raise ValueError(
+                    "enable_aic_optimizer=True requires aic_interpolation to be set. "
+                    "AICInterpolationSpec carries the AIC model/system/backend and the "
+                    "picked TP configs that constrain the optimizer sweep. "
+                    "In rapid mode, the profiler writes this to the planner ConfigMap. "
+                    "See AICInterpolationSpec for required fields."
+                )
+            if not self.enable_power_awareness:
+                raise ValueError(
+                    "enable_aic_optimizer=True requires enable_power_awareness=True. "
+                    "The AIC optimizer derives and applies per-GPU power caps; those "
+                    "caps only take effect when power awareness is enabled."
                 )
 
         if self.environment == "global-planner" and not self.global_planner_namespace:

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -55,6 +56,10 @@ from dynamo.planner.offline.trace_data import extract_metrics_from_mooncake
 if TYPE_CHECKING:
     from dynamo.common.forward_pass_metrics import ForwardPassMetrics
     from dynamo.llm import FpmEventSubscriber
+    from dynamo.planner.monitoring.aic_power_optimizer import (
+        AICPowerOptimizer,
+        PowerAwareConfig,
+    )
 
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -188,6 +193,9 @@ class NativePlannerBase:
         # Live dashboard runner (started in _async_init)
         self._dashboard_runner: Optional[aiohttp.web.AppRunner] = None
 
+        # AIC closed-loop optimizer (Phase 3; None when disabled or not configured).
+        self._aic_optimizer: Optional["AICPowerOptimizer"] = None
+
         # State machine (created after WorkerInfo is resolved)
         self._state_machine: Optional[PlannerStateMachine] = None
 
@@ -289,6 +297,27 @@ class NativePlannerBase:
             )
 
         await self._bootstrap_regression()
+
+        # AIC optimizer startup sweep (Phase 3).
+        if self.config.enable_aic_optimizer:
+            try:
+                from dynamo.planner.monitoring.aic_power_optimizer import (
+                    AICPowerOptimizer,
+                )
+
+                self._aic_optimizer = AICPowerOptimizer(
+                    self.config, self.prometheus_metrics
+                )
+                initial_config = await asyncio.to_thread(self._aic_optimizer.optimize)
+                if initial_config is not None:
+                    await self._apply_aic_config(initial_config)
+            except Exception as exc:
+                logger.error(
+                    "AIC optimizer startup failed — planner will continue with "
+                    "static power enforcement: %s",
+                    exc,
+                )
+                self._aic_optimizer = None
 
         # Log operating mode at startup
         if self.config.advisory:
@@ -597,12 +626,22 @@ class NativePlannerBase:
         if not m.is_valid():
             logger.info("Metrics contain None or NaN values, skipping")
             return None
+
+        # Aggregate token throughput for AIC drift detection (§5.6).
+        rps = m.num_req / max(1.0, self.config.throughput_adjustment_interval)
+        total_tokens_per_s = rps * (m.isl + m.osl) if m.isl > 0 and m.osl > 0 else None
+
         return TrafficObservation(
             duration_s=self.config.throughput_adjustment_interval_seconds,
             num_req=m.num_req,
             isl=m.isl,
             osl=m.osl,
             kv_hit_rate=m.kv_hit_rate,
+            # AIC optimizer signals (Phase 3) — latency in seconds to match
+            # PrometheusAPIClient conventions; m.ttft / m.itl are in ms.
+            ttft_avg=m.ttft / 1000.0 if m.ttft and m.ttft > 0 else None,
+            itl_avg=m.itl / 1000.0 if m.itl and m.itl > 0 else None,
+            total_tokens_per_s=total_tokens_per_s,
         )
 
     async def _collect_kv_hit_rate_observation(
@@ -729,6 +768,25 @@ class NativePlannerBase:
         if tick.need_worker_fpm:
             fpm_obs = self._collect_fpm()
 
+        # Populate FPM-sourced scheduled token counts on the traffic observation
+        # so AICPowerOptimizer.update_correction() can gate per-side EMA updates
+        # on actual scheduled work (prevents idle-side coefficient drag — §5.3).
+        if traffic is not None and fpm_obs is not None:
+            if fpm_obs.prefill:
+                traffic.scheduled_prefill_tokens = float(
+                    sum(
+                        fpm.scheduled_requests.sum_prefill_tokens
+                        for fpm in fpm_obs.prefill.values()
+                    )
+                )
+            if fpm_obs.decode:
+                traffic.scheduled_decode_kv_tokens = float(
+                    sum(
+                        fpm.scheduled_requests.sum_decode_kv_tokens
+                        for fpm in fpm_obs.decode.values()
+                    )
+                )
+
         return TickInput(
             now_s=now,
             traffic=traffic,
@@ -815,6 +873,163 @@ class NativePlannerBase:
         pm.power_budget_total_watts.set(budget)
         pm.power_projected_watts.set(projected)
         pm.power_budget_utilization.set(projected / budget if budget > 0 else 0.0)
+
+    def _min_prefill_max_num_batched_tokens(self) -> Optional[int]:
+        """Return the minimum ``max_num_batched_tokens`` reported by prefill workers.
+
+        Used to derive a defense-in-depth absolute prefill admission threshold
+        (§5.7 B6).  The minimum-across-workers is conservative: a single
+        under-reporting worker does not silently raise the effective floor.
+        Returns ``None`` when no prefill worker has synced this value via MDC.
+        """
+        val = (
+            self.prefill_worker_info.max_num_batched_tokens
+            if self.require_prefill
+            else None
+        )
+        return val if val and val > 0 else None
+
+    async def _apply_aic_config(self, new_config: "PowerAwareConfig") -> None:
+        """Apply an AIC-recommended config to the planner state (§6.4 + §6.7).
+
+        Order of operations:
+        1. Update per-GPU power caps in PlannerConfig (picked up by
+           _apply_power_annotations() on the next tick).
+        2. Request replica scaling via the connector.
+        3. Update drift-comparison reference in the optimizer.
+        4. Derive and emit implied admission thresholds (inherit + autoset).
+        5. Fan out /busy_threshold POSTs to all frontend pods (autoset only).
+        """
+        if new_config is None:
+            return
+
+        # 1. Update config caps — _apply_power_annotations() reads these.
+        self.config.prefill_engine_gpu_power_limit = new_config.cap_p
+        self.config.decode_engine_gpu_power_limit = new_config.cap_d
+        logger.info(
+            "_apply_aic_config: cap_p=%dW cap_d=%dW n_p=%d n_d=%d",
+            new_config.cap_p,
+            new_config.cap_d,
+            new_config.n_p,
+            new_config.n_d,
+        )
+
+        # 2. Request replica scaling.
+        targets: list[TargetReplica] = []
+        if self.require_prefill and new_config.n_p > 0:
+            targets.append(
+                TargetReplica(
+                    sub_component_type=SubComponentType.PREFILL,
+                    desired_replicas=new_config.n_p,
+                    component_name=self.prefill_worker_info.k8s_name,
+                )
+            )
+        if self.require_decode and new_config.n_d > 0:
+            targets.append(
+                TargetReplica(
+                    sub_component_type=SubComponentType.DECODE,
+                    desired_replicas=new_config.n_d,
+                    component_name=self.decode_worker_info.k8s_name,
+                )
+            )
+        if targets:
+            await self._apply_scaling_targets(targets, blocking=False)
+
+        # 3. Pin drift-comparison reference (§5.6).
+        if self._aic_optimizer is not None:
+            self._aic_optimizer._estimated_throughput = (
+                new_config.aic_seq_per_s_per_replica
+                * new_config.n_d
+                * (new_config.isl + new_config.osl)
+            )
+
+        # 4. Admission gauges (inherit + autoset both record implied θ).
+        if self.prometheus_port != 0 and self.config.admission_mode != "off":
+            pm = self.prometheus_metrics
+            pm.admission_implied_theta_decode.set(new_config.theta_decode_impl)
+            pm.admission_implied_theta_prefill_frac.set(
+                new_config.theta_prefill_frac_impl
+            )
+
+        # 5. Fan out POSTs to frontends (autoset only).
+        if self.config.admission_mode == "autoset" and isinstance(
+            self.connector, KubernetesConnector
+        ):
+            await self._fanout_busy_threshold(new_config)
+
+    async def _fanout_busy_threshold(self, new_config: "PowerAwareConfig") -> None:
+        """POST /busy_threshold to every frontend replica (§5.7 autoset path)."""
+        margin = self.config.admission_safety_margin
+        theta_d_set = min(1.0, margin * new_config.theta_decode_impl)
+        theta_pf_set = min(1.0, margin * new_config.theta_prefill_frac_impl)
+
+        # B6: absolute prefill threshold (defense-in-depth vs MDC DEFAULT_MAX_TOKENS).
+        min_M = self._min_prefill_max_num_batched_tokens()
+        theta_p_abs_set: Optional[int]
+        if min_M is not None:
+            theta_p_abs_set = math.ceil(theta_pf_set * min_M)
+            if self.prometheus_port != 0:
+                self.prometheus_metrics.admission_set_theta_prefill_abs.set(
+                    theta_p_abs_set
+                )
+        else:
+            theta_p_abs_set = None
+            if self.prometheus_port != 0:
+                self.prometheus_metrics.admission_max_batched_tokens_unavailable_total.inc()
+            logger.critical(
+                "No prefill worker reports max_num_batched_tokens via MDC; "
+                "absolute prefill admission threshold cannot be derived. "
+                "Frontend's DEFAULT_MAX_TOKENS=10M fallback may silently disable "
+                "the fractional prefill check until MDC re-syncs. "
+                "Investigate worker MDC plumbing."
+            )
+
+        if self.prometheus_port != 0:
+            pm = self.prometheus_metrics
+            pm.admission_set_theta_decode.set(theta_d_set)
+            pm.admission_set_theta_prefill_frac.set(theta_pf_set)
+
+        assert isinstance(self.connector, KubernetesConnector)
+        pods = self.connector.list_frontend_pods()
+        if not pods:
+            logger.debug("No frontend pods found; skipping /busy_threshold fanout.")
+            return
+
+        model_name = self.model_name or self.config.model_name or ""
+        # Per-pod port resolution: operator emits a named ``http`` port on
+        # the frontend container, so we read each pod's actual port from its
+        # spec and only fall back to the (deprecated) ``frontend_http_port``
+        # config field for legacy manifests.  This honors per-DGD port
+        # overrides without a config mirror — closes design-doc OQ #13.
+        results = await asyncio.gather(
+            *(
+                self.connector.post_busy_threshold(
+                    pod,
+                    model_name,
+                    port=self.connector.resolve_frontend_http_port(
+                        pod, fallback=self.config.frontend_http_port
+                    ),
+                    active_decode_blocks_threshold=theta_d_set,
+                    active_prefill_tokens_threshold=theta_p_abs_set,
+                    active_prefill_tokens_threshold_frac=theta_pf_set,
+                )
+                for pod in pods
+            ),
+            return_exceptions=True,
+        )
+
+        failed = [
+            p.metadata.name for p, r in zip(pods, results) if isinstance(r, Exception)
+        ]
+        if failed:
+            if self.prometheus_port != 0:
+                self.prometheus_metrics.admission_partial_success_total.inc(len(failed))
+            logger.error(
+                "Failed to POST /busy_threshold to %d/%d frontend pods: %s",
+                len(failed),
+                len(pods),
+                failed,
+            )
 
     async def _apply_scaling_targets(
         self, targets: list[TargetReplica], blocking: bool = False
@@ -962,6 +1177,111 @@ class NativePlannerBase:
                 effects = self.state_machine.on_tick(next_tick, tick_input)
                 await self._apply_effects(effects)
                 await self._apply_power_annotations()  # Phase 1: annotate pods with GPU power limit
+
+                # Phase 3: AIC closed-loop optimizer update + conditional re-sweep.
+                if self._aic_optimizer is not None and tick_input.traffic is not None:
+                    interval_str = f"{self.config.throughput_adjustment_interval}s"
+                    # DGD name lives on the connector, not PlannerConfig.  When
+                    # running outside K8s (virtual / global-planner connector),
+                    # the DCGM selector is meaningless and the queries below
+                    # gracefully degrade to None.
+                    dgd_name = (
+                        self.connector.graph_deployment_name
+                        if isinstance(self.connector, KubernetesConnector)
+                        else ""
+                    )
+                    # DCGM attribution labels carry the K8s namespace
+                    # (exported_namespace), not the dynamo logical namespace.
+                    # Resolve via the connector when running in-cluster.
+                    k8s_ns = (
+                        self.connector.kube_api.current_namespace
+                        if isinstance(self.connector, KubernetesConnector)
+                        else ""
+                    )
+
+                    if self.config.mode == "disagg":
+                        obs_ttft = (
+                            self.prometheus_traffic_client.get_avg_time_to_first_token(
+                                interval_str, self.model_name or ""
+                            )
+                        )
+                        obs_itl = (
+                            self.prometheus_traffic_client.get_avg_inter_token_latency(
+                                interval_str, self.model_name or ""
+                            )
+                        )
+                        self._aic_optimizer.update_correction(
+                            traffic=tick_input.traffic,
+                            observed_ttft_avg=obs_ttft if obs_ttft else None,
+                            observed_itl_avg=obs_itl if obs_itl else None,
+                            observed_power_w_prefill=(
+                                self.prometheus_traffic_client.get_avg_per_gpu_power_by_component(
+                                    interval=interval_str,
+                                    k8s_namespace=k8s_ns,
+                                    dgd_name=dgd_name,
+                                    component="prefill",
+                                    service_key=self.prefill_worker_info.k8s_name or "",
+                                )
+                                if self.require_prefill
+                                else None
+                            ),
+                            observed_power_w_decode=(
+                                self.prometheus_traffic_client.get_avg_per_gpu_power_by_component(
+                                    interval=interval_str,
+                                    k8s_namespace=k8s_ns,
+                                    dgd_name=dgd_name,
+                                    component="decode",
+                                    service_key=self.decode_worker_info.k8s_name or "",
+                                )
+                                if self.require_decode
+                                else None
+                            ),
+                        )
+                    else:  # agg mode
+                        obs_ttft = (
+                            self.prometheus_traffic_client.get_avg_time_to_first_token(
+                                interval_str, self.model_name or ""
+                            )
+                        )
+                        obs_itl = (
+                            self.prometheus_traffic_client.get_avg_inter_token_latency(
+                                interval_str, self.model_name or ""
+                            )
+                        )
+                        self._aic_optimizer.update_correction(
+                            traffic=tick_input.traffic,
+                            observed_ttft_avg=obs_ttft if obs_ttft else None,
+                            observed_itl_avg=obs_itl if obs_itl else None,
+                            observed_power_w_agg=(
+                                self.prometheus_traffic_client.get_avg_per_gpu_power_by_component(
+                                    interval=interval_str,
+                                    k8s_namespace=k8s_ns,
+                                    dgd_name=dgd_name,
+                                    component="agg",
+                                    service_key=self.decode_worker_info.k8s_name or "",
+                                )
+                                if self.require_decode
+                                else None
+                            ),
+                        )
+
+                    if self._aic_optimizer.should_reoptimize(tick_input.traffic):
+                        logger.info(
+                            "AIC optimizer: drift detected — triggering re-sweep."
+                        )
+                        try:
+                            new_aic_config = await asyncio.to_thread(
+                                self._aic_optimizer.optimize
+                            )
+                            if new_aic_config is not None:
+                                await self._apply_aic_config(new_aic_config)
+                        except Exception as exc:
+                            logger.error(
+                                "AIC re-sweep exception (planner continues with "
+                                "current config): %s",
+                                exc,
+                            )
+
                 self._report_diagnostics(next_tick, effects.diagnostics)
                 self._log_decision_summary(effects)
 

--- a/components/src/dynamo/planner/core/types.py
+++ b/components/src/dynamo/planner/core/types.py
@@ -50,6 +50,20 @@ class TrafficObservation:
     osl: float
     kv_hit_rate: Optional[float] = None
 
+    # AIC optimizer signals (Phase 3).
+    # ttft_avg / itl_avg: Prometheus-observed averages in *seconds* (not ms).
+    # Used by AICPowerOptimizer.should_reoptimize() for SLA-miss detection.
+    ttft_avg: Optional[float] = None
+    itl_avg: Optional[float] = None
+    # total_tokens_per_s: aggregate (isl+osl) token throughput across the DGD.
+    # Used for capacity-exceeded drift detection.
+    total_tokens_per_s: Optional[float] = None
+    # scheduled_*_tokens: per-side FPM-sourced work volumes.
+    # Used to gate EMA updates: skip the update when a side is idle so the
+    # coefficient doesn't drift toward idle-watt / aic-watt ≈ 0.
+    scheduled_prefill_tokens: Optional[float] = None
+    scheduled_decode_kv_tokens: Optional[float] = None
+
 
 @dataclass
 class WorkerCounts:

--- a/components/src/dynamo/planner/monitoring/aic_power_optimizer.py
+++ b/components/src/dynamo/planner/monitoring/aic_power_optimizer.py
@@ -1,0 +1,746 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""AIC-closed-loop power optimizer (Phase 3).
+
+Wraps AIConfigurator to produce a per-tick ``PowerAwareConfig`` — the
+recommended (n_p, n_d, cap_p, cap_d) tuple that the planner applies via
+``NativePlannerBase._apply_aic_config()``.
+
+Phase 3 is TDP-only: ``power_w`` columns in the AIC database are zeroed so
+we fall back to the nameplate TDP from ``system_spec["gpu"]["tdp_w"]``.
+Phase 4 will add a power-sweep dimension once the AIC team backfills measured
+per-configuration power data.
+
+Key design decisions (§5.3–§5.6 of powerplanner-design.md):
+- EMA-smoothed correction coefficients (c_ttft, c_itl, c_power_p/d/agg)
+  bridge AIC offline estimates to live serving behaviour.
+- Asymmetric clamp max(1.0, c) is applied when gating feasibility so we
+  never *loosen* SLA or under-cap power based on noisy live data.
+- EMA updates are gated: latency on ``traffic.num_req > 0``; per-side power
+  on ``traffic.scheduled_*_tokens > 0`` to prevent idle-side EMA drag.
+- Drift detection uses ONLY the upward-exceeded direction for throughput to
+  avoid spurious re-sweeps in under-loaded clusters (§5.6 "Direction matters").
+- Failure modes: fail-open at runtime (keep last config), fail-closed at
+  startup (scale to min_endpoint, disable optimizer, planner stays alive).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from dynamo.planner.config.planner_config import PlannerConfig
+    from dynamo.planner.core.types import TrafficObservation
+    from dynamo.planner.monitoring.planner_metrics import PlannerPrometheusMetrics
+
+logger = logging.getLogger(__name__)
+
+# EMA smoothing factor — §5.3 "α = 0.3".
+_EMA_ALPHA = 0.3
+# Coefficient clamp bounds — §5.3 "clamped to [0.5, 2.0] after each update".
+_COEFF_MIN = 0.5
+_COEFF_MAX = 2.0
+
+# Defensive clamp for AIC's reported per-GPU power_w.  Empirically (see
+# .agents/research/aic_power_extrapolation_2026-05-11.md), AIC's per-kernel
+# 3D-cubic interpolator can return non-physical power values when the query
+# falls into a sparse corner of the offline data lattice — observed on
+# h200_sxm + vLLM 0.19.1 + generation_attention at batch >= 256 (returned
+# ~1563 W per op vs a 721 W measured peak).  Any aic_power_w above
+# TDP × _AIC_POWER_W_NONPHYSICAL_MULTIPLE is treated as bogus and clamped to
+# TDP before being used to derive per-GPU caps.  The cap that ultimately
+# reaches NVML can never legitimately exceed TDP anyway (the daemon would
+# clamp it down silently), so this clamp only loses fidelity in the
+# "AIC was wrong" regime — never in the physical regime.
+_AIC_POWER_W_NONPHYSICAL_MULTIPLE = 1.1
+
+
+@dataclass
+class PowerAwareConfig:
+    """Output of a single AIC sweep.
+
+    Carries everything ``NativePlannerBase._apply_aic_config()`` needs to
+    update the planner state: replica counts, per-GPU power caps, drift
+    reference, and implied admission thresholds.
+
+    The ``aic_power_w_*`` fields preserve AIC's *raw* per-GPU power estimate
+    (before any EMA correction) so ``update_correction()`` can normalise
+    observed power against the AIC prediction — not against the planner's
+    applied cap.  Comparing against the cap would collapse the EMA toward
+    1.0 because the cap = ceil(aic_power_w × max(1, c_power)) by construction.
+    """
+
+    n_p: int  # recommended prefill replicas
+    n_d: int  # recommended decode replicas
+    cap_p: int  # per-GPU power cap for prefill (watts)
+    cap_d: int  # per-GPU power cap for decode (watts)
+    aic_ttft_ms: float  # AIC-estimated TTFT (before correction)
+    aic_itl_ms: float  # AIC-estimated ITL  (before correction)
+    aic_seq_per_s_per_replica: float  # saturated decode throughput, for drift ref
+    isl: int
+    osl: int
+    theta_decode_impl: float  # implied decode KV utilization (§5.7)
+    theta_prefill_frac_impl: float  # implied prefill fractional utilization
+    # Raw AIC per-GPU power estimates used as EMA denominators in
+    # update_correction().  Falls back to nameplate TDP when AIC's perf DB
+    # has zeroed power_w (Phase 3 typical state — see §6.4).
+    aic_power_w_prefill: float = 0.0
+    aic_power_w_decode: float = 0.0
+    aic_power_w_agg: float = 0.0
+
+
+class AICPowerOptimizer:
+    """Closed-loop AIC optimizer for power-aware planner (Phase 3).
+
+    Instantiated once at planner startup when ``enable_aic_optimizer=True``.
+    The public API:
+
+    * ``optimize()`` — blocking AIC sweep; run via ``asyncio.to_thread``.
+    * ``update_correction(...)`` — update EMA coefficients after each tick.
+    * ``should_reoptimize(traffic)`` — drift + hysteresis check.
+    """
+
+    def __init__(
+        self,
+        config: "PlannerConfig",
+        metrics: "PlannerPrometheusMetrics",
+    ) -> None:
+        self._config = config
+        self._metrics = metrics
+
+        spec = config.aic_interpolation
+        if spec is None:
+            raise ValueError(
+                "enable_aic_optimizer=True requires aic_interpolation to be set "
+                "in PlannerConfig. See AICInterpolationSpec for required fields."
+            )
+        self._spec = spec
+
+        # EMA coefficients — initialised from config (cold-start values).
+        self._c_ttft: float = config.aic_initial_c_ttft
+        self._c_itl: float = config.aic_initial_c_itl
+        self._c_power_p: float = config.aic_initial_c_power_prefill
+        self._c_power_d: float = config.aic_initial_c_power_decode
+        self._c_power_agg: float = config.aic_initial_c_power_agg
+
+        # Drift detection state (§5.6).
+        self._estimated_throughput: float = (
+            0.0  # tokens/s; updated by _apply_aic_config
+        )
+        self._consecutive_violation_ticks: int = 0
+        self._time_of_last_optimize: float = 0.0
+
+        # Failure-handling state (§8).
+        self._consecutive_failures: int = 0
+        self._last_optimal_config: Optional[PowerAwareConfig] = None
+        self._disabled: bool = False
+        self._disabled_reason: str = ""
+
+        # Emit initial coefficient gauges so dashboards show cold-start values.
+        self._emit_coefficient_metrics()
+
+        # Optional testbed injection: when set, replaces the real
+        # AIConfiguratorPerfEstimator instantiation inside optimize().
+        # Type: Optional[Callable[[str, str, str], Any]]  (hf_id, system, backend) → estimator
+        # Set only by the synthetic testbed; never touched in production.
+        self._aic_estimator_factory = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def optimize(self) -> Optional[PowerAwareConfig]:
+        """Run a full AIC sweep and return the recommended config.
+
+        Always call via ``asyncio.to_thread`` — the first call per process
+        takes 3-6 s (perf-database load from disk, dominated by parsing
+        ~10-100 K rows of TXT data and building cubic interpolators).
+        Subsequent calls reuse ``aiconfigurator.sdk.perf_database.databases_cache``
+        and complete in ~10-15 ms.  Measured 2026-05-11 against the
+        in-repo H200 vLLM 0.19.1 and B200 TRT-LLM 1.3.0rc6 sandboxes
+        (see .aic_bench.py).
+
+        Closed-loop budget at the default ``aic_reoptimize_interval=300s``
+        is therefore well under 0.01 % planner-CPU duty cycle at steady
+        state — the rate-limit + hysteresis guards exist for downstream
+        impact (annotation PATCH rate, frontend ``/busy_threshold`` POST
+        fanout, config flapping), not for AIC sweep CPU cost.
+
+        Returns ``None`` when the optimizer is auto-disabled (§8 rows 1, 4).
+        """
+        if self._disabled:
+            return None
+
+        spec = self._spec
+        system = self._config.aic_system or spec.system
+
+        try:
+            if self._aic_estimator_factory is not None:
+                estimator = self._aic_estimator_factory(
+                    hf_id=spec.hf_id, system=system, backend=spec.backend
+                )
+            else:
+                from dynamo.planner.monitoring.aic_estimator import (
+                    AIConfiguratorPerfEstimator,
+                )
+
+                estimator = AIConfiguratorPerfEstimator(
+                    hf_id=spec.hf_id,
+                    system=system,
+                    backend=spec.backend,
+                )
+            from dynamo.planner.config.parallelization import (
+                picked_to_aic_model_config_kwargs,
+            )
+        except ImportError as exc:
+            self._handle_sweep_failure(
+                f"aiconfigurator not installed: {exc}",
+                at_startup=(self._last_optimal_config is None),
+            )
+            return self._last_optimal_config
+
+        except Exception as exc:
+            self._handle_sweep_failure(
+                f"Failed to initialise AIC estimator: {exc}",
+                at_startup=(self._last_optimal_config is None),
+            )
+            return self._last_optimal_config
+
+        prefill_kwargs = picked_to_aic_model_config_kwargs(spec.prefill_pick)
+        decode_kwargs = picked_to_aic_model_config_kwargs(spec.decode_pick)
+
+        p_gpu = spec.prefill_pick.num_gpus
+        d_gpu = spec.decode_pick.num_gpus
+
+        # ---------- Nameplate TDP (used as fallback when power_w is unavailable) ----------
+        try:
+            tdp_w = float(estimator.database.system_spec["gpu"]["power"])
+            if tdp_w <= 0:
+                raise ValueError(f"tdp_w={tdp_w} is not positive")
+        except (KeyError, AttributeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "AIC optimizer: could not read GPU power from system spec (%s); "
+                "falling back to prefill_engine_gpu_power_limit=%d W.",
+                exc,
+                self._config.prefill_engine_gpu_power_limit,
+            )
+            tdp_w = float(self._config.prefill_engine_gpu_power_limit)
+
+        # ---------- Single-engine AIC calls (TTFT, ITL, and per-config power_w) ----------
+        try:
+            prefill_perf = estimator.estimate_prefill_perf(
+                isl=spec.isl, **prefill_kwargs
+            )
+            aic_ttft_ms = prefill_perf.get("context_latency")
+            if aic_ttft_ms is None or aic_ttft_ms <= 0:
+                raise ValueError(f"AIC returned invalid TTFT: {aic_ttft_ms}")
+            aic_ttft_ms = float(aic_ttft_ms)
+            aic_power_w_prefill = float(prefill_perf.get("power_w") or 0.0)
+        except Exception as exc:
+            self._handle_sweep_failure(
+                f"AIC prefill estimate failed: {exc}",
+                at_startup=(self._last_optimal_config is None),
+            )
+            return self._last_optimal_config
+
+        try:
+            attention_dp = max(1, spec.decode_pick.dp)
+            per_rank_max_kv = estimator.get_max_kv_tokens(
+                spec.isl, spec.osl, **decode_kwargs
+            )
+            max_kv_aggregate = max(1, per_rank_max_kv * attention_dp)
+            max_concurrency = max(1, max_kv_aggregate // (spec.isl + spec.osl))
+            batch_size_per_rank = max(1, max_concurrency // attention_dp)
+
+            decode_perf = estimator.estimate_perf(
+                spec.isl,
+                spec.osl,
+                batch_size_per_rank,
+                mode="decode",
+                **decode_kwargs,
+            )
+            aic_itl_ms = decode_perf.get("tpot")
+            if aic_itl_ms is None or aic_itl_ms <= 0:
+                raise ValueError(f"AIC returned invalid ITL (tpot): {aic_itl_ms}")
+            aic_itl_ms = float(aic_itl_ms)
+            aic_power_w_decode = float(decode_perf.get("power_w") or 0.0)
+        except Exception as exc:
+            self._handle_sweep_failure(
+                f"AIC decode estimate failed: {exc}",
+                at_startup=(self._last_optimal_config is None),
+            )
+            return self._last_optimal_config
+
+        # ---------- Power caps: use measured per-config power_w (Phase 4) or TDP (Phase 3) ----------
+        # Resolve the raw AIC power estimate per side; this value is what
+        # update_correction() will use as the EMA denominator (§5.3).  When
+        # AIC has not backfilled measured power_w yet, fall back to nameplate
+        # TDP so the closed loop remains well-defined.
+        mode = self._config.mode
+        if aic_power_w_prefill > 0 and aic_power_w_decode > 0:
+            logger.debug(
+                "AIC optimizer: using measured power_w — prefill %.0f W, decode %.0f W.",
+                aic_power_w_prefill,
+                aic_power_w_decode,
+            )
+            raw_power_w_prefill = aic_power_w_prefill
+            raw_power_w_decode = aic_power_w_decode
+        else:
+            logger.warning(
+                "AIC optimizer: power_w unavailable in AIC result "
+                "(database may not have power data yet); using nameplate TDP %.0f W.",
+                tdp_w,
+            )
+            raw_power_w_prefill = tdp_w
+            raw_power_w_decode = tdp_w
+
+        # Defensive clamp: AIC's per-kernel power interpolator can extrapolate
+        # to non-physical values at sparse-grid query points (observed on H200
+        # vLLM generation_attention at batch >= 256).  The clamped values feed
+        # cap derivation; the *raw* values are stored on PowerAwareConfig as
+        # EMA denominators so c_power_* coefficients visibly converge below 1.0
+        # whenever AIC over-predicts, giving operators an independent signal
+        # alongside the aic_power_w_clamped_total counter.
+        cap_power_w_prefill = self._clamp_aic_power_w(
+            raw_power_w_prefill, tdp_w, side="prefill"
+        )
+        cap_power_w_decode = self._clamp_aic_power_w(
+            raw_power_w_decode, tdp_w, side="decode"
+        )
+
+        if mode == "agg":
+            raw_power_w_agg = (raw_power_w_prefill + raw_power_w_decode) / 2.0
+            cap_power_w_agg = (cap_power_w_prefill + cap_power_w_decode) / 2.0
+            cap_p_per_gpu = math.ceil(cap_power_w_agg * max(1.0, self._c_power_agg))
+            cap_d_per_gpu = cap_p_per_gpu
+        else:
+            raw_power_w_agg = 0.0
+            cap_p_per_gpu = math.ceil(cap_power_w_prefill * max(1.0, self._c_power_p))
+            cap_d_per_gpu = math.ceil(cap_power_w_decode * max(1.0, self._c_power_d))
+
+        # ---------- SLA feasibility (single-engine check) ----------
+        corrected_ttft_ms = aic_ttft_ms * max(1.0, self._c_ttft)
+        corrected_itl_ms = aic_itl_ms * max(1.0, self._c_itl)
+
+        ttft_sla_ms = self._config.ttft_ms  # SLA in ms
+        itl_sla_ms = self._config.itl_ms
+
+        if corrected_ttft_ms > ttft_sla_ms or corrected_itl_ms > itl_sla_ms:
+            msg = (
+                f"AIC optimizer: infeasible SLA at single-engine level — "
+                f"corrected TTFT {corrected_ttft_ms:.1f}ms vs target {ttft_sla_ms:.1f}ms, "
+                f"corrected ITL {corrected_itl_ms:.1f}ms vs target {itl_sla_ms:.1f}ms."
+            )
+            self._handle_sweep_failure(
+                msg,
+                at_startup=(self._last_optimal_config is None),
+            )
+            return self._last_optimal_config
+
+        # ---------- Replica-count sweep ----------
+        # Throughput per decode replica at saturation (seq/s).
+        # Formula: max_concurrency sequences complete in osl decode steps,
+        # each step taking aic_itl_ms ms → seq/s = max_concurrency*1000 / (itl_ms*osl).
+        aic_seq_per_s_per_replica = (
+            max_concurrency * 1000.0 / (aic_itl_ms * max(1, spec.osl))
+        )
+
+        budget = self._config.total_gpu_power_limit  # None means unbounded
+        min_ep = self._config.min_endpoint
+        max_replicas = max(
+            min_ep,
+            (self._config.max_gpu_budget // max(1, d_gpu))
+            if self._config.max_gpu_budget > 0
+            else 256,
+        )
+
+        p_watts = cap_p_per_gpu * p_gpu  # per prefill replica
+        d_watts = cap_d_per_gpu * d_gpu  # per decode replica
+
+        best_n_p, best_n_d = self._sweep_replicas(
+            min_ep, max_replicas, p_watts, d_watts, budget
+        )
+
+        # ---------- Implied admission thresholds (§5.7) ----------
+        # θ_decode_impl: KV utilization at max concurrency per decode replica.
+        kv_total_tokens_per_replica = max_kv_aggregate  # aggregated across attention-DP
+        theta_decode_impl = min(
+            1.0,
+            max_concurrency
+            * (spec.isl + spec.osl / 2.0)
+            / max(1, kv_total_tokens_per_replica),
+        )
+        # θ_prefill_frac_impl: fraction of peak prefill capacity consumed.
+        peak_seq_s_per_replica = 1000.0 / max(0.001, aic_ttft_ms)  # at zero queueing
+        achieved_seq_s = aic_seq_per_s_per_replica  # per decode replica at saturation
+        theta_prefill_frac_impl = min(
+            1.0, achieved_seq_s / max(0.001, peak_seq_s_per_replica)
+        )
+
+        config = PowerAwareConfig(
+            n_p=best_n_p,
+            n_d=best_n_d,
+            cap_p=cap_p_per_gpu,
+            cap_d=cap_d_per_gpu,
+            aic_ttft_ms=aic_ttft_ms,
+            aic_itl_ms=aic_itl_ms,
+            aic_seq_per_s_per_replica=aic_seq_per_s_per_replica,
+            isl=spec.isl,
+            osl=spec.osl,
+            theta_decode_impl=theta_decode_impl,
+            theta_prefill_frac_impl=theta_prefill_frac_impl,
+            aic_power_w_prefill=raw_power_w_prefill,
+            aic_power_w_decode=raw_power_w_decode,
+            aic_power_w_agg=raw_power_w_agg,
+        )
+
+        # Throughput-regression check (§8 row 5) — apply regardless, just warn.
+        if self._last_optimal_config is not None:
+            old_tp = (
+                self._last_optimal_config.aic_seq_per_s_per_replica
+                * self._last_optimal_config.n_d
+                * (self._last_optimal_config.isl + self._last_optimal_config.osl)
+            )
+            new_tp = aic_seq_per_s_per_replica * best_n_d * (spec.isl + spec.osl)
+            regress_pct = (old_tp - new_tp) / max(1.0, old_tp)
+            if (
+                old_tp > 0
+                and new_tp < old_tp
+                and regress_pct > self._config.aic_throughput_regression_warn_threshold
+            ):
+                logger.warning(
+                    "AIC optimizer: re-optimization produced %.1f%% lower predicted "
+                    "throughput (old=%.0f tok/s, new=%.0f tok/s). Applying anyway — "
+                    "correction coefficients already factored in.",
+                    regress_pct * 100,
+                    old_tp,
+                    new_tp,
+                )
+                self._metrics.aic_throughput_regression_total.inc()
+
+        self._consecutive_failures = 0
+        self._consecutive_violation_ticks = 0
+        self._last_optimal_config = config
+        self._time_of_last_optimize = time.monotonic()
+        self._metrics.aic_consecutive_failures.set(0)
+        logger.info(
+            "AIC sweep complete: n_p=%d n_d=%d cap_p=%dW cap_d=%dW "
+            "corrected_TTFT=%.1fms corrected_ITL=%.1fms "
+            "θ_decode=%.3f θ_prefill_frac=%.3f",
+            best_n_p,
+            best_n_d,
+            cap_p_per_gpu,
+            cap_d_per_gpu,
+            corrected_ttft_ms,
+            corrected_itl_ms,
+            theta_decode_impl,
+            theta_prefill_frac_impl,
+        )
+        return config
+
+    def update_correction(
+        self,
+        traffic: "TrafficObservation",
+        observed_ttft_avg: Optional[float] = None,
+        observed_itl_avg: Optional[float] = None,
+        observed_power_w_prefill: Optional[float] = None,
+        observed_power_w_decode: Optional[float] = None,
+        observed_power_w_agg: Optional[float] = None,
+    ) -> None:
+        """Update EMA correction coefficients after each planner tick (§5.3).
+
+        All observed latency values are in **seconds** (matching
+        ``PrometheusAPIClient.get_avg_*`` conventions); AIC TTFT/ITL are in ms.
+        Gating rules:
+        - Latency coefficients: updated only when ``traffic.num_req > 0``.
+        - Power coefficients:   updated only when the matching component had
+          scheduled work (per-side idle-EMA guard).
+        """
+        if self._disabled or self._last_optimal_config is None:
+            return
+
+        aic_ttft_s = self._last_optimal_config.aic_ttft_ms / 1000.0
+        aic_itl_s = self._last_optimal_config.aic_itl_ms / 1000.0
+
+        changed = False
+
+        # -- Latency coefficients (gated on num_req > 0) --
+        if traffic.num_req > 0:
+            if (
+                observed_ttft_avg is not None
+                and observed_ttft_avg > 0
+                and aic_ttft_s > 0
+            ):
+                raw = observed_ttft_avg / aic_ttft_s
+                self._c_ttft = _ema_update(self._c_ttft, raw, "ttft", self._metrics)
+                changed = True
+
+            if observed_itl_avg is not None and observed_itl_avg > 0 and aic_itl_s > 0:
+                raw = observed_itl_avg / aic_itl_s
+                self._c_itl = _ema_update(self._c_itl, raw, "itl", self._metrics)
+                changed = True
+
+        mode = self._config.mode
+
+        # Power EMA denominator is AIC's *raw* per-GPU power estimate from the
+        # last sweep — NOT the planner-applied cap.  The cap is derived as
+        # ceil(aic_power_w × max(1, c_power)); using it as the denominator
+        # collapses the EMA toward 1.0 by construction (§5.3).  The raw value
+        # is preserved on _last_optimal_config so subsequent ticks normalise
+        # against the same reference between sweeps.
+        if mode == "agg":
+            # Aggregated mode — single coefficient.
+            sched_total = (traffic.scheduled_prefill_tokens or 0) + (
+                traffic.scheduled_decode_kv_tokens or 0
+            )
+            if (
+                sched_total > 0
+                and observed_power_w_agg is not None
+                and observed_power_w_agg > 0
+            ):
+                aic_power_w = self._last_optimal_config.aic_power_w_agg
+                if aic_power_w > 0:
+                    raw = observed_power_w_agg / aic_power_w
+                    self._c_power_agg = _ema_update(
+                        self._c_power_agg, raw, "power_agg", self._metrics
+                    )
+                    changed = True
+        else:
+            # Disaggregated mode — per-component.
+            if (
+                (traffic.scheduled_prefill_tokens or 0) > 0
+                and observed_power_w_prefill is not None
+                and observed_power_w_prefill > 0
+            ):
+                aic_p_w = self._last_optimal_config.aic_power_w_prefill
+                if aic_p_w > 0:
+                    raw = observed_power_w_prefill / aic_p_w
+                    self._c_power_p = _ema_update(
+                        self._c_power_p, raw, "power_prefill", self._metrics
+                    )
+                    changed = True
+
+            if (
+                (traffic.scheduled_decode_kv_tokens or 0) > 0
+                and observed_power_w_decode is not None
+                and observed_power_w_decode > 0
+            ):
+                aic_d_w = self._last_optimal_config.aic_power_w_decode
+                if aic_d_w > 0:
+                    raw = observed_power_w_decode / aic_d_w
+                    self._c_power_d = _ema_update(
+                        self._c_power_d, raw, "power_decode", self._metrics
+                    )
+                    changed = True
+
+        if changed:
+            self._emit_coefficient_metrics()
+
+    def should_reoptimize(self, traffic: "TrafficObservation") -> bool:
+        """Return True when drift detection + hysteresis says to re-sweep (§5.6).
+
+        Rate-limited by ``aic_reoptimize_interval``.
+        Hysteresis requires ``aic_drift_consecutive_ticks`` of sustained signal.
+        """
+        if self._disabled:
+            return False
+
+        elapsed = time.monotonic() - self._time_of_last_optimize
+        if elapsed < self._config.aic_reoptimize_interval:
+            return False
+
+        sla_violated = False
+        if traffic.ttft_avg is not None:
+            sla_violated = sla_violated or traffic.ttft_avg > (
+                self._config.ttft_ms / 1000.0
+            )
+        if traffic.itl_avg is not None:
+            sla_violated = sla_violated or traffic.itl_avg > (
+                self._config.itl_ms / 1000.0
+            )
+
+        # Capacity-exceeded: upward direction only (§5.6 "Direction matters").
+        capacity_exceeded = False
+        if (
+            self._estimated_throughput > 0
+            and traffic.total_tokens_per_s is not None
+            and traffic.total_tokens_per_s
+            > self._estimated_throughput
+            * (1.0 + self._config.aic_drift_relative_threshold)
+        ):
+            capacity_exceeded = True
+
+        needs_reopt = sla_violated or capacity_exceeded
+        self._consecutive_violation_ticks = (
+            self._consecutive_violation_ticks + 1 if needs_reopt else 0
+        )
+        return (
+            self._consecutive_violation_ticks
+            >= self._config.aic_drift_consecutive_ticks
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _clamp_aic_power_w(
+        self, raw_power_w: float, tdp_w: float, *, side: str
+    ) -> float:
+        """Defensive clamp for AIC's reported per-GPU power_w (§6.4, §8 row 7).
+
+        Returns ``raw_power_w`` unchanged when it is at or below
+        ``tdp_w × _AIC_POWER_W_NONPHYSICAL_MULTIPLE``.  Otherwise logs a
+        WARNING with both the raw and clamped values, increments the
+        ``aic_power_w_clamped_total{side=...}`` counter, and returns
+        ``tdp_w``.  Callers must always use the returned value when sizing
+        per-GPU caps so a single bad AIC interpolation cannot produce a
+        nominal cap larger than the GPU can physically draw.
+        """
+        threshold = tdp_w * _AIC_POWER_W_NONPHYSICAL_MULTIPLE
+        if raw_power_w <= threshold:
+            return raw_power_w
+        logger.warning(
+            "AIC optimizer: %s power_w=%.1f W exceeds TDP×%.2f (%.1f W) — "
+            "treating as non-physical interpolation artefact; clamping to TDP %.0f W "
+            "for cap computation. EMA denominator preserves the raw value so "
+            "c_power_%s converges to live/raw (typically <1) and gives an "
+            "independent signal alongside aic_power_w_clamped_total.",
+            side,
+            raw_power_w,
+            _AIC_POWER_W_NONPHYSICAL_MULTIPLE,
+            threshold,
+            tdp_w,
+            side,
+        )
+        try:
+            self._metrics.aic_power_w_clamped_total.labels(side=side).inc()
+        except Exception:
+            pass
+        return tdp_w
+
+    def _sweep_replicas(
+        self,
+        min_ep: int,
+        max_replicas: int,
+        p_watts: int,
+        d_watts: int,
+        budget: Optional[int],
+    ) -> tuple[int, int]:
+        """Find the (n_p, n_d) that maximises throughput within budget.
+
+        Strategy: maximise n_d first (decode is the throughput bottleneck for
+        OSL-heavy workloads), then use remaining budget for n_p.
+        Ties broken by fewer total GPUs, then lower cap power (§5.4).
+        """
+        # Maximum n_d given we must keep at least min_ep prefill replicas.
+        if budget is not None:
+            remaining_after_min_p = budget - min_ep * p_watts
+            if remaining_after_min_p <= 0:
+                logger.warning(
+                    "AIC optimizer: budget %dW cannot cover min_endpoint prefill "
+                    "replicas (%d × %dW); falling back to min_endpoint.",
+                    budget,
+                    min_ep,
+                    p_watts,
+                )
+                return min_ep, min_ep
+
+            best_n_d = min(max_replicas, remaining_after_min_p // max(1, d_watts))
+        else:
+            best_n_d = max_replicas
+
+        best_n_d = max(min_ep, best_n_d)
+
+        # Remaining budget after locking in best_n_d.
+        if budget is not None:
+            remaining_for_p = budget - best_n_d * d_watts
+            best_n_p = min(
+                max_replicas, max(min_ep, remaining_for_p // max(1, p_watts))
+            )
+        else:
+            best_n_p = min_ep  # conservative default when unbounded
+
+        return best_n_p, best_n_d
+
+    def _handle_sweep_failure(self, msg: str, *, at_startup: bool) -> None:
+        """Central failure handler for both startup and runtime sweep failures."""
+        if at_startup:
+            # §8 rows 1 and 4: disable the optimizer on startup failure.
+            reason = (
+                "infeasible_at_startup" if "infeasible" in msg else "startup_exception"
+            )
+            logger.error(
+                "AIC optimizer disabled (reason=%s): %s. "
+                "Planner will use static _apply_power_budget() enforcement.",
+                reason,
+                msg,
+            )
+            self._metrics.aic_optimizer_exceptions_total.inc()
+            self._metrics.aic_optimizer_disabled_reason.labels(reason=reason).set(1)
+            self._disabled = True
+            self._disabled_reason = reason
+        else:
+            # §8 rows 2 and 3: keep last config, increment failure counter.
+            self._consecutive_failures += 1
+            self._metrics.aic_consecutive_failures.set(self._consecutive_failures)
+            self._metrics.aic_optimizer_exceptions_total.inc()
+            logger.error(
+                "AIC sweep failure (%d/%d consecutive): %s",
+                self._consecutive_failures,
+                self._config.aic_max_consecutive_failures,
+                msg,
+            )
+            if self._consecutive_failures >= self._config.aic_max_consecutive_failures:
+                logger.error(
+                    "AIC optimizer: %d consecutive failures — auto-disabling. "
+                    "Restart planner pod with fixed configuration to re-enable.",
+                    self._consecutive_failures,
+                )
+                self._metrics.aic_optimizer_disabled_reason.labels(
+                    reason="max_consecutive_failures"
+                ).set(1)
+                self._disabled = True
+                self._disabled_reason = "max_consecutive_failures"
+
+    def _emit_coefficient_metrics(self) -> None:
+        """Push current EMA coefficient values to Prometheus gauges."""
+        self._metrics.aic_c_ttft.set(self._c_ttft)
+        self._metrics.aic_c_itl.set(self._c_itl)
+        mode = self._config.mode
+        if mode == "agg":
+            self._metrics.aic_c_power.labels(component="agg").set(self._c_power_agg)
+        else:
+            self._metrics.aic_c_power.labels(component="prefill").set(self._c_power_p)
+            self._metrics.aic_c_power.labels(component="decode").set(self._c_power_d)
+
+
+# ------------------------------------------------------------------
+# Module-level helpers
+# ------------------------------------------------------------------
+
+
+def _ema_update(
+    prev: float,
+    raw: float,
+    name: str,
+    metrics: "PlannerPrometheusMetrics",
+) -> float:
+    """Apply one EMA step, clamp to [0.5, 2.0], increment peg counter if saturated."""
+    updated = _EMA_ALPHA * raw + (1.0 - _EMA_ALPHA) * prev
+    clamped = max(_COEFF_MIN, min(_COEFF_MAX, updated))
+    if clamped != updated:
+        metrics.aic_correction_pegged_total.labels(coefficient=name).inc()
+        logger.critical(
+            "AIC correction coefficient '%s' pegged at clamp (raw=%.3f computed=%.3f "
+            "clamped=%.3f). AIC calibration may be far from live silicon — investigate.",
+            name,
+            raw,
+            updated,
+            clamped,
+        )
+    return clamped

--- a/components/src/dynamo/planner/monitoring/planner_metrics.py
+++ b/components/src/dynamo/planner/monitoring/planner_metrics.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from prometheus_client import Enum, Gauge
+from prometheus_client import Counter, Enum, Gauge
 
 PREFIX = "dynamo_planner"
 
@@ -166,4 +166,95 @@ class PlannerPrometheusMetrics:
         self.power_budget_utilization = Gauge(
             f"{PREFIX}_power_budget_utilization",
             "Ratio of projected power to total budget (0.0–1.0+).",
+        )
+
+        # -- AIC closed-loop optimizer (Phase 3) --------------------------
+        self.aic_c_ttft = Gauge(
+            f"{PREFIX}_aic_c_ttft",
+            "EMA-smoothed AIC TTFT correction coefficient (c_ttft).",
+        )
+        self.aic_c_itl = Gauge(
+            f"{PREFIX}_aic_c_itl",
+            "EMA-smoothed AIC ITL correction coefficient (c_itl).",
+        )
+        # Single labeled gauge for per-component power coefficients so queries
+        # can filter by component={"prefill","decode","agg"} uniformly.
+        self.aic_c_power = Gauge(
+            f"{PREFIX}_aic_c_power",
+            "EMA-smoothed AIC power correction coefficient per component.",
+            labelnames=("component",),
+        )
+        # Counts how many times a coefficient saturated at its [0.5, 2.0] clamp.
+        # A sustained increment is a CRITICAL calibration signal (§8 row 6).
+        self.aic_correction_pegged_total = Counter(
+            "dynamo_aic_correction_pegged_total",
+            "Times an AIC correction coefficient pegged at its [0.5, 2.0] clamp.",
+            labelnames=("coefficient",),
+        )
+        self.aic_consecutive_failures = Gauge(
+            "dynamo_aic_consecutive_failures",
+            "Current count of consecutive AIC sweep failures before auto-disable.",
+        )
+        self.aic_optimizer_exceptions_total = Counter(
+            "dynamo_aic_optimizer_exceptions_total",
+            "Total AIC sweep exceptions caught at runtime.",
+        )
+        # Info-style gauge: 1 when the optimizer is auto-disabled, 0 otherwise.
+        # Label carries the reason (infeasible_at_startup | startup_exception).
+        self.aic_optimizer_disabled_reason = Gauge(
+            "dynamo_aic_optimizer_disabled_reason",
+            "1 when the AIC optimizer is auto-disabled; reason in label.",
+            labelnames=("reason",),
+        )
+        self.aic_throughput_regression_total = Counter(
+            "dynamo_aic_throughput_regression_total",
+            "Times re-optimization produced a lower predicted throughput than the "
+            "previous config (informational — config is still applied).",
+        )
+        # AIC's per-op power interpolator can extrapolate non-physical values at
+        # high batch sizes / sparse data-grid corners (observed on H200 vLLM
+        # generation_attention at batch>=256). The optimizer clamps the raw
+        # power_w to nameplate TDP before deriving per-GPU caps; this counter
+        # tracks how often that defensive clamp engaged, labelled by side.
+        # A sustained increment means AIC offline data needs a backfill at the
+        # batch sizes the planner is exercising.
+        self.aic_power_w_clamped_total = Counter(
+            "dynamo_aic_power_w_clamped_total",
+            "Times AIC's reported power_w exceeded nameplate TDP and was "
+            "clamped before being used to derive per-GPU power caps.",
+            labelnames=("side",),
+        )
+
+        # -- Admission control / busy_threshold coupling (Phase 3) --------
+        # Implied thresholds derived from the AIC operating point (always
+        # updated in inherit + autoset modes).
+        self.admission_implied_theta_decode = Gauge(
+            f"{PREFIX}_admission_implied_theta_decode",
+            "Implied decode KV utilization threshold for the current AIC config.",
+        )
+        self.admission_implied_theta_prefill_frac = Gauge(
+            f"{PREFIX}_admission_implied_theta_prefill_frac",
+            "Implied prefill fractional utilization threshold for the current AIC config.",
+        )
+        # Values actually POSTed to frontends (autoset mode only).
+        self.admission_set_theta_decode = Gauge(
+            f"{PREFIX}_admission_set_theta_decode",
+            "Decode KV threshold value POSTed to frontend in autoset mode.",
+        )
+        self.admission_set_theta_prefill_frac = Gauge(
+            f"{PREFIX}_admission_set_theta_prefill_frac",
+            "Prefill fractional threshold value POSTed to frontend in autoset mode.",
+        )
+        self.admission_set_theta_prefill_abs = Gauge(
+            f"{PREFIX}_admission_set_theta_prefill_abs",
+            "Absolute prefill admission threshold (tokens) POSTed to the frontend.",
+        )
+        self.admission_max_batched_tokens_unavailable_total = Counter(
+            f"{PREFIX}_admission_max_batched_tokens_unavailable_total",
+            "Times the planner could not derive an absolute prefill threshold "
+            "because no prefill worker reported max_num_batched_tokens via MDC.",
+        )
+        self.admission_partial_success_total = Counter(
+            f"{PREFIX}_admission_partial_success_total",
+            "Cumulative count of frontend POST failures across all fanout attempts.",
         )

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -451,6 +451,49 @@ class PrometheusAPIClient:
             logger.debug("get_total_dgd_power query failed: %s", e)
         return None
 
+    def get_avg_per_gpu_power_by_component(
+        self,
+        interval: str,
+        k8s_namespace: str,
+        dgd_name: str,
+        component: str,
+        service_key: str,
+    ) -> Optional[float]:
+        """Per-GPU average draw over the last ``interval`` for one component.
+
+        Drives the per-component c_power EMA update in Phase 3+ correction
+        coefficients (§5.3).  ``component`` is ``"prefill"``, ``"decode"``,
+        or ``"agg"`` — used in log messages only.  ``service_key`` is the
+        DGD service-dict key (e.g. ``"VllmDecodeWorker"``); the operator
+        embeds its lowercase form in the pod name as
+        ``<dgd>-<replica-idx>-<service-key-lc>-<hash>``.
+
+        Filters DCGM samples by ``exported_namespace`` (K8s namespace, not
+        dynamo namespace) and ``exported_pod`` (workload pod name, not the
+        DCGM exporter's own pod).  Returns ``None`` when the query fails,
+        ``service_key`` is empty, or the result is empty.
+        """
+        if not service_key:
+            logger.debug(
+                "get_avg_per_gpu_power_by_component: empty service_key for "
+                "component=%s; cannot build pod regex.",
+                component,
+            )
+            return None
+        try:
+            result = self.prom.custom_query(
+                f"avg_over_time("
+                f"  avg(DCGM_FI_DEV_POWER_USAGE{{"
+                f'      exported_namespace="{k8s_namespace}",'
+                f'      exported_pod=~"^{dgd_name}-[0-9]+-{service_key.lower()}-.*"}})'
+                f"[{interval}:])"
+            )
+            if result:
+                return float(result[0]["value"][1])
+        except Exception as e:
+            logger.debug("get_avg_per_gpu_power_by_component query failed: %s", e)
+        return None
+
 
 def parse_frontend_metric_containers(
     result: list[dict],
@@ -476,11 +519,54 @@ _WORKER_METRIC_NAMES = {
 
 
 class DirectRouterMetricsClient:
-    """Query router's /metrics endpoint directly for real-time per-worker metrics.
+    """Query a KV-router's /metrics endpoint directly for real-time per-worker metrics.
 
     Runs a continuous background sampling loop that collects metrics at
     evenly-spaced intervals (interval / num_samples). At decision time,
     the load-based loop reads the buffer via get_recent_and_averaged_metrics().
+
+    Supported endpoints (by deployment topology — see ``_WORKER_METRIC_NAMES``
+    for the gauges this client expects):
+
+    - **KV-routed aggregated/disagg DGDs** (frontend launched with
+      ``--router-mode kv``): scrape ``http://<dgd>-frontend:8000/metrics``.
+      The per-worker ``dynamo_frontend_worker_*`` gauges are emitted by the
+      frontend's in-process KV router via ``register_worker_load_metrics``
+      and ``register_worker_timing_metrics`` (see
+      ``lib/llm/src/http/service/service_v2.rs``).
+
+    NOT supported:
+
+    - **Standalone ``python3 -m dynamo.router`` LocalRouter** (Global Planner
+      topology) — the LocalRouter pod's ``/metrics`` is served by the runtime
+      ``system_status_server`` whose Prometheus registry is *separate* from
+      the frontend HTTP service's registry.  ``register_worker_load_metrics``
+      is only invoked from ``service_v2.rs``, so the per-worker
+      ``dynamo_frontend_worker_*`` gauges never appear on the LocalRouter's
+      ``/metrics`` even when KV routing decisions update the global
+      ``WORKER_LOAD_METRICS`` static.  Pool planners using a Global Planner
+      topology must therefore drive their per-worker view from the
+      ``PrometheusAPIClient`` (router-source histograms aggregated over the
+      pool's ``dynamo_namespace``) rather than this direct scrape client.
+      See open-question #14 in ``powerplanner-design.md``.
+    - **RoundRobin / Random / PowerOfTwoChoices / LeastLoaded** routing modes
+      (the default for ``python3 -m dynamo.frontend`` with no flags) — the
+      ``WORKER_LOAD_METRICS`` `IntGaugeVec` and ``WORKER_LAST_*_GAUGE``
+      ``GaugeVec`` are registered but never written, so Prometheus omits the
+      families entirely from the exposition.  Pointing this client at such an
+      endpoint will yield an empty parse result; the planner's load-based
+      decision loop should detect this and fall back to its frontend-source
+      ``PrometheusAPIClient`` branch (see §5.3 of ``powerplanner-design.md``).
+    - **Worker /metrics endpoints** (``<dgd>-vllmworker:9090/metrics``) —
+      these expose ``dynamo_component_*`` (the worker's own work counters),
+      not the per-worker router gauges this client targets.
+
+    The class name (`DirectRouter…`) emphasizes that we bypass Prometheus
+    and scrape the router process directly to read the latest gauge value
+    rather than the rate over a long window.  This matters for the
+    load-based loop because the gauges have ``set()`` semantics — a single
+    instance per ``(worker_id, dp_rank, worker_type)`` tuple — which
+    Prometheus's scrape interval would otherwise blur out.
     """
 
     def __init__(self, router_metrics_url: str, dynamo_namespace: str):

--- a/components/src/dynamo/planner/tests/integration/test_aic_power_e2e_sim.py
+++ b/components/src/dynamo/planner/tests/integration/test_aic_power_e2e_sim.py
@@ -1,0 +1,712 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end simulation tests for the AIC power-aware planner (Phase 3 + Phase 4 preview).
+
+These tests do NOT require aiconfigurator to be installed.  They use mocked
+AIC responses parameterised from the real `aic_h200_power_data` measurements:
+
+    H200 context_attention  (prefill proxy) — p50 = 380 W, p90 = 603 W, max = 691 W
+    H200 generation_attention (decode proxy) — p50 = 263 W, p90 = 558 W, max = 700 W
+
+Scenario groups
+---------------
+1. ``TestFeedbackLoopH200``          — multi-tick EMA convergence with H200-realistic params
+2. ``TestBudgetConstraintPipeline``  — replica capping when power_w × GPUs × replicas > budget
+3. ``TestPhase4SyntheticMultiLevel`` — synthetic 3-level power sweep that exercises the exact
+                                       Phase 4 code path before the AIC team delivers it
+
+The Phase 4 synthetic scenario is the key "pipeclean" test: it proves that the
+existing optimizer already selects the right (cap, replicas) pair from a set of
+AIC responses that differ only in their `power_w` field, exactly as Phase 4 will
+do once the AIC team delivers multi-power-level data.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
+from dynamo.planner.config.parallelization import PickedParallelConfig
+from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.types import TrafficObservation
+from dynamo.planner.monitoring.aic_power_optimizer import (
+    AICPowerOptimizer,
+    PowerAwareConfig,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
+# ---------------------------------------------------------------------------
+# H200 power constants (derived from aic_h200_power_data statistics)
+# ---------------------------------------------------------------------------
+H200_TDP_W = 700.0
+
+# context_attention_perf.txt — prefill proxy
+H200_PREFILL_P50_W = 380.0
+H200_PREFILL_P90_W = 603.0
+
+# generation_attention_perf.txt — decode proxy
+H200_DECODE_P50_W = 263.0
+H200_DECODE_P90_W = 558.0
+
+# "Serving-load" operating point (steady-state heavy traffic)
+H200_PREFILL_SERVING_W = H200_PREFILL_P90_W  # 603 W/GPU at heavy prefill load
+H200_DECODE_SERVING_W = H200_DECODE_P90_W  # 558 W/GPU at heavy decode load
+
+# GPUs per H200 SXM engine (8-GPU tensor parallel)
+H200_GPUS_PER_ENGINE = 8
+
+# ---------------------------------------------------------------------------
+# Synthetic multi-level profiles (Phase 4 simulation)
+#   Three "power levels" derived by scaling the measured serving-point values.
+#   Phase 4 will get these from the AIC database at different NVML cap settings.
+# ---------------------------------------------------------------------------
+#   Level  | Cap (% TDP) | Prefill W/GPU | Decode W/GPU | Relative throughput
+#   -------+-------------+---------------+--------------+---------------------
+#   HIGH   | 100%  700W  |   603 W       |   558 W      |  1.00×
+#   MED    |  75%  525W  |   452 W       |   419 W      |  ~0.88× (rough estimate)
+#   LOW    |  50%  350W  |   302 W       |   279 W      |  ~0.70×
+_POWER_LEVELS = {
+    "high": {
+        "cap_pct": 1.00,
+        "prefill_w": H200_PREFILL_SERVING_W,
+        "decode_w": H200_DECODE_SERVING_W,
+        "ttft_ms": 50.0,  # fastest at full power
+        "itl_ms": 10.0,
+        "max_kv": 50_000,
+    },
+    "med": {
+        "cap_pct": 0.75,
+        "prefill_w": H200_PREFILL_SERVING_W * 0.75,
+        "decode_w": H200_DECODE_SERVING_W * 0.75,
+        "ttft_ms": 57.0,  # ~14% slower (throttled GEMMs)
+        "itl_ms": 11.4,
+        "max_kv": 50_000,
+    },
+    "low": {
+        "cap_pct": 0.50,
+        "prefill_w": H200_PREFILL_SERVING_W * 0.50,
+        "decode_w": H200_DECODE_SERVING_W * 0.50,
+        "ttft_ms": 70.0,  # ~40% slower
+        "itl_ms": 13.0,
+        "max_kv": 50_000,
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PICK_8GPU = PickedParallelConfig(tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1)
+
+_SPEC = AICInterpolationSpec(
+    hf_id="Qwen/Qwen3-32B",
+    system="h200_sxm",
+    backend="trtllm",
+    isl=1024,
+    osl=200,
+    sweep_max_context_length=4096,
+    prefill_interpolation_granularity=4,
+    decode_interpolation_granularity=4,
+    prefill_pick=_PICK_8GPU,
+    decode_pick=_PICK_8GPU,
+)
+
+
+def _make_config(
+    *,
+    total_gpu_power_limit: int | None = 200_000,  # 200 kW default — very generous
+    ttft: int = 200,
+    itl: int = 50,
+    min_endpoint: int = 1,
+    max_gpu_budget: int = 64,
+    c_ttft: float = 1.0,
+    c_itl: float = 1.0,
+    c_power_p: float = 1.0,
+    c_power_d: float = 1.0,
+    aic_reoptimize_interval: float = 0.0,  # no rate-limit in tests
+    aic_drift_consecutive_ticks: int = 3,
+    mode: str = "disagg",
+) -> PlannerConfig:
+    return PlannerConfig(
+        namespace="test-sim",
+        mode=mode,
+        enable_power_awareness=True,
+        total_gpu_power_limit=total_gpu_power_limit,
+        power_agent_safe_default_watts=350,
+        prefill_engine_gpu_power_limit=int(H200_TDP_W),
+        decode_engine_gpu_power_limit=int(H200_TDP_W),
+        enable_aic_optimizer=True,
+        aic_interpolation=_SPEC,
+        ttft=ttft,
+        itl=itl,
+        min_endpoint=min_endpoint,
+        max_gpu_budget=max_gpu_budget,
+        aic_reoptimize_interval=aic_reoptimize_interval,
+        aic_drift_relative_threshold=0.15,
+        aic_drift_consecutive_ticks=aic_drift_consecutive_ticks,
+        aic_max_consecutive_failures=3,
+        aic_initial_c_ttft=c_ttft,
+        aic_initial_c_itl=c_itl,
+        aic_initial_c_power_prefill=c_power_p,
+        aic_initial_c_power_decode=c_power_d,
+        aic_throughput_regression_warn_threshold=0.20,
+    )
+
+
+def _estimator_for_level(level: str) -> MagicMock:
+    """Build an AIC estimator mock using the given synthetic power-level profile."""
+    p = _POWER_LEVELS[level]
+    inst = MagicMock(name=f"AIC_{level}")
+    inst.database.system_spec = {"gpu": {"power": H200_TDP_W}}
+    inst.estimate_prefill_perf.return_value = {
+        "context_latency": p["ttft_ms"],
+        "power_w": p["prefill_w"],
+    }
+    inst.estimate_perf.return_value = {
+        "tpot": p["itl_ms"],
+        "power_w": p["decode_w"],
+    }
+    inst.get_max_kv_tokens.return_value = p["max_kv"]
+    return inst
+
+
+def _make_optimizer(config: PlannerConfig) -> tuple[AICPowerOptimizer, MagicMock]:
+    metrics = MagicMock()
+    return AICPowerOptimizer(config, metrics), metrics
+
+
+def _make_traffic(
+    *,
+    num_req: float = 20.0,
+    ttft_avg_s: float | None = None,
+    itl_avg_s: float | None = None,
+    total_tokens_per_s: float | None = 500.0,
+    scheduled_prefill_tokens: float = 8_000.0,
+    scheduled_decode_kv_tokens: float = 4_000.0,
+) -> TrafficObservation:
+    return TrafficObservation(
+        duration_s=60.0,
+        num_req=num_req,
+        isl=1024.0,
+        osl=200.0,
+        ttft_avg=ttft_avg_s,
+        itl_avg=itl_avg_s,
+        total_tokens_per_s=total_tokens_per_s,
+        scheduled_prefill_tokens=scheduled_prefill_tokens,
+        scheduled_decode_kv_tokens=scheduled_decode_kv_tokens,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Feedback loop — EMA convergence with H200-realistic power values
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackLoopH200:
+    """Multi-tick EMA feedback loop using H200 realistic power values.
+
+    The EMA denominator is AIC's raw per-GPU power estimate from the last
+    sweep (``_last_optimal_config.aic_power_w_prefill`` / ``_decode``), NOT
+    the planner-applied cap (§5.3, decision #6).  For the ``"high"`` level
+    that's ``H200_PREFILL_P90_W = 603 W`` and ``H200_DECODE_P90_W = 558 W``.
+
+    With this denominator:
+    - ``c_power_p < 1.0`` when observed < AIC's prediction (AIC over-predicts
+      power; the asymmetric clamp ``max(1.0, c)`` then leaves the cap at the
+      AIC estimate, which is conservative-correct).
+    - ``c_power_p > 1.0`` when observed > AIC's prediction (AIC under-predicts;
+      the cap inflates by ``c_power_p`` so the planner books realistic budget).
+    """
+
+    def test_ema_converges_from_cold_start(self):
+        """After N ticks of consistent power observation, c_power_p converges.
+
+        Scenario: observed power is 80% of AIC's predicted prefill power
+        (482.4 W out of 603 W).  EMA raw ratio = 482.4/603 ≈ 0.80 each tick.
+        After 20 ticks the coefficient should be within 5% of 0.80.
+        """
+        AIC_PREFILL_W = H200_PREFILL_P90_W  # 603 W (synthetic AIC estimate)
+        OBSERVED_W = AIC_PREFILL_W * 0.80  # ≈482.4 W (observed)
+        TRUE_RATIO = OBSERVED_W / AIC_PREFILL_W  # 0.80
+
+        estimator = _estimator_for_level("high")
+        config = _make_config(c_power_p=1.0)
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+        assert result is not None
+        # Sanity-check that the optimizer captured the AIC raw power as the
+        # EMA denominator — this is the bug-#2 invariant.
+        assert result.aic_power_w_prefill == pytest.approx(AIC_PREFILL_W)
+
+        traffic = _make_traffic(num_req=30.0, scheduled_prefill_tokens=10_000.0)
+
+        TICKS = 20
+        for _ in range(TICKS):
+            opt.update_correction(traffic, observed_power_w_prefill=OBSERVED_W)
+
+        assert (
+            abs(opt._c_power_p - TRUE_RATIO) < 0.05
+        ), f"c_power_p={opt._c_power_p:.3f} did not converge to {TRUE_RATIO:.3f}"
+
+    def test_ema_stable_when_observed_matches_aic_prediction(self):
+        """When observed power equals AIC's prefill power_w, c stays at 1.0.
+
+        raw = observed / aic_power_w_prefill = 1.0 → EMA(1.0, 1.0) = 1.0 forever.
+        """
+        estimator = _estimator_for_level("high")
+        config = _make_config(c_power_p=1.0)
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            opt.optimize()
+
+        traffic = _make_traffic(scheduled_prefill_tokens=5_000.0)
+
+        # observed exactly matches AIC's prefill estimate (603W).
+        # raw = 603/603 = 1.0 → EMA update: 0.3×1.0 + 0.7×1.0 = 1.0 (no change).
+        for _ in range(10):
+            opt.update_correction(
+                traffic,
+                observed_power_w_prefill=H200_PREFILL_P90_W,
+            )
+
+        assert abs(opt._c_power_p - 1.0) < 0.001
+
+    def test_decode_coefficient_independent_of_prefill(self):
+        """Decode EMA must not be contaminated by prefill observations."""
+        estimator = _estimator_for_level("high")
+        config = _make_config(c_power_p=1.0, c_power_d=1.0)
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            opt.optimize()
+
+        # Prefill active, decode idle.
+        traffic = _make_traffic(
+            scheduled_prefill_tokens=8_000.0,
+            scheduled_decode_kv_tokens=0.0,
+        )
+        initial_d = opt._c_power_d
+        BIG_PREFILL_OBS = H200_TDP_W * 1.5  # large prefill observation
+
+        for _ in range(10):
+            opt.update_correction(traffic, observed_power_w_prefill=BIG_PREFILL_OBS)
+
+        # c_power_d must not have moved (decode side was idle).
+        assert opt._c_power_d == initial_d, (
+            f"c_power_d changed from {initial_d} to {opt._c_power_d} "
+            f"despite decode side being idle"
+        )
+
+    def test_drift_detection_fires_when_sla_consistently_violated(self):
+        """TTFT > SLA for consecutive_ticks → should_reoptimize() returns True."""
+        estimator = _estimator_for_level("high")
+        config = _make_config(
+            ttft=200,
+            aic_reoptimize_interval=0.0,
+            aic_drift_consecutive_ticks=3,
+        )
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            opt.optimize()
+
+        # TTFT measured at 350ms > 200ms SLA.
+        bad_traffic = _make_traffic(ttft_avg_s=0.350)
+
+        assert opt.should_reoptimize(bad_traffic) is False  # tick 1
+        assert opt.should_reoptimize(bad_traffic) is False  # tick 2
+        assert opt.should_reoptimize(bad_traffic) is True  # tick 3 — fires
+
+    def test_no_drift_under_nominal_load(self):
+        """At normal load well within budget, no spurious reoptimization triggers."""
+        estimator = _estimator_for_level("high")
+        config = _make_config(
+            ttft=200,
+            aic_reoptimize_interval=0.0,
+            aic_drift_consecutive_ticks=3,
+        )
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+        assert result is not None
+
+        # Set the estimated throughput reference.
+        opt._estimated_throughput = 1_000.0  # tok/s
+
+        # Good traffic: TTFT within SLA, tokens within estimated capacity.
+        good_traffic = _make_traffic(
+            ttft_avg_s=0.100,  # 100ms < 200ms SLA
+            itl_avg_s=0.020,  # 20ms < 50ms SLA
+            total_tokens_per_s=800.0,  # < 1000 × 1.15 threshold
+        )
+        for _ in range(10):
+            assert opt.should_reoptimize(good_traffic) is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Budget constraint pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetConstraintPipeline:
+    """Verify that the power budget correctly restricts replica counts end-to-end.
+
+    Uses H200-realistic power_w values so the wattage numbers are grounded
+    in the actual measured data.
+    """
+
+    def test_budget_limits_replicas_to_realistic_count(self):
+        """With a realistic 40 kW budget and H200 serving power, replica count is bounded."""
+        # 8 GPUs per engine, serving power:
+        #   prefill: 603 W/GPU × 8 = 4,824 W/replica
+        #   decode:  558 W/GPU × 8 = 4,464 W/replica
+        # Budget 40 kW → can fit ~4 decode replicas (4 × 4464 = 17856) + prefill
+        estimator = _estimator_for_level("high")
+        config = _make_config(
+            total_gpu_power_limit=40_000,
+            max_gpu_budget=64,
+        )
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        # Total power must respect the budget.
+        total_w = (
+            result.n_p * result.cap_p * H200_GPUS_PER_ENGINE
+            + result.n_d * result.cap_d * H200_GPUS_PER_ENGINE
+        )
+        assert (
+            total_w <= 40_000 + 200
+        ), f"total_w={total_w} W exceeds budget=40000 W"  # small rounding tolerance
+
+    def test_corrected_cap_respected_under_budget(self):
+        """When c_power_p = 1.10 (10% over-estimate detected), cap inflates by 10%."""
+        estimator = _estimator_for_level("high")
+        config = _make_config(c_power_p=1.10, c_power_d=1.10)
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        # cap_p should be ceil(H200_PREFILL_P90_W × 1.10)
+        expected_cap_p = math.ceil(H200_PREFILL_P90_W * 1.10)
+        assert (
+            result.cap_p == expected_cap_p
+        ), f"cap_p={result.cap_p} != expected {expected_cap_p}"
+
+    def test_total_gpu_power_limit_none_gives_max_replicas(self):
+        """With a very generous power budget, replicas are bounded only by max_gpu_budget."""
+        estimator = _estimator_for_level("high")
+        config = _make_config(
+            total_gpu_power_limit=200_000,  # 200 kW — effectively unbounded
+            max_gpu_budget=16,  # 16 GPUs → 2 engines of 8 GPUs each
+        )
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        assert result.n_d >= 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Synthetic Phase 4 multi-level power sweep
+# ---------------------------------------------------------------------------
+
+
+class TestPhase4SyntheticMultiLevel:
+    """Synthetic multi-level power sweep — pipecleans the Phase 4 code path.
+
+    Phase 4 will add a ``power_level`` dimension to the AIC sweep:
+    for each candidate power cap, AIC returns a (ttft_ms, itl_ms, power_w,
+    max_kv) tuple.  The optimizer selects the highest-throughput config whose
+    per-replica power draw fits within the budget.
+
+    This test simulates that selection by calling optimize() three times with
+    different AIC mock returns (one per synthetic power level) and a fixed
+    budget that only certain levels can satisfy.  It proves that:
+
+    1. The optimizer correctly selects the highest-watt config when budget is
+       generous (``high`` level wins).
+    2. With a tighter budget, the optimizer is forced to the medium level.
+    3. With a very tight budget, only the low level fits.
+    4. The selected cap reflects the power_w from the chosen level, not TDP.
+    5. Throughput (n_d × aic_seq_per_s_per_replica) decreases monotonically as
+       budget tightens (lower power → lower throughput → fewer effective replicas).
+
+    All three scenarios use IDENTICAL optimizer configuration; only the AIC
+    mock response (i.e., which ``power_level`` the AIC database returns) varies.
+    This is exactly how Phase 4 will work at runtime.
+    """
+
+    # Per-replica wattage for each level (power_w × 8 GPUs)
+    _WATTS_PER_REPLICA = {
+        lvl: _POWER_LEVELS[lvl]["prefill_w"] * H200_GPUS_PER_ENGINE
+        for lvl in _POWER_LEVELS
+    }
+
+    def _optimize_at_level(
+        self, level: str, total_gpu_power_limit: int
+    ) -> tuple[AICPowerOptimizer, "PowerAwareConfig"]:
+        estimator = _estimator_for_level(level)
+        config = _make_config(
+            total_gpu_power_limit=total_gpu_power_limit,
+            max_gpu_budget=64,
+            ttft=300,
+            itl=100,
+        )
+        opt, _ = _make_optimizer(config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+        assert result is not None, f"optimize() returned None at level={level}"
+        return opt, result
+
+    def test_high_level_wins_with_generous_budget(self):
+        """With a 120 kW budget, the optimizer should use the full-TDP config."""
+        # high level: 603 W/GPU × 8 = 4824 W/replica → 120kW fits ~24 decode replicas
+        _, result = self._optimize_at_level("high", total_gpu_power_limit=120_000)
+        # cap should be ceil(603 × 1.0) = 603 W (not 700 W TDP fallback)
+        assert result.cap_p == math.ceil(H200_PREFILL_P90_W)
+        assert result.cap_d == math.ceil(H200_DECODE_P90_W)
+
+    def test_med_level_produces_lower_cap(self):
+        """Medium level (75% TDP) produces lower caps than high level."""
+        _, high_r = self._optimize_at_level("high", total_gpu_power_limit=120_000)
+        _, med_r = self._optimize_at_level("med", total_gpu_power_limit=120_000)
+
+        assert (
+            med_r.cap_p < high_r.cap_p
+        ), f"med cap_p={med_r.cap_p} should be < high cap_p={high_r.cap_p}"
+        assert med_r.cap_d < high_r.cap_d
+
+    def test_budget_selects_lower_power_level(self):
+        """With a tight budget, the optimizer forced to lower-watt config gets more replicas.
+
+        Key Phase 4 insight: a lower per-replica power means more replicas fit
+        in the same budget, which can offset the lower per-replica throughput.
+        """
+        # Tight budget: 20 kW.  High-level replica = 4824 W → 4 decode fit.
+        # Low-level replica = ~2420 W → 8 decode fit.
+        TIGHT_BUDGET = 20_000
+
+        _, high_r = self._optimize_at_level("high", total_gpu_power_limit=TIGHT_BUDGET)
+        _, low_r = self._optimize_at_level("low", total_gpu_power_limit=TIGHT_BUDGET)
+
+        # Low level has lower per-replica cost → should fit more decode replicas.
+        assert (
+            low_r.n_d >= high_r.n_d
+        ), f"low n_d={low_r.n_d} should be >= high n_d={high_r.n_d} at tight budget"
+
+        # Caps reflect the power_w from each level.
+        assert low_r.cap_p < high_r.cap_p
+        assert low_r.cap_d < high_r.cap_d
+
+    def test_all_levels_respect_budget(self):
+        """For every budget × level combo, total power must not exceed budget."""
+        for budget in [10_000, 25_000, 50_000, 100_000]:
+            for level in ["high", "med", "low"]:
+                _, result = self._optimize_at_level(level, total_gpu_power_limit=budget)
+                total_w = (
+                    result.n_p * result.cap_p * H200_GPUS_PER_ENGINE
+                    + result.n_d * result.cap_d * H200_GPUS_PER_ENGINE
+                )
+                assert (
+                    total_w <= budget + 500
+                ), (  # 500W rounding tolerance
+                    f"level={level}, budget={budget}: total_w={total_w} exceeds budget"
+                )
+
+    def test_caps_are_not_tdp_fallback(self):
+        """In all three levels, cap_p and cap_d must differ from TDP (700W).
+
+        The TDP fallback path emits a WARNING and returns caps based on TDP.
+        Real power_w from the H200 data is < 700W at all serving points, so
+        if the integration is working, caps will be < 700W.
+        """
+        for level in ["high", "med", "low"]:
+            _, result = self._optimize_at_level(level, total_gpu_power_limit=200_000)
+            assert result.cap_p != int(H200_TDP_W), (
+                f"level={level}: cap_p={result.cap_p} W equals TDP — "
+                "TDP fallback was triggered (power_w=0 from AIC)"
+            )
+            assert result.cap_d != int(H200_TDP_W), (
+                f"level={level}: cap_d={result.cap_d} W equals TDP — "
+                "TDP fallback was triggered (power_w=0 from AIC)"
+            )
+
+    def test_ema_correction_applied_consistently_across_levels(self):
+        """After EMA converges (c_power = 1.1), caps are inflated consistently."""
+        for level in _POWER_LEVELS:
+            estimator = _estimator_for_level(level)
+            config = _make_config(c_power_p=1.10, c_power_d=1.10)
+            opt, _ = _make_optimizer(config)
+
+            with patch(
+                "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+                return_value=estimator,
+            ):
+                result = opt.optimize()
+
+            assert result is not None
+            # cap = ceil(power_w × max(1.0, c_power)) = ceil(power_w × 1.10)
+            expected_p = math.ceil(_POWER_LEVELS[level]["prefill_w"] * 1.10)
+            expected_d = math.ceil(_POWER_LEVELS[level]["decode_w"] * 1.10)
+            assert result.cap_p == expected_p, f"level={level}: cap_p mismatch"
+            assert result.cap_d == expected_d, f"level={level}: cap_d mismatch"
+
+
+# ---------------------------------------------------------------------------
+# 4. Full scenario: from cold start through stable state
+# ---------------------------------------------------------------------------
+
+
+class TestFullDeploymentScenario:
+    """Simulate a 'day in the life' of the power-aware planner on H200.
+
+    Phase 0: Cold start — first optimize() call with c_power=1.0.
+    Phase 1: EMA calibration — 15 ticks where observed power > AIC estimate.
+    Phase 2: Stable state — coefficients have converged; no spurious re-sweeps.
+    Phase 3: Traffic surge — tokens/s spikes above capacity → drift detected.
+    Phase 4: Re-optimise — new sweep produces updated config.
+    """
+
+    def test_full_scenario_completes_without_disabling(self):
+        estimator = _estimator_for_level("high")
+        config = _make_config(
+            total_gpu_power_limit=50_000,
+            ttft=200,
+            itl=50,
+            aic_reoptimize_interval=0.0,
+            aic_drift_consecutive_ticks=3,
+        )
+        opt, _ = _make_optimizer(config)
+
+        # Phase 0: cold start sweep.
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            first_result = opt.optimize()
+        assert first_result is not None
+        assert (
+            not opt._disabled
+        ), "Optimizer disabled after first sweep — check SLA feasibility"
+
+        # Phase 1: EMA calibration — 15 ticks.
+        # - TTFT observed at 55ms vs AIC 50ms → raw_ttft = 55/50 = 1.10 → c_ttft > 1.0
+        # - ITL observed at 11ms vs AIC 10ms  → raw_itl  = 11/10 = 1.10 → c_itl  > 1.0
+        # - Prefill power observed at 637W, AIC predicted 603W → raw = 1.056 → c_power_p > 1.0
+        #   (AIC slightly under-predicts; the cap inflates by c_power_p on the next sweep).
+        OVER_PREDICT_FACTOR = 1.056
+        traffic_calibrate = _make_traffic(
+            num_req=25.0,
+            ttft_avg_s=0.055,  # 55ms vs 50ms AIC TTFT (within 200ms SLA)
+            itl_avg_s=0.011,  # 11ms vs 10ms AIC ITL
+            total_tokens_per_s=400.0,
+            scheduled_prefill_tokens=8_000.0,
+            scheduled_decode_kv_tokens=5_000.0,
+        )
+        for _ in range(15):
+            opt.update_correction(
+                traffic_calibrate,
+                observed_ttft_avg=0.055,
+                observed_itl_avg=0.011,
+                observed_power_w_prefill=H200_PREFILL_P90_W
+                * OVER_PREDICT_FACTOR,  # 637 W
+                observed_power_w_decode=H200_DECODE_P90_W * OVER_PREDICT_FACTOR,
+            )
+            # No drift should trigger during calibration (SLA not violated, no capacity surge).
+            assert opt.should_reoptimize(traffic_calibrate) is False
+
+        # TTFT/ITL calibrate above 1.0 (observed > AIC estimate).
+        assert opt._c_ttft > 1.0, f"c_ttft={opt._c_ttft} did not calibrate above 1.0"
+        assert opt._c_itl > 1.0, f"c_itl={opt._c_itl} did not calibrate above 1.0"
+        # Power coefficient normalises against AIC raw estimate (603W for high level)
+        # → raw = 637/603 = 1.056, c_power_p > 1.0 (AIC slightly under-predicts).
+        assert (
+            opt._c_power_p > 1.0
+        ), f"c_power_p={opt._c_power_p:.3f} should be > 1.0 when observed > AIC raw"
+        assert opt._c_power_p == pytest.approx(OVER_PREDICT_FACTOR, abs=0.01)
+
+        # Phase 2: stable state — 10 ticks, all metrics nominal.
+        traffic_stable = _make_traffic(
+            num_req=20.0,
+            ttft_avg_s=0.055,
+            itl_avg_s=0.011,
+            total_tokens_per_s=400.0,
+        )
+        opt._estimated_throughput = 1_000.0  # set reference
+        for _ in range(10):
+            opt.update_correction(
+                traffic_stable,
+                observed_power_w_prefill=H200_PREFILL_P90_W * OVER_PREDICT_FACTOR,
+                observed_power_w_decode=H200_DECODE_P90_W * OVER_PREDICT_FACTOR,
+            )
+            assert opt.should_reoptimize(traffic_stable) is False
+
+        # Phase 3: traffic surge — 3 ticks at 120% of estimated capacity.
+        traffic_surge = _make_traffic(
+            num_req=60.0,
+            ttft_avg_s=0.055,  # TTFT still OK (enough replicas)
+            total_tokens_per_s=1_200.0,  # 20% above 1000 threshold
+        )
+        assert opt.should_reoptimize(traffic_surge) is False  # tick 1
+        assert opt.should_reoptimize(traffic_surge) is False  # tick 2
+        assert opt.should_reoptimize(traffic_surge) is True  # tick 3 — fires!
+
+        # Phase 4: re-optimize.
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            second_result = opt.optimize()
+
+        assert second_result is not None
+        assert not opt._disabled
+        # After a valid sweep, consecutive violations reset to 0.
+        assert opt._consecutive_violation_ticks == 0

--- a/components/src/dynamo/planner/tests/integration/test_aic_power_optimizer.py
+++ b/components/src/dynamo/planner/tests/integration/test_aic_power_optimizer.py
@@ -1,0 +1,967 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for AICPowerOptimizer (Phase 3).
+
+The AIConfigurator SDK is mocked throughout so these tests run without a GPU
+or an aiconfigurator installation.
+
+Coverage:
+    optimize()      — happy path, TDP fallback, measured power_w, budget
+                      constraint, SLA infeasibility, startup failures, runtime
+                      failures, auto-disable, throughput regression warning,
+                      implied admission thresholds.
+    update_correction() — EMA update, traffic gating (latency + per-side power),
+                          agg vs disagg mode, clamp saturation.
+    should_reoptimize() — rate limit, SLA-miss trigger, capacity-exceeded trigger
+                          (upward-only), hysteresis, under-load invariance.
+    _sweep_replicas() — budget-constrained, unbounded, budget-too-small fallback.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
+from dynamo.planner.config.parallelization import PickedParallelConfig
+from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.types import TrafficObservation
+from dynamo.planner.monitoring.aic_power_optimizer import (
+    _COEFF_MAX,
+    _COEFF_MIN,
+    _EMA_ALPHA,
+    AICPowerOptimizer,
+    PowerAwareConfig,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PICK_8GPU = PickedParallelConfig(tp=8, pp=1, dp=1, moe_tp=1, moe_ep=1)
+
+_AIC_SPEC = AICInterpolationSpec(
+    hf_id="Qwen/Qwen3-32B",
+    system="h200_sxm",
+    backend="trtllm",
+    isl=1000,
+    osl=200,
+    sweep_max_context_length=4096,
+    prefill_interpolation_granularity=4,
+    decode_interpolation_granularity=4,
+    prefill_pick=_PICK_8GPU,
+    decode_pick=_PICK_8GPU,
+)
+
+
+def _make_config(
+    *,
+    mode: str = "disagg",
+    total_gpu_power_limit: int | None = 8_000,  # 8 kW — very generous
+    prefill_limit: int = 700,
+    decode_limit: int = 700,
+    ttft: int = 200,
+    itl: int = 50,
+    min_endpoint: int = 1,
+    max_gpu_budget: int = 32,
+    aic_reoptimize_interval: float = 300.0,
+    aic_drift_relative_threshold: float = 0.15,
+    aic_drift_consecutive_ticks: int = 3,
+    aic_max_consecutive_failures: int = 3,
+    aic_throughput_regression_warn_threshold: float = 0.20,
+    c_ttft: float = 1.0,
+    c_itl: float = 1.0,
+    c_power_p: float = 1.0,
+    c_power_d: float = 1.0,
+    c_power_agg: float = 1.0,
+) -> PlannerConfig:
+    return PlannerConfig(
+        namespace="test-ns",
+        mode=mode,
+        enable_power_awareness=True,
+        total_gpu_power_limit=total_gpu_power_limit,
+        power_agent_safe_default_watts=300,
+        prefill_engine_gpu_power_limit=prefill_limit,
+        decode_engine_gpu_power_limit=decode_limit,
+        enable_aic_optimizer=True,
+        aic_interpolation=_AIC_SPEC,
+        ttft=ttft,
+        itl=itl,
+        min_endpoint=min_endpoint,
+        max_gpu_budget=max_gpu_budget,
+        aic_reoptimize_interval=aic_reoptimize_interval,
+        aic_drift_relative_threshold=aic_drift_relative_threshold,
+        aic_drift_consecutive_ticks=aic_drift_consecutive_ticks,
+        aic_max_consecutive_failures=aic_max_consecutive_failures,
+        aic_initial_c_ttft=c_ttft,
+        aic_initial_c_itl=c_itl,
+        aic_initial_c_power_prefill=c_power_p,
+        aic_initial_c_power_decode=c_power_d,
+        aic_initial_c_power_agg=c_power_agg,
+        aic_throughput_regression_warn_threshold=aic_throughput_regression_warn_threshold,
+    )
+
+
+def _make_metrics() -> MagicMock:
+    """Return a MagicMock that satisfies the PlannerPrometheusMetrics interface."""
+    m = MagicMock()
+    # Prometheus Gauge-like: .set(), Counter-like: .inc()
+    # MagicMock handles all of these automatically.
+    return m
+
+
+def _make_estimator_mock(
+    *,
+    ttft_ms: float = 50.0,
+    itl_ms: float = 10.0,
+    max_kv_tokens: int = 50_000,
+    power_w_prefill: float = 400.0,
+    power_w_decode: float = 300.0,
+    tdp_w: float = 700.0,
+) -> MagicMock:
+    """Build a mock AIConfiguratorPerfEstimator with configurable returns."""
+    inst = MagicMock(name="AICEstimator")
+    inst.database.system_spec = {"gpu": {"power": tdp_w}}
+    inst.estimate_prefill_perf.return_value = {
+        "context_latency": ttft_ms,
+        "power_w": power_w_prefill,
+    }
+    inst.estimate_perf.return_value = {
+        "tpot": itl_ms,
+        "power_w": power_w_decode,
+    }
+    inst.get_max_kv_tokens.return_value = max_kv_tokens
+    return inst
+
+
+def _make_traffic(
+    *,
+    num_req: float = 10.0,
+    isl: float = 1000.0,
+    osl: float = 200.0,
+    ttft_avg: float | None = None,
+    itl_avg: float | None = None,
+    total_tokens_per_s: float | None = None,
+    scheduled_prefill_tokens: float | None = 5000.0,
+    scheduled_decode_kv_tokens: float | None = 2000.0,
+) -> TrafficObservation:
+    return TrafficObservation(
+        duration_s=60.0,
+        num_req=num_req,
+        isl=isl,
+        osl=osl,
+        ttft_avg=ttft_avg,
+        itl_avg=itl_avg,
+        total_tokens_per_s=total_tokens_per_s,
+        scheduled_prefill_tokens=scheduled_prefill_tokens,
+        scheduled_decode_kv_tokens=scheduled_decode_kv_tokens,
+    )
+
+
+def _make_optimizer_with_mock(
+    estimator_inst: MagicMock,
+    config: PlannerConfig | None = None,
+) -> tuple[AICPowerOptimizer, MagicMock]:
+    """Return (optimizer, metrics) with the estimator class patched."""
+    if config is None:
+        config = _make_config()
+    metrics = _make_metrics()
+    opt = AICPowerOptimizer(config, metrics)
+    return opt, metrics
+
+
+# ---------------------------------------------------------------------------
+# optimize() — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizeHappyPath:
+    """optimize() with a cooperative AIC mock returns a well-formed config."""
+
+    def test_returns_power_aware_config(self):
+        estimator = _make_estimator_mock(ttft_ms=50.0, itl_ms=10.0)
+        config = _make_config(ttft=200, itl=50)
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert isinstance(result, PowerAwareConfig)
+        assert result.aic_ttft_ms == pytest.approx(50.0)
+        assert result.aic_itl_ms == pytest.approx(10.0)
+        assert result.n_p >= 1
+        assert result.n_d >= 1
+
+    def test_uses_measured_power_w_for_caps(self):
+        """When AIC returns non-zero power_w, caps are derived from it, not TDP."""
+        estimator = _make_estimator_mock(
+            ttft_ms=50.0,
+            itl_ms=10.0,
+            power_w_prefill=400.0,
+            power_w_decode=300.0,
+            tdp_w=700.0,
+        )
+        config = _make_config(c_power_p=1.0, c_power_d=1.0)
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        # cap_p should be ceil(400 * max(1.0, 1.0)) = 400, not 700
+        assert result.cap_p == 400
+        assert result.cap_d == 300
+
+    def test_uses_tdp_fallback_when_power_w_zero(self):
+        """When AIC returns power_w=0, the optimizer falls back to nameplate TDP."""
+        estimator = _make_estimator_mock(
+            ttft_ms=50.0,
+            itl_ms=10.0,
+            power_w_prefill=0.0,
+            power_w_decode=0.0,
+            tdp_w=700.0,
+        )
+        config = _make_config(c_power_p=1.0, c_power_d=1.0)
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        # cap should be TDP (700) * max(1.0, c_power=1.0) = 700
+        assert result.cap_p == 700
+        assert result.cap_d == 700
+
+    def test_correction_coefficients_inflate_caps(self):
+        """c_power > 1.0 inflates caps above the measured power_w."""
+        estimator = _make_estimator_mock(power_w_prefill=400.0, power_w_decode=300.0)
+        config = _make_config(c_power_p=1.5, c_power_d=1.2)
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        import math
+
+        assert result is not None
+        assert result.cap_p == math.ceil(400.0 * 1.5)  # 600
+        assert result.cap_d == math.ceil(300.0 * 1.2)  # 360
+
+    def test_isl_osl_propagated(self):
+        estimator = _make_estimator_mock()
+        config = _make_config()
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        assert result.isl == _AIC_SPEC.isl
+        assert result.osl == _AIC_SPEC.osl
+
+    def test_implied_admission_thresholds_in_unit_interval(self):
+        """theta_decode_impl and theta_prefill_frac_impl must always be in [0, 1]."""
+        estimator = _make_estimator_mock(
+            ttft_ms=50.0, itl_ms=10.0, max_kv_tokens=100_000
+        )
+        config = _make_config()
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        assert 0.0 <= result.theta_decode_impl <= 1.0
+        assert 0.0 <= result.theta_prefill_frac_impl <= 1.0
+
+    def test_agg_mode_single_cap(self):
+        """In agg mode, cap_p == cap_d (both set from c_power_agg)."""
+        estimator = _make_estimator_mock(power_w_prefill=500.0, power_w_decode=500.0)
+        config = _make_config(mode="agg", c_power_agg=1.1)
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        assert result.cap_p == result.cap_d
+
+
+# ---------------------------------------------------------------------------
+# optimize() — defensive clamp for non-physical AIC power_w
+# ---------------------------------------------------------------------------
+
+
+class TestAICPowerWClamp:
+    """Defensive clamp guarding against non-physical AIC power_w outputs.
+
+    Context: AIC's per-kernel 3D-cubic interpolator extrapolates non-physical
+    power values at sparse-grid query points (observed on h200_sxm + vLLM
+    0.19.1 + generation_attention at batch >= 256; aggregate power_w returned
+    by estimate_perf was 1275 W vs a 700 W TDP and a 721 W measured peak).
+
+    The optimizer must:
+      - cap cap_*_per_gpu at ceil(TDP × max(1, c_power_*)) when AIC's raw
+        power_w exceeds TDP × 1.1;
+      - preserve the unclamped raw value on PowerAwareConfig.aic_power_w_*
+        so update_correction() has a true denominator and c_power_*
+        coefficients converge below 1.0 instead of being silently masked;
+      - increment aic_power_w_clamped_total{side="..."} for each clamped side.
+    """
+
+    def test_nonphysical_decode_power_clamps_cap_to_tdp(self):
+        """1275 W decode → cap_d clamped at ceil(700 W × c_power_d=1.0) = 700."""
+        estimator = _make_estimator_mock(
+            power_w_prefill=400.0,
+            power_w_decode=1275.0,
+            tdp_w=700.0,
+        )
+        config = _make_config(c_power_p=1.0, c_power_d=1.0)
+        opt, metrics = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        assert result.cap_d == 700, (
+            f"cap_d={result.cap_d} W must be clamped to TDP=700 W, "
+            "not derived from the bogus 1275 W AIC value"
+        )
+        assert result.cap_p == 400  # prefill in range → unchanged
+
+    def test_clamped_side_preserves_raw_value_on_config(self):
+        """PowerAwareConfig.aic_power_w_decode keeps the raw 1275 W so EMA
+        sees the true mismatch and c_power_decode converges below 1.0."""
+        estimator = _make_estimator_mock(
+            power_w_prefill=400.0,
+            power_w_decode=1275.0,
+            tdp_w=700.0,
+        )
+        opt, _ = _make_optimizer_with_mock(estimator)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        assert result.aic_power_w_decode == pytest.approx(1275.0), (
+            "raw AIC value must be preserved on the config so update_correction() "
+            "can normalise observed power against AIC's actual (over-)prediction"
+        )
+        assert result.aic_power_w_prefill == pytest.approx(400.0)
+
+    def test_clamp_metric_increments_only_for_offending_side(self):
+        estimator = _make_estimator_mock(
+            power_w_prefill=400.0,  # in range — should NOT clamp
+            power_w_decode=1500.0,  # > 1.1 × 700 — MUST clamp
+            tdp_w=700.0,
+        )
+        opt, metrics = _make_optimizer_with_mock(estimator)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            opt.optimize()
+
+        sides = [
+            c.kwargs.get("side")
+            for c in metrics.aic_power_w_clamped_total.labels.call_args_list
+        ]
+        assert "decode" in sides
+        assert "prefill" not in sides
+
+    def test_at_threshold_does_not_clamp(self):
+        """Boundary: power_w exactly == 1.1 × TDP must NOT clamp (<= rule)."""
+        threshold = 700.0 * 1.1
+        estimator = _make_estimator_mock(
+            power_w_prefill=threshold,
+            power_w_decode=threshold,
+            tdp_w=700.0,
+        )
+        config = _make_config(c_power_p=1.0, c_power_d=1.0)
+        opt, metrics = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        import math
+
+        assert result is not None
+        assert result.cap_p == math.ceil(threshold)  # 770
+        assert result.cap_d == math.ceil(threshold)  # 770
+        sides = [
+            c.kwargs.get("side")
+            for c in metrics.aic_power_w_clamped_total.labels.call_args_list
+        ]
+        assert sides == []
+
+    def test_agg_mode_clamps_via_averaged_path(self):
+        """In agg mode the (prefill_raw + decode_raw)/2 path uses the CLAMPED
+        per-side values, so a single bad side cannot inflate cap_p == cap_d."""
+        estimator = _make_estimator_mock(
+            power_w_prefill=400.0,
+            power_w_decode=1275.0,  # bogus
+            tdp_w=700.0,
+        )
+        config = _make_config(mode="agg", c_power_agg=1.0)
+        opt, metrics = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        import math
+
+        assert result is not None
+        # Averaged clamped path: (400 + 700) / 2 = 550
+        assert result.cap_p == math.ceil((400.0 + 700.0) / 2.0)
+        assert result.cap_p == result.cap_d
+        sides = [
+            c.kwargs.get("side")
+            for c in metrics.aic_power_w_clamped_total.labels.call_args_list
+        ]
+        assert "decode" in sides
+
+
+# ---------------------------------------------------------------------------
+# optimize() — budget constraint
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizeBudgetConstraint:
+    """Budget limits drive replica count selection."""
+
+    def test_budget_limits_replicas(self):
+        """Tight budget produces fewer replicas than the maximum."""
+        estimator = _make_estimator_mock(power_w_prefill=400.0, power_w_decode=300.0)
+        # 8-GPU engines; cap_p = 400*8 = 3200 W/replica, cap_d = 300*8 = 2400 W/replica
+        # Budget 10000 W → at most 3 decode (3×2400=7200) + 1 prefill (3200) = 10400 > 10000
+        # So expect ≤ 3 decode replicas
+        config = _make_config(
+            total_gpu_power_limit=10_000,
+            max_gpu_budget=32,
+        )
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        # Total wattage must stay within budget
+        total_w = result.n_p * result.cap_p * 8 + result.n_d * result.cap_d * 8
+        assert total_w <= 10_000 + 100  # small rounding allowance
+
+    def test_budget_too_small_returns_min_endpoint(self):
+        """When the budget can't cover min_endpoint prefill, fall back to (min_ep, min_ep)."""
+        # 8-GPU engine, cap = 700 W/GPU → 5600 W/replica
+        # Budget = 1000 W → cannot cover even 1 prefill replica
+        estimator = _make_estimator_mock(
+            power_w_prefill=0.0, power_w_decode=0.0, tdp_w=700.0
+        )
+        config = _make_config(
+            total_gpu_power_limit=1_000,  # impossibly small
+            min_endpoint=1,
+        )
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        # Should fall back to (min_ep, min_ep)
+        assert result is not None
+        assert result.n_p == 1
+        assert result.n_d == 1
+
+    def test_unbounded_budget(self):
+        """When total_gpu_power_limit is effectively unlimited, replicas are capped only by max_gpu_budget."""
+        estimator = _make_estimator_mock(power_w_prefill=400.0, power_w_decode=300.0)
+        # Validator forbids None when enable_power_awareness=True; use a very
+        # large value to make the power constraint effectively non-binding so
+        # max_gpu_budget becomes the binding constraint.
+        config = _make_config(
+            total_gpu_power_limit=200_000,  # 200 kW — far above any realistic per-DGD budget
+            max_gpu_budget=8,
+        )
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is not None
+        # With unlimited budget, n_d should be driven by max_replicas from max_gpu_budget
+        assert result.n_d >= 1
+
+
+# ---------------------------------------------------------------------------
+# optimize() — failure handling
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizeFailureHandling:
+    """Failure modes: startup disable, runtime keep-last, auto-disable."""
+
+    def test_startup_import_error_disables_optimizer(self):
+        """ImportError from aiconfigurator at startup → disabled fail-closed."""
+        config = _make_config()
+        opt, _ = _make_optimizer_with_mock(MagicMock(), config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            side_effect=ImportError("aiconfigurator not installed"),
+        ):
+            result = opt.optimize()
+
+        assert result is None
+        assert opt._disabled is True
+
+    def test_startup_sla_infeasible_disables_optimizer(self):
+        """When corrected TTFT > ttft_sla at first sweep, optimizer is disabled."""
+        # AIC estimates 180ms TTFT; SLA is 100ms; c_ttft=1.0 → corrected = 180ms > 100ms
+        estimator = _make_estimator_mock(ttft_ms=180.0, itl_ms=5.0)
+        config = _make_config(ttft=100, itl=50)  # tight TTFT SLA
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            result = opt.optimize()
+
+        assert result is None
+        assert opt._disabled is True
+
+    def test_runtime_failure_returns_last_config(self):
+        """After a successful sweep, a subsequent exception keeps the last config."""
+        estimator_ok = _make_estimator_mock(ttft_ms=50.0, itl_ms=10.0)
+        config = _make_config()
+        opt, _ = _make_optimizer_with_mock(estimator_ok, config)
+
+        # First sweep succeeds.
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator_ok,
+        ):
+            first_result = opt.optimize()
+
+        assert first_result is not None
+        assert not opt._disabled
+
+        # Second sweep: AIC throws.
+        estimator_fail = _make_estimator_mock()
+        estimator_fail.estimate_prefill_perf.side_effect = RuntimeError("AIC down")
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator_fail,
+        ):
+            second_result = opt.optimize()
+
+        assert second_result is first_result  # same object = last good config
+        assert not opt._disabled  # not disabled yet (1 of 3 failures)
+        assert opt._consecutive_failures == 1
+
+    def test_auto_disable_after_max_consecutive_failures(self):
+        """After aic_max_consecutive_failures runtime failures, optimizer disables."""
+        estimator_ok = _make_estimator_mock(ttft_ms=50.0, itl_ms=10.0)
+        config = _make_config(aic_max_consecutive_failures=2)
+        opt, _ = _make_optimizer_with_mock(estimator_ok, config)
+
+        # Bootstrap with one good sweep.
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator_ok,
+        ):
+            opt.optimize()
+
+        # Now fail max_consecutive_failures times.
+        estimator_fail = _make_estimator_mock()
+        estimator_fail.estimate_prefill_perf.side_effect = RuntimeError("AIC down")
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator_fail,
+        ):
+            for _ in range(2):
+                opt.optimize()
+
+        assert opt._disabled is True
+
+    def test_optimize_returns_none_when_already_disabled(self):
+        config = _make_config()
+        opt, _ = _make_optimizer_with_mock(MagicMock(), config)
+        opt._disabled = True
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+        ) as cls_mock:
+            result = opt.optimize()
+
+        # The estimator should never be constructed when already disabled.
+        cls_mock.assert_not_called()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# update_correction() — EMA updates and gating
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCorrection:
+    """EMA updates for latency and power correction coefficients."""
+
+    def _optimizer_with_last_config(self, **config_kwargs) -> AICPowerOptimizer:
+        """Return an optimizer with a synthetic _last_optimal_config for EMA tests.
+
+        ``aic_power_w_*`` are pinned to 700W so the EMA-update arithmetic in
+        these tests can express the AIC raw-power denominator as 700.  The
+        caps differ (400/300) — they intentionally do NOT match the raw power,
+        which exercises the bug-#2 fix (denominator must be the raw value,
+        not the cap).
+        """
+        estimator = _make_estimator_mock(ttft_ms=50.0, itl_ms=10.0)
+        config = _make_config(**config_kwargs)
+        opt, _ = _make_optimizer_with_mock(estimator, config)
+        # Inject a plausible last_optimal_config without running optimize().
+        opt._last_optimal_config = PowerAwareConfig(
+            n_p=1,
+            n_d=2,
+            cap_p=400,
+            cap_d=300,
+            aic_ttft_ms=50.0,
+            aic_itl_ms=10.0,
+            aic_seq_per_s_per_replica=100.0,
+            isl=1000,
+            osl=200,
+            theta_decode_impl=0.8,
+            theta_prefill_frac_impl=0.6,
+            aic_power_w_prefill=700.0,
+            aic_power_w_decode=700.0,
+            aic_power_w_agg=700.0,
+        )
+        return opt
+
+    def test_latency_ema_updates_when_traffic_present(self):
+        opt = self._optimizer_with_last_config(c_ttft=1.0, c_itl=1.0)
+        traffic = _make_traffic(num_req=10.0)
+        initial_c_ttft = opt._c_ttft
+
+        # Observed TTFT = 75 ms = 0.075 s; AIC TTFT = 50 ms = 0.050 s → ratio = 1.5
+        opt.update_correction(
+            traffic,
+            observed_ttft_avg=0.075,
+            observed_itl_avg=0.015,
+        )
+
+        expected_c_ttft = initial_c_ttft + _EMA_ALPHA * (1.5 - initial_c_ttft)
+        assert opt._c_ttft == pytest.approx(expected_c_ttft, rel=1e-3)
+
+    def test_latency_ema_skipped_when_no_traffic(self):
+        opt = self._optimizer_with_last_config(c_ttft=1.0, c_itl=1.0)
+        traffic = _make_traffic(num_req=0.0)
+        initial_c_ttft = opt._c_ttft
+
+        opt.update_correction(traffic, observed_ttft_avg=0.075)
+
+        # No traffic → EMA should NOT update.
+        assert opt._c_ttft == initial_c_ttft
+
+    def test_power_prefill_ema_skipped_when_idle(self):
+        """Prefill coefficient must not update when scheduled_prefill_tokens == 0."""
+        opt = self._optimizer_with_last_config(c_power_p=1.0)
+        traffic = _make_traffic(scheduled_prefill_tokens=0.0, num_req=5.0)
+        initial_c_power_p = opt._c_power_p
+
+        opt.update_correction(traffic, observed_power_w_prefill=600.0)
+
+        assert opt._c_power_p == initial_c_power_p
+
+    def test_power_prefill_ema_updates_when_active(self):
+        """Prefill coefficient updates when the prefill side has scheduled work."""
+        opt = self._optimizer_with_last_config(c_power_p=1.0)
+        # aic_p_w = config.prefill_engine_gpu_power_limit = 700
+        # observed = 840 → ratio = 840/700 = 1.2
+        traffic = _make_traffic(scheduled_prefill_tokens=5000.0)
+        initial = opt._c_power_p
+
+        opt.update_correction(traffic, observed_power_w_prefill=840.0)
+
+        expected = initial + _EMA_ALPHA * (840.0 / 700.0 - initial)
+        assert opt._c_power_p == pytest.approx(expected, rel=1e-3)
+
+    def test_power_decode_ema_gated_independently(self):
+        """Decode-side EMA ignores prefill-side scheduled tokens."""
+        opt = self._optimizer_with_last_config(c_power_d=1.0)
+        # decode side active, prefill idle
+        traffic = _make_traffic(
+            scheduled_prefill_tokens=0.0, scheduled_decode_kv_tokens=2000.0
+        )
+        initial_d = opt._c_power_d
+        initial_p = opt._c_power_p
+
+        # Synthetic last_config has aic_power_w_decode=700.0; observe 850.0 so
+        # the EMA actually moves (ratio 850/700 ≈ 1.214 ≠ initial_d=1.0).
+        opt.update_correction(
+            traffic,
+            observed_power_w_prefill=600.0,
+            observed_power_w_decode=850.0,
+        )
+
+        assert opt._c_power_p == initial_p  # prefill idle → unchanged
+        assert opt._c_power_d != initial_d  # decode active → updated
+
+    def test_agg_mode_uses_single_coefficient(self):
+        opt = self._optimizer_with_last_config(mode="agg", c_power_agg=1.0)
+        traffic = _make_traffic(
+            scheduled_prefill_tokens=3000.0, scheduled_decode_kv_tokens=2000.0
+        )
+        initial_agg = opt._c_power_agg
+        initial_p = opt._c_power_p
+
+        # aic_power_w_agg from the synthetic last_optimal_config = 700
+        # observed = 850 → ratio = 850/700 ≈ 1.214 → EMA shifts upward.
+        opt.update_correction(traffic, observed_power_w_agg=850.0)
+
+        expected_agg = initial_agg + _EMA_ALPHA * (850.0 / 700.0 - initial_agg)
+        assert opt._c_power_agg == pytest.approx(expected_agg, rel=1e-3)
+        assert opt._c_power_agg != initial_agg  # agg mode updates c_power_agg
+        # per-component coefficients should remain unchanged in agg mode
+        assert opt._c_power_p == initial_p
+
+    def test_coefficient_clamp_max(self):
+        """EMA result clamped to _COEFF_MAX = 2.0 when raw ratio is very large."""
+        opt = self._optimizer_with_last_config(c_ttft=1.9)
+        traffic = _make_traffic(num_req=5.0)
+        # observed TTFT = 10x AIC estimate → raw ratio = 10.0
+        # EMA = 1.9 + 0.3*(10.0 - 1.9) = 1.9 + 2.43 = 4.33 → clamped to 2.0
+        opt.update_correction(traffic, observed_ttft_avg=0.5)  # 500ms vs 50ms AIC
+
+        assert opt._c_ttft == _COEFF_MAX
+
+    def test_coefficient_clamp_min(self):
+        """EMA result clamped to _COEFF_MIN = 0.5 when raw ratio is very small."""
+        opt = self._optimizer_with_last_config(c_ttft=0.6)
+        traffic = _make_traffic(num_req=5.0)
+        # observed TTFT = 0.0001ms → ratio ≈ 0 → EMA drives toward 0 → clamp to 0.5
+        opt.update_correction(traffic, observed_ttft_avg=0.000001)
+
+        assert opt._c_ttft == _COEFF_MIN
+
+    def test_no_update_when_disabled(self):
+        opt = self._optimizer_with_last_config(c_ttft=1.0)
+        opt._disabled = True
+        opt.update_correction(
+            _make_traffic(num_req=10.0),
+            observed_ttft_avg=0.1,
+        )
+        assert opt._c_ttft == 1.0  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# should_reoptimize() — drift detection
+# ---------------------------------------------------------------------------
+
+
+class TestShouldReoptimize:
+    """Drift detection: rate limit, SLA miss, capacity exceeded, hysteresis."""
+
+    def _optimizer_with_recent_sweep(self, **config_kwargs) -> AICPowerOptimizer:
+        """Return an optimizer whose last sweep was just now (rate-limit applies)."""
+        config = _make_config(**config_kwargs)
+        opt, _ = _make_optimizer_with_mock(MagicMock(), config)
+        opt._time_of_last_optimize = time.monotonic()
+        opt._estimated_throughput = 1_000.0  # tok/s
+        return opt
+
+    def test_rate_limit_prevents_reoptimize(self):
+        opt = self._optimizer_with_recent_sweep(aic_reoptimize_interval=300.0)
+        # Simulate SLA violation — but interval hasn't elapsed.
+        traffic = _make_traffic(ttft_avg=5.0)  # 5s >> any SLA in ms
+        assert opt.should_reoptimize(traffic) is False
+
+    def test_sla_miss_triggers_after_hysteresis(self):
+        """3 consecutive ticks with TTFT above target → True on the third tick."""
+        opt = self._optimizer_with_recent_sweep(
+            aic_reoptimize_interval=0.0,
+            aic_drift_consecutive_ticks=3,
+            ttft=200,  # 200ms SLA
+        )
+        traffic = _make_traffic(ttft_avg=0.5)  # 500ms observed > 200ms SLA
+
+        assert opt.should_reoptimize(traffic) is False  # tick 1
+        assert opt.should_reoptimize(traffic) is False  # tick 2
+        assert opt.should_reoptimize(traffic) is True  # tick 3 — triggers
+
+    def test_no_reoptimize_on_single_sla_miss(self):
+        """One tick of SLA miss doesn't trigger when hysteresis=3."""
+        opt = self._optimizer_with_recent_sweep(
+            aic_reoptimize_interval=0.0,
+            aic_drift_consecutive_ticks=3,
+        )
+        traffic = _make_traffic(ttft_avg=5.0)
+        opt.should_reoptimize(traffic)  # tick 1 — violation
+        # Clear with a good tick.
+        good_traffic = _make_traffic(ttft_avg=0.01)
+        assert opt.should_reoptimize(good_traffic) is False
+        assert opt._consecutive_violation_ticks == 0
+
+    def test_capacity_exceeded_triggers_upward_only(self):
+        """Capacity-exceeded fires only when tokens/s > estimated × (1+threshold)."""
+        opt = self._optimizer_with_recent_sweep(
+            aic_reoptimize_interval=0.0,
+            aic_drift_consecutive_ticks=1,
+            aic_drift_relative_threshold=0.15,
+        )
+        opt._estimated_throughput = 1_000.0
+
+        # Under-load (tokens below estimate) should NOT trigger.
+        under = _make_traffic(total_tokens_per_s=200.0)
+        assert opt.should_reoptimize(under) is False
+
+        # Over-load (tokens above estimate × (1 + 0.15)) should trigger.
+        over = _make_traffic(total_tokens_per_s=1_200.0)
+        assert opt.should_reoptimize(over) is True
+
+    def test_disabled_optimizer_never_reoptimizes(self):
+        opt = self._optimizer_with_recent_sweep(aic_reoptimize_interval=0.0)
+        opt._disabled = True
+        traffic = _make_traffic(ttft_avg=10.0, total_tokens_per_s=9_999.0)
+        assert opt.should_reoptimize(traffic) is False
+
+
+# ---------------------------------------------------------------------------
+# _sweep_replicas() — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSweepReplicas:
+    """The internal replica-count sweep helper."""
+
+    def _optimizer(self) -> AICPowerOptimizer:
+        config = _make_config(min_endpoint=1, max_gpu_budget=64)
+        return AICPowerOptimizer(config, _make_metrics())
+
+    def test_budget_constrains_n_d_first(self):
+        opt = self._optimizer()
+        # p_watts=3200, d_watts=2400, budget=14000, min_ep=1
+        # After min_ep=1 prefill: remaining = 14000 - 3200 = 10800 → n_d = 10800//2400 = 4
+        # After locking n_d=4: remaining for p = 14000 - 4*2400 = 4400 → n_p = 4400//3200 = 1
+        n_p, n_d = opt._sweep_replicas(1, 10, 3200, 2400, 14_000)
+        assert n_d == 4
+        assert n_p == 1
+
+    def test_no_budget_uses_max_replicas_for_decode(self):
+        opt = self._optimizer()
+        n_p, n_d = opt._sweep_replicas(1, 5, 3200, 2400, None)
+        assert n_d == 5
+
+    def test_min_endpoint_is_lower_bound(self):
+        opt = self._optimizer()
+        n_p, n_d = opt._sweep_replicas(3, 10, 3200, 2400, 100_000)
+        assert n_p >= 3
+        assert n_d >= 3
+
+    def test_budget_too_small_returns_min_endpoint(self):
+        opt = self._optimizer()
+        # budget=100 < min_ep * p_watts=3200 → falls back to (min_ep, min_ep)
+        n_p, n_d = opt._sweep_replicas(1, 10, 3200, 2400, 100)
+        assert n_p == 1
+        assert n_d == 1
+
+
+# ---------------------------------------------------------------------------
+# Throughput regression warning
+# ---------------------------------------------------------------------------
+
+
+class TestThroughputRegressionWarning:
+    def test_regression_increments_counter(self):
+        """When re-optimization yields lower predicted throughput, counter increments."""
+        estimator = _make_estimator_mock(
+            ttft_ms=50.0, itl_ms=10.0, max_kv_tokens=50_000
+        )
+        config = _make_config(aic_throughput_regression_warn_threshold=0.05)
+        opt, metrics = _make_optimizer_with_mock(estimator, config)
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            first_result = opt.optimize()
+
+        # Inject a "previous" config with much higher throughput so the second
+        # sweep looks like a regression.
+        assert first_result is not None
+        opt._last_optimal_config = PowerAwareConfig(
+            n_p=1,
+            n_d=100,  # 100 decode replicas → huge throughput
+            cap_p=400,
+            cap_d=300,
+            aic_ttft_ms=50.0,
+            aic_itl_ms=10.0,
+            aic_seq_per_s_per_replica=1000.0,
+            isl=1000,
+            osl=200,
+            theta_decode_impl=0.8,
+            theta_prefill_frac_impl=0.6,
+            aic_power_w_prefill=400.0,
+            aic_power_w_decode=300.0,
+        )
+
+        with patch(
+            "dynamo.planner.monitoring.aic_estimator.AIConfiguratorPerfEstimator",
+            return_value=estimator,
+        ):
+            opt.optimize()
+
+        # The regression counter should have been incremented once.
+        metrics.aic_throughput_regression_total.inc.assert_called()

--- a/components/src/dynamo/planner/tests/integration/test_metric_paths_live.py
+++ b/components/src/dynamo/planner/tests/integration/test_metric_paths_live.py
@@ -1,0 +1,558 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live-cluster integration tests for the planner's metric-collection paths.
+
+Run inside the dev pod (`planner-dev`) to exercise real Prometheus, real
+router /metrics scrapes, real DCGM samples, and live MDC CRs.
+
+Skipped unless `DYN_PARENT_DGD_K8S_NAME` is set (i.e. running in the dev pod).
+
+Run from the dev pod:
+    export PYTHONPATH=/workspace/repo/components/src:/workspace/repo
+    cd /workspace/repo
+    python3 -m pytest \
+        components/src/dynamo/planner/tests/integration/test_metric_paths_live.py \
+        -v --tb=short -m 'integration'
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level gating
+# ---------------------------------------------------------------------------
+
+try:
+    from kubernetes import config as k8s_config
+
+    try:
+        k8s_config.load_incluster_config()
+        _IN_CLUSTER = True
+    except k8s_config.ConfigException:
+        _IN_CLUSTER = False
+except ImportError:
+    _IN_CLUSTER = False
+
+_DGD_NAME = os.environ.get("DYN_PARENT_DGD_K8S_NAME")
+_K8S_NAMESPACE = os.environ.get("DYN_PARENT_DGD_K8S_NAMESPACE") or os.environ.get(
+    "POD_NAMESPACE"
+)
+_DYN_NAMESPACE = os.environ.get(
+    "DYN_NAMESPACE", f"{_K8S_NAMESPACE}-{_DGD_NAME}" if _DGD_NAME else "dynamo"
+)
+
+if not (_IN_CLUSTER and _DGD_NAME):
+    pytest.skip(
+        "Live metric-path tests require running inside the dev pod with "
+        "DYN_PARENT_DGD_K8S_NAME set.",
+        allow_module_level=True,
+    )
+
+# Cluster service URLs (these match the ones documented in
+# docs/components/planner/dpp-dev-env.md).
+_PROM_URL = "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+
+# Deferred imports — these pull in heavy planner deps that need the runtime ready.
+from dynamo.planner.connectors.kubernetes import KubernetesConnector  # noqa: E402
+from dynamo.planner.monitoring.traffic_metrics import (  # noqa: E402
+    _WORKER_METRIC_NAMES,
+    DirectRouterMetricsClient,
+    PrometheusAPIClient,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+    pytest.mark.planner,
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def connector() -> KubernetesConnector:
+    return KubernetesConnector(
+        dynamo_namespace=_DYN_NAMESPACE,
+        k8s_namespace=_K8S_NAMESPACE,
+        parent_dgd_name=_DGD_NAME,
+    )
+
+
+@pytest.fixture(scope="module")
+def model_name(connector: KubernetesConnector) -> str:
+    """Resolve model name from the live DGD; fall back to env var if absent."""
+    try:
+        return connector.get_model_name(require_prefill=False, require_decode=False)
+    except Exception:
+        return os.environ.get("MODEL_NAME", "Qwen/Qwen3-0.6B")
+
+
+@pytest.fixture(scope="module")
+def prom_frontend() -> PrometheusAPIClient:
+    return PrometheusAPIClient(
+        url=_PROM_URL, dynamo_namespace=_DYN_NAMESPACE, metrics_source="frontend"
+    )
+
+
+@pytest.fixture(scope="module")
+def prom_router() -> PrometheusAPIClient:
+    return PrometheusAPIClient(
+        url=_PROM_URL, dynamo_namespace=_DYN_NAMESPACE, metrics_source="router"
+    )
+
+
+def _raw_prom_query(query: str) -> list:
+    url = f"{_PROM_URL}/api/v1/query?query={urllib.parse.quote(query)}"
+    import json
+
+    return json.loads(urllib.request.urlopen(url, timeout=10).read())["data"]["result"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Prometheus connectivity (smoke)
+# ---------------------------------------------------------------------------
+
+
+class TestPrometheusReachable:
+    def test_prometheus_responds_to_up_query(self):
+        result = _raw_prom_query("up")
+        assert result, "Prometheus did not return any 'up' samples"
+
+
+# ---------------------------------------------------------------------------
+# 2. Frontend-source metrics path
+# ---------------------------------------------------------------------------
+
+
+class TestPrometheusFrontendMetrics:
+    """PrometheusAPIClient with metrics_source='frontend' against live data.
+
+    These methods drive the throughput-based scaling loop. They must:
+      - Connect to the live Prometheus,
+      - Parse the response containers without ValidationError,
+      - Filter by model + dynamo_namespace correctly.
+    """
+
+    def test_frontend_metric_series_exists(self):
+        """Sanity: the frontend is producing metrics for our DGD."""
+        result = _raw_prom_query(
+            f'dynamo_frontend_requests_total{{dynamo_namespace="{_DYN_NAMESPACE}"}}'
+        )
+        if not result:
+            pytest.skip(
+                f"No frontend metric series for dynamo_namespace={_DYN_NAMESPACE!r}; "
+                "send at least one chat/completions request to populate."
+            )
+
+    def test_get_avg_request_count_returns_numeric(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_frontend.get_avg_request_count("5m", model_name)
+        assert isinstance(v, (int, float)), f"Expected numeric, got {type(v)}"
+        assert v >= 0, f"Negative request count: {v}"
+
+    def test_get_avg_time_to_first_token_returns_numeric(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_frontend.get_avg_time_to_first_token("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_get_avg_inter_token_latency_returns_numeric(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_frontend.get_avg_inter_token_latency("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_get_avg_request_duration_returns_numeric(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_frontend.get_avg_request_duration("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_get_avg_input_sequence_tokens_returns_numeric(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_frontend.get_avg_input_sequence_tokens("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_get_avg_output_sequence_tokens_returns_numeric(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_frontend.get_avg_output_sequence_tokens("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_model_name_filtering_excludes_other_models(
+        self, prom_frontend: PrometheusAPIClient
+    ):
+        """A bogus model name should produce 0, proving the filter is active."""
+        v = prom_frontend.get_avg_request_count("5m", "this/model-does-not-exist")
+        assert v == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Router-source metrics path
+# ---------------------------------------------------------------------------
+
+
+class TestPrometheusRouterMetrics:
+    """PrometheusAPIClient with metrics_source='router'.
+
+    Router-source queries normalise dashes to underscores when building the
+    dynamo_namespace label filter. The live router series confirms the
+    underscore form (e.g. 'myns_dynamo_system_qwen3_quickstart').
+    """
+
+    def test_router_metric_series_exists(self):
+        ns = _DYN_NAMESPACE.replace("-", "_")
+        result = _raw_prom_query(
+            f'dynamo_component_router_requests_total{{dynamo_namespace="{ns}"}}'
+        )
+        if not result:
+            pytest.skip(
+                f"No router metric series for namespace={ns!r}; "
+                "either no router is running or PodMonitor is not scraping it."
+            )
+
+    def test_router_avg_request_count_returns_numeric(
+        self, prom_router: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_router.get_avg_request_count("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_router_avg_ttft_returns_numeric(
+        self, prom_router: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_router.get_avg_time_to_first_token("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_router_avg_itl_returns_numeric(
+        self, prom_router: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_router.get_avg_inter_token_latency("5m", model_name)
+        assert isinstance(v, (int, float))
+        assert v >= 0
+
+    def test_warn_if_router_not_scraped_succeeds(
+        self, prom_router: PrometheusAPIClient
+    ):
+        """Smoke: function must not raise even if scraping is fine."""
+        prom_router.warn_if_router_not_scraped()
+
+
+# ---------------------------------------------------------------------------
+# 4. KV-hit-rate query (router-source only)
+# ---------------------------------------------------------------------------
+
+
+class TestKvHitRateLive:
+    def test_router_source_kv_hit_rate_numeric_or_none(
+        self, prom_router: PrometheusAPIClient, model_name: str
+    ):
+        v = prom_router.get_avg_kv_hit_rate("5m", model_name)
+        # On a quiet cluster Prometheus returns no data → planner returns None.
+        # If there is data, it must be a finite float in [0,1].
+        assert v is None or (isinstance(v, float) and 0.0 <= v <= 1.0), v
+
+    def test_frontend_source_kv_hit_rate_returns_none(
+        self, prom_frontend: PrometheusAPIClient, model_name: str
+    ):
+        """The KV-hit-rate histogram only exists on the router; frontend
+        source must short-circuit to None instead of querying."""
+        assert prom_frontend.get_avg_kv_hit_rate("5m", model_name) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. DCGM per-pod GPU power
+# ---------------------------------------------------------------------------
+
+
+class TestDcgmPerPodPower:
+    """DCGM query path. On clusters with working DCGM workload attribution,
+    these queries return watt values; otherwise the test skips with a clear
+    message identifying the cluster-side gap (DCGM exporter or kubelet
+    pod-info mapping not configured).
+
+    The planner-side query construction was previously broken in three
+    ways and has been fixed:
+      1. Used bare ``pod`` (DCGM exporter pod) instead of ``exported_pod``
+         (workload pod).
+      2. Used ``exported_namespace=<dynamo-namespace>`` instead of the
+         actual K8s namespace value.
+      3. Used a regex ``<dgd>-<component>-.*`` that did not accommodate
+         the operator's ``<dgd>-<replica-idx>-<service-key-lc>-<hash>``
+         format.
+
+    These tests pin the new behavior: planner queries must reach the
+    DCGM samples whenever attribution exists, not silently return None.
+    """
+
+    def test_dcgm_samples_exist_for_dgd(self):
+        """Smoke: verify DCGM is scraping pod-attribution for *something*."""
+        result = _raw_prom_query("DCGM_FI_DEV_POWER_USAGE")
+        assert result, "Prometheus reports no DCGM_FI_DEV_POWER_USAGE samples at all"
+
+    def test_dcgm_pod_attribution_for_this_dgd(self):
+        """Try to find DCGM samples attributed to a workload pod of this DGD.
+
+        Uses the canonical ``exported_pod`` label (the planner now uses
+        the same label internally).  Skip — not fail — when this cluster
+        lacks attribution; downstream tests in this class then skip too.
+        """
+        result = _raw_prom_query(
+            f'DCGM_FI_DEV_POWER_USAGE{{exported_pod=~"^{_DGD_NAME}-[0-9]+-.*"}}'
+        )
+        if not result:
+            pytest.skip(
+                f"DCGM has no exported_pod attribution for {_DGD_NAME!r} on this "
+                "cluster (cluster-side DCGM/kubelet config issue, not a planner "
+                "bug). The planner query construction has been fixed; this skip "
+                "indicates the *cluster* needs DCGM exporter pod-info wiring."
+            )
+
+    def test_planner_get_total_dgd_power_runs_without_error(
+        self, prom_frontend: PrometheusAPIClient
+    ):
+        """The planner method must not raise. With attribution it should
+        also return a positive numeric value (real watt reading)."""
+        v = prom_frontend.get_total_dgd_power(
+            k8s_namespace=_K8S_NAMESPACE, dgd_name=_DGD_NAME
+        )
+        assert v is None or isinstance(v, float)
+        # If the cluster has DCGM attribution wired (smoke test above
+        # passed without skipping) and the planner queries are correct,
+        # the value must not be None — that would indicate the fix
+        # regressed.  Only assert this when raw attribution is present.
+        attributed = _raw_prom_query(
+            f"DCGM_FI_DEV_POWER_USAGE{{"
+            f'exported_namespace="{_K8S_NAMESPACE}",'
+            f'exported_pod=~"^{_DGD_NAME}-[0-9]+-.*"}}'
+        )
+        if attributed:
+            assert v is not None, (
+                f"Raw DCGM query found {len(attributed)} samples for "
+                f"{_DGD_NAME} in {_K8S_NAMESPACE}, but planner method "
+                "returned None — selector-construction regression."
+            )
+            assert v > 0, f"Total power should be positive, got {v}"
+
+    def test_planner_per_component_query_runs_without_error(
+        self, prom_frontend: PrometheusAPIClient
+    ):
+        """Per-component query: with attribution it should reach the
+        right pod via the new ``<dgd>-<idx>-<service-key-lc>-`` regex."""
+        # qwen3-quickstart deploys as agg with VllmWorker as the decode-side
+        # service key.  Operator embeds it lowercase in pod names like
+        # qwen3-quickstart-0-vllmworker-86nvj.
+        v = prom_frontend.get_avg_per_gpu_power_by_component(
+            interval="5m",
+            k8s_namespace=_K8S_NAMESPACE,
+            dgd_name=_DGD_NAME,
+            component="agg",
+            service_key="VllmWorker",
+        )
+        assert v is None or isinstance(v, float)
+        attributed = _raw_prom_query(
+            f"DCGM_FI_DEV_POWER_USAGE{{"
+            f'exported_namespace="{_K8S_NAMESPACE}",'
+            f'exported_pod=~"^{_DGD_NAME}-[0-9]+-vllmworker-.*"}}'
+        )
+        if attributed:
+            assert v is not None, (
+                f"Raw DCGM query found {len(attributed)} samples for "
+                f"vllmworker pods in {_DGD_NAME}, but planner method "
+                "returned None — selector-construction regression."
+            )
+            assert v > 0, f"Per-component power should be positive, got {v}"
+
+    def test_planner_per_component_empty_service_key_short_circuits(
+        self, prom_frontend: PrometheusAPIClient
+    ):
+        """Empty service_key (e.g. agg-mode DGD with no decode worker info)
+        must short-circuit to None without issuing a Prometheus query that
+        would degenerate to a never-matching regex."""
+        v = prom_frontend.get_avg_per_gpu_power_by_component(
+            interval="5m",
+            k8s_namespace=_K8S_NAMESPACE,
+            dgd_name=_DGD_NAME,
+            component="prefill",
+            service_key="",
+        )
+        assert v is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Direct router /metrics scrape
+# ---------------------------------------------------------------------------
+
+
+def _discover_kv_router_metrics_url() -> Optional[str]:
+    """Discover a KV-router /metrics endpoint reachable from the dev pod.
+
+    The planner's ``DirectRouterMetricsClient`` only emits per-worker
+    ``dynamo_frontend_worker_*`` gauges when traffic flows through the
+    frontend HTTP service's *in-process* KV router, because
+    ``register_worker_load_metrics`` / ``register_worker_timing_metrics``
+    are only called from ``service_v2.rs``.  This means a single supported
+    deployment topology:
+
+    - **KV-routed aggregated/disagg DGDs**: the frontend runs the KV router
+      in-process when started with ``--router-mode kv``; metrics live on
+      ``<dgd>-frontend:8000/metrics``.  Detected here only if at least one
+      of the target gauges actually appears in the exposition (presence
+      proves the routing mode is KV).
+
+    Specifically NOT supported:
+
+    - **Global Planner standalone LocalRouter** (``python3 -m dynamo.router``):
+      the LocalRouter's ``system_status_server`` registry is *separate* from
+      the frontend HTTP service registry, so the per-worker gauges are
+      never registered there even though the global ``WORKER_LOAD_METRICS``
+      static is updated by the in-process KvScheduler.  Pool planners must
+      use ``PrometheusAPIClient`` (router-source histograms, filtered by
+      ``dynamo_namespace``) instead.  See open-question #14 in
+      ``powerplanner-design.md``.
+    - **Round-robin / random / etc. frontends** never populate the gauges,
+      so Prometheus omits the families entirely.
+
+    Discovery checks for *any* of the target gauges, not just one specific
+    family.  The ``active_*`` gauges require the worker to emit
+    ``ActiveLoad`` events through ``KvWorkerMonitor`` (KV-events plumbing
+    on the worker side), while the ``last_*`` gauges populate from
+    request-level observations on the router side.  A KV-mode frontend
+    talking to a worker that doesn't publish KV events still exposes the
+    ``last_*`` family as soon as the first request streams a token, which
+    is enough to qualify the endpoint as "KV-router-bearing".
+    """
+    target_metrics = list(_WORKER_METRIC_NAMES.values())
+
+    def _fetch(url: str) -> Optional[str]:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                return resp.read().decode("utf-8")
+        except Exception:
+            return None
+
+    def _any_gauge_present(text: str) -> bool:
+        return any(name in text for name in target_metrics)
+
+    frontend_url = f"http://{_DGD_NAME}-frontend:8000/metrics"
+    text = _fetch(frontend_url)
+    if text and _any_gauge_present(text):
+        return frontend_url
+
+    return None
+
+
+class TestDirectRouterMetricsClientLive:
+    """DirectRouterMetricsClient against a live KV-router /metrics endpoint.
+
+    The class targets the gauges populated by ``KvWorkerMonitor`` and
+    ``observe_*_gauges`` in ``lib/llm`` — both KV-router code paths.  Only
+    deployments that run an in-process KV router on the frontend HTTP
+    service expose these gauges (Global-Planner LocalRouter pods do *not*,
+    despite running KV routing — see ``_discover_kv_router_metrics_url``
+    docstring).  We discover the endpoint at runtime and skip cleanly when
+    none exists, rather than asserting against a hardcoded URL that
+    doesn't reflect the live topology.
+    """
+
+    @pytest.fixture(scope="class")
+    def metrics_url(self) -> str:
+        url = _discover_kv_router_metrics_url()
+        if url is None:
+            pytest.skip(
+                f"DGD {_DGD_NAME!r} has no reachable KV-mode frontend "
+                "/metrics endpoint exposing dynamo_frontend_worker_* gauges. "
+                "DirectRouterMetricsClient applies only to frontends started "
+                "with --router-mode kv (the gauges are registered exclusively "
+                "by lib/llm/src/http/service/service_v2.rs). Standalone "
+                "LocalRouter pods do not expose these gauges, and "
+                "round-robin/random/etc. frontends never populate them."
+            )
+        return url
+
+    def test_endpoint_responds_with_prometheus_text(self, metrics_url: str):
+        # _discover_kv_router_metrics_url already verified reachability +
+        # presence of at least one target gauge; re-fetch here as a smoke
+        # check that the endpoint is still up (catches mid-run flakiness).
+        try:
+            resp = urllib.request.urlopen(metrics_url, timeout=5)
+            text = resp.read().decode("utf-8")
+        except Exception as exc:
+            pytest.skip(f"Discovered KV-router /metrics endpoint flapped: {exc}")
+        assert (
+            "# HELP" in text or "# TYPE" in text
+        ), "Response is not Prometheus text exposition format"
+
+    @pytest.mark.asyncio
+    async def test_fetch_and_parse_returns_dict(self, metrics_url: str):
+        client = DirectRouterMetricsClient(
+            router_metrics_url=metrics_url, dynamo_namespace=_DYN_NAMESPACE
+        )
+        parsed = await client._fetch_and_parse()
+        assert isinstance(parsed, dict)
+        # The endpoint was discovered by presence of a target gauge family,
+        # so an empty dict here means the parser regressed (e.g. label name
+        # changed) — promote to a hard failure instead of a skip so we
+        # actually catch that.
+        assert parsed, (
+            "DirectRouterMetricsClient returned empty dict from an endpoint "
+            f"({metrics_url}) that the discovery probe confirmed exposes "
+            f"{sorted(_WORKER_METRIC_NAMES.values())}.  Likely a parser "
+            "regression (worker_id / worker_type label names changed?)."
+        )
+        for worker_type, by_id in parsed.items():
+            assert isinstance(by_id, dict), worker_type
+            for worker_id, metrics in by_id.items():
+                assert isinstance(metrics, dict), (worker_type, worker_id)
+                for name, value in metrics.items():
+                    assert isinstance(value, (int, float)), (name, value)
+
+
+# ---------------------------------------------------------------------------
+# 7. MDC (DynamoWorkerMetadata CR) read path
+# ---------------------------------------------------------------------------
+
+
+class TestMdcReadLive:
+    """Verify the planner can read DynamoWorkerMetadata CRs from the live cluster."""
+
+    def test_list_worker_metadata_crs_returns_items(
+        self, connector: KubernetesConnector
+    ):
+        crs = connector._list_worker_metadata_crs()
+        assert isinstance(crs, list)
+        assert crs, (
+            "No DynamoWorkerMetadata CRs found in namespace "
+            f"{_K8S_NAMESPACE!r}; the worker may not have registered yet."
+        )
+
+    def test_extract_mdc_entries_for_this_dgd(self, connector: KubernetesConnector):
+        entries = connector._extract_mdc_entries()
+        assert isinstance(entries, list)
+        if not entries:
+            pytest.skip(
+                f"No MDC entries found prefixed with {_DGD_NAME!r}-; check that "
+                "the worker pod started cleanly and registered its model card."
+            )
+        for entry in entries:
+            assert entry.card_json is not None
+            assert isinstance(entry.card_json, dict)

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -21,8 +21,11 @@ import pytest
 
 from dynamo import prometheus_names
 from dynamo.planner.monitoring.traffic_metrics import (
+    _WORKER_METRIC_NAMES,
+    DirectRouterMetricsClient,
     FrontendMetric,
     FrontendMetricContainer,
+    Metrics,
     PrometheusAPIClient,
 )
 
@@ -577,6 +580,16 @@ class TestPowerAwareDcgmQueries:
         )
         assert callable(client.get_total_dgd_power)
 
+    def test_get_avg_per_gpu_power_by_component_is_method_on_prometheus_api_client(
+        self,
+    ):
+        client = self._client()
+        assert hasattr(client, "get_avg_per_gpu_power_by_component"), (
+            "get_avg_per_gpu_power_by_component missing from PrometheusAPIClient — "
+            "the AIC closed-loop EMA update path calls this method via base.py."
+        )
+        assert callable(client.get_avg_per_gpu_power_by_component)
+
     def test_get_total_dgd_power_returns_float_on_match(self):
         client = self._client()
         with patch.object(client.prom, "custom_query") as mock_query:
@@ -634,3 +647,495 @@ class TestPowerAwareDcgmQueries:
             # No bare `pod=~` pattern should leak in.
             assert "{pod=~" not in query_str
             assert ",pod=~" not in query_str
+
+    def test_get_avg_per_gpu_power_by_component_returns_float_on_match(self):
+        client = self._client()
+        with patch.object(client.prom, "custom_query") as mock_query:
+            mock_query.return_value = [{"value": [0, "537.0"]}]
+            result = client.get_avg_per_gpu_power_by_component(
+                interval="60s",
+                k8s_namespace="kube-namespace",
+                dgd_name="my-dgd",
+                component="prefill",
+                service_key="VllmPrefillWorker",
+            )
+            assert result == pytest.approx(537.0)
+            call_args = str(mock_query.call_args).replace("'", '"')
+            assert "avg_over_time" in call_args
+            # Selector must filter by exported_pod regex matching the
+            # operator's `<dgd>-<replica-idx>-<service-key-lc>-<hash>` form.
+            assert 'exported_pod=~"^my-dgd-[0-9]+-vllmprefillworker-.*"' in call_args
+            assert 'exported_namespace="kube-namespace"' in call_args
+
+    def test_get_avg_per_gpu_power_by_component_lowercases_service_key(self):
+        """The operator embeds service_key.lower() in the pod name; the regex must too."""
+        client = self._client()
+        with patch.object(client.prom, "custom_query") as mock_query:
+            mock_query.return_value = [{"value": [0, "100.0"]}]
+            client.get_avg_per_gpu_power_by_component(
+                interval="60s",
+                k8s_namespace="ns",
+                dgd_name="dgd",
+                component="decode",
+                service_key="VllmDecodeWorker",  # mixed case
+            )
+            call_args = str(mock_query.call_args).replace("'", '"')
+            assert "vllmdecodeworker" in call_args
+            # The original mixed case must NOT appear in the regex.
+            assert "VllmDecodeWorker" not in call_args
+
+    def test_get_avg_per_gpu_power_by_component_empty_service_key_returns_none(self):
+        """Empty service_key cannot build a meaningful regex; short-circuit to None."""
+        client = self._client()
+        with patch.object(client.prom, "custom_query") as mock_query:
+            result = client.get_avg_per_gpu_power_by_component(
+                interval="60s",
+                k8s_namespace="ns",
+                dgd_name="dgd",
+                component="prefill",
+                service_key="",
+            )
+            assert result is None
+            # The Prometheus client must not even be called — a regex with
+            # empty service_key would degenerate to `^dgd-[0-9]+--.*` which
+            # never matches and just wastes a roundtrip.
+            mock_query.assert_not_called()
+
+    def test_get_avg_per_gpu_power_by_component_returns_none_on_empty(self):
+        client = self._client()
+        with patch.object(client.prom, "custom_query") as mock_query:
+            mock_query.return_value = []
+            result = client.get_avg_per_gpu_power_by_component(
+                interval="60s",
+                k8s_namespace="ns",
+                dgd_name="dgd",
+                component="decode",
+                service_key="VllmWorker",
+            )
+            assert result is None
+
+    def test_get_avg_per_gpu_power_by_component_agg_component_pod_regex(self):
+        """Agg mode uses the decode worker's k8s_name as service_key."""
+        client = self._client()
+        with patch.object(client.prom, "custom_query") as mock_query:
+            mock_query.return_value = [{"value": [0, "400.0"]}]
+            result = client.get_avg_per_gpu_power_by_component(
+                interval="30s",
+                k8s_namespace="kube-namespace",
+                dgd_name="my-dgd",
+                component="agg",
+                service_key="VllmWorker",
+            )
+            assert result == pytest.approx(400.0)
+            call_args = str(mock_query.call_args).replace("'", '"')
+            assert 'exported_pod=~"^my-dgd-[0-9]+-vllmworker-.*"' in call_args
+
+    def test_get_avg_per_gpu_power_by_component_returns_none_on_exception(self):
+        client = self._client()
+        with patch.object(client.prom, "custom_query") as mock_query:
+            mock_query.side_effect = RuntimeError("prom down")
+            result = client.get_avg_per_gpu_power_by_component(
+                interval="60s",
+                k8s_namespace="ns",
+                dgd_name="dgd",
+                component="prefill",
+                service_key="VllmPrefillWorker",
+            )
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Metrics.is_valid() — gate that controls whether the planner has enough data
+# ---------------------------------------------------------------------------
+
+
+def _valid_metrics(**overrides) -> Metrics:
+    """Return a Metrics instance with all required fields set to sane values."""
+    base = dict(
+        ttft=0.1,
+        itl=0.05,
+        num_req=10.0,
+        isl=256.0,
+        osl=128.0,
+        request_duration=1.0,
+        p_load=None,
+        d_load=None,
+        kv_hit_rate=None,
+    )
+    base.update(overrides)
+    return Metrics(**base)
+
+
+class TestMetricsIsValid:
+    def test_all_required_fields_present_returns_true(self):
+        assert _valid_metrics().is_valid() is True
+
+    @pytest.mark.parametrize(
+        "field",
+        ["ttft", "itl", "num_req", "isl", "osl", "request_duration"],
+    )
+    def test_none_required_field_returns_false(self, field):
+        m = _valid_metrics(**{field: None})
+        assert m.is_valid() is False, f"is_valid() should be False when {field}=None"
+
+    @pytest.mark.parametrize(
+        "field",
+        ["ttft", "itl", "num_req", "isl", "osl", "request_duration"],
+    )
+    def test_nan_required_field_returns_false(self, field):
+        m = _valid_metrics(**{field: float("nan")})
+        assert m.is_valid() is False, f"is_valid() should be False when {field}=NaN"
+
+    def test_optional_fields_none_does_not_affect_validity(self):
+        """p_load, d_load, kv_hit_rate are optional — None must not invalidate."""
+        m = _valid_metrics(p_load=None, d_load=None, kv_hit_rate=None)
+        assert m.is_valid() is True
+
+    def test_optional_fields_set_does_not_affect_validity(self):
+        m = _valid_metrics(p_load=0.8, d_load=0.3, kv_hit_rate=0.5)
+        assert m.is_valid() is True
+
+    def test_zero_values_are_valid(self):
+        """Zero is a legal observed value — is_valid() must not reject it."""
+        m = _valid_metrics(
+            ttft=0.0, itl=0.0, num_req=0.0, isl=0.0, osl=0.0, request_duration=0.0
+        )
+        assert m.is_valid() is True
+
+
+# ---------------------------------------------------------------------------
+# DirectRouterMetricsClient._parse_prometheus_text
+# ---------------------------------------------------------------------------
+
+# Derive the full metric names from constants so the test stays in sync with
+# any rename in prometheus_names.py without manual string updates.
+_PREFILL_TOKENS_METRIC = _WORKER_METRIC_NAMES["active_prefill_tokens"]
+_DECODE_BLOCKS_METRIC = _WORKER_METRIC_NAMES["active_decode_blocks"]
+_LAST_TTFT_METRIC = _WORKER_METRIC_NAMES["last_ttft"]
+_LAST_ISL_METRIC = _WORKER_METRIC_NAMES["last_isl"]
+_LAST_ITL_METRIC = _WORKER_METRIC_NAMES["last_itl"]
+
+
+def _prom_text(*lines: str) -> str:
+    """Join Prometheus text-exposition lines with a trailing newline."""
+    return "\n".join(lines) + "\n"
+
+
+def _gauge_block(metric_name: str, labels: dict, value: float) -> str:
+    """Build a minimal valid Prometheus gauge block for one sample."""
+    label_str = ",".join(f'{k}="{v}"' for k, v in labels.items())
+    return (
+        f"# HELP {metric_name} help\n"
+        f"# TYPE {metric_name} gauge\n"
+        f"{metric_name}{{{label_str}}} {value}"
+    )
+
+
+@pytest.fixture
+def direct_client() -> DirectRouterMetricsClient:
+    return DirectRouterMetricsClient(
+        router_metrics_url="http://localhost:9091/metrics",
+        dynamo_namespace="test-ns",
+    )
+
+
+class TestDirectRouterMetricsClientParseText:
+    def test_parse_single_prefill_worker(self, direct_client):
+        text = _prom_text(
+            _gauge_block(
+                _PREFILL_TOKENS_METRIC,
+                {"worker_type": "prefill", "worker_id": "w0"},
+                42.0,
+            )
+        )
+        result = direct_client._parse_prometheus_text(text)
+        assert "prefill" in result
+        assert "w0" in result["prefill"]
+        assert result["prefill"]["w0"]["active_prefill_tokens"] == pytest.approx(42.0)
+
+    def test_parse_multiple_workers_same_type(self, direct_client):
+        text = _prom_text(
+            _gauge_block(
+                _PREFILL_TOKENS_METRIC,
+                {"worker_type": "prefill", "worker_id": "w0"},
+                10.0,
+            ),
+            _gauge_block(
+                _PREFILL_TOKENS_METRIC,
+                {"worker_type": "prefill", "worker_id": "w1"},
+                20.0,
+            ),
+        )
+        result = direct_client._parse_prometheus_text(text)
+        assert len(result["prefill"]) == 2
+        assert result["prefill"]["w0"]["active_prefill_tokens"] == pytest.approx(10.0)
+        assert result["prefill"]["w1"]["active_prefill_tokens"] == pytest.approx(20.0)
+
+    def test_parse_separates_prefill_and_decode_workers(self, direct_client):
+        text = _prom_text(
+            _gauge_block(
+                _PREFILL_TOKENS_METRIC,
+                {"worker_type": "prefill", "worker_id": "p0"},
+                5.0,
+            ),
+            _gauge_block(
+                _DECODE_BLOCKS_METRIC,
+                {"worker_type": "decode", "worker_id": "d0"},
+                99.0,
+            ),
+        )
+        result = direct_client._parse_prometheus_text(text)
+        assert "p0" in result.get("prefill", {})
+        assert "d0" in result.get("decode", {})
+        assert "active_prefill_tokens" in result["prefill"]["p0"]
+        assert "active_decode_blocks" in result["decode"]["d0"]
+
+    def test_parse_all_five_worker_metric_fields(self, direct_client):
+        worker_labels = {"worker_type": "prefill", "worker_id": "w0"}
+        lines = []
+        for field, metric in _WORKER_METRIC_NAMES.items():
+            lines.append(_gauge_block(metric, worker_labels, float(hash(field) % 100)))
+        text = _prom_text(*lines)
+        result = direct_client._parse_prometheus_text(text)
+        parsed = result["prefill"]["w0"]
+        assert set(parsed.keys()) == set(
+            _WORKER_METRIC_NAMES.keys()
+        ), "Not all five worker metric fields were parsed"
+
+    def test_parse_ignores_metrics_not_in_worker_metric_names(self, direct_client):
+        text = _prom_text(
+            "# HELP some_other_metric help",
+            "# TYPE some_other_metric gauge",
+            'some_other_metric{worker_type="prefill",worker_id="w0"} 999',
+        )
+        result = direct_client._parse_prometheus_text(text)
+        assert result == {}, "Non-target metrics must be filtered out"
+
+    def test_parse_empty_text_returns_empty_dict(self, direct_client):
+        result = direct_client._parse_prometheus_text("")
+        assert result == {}
+
+    def test_parse_missing_worker_labels_uses_unknown(self, direct_client):
+        """Samples with no worker_type/worker_id labels fall back to 'unknown'."""
+        text = _prom_text(
+            f"# HELP {_PREFILL_TOKENS_METRIC} help",
+            f"# TYPE {_PREFILL_TOKENS_METRIC} gauge",
+            f"{_PREFILL_TOKENS_METRIC} 7.0",
+        )
+        result = direct_client._parse_prometheus_text(text)
+        assert "unknown" in result
+        assert "unknown" in result["unknown"]
+
+
+# ---------------------------------------------------------------------------
+# DirectRouterMetricsClient.get_recent_and_averaged_metrics
+# ---------------------------------------------------------------------------
+
+
+def _make_sample(worker_type: str, worker_id: str, **metrics) -> dict:
+    """Build a single sample buffer entry."""
+    return {worker_type: {worker_id: metrics}}
+
+
+class TestDirectRouterMetricsClientGetRecentAndAveraged:
+    def test_empty_buffer_returns_none(self, direct_client):
+        assert direct_client.get_recent_and_averaged_metrics("prefill") is None
+
+    def test_single_sample_recent_matches_that_sample(self, direct_client):
+        direct_client._sample_buffer = [
+            _make_sample("prefill", "w0", active_prefill_tokens=50.0, last_ttft=0.1)
+        ]
+        result = direct_client.get_recent_and_averaged_metrics("prefill")
+        assert result is not None
+        recent, per_worker_avg, cluster_avg = result
+        assert recent["w0"]["active_prefill_tokens"] == pytest.approx(50.0)
+        assert recent["w0"]["last_ttft"] == pytest.approx(0.1)
+
+    def test_single_sample_per_worker_avg_equals_recent(self, direct_client):
+        direct_client._sample_buffer = [
+            _make_sample("prefill", "w0", active_prefill_tokens=50.0)
+        ]
+        (
+            recent,
+            per_worker_avg,
+            cluster_avg,
+        ) = direct_client.get_recent_and_averaged_metrics("prefill")
+        assert per_worker_avg["w0"]["active_prefill_tokens"] == pytest.approx(50.0)
+
+    def test_multiple_samples_per_worker_averaged_over_time(self, direct_client):
+        direct_client._sample_buffer = [
+            _make_sample("prefill", "w0", active_prefill_tokens=10.0),
+            _make_sample("prefill", "w0", active_prefill_tokens=20.0),
+            _make_sample("prefill", "w0", active_prefill_tokens=30.0),
+        ]
+        _, per_worker_avg, cluster_avg = direct_client.get_recent_and_averaged_metrics(
+            "prefill"
+        )
+        assert per_worker_avg["w0"]["active_prefill_tokens"] == pytest.approx(20.0)
+        assert cluster_avg["active_prefill_tokens"] == pytest.approx(20.0)
+
+    def test_cluster_avg_aggregates_across_workers(self, direct_client):
+        """cluster_averaged must be the mean across all workers, not just one."""
+        direct_client._sample_buffer = [
+            {
+                "prefill": {
+                    "w0": {"active_prefill_tokens": 10.0},
+                    "w1": {"active_prefill_tokens": 30.0},
+                }
+            }
+        ]
+        _, per_worker_avg, cluster_avg = direct_client.get_recent_and_averaged_metrics(
+            "prefill"
+        )
+        assert cluster_avg["active_prefill_tokens"] == pytest.approx(20.0)
+
+    def test_filters_by_worker_type(self, direct_client):
+        """Requesting 'decode' must not return prefill worker data."""
+        direct_client._sample_buffer = [
+            {
+                "prefill": {"p0": {"active_prefill_tokens": 10.0}},
+                "decode": {"d0": {"active_decode_blocks": 5.0}},
+            }
+        ]
+        result_decode = direct_client.get_recent_and_averaged_metrics("decode")
+        assert result_decode is not None
+        recent, _, _ = result_decode
+        assert "d0" in recent
+        assert "p0" not in recent
+
+    def test_requested_type_absent_in_samples_returns_none(self, direct_client):
+        """If the buffer has only prefill samples, querying 'decode' should return None."""
+        direct_client._sample_buffer = [
+            _make_sample("prefill", "w0", active_prefill_tokens=1.0)
+        ]
+        result = direct_client.get_recent_and_averaged_metrics("decode")
+        assert result is None
+
+    def test_recent_reflects_latest_sample_not_oldest(self, direct_client):
+        direct_client._sample_buffer = [
+            _make_sample("prefill", "w0", active_prefill_tokens=1.0),
+            _make_sample("prefill", "w0", active_prefill_tokens=2.0),
+            _make_sample("prefill", "w0", active_prefill_tokens=99.0),
+        ]
+        recent, _, _ = direct_client.get_recent_and_averaged_metrics("prefill")
+        assert recent["w0"]["active_prefill_tokens"] == pytest.approx(99.0)
+
+    def test_workers_appearing_only_in_some_samples_averaged_correctly(
+        self, direct_client
+    ):
+        """A worker that appears in only 2 of 3 samples must be averaged over 2, not 3."""
+        direct_client._sample_buffer = [
+            _make_sample("prefill", "w0", active_prefill_tokens=10.0),
+            _make_sample("prefill", "w0", active_prefill_tokens=20.0),
+            _make_sample("prefill", "w1", active_prefill_tokens=50.0),
+        ]
+        _, per_worker_avg, _ = direct_client.get_recent_and_averaged_metrics("prefill")
+        assert per_worker_avg["w0"]["active_prefill_tokens"] == pytest.approx(15.0)
+        assert per_worker_avg["w1"]["active_prefill_tokens"] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# PrometheusAPIClient.get_avg_request_duration — router source known gap
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvgRequestDurationRouterSource:
+    """The router path queries dynamo_work_handler_request_duration_seconds, which
+    is not yet registered on the LocalRouter.  The test pins the queried metric name
+    so a future fix can be validated, and verifies the graceful 0-fallback while the
+    metric is absent."""
+
+    def test_router_source_queries_work_handler_metric(self):
+        # The router path uses the dynamo_component_ prefix (not dynamo_work_handler_)
+        # until RouterRequestMetrics exposes router_request_duration_seconds.  The TODO
+        # in traffic_metrics.py documents the intended future rename.  This test pins the
+        # current query so a prefix change doesn't go unnoticed.
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "test-ns", metrics_source="router"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.return_value = [{"value": [0, "0.5"]}]
+
+        client.get_avg_request_duration("60s", "mymodel")
+
+        call_args = str(client.prom.custom_query.call_args)
+        expected_metric = (
+            f"{prometheus_names.name_prefix.COMPONENT}_"
+            f"{prometheus_names.work_handler.REQUEST_DURATION_SECONDS}"
+        )
+        assert expected_metric in call_args, (
+            f"Router source must query {expected_metric!r} — "
+            "if this name has changed, update the TODO in traffic_metrics.py too"
+        )
+
+    def test_router_source_returns_zero_when_metric_absent(self):
+        """While the metric isn't published, Prometheus returns []; planner gets 0."""
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "test-ns", metrics_source="router"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.return_value = []
+
+        result = client.get_avg_request_duration("60s", "mymodel")
+        assert result == 0
+
+    def test_frontend_source_queries_frontend_metric(self):
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "test-ns", metrics_source="frontend"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.return_value = []
+
+        client.get_avg_request_duration("60s", "mymodel")
+
+        call_args = str(client.prom.custom_query.call_args)
+        assert prometheus_names.frontend_service.REQUEST_DURATION_SECONDS in call_args
+
+
+# ---------------------------------------------------------------------------
+# PrometheusAPIClient.get_avg_kv_hit_rate — additional edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvgKvHitRateEdgeCases:
+    def test_router_source_returns_none_on_nan(self):
+        """NaN from Prometheus must become None, not 0.0, to avoid dragging down EMA."""
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "test-ns", metrics_source="router"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.return_value = [{"value": [0, "NaN"]}]
+        result = client.get_avg_kv_hit_rate("60s", "mymodel")
+        assert result is None
+
+    def test_router_source_returns_none_on_exception(self):
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "test-ns", metrics_source="router"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.side_effect = RuntimeError("prom down")
+        result = client.get_avg_kv_hit_rate("60s", "mymodel")
+        assert result is None
+
+    def test_router_source_returns_float_on_valid_result(self):
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "test-ns", metrics_source="router"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.return_value = [{"value": [0, "0.75"]}]
+        result = client.get_avg_kv_hit_rate("60s", "mymodel")
+        assert result == pytest.approx(0.75)
+
+    def test_router_namespace_filter_uses_underscores(self):
+        """DYN_NAMESPACE 'my-ns-pool' must appear as 'my_ns_pool' in the PromQL filter."""
+        client = PrometheusAPIClient(
+            "http://localhost:9090", "my-ns-pool", metrics_source="router"
+        )
+        client.prom = MagicMock()
+        client.prom.custom_query.return_value = [{"value": [0, "0.5"]}]
+        client.get_avg_kv_hit_rate("60s", "mymodel")
+        call_args = str(client.prom.custom_query.call_args)
+        assert "my_ns_pool" in call_args, (
+            "Dashes in DYN_NAMESPACE must be normalized to underscores for the "
+            "PromQL dynamo_namespace filter (MetricsHierarchy uses underscores)"
+        )

--- a/components/src/dynamo/profiler/utils/aic_dataframe.py
+++ b/components/src/dynamo/profiler/utils/aic_dataframe.py
@@ -51,11 +51,16 @@ def build_prefill_row(
     moe_ep: int,
     backend: str = "",
     system: str = "",
+    power_w: float = 0.0,
 ) -> dict:
     """Build a single prefill row dict with the minimal columns needed by AIC picking.
 
     Only columns actually accessed by ``pick_autoscale`` and
     ``_build_disagg_summary_dict`` are populated.
+
+    ``power_w`` is the measured GPU power (watts per GPU) at this operating
+    point.  Pass the value from NVML / power monitors during THOROUGH-mode
+    benchmarks; leave at 0.0 when not measured.
     """
     num_gpus = tp * pp * dp
     seq_s = 1000.0 / ttft * dp if ttft > 0 else 0.0
@@ -85,7 +90,7 @@ def build_prefill_row(
         "backend": backend,
         "version": "",
         "system": system,
-        "power_w": 0.0,
+        "power_w": power_w,
     }
 
 
@@ -103,11 +108,16 @@ def build_decode_row(
     moe_ep: int,
     backend: str = "",
     system: str = "",
+    power_w: float = 0.0,
 ) -> dict:
     """Build a single decode row dict with the minimal columns needed by AIC picking.
 
     Only columns actually accessed by ``pick_autoscale`` and
     ``_build_disagg_summary_dict`` are populated.
+
+    ``power_w`` is the measured GPU power (watts per GPU) at this operating
+    point.  Pass the value from NVML / power monitors during THOROUGH-mode
+    benchmarks; leave at 0.0 when not measured.
     """
     seq_s = thpt_per_gpu * num_gpus / osl if osl > 0 else 0.0
 
@@ -134,7 +144,7 @@ def build_decode_row(
         "backend": backend,
         "version": "",
         "system": system,
-        "power_w": 0.0,
+        "power_w": power_w,
     }
 
 


### PR DESCRIPTION
Part of the [PR #9369 split plan](docs/design-docs/pr9369-split-plan.md).
This is **PR 4 of 6** (PR 3 — AIC Closed-Loop Optimizer + Integration Tests). **Held in Draft per plan §4.5**.

**Predecessor:** #9684 — Power budget enforcement
**Successor:** #9686 (Draft) — Stress testbed

## Scope

The algorithm-rich PR. Adds `AICPowerOptimizer` — the correction-coefficient EMA engine that observes live TTFT/ITL/power, detects drift, and re-invokes the AIC sweep. Wires it into the planner run loop. Includes frontend admission-control fanout, AIC-specific integration tests, and the live-cluster metric-paths tests. Completes the 6 shared files split with PR 1b.

~4,400 lines · 12 files.

- `monitoring/aic_power_optimizer.py` (715 LOC) — `c_ttft` / `c_itl` / `c_power_p/d/agg` correction coefficients, EMA gates, drift detection, hysteresis
- `tests/integration/test_aic_power_optimizer.py` (943 LOC) — executable spec for the EMA mechanics
- `tests/integration/test_aic_power_e2e_sim.py` (710 LOC) — end-to-end closed-loop sim
- `tests/integration/test_metric_paths_live.py` (558 LOC) — live-cluster Prometheus path checks
- `core/base.py` Phase-3 hunks — `_aic_optimizer`, `_apply_aic_config`, `_fanout_busy_threshold`, `_min_prefill_max_num_batched_tokens`, AIC tick-loop block
- `config/{defaults,planner_config}.py` — remaining 11 AIC fields + admission block
- `monitoring/{planner_metrics,traffic_metrics}.py` — AIC gauges/counters + remaining DCGM queries (`get_avg_per_gpu_power_by_component`, `get_avg_request_duration`)
- `core/types.py` — 5 new `TrafficObservation` fields (TTFT/ITL/throughput/scheduled tokens)
- `profiler/utils/aic_dataframe.py` — defensive fix (14 lines)
- `tests/unit/test_prometheus.py` — remaining ~550 lines of Phase-3 test classes

## Reviewer onboarding

Recommended reading order before diving into the diff (plan §2.4 + §3.2):

1. `docs/design-docs/powerplanner-design.md` §5.3 — correction coefficients + EMA gates
2. §5.6 — drift detection, hysteresis, `_estimated_throughput` reference
3. §5.1 — `aic_to_planner_cap` bridge between AIC and autoscaling
4. §5.7 + §6.7 — frontend `/busy_threshold` admission coupling
5. §8 (failure modes 1–14) — fail-open principle and the `power_w` clamp (row 14)

Then read `monitoring/aic_power_optimizer.py` against §5.3/§5.6/§5.1 and `core/base.py` Phase-3 additions against §6.4/§6.7. The integration tests are the executable specification.

## Tests at this tip (projection per plan §4.4 — will re-measure on dev pod before Ready)

- All PR 1a + 1b + 2 tests still pass
- `test_aic_power_optimizer.py` — 34 passed
- `test_aic_power_e2e_sim.py` — 15 passed
- `test_metric_paths_live.py` (live cluster) — 22 passed, 3 skipped (DCGM-per-pod not emitted in some clusters; open question #14)
- `test_prometheus.py` remaining additions — ~35 passed
- Plan projection: ~610 passed, 4 skipped (planner) + 43 (power_agent) = ~653 total

## Merge strategy

**Rebase-and-merge** (no squash).
