### PR TITLE
chore: trivial name change, from "chart" to "table"

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -25,7 +25,7 @@ tests/parity/
     ├── fixtures/                   ← static YAML, generated from Dynamo as oracle
     │   └── <family>/PARSER.batch.yaml         (and per-top-level-case files like PARSER.batch.8.yaml; see Fixture file schema)
     ├── capture_parser_outputs.py     ← drift-check (default) or merge any impl's output into `expected.{dynamo,vllm,sglang}`
-    ├── generate_parity_chart.py    ← print the parity-status chart (run on demand; not checked in)
+    ├── generate_parity_chart.py    ← print the parity-status table (run on demand; not checked in)
     │
     ├── dynamo.py                   ← M2 in-process wrapper (PyO3 binding)
     ├── vllm.py                     ← M2 in-process wrapper (ToolParserManager)
@@ -141,19 +141,19 @@ PR description.
 Cell values show how each engine's recorded `expected.<impl>` block relates to Dynamo (the oracle). **Convention:** a divergent peer block carries a `reason:` field iff the divergence is *intentional* (documented contract difference, vendor behavior, etc.). No `reason:` = **research-needed** — we observed the divergence but haven't classified it yet.
 
 - `=` — both engines match Dynamo (peer block is an anchor ref `*d_<case>` to dynamo's).
-- `V` — vLLM diverges, **intentional** (engine block has `reason:` field). Rendered the same color as = in the HTML chart since the divergence is accounted for.
+- `V` — vLLM diverges, **intentional** (engine block has `reason:` field). Rendered the same color as = in the HTML table since the divergence is accounted for.
 - `V?` — vLLM diverges, **research-needed** (engine block has no `reason:` yet; we observed the divergence but haven't classified it).
 - `V!` — vLLM is expected to crash; `expected.vllm.error: <substring>` records the matching error.
 - `S`, `S?`, `S!` — same as V/V?/V! for SGLang.
 - `VS`, `VS?`, `V?S`, `V!S`, `VS!`, `V?S?`, `V!S!`, … — combinations (both engines diverge with any mix of intentional/research-needed/error).
 - `n/a` — **not applicable**: engine marked `unavailable` (no parser registered for that family), OR the sub-case shape doesn't apply to this grammar (e.g. attribute-encoded DSML families have no `4.b` because there's no embedded JSON to malform).
-- `—` — **missing fixture coverage**: no fixture entry exists for that family/case yet. If the case is intentionally not applicable, add an explicit chart-only n/a stub with `description:` and `reason:` so the chart can explain it.
+- `—` — **missing fixture coverage**: no fixture entry exists for that family/case yet. If the case is intentionally not applicable, add an explicit table-only n/a stub with `description:` and `reason:` so the table can explain it.
 
 19 parsers total — split into the **Top-N models** we prioritize and
 **Others** wired into the harness for completeness. Both sections sorted
 alphabetically within themselves.
 
-The chart isn't checked in — it would drift behind the YAML every time a
+The table isn't checked in — it would drift behind the YAML every time a
 case is added or a peer block flips. Generate it on demand and save it
 somewhere you can browse:
 
@@ -176,7 +176,7 @@ generator reads every `fixtures/<family>/PARSER.*.yaml` and emits one
 cell per `(family, sub-case)` using the legend above.
 
 **Example output** (illustrative — cell values are made up, **not** a
-snapshot of current fixtures; run the script for the real chart):
+snapshot of current fixtures; run the script for the real table):
 
 ```text
 | model       | parser     | 1 | 2.a | 2.b | 2.c | 2.d | 3 | ... | 9 | 10 |
@@ -189,7 +189,7 @@ snapshot of current fixtures; run the script for the real chart):
 
 Read a row left-to-right: `=` = both engines match Dynamo, `V` / `S` =
 that engine diverges with a documented reason (rendered same color as =
-in the HTML chart), `V?` / `S?` = divergence not yet classified
+in the HTML table), `V?` / `S?` = divergence not yet classified
 (research-needed), `n/a` = case doesn't apply or peer is unavailable.
 
 ### Footnotes
@@ -290,7 +290,7 @@ fixture).
 
 ## Resolving divergences (8 steps)
 
-Each non-`=` cell in the generated chart is a divergent `expected.<impl>` block
+Each non-`=` cell in the generated table is a divergent `expected.<impl>` block
 in the family's YAML fixture (concrete `calls` + `normal_text`, or
 `{error: <substring>}`, or `{unavailable: <reason>}`). Cells that
 match Dynamo are stored as anchor refs `*d_<case>` to the dynamo
@@ -487,13 +487,13 @@ PARSER.batch.8.b:
   - ...
 ```
 
-Then regenerate the chart so the cell flips:
+Then regenerate the table so the cell flips:
 
 ```bash
 python3 tests/parity/parser/generate_parity_chart.py > PARITY.md
 ```
 
-Pytest should now be fully green; the chart cell flips to `=`.
+Pytest should now be fully green; the table cell flips to `=`.
 
 ```bash
 git add lib/parsers/ tests/parity/parser/
@@ -517,7 +517,7 @@ few classes stay recorded forever (intentional, by design):
 
 Everything else is a candidate to fix. Permanent divergences should
 carry a `reason:` field that classifies them as intentional (so the
-chart shows `V`/`S`, not `V?`/`S?`).
+table shows `V`/`S`, not `V?`/`S?`).
 
 ## Fixture file schema
 
@@ -840,5 +840,5 @@ real value-add is the cross-impl half (vLLM and SGLang).
    `{error: <substring>}` so the test asserts on a stable signature
    rather than the full volatile message. Add a `reason:` field to
    intentional divergences so they show as `V`/`S` not `V?`/`S?` in the
-   chart.
-6. Regenerate the chart: `python3 tests/parity/parser/generate_parity_chart.py > PARITY.md`.
+   table.
+6. Regenerate the table: `python3 tests/parity/parser/generate_parity_chart.py > PARITY.md`.

--- a/tests/parity/parser/capture_parser_outputs.py
+++ b/tests/parity/parser/capture_parser_outputs.py
@@ -152,7 +152,7 @@ def normalize_output(d: dict) -> dict:
 
 
 def is_na_stub(case: dict[str, Any]) -> bool:
-    """Explicit chart-only n/a stub: no parser input, no expected block."""
+    """Explicit table-only n/a stub: no parser input, no expected block."""
     return set(case) == {"description", "reason"} and all(
         isinstance(case[key], str) and case[key].strip()
         for key in ("description", "reason")

--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Generate the parity chart (matrix of cell markers) from the YAML fixtures.
+"""Generate the parity table (matrix of cell markers) from the YAML fixtures.
 
 ================================================================================
 EXAMPLE OUTPUT (truncated; illustrative, NOT a snapshot of current fixtures
-— run the script for the real chart):
+— run the script for the real table):
 
     | model          | parser     | 1 | 2.a | 2.b | 2.c | ... | 9 | 10 |
     |---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
@@ -19,7 +19,7 @@ EXAMPLE OUTPUT (truncated; illustrative, NOT a snapshot of current fixtures
 ================================================================================
 
 Reads every `tests/parity/parser/fixtures/<family>/PARSER.*.yaml` and emits
-the chart referenced in `tests/parity/README.md`.
+the table referenced in `tests/parity/README.md`.
 
 Cell markers (per peer, vllm + sglang):
   =     peer block is `*d_<case>` anchor ref to dynamo (matches)
@@ -36,11 +36,11 @@ Footnote markers `†` (no vLLM peer) and `§` (no SGLang peer) are auto-derived
 from `expected.<impl>.unavailable` across each family's cases.
 
 Run:
-    # Markdown chart to stdout
+    # Markdown table to stdout
     python3 tests/parity/parser/generate_parity_chart.py \
         > tests/parity/parser/PARITY.md
 
-    # HTML chart with clickable YAML links + hover tooltips. Write next
+    # HTML table with clickable YAML links + hover tooltips. Write next
     # to this script so `<a href="fixtures/<family>/PARSER.batch.N.yaml">`
     # resolves when opened in a browser.
     python3 tests/parity/parser/generate_parity_chart.py --html \
@@ -82,7 +82,7 @@ def _make_jinja_env() -> Environment:
 
 
 def _commit_sha() -> str | None:
-    """HEAD SHA at chart-generation time, or None if not in a git tree."""
+    """HEAD SHA at table-generation time, or None if not in a git tree."""
     try:
         out = (
             subprocess.check_output(
@@ -284,7 +284,7 @@ def _build_family_to_rust_ref() -> dict[str, tuple[str, int]]:
 
 
 # Curated featured-model order. The only hand-maintained list left in the
-# script: it picks WHICH families lead the chart and IN WHAT ORDER. The
+# script: it picks WHICH families lead the table and IN WHAT ORDER. The
 # human-readable label for each (e.g. "DeepSeek V4") is sourced from the
 # fixture YAML's `model_label:` field, so the label travels with the
 # family definition, not with this script.
@@ -293,7 +293,7 @@ def _build_family_to_rust_ref() -> dict[str, tuple[str, int]]:
 # planning notes. When that list changes, this list and the corresponding
 # `model_label:` fields under `fixtures/<family>/PARSER.batch.yaml` must
 # be updated together.
-# Alphabetical-by-family-id within the list (matches the chart row order).
+# Alphabetical-by-family-id within the list (matches the table row order).
 TOP_N_FAMILIES = [
     "deepseek_v4",
     "gemma4",
@@ -404,7 +404,7 @@ def _normalize_split_parent_cases(cases: dict) -> dict:
     Some older fixture files still define parent buckets such as
     `PARSER.batch.30`, while newer files define leaf buckets such as
     `PARSER.batch.30.a`. For display, parent+leaf duplication is confusing:
-    once any leaf exists for a parent bucket, the chart should show only the
+    once any leaf exists for a parent bucket, the table should show only the
     leaf columns. Parent entries are copied into missing leaf cells so their
     existing expectations or n/a reasons remain visible until the YAML itself
     is migrated.
@@ -1057,7 +1057,7 @@ def _build_missing_tooltip_html(family: str, sub: str) -> str:
     """Tooltip for an absent fixture entry.
 
     This is intentionally distinct from an explicit n/a stub. Missing means
-    the chart has no fixture data for this family/case; explicit n/a means a
+    the table has no fixture data for this family/case; explicit n/a means a
     fixture author recorded why the case does not apply.
     """
     case_id = f"PARSER.batch.{sub}"
@@ -1070,7 +1070,7 @@ def _build_missing_tooltip_html(family: str, sub: str) -> str:
     parts.append(
         '<pre class="ttip-pre">No fixture entry exists for this family/case. '
         "If the case is intentionally not applicable, add an explicit n/a "
-        "stub with description: and reason: so the chart can explain it.</pre>"
+        "stub with description: and reason: so the table can explain it.</pre>"
     )
     parts.append("</div>")
     return "".join(parts)
@@ -1156,7 +1156,7 @@ def _parser_inheritance_tooltip_html(
             fm = re.search(r'\("([^"]+)"\)', info["factory"])
             if fm:
                 suffix = f'  block="{fm.group(1)}"'
-        # ← THIS goes on the target family's line only when the chart cell
+        # ← THIS goes on the target family's line only when the table cell
         # IS the target (not an alias).
         marker_html = (
             "  <strong>← THIS</strong>" if (fam == family and not alias_of) else ""
@@ -1182,7 +1182,7 @@ def _parser_inheritance_tooltip_html(
                 )
 
     # Peer-availability footnote (†/§) — embedded here so symbols don't need
-    # their own native tooltip. Anchored on the chart-cell family, so an
+    # their own native tooltip. Anchored on the table-cell family, so an
     # alias inherits its target's peer markers (they share the same fixture
     # YAMLs and the same `expected.<impl>.unavailable` flags).
     peer_notes: list[str] = []
@@ -1547,9 +1547,9 @@ def render_html(
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")
     title = (
-        f"Dynamo {family_filter} parser parity chart"
+        f"Dynamo {family_filter} Parser Parity Table"
         if family_filter
-        else "Dynamo parser parity chart"
+        else "Dynamo Parser Parity Table"
     )
     command = "python3 tests/parity/parser/generate_parity_chart.py --html"
     output = "tests/parity/parser/PARITY.html"


### PR DESCRIPTION
#### Overview:

This is a trivial name change from "chart" to "table" for parser parity wording.

#### Details:

- **How is this fixed?** Rename user-facing parser parity wording from "chart" to "table"; implementation/file names are unchanged.

#### Where should the reviewer start?

`tests/parity/README.md`, then `tests/parity/parser/generate_parity_chart.py`

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology throughout documentation and user-facing text to consistently refer to "parity table" instead of "parity chart" in parser output descriptions, instructions, and page titles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->