### PR TITLE
feat(gms): add NIXL UCX transfer backend

### DIFF
--- a/lib/gpu_memory_service/cli/storage_runner.py
+++ b/lib/gpu_memory_service/cli/storage_runner.py
@@ -259,6 +259,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Byte transfer backend for restore. "
             "'nixl' uses NIXL POSIX with host staging; "
             "'nixl-gds' uses NIXL GDS_MT for direct file-to-GPU transfers; "
+            "'nixl-ucx' uses NIXL UCX for peer GPU-to-GMS transfers; "
             "'sharded-ssd' shards reads across local SSD roots using the "
             "same NIXL POSIX host-staging path."
         ),

--- a/lib/gpu_memory_service/snapshot/backends/nixl_common.py
+++ b/lib/gpu_memory_service/snapshot/backends/nixl_common.py
@@ -16,6 +16,7 @@ from gpu_memory_service.snapshot.transfer import FileTransferSource
 
 NIXL_POSIX_BACKEND = "POSIX"
 NIXL_GDS_BACKEND = "GDS_MT"
+NIXL_UCX_BACKEND = "UCX"
 
 FILE_MEM_TYPE = "FILE"
 DRAM_MEM_TYPE = "DRAM"

--- a/lib/gpu_memory_service/snapshot/backends/nixl_ucx.py
+++ b/lib/gpu_memory_service/snapshot/backends/nixl_ucx.py
@@ -1,0 +1,516 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NIXL UCX restore backend for peer VRAM -> local GMS VRAM transfers."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Mapping, Optional, Sequence
+
+from gpu_memory_service.common import cuda_utils
+from gpu_memory_service.snapshot.backends.nixl_common import (
+    NIXL_UCX_BACKEND,
+    VRAM_MEM_TYPE,
+    NixlTransferResources,
+    create_nixl_agent,
+    load_nixl_api,
+    release_nixl_transfer_resources,
+    start_transfer,
+    wait_for_transfer_done,
+)
+from gpu_memory_service.snapshot.transfer import (
+    GMSSnapshotConfig,
+    GMSTransferTarget,
+    RemoteTransferSource,
+    TransferBackendKind,
+    TransferSession,
+    validate_transfer_targets,
+)
+
+logger = logging.getLogger(__name__)
+
+GMS_NIXL_UCX_CONFIG_PATH_ENV = "GMS_NIXL_UCX_CONFIG_PATH"
+NIXL_UCX_CONFIG_PATH_CONFIG_KEY = "nixl_ucx_config_path"
+NIXL_UCX_REMOTE_AGENT_CONFIG_KEY = "nixl_ucx_remote_agent"
+NIXL_UCX_REMOTE_METADATA_CONFIG_KEY = "nixl_ucx_remote_metadata"
+NIXL_UCX_SOURCES_CONFIG_KEY = "nixl_ucx_sources"
+
+
+class NixlUCXTransferBackend:
+    """NIXL UCX backend for restoring GMS allocations from peer GPU memory."""
+
+    def __init__(self, *, config: GMSSnapshotConfig) -> None:
+        api = load_nixl_api()
+        self._device = config.device
+        self._max_workers = config.max_workers
+        self._agent_name = f"gms_ucx_loader_{self._device}_{os.getpid()}"
+        cuda_utils.cuda_runtime_set_device(self._device)
+        self._agent = create_nixl_agent(
+            api,
+            agent_name=self._agent_name,
+            backend_name=NIXL_UCX_BACKEND,
+        )
+
+        remote_metadata = load_remote_peer_metadata(config.backend_config)["metadata"]
+        if not remote_metadata:
+            raise RuntimeError(
+                f"{TransferBackendKind.NIXL_UCX.value} requires peer NIXL metadata in "
+                f"{NIXL_UCX_REMOTE_METADATA_CONFIG_KEY}"
+            )
+        self._remote_agent = _load_remote_metadata(self._agent, remote_metadata)
+        logger.info(
+            "NIXL UCX backend initialized for device %d with peer %s and %d max "
+            "in-flight transfers",
+            self._device,
+            self._remote_agent,
+            self._max_workers,
+        )
+
+    def start_restore(self, sources: Sequence[RemoteTransferSource]) -> TransferSession:
+        materialized_sources = [
+            (
+                RemoteTransferSource(
+                    allocation_id=source.allocation_id,
+                    remote_agent=self._remote_agent,
+                    va=source.va,
+                    device=source.device,
+                    byte_count=source.byte_count,
+                )
+                if not source.remote_agent
+                else source
+            )
+            for source in sources
+        ]
+        return _NixlUCXTransferSession(
+            agent=self._agent,
+            remote_agent=self._remote_agent,
+            device=self._device,
+            max_workers=self._max_workers,
+            sources=materialized_sources,
+        )
+
+    def close(self) -> None:
+        if self._agent is not None:
+            try:
+                self._agent.remove_remote_agent(self._remote_agent)
+            except Exception:
+                logger.debug(
+                    "failed to remove UCX remote agent %s",
+                    self._remote_agent,
+                    exc_info=True,
+                )
+        self._agent = None
+
+
+class _NixlUCXTransferSession:
+    def __init__(
+        self,
+        *,
+        agent: Any,
+        remote_agent: str,
+        device: int,
+        max_workers: int,
+        sources: Sequence[RemoteTransferSource],
+    ) -> None:
+        self._agent = agent
+        self._remote_agent = remote_agent
+        self._device = device
+        self._max_workers = max(1, int(max_workers))
+        self._sources = list(sources)
+        self._sources_by_id = {source.allocation_id: source for source in self._sources}
+        self._total_bytes = sum(source.byte_count for source in self._sources)
+        self._condition = threading.Condition()
+        self._targets: dict[str, GMSTransferTarget] = {}
+        self._pending_allocation_ids = {
+            source.allocation_id for source in self._sources
+        }
+        self._submitted_done = False
+        self._scheduler_thread: Optional[threading.Thread] = None
+        self._cancel_event = threading.Event()
+        self._error: Optional[BaseException] = None
+        self._stream_started_at: Optional[float] = None
+        self._first_transfer_at: Optional[float] = None
+
+    def submit_targets(self, targets: Mapping[str, GMSTransferTarget]) -> None:
+        if not targets:
+            return
+        self._validate_submitted_targets(targets)
+        self._ensure_streaming_started()
+
+        with self._condition:
+            self._raise_error_locked()
+            if self._submitted_done or self._cancel_event.is_set():
+                raise RuntimeError("NIXL UCX restore session is closed")
+            for allocation_id, target in targets.items():
+                previous = self._targets.get(allocation_id)
+                if previous is not None and previous != target:
+                    raise RuntimeError(
+                        f"NIXL UCX got duplicate target for allocation {allocation_id}"
+                    )
+                self._targets[allocation_id] = target
+            self._condition.notify_all()
+
+    def finish_restore(self) -> None:
+        if not self._sources:
+            with self._condition:
+                self._submitted_done = True
+                self._condition.notify_all()
+            return
+        self._ensure_streaming_started()
+        with self._condition:
+            self._submitted_done = True
+            self._condition.notify_all()
+
+        assert self._scheduler_thread is not None
+        self._scheduler_thread.join()
+        self._raise_error()
+
+        now = time.monotonic()
+        first_transfer_at = self._first_transfer_at or now
+        transfer_elapsed = now - first_transfer_at
+        total_elapsed = (
+            now - self._stream_started_at
+            if self._stream_started_at is not None
+            else transfer_elapsed
+        )
+        throughput = (
+            self._total_bytes / transfer_elapsed / (1024**3)
+            if transfer_elapsed > 0
+            else 0.0
+        )
+        logger.info(
+            "NIXL UCX transfers complete: %.2f GiB in %.3fs "
+            "(%.2f GiB/s, allocations=%d, max_inflight=%d, streaming=True, "
+            "total_stream_elapsed=%.3fs)",
+            self._total_bytes / (1024**3),
+            transfer_elapsed,
+            throughput,
+            len(self._sources),
+            self._max_workers,
+            total_elapsed,
+        )
+
+    def restore(self, targets: Mapping[str, GMSTransferTarget]) -> None:
+        validate_transfer_targets(self._sources, targets, device=self._device)
+        if not self._sources:
+            return
+        self.submit_targets(targets)
+        self.finish_restore()
+
+    def close(self) -> None:
+        self._cancel_event.set()
+        with self._condition:
+            self._submitted_done = True
+            self._condition.notify_all()
+        if (
+            self._scheduler_thread is not None
+            and self._scheduler_thread.is_alive()
+            and threading.current_thread() is not self._scheduler_thread
+        ):
+            self._scheduler_thread.join()
+
+    def _validate_submitted_targets(
+        self,
+        targets: Mapping[str, GMSTransferTarget],
+    ) -> None:
+        for allocation_id, target in targets.items():
+            source = self._sources_by_id.get(allocation_id)
+            if source is None:
+                raise RuntimeError(
+                    f"NIXL UCX got target for unknown allocation {allocation_id}"
+                )
+            if target.byte_count != source.byte_count:
+                raise RuntimeError(
+                    f"NIXL UCX target size mismatch for allocation {allocation_id}: "
+                    f"source={source.byte_count} target={target.byte_count}"
+                )
+            if target.device != self._device:
+                raise RuntimeError(
+                    f"NIXL UCX target device mismatch for allocation {allocation_id}: "
+                    f"backend={self._device} target={target.device}"
+                )
+
+    def _ensure_streaming_started(self) -> None:
+        if not self._sources:
+            return
+        if self._scheduler_thread is not None:
+            return
+        self._validate_remote_agents()
+        self._stream_started_at = time.monotonic()
+        logger.info(
+            "NIXL UCX streaming restore targets started: allocations=%d "
+            "bytes=%.2f GiB max_inflight=%d",
+            len(self._sources),
+            self._total_bytes / (1024**3),
+            self._max_workers,
+        )
+        self._scheduler_thread = threading.Thread(
+            target=self._run_streaming_scheduler,
+            name="nixl-ucx-streaming-scheduler",
+            daemon=True,
+        )
+        self._scheduler_thread.start()
+
+    def _validate_remote_agents(self) -> None:
+        for source in self._sources:
+            if source.remote_agent != self._remote_agent:
+                raise RuntimeError(
+                    f"{TransferBackendKind.NIXL_UCX.value} loaded peer "
+                    f"{self._remote_agent!r} but source {source.allocation_id} "
+                    f"references {source.remote_agent!r}"
+                )
+
+    def _pop_ready_source_locked(
+        self,
+    ) -> Optional[tuple[RemoteTransferSource, GMSTransferTarget]]:
+        for allocation_id in sorted(self._pending_allocation_ids):
+            target = self._targets.get(allocation_id)
+            if target is None:
+                continue
+            self._pending_allocation_ids.remove(allocation_id)
+            return self._sources_by_id[allocation_id], target
+        return None
+
+    def _run_streaming_scheduler(self) -> None:
+        inflight: list[NixlTransferResources] = []
+        try:
+            cuda_utils.cuda_runtime_set_device(self._device)
+            while True:
+                self._raise_error()
+                while len(inflight) < self._max_workers:
+                    with self._condition:
+                        ready = self._pop_ready_source_locked()
+                    if ready is None:
+                        break
+                    source, target = ready
+                    inflight.append(self._start_source_transfer(source, target))
+
+                self._poll_completed_transfers(inflight)
+
+                with self._condition:
+                    if not self._pending_allocation_ids and not inflight:
+                        return
+                    ready_exists = any(
+                        allocation_id in self._targets
+                        for allocation_id in self._pending_allocation_ids
+                    )
+                    if ready_exists and len(inflight) < self._max_workers:
+                        continue
+                    if self._submitted_done and self._pending_allocation_ids:
+                        if not ready_exists:
+                            raise RuntimeError(
+                                f"NIXL UCX missing {len(self._pending_allocation_ids)} "
+                                "restore target(s) before finish_restore"
+                            )
+                    if self._cancel_event.is_set():
+                        raise RuntimeError("NIXL UCX restore session was cancelled")
+                    self._condition.wait(timeout=0.001 if inflight else None)
+        except BaseException as exc:
+            with self._condition:
+                if self._error is None:
+                    self._error = exc
+                self._condition.notify_all()
+        finally:
+            self._drain_inflight_transfers(inflight)
+
+    def _start_source_transfer(
+        self,
+        source: RemoteTransferSource,
+        target: GMSTransferTarget,
+    ) -> NixlTransferResources:
+        transfer = self._prepare_source_transfer(source, target)
+        try:
+            start_transfer(
+                self._agent,
+                transfer.handle,
+                transfer.label,
+                TransferBackendKind.NIXL_UCX.value,
+            )
+            if self._first_transfer_at is None:
+                self._first_transfer_at = time.monotonic()
+                assert self._stream_started_at is not None
+                logger.info(
+                    "NIXL UCX first streaming transfer started after %.3fs "
+                    "from first target submission",
+                    self._first_transfer_at - self._stream_started_at,
+                )
+            return transfer
+        except Exception:
+            release_nixl_transfer_resources(self._agent, transfer)
+            raise
+
+    def _poll_completed_transfers(
+        self,
+        inflight: list[NixlTransferResources],
+    ) -> None:
+        still_running: list[NixlTransferResources] = []
+        first_error: Optional[BaseException] = None
+        for transfer in inflight:
+            state = self._agent.check_xfer_state(transfer.handle)
+            if state == "PROC":
+                still_running.append(transfer)
+                continue
+            try:
+                if state == "ERR":
+                    raise RuntimeError(f"NIXL UCX transfer failed: {transfer.label}")
+                if state != "DONE":
+                    raise RuntimeError(
+                        f"NIXL UCX transfer ended in unexpected state {state!r}: "
+                        f"{transfer.label}"
+                    )
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+            finally:
+                release_nixl_transfer_resources(self._agent, transfer)
+        inflight[:] = still_running
+        if first_error is not None:
+            raise first_error
+
+    def _drain_inflight_transfers(
+        self,
+        inflight: list[NixlTransferResources],
+    ) -> None:
+        while inflight:
+            transfer = inflight.pop(0)
+            try:
+                wait_for_transfer_done(
+                    self._agent,
+                    transfer.handle,
+                    transfer.label,
+                    TransferBackendKind.NIXL_UCX.value,
+                )
+            except Exception:
+                logger.warning(
+                    "NIXL UCX failed while draining in-flight transfer %s",
+                    transfer.label,
+                    exc_info=True,
+                )
+            finally:
+                release_nixl_transfer_resources(self._agent, transfer)
+
+    def _prepare_source_transfer(
+        self,
+        source: RemoteTransferSource,
+        target: GMSTransferTarget,
+    ) -> NixlTransferResources:
+        local_reg = None
+        local_descs = self._agent.get_xfer_descs(
+            [(target.va, target.byte_count, target.device)],
+            mem_type=VRAM_MEM_TYPE,
+        )
+        remote_descs = self._agent.get_xfer_descs(
+            [(source.va, source.byte_count, source.device)],
+            mem_type=VRAM_MEM_TYPE,
+        )
+        handle = None
+        try:
+            local_reg = self._agent.register_memory(
+                [(target.va, target.byte_count, target.device, "")],
+                VRAM_MEM_TYPE,
+                backends=[NIXL_UCX_BACKEND],
+            )
+            handle = self._agent.initialize_xfer(
+                "READ",
+                local_descs,
+                remote_descs,
+                source.remote_agent,
+                backends=[NIXL_UCX_BACKEND],
+            )
+            return NixlTransferResources(
+                handle=handle,
+                label=source.allocation_id,
+                registrations=(local_reg,),
+            )
+        except Exception:
+            release_nixl_transfer_resources(
+                self._agent,
+                NixlTransferResources(
+                    handle=handle,
+                    label=source.allocation_id,
+                    registrations=(() if local_reg is None else (local_reg,)),
+                ),
+            )
+            raise
+
+    def _raise_error(self) -> None:
+        with self._condition:
+            self._raise_error_locked()
+
+    def _raise_error_locked(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+
+def _load_remote_metadata(agent: Any, metadata: bytes | str) -> str:
+    if isinstance(metadata, str):
+        metadata = _decode_metadata_bytes(metadata)
+    remote_name = agent.add_remote_agent(metadata)
+    if isinstance(remote_name, bytes):
+        return remote_name.decode("utf-8")
+    return str(remote_name)
+
+
+def load_remote_peer_metadata(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Load and normalize UCX peer metadata from config or a JSON file."""
+    payload: dict[str, Any] = {}
+    path = config.get(NIXL_UCX_CONFIG_PATH_CONFIG_KEY) or os.environ.get(
+        GMS_NIXL_UCX_CONFIG_PATH_ENV
+    )
+    if path:
+        with open(path, encoding="utf-8") as handle:
+            payload.update(json.load(handle))
+
+    for key in (
+        NIXL_UCX_REMOTE_AGENT_CONFIG_KEY,
+        NIXL_UCX_REMOTE_METADATA_CONFIG_KEY,
+        NIXL_UCX_SOURCES_CONFIG_KEY,
+        "agent_name",
+        "metadata",
+        "sources",
+    ):
+        if key in config and config[key] is not None:
+            payload[key] = config[key]
+
+    agent_name = (
+        payload["agent_name"]
+        if "agent_name" in payload
+        else payload.get(NIXL_UCX_REMOTE_AGENT_CONFIG_KEY)
+    )
+    metadata = (
+        payload["metadata"]
+        if "metadata" in payload
+        else payload.get(NIXL_UCX_REMOTE_METADATA_CONFIG_KEY)
+    )
+    sources = (
+        payload["sources"]
+        if "sources" in payload
+        else payload.get(NIXL_UCX_SOURCES_CONFIG_KEY)
+    )
+
+    if metadata is None:
+        raise RuntimeError(
+            f"{TransferBackendKind.NIXL_UCX.value} requires peer metadata "
+            f"({NIXL_UCX_REMOTE_METADATA_CONFIG_KEY} or metadata)"
+        )
+    if isinstance(metadata, str):
+        metadata = _decode_metadata_bytes(metadata)
+
+    return {
+        "agent_name": None if agent_name is None else str(agent_name),
+        "metadata": metadata,
+        "sources": sources,
+    }
+
+
+def _decode_metadata_bytes(value: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except Exception:
+        return value.encode("latin1")

--- a/lib/gpu_memory_service/snapshot/storage_client.py
+++ b/lib/gpu_memory_service/snapshot/storage_client.py
@@ -30,6 +30,7 @@ from gpu_memory_service.snapshot.transfer import (
     StreamingTransferSession,
     TransferBackendKind,
     build_file_transfer_sources,
+    build_remote_transfer_sources,
     create_transfer_backend,
 )
 
@@ -300,7 +301,29 @@ class GMSStorageClient:
 
         try:
             manifest, saved_metadata = load_manifest_and_metadata(input_dir)
-            sources = build_file_transfer_sources(input_dir, manifest.allocations)
+            if backend_name == TransferBackendKind.NIXL_UCX.value:
+                from gpu_memory_service.snapshot.backends.nixl_ucx import (
+                    NIXL_UCX_REMOTE_METADATA_CONFIG_KEY,
+                    load_remote_peer_metadata,
+                )
+
+                peer_metadata = load_remote_peer_metadata({})
+                if peer_metadata.get("sources") is None:
+                    raise RuntimeError(
+                        f"{TransferBackendKind.NIXL_UCX.value} requires remote peer "
+                        "sources"
+                    )
+                remote_agent = peer_metadata.get("agent_name") or ""
+                backend_config[NIXL_UCX_REMOTE_METADATA_CONFIG_KEY] = peer_metadata[
+                    "metadata"
+                ]
+                sources = build_remote_transfer_sources(
+                    manifest.allocations,
+                    peer_metadata["sources"],
+                    remote_agent=remote_agent,
+                )
+            else:
+                sources = build_file_transfer_sources(input_dir, manifest.allocations)
 
             backend = create_transfer_backend(
                 backend_name,

--- a/lib/gpu_memory_service/snapshot/transfer.py
+++ b/lib/gpu_memory_service/snapshot/transfer.py
@@ -17,6 +17,7 @@ from gpu_memory_service.snapshot.model import AllocationEntry
 class TransferBackendKind(str, Enum):
     NIXL = "nixl"
     NIXL_GDS = "nixl-gds"
+    NIXL_UCX = "nixl-ucx"
     SHARDED_SSD = "sharded-ssd"
 
     def __str__(self) -> str:
@@ -31,6 +32,20 @@ class FileTransferSource:
     file_path: str
     file_offset: int
     byte_count: int
+
+
+@dataclass(frozen=True)
+class RemoteTransferSource:
+    """One source extent in a remote NIXL agent's memory."""
+
+    allocation_id: str
+    remote_agent: str
+    va: int
+    device: int
+    byte_count: int
+
+
+TransferSource = FileTransferSource | RemoteTransferSource
 
 
 @dataclass(frozen=True)
@@ -85,7 +100,7 @@ class StreamingTransferSession(TransferSession, Protocol):
 class TransferBackend(Protocol):
     """Backend capable of restoring bytes into GMS targets."""
 
-    def start_restore(self, sources: Sequence[FileTransferSource]) -> TransferSession:
+    def start_restore(self, sources: Sequence[TransferSource]) -> TransferSession:
         """Start or stage restore work for the given sources."""
 
     def close(self) -> None:
@@ -108,6 +123,50 @@ def build_file_transfer_sources(
     ]
 
 
+def build_remote_transfer_sources(
+    allocations: Sequence[AllocationEntry],
+    peer_sources: Mapping[str, Mapping[str, Any]] | Sequence[Mapping[str, Any]],
+    *,
+    remote_agent: str = "",
+) -> List[RemoteTransferSource]:
+    """Convert manifest allocation records into remote-memory transfer extents."""
+    if not isinstance(peer_sources, Mapping):
+        peer_sources = {str(source["allocation_id"]): source for source in peer_sources}
+
+    sources: List[RemoteTransferSource] = []
+    for entry in allocations:
+        source = peer_sources.get(entry.allocation_id)
+        if source is None:
+            raise RuntimeError(
+                f"Missing UCX source metadata for allocation {entry.allocation_id}"
+            )
+
+        byte_count = int(source.get("byte_count", entry.aligned_size))
+        if byte_count != int(entry.aligned_size):
+            raise RuntimeError(
+                f"UCX source size mismatch for allocation {entry.allocation_id}: "
+                f"manifest={entry.aligned_size} source={byte_count}"
+            )
+
+        va = source.get("va", source.get("addr"))
+        if va is None:
+            raise RuntimeError(
+                f"UCX source metadata for allocation {entry.allocation_id} "
+                "must include va or addr"
+            )
+
+        sources.append(
+            RemoteTransferSource(
+                allocation_id=entry.allocation_id,
+                remote_agent=str(source.get("remote_agent") or remote_agent or ""),
+                va=int(va),
+                device=int(source.get("device", 0)),
+                byte_count=byte_count,
+            )
+        )
+    return sources
+
+
 def create_transfer_backend(
     name: str,
     config: GMSSnapshotConfig,
@@ -123,6 +182,11 @@ def create_transfer_backend(
 
         return NixlGDSTransferBackend(config=config)
 
+    if name == TransferBackendKind.NIXL_UCX.value:
+        from gpu_memory_service.snapshot.backends.nixl_ucx import NixlUCXTransferBackend
+
+        return NixlUCXTransferBackend(config=config)
+
     if name == TransferBackendKind.SHARDED_SSD.value:
         from gpu_memory_service.snapshot.backends.sharded_ssd import (
             ShardedSSDTransferBackend,
@@ -137,7 +201,7 @@ def create_transfer_backend(
 
 
 def validate_transfer_targets(
-    sources: Sequence[FileTransferSource],
+    sources: Sequence[TransferSource],
     targets: Mapping[str, GMSTransferTarget],
     *,
     device: Optional[int] = None,

--- a/lib/gpu_memory_service/tests/test_snapshot_loader.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_loader.py
@@ -109,3 +109,8 @@ def test_load_device_sets_cuda_context_before_storage_client(monkeypatch):
             "clear_existing": True,
         },
     )
+
+
+def test_ucx_loader_requires_checkpoint_dir():
+    with pytest.raises(SystemExit):
+        loader.main(["--transfer-backend", "nixl-ucx"])

--- a/lib/gpu_memory_service/tests/test_snapshot_nixl_ucx.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_nixl_ucx.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for NIXL UCX restore planning and streaming."""
+
+import base64
+import threading
+
+import pytest
+
+try:
+    from gpu_memory_service.snapshot.backends import nixl_ucx
+    from gpu_memory_service.snapshot.backends.nixl_common import NixlTransferResources
+    from gpu_memory_service.snapshot.backends.nixl_ucx import _NixlUCXTransferSession
+    from gpu_memory_service.snapshot.model import AllocationEntry
+    from gpu_memory_service.snapshot.transfer import (
+        GMSTransferTarget,
+        RemoteTransferSource,
+        build_remote_transfer_sources,
+    )
+except ModuleNotFoundError:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+def test_build_remote_transfer_sources_validates_manifest_sizes():
+    allocations = [
+        AllocationEntry(
+            allocation_id="alloc-a",
+            size=4096,
+            aligned_size=4096,
+            tag="weight",
+            tensor_file="unused",
+        )
+    ]
+
+    sources = build_remote_transfer_sources(
+        allocations,
+        {
+            "alloc-a": {
+                "va": "8192",
+                "device": 3,
+                "byte_count": 4096,
+            }
+        },
+        remote_agent="peer",
+    )
+
+    assert sources == [
+        RemoteTransferSource(
+            allocation_id="alloc-a",
+            remote_agent="peer",
+            va=8192,
+            device=3,
+            byte_count=4096,
+        )
+    ]
+
+    with pytest.raises(RuntimeError, match="source size mismatch"):
+        build_remote_transfer_sources(
+            allocations,
+            {"alloc-a": {"va": 8192, "byte_count": 1}},
+            remote_agent="peer",
+        )
+
+
+def test_load_remote_peer_metadata_accepts_base64_metadata():
+    raw_metadata = b"peer-metadata"
+    payload = nixl_ucx.load_remote_peer_metadata(
+        {
+            "agent_name": "peer",
+            "metadata": base64.b64encode(raw_metadata).decode("ascii"),
+            "sources": {"alloc-a": {"va": 1, "byte_count": 2}},
+        }
+    )
+
+    assert payload["agent_name"] == "peer"
+    assert payload["metadata"] == raw_metadata
+    assert payload["sources"] == {"alloc-a": {"va": 1, "byte_count": 2}}
+
+
+def test_ucx_streaming_starts_ready_allocation_before_all_targets(monkeypatch):
+    sources = [
+        RemoteTransferSource(
+            allocation_id="alloc-a",
+            remote_agent="peer",
+            va=0xA000,
+            device=0,
+            byte_count=4096,
+        ),
+        RemoteTransferSource(
+            allocation_id="alloc-b",
+            remote_agent="peer",
+            va=0xB000,
+            device=0,
+            byte_count=4096,
+        ),
+    ]
+    targets = {
+        source.allocation_id: GMSTransferTarget(
+            allocation_id=source.allocation_id,
+            va=0x1000 + index * 0x1000,
+            device=0,
+            byte_count=source.byte_count,
+        )
+        for index, source in enumerate(sources)
+    }
+
+    started = []
+    cuda_context_calls = []
+    first_started = threading.Event()
+
+    class FakeAgent:
+        def check_xfer_state(self, handle):
+            return "DONE"
+
+        def release_xfer_handle(self, _handle):
+            return None
+
+        def deregister_memory(self, _registration):
+            return None
+
+    def fake_start_transfer(_agent, handle, label, _backend_name):
+        started.append((handle, label))
+        if label == "alloc-a":
+            first_started.set()
+
+    monkeypatch.setattr(nixl_ucx, "start_transfer", fake_start_transfer)
+    monkeypatch.setattr(
+        nixl_ucx.cuda_utils,
+        "cuda_runtime_set_device",
+        lambda device: cuda_context_calls.append(
+            (device, threading.current_thread().name)
+        ),
+    )
+    monkeypatch.setattr(
+        nixl_ucx,
+        "wait_for_transfer_done",
+        lambda *_args, **_kwargs: None,
+    )
+
+    session = _NixlUCXTransferSession(
+        agent=FakeAgent(),
+        remote_agent="peer",
+        device=0,
+        max_workers=1,
+        sources=sources,
+    )
+    next_handle = iter(["handle-a", "handle-b"])
+
+    def fake_prepare_source_transfer(source, _target):
+        assert cuda_context_calls == [(0, "nixl-ucx-streaming-scheduler")]
+        return NixlTransferResources(
+            handle=next(next_handle),
+            label=source.allocation_id,
+        )
+
+    monkeypatch.setattr(
+        session, "_prepare_source_transfer", fake_prepare_source_transfer
+    )
+
+    try:
+        session.submit_targets({"alloc-a": targets["alloc-a"]})
+        assert first_started.wait(timeout=1.0)
+        assert started == [("handle-a", "alloc-a")]
+
+        session.submit_targets({"alloc-b": targets["alloc-b"]})
+        session.finish_restore()
+        assert started == [
+            ("handle-a", "alloc-a"),
+            ("handle-b", "alloc-b"),
+        ]
+        assert cuda_context_calls == [(0, "nixl-ucx-streaming-scheduler")]
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add the `nixl-ucx` transfer backend and a `RemoteTransferSource` abstraction for peer GPU VRAM restores
- load peer NIXL metadata/sources via backend config or `GMS_NIXL_UCX_CONFIG_PATH`
- reuse the existing bounded NIXL transfer helper/handle lifecycle for UCX, keeping the stack consistent with the transfer-backend PR
- document validation/results in `gms-multigpu-benchmark-worklog.md`

## Validation
Local:
- `python3 -m py_compile lib/gpu_memory_service/snapshot/transfer.py lib/gpu_memory_service/snapshot/backends/nixl_common.py lib/gpu_memory_service/snapshot/backends/nixl_ucx.py lib/gpu_memory_service/snapshot/storage_client.py lib/gpu_memory_service/cli/storage_runner.py`
- `uvx --from black==23.1.0 black ...`
- `uvx --from ruff==0.5.2 ruff check --fix ...`
- `git diff --check`
- `PYTHONPATH=lib python3 - <<'PY' ... import/build_remote_transfer_sources smoke ... PY`

nscale `cluster-0967a26d-pool-14bee067-prctr-s2877`:
- `nixl-ucx`, 4 peer GPU pairs, 72 GiB/pair, 18 allocations/pair: 0.515s critical, 559.35 GiB/s, 288 GiB total
- `sharded-ssd`, 8x72 GiB: 12.444s critical, 46.29 GiB/s
- `nixl` PVC/VAST, 8x72 GiB: 25.803s critical, 22.32 GiB/s
- `nixl-gds`, 1x72 GiB: 12.498s critical, 5.76 GiB/s
- `nixl-gds`, 8x72 GiB: 56.595s critical, 10.18 GiB/s

Notes:
- same-node UCX CUDA IPC needs separate source/target processes; same-process agents validated correctness but used a slow path
- UCX backend intentionally avoids NIXL UCX `num_threads` in this runtime because it segfaulted in multi-process/multi-allocation tests; `max_workers` remains the bounded in-flight transfer window
- temporary workloads on s2877 were restored to replicas=1 and Ready; benchmark pod/resourceclaimtemplate were deleted

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->