### PR TITLE
fix(tcp) [v1.1.2-test]: abort writer when reader join fails (mirror of #9716)

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -177,58 +177,52 @@ async fn wait_for_connection_tasks(
     peer_port: Option<u16>,
     subject: String,
 ) -> Result<()> {
-    let (reader, writer) = tokio::join!(reader_task, writer_task);
-
-    match (reader, writer) {
-        (Ok(reader), Ok(writer)) => {
-            let reader = reader.into_inner();
-
-            let writer = match writer {
-                Ok(writer) => writer.into_inner(),
-                Err(e) => {
-                    tracing::error!(
-                        subject = %subject,
-                        peer_port = ?peer_port,
-                        err = ?e,
-                        "writer task returned error"
-                    );
-                    return Err(e);
-                }
-            };
-
-            let stream = reader.unsplit(writer);
-            wait_for_server_shutdown(stream, context).await
-        }
-        (Err(reader_err), Ok(_)) => {
+    // Await the reader first and abort the writer on reader Err — the
+    // writer parks on `bytes_rx.recv()` and won't wake on its own.
+    let reader = match reader_task.await {
+        Ok(reader) => reader,
+        Err(reader_err) => {
+            writer_task.abort();
+            let _ = writer_task.await;
             tracing::error!(
                 subject = %subject,
                 peer_port = ?peer_port,
                 err = ?reader_err,
                 "reader task failed to join"
             );
-            Err(reader_err.into())
+            return Err(reader_err.into());
         }
-        (Ok(_), Err(writer_err)) => {
+    };
+
+    let writer = match writer_task.await {
+        Ok(writer) => writer,
+        Err(writer_err) => {
             tracing::error!(
                 subject = %subject,
                 peer_port = ?peer_port,
                 err = ?writer_err,
                 "writer task failed to join"
             );
-            Err(writer_err.into())
+            return Err(writer_err.into());
         }
-        (Err(reader_err), Err(writer_err)) => {
+    };
+
+    let reader = reader.into_inner();
+    let writer = match writer {
+        Ok(writer) => writer.into_inner(),
+        Err(e) => {
             tracing::error!(
                 subject = %subject,
                 peer_port = ?peer_port,
-                reader_err = ?reader_err,
-                writer_err = ?writer_err,
-                "both reader and writer tasks failed to join"
+                err = ?e,
+                "writer task returned error"
             );
-            // Surface the reader error; the writer error is captured above.
-            Err(reader_err.into())
+            return Err(e);
         }
-    }
+    };
+
+    let stream = reader.unsplit(writer);
+    wait_for_server_shutdown(stream, context).await
 }
 
 async fn wait_for_server_shutdown(
@@ -877,6 +871,69 @@ mod tests {
         assert!(
             controller.is_killed(),
             "read error should kill the stream context"
+        );
+    }
+
+    /// Reader-side panic must abort the writer and return promptly rather than
+    /// hanging on `tokio::join!`. Locks in the fix added with this function's
+    /// sequential-await + writer-abort behavior.
+    ///
+    /// Setup: spawn a reader task that panics immediately (so
+    /// `reader_task.await` yields `Err(JoinError::panic)`), and a writer task
+    /// that parks indefinitely waiting for application bytes (so without the
+    /// abort, `tokio::join!` on the previous implementation would never wake).
+    /// Expect: `wait_for_connection_tasks` returns Err within the timeout.
+    #[tokio::test]
+    async fn test_connection_monitor_aborts_writer_when_reader_panics() {
+        // Reader task that panics immediately. The explicit JoinHandle type
+        // pins the inferred return type to the one wait_for_connection_tasks
+        // expects; `panic!` is type `!`, which coerces to that type.
+        let reader_task: tokio::task::JoinHandle<
+            FramedRead<ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
+        > = tokio::spawn(async {
+            panic!("simulated reader panic to trigger JoinError");
+        });
+
+        // Writer task that would block indefinitely waiting on application
+        // bytes. Under the pre-fix `tokio::join!` implementation, this would
+        // prevent the function from returning when the reader panicked.
+        // After the fix, the abort drives this task to completion promptly.
+        let writer_task: tokio::task::JoinHandle<
+            Result<FramedWrite<WriteHalf<tokio::net::TcpStream>, TwoPartCodec>>,
+        > = tokio::spawn(async {
+            std::future::pending::<()>().await;
+            unreachable!()
+        });
+
+        let controller = Arc::new(Controller::default());
+        let context: Arc<dyn AsyncEngineContext> = controller.clone();
+
+        // 250 ms is generous — the abort + JoinHandle resolution should fire
+        // sub-millisecond. We are checking for "doesn't hang", not "fast".
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            wait_for_connection_tasks(
+                reader_task,
+                writer_task,
+                context,
+                None,
+                "test-reader-panic".to_string(),
+            ),
+        )
+        .await;
+
+        // Outer timeout must not fire: the abort path must surface the reader
+        // JoinError before the writer would have produced any bytes.
+        assert!(
+            result.is_ok(),
+            "wait_for_connection_tasks must return after reader panic, \
+             not hang waiting on the writer"
+        );
+
+        // The inner result must be Err — the reader's JoinError propagates.
+        assert!(
+            result.unwrap().is_err(),
+            "reader panic should propagate as Err from wait_for_connection_tasks"
         );
     }
 


### PR DESCRIPTION
**Mirror of [#9716](https://github.com/ai-dynamo/dynamo/pull/9716) onto the `nnshah1/v1.1.2-test` branch.**

Stacks on top of [#9696](https://github.com/ai-dynamo/dynamo/pull/9696) (panic→warn cherry-pick), which introduces the `wait_for_connection_tasks` function on this base. Merges into `nnshah1/v1.1.2-test` after #9696.

## What

- Switch `wait_for_connection_tasks` from `tokio::join!` to sequential awaits; abort the writer if `reader_task.await` returns `Err`.
- Add `test_connection_monitor_aborts_writer_when_reader_panics` regression test that forces a reader `JoinError` and verifies the function returns within 250 ms (no hang).

## Why on this branch

`wait_for_connection_tasks` on v1.1.1's `client.rs` is byte-identical to `main`'s, so #9716's diff applies as-is. CodeRabbit raised the hang concern originally on the v1.1.2-test conn-panic backport (#9696) at https://github.com/ai-dynamo/dynamo/pull/9696#discussion_r3260726491, so it's appropriate to land the matching fix here for the v1.1.2-test image candidate.

## Test plan
- [ ] `cargo build --workspace`
- [ ] `cargo test -p dynamo-runtime tcp::client`
- [ ] CI matrix.

## Related
- #9716 — the same change on `main`.
- #9696 — base (panic→warn cherry-pick).
- #8254 — upstream panic→warn fix that introduced the helper.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->