### PR TITLE
fix(ci): point GAIE deploy test at vllm-runtime-cuda13 tag

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -764,7 +764,7 @@ jobs:
           extra_pytest_args: >-
             -m framework_with_gaie
             --frontend-image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-dynamo-frontend
-            --image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-runtime-cuda12
+            --image=${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-vllm-runtime-cuda13
 
   deploy-status-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- PR #9486 moved deploy tests to CUDA 13 and changed `vllm-copy-to-acr` to publish only `cuda_version: '["13.0"]'`, but the GAIE deploy test in `post-merge-ci.yml` was missed and still pulled `${sha}-vllm-runtime-cuda12`.
- That tag is no longer copied to ACR, so `qwen-0-vllmdecodeworker` / `qwen-0-vllmprefillworker` have been stuck in `ImagePullBackOff` until the 900s pytest-timeout fires.
- Every post-merge run since #9486 landed has failed on `GAIE Deploy Test` for this reason (e.g. https://github.com/ai-dynamo/dynamo/actions/runs/26061603484/job/76624512392).

This aligns the GAIE deploy test with `deploy-test-vllm` (`image_suffix: vllm-runtime-cuda13`).

## Test plan

- [ ] Post-merge `GAIE Deploy Test` job reaches the GAIE test phase (pods pull the image rather than ImagePullBackOff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment configuration for improved build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->