### PR TITLE
test(frontend): cap OpenResponses compliance output

### DIFF
--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -326,9 +326,11 @@ def _patch_openresponses_suite(install_dir: Path) -> None:
 
 @pytest.mark.unit
 @pytest.mark.sglang
+@pytest.mark.core
 @pytest.mark.gpu_0
 @pytest.mark.pre_merge
 def test_patch_openresponses_suite_adds_output_cap(tmp_path):
+    """Assert the OpenResponses harness patch injects a deterministic output cap."""
     source = tmp_path / "src" / "lib" / "compliance-tests.ts"
     source.parent.mkdir(parents=True)
     source.write_text(

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -57,6 +57,7 @@ BUN_VERSION = "1.3.12"
 NODE_VERSION = "20.19.0"
 OPENRESPONSES_REPO = "https://github.com/openresponses/openresponses.git"
 OPENRESPONSES_SHA = "fa29df5"
+OPENRESPONSES_MAX_OUTPUT_TOKENS = 512
 
 # Retry budget for network-touching installs. Exponential backoff starting
 # at 2s; 3 attempts caps the worst-case wait at ~6s before we surface a
@@ -285,6 +286,7 @@ def _openresponses_suite(_tools_cache, _bun_binary) -> Path:
             capture_output=True,
             text=True,
         )
+        _patch_openresponses_suite(install_dir)
         _retry_network_op(
             lambda: subprocess.run(
                 [str(_bun_binary), "install", "--frozen-lockfile"],
@@ -297,6 +299,54 @@ def _openresponses_suite(_tools_cache, _bun_binary) -> Path:
         )
         sentinel.touch()
     return install_dir
+
+
+def _patch_openresponses_suite(install_dir: Path) -> None:
+    """Bound upstream compliance generations so CI failures are deterministic."""
+    target = install_dir / "src" / "lib" / "compliance-tests.ts"
+    text = target.read_text()
+    old = "    body: JSON.stringify({ ...body, stream: streaming }),"
+    new = (
+        "    body: JSON.stringify({\n"
+        "      ...body,\n"
+        "      max_output_tokens: body.max_output_tokens ?? "
+        f"{OPENRESPONSES_MAX_OUTPUT_TOKENS},\n"
+        "      stream: streaming,\n"
+        "    }),"
+    )
+    if new in text:
+        return
+    if old not in text:
+        raise RuntimeError(
+            "OpenResponses compliance harness changed; update "
+            "_patch_openresponses_suite before running frontend compliance."
+        )
+    target.write_text(text.replace(old, new, 1))
+
+
+@pytest.mark.unit
+@pytest.mark.sglang
+@pytest.mark.gpu_0
+@pytest.mark.pre_merge
+def test_patch_openresponses_suite_adds_output_cap(tmp_path):
+    source = tmp_path / "src" / "lib" / "compliance-tests.ts"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "export async function makeRequest() {\n"
+        "  return fetch(url, {\n"
+        "    body: JSON.stringify({ ...body, stream: streaming }),\n"
+        "  });\n"
+        "}\n"
+    )
+
+    _patch_openresponses_suite(tmp_path)
+
+    text = source.read_text()
+    assert (
+        f"max_output_tokens: body.max_output_tokens ?? "
+        f"{OPENRESPONSES_MAX_OUTPUT_TOKENS}" in text
+    )
+    assert "body: JSON.stringify({ ...body, stream: streaming })," not in text
 
 
 def _install_npm_cli(


### PR DESCRIPTION
#### Overview

Follow-up for the SGLang runtime flake seen on PR #9660. The pinned OpenResponses compliance harness sends `/v1/responses` requests without `max_output_tokens`; after #9181, Dynamo intentionally forwards that as unset so backends use their own defaults. For SGLang this can mean generating until EOS/context length, which let one compliance request run past the 180s subprocess timeout.

Failed CI reference:

- PR #9660 failed job: https://github.com/ai-dynamo/dynamo/actions/runs/25978100171/job/76362113037
- Failed test: `tests/frontend/test_frontend_api_surface_compliance.py::test_frontend_api_surface_compliance`
- Failure mode: `bun run bin/compliance-test.ts ... timed out after 180 seconds`; logs showed `output_tokens=7211` before cancellation.

#### Details

- Adds `OPENRESPONSES_MAX_OUTPUT_TOKENS = 512` for the frontend API surface compliance test.
- Patches the pinned OpenResponses checkout after `git checkout` so each harness request includes `max_output_tokens` unless the request already set one.
- Preserves request-provided output caps by using `body.max_output_tokens ?? 512`.
- Adds a small unit regression test for the patch helper so future upstream harness shape changes fail before GPU runtime CI.

#### Review Notes

- This is scoped to the test harness. It does not restore a Dynamo Responses API default and should not change product behavior.
- The broad backend matrix is triggered because this touches `tests/**`. Current vLLM/TRT-LLM runtime failures match failures already seen on `main` at this PR base SHA (`8fbd8623`) and are not caused by this patch; the SGLang jobs relevant to this failure mode are passing.

#### Where should the reviewer start?

`tests/frontend/test_frontend_api_surface_compliance.py`

#### Related Issues

- Relates to PR #9660


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification to compliance test harness to ensure API requests include explicit output token limits during compliance testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->