### PR TITLE
fix(routing): exclude over-threshold workers from load-balancer candidate sets

### DIFF
--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -64,6 +64,7 @@ mod registry;
 pub mod service;
 
 pub(crate) use client::EndpointDiscoverySource;
+pub(crate) use client::RoutingInstances;
 pub(crate) use client::RoutingOccupancyState;
 pub(crate) use client::get_or_create_routing_occupancy_state;
 pub use client::{Client, RoutingInstanceCounts};

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -172,7 +172,7 @@ impl RoutingInstances {
         routable_ids: Vec<u64>,
         overloaded_ids: HashSet<u64>,
     ) -> Self {
-        let free_ids = Self::derive_free_ids(&discovered_ids, &overloaded_ids);
+        let free_ids = Self::derive_free_ids(&routable_ids, &overloaded_ids);
         Self {
             discovered_ids,
             routable_ids,
@@ -187,6 +187,10 @@ impl RoutingInstances {
 
     pub(crate) fn routable_ids(&self) -> &[u64] {
         &self.routable_ids
+    }
+
+    pub(crate) fn free_ids(&self) -> &[u64] {
+        &self.free_ids
     }
 
     pub(crate) fn counts(&self) -> RoutingInstanceCounts {
@@ -221,19 +225,18 @@ impl RoutingInstances {
     }
 
     fn report_instance_down(&self, instance_id: u64) -> Self {
-        let routable_ids = self
+        let routable_ids: Vec<u64> = self
             .routable_ids
             .iter()
             .copied()
             .filter(|id| *id != instance_id)
             .collect();
 
-        Self {
-            discovered_ids: self.discovered_ids.clone(),
+        Self::from_parts(
+            self.discovered_ids.clone(),
             routable_ids,
-            overloaded_ids: self.overloaded_ids.clone(),
-            free_ids: self.free_ids.clone(),
-        }
+            self.overloaded_ids.clone(),
+        )
     }
 
     #[cfg(test)]
@@ -264,12 +267,12 @@ impl RoutingInstances {
         )
     }
 
-    fn derive_free_ids(discovered_ids: &[u64], overloaded_ids: &HashSet<u64>) -> Vec<u64> {
+    fn derive_free_ids(routable_ids: &[u64], overloaded_ids: &HashSet<u64>) -> Vec<u64> {
         if overloaded_ids.is_empty() {
-            return discovered_ids.to_vec();
+            return routable_ids.to_vec();
         }
 
-        discovered_ids
+        routable_ids
             .iter()
             .copied()
             .filter(|id| !overloaded_ids.contains(id))

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -241,12 +241,13 @@ impl RoutingInstances {
 
     #[cfg(test)]
     fn override_routable_ids(&self, routable_ids: Vec<u64>) -> Self {
-        Self {
-            discovered_ids: self.discovered_ids.clone(),
+        // Route through from_parts so `free_ids` is recomputed from the new
+        // routable set instead of carrying the stale value forward.
+        Self::from_parts(
+            self.discovered_ids.clone(),
             routable_ids,
-            overloaded_ids: self.overloaded_ids.clone(),
-            free_ids: self.free_ids.clone(),
-        }
+            self.overloaded_ids.clone(),
+        )
     }
 
     fn set_overloaded(&self, overloaded_ids: HashSet<u64>) -> Self {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -489,14 +489,14 @@ where
 
         let instance_id = {
             let routing_instances = self.client.routing_instances();
-            let count = routing_instances.routable_ids().len();
+            let count = routing_instances.free_ids().len();
             if count == 0 {
                 return Err(anyhow::anyhow!(
                     "no instances found for endpoint {}",
                     self.client.endpoint.id()
                 ));
             }
-            routing_instances.routable_ids()[counter % count]
+            routing_instances.free_ids()[counter % count]
         };
         tracing::trace!("round robin router selected {instance_id}");
 
@@ -508,7 +508,7 @@ where
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let instance_id = {
             let routing_instances = self.client.routing_instances();
-            let count = routing_instances.routable_ids().len();
+            let count = routing_instances.free_ids().len();
             if count == 0 {
                 return Err(anyhow::anyhow!(
                     "no instances found for endpoint {}",
@@ -516,7 +516,7 @@ where
                 ));
             }
             let counter = rand::rng().random::<u64>() as usize;
-            routing_instances.routable_ids()[counter % count]
+            routing_instances.free_ids()[counter % count]
         };
         tracing::trace!("random router selected {instance_id}");
 
@@ -530,13 +530,13 @@ where
         let state = self.occupancy_state()?;
         let instance_id = {
             let routing_instances = self.client.routing_instances();
-            if routing_instances.routable_ids().is_empty() {
+            if routing_instances.free_ids().is_empty() {
                 return Err(anyhow::anyhow!(
                     "no instances found for endpoint {}",
                     self.client.endpoint.id()
                 ));
             }
-            p2c_select_from(state.as_ref(), routing_instances.routable_ids())
+            p2c_select_from(state.as_ref(), routing_instances.free_ids())
         };
         state.increment(instance_id);
         let permit = OccupancyPermit::new(state, instance_id);
@@ -589,7 +589,7 @@ where
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self.client.routing_instances().routable_ids().to_vec();
+        let instance_ids = self.client.routing_instances().free_ids().to_vec();
 
         if instance_ids.is_empty() {
             return Err(anyhow::anyhow!(
@@ -655,7 +655,7 @@ where
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self.client.routing_instances().routable_ids().to_vec();
+        let instance_ids = self.client.routing_instances().free_ids().to_vec();
         let instance_id = state
             .select_exact_min_and_increment(&instance_ids)
             .await

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -487,9 +487,12 @@ where
     /// "fleet is overloaded" case (`ResourceExhausted` / 503 retry-later,
     /// matching the post-selection check in `route()` and the KV scheduler's
     /// `AllEligibleWorkersOverloaded`) from "no workers registered at all"
-    /// (generic 5xx "no instances found").
+    /// or "all routable workers were reported down" (generic 5xx
+    /// "no instances found"). Overload is signaled only when `routable_ids`
+    /// is non-empty and `free_ids` is empty — i.e., workers are alive and
+    /// up but every one of them is over its admission threshold.
     fn empty_free_pool_error(&self, routing_instances: &RoutingInstances) -> anyhow::Error {
-        if !routing_instances.discovered_ids().is_empty() {
+        if !routing_instances.routable_ids().is_empty() {
             let cause = PipelineError::ServiceOverloaded(
                 "All workers are busy, please retry later".to_string(),
             );
@@ -690,7 +693,7 @@ where
     /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
     pub fn select_next_worker(&self) -> Option<u64> {
         let routing_instances = self.client.routing_instances();
-        let count = routing_instances.routable_ids().len();
+        let count = routing_instances.free_ids().len();
         if count == 0 {
             return None;
         }
@@ -698,11 +701,11 @@ where
         match self.router_mode {
             RouterMode::RoundRobin => {
                 let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
-                Some(routing_instances.routable_ids()[counter % count])
+                Some(routing_instances.free_ids()[counter % count])
             }
             RouterMode::Random => {
                 let counter = rand::rng().random::<u64>() as usize;
-                Some(routing_instances.routable_ids()[counter % count])
+                Some(routing_instances.free_ids()[counter % count])
             }
             RouterMode::PowerOfTwoChoices
             | RouterMode::Direct
@@ -722,7 +725,7 @@ where
     /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
     pub fn peek_next_worker(&self) -> Option<u64> {
         let routing_instances = self.client.routing_instances();
-        let count = routing_instances.routable_ids().len();
+        let count = routing_instances.free_ids().len();
         if count == 0 {
             return None;
         }
@@ -731,13 +734,13 @@ where
             RouterMode::RoundRobin => {
                 // Just peek at the current counter value without incrementing
                 let counter = self.round_robin_counter.load(Ordering::Relaxed) as usize;
-                Some(routing_instances.routable_ids()[counter % count])
+                Some(routing_instances.free_ids()[counter % count])
             }
             RouterMode::Random => {
                 // For random, peeking implies a fresh random selection since it's stateless.
                 // Note: The caller must realize that select_next_worker() will pick a DIFFERENT random worker.
                 let counter = rand::rng().random::<u64>() as usize;
-                Some(routing_instances.routable_ids()[counter % count])
+                Some(routing_instances.free_ids()[counter % count])
             }
             RouterMode::PowerOfTwoChoices
             | RouterMode::Direct
@@ -870,10 +873,13 @@ where
                 result
             } else {
                 // Instance vanished — pick a different one from the current
-                // availability list and retry the lookup once.
+                // free set and retry the lookup once. Using `free_ids()` keeps
+                // the fallback consistent with the pre-selection filter so we
+                // don't silently dispatch to an overloaded peer without
+                // re-running the admission check.
                 let routing_instances = self.client.routing_instances();
                 let fallback_id = routing_instances
-                    .routable_ids()
+                    .free_ids()
                     .iter()
                     .copied()
                     .find(|&id| id != instance_id);

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -5,7 +5,7 @@ use super::{AsyncEngineContextProvider, ResponseStream};
 use crate::error::{BackendError, DynamoError, ErrorType, match_error_chain};
 use crate::{
     component::{
-        Client, DeviceType, Endpoint, Instance, RoutingOccupancyState,
+        Client, DeviceType, Endpoint, Instance, RoutingInstances, RoutingOccupancyState,
         get_or_create_routing_occupancy_state,
     },
     discovery::EndpointInstanceId,
@@ -483,6 +483,29 @@ where
         Ok(router)
     }
 
+    /// Empty-pool error for non-KV selectors. Distinguishes the
+    /// "fleet is overloaded" case (`ResourceExhausted` / 503 retry-later,
+    /// matching the post-selection check in `route()` and the KV scheduler's
+    /// `AllEligibleWorkersOverloaded`) from "no workers registered at all"
+    /// (generic 5xx "no instances found").
+    fn empty_free_pool_error(&self, routing_instances: &RoutingInstances) -> anyhow::Error {
+        if !routing_instances.discovered_ids().is_empty() {
+            let cause = PipelineError::ServiceOverloaded(
+                "All workers are busy, please retry later".to_string(),
+            );
+            return DynamoError::builder()
+                .error_type(ErrorType::ResourceExhausted)
+                .message("All workers are busy, please retry later")
+                .cause(cause)
+                .build()
+                .into();
+        }
+        anyhow::anyhow!(
+            "no instances found for endpoint {}",
+            self.client.endpoint.id()
+        )
+    }
+
     /// Issue a request to the next available instance in a round-robin fashion
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
@@ -491,10 +514,7 @@ where
             let routing_instances = self.client.routing_instances();
             let count = routing_instances.free_ids().len();
             if count == 0 {
-                return Err(anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                ));
+                return Err(self.empty_free_pool_error(&routing_instances));
             }
             routing_instances.free_ids()[counter % count]
         };
@@ -510,10 +530,7 @@ where
             let routing_instances = self.client.routing_instances();
             let count = routing_instances.free_ids().len();
             if count == 0 {
-                return Err(anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                ));
+                return Err(self.empty_free_pool_error(&routing_instances));
             }
             let counter = rand::rng().random::<u64>() as usize;
             routing_instances.free_ids()[counter % count]
@@ -531,10 +548,7 @@ where
         let instance_id = {
             let routing_instances = self.client.routing_instances();
             if routing_instances.free_ids().is_empty() {
-                return Err(anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                ));
+                return Err(self.empty_free_pool_error(&routing_instances));
             }
             p2c_select_from(state.as_ref(), routing_instances.free_ids())
         };
@@ -589,13 +603,11 @@ where
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self.client.routing_instances().free_ids().to_vec();
+        let routing_instances = self.client.routing_instances();
+        let instance_ids = routing_instances.free_ids().to_vec();
 
         if instance_ids.is_empty() {
-            return Err(anyhow::anyhow!(
-                "no instances found for endpoint {}",
-                self.client.endpoint.id()
-            ));
+            return Err(self.empty_free_pool_error(&routing_instances));
         }
 
         // Apply a unified policy for all endpoints.
@@ -621,16 +633,13 @@ where
             cuda_to_cpu_ratio,
         );
 
-        // Select least-loaded within the chosen group
+        // Select least-loaded within the chosen group. An empty group means
+        // free workers exist but the budget-selected device class has none —
+        // same retry-later semantic as the empty-free-pool case.
         let instance_id = state
             .select_exact_min_and_increment(&candidates)
             .await
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no instances in selected device group for endpoint {}",
-                    endpoint_id
-                )
-            })?;
+            .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
         let permit = OccupancyPermit::new(state.clone(), instance_id);
         let is_cpu = matches!(
             device_type_map.get(&instance_id),
@@ -655,16 +664,12 @@ where
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self.client.routing_instances().free_ids().to_vec();
+        let routing_instances = self.client.routing_instances();
+        let instance_ids = routing_instances.free_ids().to_vec();
         let instance_id = state
             .select_exact_min_and_increment(&instance_ids)
             .await
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                )
-            })?;
+            .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
         let permit = OccupancyPermit::new(state.clone(), instance_id);
         tracing::trace!(
             "least loaded router selected {instance_id} (connections: {})",

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -483,14 +483,8 @@ where
         Ok(router)
     }
 
-    /// Empty-pool error for non-KV selectors. Distinguishes the
-    /// "fleet is overloaded" case (`ResourceExhausted` / 503 retry-later,
-    /// matching the post-selection check in `route()` and the KV scheduler's
-    /// `AllEligibleWorkersOverloaded`) from "no workers registered at all"
-    /// or "all routable workers were reported down" (generic 5xx
-    /// "no instances found"). Overload is signaled only when `routable_ids`
-    /// is non-empty and `free_ids` is empty — i.e., workers are alive and
-    /// up but every one of them is over its admission threshold.
+    /// `ResourceExhausted` when workers are routable but all overloaded;
+    /// `anyhow!("no instances found")` when no routable workers exist.
     fn empty_free_pool_error(&self, routing_instances: &RoutingInstances) -> anyhow::Error {
         if !routing_instances.routable_ids().is_empty() {
             let cause = PipelineError::ServiceOverloaded(
@@ -636,9 +630,7 @@ where
             cuda_to_cpu_ratio,
         );
 
-        // Select least-loaded within the chosen group. An empty group means
-        // free workers exist but the budget-selected device class has none —
-        // same retry-later semantic as the empty-free-pool case.
+        // Empty group: budget-selected device class has no free workers.
         let instance_id = state
             .select_exact_min_and_increment(&candidates)
             .await
@@ -872,11 +864,8 @@ where
             if let Some(result) = resolve_transport(instance_id) {
                 result
             } else {
-                // Instance vanished — pick a different one from the current
-                // free set and retry the lookup once. Using `free_ids()` keeps
-                // the fallback consistent with the pre-selection filter so we
-                // don't silently dispatch to an overloaded peer without
-                // re-running the admission check.
+                // Instance vanished — pick another from free_ids (same filter
+                // as pre-selection) and retry the lookup once.
                 let routing_instances = self.client.routing_instances();
                 let fallback_id = routing_instances
                     .free_ids()
@@ -1286,10 +1275,59 @@ mod tests {
         let result = router.generate(SingleIn::new(42u64)).await;
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
+        // With pre-selection filtering on free_ids, the single-overloaded-worker
+        // case is now caught before selection rather than after — the chosen
+        // worker is never overloaded because the candidate pool excludes it.
+        // The post-selection check in route() remains as a race-condition
+        // backstop.
         assert!(
-            msg.contains("Selected worker is overloaded"),
-            "expected selected-worker overload rejection, got: {msg}"
+            msg.contains("All workers are busy"),
+            "expected empty-free-pool rejection, got: {msg}"
         );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn round_robin_excludes_overloaded_workers_from_candidates() {
+        const TEST_RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt
+            .namespace("test_round_robin_excludes_overloaded".to_string())
+            .unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = Client::with_reconcile_interval(endpoint.clone(), TEST_RECONCILE_INTERVAL)
+            .await
+            .unwrap();
+
+        // Two workers, mark one overloaded. round_robin must never select
+        // the overloaded one — that's the whole point of selecting from
+        // free_ids instead of routable_ids. The post-selection overload
+        // check in route() would otherwise 503 one of N requests on each
+        // pass, which is the bug this PR closes for non-KV selectors.
+        client.override_instance_avail(vec![1, 2]);
+        client.set_overloaded_instances(&[1]);
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+
+        // Round-robin over N requests should land on worker 2 every time.
+        // We use peek_next_worker for a side-effect-free probe.
+        for _ in 0..6 {
+            let selected = router
+                .peek_next_worker()
+                .expect("peek should succeed with a free worker");
+            assert_eq!(
+                selected, 2,
+                "overloaded worker 1 must not appear in the candidate set"
+            );
+        }
 
         rt.shutdown();
     }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1290,7 +1290,12 @@ mod tests {
 
     #[tokio::test]
     async fn round_robin_excludes_overloaded_workers_from_candidates() {
-        const TEST_RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+        // Long reconcile interval so the synthetic override below survives
+        // the test. We still register a real endpoint instance up front so
+        // the initial reconcile (which fires immediately when the monitor
+        // task spawns) settles on a non-empty source — without that, the
+        // first reconcile would clobber the override before it takes effect.
+        const TEST_RECONCILE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3600);
 
         let rt = Runtime::from_current().unwrap();
         let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
@@ -1305,11 +1310,22 @@ mod tests {
             .await
             .unwrap();
 
-        // Two workers, mark one overloaded. round_robin must never select
-        // the overloaded one — that's the whole point of selecting from
-        // free_ids instead of routable_ids. The post-selection overload
-        // check in route() would otherwise 503 one of N requests on each
-        // pass, which is the bug this PR closes for non-KV selectors.
+        endpoint.register_endpoint_instance().await.unwrap();
+        let instances = client.wait_for_instances().await.unwrap();
+        let real_id = instances[0].id();
+        for _ in 0..50 {
+            if client.instance_ids_avail().contains(&real_id) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        // Now override with two synthetic IDs and mark one overloaded.
+        // round_robin must never select the overloaded one — that's the
+        // whole point of selecting from free_ids instead of routable_ids.
+        // The post-selection overload check in route() would otherwise 503
+        // one of N requests on each pass, which is the bug this PR closes
+        // for non-KV selectors.
         client.override_instance_avail(vec![1, 2]);
         client.set_overloaded_instances(&[1]);
 


### PR DESCRIPTION
## Summary

Admission thresholds in Dynamo are configured **per worker** (`DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD` etc.) — the load monitor flags an individual worker as over-threshold based on its own KV-cache utilization. But today none of the load-balancing modes (`RoundRobin`, `Random`, `PowerOfTwoChoices`, `LeastLoaded`, `DeviceAwareWeighted`) consult that per-worker flag during selection. They all pick from `instance_ids_avail()`, the alive set, which is **not** intersected with the busy set.

The only place per-worker thresholds influence routing today is the fleet-level reject in `route()`, which fires when **every** worker is over threshold. So if 3 of 4 workers are over their per-worker threshold, the load balancer happily keeps spreading load across all 4 — until the 4th is pushed over its threshold too, and only *then* do clients see 503s. The intended behavior is: avoid sending more load to any of the 3 over-threshold workers, route only to the 4th, and reject (503) only when *all* workers are over threshold.

## Fix

Introduce `Client::instance_ids_routable()` = `instance_ids_avail() ∩ ¬busy`. Wire it into the seven worker-picking sites in `push_router.rs` (round-robin / random / p2c / device-aware / least-loaded / `select_next_worker` / `peek_next_worker` and the vanished-instance fallback). Selection now skips per-worker-busy workers automatically. When `routable_ids` is empty (the all-busy fleet case), the existing "no instances found" path returns 503 — same outcome as today, but reached via the natural empty-candidate path rather than as a special-case gate.

Pinned-worker (`direct()`) is intentionally **not** changed in this PR — overriding pin semantics needs its own decision (e.g. introduce a `PinnedWorkerOverloaded` error variant rather than silently re-routing).

## Why narrow

#9655 is a much larger refactor that *also* addresses this gap (among other things — RCU snapshot of routing state, KV-router eligibility plumbing, terminology cleanup). This PR is the minimum behavioral fix for the load-balancer modes so the threshold semantics users already expect actually work today, ahead of the broader refactor. If #9655 lands first, this PR closes as a no-op. If this lands first, #9655 picks it up as one commit in its history and the rest of the refactor is unchanged.

## Test plan
- [x] Unit test in `client.rs` confirming `instance_ids_routable()` excludes both reported-down and busy workers.
- [ ] CI matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request routing to exclude busy and unavailable workers from being selected, enhancing system reliability and preventing routing failures.

* **Tests**
  * Added comprehensive test coverage for worker state management and routing behavior verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->