### PR TITLE
feat(vllm): OpenAI embeddings dimensions truncation (DIS-2093 vLLM side)

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2879,8 +2879,10 @@ class EmbeddingWorkerHandler:
 
         The Rust frontend forwards the request dict directly. Expected keys:
         ``model: str``, ``input: str | list[str] | list[int] | list[list[int]]``.
-        Optional ``dimensions`` and ``encoding_format`` fields are currently
-        ignored.
+        Optional ``dimensions`` (Matryoshka truncation; first N floats of each
+        embedding). ``encoding_format=base64`` is not yet supported end-to-end
+        (the Rust response type rejects strings); tracked as a separate
+        follow-up.
         """
         # Lazy import to avoid pulling PoolingParams into handlers.py at module
         # load time for non-embedding workers.
@@ -2900,6 +2902,15 @@ class EmbeddingWorkerHandler:
         # skips its own tokenizer; the previous str()-coercion path turned
         # `[1, 2, 3]` into three text prompts ("1", "2", "3") instead of one.
         prompts: list[Any] = _classify_embedding_input(input_field)
+
+        dimensions = request.get("dimensions")
+        if dimensions is not None and not isinstance(dimensions, int):
+            raise TypeError(
+                f"Invalid 'dimensions' type {type(dimensions).__name__}; "
+                "expected int"
+            )
+        if dimensions is not None and dimensions < 1:
+            raise ValueError(f"dimensions must be >= 1, got {dimensions}")
 
         pooling_params = PoolingParams()
         # Use the per-request context id (same as the chat/completion paths
@@ -2934,10 +2945,19 @@ class EmbeddingWorkerHandler:
                     f"vLLM engine.encode produced no output for input index {idx}"
                 )
 
+            embedding = _pooling_output_to_list(final_output.outputs.data)
+            if dimensions is not None:
+                if dimensions > len(embedding):
+                    raise ValueError(
+                        f"dimensions={dimensions} exceeds model embedding "
+                        f"dimension {len(embedding)}"
+                    )
+                embedding = embedding[:dimensions]
+
             embedding_objects.append(
                 {
                     "object": "embedding",
-                    "embedding": _pooling_output_to_list(final_output.outputs.data),
+                    "embedding": embedding,
                     "index": idx,
                 }
             )

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -654,8 +654,8 @@ vllm_configs = {
             ),
             # `dimensions` truncation (Matryoshka). Qwen3-Embedding-0.6B has a
             # hidden dim of 1024, so the truncated vector should be exactly 128.
-            # Built inline since `embedding_payload()`'s `extra_body` kwarg
-            # lives in PR #9722 and isn't in this branch's base.
+            # Built inline because the `embedding_payload()` helper doesn't
+            # expose an `extra_body` kwarg yet.
             EmbeddingPayload(
                 body={"input": ["Hello, world!"], "dimensions": 128},
                 repeat_count=1,

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -38,7 +38,11 @@ from tests.utils.payload_builder import (
     router_cached_tokens_chat_payload,
     router_selection_chat_payload_default,
 )
-from tests.utils.payloads import LoraTestChatPayload, ToolCallingChatPayload
+from tests.utils.payloads import (
+    EmbeddingPayload,
+    LoraTestChatPayload,
+    ToolCallingChatPayload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -647,6 +651,16 @@ vllm_configs = {
                 ],
                 repeat_count=1,
                 expected_response=["Generated 3 embeddings with dimension"],
+            ),
+            # `dimensions` truncation (Matryoshka). Qwen3-Embedding-0.6B has a
+            # hidden dim of 1024, so the truncated vector should be exactly 128.
+            # Built inline since `embedding_payload()`'s `extra_body` kwarg
+            # lives in PR #9722 and isn't in this branch's base.
+            EmbeddingPayload(
+                body={"input": ["Hello, world!"], "dimensions": 128},
+                repeat_count=1,
+                expected_log=[],
+                expected_response=["Generated 1 embeddings with dimension 128"],
             ),
         ],
     ),


### PR DESCRIPTION
#### Overview:

Adds OpenAI `/v1/embeddings` `dimensions` (Matryoshka truncation) support to the **vLLM** embedding worker. Mirror of [PR #9722](https://github.com/ai-dynamo/dynamo/pull/9722) which did the same for SGLang.

**Scope:** Only changes the vLLM `EmbeddingWorkerHandler` from #9713. Once #9713 and #9722 both land, this PR closes out the vLLM half of [DIS-2093](https://linear.app/nvidia/issue/DIS-2093) (the `dimensions` half).

#### Details:

In `EmbeddingWorkerHandler.generate`, the handler now reads `request.get("dimensions")` once before the per-input loop, validates it (must be a positive int), then per embedding asserts `dimensions <= len(embedding)` and slices to `embedding[:dimensions]`. Out-of-range values raise `ValueError` which the Rust frontend surfaces as HTTP 400.

Test: `embedding_agg` config in `tests/serve/test_vllm.py` gains a fourth payload — `dimensions=128` against Qwen3-Embedding-0.6B (hidden dim 1024). Built inline using `EmbeddingPayload(...)` directly because the `embedding_payload(..., extra_body=...)` helper from PR #9722 isn't on this branch's base.

#### Not included — `encoding_format=base64`

Same as the SGLang half of DIS-2093: the Rust frontend's response type is `Vec<f32>` (inherited from the upstream `async_openai::types::embeddings::*` re-export) and rejects base64 strings. End-to-end support requires owning the embedding response type in `lib/protocols/`. Tracked in [DIS-2099](https://linear.app/nvidia/issue/DIS-2099).

#### Stacking

Based on `feat/vllm-embedding-worker-mvp` (PR #9713). Will rebase to `main` once #9713 lands.

#### Reviewer focus

1. `components/src/dynamo/vllm/handlers.py::EmbeddingWorkerHandler.generate` — the new validation + slicing.
2. `tests/serve/test_vllm.py` — one new `dimensions=128` payload.

Refs DIS-2093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedding worker mode to serve embedding models with new `--embedding-worker` configuration flag
  * Implemented OpenAI-compatible `/v1/embeddings` endpoint supporting text, token, and batched input formats
  * Added dimension truncation support for embeddings
  * New aggregated embedding model launch script provided

* **Tests**
  * Added comprehensive test coverage for embedding worker configuration, validation, and API behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->