### PR TITLE
test(router): add prefill overload rejection case

### DIFF
--- a/components/src/dynamo/common/configuration/groups/http_args.py
+++ b/components/src/dynamo/common/configuration/groups/http_args.py
@@ -24,7 +24,7 @@ from typing import Optional, Self
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import add_argument
+from dynamo.common.configuration.utils import add_argument, nullable_float
 
 logger = logging.getLogger(__name__)
 
@@ -66,13 +66,6 @@ def _apply_legacy_env_aliases() -> None:
                 _legacy_warned.add(legacy)
                 logger.warning("%s is deprecated; use %s instead.", legacy, canonical)
             break
-
-
-def _nullable_float(value: str) -> Optional[float]:
-    """Parse a float; treat empty/'None' as unset."""
-    if value is None or value == "" or value == "None":
-        return None
-    return float(value)
 
 
 class HttpConfigBase(ConfigBase):
@@ -162,7 +155,7 @@ class HttpArgGroup(ArgGroup):
             flag_name="--http-timeout",
             env_var="DYN_HTTP_TIMEOUT",
             default=None,
-            arg_type=_nullable_float,
+            arg_type=nullable_float,
             dest="per_call_timeout_override",
             help=(
                 "Per-call timeout override (seconds). When set, replaces "

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -17,7 +17,11 @@ from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    nullable_float,
+)
 
 # Authoritative field list — used by kv_router_kwargs() to extract values.
 _KV_ROUTER_FIELDS: tuple[str, ...] = (
@@ -341,13 +345,14 @@ class KvRouterArgGroup(ArgGroup):
                 "Requests are queued if all workers exceed this fraction of "
                 "max_num_batched_tokens. Must be >= 0. Use 0.0 for maximum "
                 "queueing sensitivity (queue as soon as any tokens are active). "
+                "Pass 'None' to disable router queueing. "
                 "Note (SGLang backend): when --max-prefill-tokens is not set, MDC's "
                 "max_num_batched_tokens falls back to max_total_num_tokens (the KV "
                 "cache pool size), not the per-step prefill window, which inflates "
                 "the threshold's effective denominator. Set --max-prefill-tokens "
                 "explicitly for predictable semantics, or use a smaller threshold."
             ),
-            arg_type=float,
+            arg_type=nullable_float,
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -15,7 +15,12 @@ from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    nullable_float,
+    nullable_int,
+)
 
 # Fields forwarded verbatim as kwargs to RouterConfig.__init__.
 _ROUTER_FIELDS: tuple[str, ...] = (
@@ -24,20 +29,6 @@ _ROUTER_FIELDS: tuple[str, ...] = (
     "active_prefill_tokens_threshold_frac",
     "enforce_disagg",
 )
-
-
-def _nullable_float(value: str) -> Optional[float]:
-    """Parse a float, or return None for the literal 'None'."""
-    if value is None or value == "None":
-        return None
-    return float(value)
-
-
-def _nullable_int(value: str) -> Optional[int]:
-    """Parse an int, or return None for the literal 'None'."""
-    if value is None or value == "None":
-        return None
-    return int(value)
 
 
 class RouterConfigBase(ConfigBase):
@@ -129,7 +120,7 @@ class RouterArgGroup(ArgGroup):
                 "Threshold fraction (0.0-1.0) of KV cache block utilization above which a worker "
                 "is considered busy. Pass 'None' on the CLI to disable this check. Default: 1.0."
             ),
-            arg_type=_nullable_float,
+            arg_type=nullable_float,
         )
         add_argument(
             g,
@@ -142,7 +133,7 @@ class RouterArgGroup(ArgGroup):
                 "threshold, the worker is marked as busy. Pass 'None' on the CLI to disable this "
                 "check. Uses OR logic with --active-prefill-tokens-threshold-frac. Default: 10000000."
             ),
-            arg_type=_nullable_int,
+            arg_type=nullable_int,
         )
         add_argument(
             g,
@@ -154,7 +145,7 @@ class RouterArgGroup(ArgGroup):
                 "active_prefill_tokens > frac * max_num_batched_tokens. Pass 'None' on the CLI to "
                 "disable this check. Uses OR logic with --active-prefill-tokens-threshold. Default: 64.0."
             ),
-            arg_type=_nullable_float,
+            arg_type=nullable_float,
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -54,6 +54,20 @@ def env_or_default(
     return target_type(value) if callable(target_type) else value  # type: ignore
 
 
+def nullable_float(value: str) -> Optional[float]:
+    """Parse a float, or return None for empty/'None' values."""
+    if value is None or value == "" or value == "None":
+        return None
+    return float(value)
+
+
+def nullable_int(value: str) -> Optional[int]:
+    """Parse an int, or return None for empty/'None' values."""
+    if value is None or value == "" or value == "None":
+        return None
+    return int(value)
+
+
 def add_argument(
     parser: argparse.ArgumentParser | argparse._ArgumentGroup,
     *,

--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -96,7 +96,7 @@ def add_argument(
     """
     arg_dest = _get_dest_name(flag_name, kwargs.get("dest"))
     value_type_for_env: Optional[Union[type, Callable[..., Any]]] = None
-    if arg_type is not None and isinstance(arg_type, type):
+    if arg_type is not None and callable(arg_type):
         value_type_for_env = arg_type
     if isinstance(default, list) and (arg_type is None or arg_type is str):
         value_type_for_env = None

--- a/components/src/dynamo/common/tests/configuration/test_utils.py
+++ b/components/src/dynamo/common/tests/configuration/test_utils.py
@@ -10,6 +10,7 @@ from dynamo.common.configuration.utils import (
     add_argument,
     add_negatable_bool_argument,
     env_or_default,
+    nullable_float,
 )
 
 pytestmark = [
@@ -169,6 +170,23 @@ class TestAddArgument:
 
         with pytest.raises(SystemExit):
             parser.parse_args([])
+
+    def test_callable_type_with_non_none_default_coerces_env(self, monkeypatch):
+        """Test callable arg_type validates env values when the default has a type."""
+        monkeypatch.setenv("TEST_THRESHOLD", "None")
+        parser = argparse.ArgumentParser()
+
+        add_argument(
+            parser,
+            flag_name="--threshold",
+            env_var="TEST_THRESHOLD",
+            default=16.0,
+            help="Threshold",
+            arg_type=nullable_float,
+        )
+
+        args = parser.parse_args([])
+        assert args.threshold is None
 
 
 class TestAddNegatableBool:

--- a/components/src/dynamo/common/tests/configuration/test_utils.py
+++ b/components/src/dynamo/common/tests/configuration/test_utils.py
@@ -159,17 +159,15 @@ class TestAddArgument:
                 raise argparse.ArgumentTypeError("model-name must be non-empty")
             return value.strip()
 
-        add_argument(
-            parser,
-            flag_name="--model-name",
-            env_var="TEST_MODEL_NAME",
-            default=None,
-            help="Model name",
-            arg_type=validate_model_name,
-        )
-
-        with pytest.raises(SystemExit):
-            parser.parse_args([])
+        with pytest.raises(argparse.ArgumentTypeError, match="model-name"):
+            add_argument(
+                parser,
+                flag_name="--model-name",
+                env_var="TEST_MODEL_NAME",
+                default=None,
+                help="Model name",
+                arg_type=validate_model_name,
+            )
 
     def test_callable_type_with_non_none_default_coerces_env(self, monkeypatch):
         """Test callable arg_type validates env values when the default has a type."""

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1054,7 +1054,11 @@ def _test_router_overload_503(
     request,
     frontend_port: int,
     test_payload: dict,
-    blocks_threshold: float = 0.2,
+    blocks_threshold: float | str | None = 0.2,
+    tokens_threshold: int | str | None = None,
+    tokens_threshold_frac: float | str | None = None,
+    router_queue_threshold: float | str | None = None,
+    max_tokens: int = 50,
 ):
     """Test that 503 is returned when all workers are busy, and verify rejection metrics.
 
@@ -1073,6 +1077,10 @@ def _test_router_overload_503(
         frontend_port: Port for the frontend HTTP server
         test_payload: Base test payload to send to /v1/chat/completions
         blocks_threshold: Active decode blocks threshold for the router (default 0.2)
+        tokens_threshold: Active prefill tokens threshold for the router
+        tokens_threshold_frac: Fractional active prefill tokens threshold for the router
+        router_queue_threshold: Router queue threshold, or "None" to disable queueing
+        max_tokens: Output token count for generated overload requests
 
     Raises:
         AssertionError: If success/rejection counts or metrics don't meet expectations
@@ -1087,14 +1095,16 @@ def _test_router_overload_503(
         frontend_port=frontend_port,
         namespace=engine_workers.namespace,
         blocks_threshold=blocks_threshold,
+        tokens_threshold=tokens_threshold,
+        tokens_threshold_frac=tokens_threshold_frac,
+        router_queue_threshold=router_queue_threshold,
     ):
         frontend_url = f"http://localhost:{frontend_port}"
         url = f"http://localhost:{frontend_port}/v1/chat/completions"
 
-        # Custom payload for 503 test with more tokens to consume resources
         test_payload_503 = {
             **test_payload,
-            "max_tokens": 50,  # Longer output to consume more blocks
+            "max_tokens": max_tokens,
         }
 
         logger.info("Waiting for frontend readiness before overload test...")

--- a/tests/router/router_process.py
+++ b/tests/router/router_process.py
@@ -23,9 +23,10 @@ class FrontendRouterProcess(ManagedProcess):
         namespace: str,
         store_backend: str = "etcd",
         enforce_disagg: bool = False,
-        blocks_threshold: float | None = None,
-        tokens_threshold: float | None = None,
-        tokens_threshold_frac: float | None = None,
+        blocks_threshold: float | str | None = None,
+        tokens_threshold: int | str | None = None,
+        tokens_threshold_frac: float | str | None = None,
+        router_queue_threshold: float | str | None = None,
         request_plane: str = "nats",
         durable_kv_events: bool = False,
         router_mode: str = "kv",
@@ -64,6 +65,9 @@ class FrontendRouterProcess(ManagedProcess):
             command.extend(
                 ["--active-prefill-tokens-threshold-frac", str(tokens_threshold_frac)]
             )
+
+        if router_queue_threshold is not None:
+            command.extend(["--router-queue-threshold", str(router_queue_threshold)])
 
         if durable_kv_events:
             command.append("--router-durable-kv-events")

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -86,6 +86,25 @@ ROUTER_AIC_CONFIG = {
     "aic_tp_size": 1,
     "aic_model_path": "Qwen/Qwen3-32B",
 }
+ROUTER_OVERLOAD_503_CASES = (
+    pytest.param(
+        {
+            "blocks_threshold": 0.2,
+            "max_tokens": 50,
+        },
+        id="decode-blocks",
+    ),
+    pytest.param(
+        {
+            "blocks_threshold": "None",
+            "tokens_threshold": 1,
+            "tokens_threshold_frac": "None",
+            "router_queue_threshold": "None",
+            "max_tokens": 1,
+        },
+        id="prefill-tokens",
+    ),
+)
 ROUND_ROBIN_MOCKER_SKIP_REASON = (
     "Flaky on CI: tcp nondurable round-robin mocker router path timed out"
 )
@@ -1073,6 +1092,7 @@ def test_mocker_two_kv_router(
 @pytest.mark.parametrize(
     "durable_kv_events", [False], ids=["nondurable"], indirect=True
 )  # Use NATS Core (local indexer)
+@pytest.mark.parametrize("overload_config", ROUTER_OVERLOAD_503_CASES)
 @pytest.mark.timeout(45)  # ~3x average (~13.10s), rounded up (when enabled)
 def test_mocker_kv_router_overload_503(
     request,
@@ -1080,6 +1100,7 @@ def test_mocker_kv_router_overload_503(
     predownload_tokenizers,
     durable_kv_events,
     monkeypatch,
+    overload_config,
 ):
     """Test that KV router returns 503 when mocker workers are overloaded."""
     monkeypatch.setenv("DYN_LOG", ROUTER_OVERLOAD_DEBUG_DYN_LOG)
@@ -1107,7 +1128,7 @@ def test_mocker_kv_router_overload_503(
             request=request,
             frontend_port=frontend_port,
             test_payload=TEST_PAYLOAD,
-            blocks_threshold=0.2,
+            **overload_config,
         )
 
 


### PR DESCRIPTION
Adds a prefill-token overload variant to the router 503 e2e test and wires router queue disabling through the frontend test harness. Also centralizes nullable CLI parsers used by router configuration.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated shared configuration argument parsing utilities across router and HTTP configuration modules for improved consistency and maintainability.
  * Enhanced configuration handling to support flexible nullable threshold values.

* **Tests**
  * Expanded router overload test coverage with parametrized scenarios and dynamic threshold configuration support for more comprehensive validation across different operational settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->