### PR TITLE
feat(sglang): Prometheus metrics for embedding workload shape (DIS-2094 part 1)

### DIFF
--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -7,6 +7,7 @@ from typing import Awaitable, Callable
 
 import sglang as sgl
 
+from dynamo.common.utils.prometheus import register_engine_metrics_callback
 from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
@@ -17,6 +18,7 @@ from dynamo.sglang.publisher import (
 )
 from dynamo.sglang.register import register_model_with_readiness_gate
 from dynamo.sglang.request_handlers import EmbeddingWorkerHandler
+from dynamo.sglang.request_handlers.embedding.metrics import init_embedding_metrics
 
 
 async def init_embedding(
@@ -41,6 +43,26 @@ async def init_embedding(
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
     )
+
+    # Wire ``dynamo_embedding_*`` histograms to the worker's /metrics
+    # endpoint via a dedicated CollectorRegistry — the default Prometheus
+    # global registry is not exposed by the Dynamo SGLang publisher.
+    # Done AFTER engine init (and after setup_sgl_metrics) so the lazy
+    # ``prometheus_client`` import in metrics.py doesn't interfere with
+    # SGLang's multiprocess Prometheus setup.
+    from prometheus_client import CollectorRegistry
+
+    embedding_metrics_registry = CollectorRegistry()
+    register_engine_metrics_callback(
+        endpoint=generate_endpoint,
+        registry=embedding_metrics_registry,
+        metric_prefix_filters=["dynamo_embedding_"],
+        namespace_name=dynamo_args.namespace,
+        component_name=dynamo_args.component,
+        endpoint_name=dynamo_args.endpoint,
+        model_name=server_args.served_model_name,
+    )
+    init_embedding_metrics(embedding_metrics_registry)
 
     ready_event = asyncio.Event()
 

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -13,6 +13,10 @@ from dynamo.common.utils.otel_tracing import build_trace_headers
 from dynamo.sglang.args import Config
 from dynamo.sglang.protocol import EmbeddingRequest
 from dynamo.sglang.publisher import DynamoSglangPublisher
+from dynamo.sglang.request_handlers.embedding.metrics import (
+    observe_embedding_batch_size,
+    observe_embedding_input_tokens,
+)
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 
 
@@ -86,6 +90,14 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
                 }
             )
             prompt_tokens += ret_item.get("meta_info", {}).get("prompt_tokens", 0)
+
+        # Observe per-request embedding histograms. Failures here must never
+        # break inference, hence the broad except + log.
+        try:
+            observe_embedding_batch_size(model_name, len(embedding_objects))
+            observe_embedding_input_tokens(model_name, prompt_tokens)
+        except Exception:
+            logging.warning("Failed to record embedding metrics", exc_info=True)
 
         return {
             "object": "list",

--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -91,8 +91,6 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
             )
             prompt_tokens += ret_item.get("meta_info", {}).get("prompt_tokens", 0)
 
-        # Observe per-request embedding histograms. Failures here must never
-        # break inference, hence the broad except + log.
         try:
             observe_embedding_batch_size(model_name, len(embedding_objects))
             observe_embedding_input_tokens(model_name, prompt_tokens)

--- a/components/src/dynamo/sglang/request_handlers/embedding/metrics.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/metrics.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prometheus metrics specific to the SGLang embedding worker.
+
+The existing SGLang publisher emits chat-shaped metrics (KV gauges,
+prefill/decode counters) which are always zero on a pooling engine.
+The histograms here capture the signals that actually move on an
+embedding worker: how many inputs per request, and how many input
+tokens those inputs amount to.
+
+A third histogram (per-request embedding latency, with a `worker_id`
+label) is more naturally implemented on the Rust frontend side
+because that's where per-worker timing is observable end-to-end;
+that piece is tracked separately. The two histograms below cover
+the worker-internal view.
+
+Metric names follow Dynamo's existing ``dynamo_<scope>_<unit>``
+convention. They are intentionally NOT prefixed with ``sglang:``
+because they describe an OpenAI-spec workload shape, not an
+SGLang-engine-internal signal — once the vLLM embedding worker
+ships (see PR #9713), it will observe the same names from its own
+handler.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from prometheus_client import REGISTRY, CollectorRegistry, Histogram
+
+logger = logging.getLogger(__name__)
+
+# Bucket choices:
+#
+# batch_size: clients typically send 1 input (chat-style embedding lookup),
+# OpenAI's hosted limit is 2048; powers-of-two up to that covers both
+# common cases and the rare big batches.
+_BATCH_SIZE_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048)
+
+# input_tokens (summed across all inputs in a request): typical embedding
+# ISLs are 60-200 (sentence-level); OpenAI's per-input limit is 8192
+# tokens. Buckets span 1..8K with denser coverage in the common range.
+_INPUT_TOKENS_BUCKETS = (
+    1,
+    4,
+    16,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+)
+
+
+_EMBEDDING_BATCH_SIZE: Optional[Histogram] = None
+_EMBEDDING_INPUT_TOKENS: Optional[Histogram] = None
+
+
+def _get_or_create_batch_size_histogram(
+    registry: CollectorRegistry,
+) -> Histogram:
+    global _EMBEDDING_BATCH_SIZE
+    if _EMBEDDING_BATCH_SIZE is None:
+        _EMBEDDING_BATCH_SIZE = Histogram(
+            "dynamo_embedding_batch_size",
+            "Number of inputs per /v1/embeddings request, observed when the "
+            "worker successfully transforms the engine output. One sample per "
+            "request, not per input.",
+            labelnames=("model",),
+            buckets=_BATCH_SIZE_BUCKETS,
+            registry=registry,
+        )
+    return _EMBEDDING_BATCH_SIZE
+
+
+def _get_or_create_input_tokens_histogram(
+    registry: CollectorRegistry,
+) -> Histogram:
+    global _EMBEDDING_INPUT_TOKENS
+    if _EMBEDDING_INPUT_TOKENS is None:
+        _EMBEDDING_INPUT_TOKENS = Histogram(
+            "dynamo_embedding_input_tokens",
+            "Total prompt tokens summed across all inputs in a /v1/embeddings "
+            "request. One sample per request.",
+            labelnames=("model",),
+            buckets=_INPUT_TOKENS_BUCKETS,
+            registry=registry,
+        )
+    return _EMBEDDING_INPUT_TOKENS
+
+
+def observe_embedding_batch_size(
+    model: str,
+    batch_size: int,
+    *,
+    registry: CollectorRegistry = REGISTRY,
+) -> None:
+    """Record one observation of the request's batch size.
+
+    ``registry`` is overridable for tests; production code uses the
+    default Prometheus global registry.
+    """
+    if batch_size < 0:
+        logger.warning(
+            "Skipping batch_size observation with negative value %d", batch_size
+        )
+        return
+    _get_or_create_batch_size_histogram(registry).labels(model=model).observe(
+        batch_size
+    )
+
+
+def observe_embedding_input_tokens(
+    model: str,
+    input_tokens: int,
+    *,
+    registry: CollectorRegistry = REGISTRY,
+) -> None:
+    """Record one observation of the request's total input tokens.
+
+    ``registry`` is overridable for tests; production code uses the
+    default Prometheus global registry.
+    """
+    if input_tokens < 0:
+        logger.warning(
+            "Skipping input_tokens observation with negative value %d", input_tokens
+        )
+        return
+    _get_or_create_input_tokens_histogram(registry).labels(model=model).observe(
+        input_tokens
+    )
+
+
+def reset_metrics_for_testing() -> None:
+    """Clear cached Histogram singletons so tests can register against a fresh registry."""
+    global _EMBEDDING_BATCH_SIZE, _EMBEDDING_INPUT_TOKENS
+    _EMBEDDING_BATCH_SIZE = None
+    _EMBEDDING_INPUT_TOKENS = None

--- a/components/src/dynamo/sglang/request_handlers/embedding/metrics.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/metrics.py
@@ -3,25 +3,26 @@
 
 """Prometheus metrics specific to the SGLang embedding worker.
 
-The existing SGLang publisher emits chat-shaped metrics (KV gauges,
-prefill/decode counters) which are always zero on a pooling engine.
-The histograms here capture the signals that actually move on an
-embedding worker: how many inputs per request, and how many input
-tokens those inputs amount to.
+``prometheus_client`` imports are deferred behind helper functions because
+this module is loaded via ``dynamo.sglang.request_handlers`` before
+``sgl.Engine(...)`` runs its multiprocess-aware Prometheus setup; pulling
+``prometheus_client`` in at module load time interferes with that setup.
 
-A third histogram (per-request embedding latency, with a `worker_id`
-label) is more naturally implemented on the Rust frontend side
-because that's where per-worker timing is observable end-to-end;
-that piece is tracked separately. The two histograms below cover
-the worker-internal view.
+Histograms are also bound to a caller-provided ``CollectorRegistry`` (NOT
+the default global ``REGISTRY``) because the Dynamo SGLang worker exposes
+metrics on ``/metrics`` only when the registry has been attached via
+``dynamo.common.utils.prometheus.register_engine_metrics_callback``. The
+init function below should be called from ``init_embedding.py`` after
+engine setup, paired with that callback registration.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from prometheus_client import REGISTRY, CollectorRegistry, Histogram
+if TYPE_CHECKING:
+    from prometheus_client import CollectorRegistry, Histogram
 
 logger = logging.getLogger(__name__)
 
@@ -35,29 +36,26 @@ _BATCH_SIZE_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048)
 # input_tokens (summed across all inputs in a request): typical embedding
 # ISLs are 60-200 (sentence-level); OpenAI's per-input limit is 8192
 # tokens. Buckets span 1..8K with denser coverage in the common range.
-_INPUT_TOKENS_BUCKETS = (
-    1,
-    4,
-    16,
-    64,
-    128,
-    256,
-    512,
-    1024,
-    2048,
-    4096,
-    8192,
-)
+_INPUT_TOKENS_BUCKETS = (1, 4, 16, 64, 128, 256, 512, 1024, 2048, 4096, 8192)
 
 
-_EMBEDDING_BATCH_SIZE: Optional[Histogram] = None
-_EMBEDDING_INPUT_TOKENS: Optional[Histogram] = None
+_EMBEDDING_BATCH_SIZE: Optional["Histogram"] = None
+_EMBEDDING_INPUT_TOKENS: Optional["Histogram"] = None
 
 
-def _get_or_create_batch_size_histogram(
-    registry: CollectorRegistry,
-) -> Histogram:
-    global _EMBEDDING_BATCH_SIZE
+def init_embedding_metrics(registry: "CollectorRegistry") -> None:
+    """Create the embedding histograms against the provided registry.
+
+    Must be called AFTER engine init and ONCE per process. Subsequent
+    calls leave the existing histograms alone — this lets tests reuse
+    the function without colliding with prior production registration.
+    The caller is responsible for wiring ``registry`` to the worker's
+    ``/metrics`` endpoint via
+    ``dynamo.common.utils.prometheus.register_engine_metrics_callback``.
+    """
+    from prometheus_client import Histogram
+
+    global _EMBEDDING_BATCH_SIZE, _EMBEDDING_INPUT_TOKENS
     if _EMBEDDING_BATCH_SIZE is None:
         _EMBEDDING_BATCH_SIZE = Histogram(
             "dynamo_embedding_batch_size",
@@ -68,13 +66,6 @@ def _get_or_create_batch_size_histogram(
             buckets=_BATCH_SIZE_BUCKETS,
             registry=registry,
         )
-    return _EMBEDDING_BATCH_SIZE
-
-
-def _get_or_create_input_tokens_histogram(
-    registry: CollectorRegistry,
-) -> Histogram:
-    global _EMBEDDING_INPUT_TOKENS
     if _EMBEDDING_INPUT_TOKENS is None:
         _EMBEDDING_INPUT_TOKENS = Histogram(
             "dynamo_embedding_input_tokens",
@@ -84,49 +75,38 @@ def _get_or_create_input_tokens_histogram(
             buckets=_INPUT_TOKENS_BUCKETS,
             registry=registry,
         )
-    return _EMBEDDING_INPUT_TOKENS
 
 
-def observe_embedding_batch_size(
-    model: str,
-    batch_size: int,
-    *,
-    registry: CollectorRegistry = REGISTRY,
-) -> None:
+def observe_embedding_batch_size(model: str, batch_size: int) -> None:
     """Record one observation of the request's batch size.
 
-    ``registry`` is overridable for tests; production code uses the
-    default Prometheus global registry.
+    No-op when ``init_embedding_metrics`` has not been called — keeps
+    handler call sites cheap and crash-free in test/CI configurations
+    that don't wire metrics.
     """
+    if _EMBEDDING_BATCH_SIZE is None:
+        return
     if batch_size < 0:
         logger.warning(
             "Skipping batch_size observation with negative value %d", batch_size
         )
         return
-    _get_or_create_batch_size_histogram(registry).labels(model=model).observe(
-        batch_size
-    )
+    _EMBEDDING_BATCH_SIZE.labels(model=model).observe(batch_size)
 
 
-def observe_embedding_input_tokens(
-    model: str,
-    input_tokens: int,
-    *,
-    registry: CollectorRegistry = REGISTRY,
-) -> None:
+def observe_embedding_input_tokens(model: str, input_tokens: int) -> None:
     """Record one observation of the request's total input tokens.
 
-    ``registry`` is overridable for tests; production code uses the
-    default Prometheus global registry.
+    No-op when ``init_embedding_metrics`` has not been called.
     """
+    if _EMBEDDING_INPUT_TOKENS is None:
+        return
     if input_tokens < 0:
         logger.warning(
             "Skipping input_tokens observation with negative value %d", input_tokens
         )
         return
-    _get_or_create_input_tokens_histogram(registry).labels(model=model).observe(
-        input_tokens
-    )
+    _EMBEDDING_INPUT_TOKENS.labels(model=model).observe(input_tokens)
 
 
 def reset_metrics_for_testing() -> None:

--- a/components/src/dynamo/sglang/request_handlers/embedding/metrics.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/metrics.py
@@ -14,13 +14,6 @@ label) is more naturally implemented on the Rust frontend side
 because that's where per-worker timing is observable end-to-end;
 that piece is tracked separately. The two histograms below cover
 the worker-internal view.
-
-Metric names follow Dynamo's existing ``dynamo_<scope>_<unit>``
-convention. They are intentionally NOT prefixed with ``sglang:``
-because they describe an OpenAI-spec workload shape, not an
-SGLang-engine-internal signal — once the vLLM embedding worker
-ships (see PR #9713), it will observe the same names from its own
-handler.
 """
 
 from __future__ import annotations

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
@@ -6,6 +6,7 @@
 import pytest
 from prometheus_client import CollectorRegistry
 
+from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
 from dynamo.sglang.request_handlers.embedding.metrics import (
     init_embedding_metrics,
     observe_embedding_batch_size,
@@ -149,8 +150,6 @@ def test_observers_noop_before_init_embedding_metrics():
 def test_handler_observes_metrics_via_transform_response(monkeypatch):
     """Integration-light test: spy on the observe functions to confirm
     the handler actually calls them from ``_transform_response``."""
-    from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
-
     # Use a mock for the BaseWorkerHandler superclass init to avoid pulling in
     # the engine-level state.
     monkeypatch.setattr(
@@ -192,8 +191,6 @@ def test_handler_observes_metrics_via_transform_response(monkeypatch):
 
 def test_metric_failure_does_not_break_transform_response(monkeypatch):
     """If a metric observe call throws, the request must still succeed."""
-    from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
-
     monkeypatch.setattr(
         "dynamo.sglang.request_handlers.handler_base.BaseWorkerHandler.__init__",
         lambda self, *a, **kw: None,

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the SGLang embedding worker's Prometheus metrics."""
+
+import pytest
+from prometheus_client import CollectorRegistry
+
+from dynamo.sglang.request_handlers.embedding.metrics import (
+    observe_embedding_batch_size,
+    observe_embedding_input_tokens,
+    reset_metrics_for_testing,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_metrics_singletons():
+    """Reset the module-level Histogram singletons between tests.
+
+    The metrics module caches Histograms keyed by registry; we don't want
+    a previous test's registry to leak into a later test.
+    """
+    reset_metrics_for_testing()
+    yield
+    reset_metrics_for_testing()
+
+
+def _collect_histogram(registry: CollectorRegistry, metric_name: str) -> dict:
+    """Pull (count, sum, buckets) for the given histogram from the registry.
+
+    Returns a dict keyed by label-tuple. Each value is a dict with keys
+    ``count``, ``sum``, and ``buckets`` (a list of (le, cumulative_count)).
+    """
+    out: dict = {}
+    for family in registry.collect():
+        if family.name != metric_name:
+            continue
+        for sample in family.samples:
+            labels = tuple(sorted(sample.labels.items()))
+            entry = out.setdefault(labels, {"count": 0, "sum": 0.0, "buckets": []})
+            if sample.name.endswith("_count"):
+                entry["count"] = int(sample.value)
+            elif sample.name.endswith("_sum"):
+                entry["sum"] = float(sample.value)
+            elif sample.name.endswith("_bucket"):
+                le = sample.labels.get("le")
+                entry["buckets"].append((le, int(sample.value)))
+    return out
+
+
+def test_observe_batch_size_increments_count():
+    registry = CollectorRegistry()
+    observe_embedding_batch_size("Qwen/Qwen3-Embedding-4B", 3, registry=registry)
+    observe_embedding_batch_size("Qwen/Qwen3-Embedding-4B", 1, registry=registry)
+
+    data = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    key = (("model", "Qwen/Qwen3-Embedding-4B"),)
+    assert key in data
+    assert data[key]["count"] == 2
+    assert data[key]["sum"] == 4.0  # 3 + 1
+
+
+def test_observe_input_tokens_increments_count_and_sum():
+    registry = CollectorRegistry()
+    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 70, registry=registry)
+    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 200, registry=registry)
+    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 12, registry=registry)
+
+    data = _collect_histogram(registry, "dynamo_embedding_input_tokens")
+    key = (("model", "Qwen/Qwen3-Embedding-4B"),)
+    assert key in data
+    assert data[key]["count"] == 3
+    assert data[key]["sum"] == 282.0  # 70 + 200 + 12
+
+
+def test_observe_partitioned_by_model_label():
+    registry = CollectorRegistry()
+    observe_embedding_batch_size("model-A", 5, registry=registry)
+    observe_embedding_batch_size("model-B", 7, registry=registry)
+    observe_embedding_batch_size("model-A", 2, registry=registry)
+
+    data = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    key_a = (("model", "model-A"),)
+    key_b = (("model", "model-B"),)
+    assert data[key_a]["count"] == 2
+    assert data[key_a]["sum"] == 7.0  # 5 + 2
+    assert data[key_b]["count"] == 1
+    assert data[key_b]["sum"] == 7.0
+
+
+def test_negative_values_are_silently_dropped():
+    """Negative values are nonsensical for batch_size / input_tokens. The
+    observation helper logs a warning and skips rather than raising or
+    polluting the histogram."""
+    registry = CollectorRegistry()
+    # First a real observation, then a bad one.
+    observe_embedding_batch_size("model-A", 4, registry=registry)
+    observe_embedding_batch_size("model-A", -1, registry=registry)
+    observe_embedding_input_tokens("model-A", 100, registry=registry)
+    observe_embedding_input_tokens("model-A", -5, registry=registry)
+
+    bs = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    it = _collect_histogram(registry, "dynamo_embedding_input_tokens")
+    key = (("model", "model-A"),)
+    # Negative observations did NOT increment the count.
+    assert bs[key]["count"] == 1
+    assert bs[key]["sum"] == 4.0
+    assert it[key]["count"] == 1
+    assert it[key]["sum"] == 100.0
+
+
+def test_buckets_are_in_expected_order():
+    """The histogram's buckets should be monotonically non-decreasing in
+    cumulative count. Catches accidental bucket-reordering regressions."""
+    registry = CollectorRegistry()
+    for value in (1, 2, 5, 33, 200, 1000):
+        observe_embedding_batch_size("m", value, registry=registry)
+
+    data = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    key = (("model", "m"),)
+    assert data[key]["count"] == 6
+    buckets = data[key]["buckets"]
+    # buckets are stored in registry order, which is the construction order;
+    # cumulative counts must be monotonically non-decreasing.
+    counts = [c for _le, c in buckets]
+    assert counts == sorted(counts), f"Bucket counts not monotonic: {counts}"
+
+
+def test_handler_observes_metrics_via_transform_response(monkeypatch):
+    """Integration-light test: spy on the observe functions to confirm
+    the handler actually calls them from ``_transform_response``."""
+    from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
+
+    # Use a mock for the BaseWorkerHandler superclass init to avoid pulling in
+    # the engine-level state.
+    monkeypatch.setattr(
+        "dynamo.sglang.request_handlers.handler_base.BaseWorkerHandler.__init__",
+        lambda self, *a, **kw: None,
+    )
+
+    observed: list[tuple[str, int, int]] = []
+    monkeypatch.setattr(
+        eh,
+        "observe_embedding_batch_size",
+        lambda model, n: observed.append(("batch", model, n)),
+    )
+    monkeypatch.setattr(
+        eh,
+        "observe_embedding_input_tokens",
+        lambda model, n: observed.append(("tokens", model, n)),
+    )
+
+    handler = eh.EmbeddingWorkerHandler.__new__(eh.EmbeddingWorkerHandler)
+
+    # Simulate SGLang's response shape: list of {"embedding": [...], "meta_info":{"prompt_tokens": N}}.
+    ret = [
+        {"embedding": [0.1, 0.2, 0.3], "meta_info": {"prompt_tokens": 12}},
+        {"embedding": [0.4, 0.5, 0.6], "meta_info": {"prompt_tokens": 8}},
+    ]
+
+    out = handler._transform_response(ret, "Qwen/Qwen3-Embedding-4B")
+
+    # Sanity: response shape preserved.
+    assert out["object"] == "list"
+    assert len(out["data"]) == 2
+    assert out["usage"]["prompt_tokens"] == 20
+
+    # Metrics: both helpers called exactly once with the right model + values.
+    assert ("batch", "Qwen/Qwen3-Embedding-4B", 2) in observed
+    assert ("tokens", "Qwen/Qwen3-Embedding-4B", 20) in observed
+
+
+def test_metric_failure_does_not_break_transform_response(monkeypatch):
+    """If a metric observe call throws, the request must still succeed."""
+    from dynamo.sglang.request_handlers.embedding import embedding_handler as eh
+
+    monkeypatch.setattr(
+        "dynamo.sglang.request_handlers.handler_base.BaseWorkerHandler.__init__",
+        lambda self, *a, **kw: None,
+    )
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("prometheus_client exploded")
+
+    monkeypatch.setattr(eh, "observe_embedding_batch_size", _boom)
+
+    handler = eh.EmbeddingWorkerHandler.__new__(eh.EmbeddingWorkerHandler)
+    ret = [{"embedding": [0.1, 0.2], "meta_info": {"prompt_tokens": 4}}]
+
+    # Must not raise.
+    out = handler._transform_response(ret, "model-A")
+    assert out["data"][0]["embedding"] == [0.1, 0.2]
+    assert out["usage"]["prompt_tokens"] == 4

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
@@ -7,6 +7,7 @@ import pytest
 from prometheus_client import CollectorRegistry
 
 from dynamo.sglang.request_handlers.embedding.metrics import (
+    init_embedding_metrics,
     observe_embedding_batch_size,
     observe_embedding_input_tokens,
     reset_metrics_for_testing,
@@ -15,21 +16,26 @@ from dynamo.sglang.request_handlers.embedding.metrics import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
+    pytest.mark.core,
     pytest.mark.gpu_0,
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
 
 
-@pytest.fixture(autouse=True)
-def _isolate_metrics_singletons():
-    """Reset the module-level Histogram singletons between tests.
+@pytest.fixture
+def fresh_registry() -> CollectorRegistry:
+    """Reset the metrics-module singletons and hand back a fresh registry.
 
-    The metrics module caches Histograms keyed by registry; we don't want
-    a previous test's registry to leak into a later test.
+    Pairing the reset with the registry creation ensures that
+    ``init_embedding_metrics`` actually creates new Histograms bound to
+    THIS test's registry rather than reusing whichever one a previous
+    test bound to.
     """
     reset_metrics_for_testing()
-    yield
+    registry = CollectorRegistry()
+    init_embedding_metrics(registry)
+    yield registry
     reset_metrics_for_testing()
 
 
@@ -56,38 +62,35 @@ def _collect_histogram(registry: CollectorRegistry, metric_name: str) -> dict:
     return out
 
 
-def test_observe_batch_size_increments_count():
-    registry = CollectorRegistry()
-    observe_embedding_batch_size("Qwen/Qwen3-Embedding-4B", 3, registry=registry)
-    observe_embedding_batch_size("Qwen/Qwen3-Embedding-4B", 1, registry=registry)
+def test_observe_batch_size_increments_count(fresh_registry):
+    observe_embedding_batch_size("Qwen/Qwen3-Embedding-4B", 3)
+    observe_embedding_batch_size("Qwen/Qwen3-Embedding-4B", 1)
 
-    data = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    data = _collect_histogram(fresh_registry, "dynamo_embedding_batch_size")
     key = (("model", "Qwen/Qwen3-Embedding-4B"),)
     assert key in data
     assert data[key]["count"] == 2
     assert data[key]["sum"] == 4.0  # 3 + 1
 
 
-def test_observe_input_tokens_increments_count_and_sum():
-    registry = CollectorRegistry()
-    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 70, registry=registry)
-    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 200, registry=registry)
-    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 12, registry=registry)
+def test_observe_input_tokens_increments_count_and_sum(fresh_registry):
+    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 70)
+    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 200)
+    observe_embedding_input_tokens("Qwen/Qwen3-Embedding-4B", 12)
 
-    data = _collect_histogram(registry, "dynamo_embedding_input_tokens")
+    data = _collect_histogram(fresh_registry, "dynamo_embedding_input_tokens")
     key = (("model", "Qwen/Qwen3-Embedding-4B"),)
     assert key in data
     assert data[key]["count"] == 3
     assert data[key]["sum"] == 282.0  # 70 + 200 + 12
 
 
-def test_observe_partitioned_by_model_label():
-    registry = CollectorRegistry()
-    observe_embedding_batch_size("model-A", 5, registry=registry)
-    observe_embedding_batch_size("model-B", 7, registry=registry)
-    observe_embedding_batch_size("model-A", 2, registry=registry)
+def test_observe_partitioned_by_model_label(fresh_registry):
+    observe_embedding_batch_size("model-A", 5)
+    observe_embedding_batch_size("model-B", 7)
+    observe_embedding_batch_size("model-A", 2)
 
-    data = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    data = _collect_histogram(fresh_registry, "dynamo_embedding_batch_size")
     key_a = (("model", "model-A"),)
     key_b = (("model", "model-B"),)
     assert data[key_a]["count"] == 2
@@ -96,19 +99,17 @@ def test_observe_partitioned_by_model_label():
     assert data[key_b]["sum"] == 7.0
 
 
-def test_negative_values_are_silently_dropped():
+def test_negative_values_are_silently_dropped(fresh_registry):
     """Negative values are nonsensical for batch_size / input_tokens. The
     observation helper logs a warning and skips rather than raising or
     polluting the histogram."""
-    registry = CollectorRegistry()
-    # First a real observation, then a bad one.
-    observe_embedding_batch_size("model-A", 4, registry=registry)
-    observe_embedding_batch_size("model-A", -1, registry=registry)
-    observe_embedding_input_tokens("model-A", 100, registry=registry)
-    observe_embedding_input_tokens("model-A", -5, registry=registry)
+    observe_embedding_batch_size("model-A", 4)
+    observe_embedding_batch_size("model-A", -1)
+    observe_embedding_input_tokens("model-A", 100)
+    observe_embedding_input_tokens("model-A", -5)
 
-    bs = _collect_histogram(registry, "dynamo_embedding_batch_size")
-    it = _collect_histogram(registry, "dynamo_embedding_input_tokens")
+    bs = _collect_histogram(fresh_registry, "dynamo_embedding_batch_size")
+    it = _collect_histogram(fresh_registry, "dynamo_embedding_input_tokens")
     key = (("model", "model-A"),)
     # Negative observations did NOT increment the count.
     assert bs[key]["count"] == 1
@@ -117,14 +118,13 @@ def test_negative_values_are_silently_dropped():
     assert it[key]["sum"] == 100.0
 
 
-def test_buckets_are_in_expected_order():
+def test_buckets_are_in_expected_order(fresh_registry):
     """The histogram's buckets should be monotonically non-decreasing in
     cumulative count. Catches accidental bucket-reordering regressions."""
-    registry = CollectorRegistry()
     for value in (1, 2, 5, 33, 200, 1000):
-        observe_embedding_batch_size("m", value, registry=registry)
+        observe_embedding_batch_size("m", value)
 
-    data = _collect_histogram(registry, "dynamo_embedding_batch_size")
+    data = _collect_histogram(fresh_registry, "dynamo_embedding_batch_size")
     key = (("model", "m"),)
     assert data[key]["count"] == 6
     buckets = data[key]["buckets"]
@@ -132,6 +132,18 @@ def test_buckets_are_in_expected_order():
     # cumulative counts must be monotonically non-decreasing.
     counts = [c for _le, c in buckets]
     assert counts == sorted(counts), f"Bucket counts not monotonic: {counts}"
+
+
+def test_observers_noop_before_init_embedding_metrics():
+    """Until ``init_embedding_metrics`` is called, ``observe_*`` is a no-op.
+
+    Important: in test/CI configurations that don't wire the embedding
+    metrics endpoint, handler call sites must NOT crash.
+    """
+    reset_metrics_for_testing()
+    # Both helpers should silently do nothing — no exception.
+    observe_embedding_batch_size("m", 3)
+    observe_embedding_input_tokens("m", 100)
 
 
 def test_handler_observes_metrics_via_transform_response(monkeypatch):
@@ -146,7 +158,7 @@ def test_handler_observes_metrics_via_transform_response(monkeypatch):
         lambda self, *a, **kw: None,
     )
 
-    observed: list[tuple[str, int, int]] = []
+    observed: list[tuple[str, str, int]] = []
     monkeypatch.setattr(
         eh,
         "observe_embedding_batch_size",


### PR DESCRIPTION
#### Overview:

First half of [DIS-2094](https://linear.app/nvidia/issue/DIS-2094). Adds two Prometheus histograms that capture embedding-specific request shape, observed from the SGLang embedding worker.

**Why this exists:** The SGLang publisher today emits chat-shaped metrics (KV gauges, prefill/decode counters) that are always zero on a pooling engine. An operator monitoring an embedding fleet sees noise instead of signal. These two histograms let you actually answer "how big are batches?" and "how many tokens per request?" — the basis for capacity planning and saturation detection.

#### Metrics:

| Metric | Type | Labels | Recorded when |
|---|---|---|---|
| `dynamo_embedding_batch_size` | Histogram | `model` | One sample per request, in `_transform_response` |
| `dynamo_embedding_input_tokens` | Histogram | `model` | One sample per request, in `_transform_response` |

Bucket choices are documented in `metrics.py`:
- batch size: powers of two up to 2048 (OpenAI hosted's per-request limit)
- input tokens: dense in 1..8192 since typical sentence-level embedding ISLs are 60–200

#### Robustness:

Observations are wrapped in `try/except + log` inside `_transform_response`. A bad metric call must never break inference. Multi-process Prometheus setups can fail in surprising ways (see the SGLang publisher comments around `PROMETHEUS_MULTIPROC_DIR` for prior art).

#### Tests:

`components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py` — 6 cases:

- Count + sum increment correctly across observations.
- `model` label partitions correctly for multi-model deployments.
- Buckets are monotonically non-decreasing (regression test for accidental bucket reorder).
- Negative values are silently dropped + logged (defensive — would corrupt percentile estimates).
- Handler integration: `_transform_response` actually calls the observe helpers with right `(model, batch_size, input_tokens)` for the request.
- Handler robustness: a raising observe call does not break the OpenAI response shape.

#### Out of scope — follow-up PR

DIS-2094 also covers:
1. **`dynamo_embedding_latency_seconds`** with `worker_id` label — naturally a Rust-frontend histogram in `lib/llm/src/http/service/metrics.rs`; needs to be observed in `embeddings()` handler.
2. **Suppressing chat-shaped noise** — `output_sequence_tokens` for embedding requests (Rust), KV gauges on embedding worker (SGLang publisher).

Both touch Rust and/or larger Python surfaces; will land in a separate PR. This PR ships the worker-internal half that gives operators real signal in production today; the frontend half adds the per-worker latency SLI on top.

#### Where should the reviewer start?

1. [`components/src/dynamo/sglang/request_handlers/embedding/metrics.py`](components/src/dynamo/sglang/request_handlers/embedding/metrics.py) — the module-level Histogram singletons, bucket choices, observe helpers.
2. [`components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py`](components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py) — the new try/except observe block in `_transform_response`.
3. [`components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py`](components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py) — six unit tests.

Closes the SGLang half of DIS-2094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added metrics instrumentation for embedding requests, tracking batch size and token usage to enhance service observability and performance monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->