### PR TITLE
fix(vllm): preserve user-provided --runner flag (rebased #7680)

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -237,7 +237,7 @@ def update_engine_config_with_dynamo(
     if _uses_nixl_connector(engine_config):
         ensure_side_channel_host()
 
-    defaults = {
+    defaults: Dict[str, Any] = {
         # As of vLLM >=0.10.0 the engine unconditionally calls
         # `sampling_params.update_from_tokenizer(...)`, so we can no longer
         # skip tokenizer initialisation.  Setting this to **False** avoids

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -238,8 +238,6 @@ def update_engine_config_with_dynamo(
         ensure_side_channel_host()
 
     defaults = {
-        # vLLM 0.13+ renamed 'task' to 'runner'
-        "runner": "generate",
         # As of vLLM >=0.10.0 the engine unconditionally calls
         # `sampling_params.update_from_tokenizer(...)`, so we can no longer
         # skip tokenizer initialisation.  Setting this to **False** avoids
@@ -248,6 +246,16 @@ def update_engine_config_with_dynamo(
         "enable_log_requests": False,
         "disable_log_stats": False,
     }
+
+    # vLLM 0.13+ renamed 'task' to 'runner'.  Only default to "generate"
+    # when the user did NOT explicitly set --runner (vLLM's default is "auto").
+    # This preserves user-provided values like --runner pooling for embedding
+    # models.
+    if hasattr(engine_config, "runner"):
+        if engine_config.runner == "auto":
+            defaults["runner"] = "generate"
+        else:
+            logger.debug(f"Preserving user-provided runner: {engine_config.runner}")
 
     kv_cfg = create_kv_events_config(dynamo_config, engine_config)
     defaults["kv_events_config"] = kv_cfg

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -247,15 +247,14 @@ def update_engine_config_with_dynamo(
         "disable_log_stats": False,
     }
 
-    # vLLM 0.13+ renamed 'task' to 'runner'.  Only default to "generate"
-    # when the user did NOT explicitly set --runner (vLLM's default is "auto").
-    # This preserves user-provided values like --runner pooling for embedding
-    # models.
+    # vLLM 0.13+ renamed 'task' to 'runner'.  Dynamo intentionally does NOT
+    # override the user-supplied (or vLLM-default) runner: vLLM's "auto" mode
+    # detects generation vs pooling vs draft from the model config, and the
+    # previous unconditional `runner = "generate"` override broke embedding /
+    # pooling models that need `--runner pooling` and would also clobber a
+    # user-explicit `--runner auto`.
     if hasattr(engine_config, "runner"):
-        if engine_config.runner == "auto":
-            defaults["runner"] = "generate"
-        else:
-            logger.debug(f"Preserving user-provided runner: {engine_config.runner}")
+        logger.debug(f"Using runner={engine_config.runner} from engine args")
 
     kv_cfg = create_kv_events_config(dynamo_config, engine_config)
     defaults["kv_events_config"] = kv_cfg

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -247,12 +247,6 @@ def update_engine_config_with_dynamo(
         "disable_log_stats": False,
     }
 
-    # vLLM 0.13+ renamed 'task' to 'runner'.  Dynamo intentionally does NOT
-    # override the user-supplied (or vLLM-default) runner: vLLM's "auto" mode
-    # detects generation vs pooling vs draft from the model config, and the
-    # previous unconditional `runner = "generate"` override broke embedding /
-    # pooling models that need `--runner pooling` and would also clobber a
-    # user-explicit `--runner auto`.
     if hasattr(engine_config, "runner"):
         logger.debug(f"Using runner={engine_config.runner} from engine args")
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -22,6 +22,7 @@ from dynamo.vllm.args import (
     ensure_side_channel_host,
     get_host_ip,
     parse_args,
+    update_engine_config_with_dynamo,
 )
 from dynamo.vllm.constants import DisaggregationMode
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
@@ -738,3 +739,86 @@ def test_build_sampling_params_maps_max_thinking_tokens():
     }
     sp = build_sampling_params(request, default_sampling_params={})
     assert sp.thinking_token_budget == 1024
+
+
+# --- update_engine_config_with_dynamo: --runner preservation tests ---
+
+
+def _make_dynamo_config(**overrides):
+    """Build a minimal fake DynamoConfig for update_engine_config_with_dynamo tests."""
+    defaults = {
+        "disaggregation_mode": DisaggregationMode.AGGREGATED,
+        "use_kv_events": False,
+        "enable_local_indexer": True,
+        "benchmark_mode": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_engine_config_with_runner(runner="auto", **overrides):
+    """Build a fake engine config with runner and other fields used by defaults loop."""
+    defaults = {
+        "runner": runner,
+        "enable_prefix_caching": True,
+        "block_size": 16,
+        "skip_tokenizer_init": True,
+        "enable_log_requests": True,
+        "disable_log_stats": True,
+        "kv_events_config": None,
+        "kv_transfer_config": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestRunnerPreservation:
+    """Tests for GitHub issue #7670: --runner must not be unconditionally overridden."""
+
+    def test_runner_defaults_to_generate_when_auto(self):
+        """When user does not pass --runner (vLLM default is 'auto'),
+        Dynamo should set it to 'generate'."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="auto")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "generate"
+
+    def test_runner_pooling_preserved(self):
+        """When user passes --runner pooling (for embedding models),
+        Dynamo must NOT overwrite it."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="pooling")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "pooling"
+
+    def test_runner_generate_explicit_preserved(self):
+        """When user explicitly passes --runner generate, it should still be 'generate'."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="generate")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "generate"
+
+    def test_runner_draft_preserved(self):
+        """When user passes --runner draft, Dynamo must NOT overwrite it."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner(runner="draft")
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.runner == "draft"
+
+    def test_no_runner_attr_skipped_gracefully(self):
+        """If engine_config lacks a 'runner' attr (older vLLM), no error is raised."""
+        dynamo_cfg = _make_dynamo_config()
+        engine_cfg = _make_engine_config_with_runner()
+        del engine_cfg.runner  # simulate older vLLM without runner
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert not hasattr(engine_cfg, "runner")

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -772,15 +772,15 @@ def _make_engine_config_with_runner(runner="auto", **overrides):
 class TestRunnerPreservation:
     """update_engine_config_with_dynamo must not overwrite a user-set --runner."""
 
-    def test_runner_defaults_to_generate_when_auto(self):
-        """When user does not pass --runner (vLLM default is 'auto'),
-        Dynamo should set it to 'generate'."""
+    def test_runner_auto_is_preserved(self):
+        """When user passes --runner auto (also the vLLM default),
+        Dynamo must leave it alone so vLLM's own auto-detection runs."""
         dynamo_cfg = _make_dynamo_config()
         engine_cfg = _make_engine_config_with_runner(runner="auto")
 
         update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
 
-        assert engine_cfg.runner == "generate"
+        assert engine_cfg.runner == "auto"
 
     def test_runner_pooling_preserved(self):
         """When user passes --runner pooling (for embedding models),

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -741,9 +741,6 @@ def test_build_sampling_params_maps_max_thinking_tokens():
     assert sp.thinking_token_budget == 1024
 
 
-# --- update_engine_config_with_dynamo: --runner preservation tests ---
-
-
 def _make_dynamo_config(**overrides):
     """Build a minimal fake DynamoConfig for update_engine_config_with_dynamo tests."""
     defaults = {
@@ -773,7 +770,7 @@ def _make_engine_config_with_runner(runner="auto", **overrides):
 
 
 class TestRunnerPreservation:
-    """Tests for GitHub issue #7670: --runner must not be unconditionally overridden."""
+    """update_engine_config_with_dynamo must not overwrite a user-set --runner."""
 
     def test_runner_defaults_to_generate_when_auto(self):
         """When user does not pass --runner (vLLM default is 'auto'),


### PR DESCRIPTION
#### Overview:

Rebased, CI-passing successor to #7680 by @pecord-ent. The original PR had a `black` formatting failure that prevented merge; the bug it fixes (#7670) is **still present on main** despite #7670 being marked as closed via a commit (`7856cb2`) that turned out to live on a branch which is 1 ahead, 853 behind main — never landed.

#### Details:

`update_engine_config_with_dynamo()` in `components/src/dynamo/vllm/args.py` placed `"runner": "generate"` in the unconditional `defaults` dict and the subsequent `setattr` loop applied it without checking whether the user had set `--runner` explicitly. Embedding/pooling models that need `--runner pooling` (e.g. `google/embeddinggemma-300m`, `Qwen/Qwen3-Embedding-0.6B`) crashed at startup with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  Value error, This model does not support `--runner generate`.
```

#### Why remove the override entirely (rather than guard it)

An earlier iteration of this PR kept the override but guarded it with `engine_config.runner == "auto"` — only defaulting to `"generate"` when the user hadn't passed anything. Review feedback from @dynamo-ops and @nnshah1 pointed out that this still silently rewrote an *explicit* `--runner auto` to `generate`, making vLLM's actual auto-detection unreachable through Dynamo, and asked whether Dynamo needs to set the default at all.

It doesn't. The Dynamo-forced default predates a working `--runner auto`. Today vLLM's `auto` correctly detects the runner from the model's `config.json` architectures (`*ForCausalLM`/`*LMHeadModel` → `generate`, `*Model`/`*ForSequenceClassification`/`*EmbeddingModel` → `pooling`, etc.) and falls back to suffix matching otherwise. Three cases now work correctly:

- **Generation models** without `--runner` → vLLM sees `auto`, resolves to `generate`. Same behavior as before for callers who relied on the implicit default.
- **Embedding models that auto-detect** → vLLM sees `auto`, resolves to `pooling`. New, correct behavior — was previously impossible to reach through Dynamo.
- **Embedding models with shared architecture** (e.g. an embedding head on a `*ForCausalLM` base) → user passes `--runner pooling` explicitly; Dynamo now preserves it (the original #7670 bug).

After this PR, `update_engine_config_with_dynamo` no longer touches the `runner` field at all — just logs it.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/args.py:240-256` — `runner` removed from the unconditional `defaults` dict; the conditional block is gone.
- `components/src/dynamo/vllm/tests/test_vllm_unit.py::TestRunnerPreservation` — five cases:
  - `test_runner_auto_is_preserved` — explicit auto stays auto (vLLM autodetects).
  - `test_runner_pooling_preserved` — embedding model case from #7670.
  - `test_runner_generate_explicit_preserved` — explicit generate still works.
  - `test_runner_draft_preserved` — draft preserved.
  - `test_no_runner_attr_skipped_gracefully` — older vLLM compat.

Original author @pecord-ent is credited via `Co-authored-by:` trailer.

Fixes #7670
Refs DYN-3048 / DIS-2091
Supersedes #7680
