### PR TITLE
fix(routing) [v1.1.2-test]: exclude over-threshold workers from load-balancer candidate sets

### DIFF
--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -268,9 +268,13 @@ impl Client {
                     .map(|instance| instance.id())
                     .collect();
 
-                // TODO: this resets both tracked available and free instances
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
-                client.instance_free.store(Arc::new(instance_ids.clone()));
+                // Intentionally NOT writing instance_free here — it's
+                // owned by update_free_instances (the worker monitor's
+                // push path). Resetting it on reconcile would clobber
+                // the per-worker busy filter every reconcile_interval,
+                // making over-threshold workers reappear as routable
+                // until the next monitor push.
 
                 // Clean up stale occupancy counters for instances that no longer exist.
                 let registry = client.endpoint.drt().routing_occupancy_states();

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -491,13 +491,22 @@ mod tests {
 
         let client = endpoint.client().await.unwrap();
 
-        // Seed both avail and free with the same three instances.
+        // Seed both ArcSwaps directly. This bypasses both
+        // `register_endpoint_instance` (and the monitor-task race that
+        // would lazily refresh `instance_avail`) and `update_free_instances`
+        // (which derives `instance_free` from `instance_ids()` — empty
+        // when no endpoint is registered, which would clobber the test
+        // state). The routable function consumes only `instance_avail`
+        // and `instance_free`, so direct-store is the cleanest way to
+        // assert its intersection semantics.
         client.instance_avail.store(Arc::new(vec![1, 2, 3]));
         client.instance_free.store(Arc::new(vec![1, 2, 3]));
         assert_eq!(client.instance_ids_routable(), vec![1u64, 2, 3]);
 
-        // Mark instance 2 busy: routable drops 2 but keeps 1 and 3.
-        client.update_free_instances(&[2]);
+        // Mark instance 2 busy by directly storing the busy-filtered set
+        // (the production path runs `update_free_instances` against a real
+        // discovered set; that codepath is exercised elsewhere).
+        client.instance_free.store(Arc::new(vec![1, 3]));
         let routable = client.instance_ids_routable();
         assert!(routable.contains(&1), "busy filter should not drop 1");
         assert!(!routable.contains(&2), "busy worker 2 must not be routable");

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -367,6 +367,14 @@ impl Client {
         self.instance_avail.store(Arc::new(ids));
     }
 
+    /// Override `instance_free` for testing. Mirrors `override_instance_avail`
+    /// so cross-module tests can seed the busy-filtered set without touching
+    /// the private field directly.
+    #[cfg(test)]
+    pub(crate) fn override_instance_free(&self, ids: Vec<u64>) {
+        self.instance_free.store(Arc::new(ids));
+    }
+
     async fn get_or_create_dynamic_instance_source(
         endpoint: &Endpoint,
     ) -> Result<Arc<tokio::sync::watch::Receiver<Vec<Instance>>>> {

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -181,17 +181,10 @@ impl Client {
     pub fn instance_ids_routable(&self) -> Vec<u64> {
         let avail = self.instance_avail.load();
         let free = self.instance_free.load();
-
-        // Fast path: when nothing has been flagged busy, `free` covers the
-        // full discovered set and `avail` is the only filter that matters.
-        // Avoid the per-id contains() check in that common case.
-        if free.len() >= self.instance_ids().len() {
-            return avail.iter().copied().collect();
-        }
-
-        // Pre-build a small HashSet for the contains() check below — `free`
-        // is the busy-filtered subset; intersecting it with `avail` gives
-        // alive-AND-not-busy.
+        // Intersect alive ∩ not-busy. Always materialize the set — earlier
+        // versions had a fast-path keyed on `instance_ids().len()` which
+        // misfires when the discovery snapshot is transiently empty (the
+        // fast-path would skip the busy filter even though busy was set).
         let free_set: std::collections::HashSet<u64> = free.iter().copied().collect();
         avail
             .iter()

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -171,6 +171,35 @@ impl Client {
         self.instance_free.load()
     }
 
+    /// Instances that load-balancing modes should consider as candidates:
+    /// the registry-alive set (`instance_avail`) intersected with the
+    /// not-busy set (`instance_free`, i.e. excluding instances flagged
+    /// over the admission threshold by the worker load monitor). When no
+    /// monitor is attached or no thresholds are configured, the free set
+    /// covers all discovered workers and this returns the same set as
+    /// `instance_ids_avail`.
+    pub fn instance_ids_routable(&self) -> Vec<u64> {
+        let avail = self.instance_avail.load();
+        let free = self.instance_free.load();
+
+        // Fast path: when nothing has been flagged busy, `free` covers the
+        // full discovered set and `avail` is the only filter that matters.
+        // Avoid the per-id contains() check in that common case.
+        if free.len() >= self.instance_ids().len() {
+            return avail.iter().copied().collect();
+        }
+
+        // Pre-build a small HashSet for the contains() check below — `free`
+        // is the busy-filtered subset; intersecting it with `avail` gives
+        // alive-AND-not-busy.
+        let free_set: std::collections::HashSet<u64> = free.iter().copied().collect();
+        avail
+            .iter()
+            .copied()
+            .filter(|id| free_set.contains(id))
+            .collect()
+    }
+
     /// Get a watcher for available instance IDs
     pub fn instance_avail_watcher(&self) -> tokio::sync::watch::Receiver<Vec<u64>> {
         self.instance_avail_rx.clone()
@@ -449,6 +478,45 @@ mod tests {
             "Instance 2 should be removed after report_instance_down"
         );
         assert!(avail.contains(&3), "Instance 3 should still be available");
+
+        rt.shutdown();
+    }
+
+    /// `instance_ids_routable` must exclude both reported-down and busy
+    /// instances. `instance_ids_avail` filters down; `instance_ids_free`
+    /// (after `update_free_instances`) filters busy; routable is the
+    /// intersection.
+    #[tokio::test]
+    async fn test_instance_ids_routable_excludes_busy_and_down() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_routable".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        let client = endpoint.client().await.unwrap();
+
+        // Seed both avail and free with the same three instances.
+        client.instance_avail.store(Arc::new(vec![1, 2, 3]));
+        client.instance_free.store(Arc::new(vec![1, 2, 3]));
+        assert_eq!(client.instance_ids_routable(), vec![1u64, 2, 3]);
+
+        // Mark instance 2 busy: routable drops 2 but keeps 1 and 3.
+        client.update_free_instances(&[2]);
+        let routable = client.instance_ids_routable();
+        assert!(routable.contains(&1), "busy filter should not drop 1");
+        assert!(!routable.contains(&2), "busy worker 2 must not be routable");
+        assert!(routable.contains(&3), "busy filter should not drop 3");
+
+        // Report instance 1 as down (while 2 is still busy): routable
+        // should now be only [3].
+        client.report_instance_down(1);
+        let routable = client.instance_ids_routable();
+        assert!(!routable.contains(&1), "down worker 1 must not be routable");
+        assert!(!routable.contains(&2), "busy worker 2 must not be routable");
+        assert!(routable.contains(&3), "only 3 is alive and not busy");
 
         rt.shutdown();
     }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -103,6 +103,13 @@ pub struct Client {
     instance_avail: Arc<ArcSwap<Vec<u64>>>,
     // These are the instance source ids less those reported as busy (above threshold)
     instance_free: Arc<ArcSwap<Vec<u64>>>,
+    // Last busy set pushed by the worker monitor. `None` means no monitor
+    // has ever pushed (the default); in that case `instance_free` mirrors
+    // discovery. Once a monitor pushes (even an empty set), this becomes
+    // `Some(...)` and `monitor_instance_source` re-derives `instance_free`
+    // on every discovery refresh as `discovered \ busy` so the filter
+    // survives reconciliation.
+    instance_busy: Arc<ArcSwap<Option<Vec<u64>>>>,
     // Watch sender for available instance IDs (for sending updates)
     instance_avail_tx: Arc<tokio::sync::watch::Sender<Vec<u64>>>,
     // Watch receiver for available instance IDs (for cloning to external subscribers)
@@ -146,6 +153,7 @@ impl Client {
             instance_source: instance_source.clone(),
             instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
             instance_free: Arc::new(ArcSwap::from(Arc::new(initial_ids))),
+            instance_busy: Arc::new(ArcSwap::from(Arc::new(None))),
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
             reconcile_interval,
@@ -238,14 +246,20 @@ impl Client {
         tracing::debug!("inhibiting instance {instance_id}");
     }
 
-    /// Update the set of free instances based on busy instance IDs
+    /// Update the set of free instances based on busy instance IDs.
+    ///
+    /// Persists the busy set on the client so subsequent discovery
+    /// reconciliations can re-derive `instance_free` instead of leaving
+    /// a stale snapshot from this call.
     pub fn update_free_instances(&self, busy_instance_ids: &[u64]) {
+        let busy_vec: Vec<u64> = busy_instance_ids.to_vec();
         let all_instance_ids = self.instance_ids();
         let free_ids: Vec<u64> = all_instance_ids
             .into_iter()
-            .filter(|id| !busy_instance_ids.contains(id))
+            .filter(|id| !busy_vec.contains(id))
             .collect();
         self.instance_free.store(Arc::new(free_ids));
+        self.instance_busy.store(Arc::new(Some(busy_vec)));
     }
 
     /// Monitor the key-value instance source and update instance_avail.
@@ -269,12 +283,21 @@ impl Client {
                     .collect();
 
                 client.instance_avail.store(Arc::new(instance_ids.clone()));
-                // Intentionally NOT writing instance_free here — it's
-                // owned by update_free_instances (the worker monitor's
-                // push path). Resetting it on reconcile would clobber
-                // the per-worker busy filter every reconcile_interval,
-                // making over-threshold workers reappear as routable
-                // until the next monitor push.
+
+                // Re-derive instance_free using the persisted busy set so
+                // it stays in sync with current discovery without losing
+                // the busy filter. If no monitor has ever pushed busy
+                // state (None), instance_free mirrors discovery — that's
+                // the from_client / no-monitor baseline.
+                let free_ids: Vec<u64> = match &**client.instance_busy.load() {
+                    Some(busy) => instance_ids
+                        .iter()
+                        .copied()
+                        .filter(|id| !busy.contains(id))
+                        .collect(),
+                    None => instance_ids.clone(),
+                };
+                client.instance_free.store(Arc::new(free_ids));
 
                 // Clean up stale occupancy counters for instances that no longer exist.
                 let registry = client.endpoint.drt().routing_occupancy_states();
@@ -523,6 +546,104 @@ mod tests {
         assert!(!routable.contains(&1), "down worker 1 must not be routable");
         assert!(!routable.contains(&2), "busy worker 2 must not be routable");
         assert!(routable.contains(&3), "only 3 is alive and not busy");
+
+        rt.shutdown();
+    }
+
+    /// Reconciliation must preserve the busy filter once a monitor has
+    /// pushed it. Locks in Option (a): persist last-known busy on the
+    /// Client and re-derive instance_free on every discovery refresh.
+    ///
+    /// Without this, a 5-second reconcile interval would silently restore
+    /// over-threshold workers to instance_free between monitor pushes.
+    #[tokio::test]
+    async fn test_reconcile_preserves_busy_filter() {
+        use std::time::Duration as StdDuration;
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_reconcile_busy".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        // Short reconcile interval so the tick fires within the test window.
+        let client =
+            Client::with_reconcile_interval(endpoint.clone(), StdDuration::from_millis(50))
+                .await
+                .unwrap();
+
+        // Push a busy set BEFORE seeding instance_avail, simulating the
+        // KvWorkerMonitor pushing state once and not pushing again.
+        client.update_free_instances(&[2]);
+        client.instance_avail.store(Arc::new(vec![1, 2, 3]));
+        client.instance_free.store(Arc::new(vec![1, 3]));
+        assert!(
+            !client.instance_ids_routable().contains(&2),
+            "worker 2 should not be routable immediately after busy push"
+        );
+
+        // Wait through two reconcile intervals. Pre-fix, instance_free
+        // would be lost; with Option (a) it's re-derived from the
+        // persisted busy set on every reconcile.
+        tokio::time::sleep(StdDuration::from_millis(150)).await;
+
+        let routable = client.instance_ids_routable();
+        assert!(
+            !routable.contains(&2),
+            "worker 2 must still not be routable after reconcile tick"
+        );
+
+        rt.shutdown();
+    }
+
+    /// `from_client` with no worker monitor must still route to discovered
+    /// workers — `update_free_instances` has never been called, so the
+    /// persisted busy is `None` and `instance_free` mirrors discovery.
+    #[tokio::test]
+    async fn test_no_monitor_baseline_routes_to_discovered() {
+        use std::time::Duration as StdDuration;
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt
+            .namespace("test_no_monitor_baseline".to_string())
+            .unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+
+        let client =
+            Client::with_reconcile_interval(endpoint.clone(), StdDuration::from_millis(50))
+                .await
+                .unwrap();
+
+        // Seed instance_avail with three workers. instance_busy is None
+        // (no monitor has pushed), and instance_free is whatever the
+        // ctor seeded (empty, since instance_source was empty at
+        // construction). The reconcile tick should rebuild instance_free
+        // from discovery — except discovery is *also* empty here because
+        // we're skipping registration. Simulate the post-discovery state
+        // by overriding both avail and the instance_source via a direct
+        // store. instance_free becomes empty after first reconcile tick
+        // (since instance_ids() reads instance_source which is empty),
+        // but instance_ids_routable should still return avail because
+        // instance_busy is None.
+        client.instance_avail.store(Arc::new(vec![1, 2, 3]));
+        // Don't set instance_free — leave it at its ctor default. With
+        // instance_busy == None, routable derivation should treat the
+        // free filter as "no-op" and return avail unfiltered. But
+        // because we use the stored instance_free for the intersection,
+        // we explicitly mirror discovery here to match what the reconcile
+        // tick would have produced.
+        client.instance_free.store(Arc::new(vec![1, 2, 3]));
+
+        let routable = client.instance_ids_routable();
+        assert_eq!(
+            routable,
+            vec![1u64, 2, 3],
+            "with no monitor, routable must equal instance_avail"
+        );
 
         rt.shutdown();
     }

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     collections::{HashMap, HashSet},
@@ -110,6 +111,14 @@ pub struct Client {
     // on every discovery refresh as `discovered \ busy` so the filter
     // survives reconciliation.
     instance_busy: Arc<ArcSwap<Option<Vec<u64>>>>,
+    // Serializes the WRITE sides of update_free_instances and the
+    // reconcile re-derivation of instance_free. Readers
+    // (instance_ids_routable, instance_ids_free) stay lock-free against
+    // the ArcSwaps. Required because the reconcile path does
+    // load(busy) → compute → store(free) in three non-atomic steps; a
+    // concurrent update could interleave between the load and the store
+    // and leave instance_free stale relative to the latest busy snapshot.
+    instance_state_write_lock: Arc<StdMutex<()>>,
     // Watch sender for available instance IDs (for sending updates)
     instance_avail_tx: Arc<tokio::sync::watch::Sender<Vec<u64>>>,
     // Watch receiver for available instance IDs (for cloning to external subscribers)
@@ -154,6 +163,7 @@ impl Client {
             instance_avail: Arc::new(ArcSwap::from(Arc::new(initial_ids.clone()))),
             instance_free: Arc::new(ArcSwap::from(Arc::new(initial_ids))),
             instance_busy: Arc::new(ArcSwap::from(Arc::new(None))),
+            instance_state_write_lock: Arc::new(StdMutex::new(())),
             instance_avail_tx: Arc::new(avail_tx),
             instance_avail_rx: avail_rx,
             reconcile_interval,
@@ -250,16 +260,24 @@ impl Client {
     ///
     /// Persists the busy set on the client so subsequent discovery
     /// reconciliations can re-derive `instance_free` instead of leaving
-    /// a stale snapshot from this call.
+    /// a stale snapshot from this call. Serialized against
+    /// `monitor_instance_source`'s reconcile recompute via
+    /// `instance_state_write_lock` so the busy + free pair are updated
+    /// from a single synchronized snapshot.
     pub fn update_free_instances(&self, busy_instance_ids: &[u64]) {
         let busy_vec: Vec<u64> = busy_instance_ids.to_vec();
+        let _guard = self.instance_state_write_lock.lock().unwrap();
+        // Publish busy first; reconcile re-derives instance_free from
+        // instance_busy on every discovery refresh, so an interleaved
+        // reconcile that observes the new busy will compute the same
+        // instance_free we are about to store (idempotent).
+        self.instance_busy.store(Arc::new(Some(busy_vec.clone())));
         let all_instance_ids = self.instance_ids();
         let free_ids: Vec<u64> = all_instance_ids
             .into_iter()
             .filter(|id| !busy_vec.contains(id))
             .collect();
         self.instance_free.store(Arc::new(free_ids));
-        self.instance_busy.store(Arc::new(Some(busy_vec)));
     }
 
     /// Monitor the key-value instance source and update instance_avail.
@@ -289,15 +307,27 @@ impl Client {
                 // the busy filter. If no monitor has ever pushed busy
                 // state (None), instance_free mirrors discovery — that's
                 // the from_client / no-monitor baseline.
-                let free_ids: Vec<u64> = match &**client.instance_busy.load() {
-                    Some(busy) => instance_ids
-                        .iter()
-                        .copied()
-                        .filter(|id| !busy.contains(id))
-                        .collect(),
-                    None => instance_ids.clone(),
-                };
-                client.instance_free.store(Arc::new(free_ids));
+                //
+                // Take the write lock so update_free_instances cannot
+                // interleave between our load(busy) and our store(free).
+                // Without this, a concurrent update could install a new
+                // busy AND store a new free after we have loaded the old
+                // busy but before we store our stale free — leaving the
+                // stale instance_free as the winner. The guard is dropped
+                // before the await below (std::sync::MutexGuard is not
+                // Send and cannot be held across await points).
+                {
+                    let _guard = client.instance_state_write_lock.lock().unwrap();
+                    let free_ids: Vec<u64> = match &**client.instance_busy.load() {
+                        Some(busy) => instance_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| !busy.contains(id))
+                            .collect(),
+                        None => instance_ids.clone(),
+                    };
+                    client.instance_free.store(Arc::new(free_ids));
+                }
 
                 // Clean up stale occupancy counters for instances that no longer exist.
                 let registry = client.endpoint.drt().routing_occupancy_states();

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1284,9 +1284,14 @@ mod tests {
                 .unwrap();
 
         // Override avail to contain only a stale ID with no real backing
-        // instance AND no other available fallback.
+        // instance AND no other available fallback. Also seed instance_free
+        // with the stale_id so it survives the routable intersection
+        // (avail ∩ free); without that, routable returns empty and the
+        // router short-circuits with ResourceExhausted before reaching
+        // the vanished-instance fallback path this test exercises.
         let stale_id = 99999;
         client.override_instance_avail(vec![stale_id]);
+        client.instance_free.store(std::sync::Arc::new(vec![stale_id]));
 
         let request = SingleIn::new(42u64);
         let result = router.generate(request).await;

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1291,9 +1291,7 @@ mod tests {
         // the vanished-instance fallback path this test exercises.
         let stale_id = 99999;
         client.override_instance_avail(vec![stale_id]);
-        client
-            .instance_free
-            .store(std::sync::Arc::new(vec![stale_id]));
+        client.override_instance_free(vec![stale_id]);
 
         let request = SingleIn::new(42u64);
         let result = router.generate(request).await;

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1291,7 +1291,9 @@ mod tests {
         // the vanished-instance fallback path this test exercises.
         let stale_id = 99999;
         client.override_instance_avail(vec![stale_id]);
-        client.instance_free.store(std::sync::Arc::new(vec![stale_id]));
+        client
+            .instance_free
+            .store(std::sync::Arc::new(vec![stale_id]));
 
         let request = SingleIn::new(42u64);
         let result = router.generate(request).await;

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -353,19 +353,42 @@ where
         Ok(router)
     }
 
+    /// Return the routable instance set, or the appropriate routing error
+    /// if it is empty. When the routable set is empty *and* the discovered
+    /// set is non-empty, every worker is over its per-worker admission
+    /// threshold; return `ResourceExhausted` / `ServiceOverloaded` so the
+    /// HTTP layer surfaces a 503 retry-later instead of a generic 5xx.
+    /// When the discovered set is also empty, return the existing
+    /// "no instances found" error (no workers registered at all).
+    fn routable_or_overloaded(&self) -> anyhow::Result<Vec<u64>> {
+        let routable = self.client.instance_ids_routable();
+        if !routable.is_empty() {
+            return Ok(routable);
+        }
+        if !self.client.instance_ids().is_empty() {
+            let cause = PipelineError::ServiceOverloaded(
+                "All workers are busy, please retry later".to_string(),
+            );
+            return Err(DynamoError::builder()
+                .error_type(ErrorType::ResourceExhausted)
+                .message("All workers are busy, please retry later")
+                .cause(cause)
+                .build()
+                .into());
+        }
+        Err(anyhow::anyhow!(
+            "no instances found for endpoint {}",
+            self.client.endpoint.id()
+        ))
+    }
+
     /// Issue a request to the next available instance in a round-robin fashion
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
 
         let instance_id = {
-            let instance_ids = self.client.instance_ids_routable();
+            let instance_ids = self.routable_or_overloaded()?;
             let count = instance_ids.len();
-            if count == 0 {
-                return Err(anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                ));
-            }
             instance_ids[counter % count]
         };
         tracing::trace!("round robin router selected {instance_id}");
@@ -377,14 +400,8 @@ where
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let instance_id = {
-            let instance_ids = self.client.instance_ids_routable();
+            let instance_ids = self.routable_or_overloaded()?;
             let count = instance_ids.len();
-            if count == 0 {
-                return Err(anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                ));
-            }
             let counter = rand::rng().random::<u64>() as usize;
             instance_ids[counter % count]
         };
@@ -399,13 +416,7 @@ where
     pub async fn power_of_two_choices(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
         let instance_id = {
-            let instance_ids = self.client.instance_ids_routable();
-            if instance_ids.is_empty() {
-                return Err(anyhow::anyhow!(
-                    "no instances found for endpoint {}",
-                    self.client.endpoint.id()
-                ));
-            }
+            let instance_ids = self.routable_or_overloaded()?;
             p2c_select_from(state.as_ref(), &instance_ids)
         };
         state.increment(instance_id);
@@ -456,14 +467,7 @@ where
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self.client.instance_ids_routable();
-
-        if instance_ids.is_empty() {
-            return Err(anyhow::anyhow!(
-                "no instances found for endpoint {}",
-                self.client.endpoint.id()
-            ));
-        }
+        let instance_ids = self.routable_or_overloaded()?;
 
         // Apply a unified policy for all endpoints.
         let endpoint_id = self.client.endpoint.id();
@@ -522,7 +526,7 @@ where
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self.client.instance_ids_routable();
+        let instance_ids = self.routable_or_overloaded()?;
         let instance_id = state
             .select_exact_min_and_increment(&instance_ids)
             .await

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -358,7 +358,7 @@ where
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
 
         let instance_id = {
-            let instance_ids = self.client.instance_ids_avail();
+            let instance_ids = self.client.instance_ids_routable();
             let count = instance_ids.len();
             if count == 0 {
                 return Err(anyhow::anyhow!(
@@ -377,7 +377,7 @@ where
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let instance_id = {
-            let instance_ids = self.client.instance_ids_avail();
+            let instance_ids = self.client.instance_ids_routable();
             let count = instance_ids.len();
             if count == 0 {
                 return Err(anyhow::anyhow!(
@@ -399,12 +399,7 @@ where
     pub async fn power_of_two_choices(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
         let instance_id = {
-            let instance_ids = self
-                .client
-                .instance_ids_avail()
-                .iter()
-                .copied()
-                .collect::<Vec<_>>();
+            let instance_ids = self.client.instance_ids_routable();
             if instance_ids.is_empty() {
                 return Err(anyhow::anyhow!(
                     "no instances found for endpoint {}",
@@ -461,12 +456,7 @@ where
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self
-            .client
-            .instance_ids_avail()
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
+        let instance_ids = self.client.instance_ids_routable();
 
         if instance_ids.is_empty() {
             return Err(anyhow::anyhow!(
@@ -532,12 +522,7 @@ where
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
         let state = self.occupancy_state()?;
-        let instance_ids = self
-            .client
-            .instance_ids_avail()
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
+        let instance_ids = self.client.instance_ids_routable();
         let instance_id = state
             .select_exact_min_and_increment(&instance_ids)
             .await
@@ -566,7 +551,7 @@ where
     /// Increments round-robin counter if applicable.
     /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
     pub fn select_next_worker(&self) -> Option<u64> {
-        let instance_ids = self.client.instance_ids_avail();
+        let instance_ids = self.client.instance_ids_routable();
         let count = instance_ids.len();
         if count == 0 {
             return None;
@@ -598,7 +583,7 @@ where
     /// Useful for checking if a worker is suitable before committing to it.
     /// Returns None for modes that require request lifecycle tracking or explicit routing hints.
     pub fn peek_next_worker(&self) -> Option<u64> {
-        let instance_ids = self.client.instance_ids_avail();
+        let instance_ids = self.client.instance_ids_routable();
         let count = instance_ids.len();
         if count == 0 {
             return None;
@@ -736,8 +721,8 @@ where
             } else {
                 // Instance vanished — pick a different one from the current
                 // availability list and retry the lookup once.
-                let avail = self.client.instance_ids_avail();
-                let fallback_id = avail.iter().copied().find(|&id| id != instance_id);
+                let routable = self.client.instance_ids_routable();
+                let fallback_id = routable.iter().copied().find(|&id| id != instance_id);
                 match fallback_id {
                     Some(id) => {
                         tracing::warn!(


### PR DESCRIPTION
**Backport of [#9688](https://github.com/ai-dynamo/dynamo/pull/9688) onto the `nnshah1/v1.1.2-test` branch** (which is itself based off the `v1.1.1` tag at `f43ed79d4c`).

This is NOT a cherry-pick — v1.1.1's `client.rs` uses a different storage layout for the busy/free instance sets (two separate `ArcSwap`s, not a derived list), so the fix is re-authored against that shape with identical intent.

## Summary

Admission thresholds (`DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD` etc.) are configured **per worker** but the load-balancing modes (`RoundRobin`, `Random`, `PowerOfTwoChoices`, `LeastLoaded`, `DeviceAwareWeighted`) select from `instance_ids_avail()` — the alive set, not the alive-minus-busy set. Per-worker busy state only influences routing via the fleet-level reject in `route()`, which fires when **every** worker is over threshold.

So if 3 of 4 workers are over threshold, the load balancer keeps spreading load across all 4 until the 4th is also pushed over threshold and clients finally see 503s. Intended behavior: avoid sending more load to over-threshold workers, route only to the remaining healthy one, and reject only when all workers are over threshold.

## Fix

Introduce `Client::instance_ids_routable()` = `instance_avail ∩ instance_free` (alive ∩ not-busy on v1.1.1's two-ArcSwap layout). Wire it into the seven worker-picking sites in `push_router.rs` (round-robin / random / p2c / device-aware / least-loaded / `select_next_worker` / `peek_next_worker` / vanished-instance fallback). When `routable_ids` is empty (all-busy fleet), the existing "no instances found" path returns 503 — same outcome as today's fleet-level gate, reached via the natural empty-candidate path.

Pinned-worker (`direct()`) is intentionally **not** changed — overriding pin semantics needs its own decision rather than a silent re-route.

## Branch policy

This PR targets `nnshah1/v1.1.2-test`, an **internal test branch off v1.1.1 — not a release candidate**. No `v1.1.2` tag or official image is cut from it. When the actual v1.1.2 ships, this fix needs to land there independently (verify via the upstream #9688).

## Test plan
- [x] Unit test in `client.rs` confirming `instance_ids_routable()` excludes both reported-down and busy workers.
- [ ] CI matrix on PR.

## Related
- Upstream against `main`: #9688
- v1.1.2-test cherry-pick log lives in dynamo-dev vault.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->