### PR TITLE
feat(self-host): worker advertises non-typed metadata siblings (gh-8749)

### DIFF
--- a/lib/llm/src/common/checked_file.rs
+++ b/lib/llm/src/common/checked_file.rs
@@ -94,6 +94,16 @@ impl CheckedFile {
         self.size
     }
 
+    /// Filename (last path segment) regardless of whether the path is local
+    /// or a URL. Returns `None` only for paths that don't have a final
+    /// segment (e.g. a URL ending in `/`).
+    pub fn basename(&self) -> Option<&str> {
+        match &self.path {
+            Either::Left(p) => p.file_name().and_then(|n| n.to_str()),
+            Either::Right(u) => u.path().rsplit('/').find(|s| !s.is_empty()),
+        }
+    }
+
     /// Does the given file checksum to the same value as this CheckedFile?
     pub fn checksum_matches<P: AsRef<Path> + std::fmt::Debug>(&self, disk_file: P) -> bool {
         match b3sum(&disk_file) {

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -585,7 +585,10 @@ impl LocalModel {
             .collect();
         let harvested =
             harvest_extra_files(&self.full_path, &typed_filenames).with_context(|| {
-                format!("harvesting extra metadata files from {:?}", self.full_path)
+                format!(
+                    "harvesting extra metadata files from {}",
+                    self.full_path.display()
+                )
             })?;
         self.card.extra_files.extend(harvested);
 
@@ -714,12 +717,17 @@ pub(crate) fn self_host_base_url(
 /// Scan `model_dir` for files to advertise alongside the typed MDC slots.
 /// Skips weights, dotfiles / README (`is_ignored`), already-typed
 /// filenames, and anything that isn't a regular file. Non-recursive.
+/// Results are sorted by filename so the resulting `mdcsum` is stable
+/// across filesystems that return `read_dir` entries in different
+/// orders.
 fn harvest_extra_files(
     model_dir: &Path,
     typed_filenames: &HashSet<String>,
 ) -> anyhow::Result<Vec<CheckedFile>> {
     let mut out = Vec::new();
-    for entry in fs::read_dir(model_dir).with_context(|| format!("read_dir {model_dir:?}"))? {
+    for entry in
+        fs::read_dir(model_dir).with_context(|| format!("read_dir {}", model_dir.display()))?
+    {
         let entry = entry?;
         if !entry.file_type()?.is_file() {
             continue;
@@ -736,6 +744,7 @@ fn harvest_extra_files(
         }
         out.push(CheckedFile::from_disk(&path)?);
     }
+    out.sort_by(|a, b| a.path().cmp(&b.path()));
     Ok(out)
 }
 

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -569,9 +569,7 @@ impl LocalModel {
 
         // Advertise non-typed siblings (preprocessor_config.json,
         // special_tokens_map.json, …) so external preprocessors that load
-        // via `from_pretrained(slug_dir)` see a complete model dir. Skip
-        // weight files (mx's deny-list) and dotfiles/README. Already-typed
-        // filenames are excluded so we don't double-advertise.
+        // via `from_pretrained(slug_dir)` see a complete model dir.
         let typed_filenames: HashSet<String> = self
             .card
             .iter_metadata_files()

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -719,20 +719,27 @@ pub(crate) fn self_host_base_url(
 /// filenames, and anything that isn't a regular file. Non-recursive.
 /// Results are sorted by filename so the resulting `mdcsum` is stable
 /// across filesystems that return `read_dir` entries in different
-/// orders.
+/// orders. Returns an empty vec when `model_dir` doesn't exist (e.g.
+/// name-only `LocalModel` placeholders).
 fn harvest_extra_files(
     model_dir: &Path,
     typed_filenames: &HashSet<String>,
 ) -> anyhow::Result<Vec<CheckedFile>> {
+    if !model_dir.is_dir() {
+        return Ok(Vec::new());
+    }
     let mut out = Vec::new();
     for entry in
         fs::read_dir(model_dir).with_context(|| format!("read_dir {}", model_dir.display()))?
     {
         let entry = entry?;
-        if !entry.file_type()?.is_file() {
+        let path = entry.path();
+        // `Path::is_file` uses `fs::metadata` which follows symlinks.
+        // `entry.file_type()` / `entry.metadata()` use lstat on Unix —
+        // they would skip the HF blob symlinks we need to harvest.
+        if !path.is_file() {
             continue;
         }
-        let path = entry.path();
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
             continue;
         };
@@ -797,6 +804,11 @@ mod harvest_extra_files_tests {
         touch("special_tokens_map.json");
         // subdir (skipped — not a file)
         std::fs::create_dir(dir.path().join("subdir")).unwrap();
+        // symlink to a real file (must be followed — HF snapshot dirs
+        // are full of these pointing into blobs/)
+        let target = dir.path().join("target_for_symlink");
+        std::fs::write(&target, b"x").unwrap();
+        std::os::unix::fs::symlink(&target, dir.path().join("added_tokens.json")).unwrap();
 
         let typed: HashSet<String> = ["config.json".to_string()].into_iter().collect();
         let mut names: Vec<String> = harvest_extra_files(dir.path(), &typed)
@@ -815,7 +827,20 @@ mod harvest_extra_files_tests {
         names.sort();
         assert_eq!(
             names,
-            vec!["preprocessor_config.json", "special_tokens_map.json"]
+            vec![
+                "added_tokens.json",
+                "preprocessor_config.json",
+                "special_tokens_map.json",
+                "target_for_symlink",
+            ]
         );
+    }
+
+    #[test]
+    fn returns_empty_for_missing_dir() {
+        let typed: HashSet<String> = HashSet::new();
+        // bogus path: doesn't exist on disk; must not error
+        let result = harvest_extra_files(Path::new("/nonexistent/dynamo/test/path"), &typed);
+        assert!(result.unwrap().is_empty());
     }
 }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -11,7 +12,9 @@ use dynamo_runtime::discovery::DiscoverySpec;
 use dynamo_runtime::protocols::EndpointId;
 use dynamo_runtime::slug::Slug;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
+use modelexpress_common::providers::{HuggingFaceProvider, ModelProviderTrait as _};
 
+use crate::common::checked_file::CheckedFile;
 use crate::entrypoint::RouterConfig;
 use crate::model_card::ModelDeploymentCard;
 use crate::model_type::{ModelInput, ModelType};
@@ -564,6 +567,28 @@ impl LocalModel {
         let suffix = model_suffix.unwrap_or(dynamo_runtime::metadata_registry::BASE_SUFFIX);
         let registry = drt.metadata_artifacts();
 
+        // Advertise non-typed siblings (preprocessor_config.json,
+        // special_tokens_map.json, …) so external preprocessors that load
+        // via `from_pretrained(slug_dir)` see a complete model dir. Skip
+        // weight files (mx's deny-list) and dotfiles/README. Already-typed
+        // filenames are excluded so we don't double-advertise.
+        let typed_filenames: HashSet<String> = self
+            .card
+            .iter_metadata_files()
+            .iter()
+            .filter_map(|(cf, _)| {
+                cf.path()
+                    .and_then(Path::file_name)
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        let harvested =
+            harvest_extra_files(&self.full_path, &typed_filenames).with_context(|| {
+                format!("harvesting extra metadata files from {:?}", self.full_path)
+            })?;
+        self.card.extra_files.extend(harvested);
+
         let mut rewritten = 0usize;
         for (cf, _) in self.card.iter_metadata_files_mut() {
             let Some(local_path) = cf.path().map(Path::to_path_buf) else {
@@ -686,6 +711,34 @@ pub(crate) fn self_host_base_url(
     Ok(Some(format!("http://{host}:{}", info.port())))
 }
 
+/// Scan `model_dir` for files to advertise alongside the typed MDC slots.
+/// Skips weights, dotfiles / README (`is_ignored`), already-typed
+/// filenames, and anything that isn't a regular file. Non-recursive.
+fn harvest_extra_files(
+    model_dir: &Path,
+    typed_filenames: &HashSet<String>,
+) -> anyhow::Result<Vec<CheckedFile>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(model_dir).with_context(|| format!("read_dir {model_dir:?}"))? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if typed_filenames.contains(name)
+            || HuggingFaceProvider::is_weight_file(name)
+            || HuggingFaceProvider::is_ignored(name)
+        {
+            continue;
+        }
+        out.push(CheckedFile::from_disk(&path)?);
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod env_self_host_metadata_tests {
     use super::*;
@@ -708,5 +761,50 @@ mod env_self_host_metadata_tests {
             assert!(env_self_host_metadata_default(), "expected ON for {v:?}");
         }
         unsafe { std::env::remove_var(ENV_SELF_HOST_METADATA) };
+    }
+}
+
+#[cfg(test)]
+mod harvest_extra_files_tests {
+    use super::*;
+
+    #[test]
+    fn filters_weights_typed_and_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let touch = |name: &str| {
+            std::fs::write(dir.path().join(name), b"x").unwrap();
+        };
+        // typed slot (excluded by name)
+        touch("config.json");
+        // weight (excluded by extension)
+        touch("model.safetensors");
+        // dotfile / README (excluded by is_ignored)
+        touch(".gitattributes");
+        touch("README.md");
+        // genuine extras (kept)
+        touch("preprocessor_config.json");
+        touch("special_tokens_map.json");
+        // subdir (skipped — not a file)
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+
+        let typed: HashSet<String> = ["config.json".to_string()].into_iter().collect();
+        let mut names: Vec<String> = harvest_extra_files(dir.path(), &typed)
+            .unwrap()
+            .iter()
+            .map(|cf| {
+                cf.path()
+                    .unwrap()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["preprocessor_config.json", "special_tokens_map.json"]
+        );
     }
 }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -16,7 +16,7 @@ use modelexpress_common::providers::{HuggingFaceProvider, ModelProviderTrait as 
 
 use crate::common::checked_file::CheckedFile;
 use crate::entrypoint::RouterConfig;
-use crate::model_card::ModelDeploymentCard;
+use crate::model_card::{ModelDeploymentCard, is_weight_file};
 use crate::model_type::{ModelInput, ModelType};
 use crate::preprocessor::media::{MediaDecoder, MediaFetcher};
 use crate::request_template::RequestTemplate;
@@ -737,7 +737,7 @@ fn harvest_extra_files(
             continue;
         };
         if typed_filenames.contains(name)
-            || HuggingFaceProvider::is_weight_file(name)
+            || is_weight_file(&path)
             || HuggingFaceProvider::is_ignored(name)
         {
             continue;
@@ -785,8 +785,10 @@ mod harvest_extra_files_tests {
         };
         // typed slot (excluded by name)
         touch("config.json");
-        // weight (excluded by extension)
+        // weights — covers the mx-narrow case (safetensors) and the
+        // ecosystem-wide case (.pt) which mx alone wouldn't catch.
         touch("model.safetensors");
+        touch("pytorch_lora_weights.pt");
         // dotfile / README (excluded by is_ignored)
         touch(".gitattributes");
         touch("README.md");

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -715,10 +715,8 @@ pub(crate) fn self_host_base_url(
 /// Scan `model_dir` for files to advertise alongside the typed MDC slots.
 /// Skips weights, dotfiles / README (`is_ignored`), already-typed
 /// filenames, and anything that isn't a regular file. Non-recursive.
-/// Results are sorted by filename so the resulting `mdcsum` is stable
-/// across filesystems that return `read_dir` entries in different
-/// orders. Returns an empty vec when `model_dir` doesn't exist (e.g.
-/// name-only `LocalModel` placeholders).
+/// Returns an empty vec when `model_dir` doesn't exist (e.g. name-only
+/// `LocalModel` placeholders).
 fn harvest_extra_files(
     model_dir: &Path,
     typed_filenames: &HashSet<String>,
@@ -749,7 +747,6 @@ fn harvest_extra_files(
         }
         out.push(CheckedFile::from_disk(&path)?);
     }
-    out.sort_by(|a, b| a.path().cmp(&b.path()));
     Ok(out)
 }
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -317,13 +317,8 @@ fn symlink_force(target: &Path, link: &Path) -> anyhow::Result<()> {
 /// the fallback when `size` is absent on a `CheckedFile`.
 const ABSOLUTE_MAX_METADATA_BYTES: u64 = 1024 * 1024 * 1024;
 
-/// File extensions that identify model weights. Used by both gh-8749
-/// harvest paths — the frontend hf:// sibling harvest below and the
-/// worker self-host harvest in `local_model::move_to_self_host`. Wider
-/// than mx's `HuggingFaceProvider::is_weight_file` so a stray `.pt` /
-/// `.gguf` / `.onnx` weight doesn't ride the metadata HTTP path.
-///
-/// `.safetensors.index.json` is correctly kept: extension is `.json`.
+/// File extensions that identify model weights. Callers: the frontend
+/// hf:// sibling harvest below and `local_model::harvest_extra_files`.
 pub(crate) fn is_weight_file(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|e| e.to_str()),
@@ -732,11 +727,8 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub router_config: Option<RouterConfig>,
 
-    /// Non-typed sibling files the worker found next to the typed slots
-    /// (`preprocessor_config.json`, `special_tokens_map.json`, etc.).
-    /// Populated by the worker for self-host; ride the same
-    /// resolve-and-cache pipeline as typed slots so external preprocessors
-    /// see a complete `slug_dir`.
+    /// Sibling files (e.g. `preprocessor_config.json`) the worker
+    /// advertises alongside the typed slots.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_files: Vec<CheckedFile>,
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -846,6 +846,22 @@ impl ModelDeploymentCard {
                     bytes_to_hash.extend(gen_config.checksum().as_bytes());
                 }
 
+                // extra_files: hash each file's checksum in sorted order
+                // so two workers harvesting the same siblings produce
+                // identical mdcsums regardless of filesystem read_dir
+                // order. Without this, different siblings would collide
+                // under the same mdcsum and the frontend cache would
+                // serve stale metadata.
+                let mut extra_hashes: Vec<&str> = self
+                    .extra_files
+                    .iter()
+                    .map(|cf| cf.checksum().hash())
+                    .collect();
+                extra_hashes.sort_unstable();
+                for h in &extra_hashes {
+                    bytes_to_hash.extend(h.as_bytes());
+                }
+
                 if let Some(prompt_context_vec) = self.prompt_context.as_ref() {
                     // Paste it as the bytes of the debug format. It's a Vec of enum, so this should be
                     // fine. If the debug representation changes that only happens in a new release.

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -731,6 +731,14 @@ pub struct ModelDeploymentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub router_config: Option<RouterConfig>,
 
+    /// Non-typed sibling files the worker found next to the typed slots
+    /// (`preprocessor_config.json`, `special_tokens_map.json`, etc.).
+    /// Populated by the worker for self-host; ride the same
+    /// resolve-and-cache pipeline as typed slots so external preprocessors
+    /// see a complete `slug_dir`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_files: Vec<CheckedFile>,
+
     #[serde(skip, default)]
     checksum: OnceLock<String>,
 }
@@ -980,18 +988,12 @@ impl ModelDeploymentCard {
 
     /// Iterate populated metadata slots in deterministic order:
     /// model_info, tokenizer, prompt_formatter, chat_template_file,
-    /// gen_config. Each entry is `(file, is_custom)` — `is_custom` is
-    /// only ever true for operator-supplied chat templates, which
-    /// can't fall back to HF.
-    ///
-    /// TODO(gh-8749): external preprocessors (vllm/sglang) read
-    /// `from_pretrained(slug_dir)` and may expect siblings outside the
-    /// typed slots — `preprocessor_config.json`, `special_tokens_map.json`,
-    /// `added_tokens.json`, etc. Add an `extra_files: Vec<CheckedFile>`
-    /// MDC field so the worker can advertise everything in its model dir
-    /// minus weights. Frontend pipeline is already generic over slot count.
+    /// gen_config, then any `extra_files` siblings the worker harvested
+    /// (preprocessor_config.json, special_tokens_map.json, etc.). Each entry
+    /// is `(file, is_custom)` — `is_custom` is only ever true for
+    /// operator-supplied chat templates, which can't fall back to HF.
     pub fn iter_metadata_files(&self) -> Vec<(&CheckedFile, bool)> {
-        let mut out: Vec<(&CheckedFile, bool)> = Vec::with_capacity(5);
+        let mut out: Vec<(&CheckedFile, bool)> = Vec::with_capacity(5 + self.extra_files.len());
         if let Some(ModelInfoType::HfConfigJson(cf)) = self.model_info.as_ref() {
             out.push((cf, false));
         }
@@ -1009,12 +1011,15 @@ impl ModelDeploymentCard {
         if let Some(GenerationConfig::HfGenerationConfigJson(cf)) = self.gen_config.as_ref() {
             out.push((cf, false));
         }
+        for cf in &self.extra_files {
+            out.push((cf, false));
+        }
         out
     }
 
     /// Mutable mirror of [`Self::iter_metadata_files`].
     pub fn iter_metadata_files_mut(&mut self) -> Vec<(&mut CheckedFile, bool)> {
-        let mut out: Vec<(&mut CheckedFile, bool)> = Vec::with_capacity(5);
+        let mut out: Vec<(&mut CheckedFile, bool)> = Vec::with_capacity(5 + self.extra_files.len());
         if let Some(ModelInfoType::HfConfigJson(cf)) = self.model_info.as_mut() {
             out.push((cf, false));
         }
@@ -1032,6 +1037,9 @@ impl ModelDeploymentCard {
             out.push((pf_checked_file_mut(c), is_custom));
         }
         if let Some(GenerationConfig::HfGenerationConfigJson(cf)) = self.gen_config.as_mut() {
+            out.push((cf, false));
+        }
+        for cf in &mut self.extra_files {
             out.push((cf, false));
         }
         out
@@ -1317,6 +1325,7 @@ impl ModelDeploymentCard {
             media_decoder: None,
             media_fetcher: None,
             router_config: None,
+            extra_files: Vec::new(),
             checksum: OnceLock::new(),
         })
     }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -755,6 +755,11 @@ pub struct LoraInfo {
 }
 
 impl ModelDeploymentCard {
+    /// Number of typed metadata slots (`model_info`, `tokenizer`,
+    /// `prompt_formatter`, `chat_template_file`, `gen_config`). Used as
+    /// a capacity hint for [`Self::iter_metadata_files`].
+    const TYPED_SLOT_COUNT: usize = 5;
+
     pub fn builder() -> ModelDeploymentCardBuilder {
         ModelDeploymentCardBuilder::default()
     }
@@ -993,7 +998,8 @@ impl ModelDeploymentCard {
     /// is `(file, is_custom)` — `is_custom` is only ever true for
     /// operator-supplied chat templates, which can't fall back to HF.
     pub fn iter_metadata_files(&self) -> Vec<(&CheckedFile, bool)> {
-        let mut out: Vec<(&CheckedFile, bool)> = Vec::with_capacity(5 + self.extra_files.len());
+        let mut out: Vec<(&CheckedFile, bool)> =
+            Vec::with_capacity(Self::TYPED_SLOT_COUNT + self.extra_files.len());
         if let Some(ModelInfoType::HfConfigJson(cf)) = self.model_info.as_ref() {
             out.push((cf, false));
         }
@@ -1019,7 +1025,8 @@ impl ModelDeploymentCard {
 
     /// Mutable mirror of [`Self::iter_metadata_files`].
     pub fn iter_metadata_files_mut(&mut self) -> Vec<(&mut CheckedFile, bool)> {
-        let mut out: Vec<(&mut CheckedFile, bool)> = Vec::with_capacity(5 + self.extra_files.len());
+        let mut out: Vec<(&mut CheckedFile, bool)> =
+            Vec::with_capacity(Self::TYPED_SLOT_COUNT + self.extra_files.len());
         if let Some(ModelInfoType::HfConfigJson(cf)) = self.model_info.as_mut() {
             out.push((cf, false));
         }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -846,17 +846,20 @@ impl ModelDeploymentCard {
                     bytes_to_hash.extend(gen_config.checksum().as_bytes());
                 }
 
-                // extra_files: hash sorted checksums so two workers with
-                // identical siblings produce the same mdcsum regardless
-                // of `read_dir` order. Without this, the frontend cache
-                // could serve stale metadata.
-                let mut extra_hashes: Vec<&str> = self
+                // extra_files: hash sorted (basename, checksum) pairs so
+                // (a) workers with identical siblings produce the same
+                // mdcsum regardless of `read_dir` order, and (b) the same
+                // bytes under different filenames don't collide — otherwise
+                // the frontend cache could serve a slug_dir missing siblings.
+                let mut extras: Vec<(&str, &str)> = self
                     .extra_files
                     .iter()
-                    .map(|cf| cf.checksum().hash())
+                    .map(|cf| (cf.basename().unwrap_or(""), cf.checksum().hash()))
                     .collect();
-                extra_hashes.sort_unstable();
-                for h in &extra_hashes {
+                extras.sort_unstable();
+                for (name, h) in &extras {
+                    bytes_to_hash.extend(name.as_bytes());
+                    bytes_to_hash.push(0);
                     bytes_to_hash.extend(h.as_bytes());
                 }
 
@@ -2020,6 +2023,36 @@ mod tests {
             "size": 1u64,
         }))
         .unwrap()
+    }
+
+    /// Two MDCs with `extra_files` that share bytes but differ in basename
+    /// must produce distinct mdcsums — otherwise the frontend cache would
+    /// alias them and a slug_dir built from one worker's harvest would be
+    /// reused for another worker that needs a differently-named sibling.
+    #[test]
+    fn mdcsum_extras_distinguish_basename_at_equal_checksum() {
+        let src =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/sample-models/TinyLlama_v1.1");
+        let mut a = super::ModelDeploymentCard::load_from_disk(&src, None).unwrap();
+        let mut b = super::ModelDeploymentCard::load_from_disk(&src, None).unwrap();
+        a.extra_files.push(cf_for("/m/preprocessor_config.json"));
+        b.extra_files.push(cf_for("/m/image_processor_config.json"));
+        assert_ne!(a.mdcsum(), b.mdcsum());
+    }
+
+    /// Read-order independence: extras pushed in different order must
+    /// hash the same (sort_unstable on (basename, checksum) pairs).
+    #[test]
+    fn mdcsum_extras_stable_across_read_order() {
+        let src =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/sample-models/TinyLlama_v1.1");
+        let mut a = super::ModelDeploymentCard::load_from_disk(&src, None).unwrap();
+        let mut b = super::ModelDeploymentCard::load_from_disk(&src, None).unwrap();
+        let cf1 = cf_for("/m/a.json");
+        let cf2 = cf_for("/m/b.json");
+        a.extra_files.extend([cf1.clone(), cf2.clone()]);
+        b.extra_files.extend([cf2, cf1]);
+        assert_eq!(a.mdcsum(), b.mdcsum());
     }
 
     #[test]

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -317,13 +317,14 @@ fn symlink_force(target: &Path, link: &Path) -> anyhow::Result<()> {
 /// the fallback when `size` is absent on a `CheckedFile`.
 const ABSOLUTE_MAX_METADATA_BYTES: u64 = 1024 * 1024 * 1024;
 
-/// File extensions that identify model weights. Used by the hf:// sibling
-/// harvest to skip weight blobs (which `hub::from_hf(_, ignore_weights=true)`
-/// also already filters at download, but the snapshot dir may contain
-/// pre-existing weights from a prior unrestricted pull).
+/// File extensions that identify model weights. Used by both gh-8749
+/// harvest paths — the frontend hf:// sibling harvest below and the
+/// worker self-host harvest in `local_model::move_to_self_host`. Wider
+/// than mx's `HuggingFaceProvider::is_weight_file` so a stray `.pt` /
+/// `.gguf` / `.onnx` weight doesn't ride the metadata HTTP path.
 ///
 /// `.safetensors.index.json` is correctly kept: extension is `.json`.
-fn is_weight_file(path: &Path) -> bool {
+pub(crate) fn is_weight_file(path: &Path) -> bool {
     matches!(
         path.extension().and_then(|e| e.to_str()),
         Some("safetensors" | "bin" | "gguf" | "onnx" | "tflite" | "h5" | "pt" | "pth" | "msgpack")

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -846,12 +846,10 @@ impl ModelDeploymentCard {
                     bytes_to_hash.extend(gen_config.checksum().as_bytes());
                 }
 
-                // extra_files: hash each file's checksum in sorted order
-                // so two workers harvesting the same siblings produce
-                // identical mdcsums regardless of filesystem read_dir
-                // order. Without this, different siblings would collide
-                // under the same mdcsum and the frontend cache would
-                // serve stale metadata.
+                // extra_files: hash sorted checksums so two workers with
+                // identical siblings produce the same mdcsum regardless
+                // of `read_dir` order. Without this, the frontend cache
+                // could serve stale metadata.
                 let mut extra_hashes: Vec<&str> = self
                     .extra_files
                     .iter()

--- a/tests/frontend/test_self_host_metadata.py
+++ b/tests/frontend/test_self_host_metadata.py
@@ -92,8 +92,21 @@ def test_worker_serves_metadata_via_http(
         )
         assert miss.status_code == 404, miss.text
 
+        # extra_files harvest: a non-typed sibling that exists in the
+        # Qwen3 HF snapshot (`vocab.json`) must also be served. Doubles
+        # as a symlink-follow check — HF snapshot entries are symlinks
+        # into `blobs/`, so a non-following stat would miss this file.
+        extra_url = (
+            f"http://localhost:{system_port}/v1/metadata/{slug}/{suffix}/vocab.json"
+        )
+        extra_response = requests.get(extra_url, timeout=10)
+        assert (
+            extra_response.status_code == 200
+        ), f"GET {extra_url} returned {extra_response.status_code}: harvest did not advertise vocab.json"
+        assert extra_response.content, "vocab.json served but body was empty"
+
         logger.info(
-            "self-host metadata verified: %s/%s/config.json served from worker on port %d",
+            "self-host metadata verified: %s/%s/{config,vocab}.json served from worker on port %d",
             slug,
             suffix,
             system_port,


### PR DESCRIPTION
#### Overview

Worker side of the multimodal-completeness gap left after #9610 (frontend HF-sibling harvest). When `self_host_metadata` is enabled, the worker now advertises non-weight, non-typed, non-ignored sibling files (`preprocessor_config.json`, `special_tokens_map.json`, `added_tokens.json`, …) via a new `ModelDeploymentCard.extra_files` field. Frontend's existing `resolve_metadata_files` pipeline is generic over slot count, so these resolve, verify-and-cache, and symlink into `slug_dir` exactly like the typed slots.

#### Why now

#9610 covers HF-backed models by harvesting siblings from `hf_snapshots` at the frontend. For custom/private worker dirs without an HF source, the only way to surface those files is for the worker to advertise them. This closes the last hole before flipping `DYN_SELF_HOST_METADATA` default ON.

#### Details

- `ModelDeploymentCard.extra_files: Vec<CheckedFile>` — `#[serde(default, skip_serializing_if = "Vec::is_empty")]`, so wire-format roundtrip with older peers is invisible.
- `iter_metadata_files{,_mut}` now yield `extra_files` after typed slots; downstream resolve / verify / cache loops pick them up with zero changes.
- Harvest helper in `local_model.rs` is non-recursive (no surprise walks into nested checkpoints). "Is this junk?" delegates to `modelexpress_common::providers::HuggingFaceProvider::is_ignored` so the dotfile/README deny-list lives in one place. "Is this a weight?" uses `model_card::is_weight_file` — wider than mx's list (covers `.pt` / `.gguf` / `.onnx` / `.tflite` / `.h5` / `.pth` / `.msgpack` in addition to `.safetensors` / `.bin`) so a stray weight can't ride the metadata HTTP path. `.safetensors.index.json` is correctly kept (extension is `.json`).
- Called from `move_to_self_host` *before* the existing http-rewrite loop, so harvested files get the same `/v1/metadata/{slug}/{suffix}/{filename}` rewrite + registry registration as typed slots.

#### Test

One pure unit test on the harvest helper: tmpdir with one typed file, one weight, one dotfile, one README, two genuine extras, one subdir — asserts only the two extras land. Wire-format back-compat is statically guaranteed by `#[serde(default)]` (no separate roundtrip test needed).

#### Out of scope

- `DYN_SELF_HOST_METADATA` default flip — still gated on auto-cleanup-on-detach landing (PR4 capstone).
- Recursive harvest — current scan is the model dir only.
- Per-file size caps for extras — not added; size is captured at `CheckedFile::from_disk` time but no upper bound enforced. Frontend's existing resolve-side caps still apply.

#### Related

- gh-8749 — self-hosted metadata stack
- #9610 — frontend HF-sibling harvest (covers the HF-backed path; this PR covers the custom-worker path)
- #8855, #9057 — earlier merges in the same stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Self-hosting now automatically discovers and manages additional metadata files (such as preprocessor configs and special token mappings) alongside core model components, ensuring complete model configurations are properly cached and deployed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
