### PR TITLE
feat: Add structural tag generation for tool calls

### DIFF
--- a/components/src/dynamo/common/backend/tests/test_backend_bindings.py
+++ b/components/src/dynamo/common/backend/tests/test_backend_bindings.py
@@ -145,6 +145,9 @@ def test_python_worker_config_from_runtime_config_copies_parser_settings():
     runtime_cfg.dyn_reasoning_parser = "kimi_k25"
     runtime_cfg.exclude_tools_when_tool_choice_none = False
     runtime_cfg.enable_local_indexer = False
+    runtime_cfg.dyn_enable_structural_tag = True
+    runtime_cfg.dyn_structural_tag_scope = "always"
+    runtime_cfg.dyn_structural_tag_schema = "strict"
     # MagicMock auto-attrs would be rejected as a foreign type by the
     # strict coercer; pin them to None.
     runtime_cfg.disaggregation_mode = None
@@ -156,6 +159,9 @@ def test_python_worker_config_from_runtime_config_copies_parser_settings():
     assert config.reasoning_parser == "kimi_k25"
     assert config.exclude_tools_when_tool_choice_none is False
     assert config.enable_local_indexer is False
+    assert config.structural_tag_mode == "on"
+    assert config.structural_tag_scope == "always"
+    assert config.structural_tag_schema == "strict"
 
 
 @pytest.mark.unified
@@ -175,6 +181,9 @@ def test_python_worker_config_from_runtime_config_applies_defaults_when_fields_a
     assert cfg.endpoint_types == "chat,completions"
     assert cfg.use_kv_events is False
     assert cfg.custom_jinja_template is None
+    assert cfg.structural_tag_mode == "off"
+    assert cfg.structural_tag_scope == "auto"
+    assert cfg.structural_tag_schema == "auto"
 
 
 @pytest.mark.unified

--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -104,6 +104,9 @@ class WorkerConfig:
     # Operator override; when set, the Rust Worker uses this instead of
     # `engine.health_check_payload()`. Populated by `from_runtime_config`.
     health_check_payload: Optional[dict] = None
+    structural_tag_mode: str = "off"
+    structural_tag_scope: str = "auto"
+    structural_tag_schema: str = "auto"
 
     @classmethod
     def from_runtime_config(
@@ -142,6 +145,17 @@ class WorkerConfig:
             ),
             "enable_local_indexer": getattr(runtime_cfg, "enable_local_indexer", True),
             "enable_kv_routing": getattr(runtime_cfg, "enable_kv_routing", True),
+            "structural_tag_mode": (
+                "on"
+                if getattr(runtime_cfg, "dyn_enable_structural_tag", False)
+                else "off"
+            ),
+            "structural_tag_scope": getattr(
+                runtime_cfg, "dyn_structural_tag_scope", "auto"
+            ),
+            "structural_tag_schema": getattr(
+                runtime_cfg, "dyn_structural_tag_schema", "auto"
+            ),
         }
         # vLLM/TRT-LLM expose `disaggregation_mode`; SGLang exposes
         # `serving_mode`. Skip the probe when an override is supplied so
@@ -212,6 +226,9 @@ class Worker:
                 self.config.disaggregation_mode
             ),
             health_check_payload=self.config.health_check_payload,
+            structural_tag_mode=self.config.structural_tag_mode,
+            structural_tag_scope=self.config.structural_tag_scope,
+            structural_tag_schema=self.config.structural_tag_schema,
             runtime=runtime_cfg,
         )
 

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -29,6 +29,9 @@ class DynamoRuntimeConfig(ConfigBase):
     dyn_tool_call_parser: Optional[str] = None
     dyn_reasoning_parser: Optional[str] = None
     exclude_tools_when_tool_choice_none: bool = True
+    dyn_enable_structural_tag: bool = False
+    dyn_structural_tag_scope: str = "auto"
+    dyn_structural_tag_schema: str = "auto"
     custom_jinja_template: Optional[str] = None
     endpoint_types: str
     dump_config_to: Optional[str] = None
@@ -160,6 +163,36 @@ class DynamoRuntimeArgGroup(ArgGroup):
             default=True,
             help="Exclude tool definitions from the chat template when tool_choice='none'. "
             "Prevents models from generating raw XML tool calls in the content field.",
+        )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--dyn-enable-structural-tag",
+            env_var="DYN_ENABLE_STRUCTURAL_TAG",
+            default=False,
+            help="Enable structural tag guided decoding for tool calls.",
+        )
+        add_argument(
+            g,
+            flag_name="--dyn-structural-tag-scope",
+            env_var="DYN_STRUCTURAL_TAG_SCOPE",
+            default="auto",
+            choices=["auto", "always"],
+            help="Controls when structural tags are activated. "
+            "'auto': for required/named tool_choice, and if any tool has strict=true "
+            "or parallel_tool_calls is false. "
+            "'always': also for auto without those conditions. "
+            "tool_choice none is unaffected by auto vs always.",
+        )
+        add_argument(
+            g,
+            flag_name="--dyn-structural-tag-schema",
+            env_var="DYN_STRUCTURAL_TAG_SCHEMA",
+            default="auto",
+            choices=["auto", "strict"],
+            help="Controls parameter schema strictness inside structural tags. "
+            "'auto': real schema only for tools with strict=true; "
+            "syntactically constrained but schema-unconstrained for all other tools. "
+            "'strict': real parameter schema for all tools.",
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/utils/structural_tag.py
+++ b/components/src/dynamo/common/utils/structural_tag.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from typing import Any
+
+
+def serialize_structural_tag(structural_tag: Any) -> str | None:
+    """Return structural tag as the JSON string expected by backends."""
+    if structural_tag is None:
+        return None
+    if hasattr(structural_tag, "model_dump"):
+        structural_tag = structural_tag.model_dump()
+    return (
+        structural_tag
+        if isinstance(structural_tag, str)
+        else json.dumps(structural_tag)
+    )

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -43,6 +43,7 @@ from dynamo.common.backend.publisher import ComponentSnapshot, KvEventSource, Zm
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.input_params import InputParamManager
+from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import ModelInput
 from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang._disagg import (
@@ -717,9 +718,7 @@ class SglangLLMEngine(LLMEngine):
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:
-                if hasattr(structural_tag, "model_dump"):
-                    structural_tag = structural_tag.model_dump()
-                return {"structural_tag": json.dumps(structural_tag)}
+                return {"structural_tag": serialize_structural_tag(structural_tag)}
         return {}
 
     def _get_input_param(self, request: GenerateRequest) -> dict:

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -266,6 +266,11 @@ async def _get_runtime_config(
     runtime_config.exclude_tools_when_tool_choice_none = (
         dynamo_args.exclude_tools_when_tool_choice_none
     )
+    runtime_config.set_structural_tag_mode(
+        "on" if dynamo_args.dyn_enable_structural_tag else "off"
+    )
+    runtime_config.set_structural_tag_scope(dynamo_args.dyn_structural_tag_scope)
+    runtime_config.set_structural_tag_schema(dynamo_args.dyn_structural_tag_schema)
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     is_decode_worker = server_args.disaggregation_mode == "decode"
     runtime_config.enable_local_indexer = (

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -30,6 +30,7 @@ from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.input_params import InputParamManager
+from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
     KvEventPublisher,
     ModelInput,
@@ -1081,9 +1082,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:
-                if hasattr(structural_tag, "model_dump"):
-                    structural_tag = structural_tag.model_dump()
-                return {"structural_tag": json.dumps(structural_tag)}
+                return {"structural_tag": serialize_structural_tag(structural_tag)}
         return {}
 
     @staticmethod

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -21,6 +21,7 @@ from dynamo.common.backend.engine import (
 )
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.utils.engine_response import normalize_finish_reason
+from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import ModelInput
 from dynamo.llm.exceptions import InvalidArgument
 from dynamo.tokenspeed.args import parse_args
@@ -292,13 +293,7 @@ def _guided_decoding_params(guided_decoding: dict[str, Any]) -> dict[str, Any]:
         params["ebnf"] = grammar
 
     if structural_tag is not None:
-        if hasattr(structural_tag, "model_dump"):
-            structural_tag = structural_tag.model_dump()
-        params["structural_tag"] = (
-            structural_tag
-            if isinstance(structural_tag, str)
-            else json.dumps(structural_tag)
-        )
+        params["structural_tag"] = serialize_structural_tag(structural_tag)
 
     return params
 

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -49,6 +49,7 @@ from dynamo.common.backend.metrics import register_global_registry
 from dynamo.common.backend.publisher import ComponentSnapshot, KvEventSource, PushSource
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import KvEventPublisher, ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
@@ -879,7 +880,9 @@ class TrtllmLLMEngine(LLMEngine):
                 regex=regex,
                 grammar=guided_decoding.get("grammar"),
                 json_object=guided_decoding.get("json_object", False),
-                structural_tag=guided_decoding.get("structural_tag"),
+                structural_tag=serialize_structural_tag(
+                    guided_decoding.get("structural_tag")
+                ),
             )
 
         n = overrides.get("n")

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -34,6 +34,7 @@ from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
 
 from dynamo._core import Client, Context
+from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.logits_processing.examples import HelloWorldLogitsProcessor
@@ -1349,7 +1350,9 @@ class HandlerBase(BaseGenerativeHandler):
                 regex=regex,
                 grammar=guided_decoding.get("grammar"),
                 json_object=guided_decoding.get("json_object", False),
-                structural_tag=guided_decoding.get("structural_tag"),
+                structural_tag=serialize_structural_tag(
+                    guided_decoding.get("structural_tag")
+                ),
             )
 
         n = overrides.get("n")

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -499,6 +499,11 @@ async def init_llm_worker(
         runtime_config.exclude_tools_when_tool_choice_none = (
             config.exclude_tools_when_tool_choice_none
         )
+        runtime_config.set_structural_tag_mode(
+            "on" if config.dyn_enable_structural_tag else "off"
+        )
+        runtime_config.set_structural_tag_scope(config.dyn_structural_tag_scope)
+        runtime_config.set_structural_tag_schema(config.dyn_structural_tag_schema)
         # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
         runtime_config.enable_local_indexer = (
             config.enable_local_indexer

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -52,6 +52,7 @@ from dynamo.common.multimodal.video_loader import VideoLoader
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.common.utils.input_params import InputParamManager
+from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
 from dynamo.llm import (
     KvEventPublisher,
@@ -352,6 +353,9 @@ def build_sampling_params(
             choice=guided_decoding.get("choice"),
             grammar=guided_decoding.get("grammar"),
             whitespace_pattern=guided_decoding.get("whitespace_pattern"),
+            structural_tag=serialize_structural_tag(
+                guided_decoding.get("structural_tag")
+            ),
         )
 
     # Apply remaining sampling_options

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -656,6 +656,11 @@ async def register_vllm_model(
     runtime_config.exclude_tools_when_tool_choice_none = (
         config.exclude_tools_when_tool_choice_none
     )
+    runtime_config.set_structural_tag_mode(
+        "on" if config.dyn_enable_structural_tag else "off"
+    )
+    runtime_config.set_structural_tag_scope(config.dyn_structural_tag_scope)
+    runtime_config.set_structural_tag_schema(config.dyn_structural_tag_schema)
 
     # Propagate stream_interval so the frontend can respect --stream-interval.
     # set_engine_specific requires a JSON-encoded string (the Rust binding

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -45,6 +45,10 @@ request and share the response. See
 [Troubleshooting Tool Calls](troubleshooting.md) for what to capture and
 include when reporting an issue.
 
+## Optional: structural tags
+
+You can optionally turn on **xgrammar structural tags** so guided decoding matches the parser's tool-call format at token granularity. See [Structural tag (guided decoding for tool calls)](structural-tag.md).
+
 ## See Also
 
 - [Troubleshooting Tool Calls](troubleshooting.md) -- capture raw model
@@ -54,3 +58,5 @@ include when reporting an issue.
   tool-call parser and a reasoning parser configured together.
 - [Frontend Configuration Reference](../components/frontend/configuration.md) --
   full CLI flag reference.
+- [Structural tag (guided decoding)](structural-tag.md) — optional xgrammar
+  constraints aligned with Dynamo tool-call parsers.

--- a/docs/tool-calling/structural-tag.md
+++ b/docs/tool-calling/structural-tag.md
@@ -88,11 +88,6 @@ based on the request's `tool_choice`:
 | `auto` | Always |
 | `none` | Exclusion tag only |
 
-## Reasoning Models
-
-For reasoning models, `required` and `named` tool-choice requests
-currently do not allow preliminary reasoning before the tool call. Disable
-reasoning at request time for these requests.
 
 ## Schema Modes
 

--- a/docs/tool-calling/structural-tag.md
+++ b/docs/tool-calling/structural-tag.md
@@ -88,6 +88,12 @@ based on the request's `tool_choice`:
 | `auto` | Always |
 | `none` | Exclusion tag only |
 
+## Reasoning Models
+
+For reasoning models, `required` and `named` tool-choice requests
+currently do not allow preliminary reasoning before the tool call. Disable
+reasoning at request time for these requests.
+
 ## Schema Modes
 
 The `--dyn-structural-tag-schema` flag controls what JSON schema is used for

--- a/docs/tool-calling/structural-tag.md
+++ b/docs/tool-calling/structural-tag.md
@@ -1,0 +1,154 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Structural Tag (Guided Decoding for Tool Calls)
+subtitle: Constrain model output to valid tool call format using xgrammar structural tags
+---
+
+Structural tags use [xgrammar](https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html)
+guided decoding to constrain model output to a valid tool call format at the
+token level. Instead of hoping the model produces well-formed tool calls,
+structural tags enforce the expected format by restricting the decoding
+vocabulary at each generation step.
+
+Benefits:
+
+- **Format guarantee** — model output always matches the parser's expected
+  tool call syntax (begin/end tags, parameter structure).
+- **Schema enforcement** — tool arguments can be constrained to the function's
+  JSON schema.
+- **Single-call enforcement** — `parallel_tool_calls=false` is enforced via
+  `stop_after_first` in the grammar, not just by convention.
+- **Tool call ban** — when `tool_choice="none"`, specific tokenizer tokens can be
+  banned so the model cannot start native tool-call syntax (see
+  [trade-offs](#tool_choicenone-and-token-banning)).
+
+## Prerequisites
+
+- A backend engine with xgrammar support.
+- A Dynamo tool call parser that provides a structural tag config (see
+  [Supported Parsers](#supported-parsers) below).
+
+## Quick Start
+
+```bash
+# Launch backend with structural tag enabled
+python -m dynamo.sglang \
+  --model Qwen/Qwen3.5-4B \
+  --dyn-tool-call-parser qwen3_coder \
+  --dyn-enable-structural-tag
+
+# Launch frontend
+python -m dynamo.frontend
+```
+
+Eligible tool-calling requests will now use xgrammar structural tags for guided
+decoding. See [Activation Scope](#activation-scope) for the exact policy.
+
+## CLI Flags
+
+| Flag | Values | Default | Description |
+|---|---|---|---|
+| `--dyn-enable-structural-tag` | bool | `false` | Master switch. When disabled, tool calling works the same as without structural tags. |
+| `--dyn-structural-tag-scope` | `auto`, `always` | `auto` | Controls when structural tags are activated (see [Activation Scope](#activation-scope)). |
+| `--dyn-structural-tag-schema` | `auto`, `strict` | `auto` | Controls parameter schema strictness inside structural tags (see [Schema Modes](#schema-modes)). |
+
+## Supported Parsers
+
+Not all parsers support structural tags. Parsers without a structural tag
+config fall back to standard behaviour (a warning is logged if structural
+tags are enabled but the parser does not support them).
+
+Currently tested and supported:
+
+- `qwen3_coder`, `nemotron_nano`
+- `hermes`, `qwen25`
+- `deepseek_v3_2`, `deepseek_v4`
+
+Contributions adding structural tag support for new parsers are welcome.
+
+## Activation Scope
+
+The `--dyn-structural-tag-scope` flag controls when structural tags are used
+based on the request's `tool_choice`:
+
+### `auto` (default)
+
+| `tool_choice` | Structural tag? |
+|---|---|
+| `required` / `named` | Always |
+| `auto` | Only when any tool has `strict: true` or `parallel_tool_calls` is `false` |
+| `none` | Exclusion tag only (bans tool call tokens, see [below](#tool_choicenone-and-token-banning)) |
+
+### `always`
+
+| `tool_choice` | Structural tag? |
+|---|---|
+| `required` / `named` | Always |
+| `auto` | Always |
+| `none` | Exclusion tag only |
+
+## Schema Modes
+
+The `--dyn-structural-tag-schema` flag controls what JSON schema is used for
+tool arguments inside the structural tag:
+
+### `auto` (default)
+
+- Tools with `strict: true` — their actual parameter schema is used.
+- Tools without `strict` — an unconstrained schema is used, allowing
+  the model to generate any valid content in the parser's native format.
+
+### `strict`
+
+- All tools use their actual parameter schema regardless of the `strict`
+  flag.
+
+## `tool_choice="none"` and Token Banning
+
+When `tool_choice="none"` and structural tags are enabled, Dynamo injects an
+exclusion structural tag that bans parser-specific tool-call start tokens (for
+example `<tool_call>`) so the model cannot start native tool-call syntax.
+
+**Quality trade-off**. If tools remain in the prompt on `none` (often via
+`--no-exclude-tools-when-tool-choice-none` to keep the chat prefix stable for KV
+reuse) while bans block tool-call tokens, the model still sees tools but cannot
+complete valid tool-call text.
+
+Answers may suffer: awkward phrasing, tool-like fragments, or other artifacts.
+
+You choose between a stable shared prefix with KV reuse versus omitting tools from the prompt on `none` (default), which usually yields cleaner chat output but changes the prefix and weakens KV reuse when `tool_choice` varies. How much this matters depends on the model and workload.
+
+This interacts with the `--exclude-tools-when-tool-choice-none` flag (default:
+`true`), which strips tool definitions from the chat template when
+`tool_choice="none"`:
+
+| `exclude-tools-when-tool-choice-none` | Structural tag | Effect |
+|---|---|---|
+| `true` (default) | off | Tools removed from prompt. Model doesn't know about tools. Prompt changes break KV cache prefix sharing. |
+| `true` | on | Tools removed from prompt; tokens also banned. Prompt changes break KV cache prefix sharing. |
+| `false` | on | Tools stay in prompt; guided decoding bans tokens. Model sees tools but cannot emit banned openings. Stable KV cache prefix across different `tool_choice` values. |
+| `false` | off | Tools stay in prompt; no token ban. Same response shaping as above: no structured `tool_calls` for explicit `none`. Tool-like text may still appear in `content`. |
+
+For multi-turn conversations where `tool_choice` changes between turns,
+consider `--no-exclude-tools-when-tool-choice-none` combined with
+`--dyn-enable-structural-tag` to keep the prompt stable and benefit from
+KV cache reuse.
+
+## Example
+
+```bash
+# Launch with structural tag, strict schema, always scope
+python -m dynamo.sglang \
+  --model Qwen/Qwen3.5-4B \
+  --dyn-tool-call-parser qwen3_coder \
+  --dyn-enable-structural-tag \
+  --dyn-structural-tag-scope always \
+  --dyn-structural-tag-schema strict
+```
+
+## See Also
+
+- [Tool Call Parsing (Dynamo)](dynamo.md) — parser names and basic tool calling setup
+- [Tool Call Parsing (Engine Fallback)](engine-fallback.md) — upstream engine parsers
+- [xgrammar Structural Tag Documentation](https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html) — xgrammar format specification

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -14,7 +14,10 @@ use std::time::Duration;
 
 use dynamo_llm::local_model::LocalModel;
 use dynamo_llm::local_model::LocalModelBuilder;
-use dynamo_llm::local_model::runtime_config::{DisaggregatedEndpoint, ModelRuntimeConfig};
+use dynamo_llm::local_model::runtime_config::{
+    DisaggregatedEndpoint, ModelRuntimeConfig, StructuralTagMode, StructuralTagSchemaMode,
+    StructuralTagScope,
+};
 use dynamo_llm::model_type::{ModelInput, ModelType};
 use dynamo_llm::worker_type::WorkerType;
 use dynamo_runtime::pipeline::network::Ingress;
@@ -143,6 +146,12 @@ pub struct WorkerConfig {
     /// Python sets this via `--health-check-payload` / env; Rust-only
     /// engines leave it `None` and let `Worker` read the env directly.
     pub health_check_payload: Option<serde_json::Value>,
+    /// Structural tag guided decoding mode.
+    pub structural_tag_mode: StructuralTagMode,
+    /// Structural tag activation scope.
+    pub structural_tag_scope: StructuralTagScope,
+    /// Structural tag schema strictness.
+    pub structural_tag_schema: StructuralTagSchemaMode,
     /// Runtime / transport overrides applied via env vars before the
     /// `DistributedRuntime` is constructed.
     pub runtime: RuntimeConfig,
@@ -176,6 +185,9 @@ impl Default for WorkerConfig {
             metrics_labels: Vec::new(),
             disaggregation_mode: DisaggregationMode::Aggregated,
             health_check_payload: None,
+            structural_tag_mode: StructuralTagMode::Off,
+            structural_tag_scope: StructuralTagScope::Auto,
+            structural_tag_schema: StructuralTagSchemaMode::Auto,
             runtime: RuntimeConfig::default(),
         }
     }
@@ -993,6 +1005,9 @@ async fn build_local_model(
         tool_call_parser: config.tool_call_parser.clone(),
         reasoning_parser: config.reasoning_parser.clone(),
         exclude_tools_when_tool_choice_none: config.exclude_tools_when_tool_choice_none,
+        structural_tag_mode: config.structural_tag_mode,
+        structural_tag_scope: config.structural_tag_scope,
+        structural_tag_schema: config.structural_tag_schema,
         enable_local_indexer,
         disaggregated_endpoint,
         runtime_data: engine_config.runtime_data.clone(),

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -25,6 +25,10 @@ use dynamo_backend_common::{
     MetricsCtx, OnPublisherReady, PreprocessedRequest, RuntimeConfig as RsRuntimeConfig,
     SnapshotPublisher as RsSnapshotPublisher, Worker as RsWorker, WorkerConfig as RsWorkerConfig,
 };
+use dynamo_llm::local_model::runtime_config::{
+    StructuralTagMode as RsStructuralTagMode, StructuralTagSchemaMode as RsStructuralTagSchemaMode,
+    StructuralTagScope as RsStructuralTagScope,
+};
 use dynamo_llm::model_type::ModelInput as RsModelInput;
 use dynamo_runtime as rs;
 use dynamo_runtime::logging::{DistributedTraceContext, get_distributed_tracing_context};
@@ -274,6 +278,9 @@ impl WorkerConfig {
         runtime = None,
         disaggregation_mode = DisaggregationMode::Aggregated,
         health_check_payload = None,
+        structural_tag_mode = "off".to_string(),
+        structural_tag_scope = "auto".to_string(),
+        structural_tag_schema = "auto".to_string(),
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -295,6 +302,9 @@ impl WorkerConfig {
         runtime: Option<RuntimeConfig>,
         disaggregation_mode: DisaggregationMode,
         health_check_payload: Option<PyObject>,
+        structural_tag_mode: String,
+        structural_tag_scope: String,
+        structural_tag_schema: String,
     ) -> PyResult<Self> {
         // Delegating to the same conversion used by `register_model`.
         let model_input_rs = match model_input {
@@ -322,6 +332,33 @@ impl WorkerConfig {
             }
             _ => None,
         };
+        let st_mode = match structural_tag_mode.as_str() {
+            "off" => RsStructuralTagMode::Off,
+            "on" => RsStructuralTagMode::On,
+            other => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid structural_tag_mode: {other}. Expected 'off' or 'on'."
+                )));
+            }
+        };
+        let st_scope = match structural_tag_scope.as_str() {
+            "auto" => RsStructuralTagScope::Auto,
+            "always" => RsStructuralTagScope::Always,
+            other => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid structural_tag_scope: {other}. Expected 'auto' or 'always'."
+                )));
+            }
+        };
+        let st_schema = match structural_tag_schema.as_str() {
+            "auto" => RsStructuralTagSchemaMode::Auto,
+            "strict" => RsStructuralTagSchemaMode::Strict,
+            other => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid structural_tag_schema: {other}. Expected 'auto' or 'strict'."
+                )));
+            }
+        };
         Ok(Self {
             inner: RsWorkerConfig {
                 namespace,
@@ -340,6 +377,9 @@ impl WorkerConfig {
                 metrics_labels,
                 disaggregation_mode: disaggregation_mode.into(),
                 health_check_payload,
+                structural_tag_mode: st_mode,
+                structural_tag_scope: st_scope,
+                structural_tag_schema: st_schema,
                 runtime: runtime.map(|r| r.inner).unwrap_or_default(),
             },
         })

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -10,8 +10,8 @@ use dynamo_kv_router::protocols::{
 use llm_rs::local_model::runtime_config::DisaggregatedEndpoint as RsDisaggregatedEndpoint;
 use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeConfig;
 use llm_rs::local_model::runtime_config::StructuralTagMode as RsStructuralTagMode;
-use llm_rs::local_model::runtime_config::StructuralTagScope as RsStructuralTagScope;
 use llm_rs::local_model::runtime_config::StructuralTagSchemaMode as RsStructuralTagSchemaMode;
+use llm_rs::local_model::runtime_config::StructuralTagScope as RsStructuralTagScope;
 use pyo3::exceptions::PyValueError;
 
 fn validate_model_runtime_config(config: &RsModelRuntimeConfig) -> PyResult<()> {
@@ -235,7 +235,7 @@ impl ModelRuntimeConfig {
             _ => {
                 return Err(PyErr::new::<PyException, _>(format!(
                     "Invalid structural_tag_mode: {mode}. Expected 'off' or 'on'."
-                )))
+                )));
             }
         };
         Ok(())
@@ -249,7 +249,7 @@ impl ModelRuntimeConfig {
             _ => {
                 return Err(PyErr::new::<PyException, _>(format!(
                     "Invalid structural_tag_scope: {scope}. Expected 'auto' or 'always'."
-                )))
+                )));
             }
         };
         Ok(())
@@ -263,7 +263,7 @@ impl ModelRuntimeConfig {
             _ => {
                 return Err(PyErr::new::<PyException, _>(format!(
                     "Invalid structural_tag_schema: {schema}. Expected 'auto' or 'strict'."
-                )))
+                )));
             }
         };
         Ok(())

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -228,6 +228,7 @@ impl ModelRuntimeConfig {
         self.inner.get_engine_specific(key).map_err(to_pyerr)
     }
 
+    #[setter]
     fn set_structural_tag_mode(&mut self, mode: &str) -> PyResult<()> {
         self.inner.structural_tag_mode = match mode {
             "off" => RsStructuralTagMode::Off,
@@ -242,6 +243,7 @@ impl ModelRuntimeConfig {
     }
 
     /// Set the structural tag scope ("auto" or "always").
+    #[setter]
     fn set_structural_tag_scope(&mut self, scope: &str) -> PyResult<()> {
         self.inner.structural_tag_scope = match scope {
             "auto" => RsStructuralTagScope::Auto,
@@ -256,6 +258,7 @@ impl ModelRuntimeConfig {
     }
 
     /// Set the structural tag schema mode ("auto" or "strict").
+    #[setter]
     fn set_structural_tag_schema(&mut self, schema: &str) -> PyResult<()> {
         self.inner.structural_tag_schema = match schema {
             "auto" => RsStructuralTagSchemaMode::Auto,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -228,7 +228,6 @@ impl ModelRuntimeConfig {
         self.inner.get_engine_specific(key).map_err(to_pyerr)
     }
 
-    #[setter]
     fn set_structural_tag_mode(&mut self, mode: &str) -> PyResult<()> {
         self.inner.structural_tag_mode = match mode {
             "off" => RsStructuralTagMode::Off,
@@ -243,7 +242,6 @@ impl ModelRuntimeConfig {
     }
 
     /// Set the structural tag scope ("auto" or "always").
-    #[setter]
     fn set_structural_tag_scope(&mut self, scope: &str) -> PyResult<()> {
         self.inner.structural_tag_scope = match scope {
             "auto" => RsStructuralTagScope::Auto,
@@ -258,7 +256,6 @@ impl ModelRuntimeConfig {
     }
 
     /// Set the structural tag schema mode ("auto" or "strict").
-    #[setter]
     fn set_structural_tag_schema(&mut self, schema: &str) -> PyResult<()> {
         self.inner.structural_tag_schema = match schema {
             "auto" => RsStructuralTagSchemaMode::Auto,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -9,6 +9,9 @@ use dynamo_kv_router::protocols::{
 };
 use llm_rs::local_model::runtime_config::DisaggregatedEndpoint as RsDisaggregatedEndpoint;
 use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeConfig;
+use llm_rs::local_model::runtime_config::StructuralTagMode as RsStructuralTagMode;
+use llm_rs::local_model::runtime_config::StructuralTagScope as RsStructuralTagScope;
+use llm_rs::local_model::runtime_config::StructuralTagSchemaMode as RsStructuralTagSchemaMode;
 use pyo3::exceptions::PyValueError;
 
 fn validate_model_runtime_config(config: &RsModelRuntimeConfig) -> PyResult<()> {
@@ -223,6 +226,47 @@ impl ModelRuntimeConfig {
 
     fn get_engine_specific(&self, key: &str) -> PyResult<Option<String>> {
         self.inner.get_engine_specific(key).map_err(to_pyerr)
+    }
+
+    fn set_structural_tag_mode(&mut self, mode: &str) -> PyResult<()> {
+        self.inner.structural_tag_mode = match mode {
+            "off" => RsStructuralTagMode::Off,
+            "on" => RsStructuralTagMode::On,
+            _ => {
+                return Err(PyErr::new::<PyException, _>(format!(
+                    "Invalid structural_tag_mode: {mode}. Expected 'off' or 'on'."
+                )))
+            }
+        };
+        Ok(())
+    }
+
+    /// Set the structural tag scope ("auto" or "always").
+    fn set_structural_tag_scope(&mut self, scope: &str) -> PyResult<()> {
+        self.inner.structural_tag_scope = match scope {
+            "auto" => RsStructuralTagScope::Auto,
+            "always" => RsStructuralTagScope::Always,
+            _ => {
+                return Err(PyErr::new::<PyException, _>(format!(
+                    "Invalid structural_tag_scope: {scope}. Expected 'auto' or 'always'."
+                )))
+            }
+        };
+        Ok(())
+    }
+
+    /// Set the structural tag schema mode ("auto" or "strict").
+    fn set_structural_tag_schema(&mut self, schema: &str) -> PyResult<()> {
+        self.inner.structural_tag_schema = match schema {
+            "auto" => RsStructuralTagSchemaMode::Auto,
+            "strict" => RsStructuralTagSchemaMode::Strict,
+            _ => {
+                return Err(PyErr::new::<PyException, _>(format!(
+                    "Invalid structural_tag_schema: {schema}. Expected 'auto' or 'strict'."
+                )))
+            }
+        };
+        Ok(())
     }
 
     #[pyo3(signature = (bootstrap_host=None, bootstrap_port=None))]

--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -273,7 +273,11 @@ fn parse_tools_json(tools_json: Option<&str>) -> PyResult<Option<Vec<ToolDefinit
             })?
             .to_string();
         let parameters = inner.get("parameters").cloned();
-        defs.push(ToolDefinition { name, parameters, strict: None });
+        defs.push(ToolDefinition {
+            name,
+            parameters,
+            strict: None,
+        });
     }
     Ok(Some(defs))
 }

--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -273,7 +273,7 @@ fn parse_tools_json(tools_json: Option<&str>) -> PyResult<Option<Vec<ToolDefinit
             })?
             .to_string();
         let parameters = inner.get("parameters").cloned();
-        defs.push(ToolDefinition { name, parameters });
+        defs.push(ToolDefinition { name, parameters, strict: None });
     }
     Ok(Some(defs))
 }

--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -160,6 +160,7 @@ async fn parse_response_stream(
         tool_parser,
         None,
         tool_definitions,
+        false,
         stream,
     ));
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -669,6 +669,18 @@ class ModelRuntimeConfig:
         """Get an engine-specific runtime configuration value"""
         ...
 
+    def set_structural_tag_mode(self, mode: str) -> None:
+        """Set structural tag mode ("off" or "on")."""
+        ...
+
+    def set_structural_tag_scope(self, scope: str) -> None:
+        """Set structural tag scope ("auto" or "always")."""
+        ...
+
+    def set_structural_tag_schema(self, schema: str) -> None:
+        """Set structural tag schema mode ("auto" or "strict")."""
+        ...
+
     def set_disaggregated_endpoint(
             self,
             bootstrap_host: str | None = None,
@@ -2698,6 +2710,9 @@ class backend:
             runtime: Optional["backend.RuntimeConfig"] = None,
             disaggregation_mode: "backend.DisaggregationMode" = ...,
             health_check_payload: Optional[Dict[str, Any]] = None,
+            structural_tag_mode: str = ...,
+            structural_tag_scope: str = ...,
+            structural_tag_schema: str = ...,
         ) -> None: ...
 
     class Worker:

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -12,6 +12,10 @@ use validator::{Validate, ValidationError};
 use crate::protocols::tensor;
 use dynamo_kv_router::protocols::KvTransferEnforcement;
 
+/// Re-export from parsers crate so that `ModelRuntimeConfig` can use it
+/// directly without type duplication.
+pub use dynamo_parsers::tool_calling::StructuralTagSchemaMode;
+
 // Reserve a topology namespace so generated taints can be rebuilt without touching caller taints.
 pub const TOPOLOGY_TAINT_PREFIX: &str = "dynamo.topology/";
 
@@ -21,6 +25,24 @@ pub const TOPOLOGY_TAINT_PREFIX: &str = "dynamo.topology/";
 /// `dynamo.topology/zone=us-east-1a`.
 pub fn topology_taint(domain: &str, value: &str) -> String {
     format!("{TOPOLOGY_TAINT_PREFIX}{domain}={value}")
+}
+
+/// Master switch for structural tag guided decoding.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuralTagMode {
+    #[default]
+    Off,
+    On,
+}
+
+/// Controls when structural tags are activated based on `tool_choice`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuralTagScope {
+    #[default]
+    Auto,
+    Always,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -44,6 +66,18 @@ pub struct ModelRuntimeConfig {
     pub tool_call_parser: Option<String>,
 
     pub reasoning_parser: Option<String>,
+
+    /// Whether structural tag guided decoding is enabled for tool calls.
+    #[serde(default)]
+    pub structural_tag_mode: StructuralTagMode,
+
+    /// Controls when structural tags are activated based on tool_choice.
+    #[serde(default)]
+    pub structural_tag_scope: StructuralTagScope,
+
+    /// Controls whether tools get real or generic schemas in structural tags.
+    #[serde(default)]
+    pub structural_tag_schema: StructuralTagSchemaMode,
 
     /// When true, strip tool definitions from the chat template when tool_choice is "none".
     #[serde(default = "default_exclude_tools_when_tool_choice_none")]
@@ -151,6 +185,9 @@ impl Default for ModelRuntimeConfig {
             max_num_batched_tokens: None,
             tool_call_parser: None,
             reasoning_parser: None,
+            structural_tag_mode: StructuralTagMode::Off,
+            structural_tag_scope: StructuralTagScope::Auto,
+            structural_tag_schema: StructuralTagSchemaMode::Auto,
             exclude_tools_when_tool_choice_none: default_exclude_tools_when_tool_choice_none(),
             data_parallel_start_rank: default_data_parallel_start_rank(),
             data_parallel_size: default_data_parallel_size(),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -16,6 +16,7 @@ pub mod lightseek_mm;
 pub mod media;
 pub mod prompt;
 pub mod speculative_prefill;
+mod structural_tag;
 pub mod tools;
 use anyhow::Context;
 use anyhow::{Result, bail};
@@ -73,6 +74,7 @@ use crate::protocols::{
 use crate::tokenizers::traits::Tokenizer;
 
 use crate::preprocessor::prompt::{PromptFormatter, PromptInput, TextInput, TokenInput};
+use crate::preprocessor::structural_tag::StructuralTagApplyResult;
 
 pub use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
 pub use crate::protocols::common::preprocessor::PreprocessedEmbeddingRequest;
@@ -1664,6 +1666,7 @@ impl OpenAIPreprocessor {
         stream: S,
         request: &NvCreateChatCompletionRequest,
         prompt_injected_reasoning: bool,
+        uses_tool_call_structural_tag: bool,
     ) -> anyhow::Result<
         impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     >
@@ -1769,6 +1772,7 @@ impl OpenAIPreprocessor {
                 self.tool_call_parser.clone(),
                 request.inner.tool_choice.clone(),
                 tool_definitions,
+                uses_tool_call_structural_tag,
                 stream,
             ))
         } else {
@@ -2121,6 +2125,7 @@ impl OpenAIPreprocessor {
         tool_call_parser: Option<String>,
         tool_choice: Option<dynamo_protocols::types::ChatCompletionToolChoiceOption>,
         tool_definitions: Option<Vec<dynamo_parsers::tool_calling::ToolDefinition>>,
+        uses_tool_call_structural_tag: bool,
         stream: S,
     ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
     where
@@ -2137,37 +2142,46 @@ impl OpenAIPreprocessor {
             builder = builder.tool_definitions(tool_definitions);
         }
 
-        // Configure jail based on tool_choice
-        //
-        // For tool_choice=required or named we mirror SGLang / vLLM: assume the
-        // backend applied guided decoding and emit a bare JSON shape, so parse
-        // via the JSON array parser (base_json_parser) rather than the model's
-        // native-format parser.  If a parser is also configured we still carry
-        // it so the Immediate branch can fall back to marker-based parsing for
-        // backends that do not honor guided decoding (e.g. XML-native models
-        // like qwen3_coder — see regression test_tool_choice_required_with_
-        // qwen3_coder_parser).
-        match tool_choice {
-            Some(ChatCompletionToolChoiceOption::Named(named)) => {
-                builder = builder
-                    .tool_choice_named(named.function.name.clone())
-                    .named_tool_filter(named.function.name.clone());
-                if let Some(parser) = tool_call_parser {
-                    builder = builder.tool_call_parser(parser);
-                }
+        // When structural_tag is active, the model output is already constrained by
+        // guided decoding into a model-specific format. Always use the marker-based
+        // parser to extract tool calls from that format.
+        if uses_tool_call_structural_tag {
+            if let Some(parser) = tool_call_parser {
+                builder = builder.tool_call_parser(parser);
             }
-            Some(ChatCompletionToolChoiceOption::Required) => {
-                builder = builder.tool_choice_required();
-                if let Some(parser) = tool_call_parser {
-                    builder = builder.tool_call_parser(parser);
+        } else {
+            // Configure jail based on tool_choice
+            //
+            // For tool_choice=required or named we mirror SGLang / vLLM: assume the
+            // backend applied guided decoding and emit a bare JSON shape, so parse
+            // via the JSON array parser (base_json_parser) rather than the model's
+            // native-format parser.  If a parser is also configured we still carry
+            // it so the Immediate branch can fall back to marker-based parsing for
+            // backends that do not honor guided decoding (e.g. XML-native models
+            // like qwen3_coder — see regression test_tool_choice_required_with_
+            // qwen3_coder_parser).
+            match tool_choice {
+                Some(ChatCompletionToolChoiceOption::Named(named)) => {
+                    builder = builder
+                        .tool_choice_named(named.function.name.clone())
+                        .named_tool_filter(named.function.name.clone());
+                    if let Some(parser) = tool_call_parser {
+                        builder = builder.tool_call_parser(parser);
+                    }
                 }
-            }
-            Some(ChatCompletionToolChoiceOption::Auto)
-            | Some(ChatCompletionToolChoiceOption::None)
-            | None => {
-                // Traditional marker-based jail for auto/none/unspecified
-                if let Some(parser) = tool_call_parser {
-                    builder = builder.tool_call_parser(parser);
+                Some(ChatCompletionToolChoiceOption::Required) => {
+                    builder = builder.tool_choice_required();
+                    if let Some(parser) = tool_call_parser {
+                        builder = builder.tool_call_parser(parser);
+                    }
+                }
+                Some(ChatCompletionToolChoiceOption::Auto)
+                | Some(ChatCompletionToolChoiceOption::None)
+                | None => {
+                    // Traditional marker-based jail for auto/none/unspecified
+                    if let Some(parser) = tool_call_parser {
+                        builder = builder.tool_call_parser(parser);
+                    }
                 }
             }
         }
@@ -2569,6 +2583,12 @@ impl
         let (mut common_request, annotations, prompt_injected_reasoning) = self
             .preprocess_request_with_options(&request, tracker.as_deref(), preprocess_options)
             .await?;
+
+        let uses_tool_call_structural_tag = matches!(
+            self.try_apply_structural_tag(&request, &mut common_request)?,
+            StructuralTagApplyResult::ToolCallFormat
+        );
+
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
         let trace_state = crate::agents::trace::build_agent_trace_request_end_state(
             &common_request,
@@ -2612,8 +2632,12 @@ impl
             trace_tokens_enabled,
         );
 
-        let transformed_stream =
-            self.postprocessor_parsing_stream(stream, &request, prompt_injected_reasoning)?;
+        let transformed_stream = self.postprocessor_parsing_stream(
+            stream,
+            &request,
+            prompt_injected_reasoning,
+            uses_tool_call_structural_tag,
+        )?;
 
         // Apply audit aggregation strategy.
         // The audit branch already returns Pin<Box<...>> from scan/fold_aggregate_with_future,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2585,7 +2585,11 @@ impl
             .await?;
 
         let uses_tool_call_structural_tag = matches!(
-            self.try_apply_structural_tag(&request, &mut common_request)?,
+            self.try_apply_structural_tag(
+                &request,
+                &mut common_request,
+                prompt_injected_reasoning,
+            )?,
             StructuralTagApplyResult::ToolCallFormat
         );
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1761,6 +1761,7 @@ impl OpenAIPreprocessor {
                 .map(|tool| dynamo_parsers::tool_calling::ToolDefinition {
                     name: tool.function.name.clone(),
                     parameters: tool.function.parameters.clone(),
+                    strict: tool.function.strict,
                 })
                 .collect()
         });

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -17,6 +17,7 @@ pub mod media;
 pub mod prompt;
 pub mod speculative_prefill;
 mod structural_tag;
+mod tool_choice;
 pub mod tools;
 use anyhow::Context;
 use anyhow::{Result, bail};
@@ -74,8 +75,6 @@ use crate::protocols::{
 use crate::tokenizers::traits::Tokenizer;
 
 use crate::preprocessor::prompt::{PromptFormatter, PromptInput, TextInput, TokenInput};
-use crate::preprocessor::structural_tag::StructuralTagApplyResult;
-
 pub use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
 pub use crate::protocols::common::preprocessor::PreprocessedEmbeddingRequest;
 
@@ -2584,14 +2583,11 @@ impl
             .preprocess_request_with_options(&request, tracker.as_deref(), preprocess_options)
             .await?;
 
-        let uses_tool_call_structural_tag = matches!(
-            self.try_apply_structural_tag(
-                &request,
-                &mut common_request,
-                prompt_injected_reasoning,
-            )?,
-            StructuralTagApplyResult::ToolCallFormat
-        );
+        let uses_tool_call_structural_tag = self.apply_tool_choice_guided_decoding(
+            &request,
+            &mut common_request,
+            prompt_injected_reasoning,
+        )?;
 
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
         let trace_state = crate::agents::trace::build_agent_trace_request_end_state(

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -5,36 +5,22 @@
 
 use crate::local_model::runtime_config::{StructuralTagMode, StructuralTagScope};
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
-use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 
 use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
 use dynamo_runtime::error::{DynamoError, ErrorType};
 
-fn invalid_argument(message: impl Into<String>) -> DynamoError {
-    DynamoError::builder()
-        .error_type(ErrorType::InvalidArgument)
-        .message(message)
-        .build()
-}
-
-pub(super) enum StructuralTagApplyResult {
-    None,
-    /// Ban-only tag for `tool_choice=none`; no tool-call jail is needed.
-    ToolCallBan,
-    /// Tool-call format tag; the jail should parse the constrained output.
-    ToolCallFormat,
-}
-
 impl OpenAIPreprocessor {
     /// Apply structural tag guided decoding when enabled for this request.
-    pub(super) fn try_apply_structural_tag(
+    pub(super) fn apply_tool_choice_structural_tag(
         &self,
-        request: &NvCreateChatCompletionRequest,
-        common_request: &mut PreprocessedRequest,
+        tool_choice: &ChatCompletionToolChoiceOption,
+        tools: &[ChatCompletionTool],
+        parallel_tool_calls: Option<bool>,
         prompt_injected_reasoning: bool,
-    ) -> Result<StructuralTagApplyResult, DynamoError> {
+        preprocessed_request: &mut PreprocessedRequest,
+    ) -> Result<bool, DynamoError> {
         if self.runtime_config.structural_tag_mode == StructuralTagMode::Off {
-            return Ok(StructuralTagApplyResult::None);
+            return Ok(false);
         }
 
         let Some(parser_name) = self.tool_call_parser.as_deref() else {
@@ -42,75 +28,38 @@ impl OpenAIPreprocessor {
                 "Structural tag is enabled but --dyn-tool-call-parser is not set; \
                  structural tags will not be applied"
             );
-            return Ok(StructuralTagApplyResult::None);
+            return Ok(false);
         };
 
         let Some(builder) = Self::structural_tag_builder_for_parser(parser_name) else {
-            return Ok(StructuralTagApplyResult::None);
+            return Ok(false);
         };
 
-        let tool_choice = request
-            .inner
-            .tool_choice
-            .as_ref()
-            .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
-        let tools = request.inner.tools.as_deref().unwrap_or(&[]);
-
-        // Whether the request already carries an explicit guided-decoding constraint
-        let has_user_constraint = common_request
-            .sampling_options
-            .guided_decoding
-            .as_ref()
-            .is_some_and(|gd| gd.has_user_constraint());
-
-        match tool_choice {
-            ChatCompletionToolChoiceOption::None => {
-                // response_format already prevents tool-call generation, ban not needed.
-                if has_user_constraint || tools.is_empty() {
-                    return Ok(StructuralTagApplyResult::None);
-                }
-
-                let applied = Self::apply_tool_call_ban(builder, common_request)?;
-                return Ok(if applied {
-                    StructuralTagApplyResult::ToolCallBan
-                } else {
-                    StructuralTagApplyResult::None
-                });
+        if matches!(tool_choice, ChatCompletionToolChoiceOption::None) {
+            if tools.is_empty() {
+                return Ok(false);
             }
-            ChatCompletionToolChoiceOption::Auto => {
-                // User-provided response_format takes precedence over optional
-                // tool-call guidance; tool calls are not forced so no conflict.
-                if has_user_constraint {
-                    return Ok(StructuralTagApplyResult::None);
-                }
-            }
-            ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_) => {
-                Self::validate_tool_choice(tool_choice, tools, has_user_constraint)?;
-            }
+            return Self::apply_tool_call_ban(builder, preprocessed_request);
         }
 
         if !Self::should_apply_tool_call_format(
             self.runtime_config.structural_tag_scope,
             tool_choice,
             tools,
-            request.inner.parallel_tool_calls,
+            parallel_tool_calls,
         ) {
-            return Ok(StructuralTagApplyResult::None);
+            return Ok(false);
         }
 
         let ctx = dynamo_parsers::tool_calling::ToolCallFormatBuildContext {
             tool_choice,
             tools,
-            parallel_tool_calls: request.inner.parallel_tool_calls,
+            parallel_tool_calls,
             schema_mode: self.runtime_config.structural_tag_schema,
             starts_in_reasoning: prompt_injected_reasoning,
         };
 
-        if Self::apply_tool_call_format(parser_name, builder, &ctx, common_request)? {
-            Ok(StructuralTagApplyResult::ToolCallFormat)
-        } else {
-            Ok(StructuralTagApplyResult::None)
-        }
+        Self::apply_tool_call_format(parser_name, builder, &ctx, preprocessed_request)
     }
 
     /// Find the structural tag builder for a parser, if supported.
@@ -188,40 +137,6 @@ impl OpenAIPreprocessor {
             .get_or_insert_default();
         gd.structural_tag = Some(structural_tag);
         Ok(true)
-    }
-
-    /// Validate forced tool-choice requests.
-    fn validate_tool_choice(
-        tool_choice: &ChatCompletionToolChoiceOption,
-        tools: &[ChatCompletionTool],
-        has_user_constraint: bool,
-    ) -> Result<(), DynamoError> {
-        const RESPONSE_FORMAT_CONFLICT: &str = concat!(
-            "response_format cannot be used in the same request as ",
-            "tool_choice=\"required\" or a named tool_choice.",
-        );
-
-        match tool_choice {
-            ChatCompletionToolChoiceOption::Required if tools.is_empty() => Err(invalid_argument(
-                "tool_choice is \"required\" but tools is empty",
-            )),
-            ChatCompletionToolChoiceOption::Required if has_user_constraint => {
-                Err(invalid_argument(RESPONSE_FORMAT_CONFLICT))
-            }
-            ChatCompletionToolChoiceOption::Named(named) => {
-                if !tools.iter().any(|t| t.function.name == named.function.name) {
-                    return Err(invalid_argument(format!(
-                        "tool named \"{}\" in tool_choice is not present in tools",
-                        named.function.name
-                    )));
-                }
-                if has_user_constraint {
-                    return Err(invalid_argument(RESPONSE_FORMAT_CONFLICT));
-                }
-                Ok(())
-            }
-            _ => Ok(()),
-        }
     }
 
     /// Decide whether this request should use a tool-call format tag.

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -5,6 +5,7 @@
 
 use crate::local_model::runtime_config::{StructuralTagMode, StructuralTagScope};
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
+use crate::protocols::common::GuidedDecodingOptions;
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 
 use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
@@ -24,6 +25,7 @@ impl OpenAIPreprocessor {
         &self,
         request: &NvCreateChatCompletionRequest,
         common_request: &mut PreprocessedRequest,
+        prompt_injected_reasoning: bool,
     ) -> Result<StructuralTagApplyResult, DynamoError> {
         if self.runtime_config.structural_tag_mode == StructuralTagMode::Off {
             return Ok(StructuralTagApplyResult::None);
@@ -81,6 +83,7 @@ impl OpenAIPreprocessor {
             tools,
             parallel_tool_calls: request.inner.parallel_tool_calls,
             schema_mode: self.runtime_config.structural_tag_schema,
+            starts_in_reasoning: prompt_injected_reasoning,
         };
 
         if Self::apply_tool_call_format_structural_tag(parser_name, builder, &ctx, common_request)?
@@ -126,9 +129,7 @@ impl OpenAIPreprocessor {
                 .sampling_options
                 .guided_decoding
                 .get_or_insert_default();
-            // xgrammar accepts only one constraint at a time.
-            gd.json = None;
-            gd.structural_tag = Some(ban_tag);
+            Self::set_structural_tag_guidance(gd, ban_tag);
             Ok(true)
         } else {
             Ok(false)
@@ -166,10 +167,20 @@ impl OpenAIPreprocessor {
             .sampling_options
             .guided_decoding
             .get_or_insert_default();
-        // xgrammar accepts only one constraint at a time.
-        gd.json = None;
-        gd.structural_tag = Some(structural_tag);
+        Self::set_structural_tag_guidance(gd, structural_tag);
         Ok(true)
+    }
+
+    fn set_structural_tag_guidance(
+        gd: &mut GuidedDecodingOptions,
+        structural_tag: serde_json::Value,
+    ) {
+        gd.json = None;
+        gd.regex = None;
+        gd.choice = None;
+        gd.grammar = None;
+        gd.whitespace_pattern = None;
+        gd.structural_tag = Some(structural_tag);
     }
 
     /// Validate only structural-tag requests; other parser paths keep existing behavior.

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -6,15 +6,15 @@
 use crate::local_model::runtime_config::{StructuralTagMode, StructuralTagScope};
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
 
-use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
+use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
 use dynamo_runtime::error::{DynamoError, ErrorType};
 
 impl OpenAIPreprocessor {
     /// Apply structural tag guided decoding when enabled for this request.
     pub(super) fn apply_tool_choice_structural_tag(
         &self,
-        tool_choice: &ChatCompletionToolChoiceOption,
-        tools: &[ChatCompletionTool],
+        tool_choice: &ToolChoice,
+        tools: &[ToolDefinition],
         parallel_tool_calls: Option<bool>,
         prompt_injected_reasoning: bool,
         preprocessed_request: &mut PreprocessedRequest,
@@ -35,7 +35,7 @@ impl OpenAIPreprocessor {
             return Ok(false);
         };
 
-        if matches!(tool_choice, ChatCompletionToolChoiceOption::None) {
+        if matches!(tool_choice, ToolChoice::None) {
             if tools.is_empty() {
                 return Ok(false);
             }
@@ -142,20 +142,18 @@ impl OpenAIPreprocessor {
     /// Decide whether this request should use a tool-call format tag.
     fn should_apply_tool_call_format(
         scope: StructuralTagScope,
-        tool_choice: &ChatCompletionToolChoiceOption,
-        tools: &[ChatCompletionTool],
+        tool_choice: &ToolChoice,
+        tools: &[ToolDefinition],
         parallel_tool_calls: Option<bool>,
     ) -> bool {
         match tool_choice {
-            ChatCompletionToolChoiceOption::None => false,
-            ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_) => {
-                true
-            }
-            ChatCompletionToolChoiceOption::Auto => match scope {
+            ToolChoice::None => false,
+            ToolChoice::Required | ToolChoice::Named(_) => true,
+            ToolChoice::Auto => match scope {
                 StructuralTagScope::Always => true,
                 StructuralTagScope::Auto => {
                     let explicit_single_call = parallel_tool_calls == Some(false);
-                    tools.iter().any(|t| t.function.strict.unwrap_or(false)) || explicit_single_call
+                    tools.iter().any(|t| t.strict.unwrap_or(false)) || explicit_single_call
                 }
             },
         }

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural tag policy for chat tool-call guided decoding.
+
+use crate::local_model::runtime_config::{StructuralTagMode, StructuralTagScope};
+use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
+use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
+
+use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
+use dynamo_runtime::error::{DynamoError, ErrorType};
+
+pub(super) enum StructuralTagApplyResult {
+    None,
+    /// Ban-only tag for `tool_choice=none`; no tool-call jail is needed.
+    ToolCallBan,
+    /// Tool-call format tag; the jail should parse the constrained output.
+    ToolCallFormat,
+}
+
+impl OpenAIPreprocessor {
+    /// Apply structural tag guided decoding when enabled for this request.
+    pub(super) fn try_apply_structural_tag(
+        &self,
+        request: &NvCreateChatCompletionRequest,
+        common_request: &mut PreprocessedRequest,
+    ) -> Result<StructuralTagApplyResult, DynamoError> {
+        if self.runtime_config.structural_tag_mode == StructuralTagMode::Off {
+            return Ok(StructuralTagApplyResult::None);
+        }
+
+        let Some(parser_name) = self.tool_call_parser.as_deref() else {
+            tracing::warn!(
+                "Structural tag is enabled but --dyn-tool-call-parser is not set; \
+                 structural tags will not be applied"
+            );
+            return Ok(StructuralTagApplyResult::None);
+        };
+
+        let Some(builder) = Self::structural_tag_builder_for_parser(parser_name) else {
+            return Ok(StructuralTagApplyResult::None);
+        };
+
+        let tool_choice = request
+            .inner
+            .tool_choice
+            .as_ref()
+            .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
+
+        let tools = request.inner.tools.as_deref().unwrap_or(&[]);
+
+        Self::validate_structural_tag_tool_request(tool_choice, tools)?;
+
+        // `tool_choice=none` uses a ban tag instead of a tool-call format tag.
+        if *tool_choice == ChatCompletionToolChoiceOption::None {
+            let applied_ban = if tools.is_empty() {
+                false
+            } else {
+                Self::apply_tool_call_ban_structural_tag(builder, common_request)?
+            };
+
+            return Ok(if applied_ban {
+                StructuralTagApplyResult::ToolCallBan
+            } else {
+                StructuralTagApplyResult::None
+            });
+        }
+
+        // `auto` only activates under the configured scope policy.
+        if !Self::should_activate_structural_tag(
+            self.runtime_config.structural_tag_scope,
+            tool_choice,
+            tools,
+            request.inner.parallel_tool_calls,
+        ) {
+            return Ok(StructuralTagApplyResult::None);
+        }
+
+        let ctx = dynamo_parsers::tool_calling::ToolCallFormatBuildContext {
+            tool_choice,
+            tools,
+            parallel_tool_calls: request.inner.parallel_tool_calls,
+            schema_mode: self.runtime_config.structural_tag_schema,
+        };
+
+        if Self::apply_tool_call_format_structural_tag(parser_name, builder, &ctx, common_request)?
+        {
+            Ok(StructuralTagApplyResult::ToolCallFormat)
+        } else {
+            Ok(StructuralTagApplyResult::None)
+        }
+    }
+
+    /// Find the structural tag builder for a parser, if supported.
+    fn structural_tag_builder_for_parser(
+        parser_name: &str,
+    ) -> Option<&'static dynamo_parsers::tool_calling::StructuralTagBuilder> {
+        let parser_map = dynamo_parsers::tool_calling::parsers::get_tool_parser_map();
+        let builder = parser_map
+            .get(parser_name)
+            .and_then(|tc| tc.structural_tag_builder.as_ref());
+
+        if builder.is_none() {
+            tracing::warn!(
+                parser = parser_name,
+                "Structural tag enabled but parser does not support it; \
+                 falling back to default behaviour"
+            );
+        }
+
+        builder
+    }
+
+    /// Apply the `tool_choice=none` ban tag, if configured.
+    fn apply_tool_call_ban_structural_tag(
+        builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
+        common_request: &mut PreprocessedRequest,
+    ) -> Result<bool, DynamoError> {
+        if let Some(ban_tag) = builder.build_tool_call_ban().map_err(|e| {
+            DynamoError::builder()
+                .error_type(ErrorType::Unknown)
+                .message(format!("failed to build tool-call ban structural tag: {e}"))
+                .build()
+        })? {
+            let gd = common_request
+                .sampling_options
+                .guided_decoding
+                .get_or_insert_default();
+            gd.structural_tag = Some(ban_tag);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Build and inject the tool-call format tag, if one is needed.
+    fn apply_tool_call_format_structural_tag(
+        parser_name: &str,
+        builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
+        ctx: &dynamo_parsers::tool_calling::ToolCallFormatBuildContext<'_>,
+        common_request: &mut PreprocessedRequest,
+    ) -> Result<bool, DynamoError> {
+        let structural_tag = match builder.build_tool_call_format(ctx) {
+            Ok(Some(tag)) => tag,
+            Ok(None) => {
+                tracing::debug!(
+                    parser = parser_name,
+                    "Builder returned None for structural_tag (tool_choice={:?})",
+                    ctx.tool_choice,
+                );
+                return Ok(false);
+            }
+            Err(e) => {
+                return Err(DynamoError::builder()
+                    .error_type(ErrorType::Unknown)
+                    .message(format!(
+                        "failed to build structural_tag for parser '{parser_name}': {e}"
+                    ))
+                    .build());
+            }
+        };
+
+        let gd = common_request
+            .sampling_options
+            .guided_decoding
+            .get_or_insert_default();
+        // xgrammar accepts only one JSON-style constraint at a time.
+        gd.json = None;
+        gd.structural_tag = Some(structural_tag);
+        Ok(true)
+    }
+
+    /// Validate only structural-tag requests; other parser paths keep existing behavior.
+    fn validate_structural_tag_tool_request(
+        tool_choice: &ChatCompletionToolChoiceOption,
+        tools: &[ChatCompletionTool],
+    ) -> Result<(), DynamoError> {
+        match tool_choice {
+            ChatCompletionToolChoiceOption::Required if tools.is_empty() => {
+                Err(DynamoError::builder()
+                    .error_type(ErrorType::InvalidArgument)
+                    .message("tool_choice is \"required\" but tools is empty")
+                    .build())
+            }
+            ChatCompletionToolChoiceOption::Named(named) => {
+                if tools.iter().any(|t| t.function.name == named.function.name) {
+                    Ok(())
+                } else {
+                    Err(DynamoError::builder()
+                        .error_type(ErrorType::InvalidArgument)
+                        .message(format!(
+                            "tool named \"{}\" in tool_choice is not present in tools",
+                            named.function.name
+                        ))
+                        .build())
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Decide whether this request should use a tool-call format tag.
+    fn should_activate_structural_tag(
+        scope: StructuralTagScope,
+        tool_choice: &ChatCompletionToolChoiceOption,
+        tools: &[ChatCompletionTool],
+        parallel_tool_calls: Option<bool>,
+    ) -> bool {
+        match tool_choice {
+            ChatCompletionToolChoiceOption::None => false,
+            ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_) => {
+                true
+            }
+            ChatCompletionToolChoiceOption::Auto => match scope {
+                StructuralTagScope::Always => true,
+                StructuralTagScope::Auto => {
+                    let explicit_single_call = parallel_tool_calls == Some(false);
+                    tools.iter().any(|t| t.function.strict.unwrap_or(false)) || explicit_single_call
+                }
+            },
+        }
+    }
+}

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -5,11 +5,17 @@
 
 use crate::local_model::runtime_config::{StructuralTagMode, StructuralTagScope};
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
-use crate::protocols::common::GuidedDecodingOptions;
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 
 use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
 use dynamo_runtime::error::{DynamoError, ErrorType};
+
+fn invalid_argument(message: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(ErrorType::InvalidArgument)
+        .message(message)
+        .build()
+}
 
 pub(super) enum StructuralTagApplyResult {
     None,
@@ -48,28 +54,42 @@ impl OpenAIPreprocessor {
             .tool_choice
             .as_ref()
             .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
-
         let tools = request.inner.tools.as_deref().unwrap_or(&[]);
 
-        Self::validate_structural_tag_tool_request(tool_choice, tools)?;
+        // Whether the request already carries an explicit guided-decoding constraint
+        let has_user_constraint = common_request
+            .sampling_options
+            .guided_decoding
+            .as_ref()
+            .is_some_and(|gd| gd.has_user_constraint());
 
-        // `tool_choice=none` uses a ban tag instead of a tool-call format tag.
-        if *tool_choice == ChatCompletionToolChoiceOption::None {
-            let applied_ban = if tools.is_empty() {
-                false
-            } else {
-                Self::apply_tool_call_ban_structural_tag(builder, common_request)?
-            };
+        match tool_choice {
+            ChatCompletionToolChoiceOption::None => {
+                // response_format already prevents tool-call generation, ban not needed.
+                if has_user_constraint || tools.is_empty() {
+                    return Ok(StructuralTagApplyResult::None);
+                }
 
-            return Ok(if applied_ban {
-                StructuralTagApplyResult::ToolCallBan
-            } else {
-                StructuralTagApplyResult::None
-            });
+                let applied = Self::apply_tool_call_ban(builder, common_request)?;
+                return Ok(if applied {
+                    StructuralTagApplyResult::ToolCallBan
+                } else {
+                    StructuralTagApplyResult::None
+                });
+            }
+            ChatCompletionToolChoiceOption::Auto => {
+                // User-provided response_format takes precedence over optional
+                // tool-call guidance; tool calls are not forced so no conflict.
+                if has_user_constraint {
+                    return Ok(StructuralTagApplyResult::None);
+                }
+            }
+            ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_) => {
+                Self::validate_tool_choice(tool_choice, tools, has_user_constraint)?;
+            }
         }
 
-        // `auto` only activates under the configured scope policy.
-        if !Self::should_activate_structural_tag(
+        if !Self::should_apply_tool_call_format(
             self.runtime_config.structural_tag_scope,
             tool_choice,
             tools,
@@ -86,8 +106,7 @@ impl OpenAIPreprocessor {
             starts_in_reasoning: prompt_injected_reasoning,
         };
 
-        if Self::apply_tool_call_format_structural_tag(parser_name, builder, &ctx, common_request)?
-        {
+        if Self::apply_tool_call_format(parser_name, builder, &ctx, common_request)? {
             Ok(StructuralTagApplyResult::ToolCallFormat)
         } else {
             Ok(StructuralTagApplyResult::None)
@@ -115,7 +134,7 @@ impl OpenAIPreprocessor {
     }
 
     /// Apply the `tool_choice=none` ban tag, if configured.
-    fn apply_tool_call_ban_structural_tag(
+    fn apply_tool_call_ban(
         builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
         common_request: &mut PreprocessedRequest,
     ) -> Result<bool, DynamoError> {
@@ -129,7 +148,7 @@ impl OpenAIPreprocessor {
                 .sampling_options
                 .guided_decoding
                 .get_or_insert_default();
-            Self::set_structural_tag_guidance(gd, ban_tag);
+            gd.structural_tag = Some(ban_tag);
             Ok(true)
         } else {
             Ok(false)
@@ -137,7 +156,7 @@ impl OpenAIPreprocessor {
     }
 
     /// Build and inject the tool-call format tag, if one is needed.
-    fn apply_tool_call_format_structural_tag(
+    fn apply_tool_call_format(
         parser_name: &str,
         builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
         ctx: &dynamo_parsers::tool_calling::ToolCallFormatBuildContext<'_>,
@@ -167,53 +186,46 @@ impl OpenAIPreprocessor {
             .sampling_options
             .guided_decoding
             .get_or_insert_default();
-        Self::set_structural_tag_guidance(gd, structural_tag);
+        gd.structural_tag = Some(structural_tag);
         Ok(true)
     }
 
-    fn set_structural_tag_guidance(
-        gd: &mut GuidedDecodingOptions,
-        structural_tag: serde_json::Value,
-    ) {
-        gd.json = None;
-        gd.regex = None;
-        gd.choice = None;
-        gd.grammar = None;
-        gd.whitespace_pattern = None;
-        gd.structural_tag = Some(structural_tag);
-    }
-
-    /// Validate only structural-tag requests; other parser paths keep existing behavior.
-    fn validate_structural_tag_tool_request(
+    /// Validate forced tool-choice requests.
+    fn validate_tool_choice(
         tool_choice: &ChatCompletionToolChoiceOption,
         tools: &[ChatCompletionTool],
+        has_user_constraint: bool,
     ) -> Result<(), DynamoError> {
+        const RESPONSE_FORMAT_CONFLICT: &str = concat!(
+            "response_format cannot be used in the same request as ",
+            "tool_choice=\"required\" or a named tool_choice.",
+        );
+
         match tool_choice {
-            ChatCompletionToolChoiceOption::Required if tools.is_empty() => {
-                Err(DynamoError::builder()
-                    .error_type(ErrorType::InvalidArgument)
-                    .message("tool_choice is \"required\" but tools is empty")
-                    .build())
+            ChatCompletionToolChoiceOption::Required if tools.is_empty() => Err(invalid_argument(
+                "tool_choice is \"required\" but tools is empty",
+            )),
+            ChatCompletionToolChoiceOption::Required if has_user_constraint => {
+                Err(invalid_argument(RESPONSE_FORMAT_CONFLICT))
             }
             ChatCompletionToolChoiceOption::Named(named) => {
-                if tools.iter().any(|t| t.function.name == named.function.name) {
-                    Ok(())
-                } else {
-                    Err(DynamoError::builder()
-                        .error_type(ErrorType::InvalidArgument)
-                        .message(format!(
-                            "tool named \"{}\" in tool_choice is not present in tools",
-                            named.function.name
-                        ))
-                        .build())
+                if !tools.iter().any(|t| t.function.name == named.function.name) {
+                    return Err(invalid_argument(format!(
+                        "tool named \"{}\" in tool_choice is not present in tools",
+                        named.function.name
+                    )));
                 }
+                if has_user_constraint {
+                    return Err(invalid_argument(RESPONSE_FORMAT_CONFLICT));
+                }
+                Ok(())
             }
             _ => Ok(()),
         }
     }
 
     /// Decide whether this request should use a tool-call format tag.
-    fn should_activate_structural_tag(
+    fn should_apply_tool_call_format(
         scope: StructuralTagScope,
         tool_choice: &ChatCompletionToolChoiceOption,
         tools: &[ChatCompletionTool],

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -126,6 +126,8 @@ impl OpenAIPreprocessor {
                 .sampling_options
                 .guided_decoding
                 .get_or_insert_default();
+            // xgrammar accepts only one constraint at a time.
+            gd.json = None;
             gd.structural_tag = Some(ban_tag);
             Ok(true)
         } else {
@@ -164,7 +166,7 @@ impl OpenAIPreprocessor {
             .sampling_options
             .guided_decoding
             .get_or_insert_default();
-        // xgrammar accepts only one JSON-style constraint at a time.
+        // xgrammar accepts only one constraint at a time.
         gd.json = None;
         gd.structural_tag = Some(structural_tag);
         Ok(true)

--- a/lib/llm/src/preprocessor/tool_choice.rs
+++ b/lib/llm/src/preprocessor/tool_choice.rs
@@ -7,7 +7,8 @@ use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
 use crate::protocols::openai::tools::get_json_schema_from_tools;
 
-use dynamo_protocols::types::{ChatCompletionToolChoiceOption, ResponseFormat};
+use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
+use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption, ResponseFormat};
 use dynamo_runtime::error::{DynamoError, ErrorType};
 
 fn invalid_argument(message: impl Into<String>) -> DynamoError {
@@ -66,8 +67,8 @@ impl OpenAIPreprocessor {
         }
 
         if self.apply_tool_choice_structural_tag(
-            tool_choice,
-            tools,
+            &convert_tool_choice(tool_choice),
+            &convert_tools(tools),
             request.inner.parallel_tool_calls,
             prompt_injected_reasoning,
             common_request,
@@ -112,4 +113,26 @@ fn has_response_format_constraint(request: &NvCreateChatCompletionRequest) -> bo
         .response_format
         .as_ref()
         .is_some_and(|format| !matches!(format, ResponseFormat::Text))
+}
+
+fn convert_tool_choice(tool_choice: &ChatCompletionToolChoiceOption) -> ToolChoice {
+    match tool_choice {
+        ChatCompletionToolChoiceOption::None => ToolChoice::None,
+        ChatCompletionToolChoiceOption::Auto => ToolChoice::Auto,
+        ChatCompletionToolChoiceOption::Required => ToolChoice::Required,
+        ChatCompletionToolChoiceOption::Named(named) => {
+            ToolChoice::Named(named.function.name.clone())
+        }
+    }
+}
+
+fn convert_tools(tools: &[ChatCompletionTool]) -> Vec<ToolDefinition> {
+    tools
+        .iter()
+        .map(|tool| ToolDefinition {
+            name: tool.function.name.clone(),
+            parameters: tool.function.parameters.clone(),
+            strict: tool.function.strict,
+        })
+        .collect()
 }

--- a/lib/llm/src/preprocessor/tool_choice.rs
+++ b/lib/llm/src/preprocessor/tool_choice.rs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tool-choice guided decoding policy for OpenAI chat requests.
+
+use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
+use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
+use crate::protocols::openai::tools::get_json_schema_from_tools;
+
+use dynamo_protocols::types::{ChatCompletionToolChoiceOption, ResponseFormat};
+use dynamo_runtime::error::{DynamoError, ErrorType};
+
+fn invalid_argument(message: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(ErrorType::InvalidArgument)
+        .message(message)
+        .build()
+}
+
+impl OpenAIPreprocessor {
+    /// Apply guided decoding for OpenAI tool-choice requests.
+    ///
+    /// Structural tags are preferred when enabled and supported by the configured
+    /// tool-call parser. Forced tool-choice requests fall back to the legacy
+    /// JSON-schema constraint when structural tags are not applied.
+    pub(super) fn apply_tool_choice_guided_decoding(
+        &self,
+        request: &NvCreateChatCompletionRequest,
+        common_request: &mut PreprocessedRequest,
+        prompt_injected_reasoning: bool,
+    ) -> Result<bool, DynamoError> {
+        let tool_choice = request
+            .inner
+            .tool_choice
+            .as_ref()
+            .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
+        let tools = request.inner.tools.as_deref().unwrap_or(&[]);
+        let is_forced_tool_choice = matches!(
+            tool_choice,
+            ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_)
+        );
+        let has_explicit_guided_decoding = has_explicit_guided_decoding(request);
+        let has_response_format_constraint = has_response_format_constraint(request);
+
+        if is_forced_tool_choice && has_explicit_guided_decoding {
+            return Err(invalid_argument(concat!(
+                "guided decoding cannot be used in the same request as ",
+                "tool_choice=\"required\" or a named tool_choice.",
+            )));
+        }
+
+        // For non-forced tool choice, explicit guided decoding and response_format
+        // constrain assistant content, so tool-choice guided decoding stays inactive.
+        let has_assistant_constraint =
+            has_explicit_guided_decoding || has_response_format_constraint;
+        if !is_forced_tool_choice && has_assistant_constraint {
+            return Ok(false);
+        }
+
+        if is_forced_tool_choice
+            && has_response_format_constraint
+            && let Some(gd) = common_request.sampling_options.guided_decoding.as_mut()
+        {
+            // OpenAI `response_format` applies to assistant content, not tool calls.
+            gd.json = None;
+        }
+
+        if self.apply_tool_choice_structural_tag(
+            tool_choice,
+            tools,
+            request.inner.parallel_tool_calls,
+            prompt_injected_reasoning,
+            common_request,
+        )? {
+            return Ok(true);
+        }
+
+        match get_json_schema_from_tools(Some(tool_choice), Some(tools)) {
+            Ok(Some(schema)) => {
+                let gd = common_request
+                    .sampling_options
+                    .guided_decoding
+                    .get_or_insert_default();
+                gd.json = Some(schema);
+            }
+            Ok(None) => {}
+            Err(err) => {
+                return Err(invalid_argument(err.to_string()));
+            }
+        }
+
+        // Auto/None requests can reach here when neither structural tags nor a
+        // tool-choice JSON fallback were needed.
+        Ok(false)
+    }
+}
+
+fn has_explicit_guided_decoding(request: &NvCreateChatCompletionRequest) -> bool {
+    request.common.guided_json.is_some()
+        || request.common.guided_regex.is_some()
+        || request
+            .common
+            .guided_choice
+            .as_ref()
+            .is_some_and(|v| !v.is_empty())
+        || request.common.guided_grammar.is_some()
+}
+
+fn has_response_format_constraint(request: &NvCreateChatCompletionRequest) -> bool {
+    request
+        .inner
+        .response_format
+        .as_ref()
+        .is_some_and(|format| !matches!(format, ResponseFormat::Text))
+}

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -511,13 +511,6 @@ impl GuidedDecodingOptions {
 
         Ok(())
     }
-
-    pub fn has_user_constraint(&self) -> bool {
-        self.json.is_some()
-            || self.regex.is_some()
-            || self.choice.as_ref().is_some_and(|v| !v.is_empty())
-            || self.grammar.is_some()
-    }
 }
 
 impl SamplingOptions {
@@ -990,115 +983,5 @@ mod tests {
         let result =
             GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None);
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_has_user_constraint_empty() {
-        let gd = GuidedDecodingOptions::default();
-        assert!(!gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_json() {
-        let gd = GuidedDecodingOptions::new(
-            Some(serde_json::json!({"type": "object"})),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
-        assert!(gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_regex() {
-        let gd = GuidedDecodingOptions::new(
-            None,
-            Some(r"\d+".to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
-        assert!(gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_choice() {
-        let gd = GuidedDecodingOptions::new(
-            None,
-            None,
-            Some(vec!["yes".to_string()]),
-            None,
-            None,
-            None,
-            None,
-        );
-        assert!(gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_choice_empty_vec() {
-        let gd = GuidedDecodingOptions::new(None, None, Some(vec![]), None, None, None, None);
-        assert!(!gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_grammar() {
-        let gd = GuidedDecodingOptions::new(
-            None,
-            None,
-            None,
-            Some("root ::= 'yes'".to_string()),
-            None,
-            None,
-            None,
-        );
-        assert!(gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_backend_only() {
-        let gd = GuidedDecodingOptions::new(
-            None,
-            None,
-            None,
-            None,
-            Some("xgrammar".to_string()),
-            None,
-            None,
-        );
-        assert!(!gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_structural_tag_only() {
-        let gd = GuidedDecodingOptions::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(serde_json::json!({"type": "triggered_tags"})),
-        );
-        assert!(!gd.has_user_constraint());
-    }
-
-    #[test]
-    fn test_has_user_constraint_whitespace_pattern_only() {
-        let gd = GuidedDecodingOptions::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(r"\s+".to_string()),
-            None,
-        );
-        assert!(!gd.has_user_constraint());
     }
 }

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -374,7 +374,7 @@ pub struct GuidedDecodingOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub whitespace_pattern: Option<String>,
 
-    /// Guided decoding related (sglang only right now)
+    /// If specified, xgrammar structural tag constraint for guided decoding.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub structural_tag: Option<serde_json::Value>,
 }
@@ -782,6 +782,7 @@ mod tests {
         assert!(opts.grammar.is_none());
         assert_eq!(opts.backend, backend);
         assert!(opts.whitespace_pattern.is_none());
+        assert!(opts.structural_tag.is_none());
 
         // Only regex set
         let regex = Some(r"\d+".to_string());
@@ -838,6 +839,26 @@ mod tests {
         assert!(opts.choice.is_none());
         assert!(opts.grammar.is_none());
 
+        // Only structural_tag set
+        let structural_tag = Some(serde_json::json!({"type": "structural_tag"}));
+        let opts = GuidedDecodingOptions::validated(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            structural_tag.clone(),
+        );
+        assert!(opts.is_ok());
+        let opts = opts.unwrap();
+        assert_eq!(opts.structural_tag, structural_tag);
+        assert!(opts.json.is_none());
+        assert!(opts.regex.is_none());
+        assert!(opts.choice.is_none());
+        assert!(opts.grammar.is_none());
+        assert!(opts.whitespace_pattern.is_none());
+
         // Multiple fields set (should error)
         let opts = GuidedDecodingOptions::validated(
             Some(serde_json::json!({})),
@@ -893,6 +914,23 @@ mod tests {
         assert!(val.is_some());
         let val = val.unwrap();
         assert_eq!(val.regex, regex);
+
+        // Only structural_tag set returns Ok(Some)
+        let structural_tag = Some(serde_json::json!({"type": "structural_tag"}));
+        let opts = GuidedDecodingOptions::from_optional(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            structural_tag.clone(),
+        );
+        assert!(opts.is_ok());
+        let val = opts.unwrap();
+        assert!(val.is_some());
+        let val = val.unwrap();
+        assert_eq!(val.structural_tag, structural_tag);
 
         // Multiple set returns Err
         let opts = GuidedDecodingOptions::from_optional(

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -511,6 +511,13 @@ impl GuidedDecodingOptions {
 
         Ok(())
     }
+
+    pub fn has_user_constraint(&self) -> bool {
+        self.json.is_some()
+            || self.regex.is_some()
+            || self.choice.as_ref().is_some_and(|v| !v.is_empty())
+            || self.grammar.is_some()
+    }
 }
 
 impl SamplingOptions {
@@ -983,5 +990,115 @@ mod tests {
         let result =
             GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_has_user_constraint_empty() {
+        let gd = GuidedDecodingOptions::default();
+        assert!(!gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_json() {
+        let gd = GuidedDecodingOptions::new(
+            Some(serde_json::json!({"type": "object"})),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_regex() {
+        let gd = GuidedDecodingOptions::new(
+            None,
+            Some(r"\d+".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_choice() {
+        let gd = GuidedDecodingOptions::new(
+            None,
+            None,
+            Some(vec!["yes".to_string()]),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_choice_empty_vec() {
+        let gd = GuidedDecodingOptions::new(None, None, Some(vec![]), None, None, None, None);
+        assert!(!gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_grammar() {
+        let gd = GuidedDecodingOptions::new(
+            None,
+            None,
+            None,
+            Some("root ::= 'yes'".to_string()),
+            None,
+            None,
+            None,
+        );
+        assert!(gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_backend_only() {
+        let gd = GuidedDecodingOptions::new(
+            None,
+            None,
+            None,
+            None,
+            Some("xgrammar".to_string()),
+            None,
+            None,
+        );
+        assert!(!gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_structural_tag_only() {
+        let gd = GuidedDecodingOptions::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(serde_json::json!({"type": "triggered_tags"})),
+        );
+        assert!(!gd.has_user_constraint());
+    }
+
+    #[test]
+    fn test_has_user_constraint_whitespace_pattern_only() {
+        let gd = GuidedDecodingOptions::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(r"\s+".to_string()),
+            None,
+        );
+        assert!(!gd.has_user_constraint());
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -455,6 +455,7 @@ mod tests {
     use super::*;
     use crate::engines::ValidateRequest;
     use crate::protocols::common::{OutputOptionsProvider, StopConditionsProvider};
+    use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolType, FunctionObject};
     use serde_json::json;
 
     #[test]
@@ -795,5 +796,47 @@ mod tests {
             serde_json::to_string(&mapped).unwrap(),
             serde_json::to_string(&legacy).unwrap()
         );
+    }
+
+    #[test]
+    fn test_validate_tools_valid_names() {
+        fn make_tool(name: &str) -> ChatCompletionTool {
+            ChatCompletionTool {
+                r#type: ChatCompletionToolType::Function,
+                function: FunctionObject {
+                    name: name.to_string(),
+                    description: None,
+                    parameters: Some(json!({"type": "object", "properties": {}})),
+                    strict: None,
+                },
+            }
+        }
+
+        let tools = vec![
+            make_tool("func_name"),
+            make_tool("func-name_v2"),
+            make_tool("FuncName"),
+            make_tool("Func_Name-123"),
+        ];
+        assert!(validate::validate_tools(&Some(&tools)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_tools_invalid_names() {
+        for name in ["<func_name>", "func name", "func@name", "func,name", ""] {
+            let tools = vec![ChatCompletionTool {
+                r#type: ChatCompletionToolType::Function,
+                function: FunctionObject {
+                    name: name.to_string(),
+                    description: None,
+                    parameters: Some(json!({"type": "object", "properties": {}})),
+                    strict: None,
+                },
+            }];
+            assert!(
+                validate::validate_tools(&Some(&tools)).is_err(),
+                "expected error for name: {name:?}"
+            );
+        }
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -14,7 +14,7 @@ use super::{
     common_ext::{CommonExt, CommonExtProvider},
     nvext::NvExt,
     nvext::NvExtProvider,
-    tools, validate,
+    validate,
 };
 
 pub mod aggregator;
@@ -232,23 +232,6 @@ impl CommonExtProvider for NvCreateChatCompletionRequest {
             return Some(value);
         }
 
-        // 1) Tool-call guided decoding (highest precedence after explicit guided_json)
-        if let (Some(tool_choice), Some(tools)) =
-            (self.inner.tool_choice.as_ref(), self.inner.tools.as_deref())
-        {
-            match tools::get_json_schema_from_tools(Some(tool_choice), Some(tools)) {
-                Ok(Some(schema)) => return Some(schema),
-                Ok(None) => {}
-                Err(err) => {
-                    tracing::warn!(
-                        error = %err,
-                        "failed to derive guided_json from tool_choice"
-                    );
-                }
-            }
-        }
-
-        // 2) OpenAI `response_format` (applies to assistant content, not tool calls)
         if let Some(response_format) = self.inner.response_format.as_ref() {
             use dynamo_protocols::types::ResponseFormat;
             match response_format {
@@ -434,7 +417,7 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         validate::validate_temperature(self.inner.temperature)?;
         validate::validate_top_p(self.inner.top_p)?;
         validate::validate_tools(&self.inner.tools.as_deref())?;
-        // none for tool_choice
+        validate::validate_tool_choice(&self.inner.tool_choice, self.inner.tools.as_deref())?;
         // none for parallel_tool_calls
         validate::validate_user(self.inner.user.as_deref())?;
         // none for function call
@@ -636,6 +619,50 @@ mod tests {
 
         let err = ValidateRequest::validate(&request).expect_err("multi-choice token ids");
         assert!(err.to_string().contains("completion_token_ids"));
+    }
+
+    #[test]
+    fn test_validate_tool_choice_required_rejects_empty_tools() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "tool_choice": "required"
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let err = ValidateRequest::validate(&request).expect_err("required needs tools");
+        assert!(
+            err.to_string()
+                .contains("tool_choice is \"required\" but tools is empty")
+        );
+    }
+
+    #[test]
+    fn test_validate_tool_choice_named_rejects_missing_tool() {
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}}
+                }
+            }],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "search"}
+            }
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(request_json).expect("Failed to deserialize request");
+
+        let err = ValidateRequest::validate(&request).expect_err("named tool must exist");
+        assert!(
+            err.to_string()
+                .contains("tool named \"search\" in tool_choice is not present in tools")
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -506,6 +506,34 @@ pub fn validate_tools(
     Ok(())
 }
 
+/// Validates that forced tool_choice requests refer to available tools.
+pub fn validate_tool_choice(
+    tool_choice: &Option<dynamo_protocols::types::ChatCompletionToolChoiceOption>,
+    tools: Option<&[dynamo_protocols::types::ChatCompletionTool]>,
+) -> Result<(), anyhow::Error> {
+    use dynamo_protocols::types::ChatCompletionToolChoiceOption;
+
+    let tools_empty = tools.is_none_or(|tools| tools.is_empty());
+
+    match tool_choice {
+        Some(ChatCompletionToolChoiceOption::Required) if tools_empty => {
+            anyhow::bail!("tool_choice is \"required\" but tools is empty");
+        }
+        Some(ChatCompletionToolChoiceOption::Named(named)) => {
+            let tools = tools.unwrap_or(&[]);
+            if !tools.iter().any(|t| t.function.name == named.function.name) {
+                anyhow::bail!(
+                    "tool named \"{}\" in tool_choice is not present in tools",
+                    named.function.name
+                );
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
 /// Validates reasoning effort parameter
 pub fn validate_reasoning_effort(
     _reasoning_effort: &Option<dynamo_protocols::types::ReasoningEffort>,

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -489,6 +489,19 @@ pub fn validate_tools(
         if tool.function.name.trim().is_empty() {
             anyhow::bail!("Function name at index {} cannot be empty", i);
         }
+        if !tool
+            .function
+            .name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+        {
+            anyhow::bail!(
+                "Function at index {} has an invalid name: \"{}\". \
+                 Only a-z, A-Z, 0-9, underscores, and dashes are allowed.",
+                i,
+                tool.function.name,
+            );
+        }
     }
     Ok(())
 }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -344,8 +344,8 @@ impl CommonExtProvider for UnifiedRequest {
     }
 
     fn get_guided_json(&self) -> Option<serde_json::Value> {
-        // Delegate to the inner impl which handles tool_choice → guided_json
-        // and response_format → guided_json derivation.
+        // Delegate to the inner impl which handles guided_json and
+        // response_format → guided_json derivation.
         CommonExtProvider::get_guided_json(&self.inner)
     }
 

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -124,7 +124,7 @@ async fn postprocessor_parsing_stream_replays_unit_test_fixture() {
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -180,7 +180,7 @@ async fn postprocessor_parsing_stream_replays_interval_20_fixture() {
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -466,7 +466,7 @@ async fn postprocessor_parsing_stream_deepseek_v4_tool_continuation_keeps_inject
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, true)
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -536,7 +536,7 @@ async fn postprocessor_parsing_stream_kimi_k25_tool_continuation_suppresses_inje
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, true)
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -583,7 +583,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_enable_thinking_false_returns_
     let input_chunks = vec![mock_content_chunk("This is plain content")];
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -631,7 +631,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_strips_start_to
     ];
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -675,7 +675,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial
     let input_chunks = vec![mock_content_chunk("<thi"), mock_final_chunk()];
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -723,7 +723,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial
     let input_chunks = vec![mock_content_chunk("<thi")];
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -775,7 +775,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tracks_prefix_p
     ];
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -844,7 +844,7 @@ async fn postprocessor_parsing_stream_minimax_required_bypasses_reasoning() {
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -960,7 +960,7 @@ async fn postprocessor_parsing_stream_nemotron_required_smoke_case() {
 
         let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
         let output_stream = preprocessor
-            .postprocessor_parsing_stream(input_stream, &request, prompt_injected_reasoning)
+            .postprocessor_parsing_stream(input_stream, &request, prompt_injected_reasoning, false)
             .expect("postprocessor_parsing_stream should build");
 
         let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -1061,7 +1061,7 @@ async fn postprocessor_parsing_stream_minimax_named_bypasses_reasoning() {
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
@@ -1145,7 +1145,7 @@ async fn postprocessor_parsing_stream_minimax_named_bare_parameters() {
 
     let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
     let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1335,7 +1335,7 @@ async fn tool_choice_matrix_force_reasoning_required_bare_json() {
                 .map(Annotated::from_data),
         );
         let output_stream = preprocessor
-            .postprocessor_parsing_stream(input_stream, &request, prompt_injected)
+            .postprocessor_parsing_stream(input_stream, &request, prompt_injected, false)
             .expect("postprocessor_parsing_stream should build");
         let DrainOutput {
             reasoning,
@@ -1376,7 +1376,7 @@ async fn tool_choice_matrix_force_reasoning_named_bare_json() {
             .map(Annotated::from_data),
     );
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, true)
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
         .expect("postprocessor_parsing_stream should build");
     let DrainOutput {
         reasoning,
@@ -1406,7 +1406,7 @@ async fn tool_choice_matrix_non_force_required_no_injection_bare_json() {
             .map(Annotated::from_data),
     );
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
     let DrainOutput {
         reasoning,
@@ -1437,7 +1437,7 @@ async fn tool_choice_matrix_non_force_required_prompt_injected_with_close_marker
             .map(Annotated::from_data),
     );
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, true)
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
         .expect("postprocessor_parsing_stream should build");
     let DrainOutput {
         reasoning,
@@ -1479,7 +1479,7 @@ async fn tool_choice_matrix_non_force_required_prompt_injected_bare_json_contrac
             .map(Annotated::from_data),
     );
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, true)
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
         .expect("postprocessor_parsing_stream should build");
     let DrainOutput {
         reasoning,
@@ -1525,7 +1525,7 @@ async fn tool_choice_matrix_immediate_jail_reasoning_only_first_chunk() {
         .map(Annotated::from_data),
     );
     let output_stream = preprocessor
-        .postprocessor_parsing_stream(input_stream, &request, false)
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
     let DrainOutput {
         reasoning,

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -2219,6 +2219,7 @@ mod tests {
                     "filter": {"type": "string"},
                 },
             })),
+            strict: None,
         }];
 
         let input_stream = stream::iter(chunks);

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3623,6 +3623,7 @@ fahrenheit
                 Some("minimax_m2".to_string()),
                 None,
                 None,
+                false,
                 stream::iter(input_chunks),
             )
             .collect()

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3339,6 +3339,7 @@ fahrenheit
             Some("qwen3_coder".to_string()),
             Some(ChatCompletionToolChoiceOption::Required),
             None,
+            false,
             input_stream,
         )
         .collect()
@@ -3426,6 +3427,7 @@ fahrenheit
                 "get_weather".to_string().into(),
             )),
             None,
+            false,
             input_stream,
         )
         .collect()
@@ -3518,6 +3520,7 @@ fahrenheit
             Some("minimax_m2".to_string()),
             Some(ChatCompletionToolChoiceOption::Required),
             None,
+            false,
             stream::iter(input_chunks),
         )
         .collect()
@@ -3670,6 +3673,7 @@ fahrenheit
             Some("hermes".to_string()),
             Some(ChatCompletionToolChoiceOption::Required),
             None,
+            false,
             stream::iter(input_chunks),
         )
         .collect()
@@ -3723,6 +3727,7 @@ fahrenheit
                 "get_weather".to_string().into(),
             )),
             None,
+            false,
             stream::iter(input_chunks),
         )
         .collect()
@@ -3781,6 +3786,7 @@ fahrenheit
                 "get_weather".to_string().into(),
             )),
             None,
+            false,
             stream::iter(input_chunks),
         )
         .collect()
@@ -3826,6 +3832,7 @@ fahrenheit
                 "get_weather".to_string().into(),
             )),
             None,
+            false,
             stream::iter(input_chunks),
         )
         .collect()

--- a/lib/llm/tests/test_reasoning_parser.rs
+++ b/lib/llm/tests/test_reasoning_parser.rs
@@ -553,6 +553,7 @@ mod tests {
             Some("nemotron_deci".to_string()),
             None, // No tool_choice in this test
             None, // No tool_definitions in this test
+            false,
             reasoning_parsed_stream,
         );
 
@@ -667,6 +668,7 @@ mod tests {
             Some("kimi_k2".to_string()),
             None,
             None,
+            false,
             reasoning_parsed_stream,
         );
 
@@ -766,6 +768,7 @@ mod tests {
             Some("harmony".to_string()),
             None, // No tool_choice in this test
             None, // No tool_definitions in this test
+            false,
             reasoning_parsed_stream,
         );
 

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -170,8 +170,9 @@ async fn parse_response_stream(
         if let Some(tool_parser) = tool_parser_str {
             Box::pin(OpenAIPreprocessor::apply_tool_calling_jail(
                 Some(tool_parser),
-                None, // No tool_choice in this test
-                None, // No tool_definitions in this test
+                None,  // No tool_choice in this test
+                None,  // No tool_definitions in this test
+                false, // No structural_tag in this test
                 stream,
             ))
         } else {

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -350,10 +350,10 @@ impl ToolCallConfig {
             structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(
                 TriggeredTagsConfig {
                     begin_template: format!(
-                        "<tool_call>{{\"name\": \"{}\", \"arguments\": ",
+                        "<tool_call>\n{{\"name\": \"{}\", \"arguments\": ",
                         TOOL_NAME_PLACEHOLDER
                     ),
-                    end_template: "}</tool_call>".to_string(),
+                    end_template: "}\n</tool_call>".to_string(),
                     triggers: vec!["<tool_call>".to_string()],
                     content_style: JsonSchemaStyle::Json,
                     tool_call_ban_tokens: vec!["<tool_call>".to_string()],

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -357,7 +357,7 @@ impl ToolCallConfig {
                     triggers: vec!["<tool_call>".to_string()],
                     content_style: JsonSchemaStyle::Json,
                     tool_call_ban_tokens: vec!["<tool_call>".to_string()],
-                    reasoning_end: None,
+                    reasoning_end: Some("</think>".to_string()),
                 },
             )),
         }

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::json::JsonParserType;
+use super::structural_tag::format::JsonSchemaStyle;
+use super::structural_tag::{
+    DsmlToolCallsConfig, StructuralTagBuilder, TOOL_NAME_PLACEHOLDER, TriggeredTagsConfig,
+};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct JsonParserConfig {
@@ -315,12 +319,20 @@ impl ParserConfig {
 pub struct ToolCallConfig {
     /// Parser-specific configuration.
     pub parser_config: ParserConfig,
+
+    /// Structural tag builder for xgrammar guided decoding.
+    ///
+    /// When `Some`, the Dynamo preprocessor can generate structural tags that
+    /// constrain the backend into producing model-native tool call format.
+    #[serde(skip)]
+    pub structural_tag_builder: Option<StructuralTagBuilder>,
 }
 
 impl Default for ToolCallConfig {
     fn default() -> Self {
         Self {
             parser_config: ParserConfig::Json(JsonParserConfig::default()),
+            structural_tag_builder: None,
         }
     }
 }
@@ -335,6 +347,18 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["</tool_call>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(
+                TriggeredTagsConfig {
+                    begin_template: format!(
+                        "<tool_call>{{\"name\": \"{}\", \"arguments\": ",
+                        TOOL_NAME_PLACEHOLDER
+                    ),
+                    end_template: "}</tool_call>".to_string(),
+                    triggers: vec!["<tool_call>".to_string()],
+                    content_style: JsonSchemaStyle::Json,
+                    tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+                },
+            )),
         }
     }
 
@@ -347,6 +371,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -359,6 +384,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -369,6 +395,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["[/TOOL_CALLS]".to_string(), "".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -379,12 +406,14 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
     pub fn pythonic() -> Self {
         Self {
             parser_config: ParserConfig::Pythonic,
+            structural_tag_builder: None,
         }
     }
 
@@ -398,6 +427,7 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["<|call|>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -422,6 +452,7 @@ impl ToolCallConfig {
                 parser_type: JsonParserType::DeepseekV31,
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -437,6 +468,7 @@ impl ToolCallConfig {
                 parser_type: JsonParserType::DeepseekV3,
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -453,6 +485,15 @@ impl ToolCallConfig {
                 backoff_when_no_wrapper: true,
                 ..XmlParserConfig::default()
             }),
+            structural_tag_builder: Some(StructuralTagBuilder::TriggeredTags(
+                TriggeredTagsConfig {
+                    begin_template: format!("<tool_call>\n<function={}>\n", TOOL_NAME_PLACEHOLDER),
+                    end_template: "\n</function>\n</tool_call>".to_string(),
+                    triggers: vec!["<tool_call>\n<function=".to_string()],
+                    content_style: JsonSchemaStyle::QwenXml,
+                    tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+                },
+            )),
         }
     }
 
@@ -463,16 +504,37 @@ impl ToolCallConfig {
                 tool_call_end_tokens: vec!["</tool_calls>".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         }
     }
 
     fn deepseek_dsml(block_name: &str) -> Self {
+        let dsml_config = DsmlParserConfig {
+            block_start: format!("<｜DSML｜{}>", block_name),
+            block_end: format!("</｜DSML｜{}>", block_name),
+            ..Default::default()
+        };
+        let structural_tag = StructuralTagBuilder::DsmlToolCalls(DsmlToolCallsConfig {
+            trigger: dsml_config.block_start.clone(),
+            block_begin: format!("{}\n", dsml_config.block_start),
+            block_end: dsml_config.block_end.clone(),
+            invoke_begin_template: format!(
+                "{}\"{}\">\n",
+                dsml_config.invoke_start_prefix, TOOL_NAME_PLACEHOLDER
+            ),
+            // Keep the newline in invoke_end and separator empty so the model
+            // can either emit another invoke or close the DSML block.
+            invoke_end: format!("{}\n", dsml_config.invoke_end),
+            separator: "".to_string(),
+            // The DSML opening is several tokens (`<`, `｜DSML｜`, ...), so `tool_choice=none`
+            // cannot suppress the entire prefix, so we ban the `｜DSML｜` token.
+            // The model may still begin a tool block and hurt plain-text quality; prefer omitting tools
+            // from the prompt (default `--exclude-tools-when-tool-choice-none`) when that matters.
+            tool_call_ban_tokens: vec!["｜DSML｜".to_string()],
+        });
         Self {
-            parser_config: ParserConfig::Dsml(DsmlParserConfig {
-                block_start: format!("<｜DSML｜{}>", block_name),
-                block_end: format!("</｜DSML｜{}>", block_name),
-                ..Default::default()
-            }),
+            parser_config: ParserConfig::Dsml(dsml_config),
+            structural_tag_builder: Some(structural_tag),
         }
     }
 
@@ -524,6 +586,7 @@ impl ToolCallConfig {
                 passthrough_when_no_function: false,
                 backoff_when_no_wrapper: false,
             }),
+            structural_tag_builder: None,
         }
     }
 
@@ -533,6 +596,7 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja
         Self {
             parser_config: ParserConfig::Glm47(Glm47ParserConfig::default()),
+            structural_tag_builder: None,
         }
     }
 
@@ -544,6 +608,7 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
         Self {
             parser_config: ParserConfig::KimiK2(KimiK2ParserConfig::default()),
+            structural_tag_builder: None,
         }
     }
 
@@ -558,6 +623,7 @@ impl ToolCallConfig {
     pub fn gemma4() -> Self {
         Self {
             parser_config: ParserConfig::Gemma4,
+            structural_tag_builder: None,
         }
     }
 }

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -357,6 +357,7 @@ impl ToolCallConfig {
                     triggers: vec!["<tool_call>".to_string()],
                     content_style: JsonSchemaStyle::Json,
                     tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+                    reasoning_end: None,
                 },
             )),
         }
@@ -492,6 +493,7 @@ impl ToolCallConfig {
                     triggers: vec!["<tool_call>\n<function=".to_string()],
                     content_style: JsonSchemaStyle::QwenXml,
                     tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+                    reasoning_end: Some("</think>".to_string()),
                 },
             )),
         }
@@ -531,6 +533,7 @@ impl ToolCallConfig {
             // The model may still begin a tool block and hurt plain-text quality; prefer omitting tools
             // from the prompt (default `--exclude-tools-when-tool-choice-none`) when that matters.
             tool_call_ban_tokens: vec!["｜DSML｜".to_string()],
+            reasoning_end: Some("</think>".to_string()),
         });
         Self {
             parser_config: ParserConfig::Dsml(dsml_config),

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -659,6 +659,7 @@ mod tests {
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
+            strict: None,
         }];
         let (calls, _) = try_tool_call_parse_gemma4(input, Some(&tools)).unwrap();
         assert_eq!(calls.len(), 1);

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -11,6 +11,7 @@ pub mod json;
 pub mod parsers;
 pub mod pythonic;
 pub mod response;
+pub mod structural_tag;
 #[cfg(test)]
 pub mod tests;
 pub mod tools;
@@ -38,6 +39,10 @@ pub use parsers::{
 pub use pythonic::try_tool_call_parse_pythonic;
 pub use response::{
     CalledFunction, CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
+};
+pub use structural_tag::{
+    DsmlToolCallsConfig, StructuralTagBuilder, StructuralTagSchemaMode, TOOL_NAME_PLACEHOLDER,
+    ToolCallFormatBuildContext, TriggeredTagsConfig,
 };
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -22,6 +22,16 @@ pub mod xml;
 pub struct ToolDefinition {
     pub name: String,
     pub parameters: Option<Value>,
+    pub strict: Option<bool>,
+}
+
+/// Tool choice policy used by parser-side tool-call helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolChoice {
+    None,
+    Auto,
+    Required,
+    Named(String),
 }
 
 // Re-export main types and functions for convenience

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -160,6 +160,7 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     };
     let cfg = ToolCallConfig {
         parser_config: recovery_config,
+        structural_tag_builder: None,
     };
     try_tool_call_parse(message, &cfg, tools).await
 }
@@ -412,6 +413,7 @@ mod tests {
                     tool_call_end_tokens: vec!["".to_string()],
                     ..Default::default()
                 }),
+                structural_tag_builder: None,
             },
             None,
         )
@@ -760,6 +762,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
                 arguments_keys: vec!["arguments".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         };
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));
@@ -1208,6 +1211,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
                 arguments_keys: vec!["arguments".to_string()],
                 ..Default::default()
             }),
+            structural_tag_builder: None,
         };
         let (result, content) = try_tool_call_parse(input, &config, None).await.unwrap();
         assert_eq!(content, Some("".to_string()));

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -3067,6 +3067,7 @@ fahrenheit
                     }
                 }
             })),
+            strict: None,
         }];
         let (result, content) =
             detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
@@ -3105,6 +3106,7 @@ true
                     "enabled": {"type": "bool"},
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
             .await
@@ -3227,6 +3229,7 @@ weather forecasting
                     }
                 }
             })),
+            strict: None,
         }];
         let (result, content) =
             detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
@@ -3283,6 +3286,7 @@ weather forecasting
                     }
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("qwen3_coder"), Some(&tools))
             .await
@@ -3334,6 +3338,7 @@ weather forecasting
                     "query_list": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("minimax_m2"), Some(&tools))
             .await
@@ -3426,6 +3431,7 @@ weather forecasting
                     "enabled": {"type": "boolean"}
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("minimax_m2"), Some(&tools))
             .await
@@ -3452,6 +3458,7 @@ weather forecasting
                     "items": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
         let (result, _) = detect_and_parse_tool_call(input, Some("minimax_m2"), Some(&tools))
             .await

--- a/lib/parsers/src/tool_calling/structural_tag/builder.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/builder.rs
@@ -3,9 +3,10 @@
 
 //! Public structural tag builder API used by the Dynamo preprocessor.
 
-use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+
+use crate::tool_calling::{ToolChoice, ToolDefinition};
 
 use super::dsml::{self, DsmlToolCallsConfig};
 use super::format::{
@@ -30,9 +31,9 @@ pub enum StructuralTagSchemaMode {
 #[derive(Debug, Clone, Copy)]
 pub struct ToolCallFormatBuildContext<'a> {
     /// Resolved `tool_choice` from the request.
-    pub tool_choice: &'a ChatCompletionToolChoiceOption,
+    pub tool_choice: &'a ToolChoice,
     /// All tools from the request.
-    pub tools: &'a [ChatCompletionTool],
+    pub tools: &'a [ToolDefinition],
     /// From the request; `Some(false)` sets `stop_after_first` in the tag.
     pub parallel_tool_calls: Option<bool>,
     /// Schema strictness mode for tool arguments.
@@ -56,41 +57,37 @@ impl ToolCallFormatBuildContext<'_> {
 /// Select tools for `tool_choice` and whether at least one call is required.
 pub(crate) fn resolve_tools_to_include<'a>(
     ctx: &ToolCallFormatBuildContext<'a>,
-) -> anyhow::Result<(Vec<&'a ChatCompletionTool>, bool)> {
+) -> anyhow::Result<(Vec<&'a ToolDefinition>, bool)> {
     match ctx.tool_choice {
-        ChatCompletionToolChoiceOption::None => Ok((vec![], false)),
-        ChatCompletionToolChoiceOption::Auto => Ok((ctx.tools.iter().collect(), false)),
-        ChatCompletionToolChoiceOption::Required => {
+        ToolChoice::None => Ok((vec![], false)),
+        ToolChoice::Auto => Ok((ctx.tools.iter().collect(), false)),
+        ToolChoice::Required => {
             anyhow::ensure!(
                 !ctx.tools.is_empty(),
                 "tool_choice is \"required\" but tools is empty"
             );
             Ok((ctx.tools.iter().collect(), true))
         }
-        ChatCompletionToolChoiceOption::Named(named) => {
-            let tool = ctx
-                .tools
-                .iter()
-                .find(|t| t.function.name == named.function.name)
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "tool named \"{}\" in tool_choice is not present in tools",
-                        named.function.name
-                    )
-                })?;
+        ToolChoice::Named(name) => {
+            let tool = ctx.tools.iter().find(|t| t.name == *name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "tool named \"{}\" in tool_choice is not present in tools",
+                    name
+                )
+            })?;
             Ok((vec![tool], true))
         }
     }
 }
 
 /// Resolve one tool's argument schema for structural tag generation.
-pub(crate) fn resolve_tool_schema(tool: &ChatCompletionTool, strict_schema: bool) -> Value {
+pub(crate) fn resolve_tool_schema(tool: &ToolDefinition, strict_schema: bool) -> Value {
     // xgrammar uses `true` for syntactically valid but schema-unconstrained JSON.
     let default_schema = json!(true);
 
-    let use_tool_schema = strict_schema || tool.function.strict.unwrap_or(false);
+    let use_tool_schema = strict_schema || tool.strict.unwrap_or(false);
     if use_tool_schema {
-        tool.function.parameters.clone().unwrap_or(default_schema)
+        tool.parameters.clone().unwrap_or(default_schema)
     } else {
         default_schema
     }
@@ -137,10 +134,7 @@ impl StructuralTagBuilder {
         suffix: StructuralTag,
     ) -> anyhow::Result<StructuralTag> {
         let should_wrap_with_reasoning_tag = ctx.starts_in_reasoning
-            && matches!(
-                ctx.tool_choice,
-                ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_)
-            );
+            && matches!(ctx.tool_choice, ToolChoice::Required | ToolChoice::Named(_));
         if !should_wrap_with_reasoning_tag {
             return Ok(suffix);
         }

--- a/lib/parsers/src/tool_calling/structural_tag/builder.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/builder.rs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public structural tag builder API used by the Dynamo preprocessor.
+
+use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::dsml::{self, DsmlToolCallsConfig};
+use super::format::{AnyTokensFormat, Format, StructuralTag, TagFormat};
+use super::triggered_tags::{self, TriggeredTagsConfig};
+
+/// Controls whether tools get their real parameter schema or an
+/// unconstrained one inside structural tags.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StructuralTagSchemaMode {
+    /// Real schema only for tools with `strict: true`; others get an
+    /// unconstrained schema (`true` in xgrammar).
+    #[default]
+    Auto,
+    /// Real parameter schema for all tools regardless of `strict` flag.
+    Strict,
+}
+
+/// Request-scoped inputs for building a tool-call structural tag.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolCallFormatBuildContext<'a> {
+    /// Resolved `tool_choice` from the request.
+    pub tool_choice: &'a ChatCompletionToolChoiceOption,
+    /// All tools from the request.
+    pub tools: &'a [ChatCompletionTool],
+    /// From the request; `Some(false)` sets `stop_after_first` in the tag.
+    pub parallel_tool_calls: Option<bool>,
+    /// Schema strictness mode for tool arguments.
+    pub schema_mode: StructuralTagSchemaMode,
+}
+
+impl ToolCallFormatBuildContext<'_> {
+    /// Whether we should stop after the first matched tool-call tag.
+    pub(crate) fn stop_after_first(&self) -> bool {
+        self.parallel_tool_calls.is_some_and(|v| !v)
+    }
+
+    /// Whether all tools should use their request-provided parameter schema.
+    pub(crate) fn strict_schema(&self) -> bool {
+        self.schema_mode == StructuralTagSchemaMode::Strict
+    }
+}
+
+/// Select tools for `tool_choice` and whether at least one call is required.
+pub(crate) fn resolve_tools_to_include<'a>(
+    ctx: &ToolCallFormatBuildContext<'a>,
+) -> anyhow::Result<(Vec<&'a ChatCompletionTool>, bool)> {
+    match ctx.tool_choice {
+        ChatCompletionToolChoiceOption::None => Ok((vec![], false)),
+        ChatCompletionToolChoiceOption::Auto => Ok((ctx.tools.iter().collect(), false)),
+        ChatCompletionToolChoiceOption::Required => {
+            anyhow::ensure!(
+                !ctx.tools.is_empty(),
+                "tool_choice is \"required\" but tools is empty"
+            );
+            Ok((ctx.tools.iter().collect(), true))
+        }
+        ChatCompletionToolChoiceOption::Named(named) => {
+            let tool = ctx
+                .tools
+                .iter()
+                .find(|t| t.function.name == named.function.name)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "tool named \"{}\" in tool_choice is not present in tools",
+                        named.function.name
+                    )
+                })?;
+            Ok((vec![tool], true))
+        }
+    }
+}
+
+/// Resolve one tool's argument schema for structural tag generation.
+pub(crate) fn resolve_tool_schema(tool: &ChatCompletionTool, strict_schema: bool) -> Value {
+    // xgrammar uses `true` for syntactically valid but schema-unconstrained JSON.
+    let default_schema = json!(true);
+
+    let use_tool_schema = strict_schema || tool.function.strict.unwrap_or(false);
+    if use_tool_schema {
+        tool.function.parameters.clone().unwrap_or(default_schema)
+    } else {
+        default_schema
+    }
+}
+
+/// Builder for model-family-specific tool-call structural tags.
+#[derive(Debug, Clone)]
+pub enum StructuralTagBuilder {
+    /// Simple `triggered_tags` format with one tag template per tool.
+    TriggeredTags(TriggeredTagsConfig),
+
+    /// DeepSeek DSML format with a `triggered_tags` wrapper and invoke list.
+    DsmlToolCalls(DsmlToolCallsConfig),
+}
+
+impl StructuralTagBuilder {
+    /// Build the structural tag for the given request context.
+    ///
+    /// Returns `Ok(None)` when `tool_choice="none"` (use
+    /// [`build_tool_call_ban`](Self::build_tool_call_ban) for that case)
+    /// or when the tools list is empty for `tool_choice="auto"`.
+    ///
+    /// Returns `Err` when the request is invalid (e.g. named tool not found
+    /// in the tools list, or empty tools for `tool_choice="required"`).
+    pub fn build_tool_call_format(
+        &self,
+        ctx: &ToolCallFormatBuildContext<'_>,
+    ) -> anyhow::Result<Option<Value>> {
+        let structural_tag = match self {
+            Self::TriggeredTags(config) => triggered_tags::build_triggered_tags(config, ctx)?,
+            Self::DsmlToolCalls(config) => dsml::build_dsml_tool_calls(config, ctx)?,
+        };
+
+        structural_tag
+            .map(|tag| serde_json::to_value(tag).map_err(Into::into))
+            .transpose()
+    }
+
+    /// Build a structural tag that prevents tool-call generation for
+    /// `tool_choice="none"`.
+    ///
+    /// Returns `Ok(None)` when no ban tokens are configured.
+    pub fn build_tool_call_ban(&self) -> anyhow::Result<Option<Value>> {
+        let tokens = self.ban_tokens();
+        if tokens.is_empty() {
+            return Ok(None);
+        }
+
+        let content = Format::AnyTokens(AnyTokensFormat {
+            exclude_tokens: tokens.to_vec(),
+        });
+
+        let tag = StructuralTag {
+            format: Format::Tag(TagFormat {
+                begin: String::new(),
+                content: Box::new(content),
+                end: String::new(),
+            }),
+        };
+
+        serde_json::to_value(tag).map(Some).map_err(Into::into)
+    }
+
+    /// Returns the tokens to ban for `tool_choice="none"`.
+    pub fn ban_tokens(&self) -> &[String] {
+        match self {
+            Self::TriggeredTags(config) => &config.tool_call_ban_tokens,
+            Self::DsmlToolCalls(config) => &config.tool_call_ban_tokens,
+        }
+    }
+}

--- a/lib/parsers/src/tool_calling/structural_tag/builder.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/builder.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::dsml::{self, DsmlToolCallsConfig};
-use super::format::{AnyTokensFormat, Format, StructuralTag, TagFormat};
+use super::format::{
+    AnyTextFormat, AnyTokensFormat, Format, SequenceFormat, StructuralTag, TagFormat,
+};
 use super::triggered_tags::{self, TriggeredTagsConfig};
 
 /// Controls whether tools get their real parameter schema or an
@@ -35,6 +37,8 @@ pub struct ToolCallFormatBuildContext<'a> {
     pub parallel_tool_calls: Option<bool>,
     /// Schema strictness mode for tool arguments.
     pub schema_mode: StructuralTagSchemaMode,
+    /// Whether generation starts inside an already-opened reasoning block.
+    pub starts_in_reasoning: bool,
 }
 
 impl ToolCallFormatBuildContext<'_> {
@@ -121,8 +125,40 @@ impl StructuralTagBuilder {
         };
 
         structural_tag
+            .map(|tag| self.wrap_reasoning_prefix_if_needed(ctx, tag))
+            .transpose()?
             .map(|tag| serde_json::to_value(tag).map_err(Into::into))
             .transpose()
+    }
+
+    fn wrap_reasoning_prefix_if_needed(
+        &self,
+        ctx: &ToolCallFormatBuildContext<'_>,
+        suffix: StructuralTag,
+    ) -> anyhow::Result<StructuralTag> {
+        let should_wrap_with_reasoning_tag = ctx.starts_in_reasoning
+            && matches!(
+                ctx.tool_choice,
+                ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_)
+            );
+        if !should_wrap_with_reasoning_tag {
+            return Ok(suffix);
+        }
+
+        let reasoning_end = self.reasoning_end().ok_or_else(|| {
+            anyhow::anyhow!("reasoning end tag is not configured for structural tag")
+        })?;
+        let reasoning_prefix = Format::Tag(TagFormat {
+            begin: String::new(),
+            content: Box::new(Format::AnyText(AnyTextFormat { excludes: vec![] })),
+            end: reasoning_end.to_string(),
+        });
+
+        Ok(StructuralTag {
+            format: Format::Sequence(SequenceFormat {
+                elements: vec![reasoning_prefix, suffix.format],
+            }),
+        })
     }
 
     /// Build a structural tag that prevents tool-call generation for
@@ -155,6 +191,13 @@ impl StructuralTagBuilder {
         match self {
             Self::TriggeredTags(config) => &config.tool_call_ban_tokens,
             Self::DsmlToolCalls(config) => &config.tool_call_ban_tokens,
+        }
+    }
+
+    fn reasoning_end(&self) -> Option<&str> {
+        match self {
+            Self::TriggeredTags(config) => config.reasoning_end.as_deref(),
+            Self::DsmlToolCalls(config) => config.reasoning_end.as_deref(),
         }
     }
 }

--- a/lib/parsers/src/tool_calling/structural_tag/dsml.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/dsml.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! [`StructuralTagBuilder::DsmlToolCalls`] implementation.
+//!
+//! DSML uses two structural tag levels: an outer `triggered_tags` block and
+//! an inner `tags_with_separator` list of per-tool invoke tags.
+
+use serde::{Deserialize, Serialize};
+
+use super::TOOL_NAME_PLACEHOLDER;
+use super::builder::{ToolCallFormatBuildContext, resolve_tool_schema, resolve_tools_to_include};
+use super::format::{
+    Format, JsonSchemaFormat, JsonSchemaStyle, StructuralTag, TagFormat, TagsWithSeparatorFormat,
+    TriggeredTagsFormat,
+};
+
+/// Configuration for the nested DSML tool-call structural tag.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DsmlToolCallsConfig {
+    /// Trigger for the outer DSML block.
+    pub trigger: String,
+
+    /// Begin string for the outer block tag.
+    pub block_begin: String,
+
+    /// End string for the outer block tag.
+    pub block_end: String,
+
+    /// Invoke begin template; [`TOOL_NAME_PLACEHOLDER`] is replaced per tool.
+    pub invoke_begin_template: String,
+
+    /// End string for each invoke tag.
+    pub invoke_end: String,
+
+    /// Separator between consecutive invoke tags.
+    pub separator: String,
+
+    /// Tokens to ban when `tool_choice="none"`.
+    #[serde(default)]
+    pub tool_call_ban_tokens: Vec<String>,
+}
+
+/// Build a DSML tool-calls structural tag from config and request context.
+pub(crate) fn build_dsml_tool_calls(
+    config: &DsmlToolCallsConfig,
+    ctx: &ToolCallFormatBuildContext<'_>,
+) -> anyhow::Result<Option<StructuralTag>> {
+    let (tools_to_include, outer_at_least_one) = resolve_tools_to_include(ctx)?;
+
+    if tools_to_include.is_empty() {
+        return Ok(None);
+    }
+
+    // Per-tool invoke tags inside the DSML block.
+    let invoke_tags: Vec<TagFormat> = tools_to_include
+        .iter()
+        .map(|tool| {
+            let begin = config
+                .invoke_begin_template
+                .replace(TOOL_NAME_PLACEHOLDER, &tool.function.name);
+
+            TagFormat {
+                begin,
+                content: Box::new(Format::JsonSchema(JsonSchemaFormat {
+                    json_schema: resolve_tool_schema(tool, ctx.strict_schema()),
+                    style: JsonSchemaStyle::DeepseekXml,
+                })),
+                end: config.invoke_end.clone(),
+            }
+        })
+        .collect();
+
+    // Inner list of invokes.
+    let inner_content = Format::TagsWithSeparator(TagsWithSeparatorFormat {
+        tags: invoke_tags,
+        separator: config.separator.clone(),
+        at_least_one: true,
+        stop_after_first: ctx.stop_after_first(),
+    });
+
+    // Outer trigger that opens the DSML block.
+    let block_tag = TagFormat {
+        begin: config.block_begin.clone(),
+        content: Box::new(inner_content),
+        end: config.block_end.clone(),
+    };
+
+    Ok(Some(StructuralTag {
+        format: Format::TriggeredTags(TriggeredTagsFormat {
+            triggers: vec![config.trigger.clone()],
+            tags: vec![block_tag],
+            at_least_one: outer_at_least_one,
+            stop_after_first: false,
+        }),
+    }))
+}

--- a/lib/parsers/src/tool_calling/structural_tag/dsml.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/dsml.rs
@@ -63,7 +63,7 @@ pub(crate) fn build_dsml_tool_calls(
             // function name validated by validate_tools() in the request handler
             let begin = config
                 .invoke_begin_template
-                .replace(TOOL_NAME_PLACEHOLDER, &tool.function.name);
+                .replace(TOOL_NAME_PLACEHOLDER, &tool.name);
 
             TagFormat {
                 begin,

--- a/lib/parsers/src/tool_calling/structural_tag/dsml.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/dsml.rs
@@ -96,7 +96,7 @@ pub(crate) fn build_dsml_tool_calls(
             triggers: vec![config.trigger.clone()],
             tags: vec![block_tag],
             at_least_one: outer_at_least_one,
-            stop_after_first: false,
+            stop_after_first: ctx.stop_after_first(),
         }),
     }))
 }

--- a/lib/parsers/src/tool_calling/structural_tag/dsml.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/dsml.rs
@@ -39,6 +39,10 @@ pub struct DsmlToolCallsConfig {
     /// Tokens to ban when `tool_choice="none"`.
     #[serde(default)]
     pub tool_call_ban_tokens: Vec<String>,
+
+    /// Closing tag for prompt-injected reasoning, if this parser supports it.
+    #[serde(default)]
+    pub reasoning_end: Option<String>,
 }
 
 /// Build a DSML tool-calls structural tag from config and request context.

--- a/lib/parsers/src/tool_calling/structural_tag/dsml.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/dsml.rs
@@ -60,6 +60,7 @@ pub(crate) fn build_dsml_tool_calls(
     let invoke_tags: Vec<TagFormat> = tools_to_include
         .iter()
         .map(|tool| {
+            // function name validated by validate_tools() in the request handler
             let begin = config
                 .invoke_begin_template
                 .replace(TOOL_NAME_PLACEHOLDER, &tool.function.name);

--- a/lib/parsers/src/tool_calling/structural_tag/format.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/format.rs
@@ -39,6 +39,8 @@ pub enum Format {
     TriggeredTags(TriggeredTagsFormat),
     /// `{"type": "tags_with_separator", "tags": [...], "separator": ..., ...}`
     TagsWithSeparator(TagsWithSeparatorFormat),
+    /// `{"type": "sequence", "elements": [...]}`
+    Sequence(SequenceFormat),
     /// `{"type": "json_schema", "json_schema": ..., "style": ...}`
     JsonSchema(JsonSchemaFormat),
     /// `{"type": "any_tokens", "exclude_tokens": [...]}`
@@ -85,6 +87,12 @@ pub struct TagsWithSeparatorFormat {
     pub separator: String,
     pub at_least_one: bool,
     pub stop_after_first: bool,
+}
+
+/// `sequence`: a fixed sequence of format nodes.
+#[derive(Debug, Clone, Serialize)]
+pub struct SequenceFormat {
+    pub elements: Vec<Format>,
 }
 
 /// Content style for `json_schema` format nodes.
@@ -159,6 +167,17 @@ mod tests {
         let value = serde_json::to_value(&format).unwrap();
         assert_eq!(value["type"], "any_text");
         assert_eq!(value["excludes"][0], "<tool_call>\n<function=");
+    }
+
+    #[test]
+    fn sequence_serializes_correctly() {
+        let format = Format::Sequence(SequenceFormat {
+            elements: vec![Format::AnyText(AnyTextFormat { excludes: vec![] })],
+        });
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["type"], "sequence");
+        assert_eq!(value["elements"][0]["type"], "any_text");
     }
 
     #[test]

--- a/lib/parsers/src/tool_calling/structural_tag/format.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/format.rs
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Typed representations of xgrammar structural tag formats.
+//!
+//! This module models the subset of the
+//! [xgrammar structural tag API](https://xgrammar.mlc.ai/docs/structural_tag/structural_tag_api.html)
+//! used by Dynamo for tool-call guided decoding. The types serialize to the JSON
+//! shape expected by xgrammar backends.
+
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize, Serializer};
+use serde_json::Value;
+
+/// Top-level structural tag wrapper.
+///
+/// Serializes to `{"type": "structural_tag", "format": ...}`.
+#[derive(Debug, Clone)]
+pub struct StructuralTag {
+    pub format: Format,
+}
+
+impl Serialize for StructuralTag {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "structural_tag")?;
+        map.serialize_entry("format", &self.format)?;
+        map.end()
+    }
+}
+
+/// A format node inside a structural tag.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Format {
+    /// `{"type": "tag", "begin": ..., "content": ..., "end": ...}`
+    Tag(TagFormat),
+    /// `{"type": "triggered_tags", "triggers": [...], "tags": [...], ...}`
+    TriggeredTags(TriggeredTagsFormat),
+    /// `{"type": "tags_with_separator", "tags": [...], "separator": ..., ...}`
+    TagsWithSeparator(TagsWithSeparatorFormat),
+    /// `{"type": "json_schema", "json_schema": ..., "style": ...}`
+    JsonSchema(JsonSchemaFormat),
+    /// `{"type": "any_tokens", "exclude_tokens": [...]}`
+    AnyTokens(AnyTokensFormat),
+    /// `{"type": "any_text", "excludes": [...]}`
+    AnyText(AnyTextFormat),
+}
+
+/// `tag` format: `begin + content + end`.
+///
+/// Always serializes with `"type": "tag"` so it is valid both as a
+/// standalone format node and inside `TriggeredTagsFormat.tags`.
+#[derive(Debug, Clone)]
+pub struct TagFormat {
+    pub begin: String,
+    pub content: Box<Format>,
+    pub end: String,
+}
+
+impl Serialize for TagFormat {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry("type", "tag")?;
+        map.serialize_entry("begin", &self.begin)?;
+        map.serialize_entry("content", &self.content)?;
+        map.serialize_entry("end", &self.end)?;
+        map.end()
+    }
+}
+
+/// `triggered_tags`: free text until a trigger, then one of the configured tags.
+#[derive(Debug, Clone, Serialize)]
+pub struct TriggeredTagsFormat {
+    pub triggers: Vec<String>,
+    pub tags: Vec<TagFormat>,
+    pub at_least_one: bool,
+    pub stop_after_first: bool,
+}
+
+/// `tags_with_separator`: a tag sequence with fixed separators and no free text.
+#[derive(Debug, Clone, Serialize)]
+pub struct TagsWithSeparatorFormat {
+    pub tags: Vec<TagFormat>,
+    pub separator: String,
+    pub at_least_one: bool,
+    pub stop_after_first: bool,
+}
+
+/// Content style for `json_schema` format nodes.
+///
+/// Controls how xgrammar renders tool arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JsonSchemaStyle {
+    /// Standard JSON output.
+    #[default]
+    Json,
+    /// Qwen-style XML: `<parameter=name>value</parameter>`.
+    QwenXml,
+    /// MiniMax-style XML: `<parameter name="name">value</parameter>`.
+    MinimaxXml,
+    /// DeepSeek DSML XML parameter format.
+    DeepseekXml,
+}
+
+/// `json_schema` content format.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonSchemaFormat {
+    /// Full schema object, or `true` for unconstrained JSON.
+    pub json_schema: Value,
+
+    /// Output style for generated arguments.
+    pub style: JsonSchemaStyle,
+}
+
+/// `any_tokens` format: match zero or more tokens, excluding specific ones.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnyTokensFormat {
+    pub exclude_tokens: Vec<String>,
+}
+
+/// `any_text` format: match zero or more tokens, excluding arbitrary text.
+#[derive(Debug, Clone, Serialize)]
+pub struct AnyTextFormat {
+    pub excludes: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn structural_tag_serializes_correctly() {
+        let tag = StructuralTag {
+            format: Format::Tag(TagFormat {
+                begin: "<think>".to_string(),
+                content: Box::new(Format::AnyTokens(AnyTokensFormat {
+                    exclude_tokens: vec!["<eos>".to_string()],
+                })),
+                end: "</think>".to_string(),
+            }),
+        };
+
+        let value = serde_json::to_value(&tag).unwrap();
+        assert_eq!(value["type"], "structural_tag");
+        assert_eq!(value["format"]["type"], "tag");
+        assert_eq!(value["format"]["begin"], "<think>");
+        assert_eq!(value["format"]["content"]["type"], "any_tokens");
+    }
+
+    #[test]
+    fn any_text_serializes_correctly() {
+        let format = Format::AnyText(AnyTextFormat {
+            excludes: vec!["<tool_call>\n<function=".to_string()],
+        });
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["type"], "any_text");
+        assert_eq!(value["excludes"][0], "<tool_call>\n<function=");
+    }
+
+    #[test]
+    fn triggered_tags_serializes_at_least_one_when_false() {
+        let format = TriggeredTagsFormat {
+            triggers: vec!["<fn=".to_string()],
+            tags: vec![],
+            at_least_one: false,
+            stop_after_first: false,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["at_least_one"], false);
+    }
+
+    #[test]
+    fn triggered_tags_includes_at_least_one_when_true() {
+        let format = TriggeredTagsFormat {
+            triggers: vec!["<fn=".to_string()],
+            tags: vec![],
+            at_least_one: true,
+            stop_after_first: false,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["at_least_one"], true);
+    }
+
+    #[test]
+    fn json_schema_serializes_default_style() {
+        let format = JsonSchemaFormat {
+            json_schema: json!(true),
+            style: JsonSchemaStyle::Json,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["style"], "json");
+    }
+
+    #[test]
+    fn json_schema_serializes_non_default_style() {
+        let format = JsonSchemaFormat {
+            json_schema: json!(true),
+            style: JsonSchemaStyle::QwenXml,
+        };
+
+        let value = serde_json::to_value(&format).unwrap();
+        assert_eq!(value["style"], "qwen_xml");
+    }
+}

--- a/lib/parsers/src/tool_calling/structural_tag/mod.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/mod.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Structural tag builder for guided decoding with tool calls.
+//!
+//! Parsers with a [`StructuralTagBuilder`] can generate xgrammar structural
+//! tags that constrain guided decoding to a model-specific tool-call format.
+//!
+//! # Module layout
+//!
+//! - [`format`] — typed representations of xgrammar format nodes
+//! - [`builder`] — public builder API used by the preprocessor
+//! - [`triggered_tags`] — `triggered_tags` format implementation
+//! - [`dsml`] — DeepSeek V3.2+ DSML tool-call format implementation
+
+pub mod builder;
+pub mod dsml;
+pub mod format;
+pub mod triggered_tags;
+
+/// Placeholder in structural tag templates that is replaced with the tool
+/// function name at request time.
+pub const TOOL_NAME_PLACEHOLDER: &str = "{name}";
+
+pub use builder::{StructuralTagBuilder, StructuralTagSchemaMode, ToolCallFormatBuildContext};
+pub use dsml::DsmlToolCallsConfig;
+pub use triggered_tags::TriggeredTagsConfig;
+
+#[cfg(test)]
+mod tests;

--- a/lib/parsers/src/tool_calling/structural_tag/tests.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/tests.rs
@@ -1,0 +1,528 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_protocols::types::{
+    ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType, FunctionObject,
+};
+use serde_json::{Value, json};
+
+use super::TOOL_NAME_PLACEHOLDER;
+use super::builder::{StructuralTagBuilder, StructuralTagSchemaMode, ToolCallFormatBuildContext};
+use super::dsml::DsmlToolCallsConfig;
+use super::format::JsonSchemaStyle;
+use super::triggered_tags::TriggeredTagsConfig;
+use crate::tool_calling::ToolCallConfig;
+
+fn sample_config() -> TriggeredTagsConfig {
+    TriggeredTagsConfig {
+        begin_template: format!("<function={}>", TOOL_NAME_PLACEHOLDER),
+        end_template: "</function>".to_string(),
+        triggers: vec!["<function=".to_string()],
+        content_style: JsonSchemaStyle::Json,
+        tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+    }
+}
+
+fn sample_tools() -> Vec<ChatCompletionTool> {
+    vec![
+        ChatCompletionTool {
+            r#type: ChatCompletionToolType::Function,
+            function: FunctionObject {
+                name: "add_numbers".to_string(),
+                description: Some("Add two integers".to_string()),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"},
+                    },
+                    "required": ["a", "b"],
+                })),
+                strict: None,
+            },
+        },
+        ChatCompletionTool {
+            r#type: ChatCompletionToolType::Function,
+            function: FunctionObject {
+                name: "get_weather".to_string(),
+                description: Some("Get weather".to_string()),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                    },
+                    "required": ["location"],
+                })),
+                strict: None,
+            },
+        },
+    ]
+}
+
+fn builder() -> StructuralTagBuilder {
+    StructuralTagBuilder::TriggeredTags(sample_config())
+}
+
+fn ctx<'a>(
+    tool_choice: &'a ChatCompletionToolChoiceOption,
+    tools: &'a [ChatCompletionTool],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+) -> ToolCallFormatBuildContext<'a> {
+    ToolCallFormatBuildContext {
+        tool_choice,
+        tools,
+        parallel_tool_calls,
+        schema_mode,
+    }
+}
+
+/// Helper: build and unwrap both Result and Option layers.
+fn build_unwrap(
+    builder: &StructuralTagBuilder,
+    tool_choice: &ChatCompletionToolChoiceOption,
+    tools: &[ChatCompletionTool],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+) -> Value {
+    let c = ctx(tool_choice, tools, parallel_tool_calls, schema_mode);
+    builder
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some")
+}
+
+#[test]
+fn required_builds_all_tools_with_at_least_one() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["type"], "structural_tag");
+    assert_eq!(parsed["format"]["type"], "triggered_tags");
+    assert_eq!(parsed["format"]["at_least_one"], true);
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 2);
+    // Each tag element must have "type": "tag" per xgrammar spec.
+    assert_eq!(tags[0]["type"], "tag");
+    assert_eq!(tags[0]["begin"], "<function=add_numbers>");
+    assert_eq!(tags[1]["type"], "tag");
+    assert_eq!(tags[1]["begin"], "<function=get_weather>");
+    assert_eq!(tags[0]["end"], "</function>");
+}
+
+#[test]
+fn auto_builds_all_tools_without_at_least_one() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Auto,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["at_least_one"], false);
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 2);
+    assert_eq!(tags[0]["type"], "tag");
+    assert_eq!(tags[1]["type"], "tag");
+}
+
+#[test]
+fn named_builds_single_tool() {
+    let tools = sample_tools();
+    let named = ChatCompletionToolChoiceOption::Named(
+        dynamo_protocols::types::ChatCompletionNamedToolChoice {
+            r#type: ChatCompletionToolType::Function,
+            function: dynamo_protocols::types::FunctionName {
+                name: "get_weather".to_string(),
+            },
+        },
+    );
+    let parsed = build_unwrap(
+        &builder(),
+        &named,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["at_least_one"], true);
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0]["type"], "tag");
+    assert_eq!(tags[0]["begin"], "<function=get_weather>");
+}
+
+#[test]
+fn named_unknown_tool_returns_error() {
+    let tools = sample_tools();
+    let named = ChatCompletionToolChoiceOption::Named(
+        dynamo_protocols::types::ChatCompletionNamedToolChoice {
+            r#type: ChatCompletionToolType::Function,
+            function: dynamo_protocols::types::FunctionName {
+                name: "nonexistent".to_string(),
+            },
+        },
+    );
+    let c = ctx(&named, &tools, None, StructuralTagSchemaMode::Auto);
+    let err = builder()
+        .build_tool_call_format(&c)
+        .expect_err("should error for unknown tool");
+    assert!(
+        err.to_string().contains("nonexistent"),
+        "error should mention the missing tool name: {err}"
+    );
+}
+
+#[test]
+fn required_with_empty_tools_returns_error() {
+    let c = ctx(
+        &ChatCompletionToolChoiceOption::Required,
+        &[],
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let err = builder()
+        .build_tool_call_format(&c)
+        .expect_err("should error for empty tools");
+    assert!(
+        err.to_string().contains("empty"),
+        "error should mention empty tools: {err}"
+    );
+}
+
+#[test]
+fn none_returns_ok_none() {
+    let tools = sample_tools();
+    let c = ctx(
+        &ChatCompletionToolChoiceOption::None,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let result = builder()
+        .build_tool_call_format(&c)
+        .expect("should not error");
+    assert!(result.is_none());
+}
+
+#[test]
+fn auto_with_empty_tools_returns_ok_none() {
+    let c = ctx(
+        &ChatCompletionToolChoiceOption::Auto,
+        &[],
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let result = builder()
+        .build_tool_call_format(&c)
+        .expect("should not error");
+    assert!(result.is_none());
+}
+
+#[test]
+fn parallel_false_sets_stop_after_first() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        Some(false),
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["stop_after_first"], true);
+}
+
+#[test]
+fn parallel_true_does_not_stop_after_first() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        Some(true),
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["stop_after_first"], false);
+}
+
+#[test]
+fn non_strict_tools_get_unconstrained_schema() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert_eq!(tags[0]["content"]["json_schema"], json!(true));
+}
+
+#[test]
+fn strict_tool_uses_own_schema() {
+    let mut tools = sample_tools();
+    tools[0].function.strict = Some(true);
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert!(tags[0]["content"]["json_schema"]["properties"]["a"].is_object());
+    assert_eq!(tags[1]["content"]["json_schema"], json!(true));
+}
+
+#[test]
+fn strict_schema_mode_uses_real_schema_for_all() {
+    let tools = sample_tools();
+    let parsed = build_unwrap(
+        &builder(),
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Strict,
+    );
+
+    let tags = parsed["format"]["tags"].as_array().unwrap();
+    assert!(tags[0]["content"]["json_schema"]["properties"]["a"].is_object());
+    assert!(tags[1]["content"]["json_schema"]["properties"]["location"].is_object());
+}
+
+#[test]
+fn tool_call_ban_tag_bans_tokens() {
+    let result = builder()
+        .build_tool_call_ban()
+        .expect("should serialize")
+        .expect("should build");
+
+    assert_eq!(result["type"], "structural_tag");
+    assert_eq!(result["format"]["type"], "tag");
+    assert_eq!(result["format"]["content"]["type"], "any_tokens");
+    assert_eq!(
+        result["format"]["content"]["exclude_tokens"][0],
+        "<tool_call>"
+    );
+}
+
+#[test]
+fn tool_call_ban_empty_tokens_returns_none() {
+    let mut config = sample_config();
+    config.tool_call_ban_tokens = vec![];
+    let b = StructuralTagBuilder::TriggeredTags(config);
+    assert!(b.build_tool_call_ban().expect("should serialize").is_none());
+}
+
+// ---- DSML builder tests ----
+
+fn dsml_config() -> DsmlToolCallsConfig {
+    DsmlToolCallsConfig {
+        trigger: "<｜DSML｜function_calls>".to_string(),
+        block_begin: "<｜DSML｜function_calls>\n".to_string(),
+        block_end: "</｜DSML｜function_calls>".to_string(),
+        invoke_begin_template: format!("<｜DSML｜invoke name=\"{}\">\n", TOOL_NAME_PLACEHOLDER),
+        invoke_end: "</｜DSML｜invoke>\n".to_string(),
+        separator: "".to_string(),
+        tool_call_ban_tokens: vec![],
+    }
+}
+
+fn dsml_builder() -> StructuralTagBuilder {
+    StructuralTagBuilder::DsmlToolCalls(dsml_config())
+}
+
+fn dsml_build_unwrap(
+    tool_choice: &ChatCompletionToolChoiceOption,
+    tools: &[ChatCompletionTool],
+    parallel_tool_calls: Option<bool>,
+    schema_mode: StructuralTagSchemaMode,
+) -> Value {
+    let c = ctx(tool_choice, tools, parallel_tool_calls, schema_mode);
+    dsml_builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some")
+}
+
+#[test]
+fn dsml_required_builds_nested_structure() {
+    let tools = sample_tools();
+    let parsed = dsml_build_unwrap(
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    // Top level: structural_tag
+    assert_eq!(parsed["type"], "structural_tag");
+
+    // Outer: triggered_tags with one block tag
+    let fmt = &parsed["format"];
+    assert_eq!(fmt["type"], "triggered_tags");
+    assert_eq!(fmt["triggers"][0], "<｜DSML｜function_calls>");
+    assert_eq!(fmt["at_least_one"], true);
+    assert_eq!(fmt["stop_after_first"], false);
+    assert!(fmt.get("excludes").is_none());
+
+    let outer_tags = fmt["tags"].as_array().unwrap();
+    assert_eq!(outer_tags.len(), 1);
+
+    // Block tag wrapping the invokes
+    let block = &outer_tags[0];
+    assert_eq!(block["type"], "tag");
+    assert_eq!(block["begin"], "<｜DSML｜function_calls>\n");
+    assert_eq!(block["end"], "</｜DSML｜function_calls>");
+
+    // Inner: tags_with_separator
+    let inner = &block["content"];
+    assert_eq!(inner["type"], "tags_with_separator");
+    assert_eq!(inner["separator"], "");
+    assert_eq!(inner["at_least_one"], true);
+    assert_eq!(inner["stop_after_first"], false);
+
+    // Per-tool invoke tags
+    let invoke_tags = inner["tags"].as_array().unwrap();
+    assert_eq!(invoke_tags.len(), 2);
+    assert_eq!(invoke_tags[0]["type"], "tag");
+    assert_eq!(
+        invoke_tags[0]["begin"],
+        "<｜DSML｜invoke name=\"add_numbers\">\n"
+    );
+    assert_eq!(invoke_tags[0]["end"], "</｜DSML｜invoke>\n");
+    assert_eq!(invoke_tags[0]["content"]["type"], "json_schema");
+    assert_eq!(invoke_tags[0]["content"]["style"], "deepseek_xml");
+
+    assert_eq!(
+        invoke_tags[1]["begin"],
+        "<｜DSML｜invoke name=\"get_weather\">\n"
+    );
+}
+
+#[test]
+fn dsml_auto_sets_inner_at_least_one() {
+    let tools = sample_tools();
+    let parsed = dsml_build_unwrap(
+        &ChatCompletionToolChoiceOption::Auto,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["at_least_one"], false);
+    assert_eq!(parsed["format"]["stop_after_first"], false);
+    let inner = &parsed["format"]["tags"][0]["content"];
+    assert_eq!(inner["at_least_one"], true);
+}
+
+#[test]
+fn dsml_named_builds_single_invoke() {
+    let tools = sample_tools();
+    let named = ChatCompletionToolChoiceOption::Named(
+        dynamo_protocols::types::ChatCompletionNamedToolChoice {
+            r#type: ChatCompletionToolType::Function,
+            function: dynamo_protocols::types::FunctionName {
+                name: "get_weather".to_string(),
+            },
+        },
+    );
+    let parsed = dsml_build_unwrap(&named, &tools, None, StructuralTagSchemaMode::Auto);
+
+    let invoke_tags = parsed["format"]["tags"][0]["content"]["tags"]
+        .as_array()
+        .unwrap();
+    assert_eq!(invoke_tags.len(), 1);
+    assert_eq!(
+        invoke_tags[0]["begin"],
+        "<｜DSML｜invoke name=\"get_weather\">\n"
+    );
+}
+
+#[test]
+fn dsml_parallel_false_sets_stop_after_first() {
+    let tools = sample_tools();
+    let parsed = dsml_build_unwrap(
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        Some(false),
+        StructuralTagSchemaMode::Auto,
+    );
+
+    assert_eq!(parsed["format"]["stop_after_first"], false);
+    let inner = &parsed["format"]["tags"][0]["content"];
+    assert_eq!(inner["stop_after_first"], true);
+}
+
+#[test]
+fn dsml_none_returns_ok_none() {
+    let tools = sample_tools();
+    let c = ctx(
+        &ChatCompletionToolChoiceOption::None,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let result = dsml_builder()
+        .build_tool_call_format(&c)
+        .expect("should not error");
+    assert!(result.is_none());
+}
+
+#[test]
+fn deepseek_v4_config_builds_tool_calls_block() {
+    let tools = sample_tools();
+    let config = ToolCallConfig::deepseek_v4();
+    let builder = config
+        .structural_tag_builder
+        .as_ref()
+        .expect("deepseek_v4 should provide a structural tag builder");
+    let c = ctx(
+        &ChatCompletionToolChoiceOption::Required,
+        &tools,
+        None,
+        StructuralTagSchemaMode::Auto,
+    );
+    let parsed = builder
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    let fmt = &parsed["format"];
+    assert_eq!(fmt["type"], "triggered_tags");
+    assert_eq!(fmt["triggers"][0], "<｜DSML｜tool_calls>");
+    assert_eq!(fmt["at_least_one"], true);
+    assert!(fmt.get("excludes").is_none());
+
+    let block = &fmt["tags"][0];
+    assert_eq!(block["type"], "tag");
+    assert_eq!(block["begin"], "<｜DSML｜tool_calls>\n");
+    assert_eq!(block["end"], "</｜DSML｜tool_calls>");
+
+    let inner = &block["content"];
+    assert_eq!(inner["type"], "tags_with_separator");
+    assert_eq!(inner["at_least_one"], true);
+    assert_eq!(inner["separator"], "");
+
+    let invoke_tags = inner["tags"].as_array().unwrap();
+    assert_eq!(invoke_tags.len(), 2);
+    assert_eq!(
+        invoke_tags[0]["begin"],
+        "<｜DSML｜invoke name=\"add_numbers\">\n"
+    );
+    assert_eq!(invoke_tags[0]["end"], "</｜DSML｜invoke>\n");
+    assert_eq!(invoke_tags[0]["content"]["style"], "deepseek_xml");
+}

--- a/lib/parsers/src/tool_calling/structural_tag/tests.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/tests.rs
@@ -20,6 +20,7 @@ fn sample_config() -> TriggeredTagsConfig {
         triggers: vec!["<function=".to_string()],
         content_style: JsonSchemaStyle::Json,
         tool_call_ban_tokens: vec!["<tool_call>".to_string()],
+        reasoning_end: Some("</think>".to_string()),
     }
 }
 
@@ -74,6 +75,20 @@ fn ctx<'a>(
         tools,
         parallel_tool_calls,
         schema_mode,
+        starts_in_reasoning: false,
+    }
+}
+
+fn ctx_starting_in_reasoning<'a>(
+    tool_choice: &'a ChatCompletionToolChoiceOption,
+    tools: &'a [ChatCompletionTool],
+) -> ToolCallFormatBuildContext<'a> {
+    ToolCallFormatBuildContext {
+        tool_choice,
+        tools,
+        parallel_tool_calls: None,
+        schema_mode: StructuralTagSchemaMode::Auto,
+        starts_in_reasoning: true,
     }
 }
 
@@ -327,6 +342,40 @@ fn tool_call_ban_empty_tokens_returns_none() {
     assert!(b.build_tool_call_ban().expect("should serialize").is_none());
 }
 
+#[test]
+fn required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
+    let tools = sample_tools();
+    let c = ctx_starting_in_reasoning(&ChatCompletionToolChoiceOption::Required, &tools);
+
+    let parsed = builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    assert_eq!(parsed["format"]["type"], "sequence");
+    assert_eq!(parsed["format"]["elements"][0]["type"], "tag");
+    assert_eq!(parsed["format"]["elements"][0]["begin"], "");
+    assert_eq!(
+        parsed["format"]["elements"][0]["content"]["type"],
+        "any_text"
+    );
+    assert_eq!(parsed["format"]["elements"][0]["end"], "</think>");
+    assert_eq!(parsed["format"]["elements"][1]["type"], "triggered_tags");
+}
+
+#[test]
+fn auto_starting_in_reasoning_keeps_plain_tool_call_format() {
+    let tools = sample_tools();
+    let c = ctx_starting_in_reasoning(&ChatCompletionToolChoiceOption::Auto, &tools);
+
+    let parsed = builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    assert_eq!(parsed["format"]["type"], "triggered_tags");
+}
+
 // ---- DSML builder tests ----
 
 fn dsml_config() -> DsmlToolCallsConfig {
@@ -338,6 +387,7 @@ fn dsml_config() -> DsmlToolCallsConfig {
         invoke_end: "</｜DSML｜invoke>\n".to_string(),
         separator: "".to_string(),
         tool_call_ban_tokens: vec![],
+        reasoning_end: Some("</think>".to_string()),
     }
 }
 
@@ -480,6 +530,25 @@ fn dsml_none_returns_ok_none() {
         .build_tool_call_format(&c)
         .expect("should not error");
     assert!(result.is_none());
+}
+
+#[test]
+fn dsml_required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
+    let tools = sample_tools();
+    let c = ctx_starting_in_reasoning(&ChatCompletionToolChoiceOption::Required, &tools);
+
+    let parsed = dsml_builder()
+        .build_tool_call_format(&c)
+        .expect("build should not error")
+        .expect("build should return Some");
+
+    assert_eq!(parsed["format"]["type"], "sequence");
+    assert_eq!(parsed["format"]["elements"][0]["end"], "</think>");
+    assert_eq!(parsed["format"]["elements"][1]["type"], "triggered_tags");
+    assert_eq!(
+        parsed["format"]["elements"][1]["triggers"][0],
+        "<｜DSML｜function_calls>"
+    );
 }
 
 #[test]

--- a/lib/parsers/src/tool_calling/structural_tag/tests.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/tests.rs
@@ -595,3 +595,33 @@ fn deepseek_v4_config_builds_tool_calls_block() {
     assert_eq!(invoke_tags[0]["end"], "</｜DSML｜invoke>\n");
     assert_eq!(invoke_tags[0]["content"]["style"], "deepseek_xml");
 }
+
+/// Round-trip every supported parser through the real parser map.
+#[test]
+fn parser_map_structural_tag_smoke() {
+    let map = crate::tool_calling::parsers::get_tool_parser_map();
+    let tools = sample_tools();
+    let names = ["hermes", "qwen3_coder", "deepseek_v3_2", "deepseek_v4"];
+
+    for name in names {
+        let builder = map
+            .get(name)
+            .unwrap_or_else(|| panic!("'{name}' not in parser map"))
+            .structural_tag_builder
+            .as_ref()
+            .unwrap_or_else(|| panic!("'{name}' has no structural_tag_builder"));
+
+        let c = ctx(
+            &ChatCompletionToolChoiceOption::Required,
+            &tools,
+            None,
+            StructuralTagSchemaMode::Auto,
+        );
+        let tag = builder
+            .build_tool_call_format(&c)
+            .unwrap_or_else(|e| panic!("'{name}' failed: {e}"))
+            .unwrap_or_else(|| panic!("'{name}' returned None for Required"));
+
+        assert_eq!(tag["type"], "structural_tag", "'{name}'");
+    }
+}

--- a/lib/parsers/src/tool_calling/structural_tag/tests.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/tests.rs
@@ -512,7 +512,7 @@ fn dsml_parallel_false_sets_stop_after_first() {
         StructuralTagSchemaMode::Auto,
     );
 
-    assert_eq!(parsed["format"]["stop_after_first"], false);
+    assert_eq!(parsed["format"]["stop_after_first"], true);
     let inner = &parsed["format"]["tags"][0]["content"];
     assert_eq!(inner["stop_after_first"], true);
 }

--- a/lib/parsers/src/tool_calling/structural_tag/tests.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/tests.rs
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_protocols::types::{
-    ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType, FunctionObject,
-};
 use serde_json::{Value, json};
 
 use super::TOOL_NAME_PLACEHOLDER;
@@ -11,7 +8,7 @@ use super::builder::{StructuralTagBuilder, StructuralTagSchemaMode, ToolCallForm
 use super::dsml::DsmlToolCallsConfig;
 use super::format::JsonSchemaStyle;
 use super::triggered_tags::TriggeredTagsConfig;
-use crate::tool_calling::ToolCallConfig;
+use crate::tool_calling::{ToolCallConfig, ToolChoice, ToolDefinition};
 
 fn sample_config() -> TriggeredTagsConfig {
     TriggeredTagsConfig {
@@ -24,38 +21,30 @@ fn sample_config() -> TriggeredTagsConfig {
     }
 }
 
-fn sample_tools() -> Vec<ChatCompletionTool> {
+fn sample_tools() -> Vec<ToolDefinition> {
     vec![
-        ChatCompletionTool {
-            r#type: ChatCompletionToolType::Function,
-            function: FunctionObject {
-                name: "add_numbers".to_string(),
-                description: Some("Add two integers".to_string()),
-                parameters: Some(json!({
-                    "type": "object",
-                    "properties": {
-                        "a": {"type": "integer"},
-                        "b": {"type": "integer"},
-                    },
-                    "required": ["a", "b"],
-                })),
-                strict: None,
-            },
+        ToolDefinition {
+            name: "add_numbers".to_string(),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            })),
+            strict: None,
         },
-        ChatCompletionTool {
-            r#type: ChatCompletionToolType::Function,
-            function: FunctionObject {
-                name: "get_weather".to_string(),
-                description: Some("Get weather".to_string()),
-                parameters: Some(json!({
-                    "type": "object",
-                    "properties": {
-                        "location": {"type": "string"},
-                    },
-                    "required": ["location"],
-                })),
-                strict: None,
-            },
+        ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            })),
+            strict: None,
         },
     ]
 }
@@ -65,8 +54,8 @@ fn builder() -> StructuralTagBuilder {
 }
 
 fn ctx<'a>(
-    tool_choice: &'a ChatCompletionToolChoiceOption,
-    tools: &'a [ChatCompletionTool],
+    tool_choice: &'a ToolChoice,
+    tools: &'a [ToolDefinition],
     parallel_tool_calls: Option<bool>,
     schema_mode: StructuralTagSchemaMode,
 ) -> ToolCallFormatBuildContext<'a> {
@@ -80,8 +69,8 @@ fn ctx<'a>(
 }
 
 fn ctx_starting_in_reasoning<'a>(
-    tool_choice: &'a ChatCompletionToolChoiceOption,
-    tools: &'a [ChatCompletionTool],
+    tool_choice: &'a ToolChoice,
+    tools: &'a [ToolDefinition],
 ) -> ToolCallFormatBuildContext<'a> {
     ToolCallFormatBuildContext {
         tool_choice,
@@ -95,8 +84,8 @@ fn ctx_starting_in_reasoning<'a>(
 /// Helper: build and unwrap both Result and Option layers.
 fn build_unwrap(
     builder: &StructuralTagBuilder,
-    tool_choice: &ChatCompletionToolChoiceOption,
-    tools: &[ChatCompletionTool],
+    tool_choice: &ToolChoice,
+    tools: &[ToolDefinition],
     parallel_tool_calls: Option<bool>,
     schema_mode: StructuralTagSchemaMode,
 ) -> Value {
@@ -112,7 +101,7 @@ fn required_builds_all_tools_with_at_least_one() {
     let tools = sample_tools();
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -136,7 +125,7 @@ fn auto_builds_all_tools_without_at_least_one() {
     let tools = sample_tools();
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Auto,
+        &ToolChoice::Auto,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -152,14 +141,7 @@ fn auto_builds_all_tools_without_at_least_one() {
 #[test]
 fn named_builds_single_tool() {
     let tools = sample_tools();
-    let named = ChatCompletionToolChoiceOption::Named(
-        dynamo_protocols::types::ChatCompletionNamedToolChoice {
-            r#type: ChatCompletionToolType::Function,
-            function: dynamo_protocols::types::FunctionName {
-                name: "get_weather".to_string(),
-            },
-        },
-    );
+    let named = ToolChoice::Named("get_weather".to_string());
     let parsed = build_unwrap(
         &builder(),
         &named,
@@ -178,14 +160,7 @@ fn named_builds_single_tool() {
 #[test]
 fn named_unknown_tool_returns_error() {
     let tools = sample_tools();
-    let named = ChatCompletionToolChoiceOption::Named(
-        dynamo_protocols::types::ChatCompletionNamedToolChoice {
-            r#type: ChatCompletionToolType::Function,
-            function: dynamo_protocols::types::FunctionName {
-                name: "nonexistent".to_string(),
-            },
-        },
-    );
+    let named = ToolChoice::Named("nonexistent".to_string());
     let c = ctx(&named, &tools, None, StructuralTagSchemaMode::Auto);
     let err = builder()
         .build_tool_call_format(&c)
@@ -199,7 +174,7 @@ fn named_unknown_tool_returns_error() {
 #[test]
 fn required_with_empty_tools_returns_error() {
     let c = ctx(
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &[],
         None,
         StructuralTagSchemaMode::Auto,
@@ -217,7 +192,7 @@ fn required_with_empty_tools_returns_error() {
 fn none_returns_ok_none() {
     let tools = sample_tools();
     let c = ctx(
-        &ChatCompletionToolChoiceOption::None,
+        &ToolChoice::None,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -230,12 +205,7 @@ fn none_returns_ok_none() {
 
 #[test]
 fn auto_with_empty_tools_returns_ok_none() {
-    let c = ctx(
-        &ChatCompletionToolChoiceOption::Auto,
-        &[],
-        None,
-        StructuralTagSchemaMode::Auto,
-    );
+    let c = ctx(&ToolChoice::Auto, &[], None, StructuralTagSchemaMode::Auto);
     let result = builder()
         .build_tool_call_format(&c)
         .expect("should not error");
@@ -247,7 +217,7 @@ fn parallel_false_sets_stop_after_first() {
     let tools = sample_tools();
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         Some(false),
         StructuralTagSchemaMode::Auto,
@@ -261,7 +231,7 @@ fn parallel_true_does_not_stop_after_first() {
     let tools = sample_tools();
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         Some(true),
         StructuralTagSchemaMode::Auto,
@@ -275,7 +245,7 @@ fn non_strict_tools_get_unconstrained_schema() {
     let tools = sample_tools();
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -288,10 +258,10 @@ fn non_strict_tools_get_unconstrained_schema() {
 #[test]
 fn strict_tool_uses_own_schema() {
     let mut tools = sample_tools();
-    tools[0].function.strict = Some(true);
+    tools[0].strict = Some(true);
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -307,7 +277,7 @@ fn strict_schema_mode_uses_real_schema_for_all() {
     let tools = sample_tools();
     let parsed = build_unwrap(
         &builder(),
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         None,
         StructuralTagSchemaMode::Strict,
@@ -345,7 +315,7 @@ fn tool_call_ban_empty_tokens_returns_none() {
 #[test]
 fn required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
     let tools = sample_tools();
-    let c = ctx_starting_in_reasoning(&ChatCompletionToolChoiceOption::Required, &tools);
+    let c = ctx_starting_in_reasoning(&ToolChoice::Required, &tools);
 
     let parsed = builder()
         .build_tool_call_format(&c)
@@ -366,7 +336,7 @@ fn required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
 #[test]
 fn auto_starting_in_reasoning_keeps_plain_tool_call_format() {
     let tools = sample_tools();
-    let c = ctx_starting_in_reasoning(&ChatCompletionToolChoiceOption::Auto, &tools);
+    let c = ctx_starting_in_reasoning(&ToolChoice::Auto, &tools);
 
     let parsed = builder()
         .build_tool_call_format(&c)
@@ -396,8 +366,8 @@ fn dsml_builder() -> StructuralTagBuilder {
 }
 
 fn dsml_build_unwrap(
-    tool_choice: &ChatCompletionToolChoiceOption,
-    tools: &[ChatCompletionTool],
+    tool_choice: &ToolChoice,
+    tools: &[ToolDefinition],
     parallel_tool_calls: Option<bool>,
     schema_mode: StructuralTagSchemaMode,
 ) -> Value {
@@ -412,7 +382,7 @@ fn dsml_build_unwrap(
 fn dsml_required_builds_nested_structure() {
     let tools = sample_tools();
     let parsed = dsml_build_unwrap(
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -467,7 +437,7 @@ fn dsml_required_builds_nested_structure() {
 fn dsml_auto_sets_inner_at_least_one() {
     let tools = sample_tools();
     let parsed = dsml_build_unwrap(
-        &ChatCompletionToolChoiceOption::Auto,
+        &ToolChoice::Auto,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -482,14 +452,7 @@ fn dsml_auto_sets_inner_at_least_one() {
 #[test]
 fn dsml_named_builds_single_invoke() {
     let tools = sample_tools();
-    let named = ChatCompletionToolChoiceOption::Named(
-        dynamo_protocols::types::ChatCompletionNamedToolChoice {
-            r#type: ChatCompletionToolType::Function,
-            function: dynamo_protocols::types::FunctionName {
-                name: "get_weather".to_string(),
-            },
-        },
-    );
+    let named = ToolChoice::Named("get_weather".to_string());
     let parsed = dsml_build_unwrap(&named, &tools, None, StructuralTagSchemaMode::Auto);
 
     let invoke_tags = parsed["format"]["tags"][0]["content"]["tags"]
@@ -506,7 +469,7 @@ fn dsml_named_builds_single_invoke() {
 fn dsml_parallel_false_sets_stop_after_first() {
     let tools = sample_tools();
     let parsed = dsml_build_unwrap(
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         Some(false),
         StructuralTagSchemaMode::Auto,
@@ -521,7 +484,7 @@ fn dsml_parallel_false_sets_stop_after_first() {
 fn dsml_none_returns_ok_none() {
     let tools = sample_tools();
     let c = ctx(
-        &ChatCompletionToolChoiceOption::None,
+        &ToolChoice::None,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -535,7 +498,7 @@ fn dsml_none_returns_ok_none() {
 #[test]
 fn dsml_required_starting_in_reasoning_wraps_tool_calls_in_sequence() {
     let tools = sample_tools();
-    let c = ctx_starting_in_reasoning(&ChatCompletionToolChoiceOption::Required, &tools);
+    let c = ctx_starting_in_reasoning(&ToolChoice::Required, &tools);
 
     let parsed = dsml_builder()
         .build_tool_call_format(&c)
@@ -560,7 +523,7 @@ fn deepseek_v4_config_builds_tool_calls_block() {
         .as_ref()
         .expect("deepseek_v4 should provide a structural tag builder");
     let c = ctx(
-        &ChatCompletionToolChoiceOption::Required,
+        &ToolChoice::Required,
         &tools,
         None,
         StructuralTagSchemaMode::Auto,
@@ -612,7 +575,7 @@ fn parser_map_structural_tag_smoke() {
             .unwrap_or_else(|| panic!("'{name}' has no structural_tag_builder"));
 
         let c = ctx(
-            &ChatCompletionToolChoiceOption::Required,
+            &ToolChoice::Required,
             &tools,
             None,
             StructuralTagSchemaMode::Auto,

--- a/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
@@ -35,6 +35,10 @@ pub struct TriggeredTagsConfig {
     /// Tokens to ban when `tool_choice="none"`.
     #[serde(default)]
     pub tool_call_ban_tokens: Vec<String>,
+
+    /// Closing tag for prompt-injected reasoning, if this parser supports it.
+    #[serde(default)]
+    pub reasoning_end: Option<String>,
 }
 
 /// Build a `triggered_tags` structural tag from config and request context.

--- a/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
@@ -57,6 +57,7 @@ pub(crate) fn build_triggered_tags(
     let tags: Vec<TagFormat> = tools_to_include
         .iter()
         .map(|tool| {
+            // function name validated by validate_tools() in the request handler
             let begin = config
                 .begin_template
                 .replace(TOOL_NAME_PLACEHOLDER, &tool.function.name);

--- a/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
@@ -60,7 +60,7 @@ pub(crate) fn build_triggered_tags(
             // function name validated by validate_tools() in the request handler
             let begin = config
                 .begin_template
-                .replace(TOOL_NAME_PLACEHOLDER, &tool.function.name);
+                .replace(TOOL_NAME_PLACEHOLDER, &tool.name);
 
             TagFormat {
                 begin,

--- a/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
+++ b/lib/parsers/src/tool_calling/structural_tag/triggered_tags.rs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! [`StructuralTagBuilder::TriggeredTags`] implementation.
+//!
+//! Builds xgrammar `triggered_tags` tool-call formats.
+
+use serde::{Deserialize, Serialize};
+
+use super::TOOL_NAME_PLACEHOLDER;
+use super::builder::{ToolCallFormatBuildContext, resolve_tool_schema, resolve_tools_to_include};
+use super::format::{
+    Format, JsonSchemaFormat, JsonSchemaStyle, StructuralTag, TagFormat, TriggeredTagsFormat,
+};
+
+/// Configuration for `triggered_tags` formats where each tool is a tag.
+///
+/// The model can emit free text until a trigger is encountered, then guided
+/// decoding constrains the output to the matching tool call structure.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TriggeredTagsConfig {
+    /// Begin tag template; [`TOOL_NAME_PLACEHOLDER`] is replaced per tool.
+    pub begin_template: String,
+
+    /// End tag appended after each tool call's content.
+    pub end_template: String,
+
+    /// Trigger patterns that signal the start of a tool call in the output.
+    pub triggers: Vec<String>,
+
+    /// Content style passed to xgrammar.
+    #[serde(default)]
+    pub content_style: JsonSchemaStyle,
+
+    /// Tokens to ban when `tool_choice="none"`.
+    #[serde(default)]
+    pub tool_call_ban_tokens: Vec<String>,
+}
+
+/// Build a `triggered_tags` structural tag from config and request context.
+pub(crate) fn build_triggered_tags(
+    config: &TriggeredTagsConfig,
+    ctx: &ToolCallFormatBuildContext<'_>,
+) -> anyhow::Result<Option<StructuralTag>> {
+    let (tools_to_include, at_least_one) = resolve_tools_to_include(ctx)?;
+
+    if tools_to_include.is_empty() {
+        return Ok(None);
+    }
+
+    let strict_schema = ctx.strict_schema();
+
+    let tags: Vec<TagFormat> = tools_to_include
+        .iter()
+        .map(|tool| {
+            let begin = config
+                .begin_template
+                .replace(TOOL_NAME_PLACEHOLDER, &tool.function.name);
+
+            TagFormat {
+                begin,
+                content: Box::new(Format::JsonSchema(JsonSchemaFormat {
+                    json_schema: resolve_tool_schema(tool, strict_schema),
+                    style: config.content_style,
+                })),
+                end: config.end_template.clone(),
+            }
+        })
+        .collect();
+
+    Ok(Some(StructuralTag {
+        format: Format::TriggeredTags(TriggeredTagsFormat {
+            triggers: config.triggers.clone(),
+            tags,
+            at_least_one,
+            stop_after_first: ctx.stop_after_first(),
+        }),
+    }))
+}

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -684,6 +684,7 @@ mod tests {
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
+            strict: None,
         }];
 
         // Tool call block references a function not in the tools list — the
@@ -739,6 +740,7 @@ mod tests {
                     "label": {"type": "string"}
                 }
             })),
+            strict: None,
         }];
 
         let message = "<tool_call>set_temperature<arg_key>degrees</arg_key><arg_value>72.5</arg_value><arg_key>enabled</arg_key><arg_value>true</arg_value><arg_key>count</arg_key><arg_value>3</arg_value><arg_key>label</arg_key><arg_value>warm</arg_value></tool_call>";
@@ -770,6 +772,7 @@ mod tests {
                     "tags": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
 
         // Model emits comma-separated values without JSON brackets
@@ -796,6 +799,7 @@ mod tests {
                     "ids": {"type": "array"}
                 }
             })),
+            strict: None,
         }];
 
         // Model emits proper JSON array
@@ -820,6 +824,7 @@ mod tests {
                     "count": {"type": "integer"}
                 }
             })),
+            strict: None,
         }];
 
         // "not_a_number" can't be parsed as integer — should fall back to string

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -573,6 +573,7 @@ mod tests {
                     "location": {"type": "string"}
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>"#;

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -812,6 +812,7 @@ mod tests {
                     "precise_count": {"type": "number"}
                 }
             })),
+            strict: None,
         }];
 
         let (calls, normal) =
@@ -958,6 +959,7 @@ Orlando
                     "config": {"type": "object"}
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -1216,6 +1218,7 @@ NYC
                 },
                 "required": ["param1", "param2", "param3", "param4", "param5", "param6", "param7", "param8"]
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -1279,6 +1282,7 @@ NYC
                     "bool_param": {"type": "boolean"}
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>
@@ -1332,6 +1336,7 @@ NYC
                     }
                 }
             })),
+            strict: None,
         }];
 
         let input = r#"<tool_call>


### PR DESCRIPTION
#### Overview:

This PR adds automatic [xgrammar structural tag](https://blog.mlc.ai/2026/05/04/xgrammar-2-fast-customizable-structured-generation) generation for tool-calling requests. Structural tags can be enabled for any tool-calling request, letting Dynamo constrain decoding directly in each model's native tool-call format, preventing format drift during generation and enforcing function parameter schemas.

Dynamo already supports the `tool_choice` parameter, but forced tool choice (`required` / `named`) currently relies on a generated JSON-schema constraint rather than the model's native tool-call format. This can degrade response quality because the model is guided to produce a format it was not trained to use for tool calling. It also does not allow preliminary reasoning before a forced tool call. `parallel_tool_calls=false` is not enforced at all.

With structural tags enabled, `required` and `named` tool choice are enforced directly in the parser-specific native format. Strict tool schemas are also enforced during generation, and `parallel_tool_calls=false` is supported via a grammar-level constraint.

For `tool_choice="none"`, structural tags provide a token-ban path. This allows tool definitions to remain in the prompt with `--no-exclude-tools-when-tool-choice-none` for prefix/KV-cache stability, while still preventing the model from starting native tool-call syntax.

For reasoning models, structural tags also handle prompts that already start inside a reasoning block, allowing the model to close reasoning before emitting the tool call.

Structural tags are disabled by default and can be configured with `--dyn-enable-structural-tag`, `--dyn-structural-tag-scope`, and `--dyn-structural-tag-schema`. This PR adds support for the `hermes`, `qwen3_coder`, `deepseek_v3_2`, and `deepseek_v4` tool-call parsers.

#### Details:

- Added structural tag builders for supported native tool-call formats.
- Added runtime options for enabling structural tags, selecting activation scope, and choosing schema strictness.
- Integrated automatic structural tag generation into the preprocessor for eligible tool-calling requests.
- Added support for required/named tool choice, strict schemas, `parallel_tool_calls=false`, and `tool_choice="none"` token bans in the structural-tag path.
- Added support for prompt-injected reasoning prefixes before forced tool calls.
- Added docs for usage, activation policy, schema modes, supported parsers, and `tool_choice="none"` trade-offs.
- Added parser-level tests for structural tag generation and config behavior.

BFCL V3 was run with `temperature=1.0` and xgrammar v0.2.1 on the `simple`, `multiple`, and `parallel` categories to check tool-call quality. Results remain close to the baseline.

| Model | Mode | simple | multiple | parallel |
|---|---|---:|---:|---:|
| DeepSeek-V4-Flash | baseline | 0.935 | 0.955 | 0.880 |
| DeepSeek-V4-Flash | structural tags, strict=false | 0.9375 | 0.935 | 0.910 |
| DeepSeek-V4-Flash | structural tags, strict=true | 0.9225 | 0.925 | 0.875 |
| Qwen3.6-35B-A3B | baseline | 0.910 | 0.945 | 0.910 |
| Qwen3.6-35B-A3B | structural tags, strict=false | 0.920 | 0.940 | 0.910 |
| Qwen3.6-35B-A3B | structural tags, strict=true | 0.910 | 0.910 | 0.895 |

Examples demonstrating `tool_choice` and `parallel_tool_calls` behavior:

```python
# tool_choice="required" forces a tool call.
resp = client.chat.completions.create(
    model="Qwen/Qwen3.6-35B-A3B-FP8",
    messages=[{"role": "user", "content": "Hi!"}],
    tools=[get_weather_tool],
    tool_choice="required",
    temperature=0,
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
)
# finish_reason="tool_calls"
# tool_calls=[{"name": "get_weather", "arguments": {"location": "San Francisco, CA"}}]

# Named tool_choice forces the selected tool.
resp = client.chat.completions.create(
    model="Qwen/Qwen3.6-35B-A3B-FP8",
    messages=[{"role": "user", "content": "Solve 2+2"}],
    tools=[get_weather_tool, calculator_tool],
    tool_choice={"type": "function", "function": {"name": "get_weather"}},
    temperature=0,
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
)
# finish_reason="tool_calls"
# tool_calls=[{"name": "get_weather", "arguments": {"location": "San Francisco, CA"}}]

# tool_choice="none" uses the structural-tag ban path.
resp = client.chat.completions.create(
    model="Qwen/Qwen3.6-35B-A3B-FP8",
    messages=[{"role": "user", "content": "The weather in Tokyo"}],
    tools=[get_weather_tool],
    tool_choice="none",
    temperature=0,
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
)
# content="Let me check the current weather in Tokyo for you.\n\n"

# parallel_tool_calls=false constrains auto mode to one call.
resp = client.chat.completions.create(
    model="Qwen/Qwen3.6-35B-A3B-FP8",
    messages=[{"role": "user", "content": "The weather in Seoul and Tokyo"}],
    tools=[get_weather_tool],
    tool_choice="auto",
    parallel_tool_calls=False,
    temperature=0,
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
)
# finish_reason="tool_calls"
# tool_calls=[{"name": "get_weather", "arguments": {"location": "Seoul"}}]
```

#### Where should the reviewer start?

- `lib/parsers/src/tool_calling/structural_tag/` — structural tag format types, builders, and tests.
- `lib/llm/src/preprocessor/structural_tag.rs` — preprocessor policy and guided-decoding injection.
- `lib/parsers/src/tool_calling/config.rs` — parser-specific structural tag configuration.
- `components/src/dynamo/common/configuration/groups/runtime_args.py` — new runtime flags.
- `docs/tool-calling/structural-tag.md` — user-facing documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added structural tags support for tool-call guided decoding across multiple inference backends (SGLang, TokenSpeed, TensorRT-LLM, vLLM).
  * Added three new configuration options: `--dyn-enable-structural-tag`, `--dyn-structural-tag-scope`, and `--dyn-structural-tag-schema` to control structural tag behavior.

* **Documentation**
  * Added comprehensive guide on using structural tags for constrained tool-call formatting during guided decoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->