### PR TITLE
feat(sglang): OpenAI embeddings dimensions (DIS-2093)

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -4,7 +4,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import sglang as sgl
 
@@ -55,6 +55,15 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         else:
             raise TypeError(f"Invalid input type: {type(embedding_request.input)}")
 
+        # Lower-bound validation runs BEFORE async_encode so an obviously
+        # bad request (e.g. ``dimensions=0``) is rejected as HTTP 400
+        # without spending a full pooling forward pass. The upper-bound
+        # check stays in ``_transform_response`` because it needs to
+        # compare against the actual embedding length returned by SGLang.
+        dimensions = embedding_request.dimensions
+        if dimensions is not None and dimensions < 1:
+            raise ValueError(f"dimensions must be >= 1, got {dimensions}")
+
         trace_header = context.trace_headers() if self.enable_trace else None
         trace_id = context.trace_id
 
@@ -65,11 +74,33 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         )
 
         # Transform the response to OpenAI format
-        response = self._transform_response(result, embedding_request.model)
+        response = self._transform_response(
+            result,
+            embedding_request.model,
+            dimensions=dimensions,
+        )
         yield response
 
-    def _transform_response(self, ret, model_name):
-        """Transform SGLang response to OpenAI embedding format"""
+    def _transform_response(
+        self,
+        ret: Any,
+        model_name: str,
+        dimensions: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Transform SGLang response to OpenAI embedding format.
+
+        Applies the optional ``dimensions`` field for Matryoshka-style
+        truncation (slice leading N).
+
+        Note: ``encoding_format=base64`` is part of the OpenAI spec but
+        cannot be honored at this layer alone -- the Rust frontend's
+        response aggregator deserializes ``data[].embedding`` as
+        ``Vec<f32>`` (inherited from the upstream ``async_openai``
+        embeddings types), so a base64 string here would be rejected
+        downstream. Supporting it end-to-end requires owning the
+        embedding response type in ``lib/protocols`` and updating the
+        aggregator. Tracked separately.
+        """
         if not isinstance(ret, list):
             ret = [ret]
 
@@ -77,10 +108,21 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         prompt_tokens = 0
 
         for idx, ret_item in enumerate(ret):
+            embedding: List[float] = list(ret_item["embedding"])
+            if dimensions is not None:
+                # Lower-bound (dimensions >= 1) is checked upfront in
+                # ``generate`` before async_encode runs.
+                if dimensions > len(embedding):
+                    raise ValueError(
+                        f"dimensions={dimensions} exceeds model embedding "
+                        f"dimension {len(embedding)}"
+                    )
+                embedding = embedding[:dimensions]
+
             embedding_objects.append(
                 {
                     "object": "embedding",
-                    "embedding": ret_item["embedding"],
+                    "embedding": embedding,
                     "index": idx,
                 }
             )

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -601,6 +601,15 @@ sglang_configs = {
                 repeat_count=1,
                 expected_response=["Generated 3 embeddings with dimension"],
             ),
+            # Test `dimensions` truncation (Matryoshka). Qwen3-Embedding-4B
+            # has a hidden dim well above 128, so the truncated vector should
+            # be exactly 128 floats long.
+            embedding_payload(
+                input_text="Hello, world!",
+                repeat_count=1,
+                expected_response=["Generated 1 embeddings with dimension 128"],
+                extra_body={"dimensions": 128},
+            ),
         ],
     ),
     "completions_only": SGLangConfig(

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -432,11 +432,15 @@ def embedding_payload_default(
     repeat_count: int = 3,
     expected_response: Optional[List[str]] = None,
     expected_log: Optional[List[str]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
 ) -> EmbeddingPayload:
+    body: Dict[str, Any] = {
+        "input": ["The sky is blue.", "Machine learning is fascinating."],
+    }
+    if extra_body:
+        body.update(extra_body)
     return EmbeddingPayload(
-        body={
-            "input": ["The sky is blue.", "Machine learning is fascinating."],
-        },
+        body=body,
         repeat_count=repeat_count,
         expected_log=expected_log or [],
         expected_response=expected_response
@@ -449,6 +453,7 @@ def embedding_payload(
     repeat_count: int = 3,
     expected_response: Optional[List[str]] = None,
     expected_log: Optional[List[str]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
 ) -> EmbeddingPayload:
     # Normalize input to list for consistent processing
     if isinstance(input_text, str):
@@ -458,10 +463,14 @@ def embedding_payload(
         input_list = input_text
         expected_count = len(input_text)
 
+    body: Dict[str, Any] = {
+        "input": input_list,
+    }
+    if extra_body:
+        body.update(extra_body)
+
     return EmbeddingPayload(
-        body={
-            "input": input_list,
-        },
+        body=body,
         repeat_count=repeat_count,
         expected_log=expected_log or [],
         expected_response=expected_response


### PR DESCRIPTION
#### Overview:

Closes one of the two OpenAI `/v1/embeddings` spec gaps tracked in [DIS-2093](https://linear.app/nvidia/issue/DIS-2093): the `dimensions` field (Matryoshka truncation).

**Scope:** This PR only changes the **SGLang** embedding handler. The vLLM backend doesn't have an embedding worker yet (that's [PR #9713](https://github.com/ai-dynamo/dynamo/pull/9713)), so there's nothing on the vLLM side to update here. **This PR can be reviewed and merged on its own** — it doesn't depend on #9713, and #9713 doesn't depend on it. Once both land, the vLLM handler should pick up the same `_transform_response` logic (and at that point a shared helper may be worth lifting out).

The other field in DIS-2093 — `encoding_format=base64` — was originally in scope but verified on dynamo-aks-dev to **not work end-to-end** because the Rust frontend's response type rejects a base64 string. It's been split out to a separate follow-up; see the "Deferred" section below.

#### Details:

**`dimensions` (Matryoshka truncation):** The field was declared on `EmbeddingRequest` and accepted by the Rust frontend, but the SGLang handler ignored it. Now `_transform_response` slices each embedding to the first N floats. Validates `1 <= dimensions <= model_hidden_dim`; otherwise raises `ValueError` which the frontend surfaces as HTTP 400.

**Note on Matryoshka correctness:** truncation is semantically meaningful only for models trained with Matryoshka representation learning (Qwen3-Embedding, BGE-M3, OpenAI `text-embedding-3-*`). On non-Matryoshka models the leading slice is still a valid vector but loses quality. Per the OpenAI spec we honor the request regardless; downstream caveat for users.

#### Test plan:

One new payload added to `tests/serve/test_sglang.py`'s `embedding_agg` config:

- [ ] `dimensions=128` → assert vector length is exactly 128 (passes on Qwen3-Embedding-4B which has hidden dim 2560).

The existing default + single-string + 3-string-list payloads also continue to pass.

`embedding_payload` and `embedding_payload_default` gained an `extra_body` kwarg in `tests/utils/payload_builder.py` so future callers can attach arbitrary OpenAI fields without introducing new helpers per field.

#### Deferred — `encoding_format=base64`

Implementation attempt was reverted from this PR. Verified on dynamo-aks-dev with an A100:

- The Python handler can pack a (possibly-truncated) float list as little-endian float32 + base64-encode it.
- **But** the Rust frontend's `NvCreateEmbeddingResponse::from_annotated_stream` aggregator deserializes `data[].embedding` as `Vec<f32>` (inherited from the upstream `async_openai::types::embeddings::*` re-export). A base64 string is rejected with:

  > invalid type: string "AAACOQAA...", expected a sequence

End-to-end `encoding_format=base64` support requires owning the embedding response type in `lib/protocols/` (per the rubric in `lib/protocols/CLAUDE.md`) and updating the aggregator. That's a sizable Rust-side change orthogonal to the SGLang handler change. Tracked as [DIS-2099](https://linear.app/nvidia/issue/DIS-2099) — the Python implementation reverted from this PR is preserved in its git history so the follow-up doesn't start from scratch.

#### Where should the reviewer start?

1. [`components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py`](components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py) — `_transform_response()` now accepts an optional `dimensions` arg and slices each embedding accordingly.
2. [`components/src/dynamo/sglang/protocol.py`](components/src/dynamo/sglang/protocol.py) — the field on `EmbeddingRequest` was already declared in main; only the handler change is functional.
3. [`tests/utils/payload_builder.py`](tests/utils/payload_builder.py) — `extra_body` parameter is a small reusable surface for OpenAI-field-passthrough tests.
4. [`tests/serve/test_sglang.py`](tests/serve/test_sglang.py) — the new `dimensions=128` payload.

Closes the `dimensions` part of DIS-2093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Embedding responses can now be truncated to specified dimensions, enabling flexible vector size control.

* **Tests**
  * Added test coverage for dimension truncation in embedding requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->