### PR TITLE
fix(mocker): gate vLLM waiting-request admission on full ISL fit (#9718)

### DIFF
--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -171,7 +171,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None, scheduler_reserve_full_isl=true))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -181,6 +181,7 @@ impl MockEngineArgs {
         max_num_batched_tokens: Option<usize>,
         enable_prefix_caching: bool,
         enable_chunked_prefill: bool,
+        scheduler_reserve_full_isl: bool,
         speedup_ratio: f64,
         decode_speedup_ratio: f64,
         dp_size: u32,
@@ -240,6 +241,7 @@ impl MockEngineArgs {
             .max_num_batched_tokens(max_num_batched_tokens)
             .enable_prefix_caching(enable_prefix_caching)
             .enable_chunked_prefill(enable_chunked_prefill)
+            .scheduler_reserve_full_isl(scheduler_reserve_full_isl)
             .speedup_ratio(speedup_ratio)
             .decode_speedup_ratio(decode_speedup_ratio)
             .dp_size(dp_size)

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1813,7 +1813,6 @@ class MockEngineArgs:
         max_num_batched_tokens: Optional[int] = 8192,
         enable_prefix_caching: bool = True,
         enable_chunked_prefill: bool = True,
-        scheduler_reserve_full_isl: bool = True,
         speedup_ratio: float = 1.0,
         decode_speedup_ratio: float = 1.0,
         dp_size: int = 1,
@@ -1854,6 +1853,7 @@ class MockEngineArgs:
         enable_g4_storage: bool = False,
         bandwidth_g2_to_g4_gbps: Optional[float] = None,
         bandwidth_g4_to_g2_gbps: Optional[float] = None,
+        scheduler_reserve_full_isl: bool = True,
     ) -> None:
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1813,6 +1813,7 @@ class MockEngineArgs:
         max_num_batched_tokens: Optional[int] = 8192,
         enable_prefix_caching: bool = True,
         enable_chunked_prefill: bool = True,
+        scheduler_reserve_full_isl: bool = True,
         speedup_ratio: float = 1.0,
         decode_speedup_ratio: float = 1.0,
         dp_size: int = 1,

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -227,6 +227,12 @@ pub struct PrefillCost {
     /// Subset of `cached_tokens` backed by active blocks; TRT-LLM no-evict
     /// capacity reservation discounts only these (inactive reuse is re-consumed).
     pub active_cached_tokens: usize,
+    /// Blocks whose content is cached but currently in the inactive pool
+    /// (not pinned by any running request). Reusing these on admission promotes
+    /// them from inactive→active and consumes free-pool capacity just like a
+    /// freshly allocated block would. Used by the full-ISL admission gate so it
+    /// doesn't undercount demand when shared prefix has gone inactive.
+    pub inactive_overlap_blocks: usize,
 }
 
 impl PrefillCost {
@@ -459,6 +465,7 @@ struct MockEngineArgsSerde {
     max_num_batched_tokens: OptionalConfigValue<usize>,
     enable_prefix_caching: OptionalConfigValue<bool>,
     enable_chunked_prefill: OptionalConfigValue<bool>,
+    scheduler_reserve_full_isl: OptionalConfigValue<bool>,
     speedup_ratio: OptionalConfigValue<f64>,
     decode_speedup_ratio: OptionalConfigValue<f64>,
     dp_size: OptionalConfigValue<u32>,
@@ -554,6 +561,14 @@ pub struct MockEngineArgs {
 
     #[builder(default = true)]
     pub enable_chunked_prefill: bool,
+
+    /// If true, the scheduler refuses to admit a waiting request unless the
+    /// full input sequence (minus prefix-cache hits) fits in available KV
+    /// capacity. Mirrors vLLM's `scheduler_reserve_full_isl` (default `True`
+    /// upstream) and prevents over-admission / preemption thrash under
+    /// chunked prefill when running long-context traces.
+    #[builder(default = true)]
+    pub scheduler_reserve_full_isl: bool,
 
     #[builder(default = "1.0")]
     #[validate(range(min = 0.0))]
@@ -900,6 +915,12 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         {
             builder = builder.enable_chunked_prefill(enable_chunked_prefill);
         }
+        if let Some(scheduler_reserve_full_isl) = compat
+            .scheduler_reserve_full_isl
+            .into_non_null("scheduler_reserve_full_isl")?
+        {
+            builder = builder.scheduler_reserve_full_isl(scheduler_reserve_full_isl);
+        }
         if let Some(speedup_ratio) = compat.speedup_ratio.into_non_null("speedup_ratio")? {
             builder = builder.speedup_ratio(speedup_ratio);
         }
@@ -1204,6 +1225,7 @@ mod tests {
             "max_num_batched_tokens": args.max_num_batched_tokens,
             "enable_prefix_caching": args.enable_prefix_caching,
             "enable_chunked_prefill": args.enable_chunked_prefill,
+            "scheduler_reserve_full_isl": args.scheduler_reserve_full_isl,
             "speedup_ratio": args.speedup_ratio,
             "decode_speedup_ratio": args.decode_speedup_ratio,
             "dp_size": args.dp_size,

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -1279,6 +1279,7 @@ impl KvManager {
             new_tokens,
             cached_tokens,
             active_cached_tokens,
+            inactive_overlap_blocks: overlap_blocks - active_overlap_blocks,
         }
     }
 }

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1026,10 +1026,19 @@ impl VllmCore {
             .get(&uuid)
             .unwrap_or_else(|| panic!("schedule_request: {uuid} missing from state.requests"));
         request.debug_assert_invariants(uuid);
+        // Compute prefill cost once when either consumer needs it: the
+        // `cached_prefix_tokens` calc below (fresh requests only) and the
+        // waiting-admission gate further down. Avoids scanning the
+        // sequence blocks twice for a single fresh-from-waiting admit.
+        let prefill_cost = if request.num_computed_tokens == 0
+            || (from_waiting && self.args.scheduler_reserve_full_isl)
+        {
+            Some(self.kv_manager.get_prefill_cost(&request.sequence))
+        } else {
+            None
+        };
         let cached_prefix_tokens = if request.num_computed_tokens == 0 {
-            self.kv_manager
-                .get_prefill_cost(&request.sequence)
-                .cached_tokens
+            prefill_cost.as_ref().map(|c| c.cached_tokens).unwrap_or(0)
         } else {
             0
         };
@@ -1046,6 +1055,29 @@ impl VllmCore {
             && prompt_remaining > *token_budget
         {
             return ScheduleOutcome::Blocked;
+        }
+
+        // Mirror vLLM's `scheduler_reserve_full_isl`: when admitting a
+        // request off the waiting queue, refuse if the full ISL cannot fit
+        // in currently free KV capacity. Demand includes both the
+        // freshly-allocated blocks (uncached suffix) AND any cached blocks
+        // sitting in the inactive pool — reusing those promotes them from
+        // inactive→active and consumes free-pool capacity. Returning
+        // `Blocked` here bypasses the shared preemption branch below, so
+        // running requests are not evicted to make room for an admission
+        // that real vLLM would never have accepted.
+        if from_waiting && self.args.scheduler_reserve_full_isl && remaining_known_tokens > 0 {
+            let cost = prefill_cost
+                .as_ref()
+                .expect("prefill_cost is computed eagerly when reserve-full-isl gate fires");
+            let free_blocks = self
+                .kv_manager
+                .max_capacity()
+                .saturating_sub(self.kv_manager.num_active_blocks());
+            let demand = cost.new_blocks + cost.inactive_overlap_blocks;
+            if demand > free_blocks {
+                return ScheduleOutcome::Blocked;
+            }
         }
 
         let desired_tokens = remaining_known_tokens.min(*token_budget);

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -309,6 +309,9 @@ mod core_behavior {
             .max_num_seqs(Some(3))
             .enable_chunked_prefill(true)
             .enable_prefix_caching(false)
+            // Disable the full-ISL admission gate so this test continues
+            // to exercise the LIFO preemption ordering as written.
+            .scheduler_reserve_full_isl(false)
             .preemption_mode(PreemptionMode::Lifo)
             .speedup_ratio(0.0)
             .build()
@@ -338,6 +341,122 @@ mod core_behavior {
         assert_eq!(pass1.mocker_metrics.vllm_preemptions_total, 0);
         assert_eq!(pass2.mocker_metrics.vllm_preemptions_total, 1);
         assert_eq!(pass2.mocker_metrics.waiting_requests, 1);
+    }
+
+    /// Regression for https://github.com/ai-dynamo/dynamo/issues/9718:
+    /// when admitting a waiting request whose full ISL cannot fit in
+    /// available KV, the scheduler must leave the request queued instead
+    /// of preempting running work to make a partial chunk fit. Matches
+    /// vLLM's default `scheduler_reserve_full_isl=True` semantics.
+    #[test]
+    fn test_full_isl_gate_blocks_admission_without_preempt() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(6)
+            .max_num_batched_tokens(Some(12))
+            .max_num_seqs(Some(3))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .preemption_mode(PreemptionMode::Lifo)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        assert!(
+            args.scheduler_reserve_full_isl,
+            "scheduler_reserve_full_isl should default to true (vLLM parity)"
+        );
+
+        let mut core = VllmCore::new(args);
+        let r1 = Uuid::from_u128(1);
+        let r2 = Uuid::from_u128(2);
+        let r3 = Uuid::from_u128(3);
+        // r1 + r2 together pin 4 of 6 blocks; r3's 12-token prompt needs
+        // 3 blocks but only 2 are free at admission time.
+        for (uuid, range) in [(r1, 0u32..8u32), (r2, 100u32..108u32), (r3, 200u32..212u32)] {
+            core.receive(DirectRequest {
+                tokens: range.collect(),
+                max_output_tokens: 2,
+                uuid: Some(uuid),
+                dp_rank: 0,
+                arrival_timestamp_ms: None,
+            });
+        }
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass1 = core.execute_pass(&mut collector, 0.0);
+        let pass2 = core.execute_pass(&mut collector, 1.0);
+
+        // r3 must never have been admitted, so it should not appear in
+        // either pass's admissions.
+        let admitted_ever: Vec<Uuid> = pass1
+            .admissions
+            .iter()
+            .chain(pass2.admissions.iter())
+            .map(|a| a.uuid)
+            .collect();
+        assert!(
+            !admitted_ever.contains(&r3),
+            "r3 should not be admitted while its full ISL cannot fit; admissions: {:?}",
+            admitted_ever
+        );
+
+        // r3 must still be queued, never preempted, never partially
+        // computed.
+        assert!(
+            core.state.waiting.contains(&r3),
+            "r3 must remain in the waiting queue"
+        );
+        let r3_state = core.state.requests.get(&r3).unwrap();
+        assert_eq!(r3_state.num_preemptions, 0);
+        assert_eq!(r3_state.num_computed_tokens, 0);
+
+        // r2 must not be preempted by r3's failed admission attempt.
+        let r2_state = core.state.requests.get(&r2).unwrap();
+        assert_eq!(
+            r2_state.num_preemptions, 0,
+            "running r2 must not be preempted to admit a waiting r3 that real vLLM would refuse"
+        );
+        assert_eq!(r2_state.status, RequestStatus::Running);
+    }
+
+    /// Opt-out: when `scheduler_reserve_full_isl=false` the legacy
+    /// chunk-fits-then-preempt behavior is preserved.
+    #[test]
+    fn test_full_isl_gate_disabled_falls_back_to_preempt() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(6)
+            .max_num_batched_tokens(Some(12))
+            .max_num_seqs(Some(3))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(false)
+            .scheduler_reserve_full_isl(false)
+            .preemption_mode(PreemptionMode::Lifo)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let r1 = Uuid::from_u128(1);
+        let r2 = Uuid::from_u128(2);
+        let r3 = Uuid::from_u128(3);
+        for (uuid, range) in [(r1, 0u32..8u32), (r2, 100u32..108u32), (r3, 200u32..212u32)] {
+            core.receive(DirectRequest {
+                tokens: range.collect(),
+                max_output_tokens: 2,
+                uuid: Some(uuid),
+                dp_rank: 0,
+                arrival_timestamp_ms: None,
+            });
+        }
+        let mut collector = crate::replay::TraceCollector::default();
+        core.execute_pass(&mut collector, 0.0);
+        core.execute_pass(&mut collector, 1.0);
+
+        let r2_state = core.state.requests.get(&r2).unwrap();
+        assert_eq!(
+            r2_state.num_preemptions, 1,
+            "with gate disabled, r3 admission must still trigger LIFO preempt of r2"
+        );
     }
 
     #[test]
@@ -492,6 +611,9 @@ mod router_events {
             .max_num_seqs(Some(3))
             .enable_chunked_prefill(true)
             .enable_prefix_caching(true)
+            // Disable the full-ISL admission gate so this test continues
+            // to exercise the preemption + KV-removal event path.
+            .scheduler_reserve_full_isl(false)
             .preemption_mode(PreemptionMode::Lifo)
             .speedup_ratio(0.0)
             .build()

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -419,6 +419,138 @@ mod core_behavior {
         assert_eq!(r2_state.status, RequestStatus::Running);
     }
 
+    /// Regression for the inactive-overlap branch of the admission gate.
+    /// When prefix caching is enabled and a completed request leaves
+    /// cached blocks in the inactive pool, a later waiting request that
+    /// reuses those blocks must count them as demand — promoting them
+    /// from inactive→active still consumes free-pool capacity. Without
+    /// this accounting the gate would over-admit and trigger preemption.
+    #[test]
+    fn test_full_isl_gate_counts_inactive_overlap_blocks() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(6)
+            .max_num_batched_tokens(Some(24))
+            .max_num_seqs(Some(3))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .preemption_mode(PreemptionMode::Lifo)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+
+        // Phase 1: run r1 (16 tokens = 4 full prefix blocks, 1 decode
+        // token) to completion. Its prefix blocks should land in the
+        // inactive pool with prefix-caching enabled.
+        let r1 = Uuid::from_u128(1);
+        core.receive(DirectRequest {
+            tokens: (0u32..16).collect(),
+            max_output_tokens: 1,
+            uuid: Some(r1),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut now_ms = 0.0;
+        // Drive a small number of passes until r1 leaves the engine.
+        for _ in 0..10 {
+            if !core.state.requests.contains_key(&r1) {
+                break;
+            }
+            let pass = core.execute_pass(&mut collector, now_ms);
+            now_ms = pass.end_ms;
+        }
+        assert!(
+            !core.state.requests.contains_key(&r1),
+            "r1 must complete before phase 2"
+        );
+        assert_eq!(
+            core.kv_manager.num_active_blocks(),
+            0,
+            "no active blocks after r1 completes"
+        );
+        let inactive_after_r1 = core.kv_manager.num_inactive_blocks();
+        assert!(
+            inactive_after_r1 >= 3,
+            "expected r1's prefix blocks to land in inactive pool; got {inactive_after_r1}"
+        );
+
+        // Phase 2: pin two blocks with r_pin. A 4-token prompt + 1
+        // decode token round up to two blocks; large `max_output_tokens`
+        // keeps the sequence resident across the next pass.
+        let r_pin = Uuid::from_u128(2);
+        core.receive(DirectRequest {
+            tokens: (1000u32..1004).collect(),
+            max_output_tokens: 16,
+            uuid: Some(r_pin),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms;
+        assert_eq!(
+            core.state.requests.get(&r_pin).unwrap().status,
+            RequestStatus::Running,
+            "r_pin should be admitted on the first pass"
+        );
+        assert_eq!(
+            core.kv_manager.num_active_blocks(),
+            2,
+            "r_pin pins 2 blocks (4-token prompt + 1 decode rounded up to 2 blocks)"
+        );
+
+        // Phase 3: r2 shares the first 12 tokens with r1 (3 cached blocks
+        // still in inactive) plus 8 fresh tokens (2 new blocks). Demand =
+        // 2 new + 3 inactive_overlap = 5. Free = 6 - 2 = 4. Without
+        // counting inactive_overlap, demand would be 2 and r2 would be
+        // admitted, then partial-allocate and preempt r_pin.
+        let r2 = Uuid::from_u128(3);
+        let mut r2_tokens: Vec<u32> = (0u32..12).collect();
+        r2_tokens.extend(200u32..208);
+        core.receive(DirectRequest {
+            tokens: r2_tokens,
+            max_output_tokens: 1,
+            uuid: Some(r2),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+
+        // Sanity-check the prefill_cost surface before exercising the
+        // gate. The split into new vs inactive overlap is what the gate
+        // relies on.
+        let cost = {
+            let req = core.state.requests.get(&r2).unwrap();
+            core.kv_manager.get_prefill_cost(&req.sequence)
+        };
+        assert_eq!(
+            cost.inactive_overlap_blocks, 3,
+            "r2 should have 3 inactive-overlap blocks (12 cached tokens)"
+        );
+        assert_eq!(
+            cost.new_blocks, 2,
+            "r2 should have 2 new blocks for its uncached suffix"
+        );
+
+        let _pass = core.execute_pass(&mut collector, now_ms);
+
+        // Gate should refuse to admit r2 (5 > 4) and leave r_pin running
+        // untouched.
+        assert!(
+            core.state.waiting.contains(&r2),
+            "r2 must stay in waiting when full demand (new + inactive_overlap) > free"
+        );
+        let r2_state = core.state.requests.get(&r2).unwrap();
+        assert_eq!(r2_state.num_preemptions, 0);
+        assert_eq!(r2_state.num_computed_tokens, 0);
+        let r_pin_state = core.state.requests.get(&r_pin).unwrap();
+        assert_eq!(
+            r_pin_state.num_preemptions, 0,
+            "r_pin must not be preempted when the gate correctly accounts for inactive_overlap"
+        );
+        assert_eq!(r_pin_state.status, RequestStatus::Running);
+    }
+
     /// Opt-out: when `scheduler_reserve_full_isl=false` the legacy
     /// chunk-fits-then-preempt behavior is preserved.
     #[test]


### PR DESCRIPTION
## Summary

- Adds `scheduler_reserve_full_isl: bool` to `MockEngineArgs` (default `true`), mirroring vLLM's upstream default.
- In the mocker's vLLM scheduler (`lib/mocker/src/scheduler/vllm/core.rs`), gates the `from_waiting=true` admission path on whether the full ISL (minus prefix-cache hits) fits in currently free KV capacity. Returns `ScheduleOutcome::Blocked` *before* the shared preemption branch, so running requests are no longer evicted to make room for an admission real vLLM would have refused.
- Wires the kwarg through the pyo3 binding (`lib/bindings/python/rust/llm/replay.rs`) and the `_core.pyi` stub.

Fixes #9718.

## Why

Real vLLM passes `full_sequence_must_fit=self.scheduler_reserve_full_isl` into `kv_cache_manager.allocate_slots()` on the waiting-request path ([`vllm/v1/core/sched/scheduler.py:721-740`](https://github.com/vllm-project/vllm/blob/57fef4e0bf0bfaddf117dfdc9367e1fb957b423f/vllm/v1/core/sched/scheduler.py#L721-L740)); on `None` it `break`s the waiting loop without preempting. The mocker had no equivalent gate — `schedule_request()` used a single path for running and waiting requests with a chunk-sized allocation target, so a partial allocation for a fresh admission fell through to `state.preempt()`, producing preemption thrash on long-context multi-session replays (>26 min vs ~32s on a Mooncake replay).

SGLang's path is unchanged: real SGLang's admission gate is unconditional (see `python/sglang/srt/managers/schedule_policy.py:add_one_req`, `if total_tokens >= self.rem_total_tokens: return AddReqResult.NO_TOKEN`), and the mocker's `lib/mocker/src/scheduler/sglang/prefill.rs:75-79` already mirrors that unconditional check.

## What does vLLM actually do with a request that can't currently fit?

It **defers admission**, it does not reject. Two distinct mechanisms layered in vLLM, only one of which this PR mirrors:

1. **Hard reject at request ingest (out of scope for this PR).** vLLM rejects a request with `len(prompt_tokens) > max_model_len` at the API/engine layer with a 400. This is independent of the scheduler. The mocker is a simulator, not an engine, and doesn't model this path — requests are accepted regardless of size.

2. **Scheduler admission deferral (what this PR mirrors).** Inside the waiting-request loop:

    ```python
    new_blocks = self.kv_cache_manager.allocate_slots(
        request, num_new_tokens, ...,
        full_sequence_must_fit=self.scheduler_reserve_full_isl,
    )
    if new_blocks is None:
        # The request cannot be scheduled.
        ...
        break
    ```
    ([`vllm/v1/core/sched/scheduler.py:721-740`](https://github.com/vllm-project/vllm/blob/57fef4e0bf0bfaddf117dfdc9367e1fb957b423f/vllm/v1/core/sched/scheduler.py#L721-L740))

    The request was `peek_request`'d (not popped) before this, so on `break` it stays at the head of `self.waiting`. Next scheduler pass tries again. There is no time bound and no derived "this will never fit" rejection — vLLM trusts that `num_gpu_blocks` is sized to admit any prompt that passed the ingest check (~`max_model_len` tokens), so any well-formed request is admissible eventually.

The all-or-nothing precheck inside `allocate_slots` is here: [`vllm/v1/core/kv_cache_manager.py:346-360`](https://github.com/vllm-project/vllm/blob/57fef4e0bf0bfaddf117dfdc9367e1fb957b423f/vllm/v1/core/kv_cache_manager.py#L346-L360). And the default flag value is here: [`vllm/config/scheduler.py:140`](https://github.com/vllm-project/vllm/blob/57fef4e0bf0bfaddf117dfdc9367e1fb957b423f/vllm/config/scheduler.py#L140).

The mocker behavior with this PR matches mechanism #2: a request whose full ISL doesn't fit stays in `waiting`, the gate returns `ScheduleOutcome::Blocked` for that pass, no preempt fires, and the next pass retries.

## Test plan

- [x] `cargo test -p dynamo-mocker --lib` — 252 passed (2 new tests below + all existing).
- [x] `cargo clippy -p dynamo-mocker --all-targets --no-deps -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] New test `test_full_isl_gate_blocks_admission_without_preempt`: regression for #9718 — r3 (12-token prompt, needs 3 blocks) with 2 free blocks left after r1+r2 are running. With the default gate enabled: r3 stays in `waiting`, r2's `num_preemptions == 0`.
- [x] New test `test_full_isl_gate_disabled_falls_back_to_preempt`: same setup with `scheduler_reserve_full_isl(false)` — r2 is preempted, verifying the opt-out preserves legacy behavior.
- [x] Two existing preemption tests (`test_preemption_requeues_newest_running_request`, `test_preemption_recompute_events_apply_cleanly`) explicitly opt out via `.scheduler_reserve_full_isl(false)` to keep exercising LIFO/KV-removal event paths.
- [x] Round-trip JSON test asserts `scheduler_reserve_full_isl` survives serde.
- [ ] Python bindings: macOS build of `lib/bindings/python` blocked by pre-existing Linux-only deps (`O_DIRECT`, NUMA, `fallocate`) — relying on Linux CI for full verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)