### PR TITLE
build(container): bump nixl_ref 0.10.1 -> v1.1.0 + source-build Abseil prereq

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -27,7 +27,7 @@ dynamo:
   nats_version: v2.10.28
   etcd_version: v3.5.21
 
-  nixl_ref: 0.10.1
+  nixl_ref: v1.1.0
   nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
@@ -67,7 +67,7 @@ vllm:
     vllm_ref: v0.16.0
   flashinf_ref: v0.6.8.post1
   vllm_omni_ref: "v0.20.0"
-  nixl_ref: 0.10.1
+  nixl_ref: v1.1.0
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
@@ -90,7 +90,7 @@ sglang:
   # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
   # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
   # build doesn't leak into the runtime image.
-  nixl_ref: 0.10.1
+  nixl_ref: v1.1.0
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"
@@ -101,7 +101,7 @@ trtllm:
     runtime_image: nvcr.io/nvidia/cuda-dl-base
     base_image_tag: 26.02-py3
     runtime_image_tag: 26.02-cuda13.1-runtime-ubuntu24.04
-  nixl_ref: 0.10.1
+  nixl_ref: v1.1.0
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"


### PR DESCRIPTION
## Summary

Bump `*.nixl_ref` from `0.10.1` → `v1.1.0` in all 4 sections of `container/context.yaml`.

**Marked draft** — major version bump (0.x → 1.x). Looking for maintainer review on API-compat regressions in dynamo's serving stack.

## Why bump NIXL

NIXL `v1.1.0` brings four fixes that materially affect AWS p6e-gb200 EFA fabric performance:

| Fix | What it does | Impact without |
|---|---|---|
| [#1461](https://github.com/ai-dynamo/nixl/pull/1461) | NUMA-aware EFA rail selection | Aggregate bandwidth caps at ~1.79 GB/s on p6e-gb200 (4 GPU + 4 EFA per pod) instead of the expected ~190 GB/s. |
| [#1510](https://github.com/ai-dynamo/nixl/pull/1510) | Active rail tracking for multi-rail concurrent transfers | Concurrent transfers serialize onto one rail. |
| [#1506](https://github.com/ai-dynamo/nixl/pull/1506) | Multi-GPU memory-region fix | TP > 1 workers fail to register large VRAM blocks across GPUs. |
| [#1433](https://github.com/ai-dynamo/nixl/pull/1433) | Transfer handle repost notification fix | Race on transfer completion. |

These gains were validated by yutwu (NVIDIA teammate) during the GLM-5.1 v7→v7.5 image bump on AWS p6e-gb200.

## What changes

| File | Change |
|---|---|
| `container/context.yaml` | Bump `nixl_ref: 0.10.1 → v1.1.0` (×4). |

## On the Abseil source-build (initially considered, not needed)

NIXL v1.0.0+ uses `VLOG(1)` / `DVLOG(2)` in `nixl_log.h`, which require Abseil >= 20240116. NIXL's `meson.build` searches for system Abseil via pkg-config and hard-errors at configure time if it finds an old version.

An earlier draft of this PR added an Abseil 20240722.0 source-build to `wheel_builder.Dockerfile` (the manylinux_2_28 / AlmaLinux 8 base typically has no system Abseil) plus COPY steps into `dynamo_runtime` and `trtllm_runtime`. That turned out to be unnecessary: NIXL ≥ 1.1.0's meson subproject builds Abseil statically into `libnixl.so` on manylinux, so no system Abseil install is needed at build time AND no runtime Abseil install is needed in the downstream stages either. The source-build is removed from this PR.

## Tag-format note

`ai-dynamo/nixl` mixes tag conventions:
- `0.1.1`, `0.10.0`, `0.10.1` (no `v` prefix)
- `v1.1.0` (with `v` prefix)

This PR uses `v1.1.0` to match the upstream tag.

## Risk

**MEDIUM.** Major version bump.

- **Python NIXL bindings**: 0.10.1 → v1.1.0 may have API changes. Dynamo's serving code that imports `nixl` needs verification — worker init + a basic KV transfer smoke is sufficient.
- **Image size**: negligible — only `context.yaml` changes.
- **Build time**: unchanged.

## Test plan

- [ ] CI builds clean on both arches.
- [ ] In-image smoke: NIXL agent reports `version` 1.1.0.
- [ ] Live disagg TRT-LLM serving on EFA: NIXL LIBFABRIC backend, READY 3/3, 0 restarts.

## Note on stale branch state

This branch was rebased and currently shows unintended downgrades in `context.yaml` for `etcd_version` and `nixl_gdrcopy_ref` due to upstream main moving forward. A rebase is needed before this is mergeable — those keys should NOT change from current main.
