### PR TITLE
fix(grpc): return not_found for unknown models before request parsing

### DIFF
--- a/lib/llm/src/grpc/service/kserve.rs
+++ b/lib/llm/src/grpc/service/kserve.rs
@@ -325,6 +325,10 @@ impl GrpcInferenceService for KserveService {
         let model = request.model_name.clone();
         let request_id = request.id.clone();
 
+        if !model.is_empty() && self.state().manager().get_model(&model).is_none() {
+            return Err(Status::not_found(format!("Model '{}' not found", model)));
+        }
+
         // [gluo TODO] refactor to reuse code, inference logic is largely the same
         if self.state().is_tensor_model(&model) {
             let set_raw_output_contents = !request.raw_input_contents.is_empty();
@@ -380,6 +384,15 @@ impl GrpcInferenceService for KserveService {
             }
         }
 
+        let effective_model = &completion_request.inner.model;
+        if effective_model.is_empty() || self.state().manager().get_model(effective_model).is_none()
+        {
+            return Err(Status::not_found(format!(
+                "Model '{}' not found",
+                effective_model
+            )));
+        }
+
         let (stream, parsing_options) =
             completion_response_stream(self.state_clone(), completion_request, &metadata).await?;
 
@@ -431,6 +444,14 @@ impl GrpcInferenceService for KserveService {
                 };
 
                 let model = request.model_name.clone();
+
+                if !model.is_empty() && state.manager().get_model(&model).is_none() {
+                    yield ModelStreamInferResponse {
+                        error_message: format!("Model '{}' not found", model),
+                        infer_response: None,
+                    };
+                    continue;
+                }
 
                 // [gluo TODO] refactor to reuse code, inference logic is largely the same
                 if state.is_tensor_model(&model) {
@@ -500,6 +521,15 @@ impl GrpcInferenceService for KserveService {
                     if completion_request.inner.max_tokens.unwrap_or(0) == 0 {
                         completion_request.inner.max_tokens = Some(template.max_completion_tokens);
                     }
+                }
+
+                let effective_model = &completion_request.inner.model;
+                if effective_model.is_empty() || state.manager().get_model(effective_model).is_none() {
+                    yield ModelStreamInferResponse {
+                        error_message: format!("Model '{}' not found", effective_model),
+                        infer_response: None,
+                    };
+                    continue;
                 }
 
                 let streaming = completion_request.inner.stream.unwrap_or(false);


### PR DESCRIPTION
#### Overview:

This PR improves error handling in the KServe gRPC service by adding explicit model existence checks before processing inference requests.

#### Details:

- **`model_infer`** – added a guard that checks `manager.get_model(&model).is_none()` and immediately returns `Status::not_found` if the model does not exist.
- **`model_stream_infer`** – inside the request loop, similar check yields a `ModelStreamInferResponse` with an explicit `error_message` when the model is missing, then continues to the next request.

#### Where should the reviewer start?

- `lib/llm/src/grpc/service/kserve/service.rs` – look at the `model_infer` and `model_stream_infer` methods (around lines 330 and 430 after the change). The added blocks are clearly marked and follow the existing `FIXME` comment.

#### Related Issues:

- Closes #N/A (this is a proactive improvement; no open issue references)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved error handling for inference requests by validating that requested models exist before processing
- Users now receive clearer error messages when attempting to use unavailable models

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->