### PR TITLE
fix(planner): decay prefill avg ISL on idle FPMs

### DIFF
--- a/components/src/dynamo/planner/core/perf_model/prefill.py
+++ b/components/src/dynamo/planner/core/perf_model/prefill.py
@@ -47,8 +47,13 @@ class PrefillRegressionModel(_BaseRegressionModel):
 
     def _update_moving_averages(self, fpm: ForwardPassMetrics) -> None:
         sched = fpm.scheduled_requests
+        # TODO: This is scheduled prefill tokens per FPM request, not true
+        # frontend request ISL. Prefer request-level ISL once it is available
+        # at admission time.
         if sched.num_prefill_requests > 0:
             self._avg_isl.add(sched.sum_prefill_tokens / sched.num_prefill_requests)
+        else:
+            self._avg_isl.add(0.0)
         self._avg_num_prefill.add(float(sched.num_prefill_requests))
 
     @property

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -141,6 +141,27 @@ class TestPrefillRegressionModel:
             model.add_observation(fpm)
         assert abs(model.avg_isl - 2000.0) < 1.0
 
+    def test_idle_fpms_decay_avg_isl_after_traffic(self):
+        model = PrefillRegressionModel(
+            max_num_fpm_samples=3, min_observations=3, bucket_count=16
+        )
+        model.add_observation(_make_fpm(wall_time=0.0))
+        assert model.avg_isl == 0.0
+
+        for isl in [1000, 2000, 3000]:
+            model.add_observation(
+                _make_fpm(
+                    sum_prefill_tokens=isl,
+                    num_prefill_requests=1,
+                    wall_time=0.01,
+                )
+            )
+        assert abs(model.avg_isl - 2000.0) < 1.0
+
+        for _ in range(3):
+            model.add_observation(_make_fpm(wall_time=0.0))
+        assert model.avg_isl == 0.0
+
     def test_find_best_engine_prefill_rps(self):
         model = PrefillRegressionModel(
             max_num_fpm_samples=50, min_observations=3, bucket_count=16


### PR DESCRIPTION
## Summary

- Decay the prefill regression avg ISL tracker with idle FPM samples so stale long-prompt traffic does not permanently block SLA scale-down.
- Add a TODO clarifying this value is scheduled prefill tokens per FPM request, not true frontend request ISL.
- Add unit coverage for idle FPMs decaying avg_isl after traffic.

## Test plan

- .venv/bin/python -m pytest components/src/dynamo/planner/tests/unit/test_load_based_scaling.py -q (39 passed before rebasing onto fresh origin/main)
- On the fresh origin/main PR branch, the same local venv skips the file because the native dynamo._core extension is stale and lacks RoutingConstraints; CI should rebuild it.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics collection for input sequence length to ensure consistent tracking during both active and idle periods, rather than skipping updates when idle.

* **Tests**
  * Added test case to verify input sequence length averaging behavior across transitions between traffic and idle conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->