### PR TITLE
feat(config): replace --no-admission-control with --admission-control {token-capacity,none}, default none

### DIFF
--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -30,6 +30,19 @@ _ROUTER_FIELDS: tuple[str, ...] = (
     "enforce_disagg",
 )
 
+# Valid values for --admission-control.
+#
+# - "token-capacity": apply the configured per-worker busy thresholds
+#   (--active-decode-blocks-threshold, --active-prefill-tokens-threshold,
+#   --active-prefill-tokens-threshold-frac).
+# - "none": disable busy-worker admission checks entirely; router queueing
+#   remains controlled by --router-queue-threshold.
+#
+# The name is intentionally broader than "kv-capacity" / "blocks" so that
+# future admission schemes (encoder-cache, TPS budget, billing-based, ...)
+# can be added as additional enum values without renaming the flag.
+ADMISSION_CONTROL_CHOICES: tuple[str, ...] = ("token-capacity", "none")
+
 
 class RouterConfigBase(ConfigBase):
     """Mixin carrying the shared router configuration fields."""
@@ -40,16 +53,28 @@ class RouterConfigBase(ConfigBase):
     active_decode_blocks_threshold: Optional[float]
     active_prefill_tokens_threshold: Optional[int]
     active_prefill_tokens_threshold_frac: Optional[float]
-    no_admission_control: bool = False
+    admission_control: str = "none"
 
     def router_kwargs(self) -> dict:
         """Return a dict suitable for ``RouterConfig(mode, kv_config, **kwargs)``."""
-        self.apply_no_admission_control()
+        self.apply_admission_control()
         return {f: getattr(self, f) for f in _ROUTER_FIELDS}
 
-    def apply_no_admission_control(self) -> None:
-        if not self.no_admission_control:
+    def apply_admission_control(self) -> None:
+        """Apply the --admission-control mode to the busy thresholds.
+
+        - "token-capacity": keep the configured busy thresholds as-is.
+        - "none": clear all busy thresholds; router queueing remains controlled
+          by --router-queue-threshold.
+        """
+        if self.admission_control not in ADMISSION_CONTROL_CHOICES:
+            raise ValueError(
+                f"--admission-control must be one of "
+                f"{ADMISSION_CONTROL_CHOICES}, got {self.admission_control!r}"
+            )
+        if self.admission_control == "token-capacity":
             return
+        # "none" — disable admission checks.
         self.active_decode_blocks_threshold = None
         self.active_prefill_tokens_threshold = None
         self.active_prefill_tokens_threshold_frac = None
@@ -149,15 +174,16 @@ class RouterArgGroup(ArgGroup):
         )
         add_argument(
             g,
-            flag_name="--no-admission-control",
-            env_var="DYN_NO_ADMISSION_CONTROL",
-            default=False,
+            flag_name="--admission-control",
+            env_var="DYN_ADMISSION_CONTROL",
+            default="none",
             help=(
-                "Disable busy-worker admission checks by clearing "
-                "--active-decode-blocks-threshold, --active-prefill-tokens-threshold, "
-                "and --active-prefill-tokens-threshold-frac. Router queueing remains "
-                "controlled by --router-queue-threshold."
+                "Admission control mode. 'token-capacity' enables per-worker busy "
+                "checks using --active-decode-blocks-threshold, "
+                "--active-prefill-tokens-threshold, and "
+                "--active-prefill-tokens-threshold-frac. 'none' disables those "
+                "busy checks; router queueing remains controlled by "
+                "--router-queue-threshold."
             ),
-            arg_type=None,
-            action="store_true",
+            choices=list(ADMISSION_CONTROL_CHOICES),
         )

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -41,6 +41,12 @@ _ROUTER_FIELDS: tuple[str, ...] = (
 # - "none": disable busy-worker admission checks entirely; router queueing
 #   remains controlled by --router-queue-threshold.
 ADMISSION_CONTROL_CHOICES: tuple[str, ...] = ("token-capacity", "none")
+# Sentinel default — distinguishes "user did not pass --admission-control"
+# (auto-decide based on whether any threshold flag is explicitly set)
+# from "user explicitly passed --admission-control none" (treat as
+# contradiction if combined with an explicit threshold flag, raise).
+# Not in ADMISSION_CONTROL_CHOICES so argparse never accepts it from input.
+_ADMISSION_CONTROL_AUTO: str = "_auto_"
 
 
 class RouterConfigBase(ConfigBase):
@@ -52,7 +58,10 @@ class RouterConfigBase(ConfigBase):
     active_decode_blocks_threshold: Optional[float]
     active_prefill_tokens_threshold: Optional[int]
     active_prefill_tokens_threshold_frac: Optional[float]
-    admission_control: str = "none"
+    # Sentinel default — see _ADMISSION_CONTROL_AUTO comment. After
+    # apply_admission_control runs, this is always one of
+    # ADMISSION_CONTROL_CHOICES.
+    admission_control: str = _ADMISSION_CONTROL_AUTO
 
     def router_kwargs(self) -> dict:
         """Return a dict suitable for ``RouterConfig(mode, kv_config, **kwargs)``."""
@@ -62,26 +71,22 @@ class RouterConfigBase(ConfigBase):
     def apply_admission_control(self) -> None:
         """Apply the --admission-control mode to the busy thresholds.
 
+        Three input modes:
+        - `_ADMISSION_CONTROL_AUTO` (sentinel default; the user did not pass
+          --admission-control and did not set DYN_ADMISSION_CONTROL): if any
+          threshold flag is explicitly set, auto-promote to "token-capacity"
+          so the threshold takes effect (preserves the v1.0.x / v1.1.x
+          launch-config contract where setting a threshold flag implicitly
+          activated admission control). Otherwise resolve to "none".
         - "token-capacity": keep the configured busy thresholds as-is.
-        - "none": clear all busy thresholds; router queueing remains controlled
-          by --router-queue-threshold.
+        - "none" (explicit): clear all busy thresholds; if any threshold
+          flag was also explicitly set, raise — the combination is a
+          contradiction (you explicitly turned admission off while also
+          configuring a threshold value).
 
-        Compatibility auto-switch: if mode is "none" (the default) AND any
-        of the threshold flags was explicitly set to a non-None value, the
-        mode auto-promotes to "token-capacity" so the thresholds take
-        effect. This preserves the v1.0.x / v1.1.x launch-config contract
-        where passing a threshold flag implicitly activated admission
-        control. The auto-switch is logged at INFO so operators can see
-        it in startup output.
+        After this method returns, ``self.admission_control`` is always one
+        of ADMISSION_CONTROL_CHOICES.
         """
-        if self.admission_control not in ADMISSION_CONTROL_CHOICES:
-            raise ValueError(
-                f"--admission-control must be one of "
-                f"{ADMISSION_CONTROL_CHOICES}, got {self.admission_control!r}"
-            )
-        if self.admission_control == "token-capacity":
-            return
-        # mode is "none"
         explicit_thresholds: list[str] = []
         if self.active_decode_blocks_threshold is not None:
             explicit_thresholds.append("--active-decode-blocks-threshold")
@@ -89,17 +94,38 @@ class RouterConfigBase(ConfigBase):
             explicit_thresholds.append("--active-prefill-tokens-threshold")
         if self.active_prefill_tokens_threshold_frac is not None:
             explicit_thresholds.append("--active-prefill-tokens-threshold-frac")
-        if explicit_thresholds:
-            logger.info(
-                "admission-control: auto-switching mode 'none' -> 'token-capacity' "
-                "because %s was explicitly set. Pass --admission-control token-capacity "
-                "to make this explicit, or unset the threshold(s) to keep mode='none'.",
-                ", ".join(explicit_thresholds),
-            )
-            self.admission_control = "token-capacity"
+
+        if self.admission_control == _ADMISSION_CONTROL_AUTO:
+            if explicit_thresholds:
+                logger.info(
+                    "admission-control: implicit mode resolved to 'token-capacity' "
+                    "because %s was explicitly set. Pass --admission-control "
+                    "token-capacity to make this explicit, or unset the "
+                    "threshold(s) to keep admission control disabled.",
+                    ", ".join(explicit_thresholds),
+                )
+                self.admission_control = "token-capacity"
+                return
+            self.admission_control = "none"
+            # no thresholds set; nothing to clear
             return
-        # "none" with no thresholds explicitly set — clear (no-op, but
-        # keep the assignment for symmetry with future fields).
+
+        if self.admission_control not in ADMISSION_CONTROL_CHOICES:
+            raise ValueError(
+                f"--admission-control must be one of "
+                f"{ADMISSION_CONTROL_CHOICES}, got {self.admission_control!r}"
+            )
+        if self.admission_control == "token-capacity":
+            return
+        # admission_control == "none" (explicit). Contradiction with any
+        # explicit threshold flag — raise rather than silently overriding.
+        if explicit_thresholds:
+            raise ValueError(
+                "--admission-control none cannot be combined with explicit "
+                f"{', '.join(explicit_thresholds)} — drop the threshold flag(s) "
+                "to keep admission disabled, or pass --admission-control "
+                "token-capacity to activate the threshold(s)."
+            )
         self.active_decode_blocks_threshold = None
         self.active_prefill_tokens_threshold = None
         self.active_prefill_tokens_threshold_frac = None
@@ -201,7 +227,7 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--admission-control",
             env_var="DYN_ADMISSION_CONTROL",
-            default="none",
+            default=_ADMISSION_CONTROL_AUTO,
             help=(
                 "Admission control mode. 'token-capacity' enables per-worker busy "
                 "checks using --active-decode-blocks-threshold, "

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -37,10 +37,6 @@ _ROUTER_FIELDS: tuple[str, ...] = (
 #   --active-prefill-tokens-threshold-frac).
 # - "none": disable busy-worker admission checks entirely; router queueing
 #   remains controlled by --router-queue-threshold.
-#
-# The name is intentionally broader than "kv-capacity" / "blocks" so that
-# future admission schemes (encoder-cache, TPS budget, billing-based, ...)
-# can be added as additional enum values without renaming the flag.
 ADMISSION_CONTROL_CHOICES: tuple[str, ...] = ("token-capacity", "none")
 
 

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -11,6 +11,7 @@ returns a dict that can be unpacked into
 ``RouterConfig(mode, kv_config, **config.router_kwargs())``.
 """
 
+import logging
 from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
@@ -21,6 +22,8 @@ from dynamo.common.configuration.utils import (
     nullable_float,
     nullable_int,
 )
+
+logger = logging.getLogger(__name__)
 
 # Fields forwarded verbatim as kwargs to RouterConfig.__init__.
 _ROUTER_FIELDS: tuple[str, ...] = (
@@ -62,6 +65,14 @@ class RouterConfigBase(ConfigBase):
         - "token-capacity": keep the configured busy thresholds as-is.
         - "none": clear all busy thresholds; router queueing remains controlled
           by --router-queue-threshold.
+
+        Compatibility auto-switch: if mode is "none" (the default) AND any
+        of the threshold flags was explicitly set to a non-None value, the
+        mode auto-promotes to "token-capacity" so the thresholds take
+        effect. This preserves the v1.0.x / v1.1.x launch-config contract
+        where passing a threshold flag implicitly activated admission
+        control. The auto-switch is logged at INFO so operators can see
+        it in startup output.
         """
         if self.admission_control not in ADMISSION_CONTROL_CHOICES:
             raise ValueError(
@@ -70,7 +81,25 @@ class RouterConfigBase(ConfigBase):
             )
         if self.admission_control == "token-capacity":
             return
-        # "none" — disable admission checks.
+        # mode is "none"
+        explicit_thresholds: list[str] = []
+        if self.active_decode_blocks_threshold is not None:
+            explicit_thresholds.append("--active-decode-blocks-threshold")
+        if self.active_prefill_tokens_threshold is not None:
+            explicit_thresholds.append("--active-prefill-tokens-threshold")
+        if self.active_prefill_tokens_threshold_frac is not None:
+            explicit_thresholds.append("--active-prefill-tokens-threshold-frac")
+        if explicit_thresholds:
+            logger.info(
+                "admission-control: auto-switching mode 'none' -> 'token-capacity' "
+                "because %s was explicitly set. Pass --admission-control token-capacity "
+                "to make this explicit, or unset the threshold(s) to keep mode='none'.",
+                ", ".join(explicit_thresholds),
+            )
+            self.admission_control = "token-capacity"
+            return
+        # "none" with no thresholds explicitly set — clear (no-op, but
+        # keep the assignment for symmetry with future fields).
         self.active_decode_blocks_threshold = None
         self.active_prefill_tokens_threshold = None
         self.active_prefill_tokens_threshold_frac = None

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -48,6 +48,16 @@ ADMISSION_CONTROL_CHOICES: tuple[str, ...] = ("token-capacity", "none")
 # Not in ADMISSION_CONTROL_CHOICES so argparse never accepts it from input.
 _ADMISSION_CONTROL_AUTO: str = "_auto_"
 
+# Production defaults for the busy thresholds, applied only when
+# admission-control resolves to "token-capacity". The CLI/env defaults are
+# `None` (sentinel for "user did not set this") so apply_admission_control
+# can distinguish "user explicitly passed a threshold" from "argparse
+# filled in a default" — and so explicit `--admission-control none` does
+# not raise the contradiction error against defaults the user never set.
+_DEFAULT_ACTIVE_DECODE_BLOCKS_THRESHOLD: float = 1.0
+_DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD: int = 10_000_000
+_DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: float = 64.0
+
 
 class RouterConfigBase(ConfigBase):
     """Mixin carrying the shared router configuration fields."""
@@ -105,20 +115,36 @@ class RouterConfigBase(ConfigBase):
                     ", ".join(explicit_thresholds),
                 )
                 self.admission_control = "token-capacity"
-                return
-            self.admission_control = "none"
-            # no thresholds set; nothing to clear
-            return
+            else:
+                self.admission_control = "none"
 
         if self.admission_control not in ADMISSION_CONTROL_CHOICES:
             raise ValueError(
                 f"--admission-control must be one of "
                 f"{ADMISSION_CONTROL_CHOICES}, got {self.admission_control!r}"
             )
+
         if self.admission_control == "token-capacity":
+            # Fill in production defaults for any threshold the user did not
+            # explicitly set. Until now the threshold fields default to None
+            # so the explicit-user check above stays accurate.
+            if self.active_decode_blocks_threshold is None:
+                self.active_decode_blocks_threshold = (
+                    _DEFAULT_ACTIVE_DECODE_BLOCKS_THRESHOLD
+                )
+            if self.active_prefill_tokens_threshold is None:
+                self.active_prefill_tokens_threshold = (
+                    _DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD
+                )
+            if self.active_prefill_tokens_threshold_frac is None:
+                self.active_prefill_tokens_threshold_frac = (
+                    _DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC
+                )
             return
-        # admission_control == "none" (explicit). Contradiction with any
-        # explicit threshold flag — raise rather than silently overriding.
+
+        # admission_control == "none" (explicit or auto-resolved). Contradiction
+        # with any explicit threshold flag — raise rather than silently
+        # overriding.
         if explicit_thresholds:
             raise ValueError(
                 "--admission-control none cannot be combined with explicit "
@@ -126,9 +152,7 @@ class RouterConfigBase(ConfigBase):
                 "to keep admission disabled, or pass --admission-control "
                 "token-capacity to activate the threshold(s)."
             )
-        self.active_decode_blocks_threshold = None
-        self.active_prefill_tokens_threshold = None
-        self.active_prefill_tokens_threshold_frac = None
+        # All thresholds remain None (their argparse default) — nothing to clear.
 
 
 class RouterArgGroup(ArgGroup):
@@ -191,10 +215,12 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--active-decode-blocks-threshold",
             env_var="DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD",
-            default=1.0,
+            default=None,
             help=(
                 "Threshold fraction (0.0-1.0) of KV cache block utilization above which a worker "
-                "is considered busy. Pass 'None' on the CLI to disable this check. Default: 1.0."
+                "is considered busy. Setting this implies --admission-control token-capacity. "
+                "Pass 'None' on the CLI to disable this check. "
+                "Token-capacity default: 1.0."
             ),
             arg_type=nullable_float,
         )
@@ -202,12 +228,14 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--active-prefill-tokens-threshold",
             env_var="DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD",
-            default=10_000_000,
+            default=None,
             help=(
                 "Literal token count threshold for determining when a worker is considered busy "
                 "based on prefill token utilization. When active prefill tokens exceed this "
-                "threshold, the worker is marked as busy. Pass 'None' on the CLI to disable this "
-                "check. Uses OR logic with --active-prefill-tokens-threshold-frac. Default: 10000000."
+                "threshold, the worker is marked as busy. Setting this implies "
+                "--admission-control token-capacity. Pass 'None' on the CLI to disable this "
+                "check. Uses OR logic with --active-prefill-tokens-threshold-frac. "
+                "Token-capacity default: 10000000."
             ),
             arg_type=nullable_int,
         )
@@ -215,11 +243,13 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--active-prefill-tokens-threshold-frac",
             env_var="DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC",
-            default=64.0,
+            default=None,
             help=(
                 "Fraction of max_num_batched_tokens for busy detection. Worker is busy when "
-                "active_prefill_tokens > frac * max_num_batched_tokens. Pass 'None' on the CLI to "
-                "disable this check. Uses OR logic with --active-prefill-tokens-threshold. Default: 64.0."
+                "active_prefill_tokens > frac * max_num_batched_tokens. Setting this implies "
+                "--admission-control token-capacity. Pass 'None' on the CLI to disable this "
+                "check. Uses OR logic with --active-prefill-tokens-threshold. "
+                "Token-capacity default: 64.0."
             ),
             arg_type=nullable_float,
         )

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -12,7 +12,7 @@ returns a dict that can be unpacked into
 """
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
@@ -49,14 +49,23 @@ ADMISSION_CONTROL_CHOICES: tuple[str, ...] = ("token-capacity", "none")
 _ADMISSION_CONTROL_AUTO: str = "_auto_"
 
 # Production defaults for the busy thresholds, applied only when
-# admission-control resolves to "token-capacity". The CLI/env defaults are
-# `None` (sentinel for "user did not set this") so apply_admission_control
-# can distinguish "user explicitly passed a threshold" from "argparse
-# filled in a default" — and so explicit `--admission-control none` does
-# not raise the contradiction error against defaults the user never set.
+# admission-control resolves to "token-capacity" AND the user did not pass
+# the corresponding flag at all.
 _DEFAULT_ACTIVE_DECODE_BLOCKS_THRESHOLD: float = 1.0
 _DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD: int = 10_000_000
 _DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: float = 64.0
+
+# Sentinel default for the three threshold flags. Distinguishes three
+# states that all collapse to the same Python value otherwise:
+#   - `_THRESHOLD_UNSET`: user did not pass the flag and the env var is
+#     unset — fill the production default in token-capacity mode.
+#   - `None`: user explicitly passed `--<flag> None` (or set the env var
+#     to "None") — keep the check disabled even in token-capacity mode.
+#   - numeric: user-supplied value — keep as-is.
+# Replaced with `None` in `apply_admission_control` before the value
+# leaves the config object, so downstream consumers still see
+# `Optional[float|int]`.
+_THRESHOLD_UNSET: Any = object()
 
 
 class RouterConfigBase(ConfigBase):
@@ -98,11 +107,11 @@ class RouterConfigBase(ConfigBase):
         of ADMISSION_CONTROL_CHOICES.
         """
         explicit_thresholds: list[str] = []
-        if self.active_decode_blocks_threshold is not None:
+        if self.active_decode_blocks_threshold is not _THRESHOLD_UNSET:
             explicit_thresholds.append("--active-decode-blocks-threshold")
-        if self.active_prefill_tokens_threshold is not None:
+        if self.active_prefill_tokens_threshold is not _THRESHOLD_UNSET:
             explicit_thresholds.append("--active-prefill-tokens-threshold")
-        if self.active_prefill_tokens_threshold_frac is not None:
+        if self.active_prefill_tokens_threshold_frac is not _THRESHOLD_UNSET:
             explicit_thresholds.append("--active-prefill-tokens-threshold-frac")
 
         if self.admission_control == _ADMISSION_CONTROL_AUTO:
@@ -125,18 +134,19 @@ class RouterConfigBase(ConfigBase):
             )
 
         if self.admission_control == "token-capacity":
-            # Fill in production defaults for any threshold the user did not
-            # explicitly set. Until now the threshold fields default to None
-            # so the explicit-user check above stays accurate.
-            if self.active_decode_blocks_threshold is None:
+            # Fill production defaults only for thresholds the user did not
+            # pass at all. Explicit `None` from the user is preserved so the
+            # documented "Pass 'None' on the CLI to disable this check"
+            # semantic holds even in token-capacity mode.
+            if self.active_decode_blocks_threshold is _THRESHOLD_UNSET:
                 self.active_decode_blocks_threshold = (
                     _DEFAULT_ACTIVE_DECODE_BLOCKS_THRESHOLD
                 )
-            if self.active_prefill_tokens_threshold is None:
+            if self.active_prefill_tokens_threshold is _THRESHOLD_UNSET:
                 self.active_prefill_tokens_threshold = (
                     _DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD
                 )
-            if self.active_prefill_tokens_threshold_frac is None:
+            if self.active_prefill_tokens_threshold_frac is _THRESHOLD_UNSET:
                 self.active_prefill_tokens_threshold_frac = (
                     _DEFAULT_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC
                 )
@@ -152,7 +162,10 @@ class RouterConfigBase(ConfigBase):
                 "to keep admission disabled, or pass --admission-control "
                 "token-capacity to activate the threshold(s)."
             )
-        # All thresholds remain None (their argparse default) — nothing to clear.
+        # Sentinel → None so downstream sees the documented Optional[…] type.
+        self.active_decode_blocks_threshold = None
+        self.active_prefill_tokens_threshold = None
+        self.active_prefill_tokens_threshold_frac = None
 
 
 class RouterArgGroup(ArgGroup):
@@ -215,7 +228,7 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--active-decode-blocks-threshold",
             env_var="DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD",
-            default=None,
+            default=_THRESHOLD_UNSET,
             help=(
                 "Threshold fraction (0.0-1.0) of KV cache block utilization above which a worker "
                 "is considered busy. Setting this implies --admission-control token-capacity. "
@@ -228,7 +241,7 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--active-prefill-tokens-threshold",
             env_var="DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD",
-            default=None,
+            default=_THRESHOLD_UNSET,
             help=(
                 "Literal token count threshold for determining when a worker is considered busy "
                 "based on prefill token utilization. When active prefill tokens exceed this "
@@ -243,7 +256,7 @@ class RouterArgGroup(ArgGroup):
             g,
             flag_name="--active-prefill-tokens-threshold-frac",
             env_var="DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC",
-            default=None,
+            default=_THRESHOLD_UNSET,
             help=(
                 "Fraction of max_num_batched_tokens for busy detection. Worker is busy when "
                 "active_prefill_tokens > frac * max_num_batched_tokens. Setting this implies "

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -97,31 +97,52 @@ class RouterConfigBase(ConfigBase):
           so the threshold takes effect (preserves the v1.0.x / v1.1.x
           launch-config contract where setting a threshold flag implicitly
           activated admission control). Otherwise resolve to "none".
-        - "token-capacity": keep the configured busy thresholds as-is.
+        - "token-capacity": keep configured thresholds as-is, fill
+          production defaults for thresholds the user did not pass.
         - "none" (explicit): clear all busy thresholds; if any threshold
-          flag was also explicitly set, raise — the combination is a
-          contradiction (you explicitly turned admission off while also
-          configuring a threshold value).
+          flag was set to a *numeric* value, raise — explicit `--<flag>
+          None` is consistent with admission disabled and silently kept.
 
         After this method returns, ``self.admission_control`` is always one
-        of ADMISSION_CONTROL_CHOICES.
+        of ADMISSION_CONTROL_CHOICES and the threshold fields are
+        ``Optional[float|int]``. Calling the method again on the resolved
+        state is a no-op (idempotent).
         """
-        explicit_thresholds: list[str] = []
-        if self.active_decode_blocks_threshold is not _THRESHOLD_UNSET:
-            explicit_thresholds.append("--active-decode-blocks-threshold")
-        if self.active_prefill_tokens_threshold is not _THRESHOLD_UNSET:
-            explicit_thresholds.append("--active-prefill-tokens-threshold")
-        if self.active_prefill_tokens_threshold_frac is not _THRESHOLD_UNSET:
-            explicit_thresholds.append("--active-prefill-tokens-threshold-frac")
+        # `numeric_thresholds` is the subset that actually configures a cap.
+        # The auto-promote rule and the explicit-`none` contradiction both
+        # key off this — explicit `--<flag> None` is consistent with
+        # admission disabled, so it never auto-promotes and never raises.
+        # Restricting the contradiction check to numeric values also makes
+        # this method idempotent: after the sentinel → None normalization
+        # below, a subsequent call sees fields that are `None` (no longer
+        # _THRESHOLD_UNSET) and correctly treats them as "no numeric cap".
+        numeric_thresholds: list[str] = []
+        for value, flag in (
+            (
+                self.active_decode_blocks_threshold,
+                "--active-decode-blocks-threshold",
+            ),
+            (
+                self.active_prefill_tokens_threshold,
+                "--active-prefill-tokens-threshold",
+            ),
+            (
+                self.active_prefill_tokens_threshold_frac,
+                "--active-prefill-tokens-threshold-frac",
+            ),
+        ):
+            if value is _THRESHOLD_UNSET or value is None:
+                continue
+            numeric_thresholds.append(flag)
 
         if self.admission_control == _ADMISSION_CONTROL_AUTO:
-            if explicit_thresholds:
+            if numeric_thresholds:
                 logger.info(
                     "admission-control: implicit mode resolved to 'token-capacity' "
-                    "because %s was explicitly set. Pass --admission-control "
+                    "because %s was set to a numeric value. Pass --admission-control "
                     "token-capacity to make this explicit, or unset the "
                     "threshold(s) to keep admission control disabled.",
-                    ", ".join(explicit_thresholds),
+                    ", ".join(numeric_thresholds),
                 )
                 self.admission_control = "token-capacity"
             else:
@@ -152,20 +173,24 @@ class RouterConfigBase(ConfigBase):
                 )
             return
 
-        # admission_control == "none" (explicit or auto-resolved). Contradiction
-        # with any explicit threshold flag — raise rather than silently
-        # overriding.
-        if explicit_thresholds:
+        # admission_control == "none" (explicit or auto-resolved). A numeric
+        # threshold value alongside explicit `none` is a contradiction; an
+        # explicit `--<flag> None` is consistent and silently kept.
+        if numeric_thresholds:
             raise ValueError(
                 "--admission-control none cannot be combined with explicit "
-                f"{', '.join(explicit_thresholds)} — drop the threshold flag(s) "
+                f"{', '.join(numeric_thresholds)} — drop the threshold flag(s) "
                 "to keep admission disabled, or pass --admission-control "
                 "token-capacity to activate the threshold(s)."
             )
         # Sentinel → None so downstream sees the documented Optional[…] type.
-        self.active_decode_blocks_threshold = None
-        self.active_prefill_tokens_threshold = None
-        self.active_prefill_tokens_threshold_frac = None
+        # Explicit user-passed `None` already matches; this is a no-op for those.
+        if self.active_decode_blocks_threshold is _THRESHOLD_UNSET:
+            self.active_decode_blocks_threshold = None
+        if self.active_prefill_tokens_threshold is _THRESHOLD_UNSET:
+            self.active_prefill_tokens_threshold = None
+        if self.active_prefill_tokens_threshold_frac is _THRESHOLD_UNSET:
+            self.active_prefill_tokens_threshold_frac = None
 
 
 class RouterArgGroup(ArgGroup):

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -476,13 +476,14 @@ def test_admission_control_token_capacity_with_custom_thresholds(
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
 
 
-def test_admission_control_none_with_threshold_auto_switches_to_token_capacity(
+def test_admission_control_explicit_none_with_threshold_raises(
     monkeypatch,
 ) -> None:
-    """Explicit --admission-control none combined with an explicit threshold
-    flag auto-promotes mode to 'token-capacity' so the threshold takes
-    effect — preserves the v1.0.x/v1.1.x launch-config contract where
-    setting a threshold flag implicitly activated admission control."""
+    """Explicit --admission-control none combined with an explicit
+    threshold flag is a contradiction and must raise. The implicit-default
+    case (no --admission-control flag passed) auto-promotes instead — see
+    test_admission_control_default_none_with_explicit_threshold_auto_switches.
+    """
     _clear_admission_control_env(monkeypatch)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
@@ -493,10 +494,27 @@ def test_admission_control_none_with_threshold_auto_switches_to_token_capacity(
             "none",
             "--active-decode-blocks-threshold",
             "0.5",
-            "--active-prefill-tokens-threshold",
-            "1000",
-            "--active-prefill-tokens-threshold-frac",
-            "2.0",
+        ]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    with pytest.raises(ValueError, match="cannot be combined with explicit"):
+        config.validate()
+
+
+def test_admission_control_explicit_none_without_thresholds_resolves_to_none(
+    monkeypatch,
+) -> None:
+    """Explicit --admission-control none with no threshold flags is a
+    legal config: admission disabled, queue threshold preserved."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--admission-control",
+            "none",
             "--router-queue-threshold",
             "32.0",
         ]
@@ -505,10 +523,10 @@ def test_admission_control_none_with_threshold_auto_switches_to_token_capacity(
     config = FrontendConfig.from_cli_args(args)
     config.validate()
 
-    assert config.admission_control == "token-capacity"
-    assert config.active_decode_blocks_threshold == 0.5
-    assert config.active_prefill_tokens_threshold == 1000
-    assert config.active_prefill_tokens_threshold_frac == 2.0
+    assert config.admission_control == "none"
+    assert config.active_decode_blocks_threshold is None
+    assert config.active_prefill_tokens_threshold is None
+    assert config.active_prefill_tokens_threshold_frac is None
     assert config.router_queue_threshold == 32.0
 
 

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -590,6 +590,37 @@ def test_admission_control_default_none_with_no_thresholds_stays_none(
     assert config.router_queue_threshold == 32.0
 
 
+def test_admission_control_token_capacity_with_explicit_none_threshold_keeps_disabled(
+    monkeypatch,
+) -> None:
+    """Explicit ``--<threshold> None`` keeps that specific check disabled
+    even in ``--admission-control token-capacity`` mode, matching the
+    "Pass 'None' on the CLI to disable this check" help text. The other
+    thresholds still receive production defaults."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--admission-control",
+            "token-capacity",
+            "--active-decode-blocks-threshold",
+            "None",
+        ]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.admission_control == "token-capacity"
+    # Explicit `None` is preserved — the documented disable-this-check semantic.
+    assert config.active_decode_blocks_threshold is None
+    # Un-passed thresholds still receive their production defaults.
+    assert config.active_prefill_tokens_threshold == 10_000_000
+    assert config.active_prefill_tokens_threshold_frac == 64.0
+
+
 def test_admission_control_env_var(monkeypatch) -> None:
     _clear_admission_control_env(monkeypatch)
     monkeypatch.setenv("DYN_ADMISSION_CONTROL", "token-capacity")

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -535,7 +535,14 @@ def test_admission_control_default_none_with_explicit_threshold_auto_switches(
 ) -> None:
     """Pre-v1.1.2 launch-config compatibility: passing a threshold flag
     without --admission-control auto-promotes mode from the new 'none'
-    default to 'token-capacity' so the threshold actually fires."""
+    default to 'token-capacity' so the threshold actually fires.
+
+    User-set thresholds keep their values; unset thresholds receive
+    production defaults — same as passing --admission-control token-capacity
+    explicitly. This matches the v1.0.x/v1.1.x contract where setting any
+    threshold flag implicitly activated admission control with defaults
+    filling in the rest.
+    """
     _clear_admission_control_env(monkeypatch)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
@@ -555,8 +562,9 @@ def test_admission_control_default_none_with_explicit_threshold_auto_switches(
     assert config.admission_control == "token-capacity"
     assert config.active_decode_blocks_threshold == 0.85
     assert config.active_prefill_tokens_threshold == 10000
-    # _frac was not passed → remains None (auto-switch doesn't fabricate defaults)
-    assert config.active_prefill_tokens_threshold_frac is None
+    # _frac was not passed → filled in with production default 64.0
+    # (auto-switch matches --admission-control token-capacity).
+    assert config.active_prefill_tokens_threshold_frac == 64.0
 
 
 def test_admission_control_default_none_with_no_thresholds_stays_none(

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -476,9 +476,13 @@ def test_admission_control_token_capacity_with_custom_thresholds(
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
 
 
-def test_admission_control_none_clears_busy_thresholds_but_keeps_queue(
+def test_admission_control_none_with_threshold_auto_switches_to_token_capacity(
     monkeypatch,
 ) -> None:
+    """Explicit --admission-control none combined with an explicit threshold
+    flag auto-promotes mode to 'token-capacity' so the threshold takes
+    effect — preserves the v1.0.x/v1.1.x launch-config contract where
+    setting a threshold flag implicitly activated admission control."""
     _clear_admission_control_env(monkeypatch)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
@@ -501,18 +505,63 @@ def test_admission_control_none_clears_busy_thresholds_but_keeps_queue(
     config = FrontendConfig.from_cli_args(args)
     config.validate()
 
+    assert config.admission_control == "token-capacity"
+    assert config.active_decode_blocks_threshold == 0.5
+    assert config.active_prefill_tokens_threshold == 1000
+    assert config.active_prefill_tokens_threshold_frac == 2.0
+    assert config.router_queue_threshold == 32.0
+
+
+def test_admission_control_default_none_with_explicit_threshold_auto_switches(
+    monkeypatch,
+) -> None:
+    """Pre-v1.1.2 launch-config compatibility: passing a threshold flag
+    without --admission-control auto-promotes mode from the new 'none'
+    default to 'token-capacity' so the threshold actually fires."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--active-decode-blocks-threshold",
+            "0.85",
+            "--active-prefill-tokens-threshold",
+            "10000",
+        ]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.admission_control == "token-capacity"
+    assert config.active_decode_blocks_threshold == 0.85
+    assert config.active_prefill_tokens_threshold == 10000
+    # _frac was not passed → remains None (auto-switch doesn't fabricate defaults)
+    assert config.active_prefill_tokens_threshold_frac is None
+
+
+def test_admission_control_default_none_with_no_thresholds_stays_none(
+    monkeypatch,
+) -> None:
+    """When no threshold flag is explicitly set, the default 'none' is
+    preserved (no auto-switch). Already covered by
+    test_frontend_admission_control_defaults_to_none — this is the
+    explicit symmetry check next to the auto-switch tests above."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--router-queue-threshold", "32.0"])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
     assert config.admission_control == "none"
     assert config.active_decode_blocks_threshold is None
     assert config.active_prefill_tokens_threshold is None
     assert config.active_prefill_tokens_threshold_frac is None
     assert config.router_queue_threshold == 32.0
-    assert config.router_kwargs() == {
-        "active_decode_blocks_threshold": None,
-        "active_prefill_tokens_threshold": None,
-        "active_prefill_tokens_threshold_frac": None,
-        "enforce_disagg": False,
-    }
-    assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
 
 
 def test_admission_control_env_var(monkeypatch) -> None:

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -23,7 +23,7 @@ def _clear_admission_control_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD",
         "DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD",
         "DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC",
-        "DYN_NO_ADMISSION_CONTROL",
+        "DYN_ADMISSION_CONTROL",
         "DYN_ROUTER_QUEUE_THRESHOLD",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -391,7 +391,9 @@ def test_load_aware_frontend_implies_kv_router_mode() -> None:
     assert config.router_assume_kv_reuse is False
 
 
-def test_frontend_uses_admission_control_defaults(monkeypatch) -> None:
+def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
+    """Default --admission-control is 'none': busy thresholds are cleared
+    even though the underlying threshold flags have non-None defaults."""
     _clear_admission_control_env(monkeypatch)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
@@ -401,13 +403,41 @@ def test_frontend_uses_admission_control_defaults(monkeypatch) -> None:
     config = FrontendConfig.from_cli_args(args)
     config.validate()
 
+    assert config.admission_control == "none"
+    assert config.active_decode_blocks_threshold is None
+    assert config.active_prefill_tokens_threshold is None
+    assert config.active_prefill_tokens_threshold_frac is None
+    assert config.router_queue_threshold == 16.0
+
+
+def test_admission_control_token_capacity_preserves_busy_thresholds(
+    monkeypatch,
+) -> None:
+    """With --admission-control token-capacity, the configured busy thresholds
+    flow through to router_kwargs unchanged."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--admission-control", "token-capacity"])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.admission_control == "token-capacity"
     assert config.active_decode_blocks_threshold == 1.0
     assert config.active_prefill_tokens_threshold == 10_000_000
     assert config.active_prefill_tokens_threshold_frac == 64.0
     assert config.router_queue_threshold == 16.0
+    assert config.router_kwargs() == {
+        "active_decode_blocks_threshold": 1.0,
+        "active_prefill_tokens_threshold": 10_000_000,
+        "active_prefill_tokens_threshold_frac": 64.0,
+        "enforce_disagg": False,
+    }
 
 
-def test_no_admission_control_clears_busy_thresholds_but_keeps_queue(
+def test_admission_control_token_capacity_with_custom_thresholds(
     monkeypatch,
 ) -> None:
     _clear_admission_control_env(monkeypatch)
@@ -416,7 +446,8 @@ def test_no_admission_control_clears_busy_thresholds_but_keeps_queue(
 
     args = parser.parse_args(
         [
-            "--no-admission-control",
+            "--admission-control",
+            "token-capacity",
             "--active-decode-blocks-threshold",
             "0.5",
             "--active-prefill-tokens-threshold",
@@ -431,7 +462,46 @@ def test_no_admission_control_clears_busy_thresholds_but_keeps_queue(
     config = FrontendConfig.from_cli_args(args)
     config.validate()
 
-    assert config.no_admission_control is True
+    assert config.admission_control == "token-capacity"
+    assert config.active_decode_blocks_threshold == 0.5
+    assert config.active_prefill_tokens_threshold == 1000
+    assert config.active_prefill_tokens_threshold_frac == 2.0
+    assert config.router_queue_threshold == 32.0
+    assert config.router_kwargs() == {
+        "active_decode_blocks_threshold": 0.5,
+        "active_prefill_tokens_threshold": 1000,
+        "active_prefill_tokens_threshold_frac": 2.0,
+        "enforce_disagg": False,
+    }
+    assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
+
+
+def test_admission_control_none_clears_busy_thresholds_but_keeps_queue(
+    monkeypatch,
+) -> None:
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--admission-control",
+            "none",
+            "--active-decode-blocks-threshold",
+            "0.5",
+            "--active-prefill-tokens-threshold",
+            "1000",
+            "--active-prefill-tokens-threshold-frac",
+            "2.0",
+            "--router-queue-threshold",
+            "32.0",
+        ]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.admission_control == "none"
     assert config.active_decode_blocks_threshold is None
     assert config.active_prefill_tokens_threshold is None
     assert config.active_prefill_tokens_threshold_frac is None
@@ -443,3 +513,18 @@ def test_no_admission_control_clears_busy_thresholds_but_keeps_queue(
         "enforce_disagg": False,
     }
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
+
+
+def test_admission_control_env_var(monkeypatch) -> None:
+    _clear_admission_control_env(monkeypatch)
+    monkeypatch.setenv("DYN_ADMISSION_CONTROL", "token-capacity")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args([])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.admission_control == "token-capacity"
+    assert config.active_decode_blocks_threshold == 1.0

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -590,6 +590,55 @@ def test_admission_control_default_none_with_no_thresholds_stays_none(
     assert config.router_queue_threshold == 32.0
 
 
+def test_admission_control_apply_is_idempotent(monkeypatch) -> None:
+    """``apply_admission_control()`` runs once in ``validate()`` and again
+    when ``router_kwargs()`` builds the worker config. The second call
+    must not raise the explicit-none contradiction against the ``None``
+    threshold values its first call normalized them to."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args([])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()  # first apply
+    # router_kwargs() runs apply_admission_control() again on the
+    # already-normalized state. Must not raise.
+    kwargs = config.router_kwargs()
+
+    assert config.admission_control == "none"
+    assert kwargs["active_decode_blocks_threshold"] is None
+    assert kwargs["active_prefill_tokens_threshold"] is None
+    assert kwargs["active_prefill_tokens_threshold_frac"] is None
+
+
+def test_admission_control_explicit_none_threshold_with_none_mode_ok(
+    monkeypatch,
+) -> None:
+    """``--admission-control none --active-decode-blocks-threshold None``
+    is consistent (both say disabled) — must not raise. Only a *numeric*
+    threshold value alongside explicit ``none`` is a contradiction."""
+    _clear_admission_control_env(monkeypatch)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--admission-control",
+            "none",
+            "--active-decode-blocks-threshold",
+            "None",
+        ]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.admission_control == "none"
+    assert config.active_decode_blocks_threshold is None
+
+
 def test_admission_control_token_capacity_with_explicit_none_threshold_keeps_disabled(
     monkeypatch,
 ) -> None:

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -149,7 +149,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
                 raise ValueError(
                     "--serve-indexer and --use-remote-indexer are mutually exclusive"
                 )
-        self.apply_no_admission_control()
+        self.apply_admission_control()
 
 
 @register_encoder(FrontendConfig)

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -76,7 +76,7 @@ For MoE models, AIC requires `aic_tp_size * aic_attention_dp_size == aic_moe_tp_
 | `--active-decode-blocks-threshold` | `DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD` | `1.0` | KV cache utilization fraction (0.0–1.0) for busy detection. Pass `None` to disable |
 | `--active-prefill-tokens-threshold` | `DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD` | `10000000` | Absolute token count for prefill busy detection. Pass `None` to disable |
 | `--active-prefill-tokens-threshold-frac` | `DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC` | `64.0` | Fraction of `max_num_batched_tokens` for prefill busy detection. OR logic with absolute threshold. Pass `None` to disable |
-| `--no-admission-control` | `DYN_NO_ADMISSION_CONTROL` | `false` | Disable busy-worker admission checks by clearing the busy thresholds. Router queueing remains controlled by `--router-queue-threshold` |
+| `--admission-control` | `DYN_ADMISSION_CONTROL` | `none` | Admission control mode. `token-capacity` applies the busy thresholds above; `none` clears them. Router queueing remains controlled by `--router-queue-threshold` |
 
 ## Model Discovery
 

--- a/docs/fault-tolerance/request-rejection.md
+++ b/docs/fault-tolerance/request-rejection.md
@@ -55,7 +55,7 @@ python -m dynamo.frontend \
 | `--active-decode-blocks-threshold` | float (0.0-1.0) | KV cache block utilization threshold |
 | `--active-prefill-tokens-threshold` | int | Prefill token count threshold |
 | `--active-prefill-tokens-threshold-frac` | float | Prefill token threshold as a fraction of `max_num_batched_tokens` |
-| `--no-admission-control` | bool | Clear all busy thresholds while leaving router queueing controlled by `--router-queue-threshold` |
+| `--admission-control` | `token-capacity` \| `none` | Admission control mode. `token-capacity` applies the busy thresholds above; `none` (the default) clears them while leaving router queueing controlled by `--router-queue-threshold`. To enable busy-worker admission, you must pass `--admission-control token-capacity` |
 
 ### Dynamic Configuration via API
 

--- a/docs/fault-tolerance/request-rejection.md
+++ b/docs/fault-tolerance/request-rejection.md
@@ -42,10 +42,11 @@ When all workers exceed their configured busy thresholds, new requests receive a
 
 ### Frontend Arguments
 
-Configure busy thresholds when starting the frontend:
+Configure busy thresholds when starting the frontend. `--admission-control token-capacity` is required to activate the thresholds; the default (`none`) leaves them disabled.
 
 ```bash
 python -m dynamo.frontend \
+    --admission-control token-capacity \
     --active-decode-blocks-threshold 0.85 \
     --active-prefill-tokens-threshold 10000
 ```

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -71,7 +71,7 @@ pub const ANNOTATION_REQUEST_ID: &str = "request_id";
 
 const VALIDATION_PREFIX: &str = "Validation: ";
 const ADMISSION_CONTROL_REJECTION_HINT: &str =
-    "If this rejection is not intended, consider passing --no-admission-control to the frontend.";
+    "If this rejection is not intended, consider passing --admission-control none to the frontend.";
 
 // Default axum max body limit without configuring is 2MB: https://docs.rs/axum/latest/axum/extract/struct.DefaultBodyLimit.html
 /// Default body limit in bytes (45MB) to support 500k+ token payloads.


### PR DESCRIPTION
## Summary

Rename the frontend's admission-control knob from a boolean opt-out
flag (`--no-admission-control` / `DYN_NO_ADMISSION_CONTROL`) to an
enum-valued flag (`--admission-control` / `DYN_ADMISSION_CONTROL`)
with two choices:

- **`token-capacity`** — apply the per-worker busy thresholds
  (`--active-decode-blocks-threshold`, `--active-prefill-tokens-threshold`,
  `--active-prefill-tokens-threshold-frac`). This is what today's "admission
  control ON" path does.
- **`none`** — clear those busy thresholds; router queueing remains
  controlled by `--router-queue-threshold`. Equivalent to today's
  `--no-admission-control`.

**Default: `none`.**

## Why `token-capacity` and not `kv-capacity` / `blocks` / etc

The name is intentionally broader than the current KV-cache-centric
thresholds. The same enum slot will accommodate future admission
schemes that aren't strictly KV-cache-based: encoder-cache budgeting,
TPS budgets, billing-based admission, etc. Adding those later becomes
"add a new enum value" rather than "rename the flag again."

## Behavioral change (please read)

The default flips from "admission control implicitly ON" (today's
behavior — the per-worker thresholds defaulted to non-`None` values
and were active unless the user passed `--no-admission-control`) to
"admission control OFF" (`--admission-control none`).

This is a deliberate decision to align with the principle **thresholds
opt-in, not opt-out**. Operators who want busy-worker rejection must
now opt in.

## Migration

- **If you were passing `--no-admission-control` today:** pass nothing
  (since `none` is the new default), or pass `--admission-control none`
  for explicitness. `DYN_NO_ADMISSION_CONTROL` is gone — switch to
  `DYN_ADMISSION_CONTROL=none` if you still want that env-driven.
- **If you were NOT passing the old flag and relying on busy-worker
  admission firing:** you must now pass `--admission-control token-capacity`
  (or set `DYN_ADMISSION_CONTROL=token-capacity`) explicitly. Without
  this, busy thresholds are cleared by `validate()` and rejection on
  worker-busy won't happen.
- **The Rust rejection-hint string** in `lib/llm/src/http/service/openai.rs`
  is updated to point users at the new flag form
  (`--admission-control none`).
- **Docs**: `docs/components/frontend/configuration.md` and
  `docs/fault-tolerance/request-rejection.md` are updated to the new flag.

No deprecation alias / warning period. Clean break, single commit —
this is a config knob, not a published API.

## Test plan

- [x] `git grep -in "no.admission.control\|no_admission_control\|NO_ADMISSION_CONTROL"` → zero matches in the working tree
- [x] `git grep -in "admission.control\|admission_control"` in `components/` and `lib/` → every match is the new naming
- [x] Pre-commit hooks pass (isort, black, flake8, ruff, codespell, etc.)
- [x] Updated tests in `components/src/dynamo/common/tests/configuration/test_kv_router_args.py`:
  - default behavior (`admission_control == "none"`, thresholds cleared after `validate()`)
  - `--admission-control token-capacity` preserves default thresholds
  - `--admission-control token-capacity` with custom thresholds flows through `router_kwargs()`
  - `--admission-control none` clears thresholds, preserves `--router-queue-threshold`
  - `DYN_ADMISSION_CONTROL` env-var path
- [ ] Pytest run in CI (not runnable locally outside a dev container with `dynamo.llm` installed)
- [ ] Rust build / `cargo check` in CI (the only Rust change is a string literal)
- [ ] Manual smoke: start frontend with no flags, confirm `/health` works and busy thresholds are cleared in logs; start with `--admission-control token-capacity --active-decode-blocks-threshold 0.5` and confirm rejection hint mentions `--admission-control none`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced `--no-admission-control` boolean flag with `--admission-control` enum option supporting `token-capacity` or `none` (default).
  * `none` mode disables busy-threshold admission control; `token-capacity` applies configured thresholds.

* **Documentation**
  * Updated configuration and request-rejection documentation to reflect the new admission control modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->