### PR TITLE
First draft of bypassing global router in response stream

### DIFF
--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -134,6 +134,7 @@ async def _serve_disagg(
                     ("service", "global_router"),
                     ("type", "prefill"),
                 ],
+                defer_response_stream=True,
             ),
             decode_endpoint.serve_endpoint(
                 handler.handle_decode,
@@ -142,6 +143,7 @@ async def _serve_disagg(
                     ("service", "global_router"),
                     ("type", "decode"),
                 ],
+                defer_response_stream=True,
             ),
         )
     except Exception as e:
@@ -184,6 +186,7 @@ async def _serve_agg(
                 ("service", "global_router"),
                 ("type", "agg"),
             ],
+            defer_response_stream=True,
         )
     except Exception as e:
         logger.error(f"Failed to serve agg endpoint: {e}")

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -13,6 +13,7 @@ Supports two modes:
 Both modes support priority-based pool overrides from agent hints.
 """
 
+import json
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -21,6 +22,13 @@ from dynamo.runtime import Client, DistributedRuntime
 from .pool_selection import get_priority_retry_order, load_config
 
 logger = logging.getLogger(__name__)
+
+
+def _connection_subject(connection_info: Dict[str, Any]) -> Optional[str]:
+    try:
+        return json.loads(connection_info.get("info", "{}")).get("subject")
+    except (TypeError, json.JSONDecodeError):
+        return None
 
 
 class GlobalRouterHandler:
@@ -79,6 +87,8 @@ class GlobalRouterHandler:
         namespaces: List[str],
         clients: Dict[str, Client],
         pool_priorities: List[int],
+        response_connection_info: Optional[Dict[str, Any]] = None,
+        context: Optional[Any] = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Forward a request to the selected pool and retry faster pools on failure.
@@ -98,6 +108,29 @@ class GlobalRouterHandler:
             yielded_output = False
 
             try:
+                if response_connection_info is not None:
+                    request_id = context.id() if context is not None else None
+                    logger.info(
+                        f"Delegating {request_type} response stream directly to downstream "
+                        f"router: request_id={request_id}, namespace={namespace}, "
+                        f"transport={response_connection_info.get('transport')}, "
+                        f"response_subject={_connection_subject(response_connection_info)}"
+                    )
+                    await client.forward(
+                        request,
+                        response_connection_info,
+                        context=context,
+                    )
+                    logger.info(
+                        f"Delegated {request_type} request to {namespace}; global router "
+                        f"will not publish response stream: request_id={request_id}"
+                    )
+                    return
+
+                logger.info(
+                    f"Relaying {request_type} response stream through global router: "
+                    f"namespace={namespace}"
+                )
                 stream = await client.generate(request)
                 async for output in stream:
                     yielded_output = True
@@ -206,7 +239,7 @@ class GlobalRouterHandler:
         logger.info(f"Global Router initialized (agg): {len(self.agg_clients)} pools")
 
     async def handle_prefill(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], context: Optional[Any] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Handle prefill requests from the frontend (disagg mode).
@@ -256,11 +289,15 @@ class GlobalRouterHandler:
             namespaces=self.config.prefill_pool_dynamo_namespaces,
             clients=self.prefill_clients,
             pool_priorities=self.config.prefill_pool_priorities,
+            response_connection_info=(
+                context.connection_info() if context is not None else None
+            ),
+            context=context,
         ):
             yield data
 
     async def handle_decode(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], context: Optional[Any] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Handle decode requests from the frontend (disagg mode).
@@ -314,11 +351,15 @@ class GlobalRouterHandler:
             namespaces=self.config.decode_pool_dynamo_namespaces,
             clients=self.decode_clients,
             pool_priorities=self.config.decode_pool_priorities,
+            response_connection_info=(
+                context.connection_info() if context is not None else None
+            ),
+            context=context,
         ):
             yield data
 
     async def handle_generate(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], context: Optional[Any] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Handle generate requests (agg mode).
@@ -372,6 +413,10 @@ class GlobalRouterHandler:
             namespaces=self.config.agg_pool_dynamo_namespaces,
             clients=self.agg_clients,
             pool_priorities=self.config.agg_pool_priorities,
+            response_connection_info=(
+                context.connection_info() if context is not None else None
+            ),
+            context=context,
         ):
             yield data
 

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -4,10 +4,14 @@
 // Context is a wrapper around the AsyncEngineContext to allow for Python bindings.
 
 use dynamo_runtime::logging::DistributedTraceContext;
+use dynamo_runtime::pipeline::network::ConnectionInfo;
 pub use dynamo_runtime::pipeline::AsyncEngineContext;
 use dynamo_runtime::pipeline::context::Controller;
 use pyo3::prelude::*;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::sync::watch;
 
 // Context is a wrapper around the AsyncEngineContext to allow for Python bindings.
@@ -21,6 +25,8 @@ pub struct Context {
     /// First-token signal for decode-mode disagg. `None` on aggregated /
     /// prefill requests.
     first_token: Option<watch::Sender<bool>>,
+    connection_info: Option<ConnectionInfo>,
+    response_delegated: Option<Arc<AtomicBool>>,
 }
 
 impl Context {
@@ -29,10 +35,37 @@ impl Context {
         trace_context: Option<DistributedTraceContext>,
         first_token: Option<watch::Sender<bool>>,
     ) -> Self {
+        Self::new_with_connection_info(inner, trace_context, first_token, None)
+    }
+
+    pub fn new_with_connection_info(
+        inner: Arc<dyn AsyncEngineContext>,
+        trace_context: Option<DistributedTraceContext>,
+        first_token: Option<watch::Sender<bool>>,
+        connection_info: Option<ConnectionInfo>,
+    ) -> Self {
+        Self::new_with_response_controls(
+            inner,
+            trace_context,
+            first_token,
+            connection_info,
+            None,
+        )
+    }
+
+    pub fn new_with_response_controls(
+        inner: Arc<dyn AsyncEngineContext>,
+        trace_context: Option<DistributedTraceContext>,
+        first_token: Option<watch::Sender<bool>>,
+        connection_info: Option<ConnectionInfo>,
+        response_delegated: Option<Arc<AtomicBool>>,
+    ) -> Self {
         Self {
             inner,
             trace_context,
             first_token,
+            connection_info,
+            response_delegated,
         }
     }
 
@@ -43,6 +76,12 @@ impl Context {
 
     pub fn inner(&self) -> Arc<dyn AsyncEngineContext> {
         self.inner.clone()
+    }
+
+    pub fn set_response_delegated(&self) {
+        if let Some(response_delegated) = &self.response_delegated {
+            response_delegated.store(true, Ordering::SeqCst);
+        }
     }
 }
 
@@ -59,6 +98,8 @@ impl Context {
             inner: Arc::new(controller),
             trace_context: None,
             first_token: None,
+            connection_info: None,
+            response_delegated: None,
         }
     }
 
@@ -104,6 +145,23 @@ impl Context {
         if let Some(tx) = &self.first_token {
             let _ = tx.send(true);
         }
+    }
+
+    /// Response stream connection information supplied by the upstream caller.
+    /// Python routers can pass this to `Client.forward(...)` to delegate response
+    /// ownership to a downstream router or worker.
+    fn connection_info(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        match &self.connection_info {
+            Some(connection_info) => {
+                let py_obj: PyObject = pythonize::pythonize(py, connection_info)?.into();
+                Ok(Some(py_obj))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn mark_response_delegated(&self) {
+        self.set_response_delegated();
     }
 
     // Expose trace information to Python for debugging

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::AtomicBool,
+};
 
 use anyhow::{Error, Result};
 use pyo3::prelude::*;
@@ -16,6 +19,9 @@ use tokio_util::sync::CancellationToken;
 
 use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
 use dynamo_runtime::logging::get_distributed_tracing_context;
+use dynamo_runtime::pipeline::network::{
+    ConnectionInfo, RESPONSE_CONNECTION_INFO_CONTEXT_KEY, RESPONSE_DELEGATED_CONTEXT_KEY,
+};
 pub use dynamo_runtime::{
     pipeline::{AsyncEngine, AsyncEngineContextProvider, Data, ManyOut, ResponseStream, SingleIn},
     protocols::{annotated::Annotated, maybe_error::MaybeError},
@@ -151,6 +157,12 @@ where
         // Create a context
         let (request, context) = request.transfer(());
         let ctx = context.context();
+        let connection_info = context
+            .clone_unique::<ConnectionInfo>(RESPONSE_CONNECTION_INFO_CONTEXT_KEY)
+            .ok();
+        let response_delegated = context
+            .clone_unique::<Arc<AtomicBool>>(RESPONSE_DELEGATED_CONTEXT_KEY)
+            .ok();
 
         let id = context.id().to_string();
         tracing::trace!("processing request: {}", id);
@@ -185,7 +197,13 @@ where
                 // Create context with trace information
                 let py_ctx = Py::new(
                     py,
-                    Context::new(ctx_python.clone(), current_trace_context, None),
+                    Context::new_with_response_controls(
+                        ctx_python.clone(),
+                        current_trace_context,
+                        None,
+                        connection_info,
+                        response_delegated,
+                    ),
                 )?;
 
                 let gen_result = if has_context {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -848,7 +848,7 @@ impl DistributedRuntime {
 
 #[pymethods]
 impl Endpoint {
-    #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None))]
+    #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None, defer_response_stream = false))]
     fn serve_endpoint<'p>(
         &self,
         py: Python<'p>,
@@ -856,12 +856,17 @@ impl Endpoint {
         graceful_shutdown: Option<bool>,
         metrics_labels: Option<Vec<(String, String)>>,
         health_check_payload: Option<&Bound<'p, PyDict>>,
+        defer_response_stream: Option<bool>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let engine = Arc::new(engine::PythonAsyncEngine::new(
             generator,
             self.event_loop.clone(),
         )?);
-        let ingress = JsonServerStreamingIngress::for_engine(engine.clone()).map_err(to_pyerr)?;
+        let ingress = JsonServerStreamingIngress::for_engine_with_deferred_response_stream(
+            engine.clone(),
+            defer_response_stream.unwrap_or(false),
+        )
+        .map_err(to_pyerr)?;
 
         // Convert Python dict to serde_json::Value if provided and validate it's an object
         let health_payload_json = health_check_payload
@@ -1233,6 +1238,45 @@ impl Client {
             tokio::spawn(process_stream(stream, tx));
 
             Ok(AsyncResponseStream::new(rx, annotated))
+        })
+    }
+
+    /// Forward a request while preserving the caller-provided response connection.
+    #[pyo3(signature = (request, connection_info, context=None))]
+    fn forward<'p>(
+        &self,
+        py: Python<'p>,
+        request: PyObject,
+        connection_info: PyObject,
+        context: Option<context::Context>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
+        let request_ctx = create_request_context(request, &context);
+        let connection_info: rs::pipeline::network::ConnectionInfo =
+            pythonize::depythonize(&connection_info.into_bound(py))?;
+
+        let client = self.router.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            match context {
+                Some(context) => {
+                    let span = get_span_for_context(&context, "forward");
+                    client
+                        .forward(request_ctx, connection_info)
+                        .instrument(span)
+                        .await
+                        .map_err(to_pyerr)?;
+                    context.set_response_delegated();
+                }
+                _ => {
+                    client
+                        .forward(request_ctx, connection_info)
+                        .await
+                        .map_err(to_pyerr)?;
+                }
+            };
+
+            Ok(())
         })
     }
 }

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -321,6 +321,14 @@ pub struct ConnectionInfo {
     pub info: String,
 }
 
+/// Runtime context key used to expose the original response stream connection
+/// to Python handlers that need to delegate response ownership downstream.
+pub const RESPONSE_CONNECTION_INFO_CONTEXT_KEY: &str = "dynamo.response_connection_info";
+
+/// Runtime context key for a shared flag set when a handler delegates response
+/// publishing to a downstream endpoint.
+pub const RESPONSE_DELEGATED_CONTEXT_KEY: &str = "dynamo.response_delegated";
+
 /// When registering a new TransportStream on the server, the caller specifies if the
 /// stream is a sender, receiver or both.
 ///
@@ -405,14 +413,20 @@ pub struct Ingress<Req: PipelineIO, Resp: PipelineIO> {
     metrics: OnceLock<Arc<WorkHandlerMetrics>>,
     /// Endpoint-specific notifier for health check timer resets
     endpoint_health_check_notifier: OnceLock<Arc<tokio::sync::Notify>>,
+    defer_response_stream: bool,
 }
 
 impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
     pub fn new() -> Arc<Self> {
+        Self::new_with_deferred_response_stream(false)
+    }
+
+    pub fn new_with_deferred_response_stream(defer_response_stream: bool) -> Arc<Self> {
         Arc::new(Self {
             segment: OnceLock::new(),
             metrics: OnceLock::new(),
             endpoint_health_check_notifier: OnceLock::new(),
+            defer_response_stream,
         })
     }
 
@@ -460,13 +474,20 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
     }
 
     pub fn for_engine(engine: ServiceEngine<Req, Resp>) -> Result<Arc<Self>> {
+        Self::for_engine_with_deferred_response_stream(engine, false)
+    }
+
+    pub fn for_engine_with_deferred_response_stream(
+        engine: ServiceEngine<Req, Resp>,
+        defer_response_stream: bool,
+    ) -> Result<Arc<Self>> {
         let frontend = SegmentSource::<Req, Resp>::new();
         let backend = ServiceBackend::from_engine(engine);
 
         // create the pipeline
         let pipeline = frontend.link(backend)?.link(frontend)?;
 
-        let ingress = Ingress::new();
+        let ingress = Ingress::new_with_deferred_response_stream(defer_response_stream);
         ingress.attach(pipeline)?;
 
         Ok(ingress)

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -148,6 +148,12 @@ impl<T> AddressedRequest<T> {
     }
 }
 
+fn tcp_response_subject(connection_info: &ConnectionInfo) -> Option<String> {
+    serde_json::from_str::<tcp::TcpStreamConnectionInfo>(&connection_info.info)
+        .ok()
+        .map(|ci| ci.subject)
+}
+
 pub struct AddressedPushRouter {
     // Request transport (unified trait object - works with all transports)
     req_client: Arc<dyn RequestPlaneClient>,
@@ -198,6 +204,80 @@ impl AddressedPushRouter {
         self.resp_transport
             .clear_instance_tombstone(instance_id)
             .await
+    }
+}
+
+impl AddressedPushRouter {
+    pub async fn send_with_connection_info<T>(
+        &self,
+        request: SingleIn<AddressedRequest<T>>,
+        connection_info: ConnectionInfo,
+    ) -> Result<(), Error>
+    where
+        T: Data + Serialize,
+    {
+        let queue_start = Instant::now();
+        REQUEST_PLANE_INFLIGHT.inc();
+        let inflight_guard = InflightGuard::new();
+
+        let request_id = request.context().id().to_string();
+        let (addressed_request, context) = request.transfer(());
+        let (request, address, _instance_info) = addressed_request.into_parts();
+        let engine_ctx = context.context();
+        let response_transport = connection_info.transport.clone();
+        let response_subject = tcp_response_subject(&connection_info);
+
+        // TODO: once we add a tombstone-only API:
+        // if let Some(inst) = &instance_info {
+        //     self.ensure_instance_not_tombstoned(&inst.endpoint_instance_id()).await?;
+        // }
+
+        let control_message = RequestControlMessage {
+            id: engine_ctx.id().to_string(),
+            request_type: RequestType::SingleIn,
+            response_type: ResponseType::ManyOut,
+            connection_info,
+            frontend_send_ts_ns: None,
+        };
+
+        let ctrl = serde_json::to_vec(&control_message)?;
+        let data = serde_json::to_vec(&request)?;
+
+        let msg = TwoPartMessage::from_parts(ctrl.into(), data.into());
+        let buffer = TwoPartCodec::default().encode_message(msg)?;
+
+        REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
+
+        let tx_start = Instant::now();
+
+        let mut headers = std::collections::HashMap::new();
+        inject_trace_headers_into_map(&mut headers);
+        headers.insert("request-id".to_string(), request_id.clone());
+
+        let send_ts_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        headers.insert("x-frontend-send-ts-ns".to_string(), send_ts_ns.to_string());
+
+        tracing::info!(
+            request_id = %request_id,
+            address = %address,
+            response_transport = %response_transport,
+            response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+            "forwarding request with delegated response stream"
+        );
+
+        self.req_client
+            .send_request(address, buffer, headers)
+            .await?;
+
+        REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
+
+        // Do not disarm. No response stream takes over this gauge.
+        drop(inflight_guard);
+
+        Ok(())
     }
 }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -15,6 +15,7 @@ use crate::{
     pipeline::{
         AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn,
         error::{PipelineError, PipelineErrorExt},
+        network::ConnectionInfo,
     },
     protocols::{EndpointId, maybe_error::MaybeError},
     traits::DistributedRuntimeProvider,
@@ -98,6 +99,38 @@ impl Drop for OccupancyPermit {
     fn drop(&mut self) {
         if self.armed {
             self.state.decrement(self.instance_id);
+        }
+    }
+}
+
+struct SelectedRoute {
+    instance_id: u64,
+    permit: Option<OccupancyPermit>,
+}
+
+impl SelectedRoute {
+    fn new(instance_id: u64) -> Self {
+        Self {
+            instance_id,
+            permit: None,
+        }
+    }
+
+    fn with_permit(permit: OccupancyPermit) -> Self {
+        Self {
+            instance_id: permit.instance_id(),
+            permit: Some(permit),
+        }
+    }
+
+    fn instance_id(&self) -> u64 {
+        self.instance_id
+    }
+
+    fn into_tracked_stream<U: Data>(self, stream: ManyOut<U>) -> ManyOut<U> {
+        match self.permit {
+            Some(permit) => permit.into_tracked_stream(stream),
+            None => stream,
         }
     }
 }
@@ -485,6 +518,11 @@ where
 
     /// Issue a request to the next available instance in a round-robin fashion
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let selected = self.select_round_robin()?;
+        self.generate_selected_route(selected, request).await
+    }
+
+    fn select_round_robin(&self) -> anyhow::Result<SelectedRoute> {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
 
         let instance_id = {
@@ -500,12 +538,16 @@ where
         };
         tracing::trace!("round robin router selected {instance_id}");
 
-        self.generate_with_fault_detection(instance_id, request)
-            .await
+        Ok(SelectedRoute::new(instance_id))
     }
 
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let selected = self.select_random()?;
+        self.generate_selected_route(selected, request).await
+    }
+
+    fn select_random(&self) -> anyhow::Result<SelectedRoute> {
         let instance_id = {
             let instance_ids = self.client.instance_ids_avail();
             let count = instance_ids.len();
@@ -520,13 +562,17 @@ where
         };
         tracing::trace!("random router selected {instance_id}");
 
-        self.generate_with_fault_detection(instance_id, request)
-            .await
+        Ok(SelectedRoute::new(instance_id))
     }
 
     /// Issue a request using power-of-two-choices: pick 2 random healthy workers,
     /// route to the one with fewer in-flight requests.
     pub async fn power_of_two_choices(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let selected = self.select_power_of_two_choices()?;
+        self.generate_selected_route(selected, request).await
+    }
+
+    fn select_power_of_two_choices(&self) -> anyhow::Result<SelectedRoute> {
         let state = self.occupancy_state()?;
         let instance_id = {
             let instance_ids = self
@@ -546,13 +592,7 @@ where
         state.increment(instance_id);
         let permit = OccupancyPermit::new(state, instance_id);
 
-        match self
-            .generate_with_fault_detection(instance_id, request)
-            .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
+        Ok(SelectedRoute::with_permit(permit))
     }
 
     /// Issue a request to a specific endpoint
@@ -561,6 +601,11 @@ where
         request: SingleIn<T>,
         instance_id: u64,
     ) -> anyhow::Result<ManyOut<U>> {
+        let selected = self.select_direct(instance_id)?;
+        self.generate_selected_route(selected, request).await
+    }
+
+    fn select_direct(&self, instance_id: u64) -> anyhow::Result<SelectedRoute> {
         // When fault detection is disabled, check the raw discovery list
         // (not filtered by report_instance_down) so transient failures
         // don't poison the instance for subsequent retries.
@@ -577,8 +622,7 @@ where
             ));
         }
 
-        self.generate_with_fault_detection(instance_id, request)
-            .await
+        Ok(SelectedRoute::new(instance_id))
     }
 
     /// Issue a request using device-aware weighted routing.
@@ -590,6 +634,11 @@ where
     /// If only one device class exists (all CPU or all non-CPU), this naturally
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let selected = self.select_device_aware_weighted().await?;
+        self.generate_selected_route(selected, request).await
+    }
+
+    async fn select_device_aware_weighted(&self) -> anyhow::Result<SelectedRoute> {
         let state = self.occupancy_state()?;
         let instance_ids = self
             .client
@@ -650,17 +699,16 @@ where
             "DeviceAwareWeighted selected instance"
         );
 
-        match self
-            .generate_with_fault_detection(instance_id, request)
-            .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
+        Ok(SelectedRoute::with_permit(permit))
     }
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        let selected = self.select_least_loaded().await?;
+        self.generate_selected_route(selected, request).await
+    }
+
+    async fn select_least_loaded(&self) -> anyhow::Result<SelectedRoute> {
         let state = self.occupancy_state()?;
         let instance_ids = self
             .client
@@ -683,13 +731,7 @@ where
             state.load(instance_id)
         );
 
-        match self
-            .generate_with_fault_detection(instance_id, request)
-            .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
+        Ok(SelectedRoute::with_permit(permit))
     }
 
     /// Select the next worker according to the routing mode.
@@ -778,24 +820,25 @@ where
     }
     */
 
-    async fn generate_with_fault_detection(
-        &self,
-        mut instance_id: u64,
-        request: SingleIn<T>,
-    ) -> anyhow::Result<ManyOut<U>> {
-        let route_start = Instant::now();
-        let request_id = request.id().to_string();
-        let route_span = if matches!(self.router_mode, RouterMode::KV) {
-            tracing::Span::none()
-        } else {
-            tracing::info_span!(
-                "router.route_request",
-                request_id = %request_id,
-                worker_id = instance_id,
-                router_mode = ?self.router_mode,
-            )
-        };
+    async fn select_route(&self) -> anyhow::Result<SelectedRoute> {
+        match self.router_mode {
+            RouterMode::Random => self.select_random(),
+            RouterMode::RoundRobin => self.select_round_robin(),
+            RouterMode::PowerOfTwoChoices => self.select_power_of_two_choices(),
+            RouterMode::KV => {
+                anyhow::bail!("KV routing should not use PushRouter route selection directly");
+            }
+            RouterMode::Direct => {
+                anyhow::bail!(
+                    "Direct routing should not use PushRouter route selection directly; use DirectRoutingRouter wrapper"
+                );
+            }
+            RouterMode::LeastLoaded => self.select_least_loaded().await,
+            RouterMode::DeviceAwareWeighted => self.select_device_aware_weighted().await,
+        }
+    }
 
+    fn check_worker_capacity(&self, request_id: &str, instance_id: u64) -> anyhow::Result<()> {
         // Check if all workers are busy (when fault detection is enabled).
         if self.fault_detection_enabled {
             let free_instances = self.client.instance_ids_free();
@@ -831,81 +874,116 @@ where
             }
         }
 
+        Ok(())
+    }
+
+    fn resolve_transport_address(
+        &self,
+        instance_id: &mut u64,
+    ) -> anyhow::Result<(String, &'static str, Instance)> {
         // Resolve transport address; if the selected instance disappeared
         // between selection and dispatch, fall back to another available one.
-        let (address, _transport_kind, instance) = {
-            use crate::component::TransportType;
+        use crate::component::TransportType;
 
-            let resolve_transport = |id: u64| {
-                let instances = self.client.instances();
-                instances
-                    .iter()
-                    .find(|i| i.instance_id == id)
-                    .map(|instance| {
-                        let (addr, kind) = match &instance.transport {
-                            TransportType::Http(http_endpoint) => {
-                                tracing::debug!(
-                                    instance_id = id,
-                                    http_endpoint = %http_endpoint,
-                                    "Using HTTP transport for instance"
-                                );
-                                (http_endpoint.clone(), "transport.http.request")
-                            }
-                            TransportType::Tcp(tcp_endpoint) => {
-                                tracing::debug!(
-                                    instance_id = id,
-                                    tcp_endpoint = %tcp_endpoint,
-                                    "Using TCP transport for instance"
-                                );
-                                (tcp_endpoint.clone(), "transport.tcp.request")
-                            }
-                            TransportType::Nats(subject) => {
-                                tracing::debug!(
-                                    instance_id = id,
-                                    subject = %subject,
-                                    "Using NATS transport for instance"
-                                );
-                                (subject.clone(), "transport.nats.request")
-                            }
-                        };
-                        (addr, kind, instance.clone())
-                    })
-            };
-
-            if let Some(result) = resolve_transport(instance_id) {
-                result
-            } else {
-                // Instance vanished — pick a different one from the current
-                // availability list and retry the lookup once.
-                let avail = self.client.instance_ids_avail();
-                let fallback_id = avail.iter().copied().find(|&id| id != instance_id);
-                match fallback_id {
-                    Some(id) => {
-                        tracing::warn!(
-                            original_instance = instance_id,
-                            fallback_instance = id,
-                            "Instance disappeared during routing, reselecting"
-                        );
-                        instance_id = id;
-                        resolve_transport(id).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "Fallback instance {} also not found for endpoint {}",
-                                id,
-                                self.client.endpoint.id()
-                            )
-                        })?
-                    }
-                    None => {
-                        return Err(anyhow::anyhow!(
-                            "Instance {} not found and no other instances available \
-                             for endpoint {}",
-                            instance_id,
-                            self.client.endpoint.id()
-                        ));
-                    }
-                }
-            }
+        let resolve_transport = |id: u64| {
+            let instances = self.client.instances();
+            instances
+                .iter()
+                .find(|i| i.instance_id == id)
+                .map(|instance| {
+                    let (addr, kind) = match &instance.transport {
+                        TransportType::Http(http_endpoint) => {
+                            tracing::debug!(
+                                instance_id = id,
+                                http_endpoint = %http_endpoint,
+                                "Using HTTP transport for instance"
+                            );
+                            (http_endpoint.clone(), "transport.http.request")
+                        }
+                        TransportType::Tcp(tcp_endpoint) => {
+                            tracing::debug!(
+                                instance_id = id,
+                                tcp_endpoint = %tcp_endpoint,
+                                "Using TCP transport for instance"
+                            );
+                            (tcp_endpoint.clone(), "transport.tcp.request")
+                        }
+                        TransportType::Nats(subject) => {
+                            tracing::debug!(
+                                instance_id = id,
+                                subject = %subject,
+                                "Using NATS transport for instance"
+                            );
+                            (subject.clone(), "transport.nats.request")
+                        }
+                    };
+                    (addr, kind, instance.clone())
+                })
         };
+
+        if let Some(result) = resolve_transport(*instance_id) {
+            return Ok(result);
+        }
+
+        // Instance vanished — pick a different one from the current
+        // availability list and retry the lookup once.
+        let avail = self.client.instance_ids_avail();
+        let fallback_id = avail.iter().copied().find(|&id| id != *instance_id);
+        match fallback_id {
+            Some(id) => {
+                tracing::warn!(
+                    original_instance = *instance_id,
+                    fallback_instance = id,
+                    "Instance disappeared during routing, reselecting"
+                );
+                *instance_id = id;
+                resolve_transport(id).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Fallback instance {} also not found for endpoint {}",
+                        id,
+                        self.client.endpoint.id()
+                    )
+                })
+            }
+            None => Err(anyhow::anyhow!(
+                "Instance {} not found and no other instances available for endpoint {}",
+                *instance_id,
+                self.client.endpoint.id()
+            )),
+        }
+    }
+
+    fn route_span(&self, request_id: &str, instance_id: u64) -> tracing::Span {
+        if matches!(self.router_mode, RouterMode::KV) {
+            tracing::Span::none()
+        } else {
+            tracing::info_span!(
+                "router.route_request",
+                request_id = %request_id,
+                worker_id = instance_id,
+                router_mode = ?self.router_mode,
+            )
+        }
+    }
+
+    fn prepare_addressed_request(
+        &self,
+        mut instance_id: u64,
+        request: SingleIn<T>,
+    ) -> anyhow::Result<(
+        u64,
+        &'static str,
+        SingleIn<AddressedRequest<T>>,
+        tracing::Span,
+    )> {
+        let route_start = Instant::now();
+        let request_id = request.id().to_string();
+        let route_span = self.route_span(&request_id, instance_id);
+
+        self.check_worker_capacity(&request_id, instance_id)?;
+
+        let (address, transport_kind, instance) =
+            self.resolve_transport_address(&mut instance_id)?;
 
         let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
@@ -913,7 +991,78 @@ where
             .with_label_values(&[STAGE_ROUTE])
             .observe(route_start.elapsed().as_secs_f64());
 
-        let _nvtx_transport = dynamo_nvtx_range!(_transport_kind);
+        Ok((instance_id, transport_kind, request, route_span))
+    }
+
+    async fn generate_selected_route(
+        &self,
+        selected: SelectedRoute,
+        request: SingleIn<T>,
+    ) -> anyhow::Result<ManyOut<U>> {
+        let instance_id = selected.instance_id();
+        match self
+            .generate_with_fault_detection(instance_id, request)
+            .await
+        {
+            Ok(stream) => Ok(selected.into_tracked_stream(stream)),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn forward_selected_route(
+        &self,
+        selected: SelectedRoute,
+        request: SingleIn<T>,
+        response_connection_info: ConnectionInfo,
+    ) -> anyhow::Result<()> {
+        let instance_id = selected.instance_id();
+        let result = self
+            .forward_with_response(instance_id, request, response_connection_info)
+            .await;
+
+        // Forwarded responses bypass this router, so occupancy can only cover
+        // selection through request-plane send.
+        drop(selected);
+        result
+    }
+
+    async fn forward_with_response(
+        &self,
+        instance_id: u64,
+        request: SingleIn<T>,
+        response_connection_info: ConnectionInfo,
+    ) -> anyhow::Result<()> {
+        let (instance_id, transport_kind, request, route_span) =
+            self.prepare_addressed_request(instance_id, request)?;
+
+        let _nvtx_transport = dynamo_nvtx_range!(transport_kind);
+        let result = self
+            .addressed
+            .send_with_connection_info(request, response_connection_info)
+            .instrument(route_span)
+            .await;
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if self.fault_detection_enabled && is_inhibited(err.as_ref()) {
+                    tracing::debug!("Reporting instance {instance_id} down due to error: {err}");
+                    self.client.report_instance_down(instance_id);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn generate_with_fault_detection(
+        &self,
+        instance_id: u64,
+        request: SingleIn<T>,
+    ) -> anyhow::Result<ManyOut<U>> {
+        let (instance_id, transport_kind, request, route_span) =
+            self.prepare_addressed_request(instance_id, request)?;
+
+        let _nvtx_transport = dynamo_nvtx_range!(transport_kind);
         let stream: anyhow::Result<ManyOut<U>> = self
             .addressed
             .generate(request)
@@ -999,21 +1148,24 @@ where
     U: Data + for<'de> Deserialize<'de> + MaybeError,
 {
     async fn generate(&self, request: SingleIn<T>) -> Result<ManyOut<U>, Error> {
-        match self.router_mode {
-            RouterMode::Random => self.random(request).await,
-            RouterMode::RoundRobin => self.round_robin(request).await,
-            RouterMode::PowerOfTwoChoices => self.power_of_two_choices(request).await,
-            RouterMode::KV => {
-                anyhow::bail!("KV routing should not call generate on PushRouter");
-            }
-            RouterMode::Direct => {
-                anyhow::bail!(
-                    "Direct routing should not call generate on PushRouter directly; use DirectRoutingRouter wrapper"
-                );
-            }
-            RouterMode::LeastLoaded => self.least_loaded(request).await,
-            RouterMode::DeviceAwareWeighted => self.device_aware_weighted(request).await,
-        }
+        let selected = self.select_route().await?;
+        self.generate_selected_route(selected, request).await
+    }
+}
+
+impl<T, U> PushRouter<T, U>
+where
+    T: Data + Serialize,
+    U: Data + for<'de> Deserialize<'de> + MaybeError,
+{
+    pub async fn forward(
+        &self,
+        request: SingleIn<T>,
+        response_connection_info: ConnectionInfo,
+    ) -> Result<(), Error> {
+        let selected = self.select_route().await?;
+        self.forward_selected_route(selected, request, response_connection_info)
+            .await
     }
 }
 

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -10,7 +10,10 @@ use crate::metrics::work_handler_perf::{
 use crate::protocols::maybe_error::MaybeError;
 use prometheus::{Histogram, IntCounter, IntCounterVec, IntGauge};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Instant;
 use tracing::Instrument;
 use tracing::info_span;
@@ -138,6 +141,44 @@ impl Drop for RequestMetricsGuard {
     }
 }
 
+fn tcp_response_subject(connection_info: &ConnectionInfo) -> Option<String> {
+    serde_json::from_str::<tcp::TcpStreamConnectionInfo>(&connection_info.info)
+        .ok()
+        .map(|ci| ci.subject)
+}
+
+async fn create_response_publisher(
+    context: Arc<dyn AsyncEngineContext>,
+    connection_info: ConnectionInfo,
+    metrics: Option<&Arc<WorkHandlerMetrics>>,
+) -> Result<StreamSender, PipelineError> {
+    let request_id = context.id().to_string();
+    let response_transport = connection_info.transport.clone();
+    let response_subject = tcp_response_subject(&connection_info);
+
+    tracing::info!(
+        request_id = %request_id,
+        response_transport = %response_transport,
+        response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+        "opening response stream to upstream caller"
+    );
+
+    tcp::client::TcpClient::create_response_stream(
+        context,
+        connection_info,
+        metrics.map(|m| m.cancellation_total.clone()),
+    )
+    .await
+    .map_err(|e| {
+        if let Some(m) = metrics {
+            m.error_counter
+                .with_label_values(&[work_handler::error_types::RESPONSE_STREAM])
+                .inc();
+        }
+        PipelineError::Generic(format!("Failed to create response stream: {:?}", e,))
+    })
+}
+
 #[async_trait]
 impl<T: Data, U: Data> PushWorkHandler for Ingress<SingleIn<T>, ManyOut<U>>
 where
@@ -241,25 +282,38 @@ where
         // extend request with context
         tracing::trace!("received control message: {:?}", control_msg);
         tracing::trace!("received request: {:?}", request);
-        let request: context::Context<T> = Context::with_id(request, control_msg.id);
+        let mut request: context::Context<T> = Context::with_id(request, control_msg.id);
+        let response_delegated = Arc::new(AtomicBool::new(false));
+        request.insert_unique(
+            RESPONSE_CONNECTION_INFO_CONTEXT_KEY,
+            control_msg.connection_info.clone(),
+        );
+        request.insert_unique(RESPONSE_DELEGATED_CONTEXT_KEY, response_delegated.clone());
 
-        // todo - eventually have a handler class which will returned an abstracted object, but for now,
-        // we only support tcp here, so we can just unwrap the connection info
-        tracing::trace!("creating tcp response stream");
-        let mut publisher = tcp::client::TcpClient::create_response_stream(
-            request.context(),
-            control_msg.connection_info,
-            self.metrics().map(|m| m.cancellation_total.clone()),
-        )
-        .await
-        .map_err(|e| {
-            if let Some(m) = self.metrics() {
-                m.error_counter
-                    .with_label_values(&[work_handler::error_types::RESPONSE_STREAM])
-                    .inc();
-            }
-            PipelineError::Generic(format!("Failed to create response stream: {:?}", e,))
-        })?;
+        let request_context = request.context();
+
+        let mut publisher = if self.defer_response_stream {
+            let response_subject = tcp_response_subject(&control_msg.connection_info);
+            tracing::info!(
+                request_id = %request_context.id(),
+                response_transport = %control_msg.connection_info.transport,
+                response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+                "deferring response stream creation; handler may delegate response"
+            );
+            None
+        } else {
+            // todo - eventually have a handler class which will returned an abstracted object, but for now,
+            // we only support tcp here, so we can just unwrap the connection info
+            tracing::trace!("creating tcp response stream");
+            Some(
+                create_response_publisher(
+                    request_context.clone(),
+                    control_msg.connection_info.clone(),
+                    self.metrics(),
+                )
+                .await?,
+            )
+        };
 
         tracing::trace!("calling generate");
         let stream = self
@@ -279,10 +333,45 @@ where
 
         // the prolouge is sent to the client to indicate that the stream is ready to receive data
         // or if the generate call failed, the error is sent to the client
+        let mut first_response = None;
         let mut stream = match stream {
             Ok(stream) => {
+                let mut stream = stream;
+                if self.defer_response_stream {
+                    first_response = stream.next().await;
+                    if response_delegated.load(Ordering::SeqCst) {
+                        if first_response.is_some() {
+                            tracing::warn!(
+                                "response stream was delegated after yielding a response; dropping local response"
+                            );
+                        }
+                        let response_subject = tcp_response_subject(&control_msg.connection_info);
+                        tracing::info!(
+                            request_id = %request_context.id(),
+                            response_transport = %control_msg.connection_info.transport,
+                            response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+                            "response stream delegated downstream; ingress will not publish response"
+                        );
+                        return Ok(());
+                    }
+
+                    tracing::trace!("creating deferred tcp response stream");
+                    publisher = Some(
+                        create_response_publisher(
+                            request_context.clone(),
+                            control_msg.connection_info.clone(),
+                            self.metrics(),
+                        )
+                        .await?,
+                    );
+                }
+
                 tracing::trace!("Successfully generated response stream; sending prologue");
-                let _result = publisher.send_prologue(None).await;
+                let _result = publisher
+                    .as_mut()
+                    .expect("response publisher initialized")
+                    .send_prologue(None)
+                    .await;
                 WORK_HANDLER_TIME_TO_FIRST_RESPONSE_SECONDS
                     .observe(start_time.elapsed().as_secs_f64());
                 stream
@@ -302,17 +391,39 @@ where
                     tracing::error!("Failed to generate response stream: {error_string}");
                 }
 
-                let _result = publisher.send_prologue(Some(error_string)).await;
+                if publisher.is_none() {
+                    publisher = Some(
+                        create_response_publisher(
+                            request_context.clone(),
+                            control_msg.connection_info.clone(),
+                            self.metrics(),
+                        )
+                        .await?,
+                    );
+                }
+                let _result = publisher
+                    .as_mut()
+                    .expect("response publisher initialized")
+                    .send_prologue(Some(error_string))
+                    .await;
                 Err(e)?
             }
         };
 
+        let publisher = publisher.expect("response publisher initialized");
         let context = stream.context();
 
         // TODO: Detect end-of-stream using Server-Sent Events (SSE)
         let mut send_complete_final = true;
         let mut saw_error_response = false;
-        while let Some(resp) = stream.next().await {
+        loop {
+            let resp = match first_response.take() {
+                Some(resp) => Some(resp),
+                None => stream.next().await,
+            };
+            let Some(resp) = resp else {
+                break;
+            };
             tracing::trace!("Sending response: {:?}", resp);
             let is_error = resp.err().is_some();
             if is_error {


### PR DESCRIPTION
#### Overview:

This is a first draft of a change that allows the local router to send the response stream directly to frontend and bypass the global router.  We still need to explore how we're going to handle informing global router of errors, and eventually also let global router be aware of load (we are bypassing the Occupancy tracking logic which should be fine for right now since it does not seem like any of the load based routing policies are being used by global router).

#### Details:

In PushRouter we defined a new top level method called forward (debating this name since could be confused with mode.fwd haha) that acts as an alternative to generate .  Unlike generate it does not return a ManyOut, it selects a route using the specified load balancing policy and just sends the request.  For delegated response streams, we support passing Connection Info, this has the tcp connection info that informs the responder where to send data back.

#### Where should the reviewer start?

I would say first look at the changes to push_router.rs and addressed_router.rs.
The rest of the changes are primarily plumbing related for the connection info state that we are accepting for the delegated response stream.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deferring response stream initialization during endpoint serving.
  * Introduced response delegation capability, allowing responses to be forwarded to downstream routers while preserving upstream connection information.

* **Refactor**
  * Refactored request routing and dispatch logic to separate route selection from request dispatch for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->