### PR TITLE
feat(container): add --has-trtllm-context flag to render.py [RFC]

### DIFF
--- a/container/render.py
+++ b/container/render.py
@@ -84,6 +84,19 @@ def parse_args():
     )
     parser.add_argument("--make-efa", action="store_true", help="Enable AWS EFA")
     parser.add_argument(
+        "--has-trtllm-context",
+        action="store_true",
+        help=(
+            "Render the `COPY --from=trtllm_wheel / /trtllm_wheel/` line in the trtllm "
+            "framework stage. Use this when you plan to invoke `docker build` with "
+            "`--build-context trtllm_wheel=<dir>` AND `--build-arg HAS_TRTLLM_CONTEXT=1`. "
+            "Without this flag, the COPY line is omitted at render time (per "
+            'context.yaml `trtllm.has_trtllm_context` default "0"), and a build that '
+            "passes `--build-arg HAS_TRTLLM_CONTEXT=1` will fail because /trtllm_wheel "
+            "doesn't exist inside the container."
+        ),
+    )
+    parser.add_argument(
         "--output-short-filename",
         action="store_true",
         help="Output filename is rendered.Dockerfile instead of <framework>-<target>-cuda<cuda_version>-<arch>-rendered.Dockerfile",
@@ -225,6 +238,13 @@ def main():
     script_dir = Path(__file__).parent
     with open(f"{script_dir}/context.yaml", "r") as f:
         context = yaml.safe_load(f)
+
+    # --has-trtllm-context overrides the context.yaml default so users can opt
+    # into the local-wheel-build-context path at render time without editing
+    # context.yaml. The build-time ARG HAS_TRTLLM_CONTEXT must agree with this
+    # at `docker build` time — see trtllm_framework.Dockerfile for the gate.
+    if getattr(args, "has_trtllm_context", False):
+        context.setdefault("trtllm", {})["has_trtllm_context"] = "1"
 
     render(args, context, script_dir)
 


### PR DESCRIPTION
## Summary

Adds a `--has-trtllm-context` CLI flag to `container/render.py` that overrides the `context.yaml` default for `trtllm.has_trtllm_context` at render time. Mirrors how `--make-efa` works today.

**Marked draft as RFC** — the design space is broad and this is the minimal-risk option. Looking for maintainer feedback on whether a more invasive redesign is preferred.

## Background

The trtllm framework Dockerfile gates `COPY --from=trtllm_wheel / /trtllm_wheel/` at *render time* (Jinja `{% if context.trtllm.has_trtllm_context == "1" %}`) while the install RUN that consumes `/trtllm_wheel` is gated at *build time* (ARG `HAS_TRTLLM_CONTEXT`). The two flags must agree. Without this PR, the only way to flip the render-time gate is to manually edit `container/context.yaml` — easy to forget, and the resulting build failure leaves the user staring at `find: '/trtllm_wheel': No such file or directory` without an obvious path to the fix.

## The fix in this PR

```python
parser.add_argument("--has-trtllm-context", action="store_true", ...)
# ...
if getattr(args, "has_trtllm_context", False):
    context.setdefault("trtllm", {})["has_trtllm_context"] = "1"
```

Usage:

```bash
# Build with a local trtllm wheel:
python3 container/render.py --framework trtllm --target runtime \
  --cuda-version 13.1 --platform linux/amd64 --has-trtllm-context
docker build --build-arg HAS_TRTLLM_CONTEXT=1 \
  --build-context trtllm_wheel=./my-wheel-dir/ \
  -f container/trtllm-runtime-cuda13.1-amd64-rendered.Dockerfile ...

# Default (PyPI or wheel-image install) — unchanged:
python3 container/render.py --framework trtllm --target runtime ...
docker build ...
```

## Alternatives considered (and not pursued)

| Approach | Why not |
|---|---|
| Drop the Jinja gate entirely; always emit COPY | Breaks every build that doesn't pass `--build-context trtllm_wheel=`. BuildKit fails immediately with `target stage trtllm_wheel could not be found`. Significant downstream migration burden. |
| Bump `context.yaml: has_trtllm_context: "0" → "1"` as the new default | Same break — every build using default render now needs to pass `--build-context trtllm_wheel=`. |
| Sentinel empty fallback stage (à la `trtllm_wheel_image_empty`) | `--build-context NAME=...` is a CLI flag, not a stage reference. There's no Dockerfile-level fallback mechanism for missing contexts the way `FROM ${TRTLLM_WHEEL_IMAGE}` provides for images. |
| Couple the render flag to the build ARG via a generated build wrapper script | Larger surface; render.py would need to emit a `build.sh` alongside the Dockerfile. Better as a follow-up. |

The CLI flag (this PR) is the minimal-invasive option: no Dockerfile changes, no breakage of existing renders, no default flip. Users who want the local-wheel path opt in explicitly with `--has-trtllm-context`.

## Companion PRs

This is one of four small PRs internalizing fixes that were previously layered via the external `install_efa_libfabric_nixl_fix2.sh` script:

| PR | What |
|---|---|
| [#9703](https://github.com/ai-dynamo/dynamo/pull/9703) | `fix(container)`: ofi-nccl rm path |
| **this PR** | `feat(container)`: render.py `--has-trtllm-context` flag |
| [#9705](https://github.com/ai-dynamo/dynamo/pull/9705) | `build(container)`: nixl_gdrcopy_ref v2.5.1 → v2.5.2 |
| [#9727](https://github.com/ai-dynamo/dynamo/pull/9727) | `feat(container)`: build upstream libfabric (v2.5.1) into the aws stage |

Together, these four merged make `python3 container/render.py --framework trtllm --target runtime --cuda-version 13.1 --make-efa --has-trtllm-context && docker build ... --target aws ...` produce an EFA-correct image with no post-process. Validated end-to-end via the v4 internalized image (see [`prs-internalized-v4-validation-2026-05-21.md`](https://github.com/yifjiang/dynamo-gb200-test-mirror/blob/main/docs/prs-internalized-v4-validation-2026-05-21.md)) — Qwen3-Coder-480B-A35B-Instruct-FP4 on GB200 + Qwen3-30B-A3B-FP8 on H100, both READY 3/3 with 0 restarts.

## Risk

LOW. Adds a CLI argument; default behavior is unchanged when the flag is absent. Render output is byte-identical to today for all existing invocation patterns.

## Test plan

- [x] Render without flag → `grep -c "COPY --from=trtllm_wheel / /trtllm_wheel/"` returns 0 (unchanged)
- [x] Render with `--has-trtllm-context` → same grep returns 1
- [x] Resulting image with the flag set + `--build-context trtllm_wheel=...` + `--build-arg HAS_TRTLLM_CONTEXT=1` builds successfully and runs cleanly on GB200 + H100 (v4 validation).
- [ ] CI pre-commit / isort / black / codespell

🤖 Generated with [Claude Code](https://claude.com/claude-code)