### PR TITLE
fix: tune Qwen3-235B disagg GPU memory fraction

### DIFF
--- a/docs/performance/tuning.md
+++ b/docs/performance/tuning.md
@@ -72,7 +72,7 @@ Each engine backend has its own CLI flag to control what fraction of GPU memory 
 
 Dynamo launch scripts use absolute KV cache overrides for deterministic, parallel-safe GPU memory control. For vLLM, `_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES` maps to `--kv-cache-memory-bytes`. For SGLang, `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` maps to `--max-total-tokens`. These are set by `tests/utils/profile_pytest.py` during binary-search profiling and by `tests/utils/pytest_parallel_gpu.py` at runtime.
 
-Setting a lower memory fraction leaves more headroom for other CUDA allocations (e.g. activation buffers, NCCL buffers) at the cost of a smaller KV cache. Setting it higher allows more concurrent requests but risks OOM from non-KV-cache allocations. Typical production values are 0.85-0.95.
+Setting a lower memory fraction leaves more headroom for other CUDA allocations (e.g. activation buffers, NCCL buffers) at the cost of a smaller KV cache. Setting it higher allows more concurrent requests but risks OOM from non-KV-cache allocations. Typical production values are 0.85-0.95, but large MoE and disaggregated recipes should start closer to 0.85 and only move higher after a load-and-request validation on the target hardware. Recipe READMEs should document any per-hardware or per-worker values that differ from the backend default.
 
 > [!Important]
 > In vLLM, when `--kv-cache-memory-bytes` is set to an explicit value (not None), it **overrides and ignores** `--gpu-memory-utilization` for KV cache sizing ([vLLM CacheConfig docs](https://docs.vllm.ai/en/stable/api/vllm/config/cache/)). This is exactly why we use `--kv-cache-memory-bytes` for parallel-safe allocation: it provides a deterministic, absolute KV cache cap that is immune to profiling races.

--- a/recipes/qwen3-235b-a22b-fp8/README.md
+++ b/recipes/qwen3-235b-a22b-fp8/README.md
@@ -80,6 +80,16 @@ The difference: the default CUTLASS MoE backend in TRT-LLM 1.3.x falls through t
 | Disaggregated (Hopper) | 16x H100/H200 | ~1.3TB |
 | Disaggregated (Blackwell) | 16x B100/B200 | ~1.3TB |
 
+## GPU Memory Fractions
+
+The TensorRT-LLM `free_gpu_memory_fraction` values in these recipes reserve headroom for non-KV-cache allocations after the model is loaded. Treat them as recipe-specific validation points rather than generic defaults.
+
+| Configuration | Worker | Hopper | Blackwell | Rationale |
+|--------------|--------|--------|-----------|-----------|
+| Aggregated | Worker | `0.8` | `0.8` | Leaves room for MoE, attention, and CUDA graph workspace while keeping a useful KV cache budget. |
+| Disaggregated | Prefill | `0.7` | `0.7` | Prefill uses large prompt batches and transfer buffers; a lower fraction leaves room for workspace growth. |
+| Disaggregated | Decode | `0.85` | `0.85` | Validated on H200 and B200 for TP4 x EP4 decode. Higher fractions can over-reserve KV cache and leave too little headroom for runtime workspace allocations. |
+
 ## Notes
 
 - Update `storageClassName` in `model-cache/model-cache.yaml` before deploying

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy.yaml
@@ -45,7 +45,7 @@ data:
     enable_chunked_prefill: false
     kv_cache_config:
       enable_block_reuse: false
-      free_gpu_memory_fraction: 0.95
+      free_gpu_memory_fraction: 0.85
       dtype: fp8
     cache_transceiver_config:
       backend: DEFAULT

--- a/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml
@@ -40,7 +40,7 @@ data:
     enable_chunked_prefill: false
     kv_cache_config:
       enable_block_reuse: false
-      free_gpu_memory_fraction: 0.95
+      free_gpu_memory_fraction: 0.85
       dtype: fp8
     cache_transceiver_config:
       backend: DEFAULT


### PR DESCRIPTION
## Summary

- Lower the Qwen3-235B FP8 TensorRT-LLM disaggregated decode `free_gpu_memory_fraction` from `0.95` to `0.85` on Hopper and Blackwell.
- Document the per-worker GPU memory fractions in the Qwen3-235B recipe README.
- Clarify tuning guidance so large MoE/disaggregated recipes treat memory fractions as hardware-validated recipe values rather than generic defaults.

## Why

The previous decode value reserved too much memory for KV cache and left too little headroom for runtime workspace allocations. The fix keeps prefill at `0.7`, aggregated at `0.8`, and uses a validated `0.85` decode fraction for both H200 and B200.

## Validation

- YAML parse check for the Hopper and Blackwell disagg deploy files.
- Hopper/H200 smoke: decode at `0.85` loaded successfully, allocated about `65.73 GiB` KV cache per decode rank, and completed an end-to-end request.
- Blackwell/B200 smoke: decode at `0.85` loaded successfully, allocated about `97.68 GiB` KV cache per decode rank, and completed an end-to-end request.

Notes: the B200 smoke used a DRA-adapted test manifest because the NScale cluster exposes GPUs through DRA rather than classic `nvidia.com/gpu` requests.