### PR TITLE
fix: apply DGDR DGD overrides (DYN-3042)

### DIFF
--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -295,9 +295,9 @@ type OverridesSpec struct {
 	// +optional
 	ProfilingJob *batchv1.JobSpec `json:"profilingJob,omitempty"`
 
-	// DGD allows providing a full or partial nvidia.com/v1alpha1 DynamoGraphDeployment
-	// to use as the base for the generated deployment. Fields from profiling results
-	// are merged on top. Use this to override backend worker images.
+	// DGD allows providing a full or partial nvidia.com/v1alpha1 DynamoGraphDeployment.
+	// Fields set here are merged into the profiler-generated deployment and take
+	// precedence. Use this to override backend worker images.
 	//
 	// The field is stored as a raw embedded resource rather than a typed
 	// *v1alpha1.DynamoGraphDeployment to avoid a circular import: v1alpha1 already

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -718,9 +718,9 @@ spec:
                   properties:
                     dgd:
                       description: |-
-                        DGD allows providing a full or partial nvidia.com/v1alpha1 DynamoGraphDeployment
-                        to use as the base for the generated deployment. Fields from profiling results
-                        are merged on top. Use this to override backend worker images.
+                        DGD allows providing a full or partial nvidia.com/v1alpha1 DynamoGraphDeployment.
+                        Fields set here are merged into the profiler-generated deployment and take
+                        precedence. Use this to override backend worker images.
 
                         The field is stored as a raw embedded resource rather than a typed
                         *v1alpha1.DynamoGraphDeployment to avoid a circular import: v1alpha1 already

--- a/deploy/operator/internal/controller/dgd_overrides.go
+++ b/deploy/operator/internal/controller/dgd_overrides.go
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	dgdv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+const dgdOverrideKind = "DynamoGraphDeployment"
+
+func applyDGDOverrides(generated *dgdv1alpha1.DynamoGraphDeployment, override *runtime.RawExtension) error {
+	if generated == nil || override == nil || len(override.Raw) == 0 {
+		return nil
+	}
+
+	overrideJSON, err := sigsyaml.YAMLToJSON(override.Raw)
+	if err != nil {
+		return fmt.Errorf("convert DGD override to JSON: %w", err)
+	}
+
+	var overrideDGD dgdv1alpha1.DynamoGraphDeployment
+	decoder := json.NewDecoder(bytes.NewReader(overrideJSON))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&overrideDGD); err != nil {
+		return fmt.Errorf("unmarshal DGD override: %w", err)
+	}
+	if overrideDGD.APIVersion != "" && overrideDGD.APIVersion != dgdv1alpha1.GroupVersion.String() {
+		return fmt.Errorf("DGD override apiVersion must be %q, got %q", dgdv1alpha1.GroupVersion.String(), overrideDGD.APIVersion)
+	}
+	if overrideDGD.Kind != "" && overrideDGD.Kind != dgdOverrideKind {
+		return fmt.Errorf("DGD override kind must be %q, got %q", dgdOverrideKind, overrideDGD.Kind)
+	}
+
+	generatedJSON, err := json.Marshal(generated)
+	if err != nil {
+		return fmt.Errorf("marshal generated DGD: %w", err)
+	}
+
+	var generatedPatch map[string]any
+	if err := json.Unmarshal(generatedJSON, &generatedPatch); err != nil {
+		return fmt.Errorf("unmarshal generated DGD: %w", err)
+	}
+
+	var userPatch map[string]any
+	if err := json.Unmarshal(overrideJSON, &userPatch); err != nil {
+		return fmt.Errorf("unmarshal DGD override patch: %w", err)
+	}
+
+	mergedPatch := mergeJSONPatch(generatedPatch, userPatch)
+	mergedJSON, err := json.Marshal(mergedPatch)
+	if err != nil {
+		return fmt.Errorf("marshal merged DGD: %w", err)
+	}
+
+	if err := json.Unmarshal(mergedJSON, generated); err != nil {
+		return fmt.Errorf("unmarshal merged DGD: %w", err)
+	}
+	return nil
+}
+
+func mergeJSONPatch(base, patch map[string]any) map[string]any {
+	for key, patchValue := range patch {
+		if patchValue == nil {
+			delete(base, key)
+			continue
+		}
+
+		patchMap, patchIsMap := patchValue.(map[string]any)
+		baseMap, baseIsMap := base[key].(map[string]any)
+		if patchIsMap && baseIsMap {
+			base[key] = mergeJSONPatch(baseMap, patchMap)
+			continue
+		}
+		if patchIsMap {
+			base[key] = mergeJSONPatch(map[string]any{}, patchMap)
+			continue
+		}
+
+		base[key] = patchValue
+	}
+	return base
+}

--- a/deploy/operator/internal/controller/dgd_overrides_test.go
+++ b/deploy/operator/internal/controller/dgd_overrides_test.go
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	dgdv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestApplyDGDOverrides_MergesServiceImageWithoutDroppingGeneratedFields(t *testing.T) {
+	replicas := int32(2)
+	generated := &dgdv1alpha1.DynamoGraphDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dgdv1alpha1.GroupVersion.String(),
+			Kind:       dgdOverrideKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "generated-dgd",
+			Labels: map[string]string{"generated": "keep"},
+		},
+		Spec: dgdv1alpha1.DynamoGraphDeploymentSpec{
+			Services: map[string]*dgdv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"TRTLLMWorker": {
+					Replicas: &replicas,
+					ExtraPodSpec: &dgdv1alpha1.ExtraPodSpec{
+						MainContainer: &corev1.Container{
+							Image: "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0",
+							Args:  []string{"--generated-arg"},
+						},
+					},
+				},
+				"Frontend": {
+					Replicas: &replicas,
+				},
+			},
+		},
+	}
+
+	override := &runtime.RawExtension{Raw: []byte(`{
+		"apiVersion": "nvidia.com/v1alpha1",
+		"kind": "DynamoGraphDeployment",
+		"metadata": {
+			"labels": {
+				"override": "applied"
+			}
+		},
+		"spec": {
+			"services": {
+				"TRTLLMWorker": {
+					"extraPodSpec": {
+						"mainContainer": {
+							"image": "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"
+						}
+					}
+				}
+			}
+		}
+	}`)}
+
+	if err := applyDGDOverrides(generated, override); err != nil {
+		t.Fatalf("applyDGDOverrides() error = %v", err)
+	}
+
+	if got := generated.Labels["generated"]; got != "keep" {
+		t.Fatalf("generated label = %q, want keep", got)
+	}
+	if got := generated.Labels["override"]; got != "applied" {
+		t.Fatalf("override label = %q, want applied", got)
+	}
+
+	worker := generated.Spec.Services["TRTLLMWorker"]
+	if worker == nil {
+		t.Fatal("TRTLLMWorker service missing after override")
+	}
+	if worker.Replicas == nil || *worker.Replicas != 2 {
+		t.Fatalf("TRTLLMWorker replicas = %v, want 2", worker.Replicas)
+	}
+	if worker.ExtraPodSpec == nil || worker.ExtraPodSpec.MainContainer == nil {
+		t.Fatalf("TRTLLMWorker main container missing after override: %#v", worker)
+	}
+	if got, want := worker.ExtraPodSpec.MainContainer.Image, "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"; got != want {
+		t.Fatalf("TRTLLMWorker image = %q, want %q", got, want)
+	}
+	if got, want := worker.ExtraPodSpec.MainContainer.Args, []string{"--generated-arg"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("TRTLLMWorker args = %#v, want %#v", got, want)
+	}
+	if generated.Spec.Services["Frontend"] == nil {
+		t.Fatal("Frontend service missing after override")
+	}
+}
+
+func TestApplyDGDOverrides_RejectsWrongKind(t *testing.T) {
+	generated := &dgdv1alpha1.DynamoGraphDeployment{}
+	override := &runtime.RawExtension{Raw: []byte(`{
+		"apiVersion": "nvidia.com/v1alpha1",
+		"kind": "ConfigMap"
+	}`)}
+
+	if err := applyDGDOverrides(generated, override); err == nil {
+		t.Fatal("applyDGDOverrides() error = nil, want invalid kind error")
+	}
+}
+
+func TestApplyDGDOverrides_RejectsUnknownFields(t *testing.T) {
+	generated := &dgdv1alpha1.DynamoGraphDeployment{}
+	override := &runtime.RawExtension{Raw: []byte(`{
+		"apiVersion": "nvidia.com/v1alpha1",
+		"kind": "DynamoGraphDeployment",
+		"spec": {
+			"services": {
+				"TRTLLMWorker": {
+					"extraPodSpec": {
+						"mainContainer": {
+							"imag": "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"
+						}
+					}
+				}
+			}
+		}
+	}`)}
+
+	if err := applyDGDOverrides(generated, override); err == nil {
+		t.Fatal("applyDGDOverrides() error = nil, want unknown field error")
+	}
+}

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -931,6 +931,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	if err := yaml.Unmarshal([]byte(dgdSpecYAML), generatedDGD); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to unmarshal generated deployment from annotation: %w", err)
 	}
+	if dgdr.Spec.Overrides != nil {
+		if err := applyDGDOverrides(generatedDGD, dgdr.Spec.Overrides.DGD); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to apply DGD overrides: %w", err)
+		}
+	}
 
 	// Determine DGD name and namespace from generated deployment
 	dgdName := generatedDGD.Name
@@ -1950,6 +1955,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	// collides when multiple DGDRs share identical specs. Derive the name from
 	// DGDR identity instead, respecting an explicit override if the user set one.
 	dgd.Name = computeDGDName(dgdr)
+	if dgdr.Spec.Overrides != nil {
+		if err := applyDGDOverrides(dgd, dgdr.Spec.Overrides.DGD); err != nil {
+			return nil, "", fmt.Errorf("failed to apply DGD overrides: %w", err)
+		}
+	}
 
 	logger.Info("Parsed profiling output", "profilerDGDName", dgd.Name, "additionalResources", len(additionalResources))
 

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -840,6 +842,172 @@ spec:
 			Expect(outputCM.OwnerReferences).Should(HaveLen(1))
 			Expect(outputCM.OwnerReferences[0].Kind).Should(Equal("DynamoGraphDeploymentRequest"))
 			Expect(outputCM.OwnerReferences[0].Name).Should(Equal(dgdrName))
+		})
+
+		It("Should apply DGD overrides to generated deployment specs", func() {
+			ctx := context.Background()
+			dgdrName := "test-dgdr-dgd-overrides"
+			namespace := defaultNamespace
+			dgdName := dgdrName + "-dgd"
+			overrideImage := "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"
+
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"nvidia.com/generated-dgd-spec": `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: test-dgdr-dgd-overrides-dgd
+  labels:
+    generated: keep
+spec:
+  services:
+    TRTLLMWorker:
+      replicas: 2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0
+          args:
+          - --generated-arg
+    Frontend:
+      replicas: 1`,
+					},
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:   "test-model",
+					Backend: "trtllm",
+					Image:   "test-profiler:latest",
+					Overrides: &nvidiacomv1beta1.OverridesSpec{
+						DGD: &runtime.RawExtension{Raw: []byte(`{
+								"apiVersion": "nvidia.com/v1alpha1",
+								"kind": "DynamoGraphDeployment",
+								"metadata": {
+									"labels": {
+										"override": "applied",
+										"nvidia.com/managed-by": "user"
+									}
+								},
+								"spec": {
+									"services": {
+										"TRTLLMWorker": {
+											"extraPodSpec": {
+												"mainContainer": {
+													"image": "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"
+												}
+											}
+										}
+									}
+								}
+							}`)},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+
+			_, err := reconciler.createDGD(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+
+			dgd := &dgdv1alpha1.DynamoGraphDeployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: namespace}, dgd)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
+
+			Expect(dgd.Labels).Should(HaveKeyWithValue("generated", "keep"))
+			Expect(dgd.Labels).Should(HaveKeyWithValue("override", "applied"))
+			Expect(dgd.Labels).Should(HaveKeyWithValue(nvidiacomv1beta1.LabelManagedBy, nvidiacomv1beta1.LabelValueDynamoOperator))
+
+			worker := dgd.Spec.Services["TRTLLMWorker"]
+			Expect(worker).NotTo(BeNil())
+			Expect(worker.Replicas).NotTo(BeNil())
+			Expect(*worker.Replicas).Should(Equal(int32(2)))
+			Expect(worker.ExtraPodSpec).NotTo(BeNil())
+			Expect(worker.ExtraPodSpec.MainContainer).NotTo(BeNil())
+			Expect(worker.ExtraPodSpec.MainContainer.Image).Should(Equal(overrideImage))
+			Expect(worker.ExtraPodSpec.MainContainer.Args).Should(Equal([]string{"--generated-arg"}))
+
+			frontend := dgd.Spec.Services["Frontend"]
+			Expect(frontend).NotTo(BeNil())
+			Expect(frontend.Replicas).NotTo(BeNil())
+			Expect(*frontend.Replicas).Should(Equal(int32(1)))
+		})
+
+		It("Should apply DGD overrides to generated selected config", func() {
+			ctx := context.Background()
+			dgdrName := "test-dgdr-generated-dgd-overrides"
+			namespace := defaultNamespace
+			overrideImage := "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"
+
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName,
+					Namespace: namespace,
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model:   "test-model",
+					Backend: "trtllm",
+					Image:   "test-profiler:latest",
+					Overrides: &nvidiacomv1beta1.OverridesSpec{
+						DGD: &runtime.RawExtension{Raw: []byte(`{
+							"apiVersion": "nvidia.com/v1alpha1",
+							"kind": "DynamoGraphDeployment",
+							"spec": {
+								"services": {
+									"TRTLLMWorker": {
+										"extraPodSpec": {
+											"mainContainer": {
+												"image": "nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0-cuda13"
+											}
+										}
+									}
+								}
+							}
+						}`)},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+
+			outputCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getOutputConfigMapName(dgdr),
+					Namespace: namespace,
+				},
+				Data: map[string]string{
+					ProfilingOutputFile: `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-generated
+spec:
+  services:
+    TRTLLMWorker:
+      replicas: 2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0rc0
+          args:
+          - --generated-arg`,
+				},
+			}
+			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
+
+			profilingResults, dgdName, err := reconciler.generateDGDSpec(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dgdName).Should(Equal(dgdrName + "-dgd"))
+			Expect(profilingResults.SelectedConfig).NotTo(BeNil())
+
+			var selected dgdv1alpha1.DynamoGraphDeployment
+			Expect(json.Unmarshal(profilingResults.SelectedConfig.Raw, &selected)).Should(Succeed())
+			Expect(selected.Spec.Services["TRTLLMWorker"].ExtraPodSpec.MainContainer.Image).Should(Equal(overrideImage))
+
+			updated := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, updated)).Should(Succeed())
+			generatedYAML := updated.Annotations["nvidia.com/generated-dgd-spec"]
+			Expect(generatedYAML).Should(ContainSubstring(overrideImage))
+			Expect(generatedYAML).Should(ContainSubstring("--generated-arg"))
 		})
 
 		It("Should adopt additional ConfigMaps when DGD already exists", func() {


### PR DESCRIPTION
## Summary
- merge spec.overrides.dgd into profiler-generated DynamoGraphDeployments before selected-config storage and final DGD creation
- validate DGD override fields strictly so typos fail reconciliation instead of being silently dropped
- update DGDR API/CRD descriptions and add regression coverage for image overrides

## Tests
- go test ./internal/controller -run TestApplyDGDOverrides -count=1
- go test ./internal/controller -run TestControllers -ginkgo.focus "Should apply DGD overrides" -count=1 *(fails locally: missing ../../bin/k8s/1.29.0-linux-amd64/etcd envtest binary)*

Fixes DYN-3042
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled user-provided overrides for DynamoGraph Deployments that merge with profiler-generated specifications
  * Override fields take precedence over generated values, allowing customization of container images, labels, and other deployment properties
  * Overrides are validated against the deployment schema to ensure correctness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->