### PR TITLE
docs: move Agents section between Reasoning and Multimodal

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -152,16 +152,6 @@ navigation:
   # ==================== User Guides ====================
   - section: User Guides
     contents:
-      - section: Agents
-        slug: agents
-        path: agents/README.md
-        contents:
-          - page: Agent Tracing
-            path: agents/agent-tracing.md
-          - page: Agent Hints
-            path: agents/agent-hints.md
-          - page: Use Pi-Mono with Dynamo
-            path: agents/pi-mono.md
       - page: Disaggregated Serving
         path: features/disaggregated-serving/README.md
       - page: KV Cache Aware Routing
@@ -186,6 +176,16 @@ navigation:
             path: reasoning/dynamo.md
           - page: Reasoning Parsing (Engine Fallback)
             path: reasoning/engine-fallback.md
+      - section: Agents
+        slug: agents
+        path: agents/README.md
+        contents:
+          - page: Agent Tracing
+            path: agents/agent-tracing.md
+          - page: Agent Hints
+            path: agents/agent-hints.md
+          - page: Use Pi-Mono with Dynamo
+            path: agents/pi-mono.md
       - section: Multimodal
         path: features/multimodal/README.md
         contents:


### PR DESCRIPTION
## Summary
- Reorder `docs/index.yml` nav: Agents now sits between Reasoning and Multimodal under User Guides.
- Request from @harryskim to shift doc section order

## Test plan
- [ ] `fern check` passes in CI
- [ ] Nav renders Tool Calling → Reasoning → Agents → Multimodal on the docs site
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the User Guides navigation to reposition the Agents section in the documentation menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->