### PR TITLE
fix(tcp): abort writer when reader join fails to avoid monitor hang

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -878,6 +878,69 @@ mod tests {
         );
     }
 
+    /// Reader-side panic must abort the writer and return promptly rather than
+    /// hanging on `tokio::join!`. Locks in the fix added with this function's
+    /// sequential-await + writer-abort behavior.
+    ///
+    /// Setup: spawn a reader task that panics immediately (so
+    /// `reader_task.await` yields `Err(JoinError::panic)`), and a writer task
+    /// that parks indefinitely waiting for application bytes (so without the
+    /// abort, `tokio::join!` on the previous implementation would never wake).
+    /// Expect: `wait_for_connection_tasks` returns Err within the timeout.
+    #[tokio::test]
+    async fn test_connection_monitor_aborts_writer_when_reader_panics() {
+        // Reader task that panics immediately. The explicit JoinHandle type
+        // pins the inferred return type to the one wait_for_connection_tasks
+        // expects; `panic!` is type `!`, which coerces to that type.
+        let reader_task: tokio::task::JoinHandle<
+            FramedRead<ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
+        > = tokio::spawn(async {
+            panic!("simulated reader panic to trigger JoinError");
+        });
+
+        // Writer task that would block indefinitely waiting on application
+        // bytes. Under the pre-fix `tokio::join!` implementation, this would
+        // prevent the function from returning when the reader panicked.
+        // After the fix, the abort drives this task to completion promptly.
+        let writer_task: tokio::task::JoinHandle<
+            Result<FramedWrite<WriteHalf<tokio::net::TcpStream>, TwoPartCodec>>,
+        > = tokio::spawn(async {
+            std::future::pending::<()>().await;
+            unreachable!()
+        });
+
+        let controller = Arc::new(Controller::default());
+        let context: Arc<dyn AsyncEngineContext> = controller.clone();
+
+        // 250 ms is generous — the abort + JoinHandle resolution should fire
+        // sub-millisecond. We are checking for "doesn't hang", not "fast".
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            wait_for_connection_tasks(
+                reader_task,
+                writer_task,
+                context,
+                None,
+                "test-reader-panic".to_string(),
+            ),
+        )
+        .await;
+
+        // Outer timeout must not fire: the abort path must surface the reader
+        // JoinError before the writer would have produced any bytes.
+        assert!(
+            result.is_ok(),
+            "wait_for_connection_tasks must return after reader panic, \
+             not hang waiting on the writer"
+        );
+
+        // The inner result must be Err — the reader's JoinError propagates.
+        assert!(
+            result.unwrap().is_err(),
+            "reader panic should propagate as Err from wait_for_connection_tasks"
+        );
+    }
+
     // ==================== handle_reader tests ====================
 
     struct ReaderHarness {

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -878,7 +878,15 @@ mod tests {
         );
     }
 
-    /// Reader panic must abort the writer; the function must not hang.
+    /// Reader-side panic must abort the writer and return promptly rather than
+    /// hanging on `tokio::join!`. Locks in the fix added with this function's
+    /// sequential-await + writer-abort behavior.
+    ///
+    /// Setup: spawn a reader task that panics immediately (so
+    /// `reader_task.await` yields `Err(JoinError::panic)`), and a writer task
+    /// that parks indefinitely waiting for application bytes (so without the
+    /// abort, `tokio::join!` on the previous implementation would never wake).
+    /// Expect: `wait_for_connection_tasks` returns Err within the timeout.
     #[tokio::test]
     async fn test_connection_monitor_aborts_writer_when_reader_panics() {
         // Reader task that panics immediately. The explicit JoinHandle type

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -177,12 +177,8 @@ async fn wait_for_connection_tasks(
     peer_port: Option<u16>,
     subject: String,
 ) -> Result<()> {
-    // Await the reader first. If it panics or returns Err, we abort the
-    // writer rather than waiting on `tokio::join!` to surface the failure
-    // — the writer parks in `bytes_rx.recv()` waiting for app data, and
-    // dropping the reader-side `alive_tx` does not unblock that recv.
-    // Without abort, a failed reader can leave the monitor stuck on the
-    // join indefinitely with no error logged and no cleanup.
+    // Await the reader first and abort the writer on reader Err — the
+    // writer parks on `bytes_rx.recv()` and won't wake on its own.
     let reader = match reader_task.await {
         Ok(reader) => reader,
         Err(reader_err) => {

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -177,58 +177,56 @@ async fn wait_for_connection_tasks(
     peer_port: Option<u16>,
     subject: String,
 ) -> Result<()> {
-    let (reader, writer) = tokio::join!(reader_task, writer_task);
-
-    match (reader, writer) {
-        (Ok(reader), Ok(writer)) => {
-            let reader = reader.into_inner();
-
-            let writer = match writer {
-                Ok(writer) => writer.into_inner(),
-                Err(e) => {
-                    tracing::error!(
-                        subject = %subject,
-                        peer_port = ?peer_port,
-                        err = ?e,
-                        "writer task returned error"
-                    );
-                    return Err(e);
-                }
-            };
-
-            let stream = reader.unsplit(writer);
-            wait_for_server_shutdown(stream, context).await
-        }
-        (Err(reader_err), Ok(_)) => {
+    // Await the reader first. If it panics or returns Err, we abort the
+    // writer rather than waiting on `tokio::join!` to surface the failure
+    // — the writer parks in `bytes_rx.recv()` waiting for app data, and
+    // dropping the reader-side `alive_tx` does not unblock that recv.
+    // Without abort, a failed reader can leave the monitor stuck on the
+    // join indefinitely with no error logged and no cleanup.
+    let reader = match reader_task.await {
+        Ok(reader) => reader,
+        Err(reader_err) => {
+            writer_task.abort();
+            let _ = writer_task.await;
             tracing::error!(
                 subject = %subject,
                 peer_port = ?peer_port,
                 err = ?reader_err,
                 "reader task failed to join"
             );
-            Err(reader_err.into())
+            return Err(reader_err.into());
         }
-        (Ok(_), Err(writer_err)) => {
+    };
+
+    let writer = match writer_task.await {
+        Ok(writer) => writer,
+        Err(writer_err) => {
             tracing::error!(
                 subject = %subject,
                 peer_port = ?peer_port,
                 err = ?writer_err,
                 "writer task failed to join"
             );
-            Err(writer_err.into())
+            return Err(writer_err.into());
         }
-        (Err(reader_err), Err(writer_err)) => {
+    };
+
+    let reader = reader.into_inner();
+    let writer = match writer {
+        Ok(writer) => writer.into_inner(),
+        Err(e) => {
             tracing::error!(
                 subject = %subject,
                 peer_port = ?peer_port,
-                reader_err = ?reader_err,
-                writer_err = ?writer_err,
-                "both reader and writer tasks failed to join"
+                err = ?e,
+                "writer task returned error"
             );
-            // Surface the reader error; the writer error is captured above.
-            Err(reader_err.into())
+            return Err(e);
         }
-    }
+    };
+
+    let stream = reader.unsplit(writer);
+    wait_for_server_shutdown(stream, context).await
 }
 
 async fn wait_for_server_shutdown(

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -878,15 +878,7 @@ mod tests {
         );
     }
 
-    /// Reader-side panic must abort the writer and return promptly rather than
-    /// hanging on `tokio::join!`. Locks in the fix added with this function's
-    /// sequential-await + writer-abort behavior.
-    ///
-    /// Setup: spawn a reader task that panics immediately (so
-    /// `reader_task.await` yields `Err(JoinError::panic)`), and a writer task
-    /// that parks indefinitely waiting for application bytes (so without the
-    /// abort, `tokio::join!` on the previous implementation would never wake).
-    /// Expect: `wait_for_connection_tasks` returns Err within the timeout.
+    /// Reader panic must abort the writer; the function must not hang.
     #[tokio::test]
     async fn test_connection_monitor_aborts_writer_when_reader_panics() {
         // Reader task that panics immediately. The explicit JoinHandle type


### PR DESCRIPTION
## Summary

When the reader task in `wait_for_connection_tasks` (lib/runtime/src/pipeline/network/tcp/client.rs) panics or otherwise returns `Err`, `tokio::join!(reader_task, writer_task)` will not surface the failure until the writer task also exits. The writer parks in `bytes_rx.recv()` waiting for application data, and dropping the reader-side `alive_tx` does **not** unblock that recv — so a failed reader can leave the monitor stuck on the join indefinitely with no error log and no cleanup path.

## Fix

Switch from `tokio::join!` to sequential awaits and abort the writer as soon as the reader handle returns `Err`.

```rust
let reader = match reader_task.await {
    Ok(reader) => reader,
    Err(reader_err) => {
        writer_task.abort();
        let _ = writer_task.await;
        // ... log + return reader_err ...
    }
};
let writer = match writer_task.await {
    Ok(writer) => writer,
    Err(writer_err) => { /* ... log + return ... */ }
};
// ... unsplit + wait_for_server_shutdown ...
```

Behavior on the happy paths is unchanged:

| Outcome | Behavior |
|---|---|
| reader Ok + writer Ok | unsplit + `wait_for_server_shutdown` (unchanged) |
| reader Ok + writer Err | return writer error (unchanged) |
| reader join Err | **abort writer, await its join, log + return reader err** (new) |
| writer join Err (after reader Ok) | log + return writer err (unchanged) |

## Provenance

CodeRabbit raised this on the v1.1.2-test backport of #8254 (panic→warn fix) at https://github.com/ai-dynamo/dynamo/pull/9696#discussion_r3260726491 — the concern is **upstream-design rather than backport-specific**. Applying it here on `main` where reviewer attention matches the scope. After this lands the v1.1.2-test branch can pick up the same change via a focused backport.

## Test plan
- [ ] `cargo build --workspace`
- [ ] `cargo test -p dynamo-runtime tcp::client`
- [ ] CI matrix.

Manual reasoning: the abort path is exercised whenever the reader task panics (the new behavior #8254 introduced is that the reader now returns `Err` on RST mid-stream instead of panicking, but a panic in the reader is still possible from unexpected paths — and that is where the hang would manifest).

## Related
- #8254 — upstream panic→warn fix that introduced the wait_for_connection_tasks helper.
- #9696 — v1.1.2-test backport where CodeRabbit raised the concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and diagnostic logging for network connection failures, providing improved visibility into TCP connection issues and failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->