### PR TITLE
build(container): bump nixl_gdrcopy_ref to v2.5.2 (kernel >=6.15 fix)

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -29,7 +29,7 @@ dynamo:
 
   nixl_ref: 0.10.1
   nixl_ucx_ref: v1.20.x
-  nixl_gdrcopy_ref: v2.5.1
+  nixl_gdrcopy_ref: v2.5.2
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0
   # Keep in sync with upstream NIXL's contrib/Dockerfile.manylinux.


### PR DESCRIPTION
## Summary

Bumps `container/context.yaml: dynamo.nixl_gdrcopy_ref` from `v2.5.1` to `v2.5.2`. One-line change.

## Why

GDRCopy v2.5.1 fails to build on host kernel ≥ 6.15:

```
error: redefinition of 'vm_flags_set'
```

Linux 6.15 changed `vm_flags_set` declaration; GDRCopy v2.5.2 adapts.

The dynamo wheel_builder stage builds the GDRCopy *userspace* library fine on the build host (which is typically a 6.14 kernel slurm node), but the resulting kmod source RPM can't compile against a 6.15+ kernel when the GPU Operator on the deploy host eventually tries to build it. This blocks GPU Direct RDMA on any deploy AMI that ships a kernel ≥ 6.15 — which is increasingly the default for Ubuntu 24.04 EKS nodes.

Surfaced during EFA validation on AWS p6e-gb200 (2026-05-09 v9-efa image build cycle); flagged as kernel constraint in the v9-efa recipe docs.

## Companion PRs

This is one of four small PRs internalizing fixes that were previously layered via the external `install_efa_libfabric_nixl_fix2.sh` script:

| PR | What |
|---|---|
| [#9703](https://github.com/ai-dynamo/dynamo/pull/9703) | `fix(container)`: ofi-nccl rm path |
| [#9704](https://github.com/ai-dynamo/dynamo/pull/9704) | `feat(container)`: render.py `--has-trtllm-context` flag |
| **this PR** | `build(container)`: nixl_gdrcopy_ref v2.5.1 → v2.5.2 |
| [#9727](https://github.com/ai-dynamo/dynamo/pull/9727) | `feat(container)`: build upstream libfabric (v2.5.1) into the aws stage |

Together, these four merged make `python3 container/render.py --framework trtllm --target runtime --cuda-version 13.1 --make-efa --has-trtllm-context && docker build ... --target aws ...` produce an EFA-correct image with no post-process. Validated end-to-end via the v4 internalized image (see [`prs-internalized-v4-validation-2026-05-21.md`](https://github.com/yifjiang/dynamo-gb200-test-mirror/blob/main/docs/prs-internalized-v4-validation-2026-05-21.md)) — Qwen3-Coder-480B-A35B-Instruct-FP4 on GB200 + Qwen3-30B-A3B-FP8 on H100, both READY 3/3 with 0 restarts.

## Risk

LOW. v2.5.2 is fully API-backward-compatible with v2.5.1. The wheel_builder stage and NIXL's linkage against GDRCopy are unaffected. The only behavioral change is that the resulting kmod source RPM can build against newer kernels at deploy time.

## Test plan

- [x] Sanity: `python3 container/render.py --framework trtllm --target wheel_builder --cuda-version 13.1 --platform linux/amd64` renders cleanly with `NIXL_GDRCOPY_REF=v2.5.2`.
- [x] Container builds, libgdrapi present in ldconfig (v4 validation).
- [ ] CI: trtllm-pipeline build (wheel_builder stage clones gdrcopy at the new ref).
- [ ] Manual on a kernel ≥ 6.15 host: load the kmod and confirm `dmesg | grep gdrcopy` shows no `vm_flags_set` redef error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA/NIXL configuration to latest version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->