### PR TITLE
fix(ci): make vcluster create race-safe in Self-bootstrap path

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -110,15 +110,47 @@ runs:
         NAMESPACE: ${{ steps.resolve-names.outputs.namespace }}
       run: |
         echo "::group::Create vCluster ${VCLUSTER_NAME} in ${NAMESPACE}"
-        set -x
-        # The K8s version must be supported by the kr8s Python library used in deploy tests.
-        # This is independent of the host cluster version.
-        vcluster create ${VCLUSTER_NAME} \
-          --namespace ${NAMESPACE} \
-          --connect=false \
-          --upgrade \
-          --set controlPlane.distro.k8s.enabled=true \
-          --set controlPlane.distro.k8s.version=${{ inputs.vcluster_k8s_version }}
+
+        # When two parallel matrix jobs both hit the Self-bootstrap (rerun) path,
+        # they race on `vcluster create` because the underlying `helm upgrade
+        # --install` is not atomic — one job's release-secret commit wins and the
+        # other fails with `release: already exists`. The `--upgrade` flag does
+        # not serialize this. Recover by re-checking `vcluster list`: if a
+        # concurrent job already produced the cluster, treat as success and let
+        # the subsequent "Wait for vCluster pod to be ready" step block on that
+        # job's bootstrap finishing.
+        #
+        # The K8s version must be supported by the kr8s Python library used in
+        # deploy tests; this is independent of the host cluster version.
+        create_ok=false
+        for attempt in 1 2 3 4 5 6; do
+          set -x
+          if vcluster create ${VCLUSTER_NAME} \
+               --namespace ${NAMESPACE} \
+               --connect=false \
+               --upgrade \
+               --set controlPlane.distro.k8s.enabled=true \
+               --set controlPlane.distro.k8s.version=${{ inputs.vcluster_k8s_version }}; then
+            set +x
+            create_ok=true
+            break
+          fi
+          set +x
+          if vcluster list -n "${NAMESPACE}" --output json 2>/dev/null \
+             | jq -e --arg name "${VCLUSTER_NAME}" \
+               'map(select(.Name == $name)) | length > 0' &>/dev/null; then
+            echo "vCluster ${VCLUSTER_NAME} now visible (concurrent matrix job won the create race); proceeding"
+            create_ok=true
+            break
+          fi
+          echo "vcluster create failed and ${VCLUSTER_NAME} not visible; retrying in 10s (attempt ${attempt}/6)..."
+          sleep 10
+        done
+
+        if [ "${create_ok}" != "true" ]; then
+          echo "::error::vcluster create did not succeed after 6 attempts"
+          exit 1
+        fi
         echo "::endgroup::"
 
     - name: Wait for vCluster pod to be ready


### PR DESCRIPTION
## Summary
- Wrap the `vcluster create` call in `setup-dynamo-operator` in a retry loop that recovers when a concurrent matrix job has already produced the cluster.
- Eliminates the `Error: release: already exists` failure observed when two parallel matrix jobs hit the Self-bootstrap (rerun) path simultaneously.

## Background
Observed in [run 25950942929](https://github.com/ai-dynamo/dynamo/actions/runs/25950942929/job/76292475282?pr=9638) on PR #9638:

```
04:06:58 sglang Deploy Test / agg & agg_router both start
04:07:07 both: vCluster not found in namespace ...   → exists=false (Self-bootstrap fires)
04:07:08-09 both: vcluster create ... (running in parallel)
04:07:13 agg_router wins, proceeds
04:07:13 agg: helm "Release ci-25950942929 does not exist. Installing it now."
04:07:13 agg: Error: release: already exists           → 19s job, exit 1
```

The vCluster had disappeared from the AKS namespace between `deploy-operator` finishing and the sglang matrix starting (~70min gap — root cause unclear, possibly node eviction or external cleanup; out of scope here). Both sglang profiles entered the recovery path simultaneously. `vcluster create --upgrade` does not serialize between callers — under the hood it runs `helm upgrade --install` whose release-secret commit is a non-atomic two-step (existence check → write), so one parallel commit wins and the other gets the "already exists" error mid-install.

## What changed
`.github/actions/setup-dynamo-operator/action.yml` — wrapped the `Create vCluster` step:

```bash
for attempt in 1 2 3 4 5 6; do
  if vcluster create ${VCLUSTER_NAME} ... ; then
    create_ok=true
    break
  fi
  # Did a concurrent job win the race?
  if vcluster list ... | jq -e '... .Name == "$name" ...'; then
    echo "concurrent matrix job won the create race; proceeding"
    create_ok=true
    break
  fi
  sleep 10
done
```

~60s total budget. The subsequent `Wait for vCluster pod to be ready` step then blocks on the winning job's bootstrap finishing (its `kubectl wait --for=condition=ready` is unchanged).

## Out of scope
- **Why the vCluster disappeared.** Not addressed here — that's an AKS / nscleanup / lifecycle question for a separate investigation.
- **Connect-vcluster port-forward race** — fixed in #9638 (merged).

## Test plan
- [ ] CI pre-merge passes on this PR.
- [ ] Re-run any historical job that hit `Error: release: already exists` to confirm recovery.
- [ ] Confirm the new error message surfaces when `vcluster create` genuinely cannot succeed (not a race) — should fail with `::error::vcluster create did not succeed after 6 attempts` after ~60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability when provisioning virtual clusters: creation now retries on transient failures and detects already-created clusters to avoid race-condition failures, failing only after verified retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->