### PR TITLE
fix(container): remove correct ofi-nccl paths in aws.Dockerfile

### DIFF
--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -36,7 +36,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
     rm -rf /tmp/efa && \
-    rm -rf /opt/amazon/aws-ofi-nccl && \
+    # Disable the EFA installer's aws-ofi-nccl plugin: it crashes TRT-LLM at engine init.
+    # The plugin is installed at /opt/amazon/ofi-nccl (no `aws-` prefix), but ld.so picks
+    # it up via /etc/ld.so.conf.d/aws-ofi-nccl.conf (which DOES carry the `aws-` prefix).
+    # Remove both, and also the cuda-dl-base location /opt/amazon/aws-ofi-nccl if present,
+    # before re-running ldconfig.
+    rm -rf /opt/amazon/aws-ofi-nccl /opt/amazon/ofi-nccl \
+           /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
     ldconfig
 
 ENV EFA_VERSION="${EFA_VERSION}"


### PR DESCRIPTION
## Summary

The `--make-efa` aws stage's `rm -rf /opt/amazon/aws-ofi-nccl` is a silent no-op — the EFA installer (1.46/1.47/1.48) places its ofi-nccl plugin at `/opt/amazon/ofi-nccl/` (no `aws-` prefix), and registers it via `/etc/ld.so.conf.d/aws-ofi-nccl.conf` (which DOES keep the `aws-` prefix). The comment above the line documents the intent — "disable ofi-nccl, it crashes TRT-LLM at engine init" — but the implementation never realizes it.

This PR removes all three things that actually need to be removed:

- `/opt/amazon/aws-ofi-nccl/` (from cuda-dl-base, if present)
- `/opt/amazon/ofi-nccl/` (the EFA installer's actual plugin install)
- `/etc/ld.so.conf.d/aws-ofi-nccl.conf` (so ldconfig stops resolving the plugin's `libnccl-net-ofi.so`)

Trailing `ldconfig` already refreshes the cache.

## Reproducibility

**Pre-fix**, in any image built with `--make-efa`:

```bash
ldconfig -p | grep libnccl-net-ofi
# → /opt/amazon/ofi-nccl/lib/libnccl-net-ofi.so
ls /opt/amazon/ofi-nccl/
# → plugin directory still present despite the rm
```

**Post-fix** (verified end-to-end via the v4 internalized image, see [`prs-internalized-v4-validation-2026-05-21.md`](https://github.com/yifjiang/dynamo-gb200-test-mirror/blob/main/docs/prs-internalized-v4-validation-2026-05-21.md)):

```bash
ldconfig -p | grep libnccl-net-ofi   # no output
ls /opt/amazon/ofi-nccl/             # No such file or directory
ls /etc/ld.so.conf.d/ | grep ofi     # no output
```

## Background

Surfaced during EFA validation on AWS p6e-gb200. The ofi-nccl plugin auto-loading conflicts with TRT-LLM's engine init on GB200 disagg workloads — TRT-LLM workers CrashLoopBackOff when ofi-nccl is in ldconfig. Was previously fixed externally via the v9-efa-fix2 post-process script; this PR moves the fix into dynamo proper so `--make-efa` produces images that don't need the post-process.

## Risk

LOW. Turns a no-op into a working removal:

- Images that previously shipped an unwanted plugin no longer do.
- Images that previously functioned correctly aren't affected (the rm targets exist only on `--make-efa` images, and the plugin's removal makes TRT-LLM disagg start working — no other consumer in our images uses it).
- Non-EFA paths (no `--make-efa`) are completely untouched.

## Companion PRs

This is one of four small PRs internalizing fixes that were previously layered via the external `install_efa_libfabric_nixl_fix2.sh` script:

| PR | What |
|---|---|
| **this PR** | `fix(container)`: ofi-nccl rm path |
| [#9704](https://github.com/ai-dynamo/dynamo/pull/9704) | `feat(container)`: render.py `--has-trtllm-context` flag |
| [#9705](https://github.com/ai-dynamo/dynamo/pull/9705) | `build(container)`: nixl_gdrcopy_ref v2.5.1 → v2.5.2 |
| [#9727](https://github.com/ai-dynamo/dynamo/pull/9727) | `feat(container)`: build upstream libfabric (v2.5.1) into the aws stage |

Together, these four merged make `python3 container/render.py --framework trtllm --target runtime --cuda-version 13.1 --make-efa --has-trtllm-context && docker build ... --target aws ...` produce an EFA-correct image with no post-process. Validated end-to-end on GB200 (dev-01) and H100 (dev-02) — Qwen3-Coder-480B-A35B-Instruct-FP4 + Qwen3-30B-A3B-FP8 live disagg, READY 3/3, 0 restarts.

## Test plan

- [x] Render the trtllm-runtime Dockerfile with `--make-efa` produces the expanded rm line.
- [x] Build the image and confirm `/opt/amazon/ofi-nccl/` is absent and `ldconfig -p | grep libnccl-net-ofi` is empty (verified on v4 arm64 + x86 images).
- [x] Live TRT-LLM disagg starts cleanly (no CrashLoopBackOff at engine init).
- [ ] CI pre-commit, isort, black, codespell pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)