### PR TITLE
feat(metrics): add dynamo_embedding_latency_seconds frontend histogram

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -108,6 +108,10 @@ class frontend_service:
     TIME_TO_FIRST_TOKEN_SECONDS = "time_to_first_token_seconds"
     # Inter-token latency in seconds
     INTER_TOKEN_LATENCY_SECONDS = "inter_token_latency_seconds"
+    # End-to-end latency of an OpenAI `/v1/embeddings` request, in seconds.
+    # Separate from `REQUEST_DURATION_SECONDS` so its buckets can be sized for
+    # pooling-model latencies (sub-second) without sacrificing resolution.
+    EMBEDDING_LATENCY_SECONDS = "embedding_latency_seconds"
     # Model configuration metrics
     # Runtime config metrics (from ModelRuntimeConfig):
     # Total KV blocks available for a worker serving the model

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -265,6 +265,11 @@ pub struct Metrics {
     output_tokens_counter: IntCounterVec,
     time_to_first_token: HistogramVec,
     inter_token_latency: HistogramVec,
+    /// End-to-end latency of an OpenAI `/v1/embeddings` request. Distinct from
+    /// `request_duration` so the buckets can be sized for sub-second pooling
+    /// inference rather than the 1-512s LLM-generation range. Labeled by
+    /// `model`.
+    embedding_latency: HistogramVec,
 
     // Runtime configuration metrics. Note: Some of these metrics represent counter-like values from
     // source systems, but are implemented as gauges because they are copied/synchronized from upstream
@@ -624,6 +629,26 @@ impl Metrics {
         )
         .unwrap();
 
+        // Embedding latency buckets: pooling-model inference is typically
+        // sub-second (60-200 token inputs on L4-class GPUs land in the 5-50ms
+        // range), so 1ms..10s on a log scale gives p50/p99 resolution that
+        // the 1..512s `request_duration` buckets cannot.
+        let (emb_min, emb_max, emb_count) =
+            parse_bucket_config("DYN_METRICS_EMBEDDING_LATENCY", 0.001, 10.0, 14);
+        let embedding_latency_buckets = generate_log_buckets(emb_min, emb_max, emb_count);
+
+        let embedding_latency = HistogramVec::new(
+            HistogramOpts::new(
+                frontend_metric_name(frontend_service::EMBEDDING_LATENCY_SECONDS),
+                "End-to-end latency of /v1/embeddings requests, in seconds. \
+                 Distinct from request_duration_seconds so the bucket range can \
+                 cover sub-second pooling-model inference.",
+            )
+            .buckets(embedding_latency_buckets),
+            &["model"],
+        )
+        .unwrap();
+
         let cached_tokens = HistogramVec::new(
             HistogramOpts::new(
                 frontend_metric_name(frontend_service::CACHED_TOKENS),
@@ -755,6 +780,7 @@ impl Metrics {
             output_tokens_counter,
             time_to_first_token,
             inter_token_latency,
+            embedding_latency,
             model_total_kv_blocks,
             model_max_num_seqs,
             model_max_num_batched_tokens,
@@ -833,6 +859,38 @@ impl Metrics {
         self.inflight_gauge.with_label_values(&[model]).get()
     }
 
+    /// Record one observation of the end-to-end latency of an
+    /// `/v1/embeddings` request, in seconds. Labeled by model.
+    ///
+    /// Negative values are dropped (they can only happen from a clock skew or
+    /// programming bug; recording them would corrupt percentile estimates).
+    pub fn observe_embedding_latency(&self, model: &str, seconds: f64) {
+        if !seconds.is_finite() || seconds < 0.0 {
+            return;
+        }
+        self.embedding_latency
+            .with_label_values(&[model])
+            .observe(seconds);
+    }
+
+    /// Get the cumulative count of embedding latency observations for the given
+    /// model. Test helper.
+    #[cfg(test)]
+    pub fn embedding_latency_count(&self, model: &str) -> u64 {
+        self.embedding_latency
+            .with_label_values(&[model])
+            .get_sample_count()
+    }
+
+    /// Get the cumulative sum (seconds) of embedding latency observations for
+    /// the given model. Test helper.
+    #[cfg(test)]
+    pub fn embedding_latency_sum(&self, model: &str) -> f64 {
+        self.embedding_latency
+            .with_label_values(&[model])
+            .get_sample_sum()
+    }
+
     fn inc_inflight_gauge(&self, model: &str) {
         self.inflight_gauge.with_label_values(&[model]).inc();
         self.active_requests_gauge.with_label_values(&[model]).inc();
@@ -876,6 +934,7 @@ impl Metrics {
         registry.register(Box::new(self.output_tokens_counter.clone()))?;
         registry.register(Box::new(self.time_to_first_token.clone()))?;
         registry.register(Box::new(self.inter_token_latency.clone()))?;
+        registry.register(Box::new(self.embedding_latency.clone()))?;
 
         // Register runtime configuration metrics
         registry.register(Box::new(self.model_total_kv_blocks.clone()))?;
@@ -2684,5 +2743,81 @@ mod tests {
             error: None,
         };
         assert!(run_event_converter(annotated).is_ok());
+    }
+
+    #[test]
+    fn test_observe_embedding_latency_records_observation() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "embed-test";
+        assert_eq!(metrics.embedding_latency_count(model), 0);
+        assert_eq!(metrics.embedding_latency_sum(model), 0.0);
+
+        metrics.observe_embedding_latency(model, 0.005);
+        metrics.observe_embedding_latency(model, 0.020);
+
+        assert_eq!(metrics.embedding_latency_count(model), 2);
+        assert!((metrics.embedding_latency_sum(model) - 0.025).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_observe_embedding_latency_drops_invalid_values() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "embed-test";
+
+        metrics.observe_embedding_latency(model, -0.5);
+        metrics.observe_embedding_latency(model, f64::NAN);
+        metrics.observe_embedding_latency(model, f64::INFINITY);
+        metrics.observe_embedding_latency(model, f64::NEG_INFINITY);
+
+        assert_eq!(metrics.embedding_latency_count(model), 0);
+        assert_eq!(metrics.embedding_latency_sum(model), 0.0);
+
+        // Zero is allowed (boundary case for finite, non-negative).
+        metrics.observe_embedding_latency(model, 0.0);
+        assert_eq!(metrics.embedding_latency_count(model), 1);
+    }
+
+    #[test]
+    fn test_observe_embedding_latency_partitions_by_model() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let m1 = "embed-a";
+        let m2 = "embed-b";
+
+        metrics.observe_embedding_latency(m1, 0.010);
+        metrics.observe_embedding_latency(m1, 0.030);
+        metrics.observe_embedding_latency(m2, 0.005);
+
+        assert_eq!(metrics.embedding_latency_count(m1), 2);
+        assert_eq!(metrics.embedding_latency_count(m2), 1);
+        assert!((metrics.embedding_latency_sum(m1) - 0.040).abs() < 1e-9);
+        assert!((metrics.embedding_latency_sum(m2) - 0.005).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_embedding_latency_registered_in_registry() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        metrics.observe_embedding_latency("embed-test", 0.012);
+
+        let metric_families = registry.gather();
+        let found = metric_families.iter().any(|mf| {
+            mf.name()
+                .ends_with(frontend_service::EMBEDDING_LATENCY_SECONDS)
+        });
+        assert!(
+            found,
+            "embedding_latency_seconds histogram must be registered with the registry"
+        );
     }
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -457,6 +457,7 @@ impl Metrics {
     /// - `DYN_METRICS_OUTPUT_SEQUENCE_{MIN,MAX,COUNT}` - Output sequence length histogram (defaults: 50.0, 32000.0, 10)
     /// - `DYN_METRICS_TTFT_{MIN,MAX,COUNT}` - Time to first token histogram (defaults: 0.001, 480.0, 18)
     /// - `DYN_METRICS_ITL_{MIN,MAX,COUNT}` - Inter-token latency histogram (defaults: 0.001, 2.0, 13)
+    /// - `DYN_METRICS_EMBEDDING_LATENCY_{MIN,MAX,COUNT}` - End-to-end `/v1/embeddings` latency histogram (defaults: 0.001, 10.0, 14)
     ///
     /// ## Model Configuration Metrics
     ///

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -838,6 +838,13 @@ async fn embeddings(
     // todo - when optional, if none, apply a default
     let model = &request.inner.model;
 
+    // Start the embedding-specific latency timer. Distinct from
+    // `request_duration` (which has 1..512s LLM-gen buckets); pooling-model
+    // requests are sub-second and need finer-grained buckets to be useful for
+    // SLO tracking. Only observed on the success path -- error/cancel paths
+    // already increment requests_total with status=error.
+    let embedding_start = std::time::Instant::now();
+
     // Create inflight_guard early to ensure all errors are counted
     let mut inflight = state.metrics_clone().create_inflight_guard(
         model,
@@ -898,6 +905,9 @@ async fn embeddings(
             err_response
         })?;
 
+    state
+        .metrics_clone()
+        .observe_embedding_latency(&model_name, embedding_start.elapsed().as_secs_f64());
     inflight.mark_ok();
     Ok(Json(response).into_response())
 }

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -223,6 +223,11 @@ pub mod frontend_service {
     /// Inter-token latency in seconds
     pub const INTER_TOKEN_LATENCY_SECONDS: &str = "inter_token_latency_seconds";
 
+    /// End-to-end latency of an OpenAI `/v1/embeddings` request, in seconds.
+    /// Separate from `REQUEST_DURATION_SECONDS` so its buckets can be sized for
+    /// pooling-model latencies (sub-second) without sacrificing resolution.
+    pub const EMBEDDING_LATENCY_SECONDS: &str = "embedding_latency_seconds";
+
     /// Model configuration metrics
     ///
     /// Runtime config metrics (from ModelRuntimeConfig):


### PR DESCRIPTION
#### Overview:

Adds a dedicated Prometheus histogram `dynamo_embedding_latency_seconds` for end-to-end `/v1/embeddings` request latency, observed in the Rust frontend `embeddings()` handler. This is **Part 2** of DIS-2094 (embedding-specific Prometheus metrics); Part 1 (SGLang-side per-worker batch size / input token metrics) is in #9753.

#### Details:

- New constant `EMBEDDING_LATENCY_SECONDS` in `lib/runtime/src/metrics/prometheus_names.rs`.
- New `embedding_latency: HistogramVec` field on the frontend `Metrics` struct in `lib/llm/src/http/service/metrics.rs`. Buckets default to 1ms..10s on a log scale (overridable via `DYN_METRICS_EMBEDDING_LATENCY`). The bucket range is intentionally tighter than `request_duration_seconds` (which is 1..512s for LLM generation) because pooling-model inference is sub-second and would otherwise lose all resolution.
- `observe_embedding_latency(model, seconds)` public method + `#[cfg(test)]` `embedding_latency_count`/`embedding_latency_sum` test helpers.
- Registered in the Prometheus registry alongside the other frontend histograms.
- Observed in `embeddings()` handler at `lib/llm/src/http/service/openai.rs`: a timer Instant is captured at the start of the handler and the elapsed time is recorded on the success path right before `inflight.mark_ok()`. Error/cancel paths intentionally do not observe — `requests_total{status="error"}` already captures those.
- Unit tests: normal observation, invalid value drops (NaN, +/-Inf, negative), per-model label partitioning, registry registration.

##### `output_sequence_tokens` suppression for embeddings

Originally scoped as a second change in this PR, but on inspection it's already handled: the existing `if self.osl > 0` guard at the response-collector observation site (`metrics.rs`) means embedding requests — which never increment `osl` above 0 — already produce no `output_sequence_tokens` observations. No code change needed.

#### Where should the reviewer start?

- `lib/llm/src/http/service/metrics.rs` — struct field, init with bucket sizing, observe method + test helpers, registry registration, four new unit tests at the bottom of the test module.
- `lib/llm/src/http/service/openai.rs` `embeddings()` handler — timer Instant + observation site.
- `lib/runtime/src/metrics/prometheus_names.rs` — the new constant + rationale comment.

Linear: https://linear.app/nvidia/issue/DIS-2094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedding request latency metrics to the monitoring system for improved observability. The new Prometheus histogram metric captures end-to-end embedding request performance with per-model tracking and configurable histogram buckets, enabling operators to analyze request latency patterns and identify performance bottlenecks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->