### PR TITLE
test(ci): parallelize backend gpu1 leftovers

### DIFF
--- a/components/src/dynamo/frontend/tests/test_sglang_processor_api.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_api.py
@@ -12,12 +12,13 @@ import pickle
 
 import pytest
 
-# Total runtime ~0.08s — no need for parallel marker.
+# Needs sglang packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -49,12 +49,13 @@ from dynamo.frontend.utils import (
     random_uuid,
 )
 
-# Needs sglang packages (gpu_1 container).  No need for parallel marker.
+# Needs sglang packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 MODEL = "Qwen/Qwen3-0.6B"

--- a/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
@@ -21,12 +21,13 @@ from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
 from dynamo.frontend.sglang_prepost import SglangStreamingPostProcessor
 
-# Needs sglang packages (gpu_1 container).  No need for parallel marker.
+# Needs sglang packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.sglang,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 MODEL = "Qwen/Qwen3-0.6B"

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -15,12 +15,13 @@ from transformers import AutoTokenizer
 
 from dynamo.frontend.prepost import _prepare_request
 
-# Needs vllm packages (gpu_1 container).  No need for parallel marker.
+# Needs vllm packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 MODEL = "Qwen/Qwen3-0.6B"

--- a/components/src/dynamo/sglang/tests/test_sglang_engine.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_engine.py
@@ -16,6 +16,7 @@ from typing import cast
 
 import pytest
 import pytest_asyncio
+from tests.utils.gpu_args import build_gpu_mem_args
 
 MODEL_ID = "Qwen/Qwen3-0.6B"
 _BASE_ARGV = [
@@ -37,7 +38,6 @@ pytestmark = [
     pytest.mark.sglang,
     pytest.mark.unified,
     pytest.mark.gpu_1,
-    pytest.mark.pre_merge,
     pytest.mark.timeout(300),
     pytest.mark.skipif(
         importlib.util.find_spec("sglang") is None,
@@ -71,7 +71,9 @@ class _FakeContext:
 async def started_engine():
     from dynamo.sglang.llm_engine import SglangLLMEngine
 
-    engine, _ = await SglangLLMEngine.from_args(_BASE_ARGV)
+    engine, _ = await SglangLLMEngine.from_args(
+        [*_BASE_ARGV, *build_gpu_mem_args("build_sglang_gpu_mem_args")]
+    )
     try:
         # Worker_id 0 is fine for tests — the engine doesn't use it.
         engine_config = await engine.start(0)
@@ -80,7 +82,18 @@ async def started_engine():
         await engine.cleanup()
 
 
-async def test_start_populates_registration_metadata(started_engine):
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(3.7)
+@pytest.mark.requested_sglang_kv_tokens(2048)
+async def test_sglang_engine_all(started_engine, monkeypatch):
+    await _check_start_populates_registration_metadata(started_engine)
+    await _check_runtime_data_includes_worker_group(monkeypatch)
+    await _check_generate_streams_chunks_with_coherent_final_usage(started_engine)
+    await _check_abort_and_cleanup_are_safe_before_start()
+    await _check_abort_unknown_request_on_running_engine(started_engine)
+
+
+async def _check_start_populates_registration_metadata(started_engine):
     """``start`` must derive ``kv_cache_block_size`` from SGLang's page size
     and populate ``max_num_seqs`` from ``max-running-requests`` — without
     these values the Rust registration path has no routing signals."""
@@ -93,7 +106,7 @@ async def test_start_populates_registration_metadata(started_engine):
     assert cfg.max_num_seqs == 4
 
 
-async def test_runtime_data_includes_worker_group(monkeypatch):
+async def _check_runtime_data_includes_worker_group(monkeypatch):
     from dynamo.sglang import llm_engine as llm_engine_mod
     from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY
 
@@ -108,7 +121,7 @@ async def test_runtime_data_includes_worker_group(monkeypatch):
     }
 
 
-async def test_generate_streams_chunks_with_coherent_final_usage(started_engine):
+async def _check_generate_streams_chunks_with_coherent_final_usage(started_engine):
     engine, _ = started_engine
     ctx = _FakeContext("gen-1")
 
@@ -133,7 +146,7 @@ async def test_generate_streams_chunks_with_coherent_final_usage(started_engine)
     assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
 
 
-async def test_abort_and_cleanup_are_safe_before_start():
+async def _check_abort_and_cleanup_are_safe_before_start():
     from dynamo.sglang.llm_engine import SglangLLMEngine
 
     engine, _ = await SglangLLMEngine.from_args(_BASE_ARGV)
@@ -142,7 +155,7 @@ async def test_abort_and_cleanup_are_safe_before_start():
     await engine.cleanup()
 
 
-async def test_abort_unknown_request_on_running_engine(started_engine):
+async def _check_abort_unknown_request_on_running_engine(started_engine):
     """SGLang's ``abort_request`` is best-effort; an unknown rid must not raise."""
     engine, _ = started_engine
     await engine.abort(cast(object, _FakeContext("never-submitted")))  # type: ignore[arg-type]

--- a/components/src/dynamo/sglang/tests/test_sglang_engine.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_engine.py
@@ -86,7 +86,10 @@ async def started_engine():
 @pytest.mark.pre_merge
 @pytest.mark.profiled_vram_gib(3.7)
 @pytest.mark.requested_sglang_kv_tokens(2048)
+@pytest.mark.core
+@pytest.mark.model(MODEL_ID)
 async def test_sglang_engine_all(started_engine, monkeypatch):
+    """Run the SGLang engine pre-merge checks under one engine startup."""
     await _check_start_populates_registration_metadata(started_engine)
     await _check_runtime_data_includes_worker_group(monkeypatch)
     await _check_generate_streams_chunks_with_coherent_final_usage(started_engine)

--- a/components/src/dynamo/sglang/tests/test_sglang_engine.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_engine.py
@@ -16,6 +16,7 @@ from typing import cast
 
 import pytest
 import pytest_asyncio
+
 from tests.utils.gpu_args import build_gpu_mem_args
 
 MODEL_ID = "Qwen/Qwen3-0.6B"

--- a/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_cuda_ipc.py
+++ b/components/src/dynamo/trtllm/tests/multimodal/test_trtllm_cuda_ipc.py
@@ -29,6 +29,8 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.trtllm,
     pytest.mark.gpu_1,
+    pytest.mark.profiled_vram_gib(2.0),
+    pytest.mark.requested_trtllm_vram_gib(2.0),
 ]
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
@@ -81,9 +81,11 @@ class TestTensorRTLLMEngine:
         engine_args["backend"] = Backend.AUTODEPLOY
         # This allows us to catch cases where a field being pruned away is now supported by
         # AutoDeploy when bumping TRT-LLM.
-        with pytest.raises(
-            pydantic.ValidationError
-        ) if is_forbidden else contextlib.nullcontext():
+        with (
+            pytest.raises(pydantic.ValidationError)
+            if is_forbidden
+            else contextlib.nullcontext()
+        ):
             ADLlmArgs(model="foo", **engine_args)
 
         engine = TensorRTLLMEngine(engine_args=engine_args)

--- a/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
@@ -28,6 +28,7 @@ pytestmark = [
     # the `gpu_0` marker.
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 _PYTORCH_LLM_CLS_NAME = "dynamo.trtllm.engine.LLM"
 _AUTODEPLOY_LLM_CLS_NAME = "tensorrt_llm._torch.auto_deploy.LLM"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
@@ -20,6 +20,7 @@ pytestmark = [
     pytest.mark.unified,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
     pytest.mark.skipif(
         importlib.util.find_spec("tensorrt_llm") is None,
         reason="tensorrt_llm not installed in this container",

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
@@ -18,6 +18,7 @@ from typing import cast
 
 import pytest
 import pytest_asyncio
+from tests.utils.gpu_args import build_trtllm_override_args
 
 MODEL_ID = "Qwen/Qwen3-0.6B"
 _BASE_ARGV = [
@@ -37,7 +38,6 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.unified,
     pytest.mark.gpu_1,
-    pytest.mark.pre_merge,
     pytest.mark.timeout(300),
     pytest.mark.skipif(
         importlib.util.find_spec("tensorrt_llm") is None,
@@ -67,7 +67,9 @@ class _FakeContext:
 async def started_engine():
     from dynamo.trtllm.llm_engine import TrtllmLLMEngine
 
-    engine, _ = await TrtllmLLMEngine.from_args(_BASE_ARGV)
+    engine, _ = await TrtllmLLMEngine.from_args(
+        [*_BASE_ARGV, *build_trtllm_override_args()]
+    )
     try:
         # Worker_id 0 is fine for tests — `disagg_machine_id` is derived
         # from worker_id but unused outside disagg PREFILL/DECODE roles.
@@ -77,7 +79,19 @@ async def started_engine():
         await engine.cleanup()
 
 
-async def test_start_populates_registration_metadata(started_engine):
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(3.9)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
+async def test_trtllm_engine_all(started_engine):
+    await _check_start_populates_registration_metadata(started_engine)
+    await _check_generate_streams_chunks_with_coherent_final_usage(started_engine)
+    await _check_abort_and_cleanup_are_safe_before_start()
+    await _check_abort_unknown_request_on_running_engine(started_engine)
+    await _check_drain_is_noop_for_aggregated_workers()
+    await _check_drain_returns_when_engine_idle()
+
+
+async def _check_start_populates_registration_metadata(started_engine):
     """``start`` threads ``max_seq_len`` / ``kv_block_size`` / ``max_batch_size``
     from ``from_args``'s parsed config through to ``EngineConfig`` —
     mismatches here surface as incorrect Rust-side routing decisions."""
@@ -87,7 +101,7 @@ async def test_start_populates_registration_metadata(started_engine):
     assert cfg.max_num_seqs == 4
 
 
-async def test_generate_streams_chunks_with_coherent_final_usage(started_engine):
+async def _check_generate_streams_chunks_with_coherent_final_usage(started_engine):
     engine, _ = started_engine
     ctx = _FakeContext("gen-1")
 
@@ -112,16 +126,18 @@ async def test_generate_streams_chunks_with_coherent_final_usage(started_engine)
     assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
 
 
-async def test_abort_and_cleanup_are_safe_before_start():
+async def _check_abort_and_cleanup_are_safe_before_start():
     from dynamo.trtllm.llm_engine import TrtllmLLMEngine
 
-    engine, _ = await TrtllmLLMEngine.from_args(_BASE_ARGV)
+    engine, _ = await TrtllmLLMEngine.from_args(
+        [*_BASE_ARGV, *build_trtllm_override_args()]
+    )
     await engine.abort(cast(object, _FakeContext()))  # type: ignore[arg-type]
     await engine.cleanup()
     await engine.cleanup()
 
 
-async def test_abort_unknown_request_on_running_engine(started_engine):
+async def _check_abort_unknown_request_on_running_engine(started_engine):
     """``_active_requests`` is only populated during ``generate``.  An unknown
     request id is silently ignored rather than raised."""
     engine, _ = started_engine
@@ -170,7 +186,7 @@ def _engine_with_stub(disagg_mode, stats_sequence: list[dict]):
     return engine
 
 
-async def test_drain_is_noop_for_aggregated_workers():
+async def _check_drain_is_noop_for_aggregated_workers():
     """Drain only matters on prefill workers (in-flight NIXL transfers).
     Aggregated/decode workers exit immediately so shutdown isn't gated
     on an unnecessary stats poll."""
@@ -180,7 +196,7 @@ async def test_drain_is_noop_for_aggregated_workers():
     await engine.drain()  # must return without consuming a stat
 
 
-async def test_drain_returns_when_engine_idle():
+async def _check_drain_returns_when_engine_idle():
     """Polls until active+queued == 0, then returns. The drain loop must
     not hang once the engine reports idle."""
     from dynamo.trtllm.constants import DisaggregationMode as TrtDisagg

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
@@ -18,6 +18,7 @@ from typing import cast
 
 import pytest
 import pytest_asyncio
+
 from tests.utils.gpu_args import build_trtllm_override_args
 
 MODEL_ID = "Qwen/Qwen3-0.6B"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
@@ -83,7 +83,10 @@ async def started_engine():
 @pytest.mark.pre_merge
 @pytest.mark.profiled_vram_gib(3.9)
 @pytest.mark.requested_trtllm_kv_tokens(2592)
+@pytest.mark.core
+@pytest.mark.model(MODEL_ID)
 async def test_trtllm_engine_all(started_engine):
+    """Run the TRT-LLM engine pre-merge checks under one engine startup."""
     await _check_start_populates_registration_metadata(started_engine)
     await _check_generate_streams_chunks_with_coherent_final_usage(started_engine)
     await _check_abort_and_cleanup_are_safe_before_start()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -30,6 +30,7 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.pre_merge,
     pytest.mark.gpu_1,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_main_init.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_main_init.py
@@ -15,6 +15,7 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -37,6 +37,7 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -22,6 +22,7 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 _DIFFUSION_FIELDS = {f.name for f in dataclasses.fields(OmniDiffusionKwargs)}

--- a/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
@@ -20,6 +20,7 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
@@ -21,6 +21,7 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -30,6 +30,7 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -22,6 +22,7 @@ pytestmark = [
     pytest.mark.vllm,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -483,11 +483,12 @@ class TestAudioFormatterOutputFormat:
 
         f = self._make_formatter()
         mm = self._make_mm_output()
-        with patch.object(
-            f, "_encode_audio", return_value=(b"bytes", "audio/ogg")
-        ), _patch(
-            "dynamo.vllm.omni.output_formatter.upload_to_fs",
-            return_value="http://x/a.ogg",
+        with (
+            patch.object(f, "_encode_audio", return_value=(b"bytes", "audio/ogg")),
+            _patch(
+                "dynamo.vllm.omni.output_formatter.upload_to_fs",
+                return_value="http://x/a.ogg",
+            ),
         ):
             result = await f.format(
                 mm, "r4", response_format="url", output_format="opus"

--- a/examples/backends/trtllm/launch/agg_router.sh
+++ b/examples/backends/trtllm/launch/agg_router.sh
@@ -6,6 +6,7 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_trtllm_override_args_with_mem
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
 # Environment variables with defaults
@@ -13,6 +14,12 @@ export DYNAMO_HOME=${DYNAMO_HOME:-"/workspace"}
 export MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen3-0.6B"}
 export SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"Qwen/Qwen3-0.6B"}
 export AGG_ENGINE_ARGS=${AGG_ENGINE_ARGS:-"$DYNAMO_HOME/examples/backends/trtllm/engine_configs/qwen3/agg.yaml"}
+
+OVERRIDE_JSON=$(build_trtllm_override_args_with_mem)
+TRTLLM_OVERRIDE_ARGS=()
+if [[ -n "$OVERRIDE_JSON" ]]; then
+    TRTLLM_OVERRIDE_ARGS=(--override-engine-args "$OVERRIDE_JSON")
+fi
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 print_launch_banner "Launching Aggregated + KV Routing" "$MODEL_PATH" "$HTTP_PORT"
@@ -26,7 +33,8 @@ python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$AGG_ENGINE_ARGS" \
-  --publish-events-and-metrics &
+  --publish-events-and-metrics \
+  "${TRTLLM_OVERRIDE_ARGS[@]}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest
 wait_any_exit

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -1110,6 +1110,7 @@ class TestToolCallingModelBehavior:
 
 
 def _run_with_assertion_reruns(func, *args, attempts: int = 3):
+    """Retry assertion-only checks that can vary with model generation."""
     for attempt in range(attempts):
         try:
             return func(*args)
@@ -1119,6 +1120,7 @@ def _run_with_assertion_reruns(func, *args, attempts: int = 3):
 
 
 @pytest.mark.pre_merge
+@pytest.mark.core
 @pytest.mark.timeout(420)
 def test_tool_calling_sglang_all(client: OpenAI, model: str):
     """Run the pre-merge tool-calling scenarios under one SGLang worker startup."""

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -643,9 +643,9 @@ def parse_and_validate_tool_call(
 
 
 def assert_finish_reason(result: StreamResult, allowed: set[str]) -> None:
-    assert result.finish_reason in allowed, (
-        f"unexpected finish_reason={result.finish_reason!r}, allowed={sorted(allowed)}"
-    )
+    assert (
+        result.finish_reason in allowed
+    ), f"unexpected finish_reason={result.finish_reason!r}, allowed={sorted(allowed)}"
 
 
 def assistant_tool_message_from_result(result: StreamResult) -> dict[str, Any]:
@@ -738,9 +738,9 @@ class TestToolCallingProtocol:
             args = json.loads(tc["function"]["arguments"])
             assert isinstance(args, dict)
             for required_field in schema[fn_name].get("required", []):
-                assert required_field in args, (
-                    f"{fn_name} missing required field {required_field!r}"
-                )
+                assert (
+                    required_field in args
+                ), f"{fn_name} missing required field {required_field!r}"
 
     def test_tool_choice_none_suppresses_tool_calls(self, client: OpenAI, model: str):
         result = stream_chat(
@@ -1119,8 +1119,6 @@ def _run_with_assertion_reruns(func, *args, attempts: int = 3):
 
 
 @pytest.mark.pre_merge
-@pytest.mark.profiled_vram_gib(3.7)
-@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(420)
 def test_tool_calling_sglang_all(client: OpenAI, model: str):
     """Run the pre-merge tool-calling scenarios under one SGLang worker startup."""

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -28,6 +28,7 @@ import psutil
 import pytest
 
 from tests.conftest import EtcdServer, NatsServer
+from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_ports
@@ -46,7 +47,6 @@ pytestmark = [
     pytest.mark.e2e,
     pytest.mark.gpu_1,
     pytest.mark.integration,
-    pytest.mark.pre_merge,
     pytest.mark.model(MODEL_NAME),
     pytest.mark.timeout(300),
 ]
@@ -169,6 +169,7 @@ class WorkerProcess(ManagedProcess):
                 "--dyn-tool-call-parser",
                 "qwen25",
             ]
+        command.extend(build_gpu_mem_args("build_sglang_gpu_mem_args", env=env))
 
         super().__init__(
             command=command,
@@ -643,8 +644,7 @@ def parse_and_validate_tool_call(
 
 def assert_finish_reason(result: StreamResult, allowed: set[str]) -> None:
     assert result.finish_reason in allowed, (
-        f"unexpected finish_reason={result.finish_reason!r}, "
-        f"allowed={sorted(allowed)}"
+        f"unexpected finish_reason={result.finish_reason!r}, allowed={sorted(allowed)}"
     )
 
 
@@ -738,9 +738,9 @@ class TestToolCallingProtocol:
             args = json.loads(tc["function"]["arguments"])
             assert isinstance(args, dict)
             for required_field in schema[fn_name].get("required", []):
-                assert (
-                    required_field in args
-                ), f"{fn_name} missing required field {required_field!r}"
+                assert required_field in args, (
+                    f"{fn_name} missing required field {required_field!r}"
+                )
 
     def test_tool_choice_none_suppresses_tool_calls(self, client: OpenAI, model: str):
         result = stream_chat(
@@ -1107,3 +1107,57 @@ class TestToolCallingModelBehavior:
             parse_and_validate_tool_call(
                 result.tool_calls[0], schema, expected_name="get_weather"
             )
+
+
+def _run_with_assertion_reruns(func, *args, attempts: int = 3):
+    for attempt in range(attempts):
+        try:
+            return func(*args)
+        except AssertionError:
+            if attempt == attempts - 1:
+                raise
+
+
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(3.7)
+@pytest.mark.requested_sglang_kv_tokens(2048)
+@pytest.mark.timeout(420)
+def test_tool_calling_sglang_all(client: OpenAI, model: str):
+    """Run the pre-merge tool-calling scenarios under one SGLang worker startup."""
+    protocol = TestToolCallingProtocol()
+    protocol.test_stream_has_required_chunk_shape(client, model)
+    protocol.test_single_tool_call_schema_valid(client, model)
+    protocol.test_tool_choice_required_forces_a_tool_call(client, model)
+    protocol.test_tool_choice_none_suppresses_tool_calls(client, model)
+    _run_with_assertion_reruns(
+        protocol.test_named_tool_choice_forces_specific_function, client, model
+    )
+    _run_with_assertion_reruns(
+        protocol.test_parallel_multi_tool_request_includes_all_expected_tools,
+        client,
+        model,
+    )
+    _run_with_assertion_reruns(protocol.test_array_argument_schema_valid, client, model)
+    _run_with_assertion_reruns(protocol.test_no_tools_is_plain_text, client, model)
+
+    multi_turn = TestToolCallingMultiTurn()
+    _run_with_assertion_reruns(
+        multi_turn.test_tool_result_is_consumed_and_final_answer_is_text, client, model
+    )
+    _run_with_assertion_reruns(
+        multi_turn.test_chained_tool_use_search_then_calculate, client, model
+    )
+    _run_with_assertion_reruns(
+        multi_turn.test_multiple_prior_tool_results_synthesize_to_text, client, model
+    )
+
+    behavior = TestToolCallingModelBehavior()
+    _run_with_assertion_reruns(
+        behavior.test_many_tools_prefers_calculator_for_math_question, client, model
+    )
+    _run_with_assertion_reruns(
+        behavior.test_unicode_arguments_are_preserved, client, model
+    )
+    _run_with_assertion_reruns(
+        behavior.test_system_instruction_encourages_tool_use, client, model
+    )

--- a/tests/kvbm_integration/test_consolidator_config_unit.py
+++ b/tests/kvbm_integration/test_consolidator_config_unit.py
@@ -54,6 +54,7 @@ class TestShouldEnableConsolidatorDict:
 @pytest.mark.kvbm
 @pytest.mark.trtllm
 @pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(0)
 class TestShouldEnableConsolidatorTyped:
     """Tests that need trtllm (requires GPU for import)."""
 

--- a/tests/mm_router/test_mm_router_e2e.py
+++ b/tests/mm_router/test_mm_router_e2e.py
@@ -25,6 +25,7 @@ import pytest
 import requests
 
 from tests.conftest import EtcdServer, NatsServer
+from tests.utils.gpu_args import build_trtllm_override_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_ports
@@ -43,7 +44,6 @@ SINGLE_IMAGE_TOTAL_BLOCKS_RANGE = (20, 260)
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.pre_merge,
     pytest.mark.trtllm,
     pytest.mark.multimodal,
     pytest.mark.gpu_1,
@@ -114,6 +114,7 @@ class TRTLLMWorkerProcess(ManagedProcess):
                 "--publish-events-and-metrics",
                 "--kv-block-size",
                 str(BLOCK_SIZE),
+                *build_trtllm_override_args(),
             ],
             env=_make_process_env(DYN_SYSTEM_PORT=str(system_port)),
             health_check_urls=[
@@ -278,9 +279,33 @@ def _send_request_get_overlap(
     return overlap, total, recent_logs
 
 
+@pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(20.0)
+@pytest.mark.requested_trtllm_vram_gib(20.0)
+@pytest.mark.timeout(1800)
+def test_trtllm_mm_overlap_all(start_trtllm_mm_services, predownload_models):
+    """Run all TRT-LLM MM overlap scenarios under one worker startup."""
+    _check_text_only_overlap_repeated_prompt(
+        start_trtllm_mm_services, predownload_models
+    )
+    _check_repeated_three_images(start_trtllm_mm_services, predownload_models)
+    _check_repeated_single_image(start_trtllm_mm_services, predownload_models)
+    _check_repeated_two_identical_images(start_trtllm_mm_services, predownload_models)
+    _check_staircase_single_to_double_to_triple_identical_image(
+        start_trtllm_mm_services, predownload_models
+    )
+    _check_diff_images_less_than_same(start_trtllm_mm_services, predownload_models)
+    _check_same_images_different_prompt_less_than_same_prompt(
+        start_trtllm_mm_services, predownload_models
+    )
+    _check_swapped_order_less_than_same_order(
+        start_trtllm_mm_services, predownload_models
+    )
+
+
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_text_only_overlap_repeated_prompt(
+def _check_text_only_overlap_repeated_prompt(
     start_trtllm_mm_services, predownload_models
 ):
     """Text-only routing should increase overlap on repeat and then stabilize."""
@@ -326,9 +351,7 @@ def test_trtllm_text_only_overlap_repeated_prompt(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_repeated_three_images(
-    start_trtllm_mm_services, predownload_models
-):
+def _check_repeated_three_images(start_trtllm_mm_services, predownload_models):
     """For repeated same 3-image request: low first overlap, then increase, then stable."""
     frontend_port, router_proc = start_trtllm_mm_services
 
@@ -369,9 +392,7 @@ def test_trtllm_mm_overlap_repeated_three_images(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_repeated_single_image(
-    start_trtllm_mm_services, predownload_models
-):
+def _check_repeated_single_image(start_trtllm_mm_services, predownload_models):
     """For repeated same single-image request: low first overlap, then increase, then stable."""
     frontend_port, router_proc = start_trtllm_mm_services
 
@@ -412,9 +433,7 @@ def test_trtllm_mm_overlap_repeated_single_image(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_repeated_two_identical_images(
-    start_trtllm_mm_services, predownload_models
-):
+def _check_repeated_two_identical_images(start_trtllm_mm_services, predownload_models):
     """For repeated same two-identical-image request: low first overlap, then increase, then stable."""
     frontend_port, router_proc = start_trtllm_mm_services
 
@@ -453,7 +472,7 @@ def test_trtllm_mm_overlap_repeated_two_identical_images(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_staircase_single_to_double_to_triple_identical_image(
+def _check_staircase_single_to_double_to_triple_identical_image(
     start_trtllm_mm_services, predownload_models
 ):
     """Single->double->triple identical image requests follow prefix-overlap semantics."""
@@ -508,9 +527,7 @@ def test_trtllm_mm_overlap_staircase_single_to_double_to_triple_identical_image(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_diff_images_less_than_same(
-    start_trtllm_mm_services, predownload_models
-):
+def _check_diff_images_less_than_same(start_trtllm_mm_services, predownload_models):
     """Different images should produce lower overlap than repeated identical images."""
     frontend_port, router_proc = start_trtllm_mm_services
     baseline_payload = _build_payload(
@@ -547,9 +564,9 @@ def test_trtllm_mm_overlap_diff_images_less_than_same(
     overlap_probe, total_probe, segment_probe = _send_request_get_overlap(
         frontend_port, router_proc, probe_payload, "probe_different_images_req1"
     )
-    assert (
-        total_probe > 0
-    ), f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
+    assert total_probe > 0, (
+        f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
+    )
     assert abs(total_probe - total_baseline) <= 4, (
         f"Expected different-images total blocks to stay near baseline, "
         f"got different={total_probe}, baseline={total_baseline}"
@@ -564,7 +581,7 @@ def test_trtllm_mm_overlap_diff_images_less_than_same(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_same_images_different_prompt_less_than_same_prompt(
+def _check_same_images_different_prompt_less_than_same_prompt(
     start_trtllm_mm_services, predownload_models
 ):
     """Same images but different prompt should produce lower overlap than repeated same prompt."""
@@ -609,9 +626,9 @@ def test_trtllm_mm_overlap_same_images_different_prompt_less_than_same_prompt(
     overlap_probe, total_probe, segment_probe = _send_request_get_overlap(
         frontend_port, router_proc, probe_payload, "probe_same_images_prompt_b_req1"
     )
-    assert (
-        total_probe > 0
-    ), f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
+    assert total_probe > 0, (
+        f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
+    )
     assert abs(total_probe - total_baseline) <= 4, (
         f"Expected different-prompt total blocks to stay near baseline, "
         f"got different_prompt={total_probe}, baseline={total_baseline}"
@@ -626,7 +643,7 @@ def test_trtllm_mm_overlap_same_images_different_prompt_less_than_same_prompt(
 
 @pytest.mark.timeout(1800)
 @pytest.mark.nightly
-def test_trtllm_mm_overlap_swapped_order_less_than_same_order(
+def _check_swapped_order_less_than_same_order(
     start_trtllm_mm_services, predownload_models
 ):
     """Swapping order of three distinct images should result in near-zero overlap."""

--- a/tests/mm_router/test_mm_router_e2e.py
+++ b/tests/mm_router/test_mm_router_e2e.py
@@ -564,9 +564,9 @@ def _check_diff_images_less_than_same(start_trtllm_mm_services, predownload_mode
     overlap_probe, total_probe, segment_probe = _send_request_get_overlap(
         frontend_port, router_proc, probe_payload, "probe_different_images_req1"
     )
-    assert total_probe > 0, (
-        f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
-    )
+    assert (
+        total_probe > 0
+    ), f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
     assert abs(total_probe - total_baseline) <= 4, (
         f"Expected different-images total blocks to stay near baseline, "
         f"got different={total_probe}, baseline={total_baseline}"
@@ -626,9 +626,9 @@ def _check_same_images_different_prompt_less_than_same_prompt(
     overlap_probe, total_probe, segment_probe = _send_request_get_overlap(
         frontend_port, router_proc, probe_payload, "probe_same_images_prompt_b_req1"
     )
-    assert total_probe > 0, (
-        f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
-    )
+    assert (
+        total_probe > 0
+    ), f"No routing score found.\nRecent logs:\n{segment_probe[-4000:]}"
     assert abs(total_probe - total_baseline) <= 4, (
         f"Expected different-prompt total blocks to stay near baseline, "
         f"got different_prompt={total_probe}, baseline={total_baseline}"

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -307,7 +307,7 @@ def test_sglang_dp_workers_use_contiguous_kv_event_port_blocks(monkeypatch):
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
-@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.timeout(150)  # ~3x average (~46s/test), rounded up
@@ -445,7 +445,7 @@ def test_router_decisions_sglang_disagg(
 @pytest.mark.skip_in_nightly
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
-@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.parametrize(
     "store_backend,durable_kv_events,request_plane",

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -21,6 +21,7 @@ from tests.router.e2e_harness import (
 )
 from tests.router.helper import generate_random_suffix
 from tests.utils.constants import DefaultPort
+from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (
     allocate_contiguous_ports,
@@ -168,6 +169,8 @@ class SGLangProcess(ManagedEngineProcessMixin):
             if context_length is not None:
                 command.extend(["--context-length", str(context_length)])
 
+            command.extend(build_gpu_mem_args("build_sglang_gpu_mem_args"))
+
             if disaggregation_mode is not None:
                 command.extend(["--disaggregation-mode", disaggregation_mode])
                 command.extend(["--disaggregation-transfer-backend", "nixl"])
@@ -304,6 +307,8 @@ def test_sglang_dp_workers_use_contiguous_kv_event_port_blocks(monkeypatch):
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.timeout(150)  # ~3x average (~46s/test), rounded up
 def test_sglang_kv_router_basic(
@@ -330,6 +335,8 @@ def test_sglang_kv_router_basic(
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_router_decisions_sglang_multiple_workers(
@@ -440,6 +447,8 @@ def test_router_decisions_sglang_disagg(
 @pytest.mark.skip_in_nightly
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.parametrize(
     "store_backend,durable_kv_events,request_plane",
     [

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -335,8 +335,6 @@ def test_sglang_kv_router_basic(
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
-@pytest.mark.profiled_vram_gib(7.4)
-@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_router_decisions_sglang_multiple_workers(

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -335,6 +335,8 @@ def test_sglang_kv_router_basic(
 @pytest.mark.model(MODEL_NAME)
 @pytest.mark.pre_merge
 @pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(12.0)
+@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(300)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_router_decisions_sglang_multiple_workers(

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -20,6 +20,7 @@ from tests.router.e2e_harness import (
 )
 from tests.router.helper import generate_random_suffix
 from tests.utils.constants import DefaultPort
+from tests.utils.gpu_args import build_trtllm_override_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import allocate_ports, deallocate_ports
 
@@ -191,6 +192,8 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
             if enable_attention_dp:
                 command.append("--enable-attention-dp")
 
+            command.extend(build_trtllm_override_args())
+
             # Each TRT-LLM worker needs a unique DYN_SYSTEM_PORT to avoid conflicts.
             # Ports are dynamically allocated for xdist-safe parallel execution.
             system_port = self._system_ports[worker_idx]
@@ -234,6 +237,8 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
 
 @pytest.mark.gpu_1
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(7.8)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.timeout(300)
 def test_trtllm_kv_router_basic(
@@ -295,6 +300,8 @@ def test_router_decisions_trtllm_attention_dp(
 
 @pytest.mark.gpu_1
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(7.8)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.timeout(150)  # ~3x average (~45s/test), rounded up
 def test_router_decisions_trtllm_multiple_workers(
@@ -355,6 +362,8 @@ def test_router_decisions_trtllm_disagg(
 
 @pytest.mark.gpu_1
 @pytest.mark.nightly
+@pytest.mark.profiled_vram_gib(7.8)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(150)  # ~3x average (~45s/test), rounded up
 @pytest.mark.parametrize(
     "store_backend,durable_kv_events,request_plane",

--- a/tests/router/test_router_e2e_with_unified.py
+++ b/tests/router/test_router_e2e_with_unified.py
@@ -251,6 +251,8 @@ def test_unified_vllm_router_decisions_dp(
 @pytest.mark.gpu_1
 @pytest.mark.sglang
 @pytest.mark.model(SGLANG_MODEL_NAME)
+@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_unified_sglang_kv_router_basic(
@@ -279,6 +281,8 @@ def test_unified_sglang_kv_router_basic(
 @pytest.mark.gpu_1
 @pytest.mark.sglang
 @pytest.mark.model(SGLANG_MODEL_NAME)
+@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_unified_sglang_router_decisions_multiple_workers(
@@ -353,6 +357,8 @@ def test_unified_sglang_router_decisions_dp(
 @pytest.mark.gpu_1
 @pytest.mark.trtllm
 @pytest.mark.model(TRTLLM_MODEL_NAME)
+@pytest.mark.profiled_vram_gib(7.8)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_unified_trtllm_kv_router_basic(
@@ -382,6 +388,8 @@ def test_unified_trtllm_kv_router_basic(
 @pytest.mark.gpu_1
 @pytest.mark.trtllm
 @pytest.mark.model(TRTLLM_MODEL_NAME)
+@pytest.mark.profiled_vram_gib(7.8)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_unified_trtllm_router_decisions_multiple_workers(

--- a/tests/router/test_router_e2e_with_unified.py
+++ b/tests/router/test_router_e2e_with_unified.py
@@ -251,7 +251,7 @@ def test_unified_vllm_router_decisions_dp(
 @pytest.mark.gpu_1
 @pytest.mark.sglang
 @pytest.mark.model(SGLANG_MODEL_NAME)
-@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
@@ -281,7 +281,7 @@ def test_unified_sglang_kv_router_basic(
 @pytest.mark.gpu_1
 @pytest.mark.sglang
 @pytest.mark.model(SGLANG_MODEL_NAME)
-@pytest.mark.profiled_vram_gib(7.4)
+@pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -156,7 +156,9 @@ sglang_configs = {
         script_name="disagg_same_gpu.sh",
         marks=[
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(9.9),  # actual profiled peak with kv-tokens
+            pytest.mark.profiled_vram_gib(
+                13.0
+            ),  # observed ~12.1 GiB with kv-tokens; rounded up
             pytest.mark.requested_sglang_kv_tokens(
                 37472
             ),  # KV cache cap (2x safety over min=18736)
@@ -200,7 +202,7 @@ sglang_configs = {
         script_name="disagg_same_gpu.sh",
         marks=[
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(9.9),
+            pytest.mark.profiled_vram_gib(13.0),
             pytest.mark.requested_sglang_kv_tokens(37472),
             pytest.mark.timeout(420),
             pytest.mark.post_merge,
@@ -226,7 +228,7 @@ sglang_configs = {
         script_name="disagg_same_gpu.sh",
         marks=[
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(9.9),
+            pytest.mark.profiled_vram_gib(13.0),
             pytest.mark.requested_sglang_kv_tokens(37472),
             pytest.mark.timeout(420),
             pytest.mark.post_merge,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -198,6 +198,8 @@ trtllm_configs = {
             pytest.mark.gpu_1,
             pytest.mark.pre_merge,
             pytest.mark.trtllm,
+            pytest.mark.profiled_vram_gib(3.9),
+            pytest.mark.requested_trtllm_kv_tokens(2592),
             pytest.mark.timeout(
                 300
             ),  # 3x measured time (37.91s) + download time (180s)
@@ -573,9 +575,9 @@ def test_deployment(
     """
     Test dynamo deployments with different configurations.
     """
-    assert (
-        num_system_ports >= 2
-    ), "serve tests require at least SYSTEM_PORT1 + SYSTEM_PORT2"
+    assert num_system_ports >= 2, (
+        "serve tests require at least SYSTEM_PORT1 + SYSTEM_PORT2"
+    )
     # Use per-test ports so tests can run safely under pytest-xdist.
     config = dataclasses.replace(
         trtllm_config_test,
@@ -597,6 +599,8 @@ def test_deployment(
 @pytest.mark.gpu_1
 @pytest.mark.trtllm
 @pytest.mark.pre_merge
+@pytest.mark.profiled_vram_gib(3.9)
+@pytest.mark.requested_trtllm_kv_tokens(2592)
 @pytest.mark.timeout(660)  # 3x measured time (159.68s) + download time (180s)
 def test_chat_only_aggregated_with_test_logits_processor(
     request,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -575,9 +575,9 @@ def test_deployment(
     """
     Test dynamo deployments with different configurations.
     """
-    assert num_system_ports >= 2, (
-        "serve tests require at least SYSTEM_PORT1 + SYSTEM_PORT2"
-    )
+    assert (
+        num_system_ports >= 2
+    ), "serve tests require at least SYSTEM_PORT1 + SYSTEM_PORT2"
     # Use per-test ports so tests can run safely under pytest-xdist.
     config = dataclasses.replace(
         trtllm_config_test,

--- a/tests/test_predownload_models.py
+++ b/tests/test_predownload_models.py
@@ -34,6 +34,7 @@ import pytest
             "predownload_models_sglang_gpu1",
             marks=[
                 pytest.mark.sglang,
+                pytest.mark.core,
                 pytest.mark.e2e,
                 pytest.mark.gpu_1,
                 pytest.mark.profiled_vram_gib(0),
@@ -43,6 +44,7 @@ import pytest
             "predownload_models_trtllm_gpu1",
             marks=[
                 pytest.mark.trtllm,
+                pytest.mark.core,
                 pytest.mark.e2e,
                 pytest.mark.gpu_1,
                 pytest.mark.profiled_vram_gib(0),

--- a/tests/test_predownload_models.py
+++ b/tests/test_predownload_models.py
@@ -32,11 +32,21 @@ import pytest
         ),
         pytest.param(
             "predownload_models_sglang_gpu1",
-            marks=[pytest.mark.sglang, pytest.mark.e2e, pytest.mark.gpu_1],
+            marks=[
+                pytest.mark.sglang,
+                pytest.mark.e2e,
+                pytest.mark.gpu_1,
+                pytest.mark.profiled_vram_gib(0),
+            ],
         ),
         pytest.param(
             "predownload_models_trtllm_gpu1",
-            marks=[pytest.mark.trtllm, pytest.mark.e2e, pytest.mark.gpu_1],
+            marks=[
+                pytest.mark.trtllm,
+                pytest.mark.e2e,
+                pytest.mark.gpu_1,
+                pytest.mark.profiled_vram_gib(0),
+            ],
         ),
         pytest.param(
             "predownload_models_vllm_gpu2",

--- a/tests/utils/gpu_args.py
+++ b/tests/utils/gpu_args.py
@@ -11,9 +11,9 @@ from collections.abc import Mapping
 from pathlib import Path
 
 
-def build_gpu_mem_args(
+def _call_gpu_utils_function(
     function_name: str, env: Mapping[str, str] | None = None
-) -> list[str]:
+) -> str:
     """Call a backend memory-args function from examples/common/gpu_utils.sh."""
     repo_root = Path(__file__).resolve().parents[2]
     gpu_utils = repo_root / "examples" / "common" / "gpu_utils.sh"
@@ -25,4 +25,19 @@ def build_gpu_mem_args(
         env=env,
         text=True,
     )
-    return shlex.split(result.stdout.strip())
+    return result.stdout.strip()
+
+
+def build_gpu_mem_args(
+    function_name: str, env: Mapping[str, str] | None = None
+) -> list[str]:
+    """Call a backend memory-args function that returns shell-style CLI args."""
+    return shlex.split(_call_gpu_utils_function(function_name, env=env))
+
+
+def build_trtllm_override_args(env: Mapping[str, str] | None = None) -> list[str]:
+    """Return TRT-LLM override CLI args from GPU parallel scheduler env vars."""
+    override_json = _call_gpu_utils_function("build_trtllm_override_args_with_mem", env)
+    if not override_json:
+        return []
+    return ["--override-engine-args", override_json]


### PR DESCRIPTION
## Overview:

Moves the remaining single-GPU backend CI leftovers into the VRAM-aware parallel stage where they are safe to schedule.

This follows up on #9634, which parallelized earlier leftover vLLM tests and adjusted several umbrella/label configurations. After that change, pre-merge still had runnable backend tests in the sequential bucket. This PR moves the safe leftovers across vLLM, SGLang, and TRT-LLM into the parallel scheduler, while leaving the cases with known parallel-safety risk in sequential.

The CI performance numbers below compare the previous bucket layout against this PR's bucket layout.

## Details:

- Adds `profiled_vram_gib(0)` markers to unit-style tests that need GPU-runtime containers but do not allocate GPU VRAM.
- Adds profiled umbrella tests for SGLang/TRT-LLM engine, router, tool-calling, and multimodal flows so CI pays backend startup cost once per scenario group.
- Threads GPU-scheduler memory limits into SGLang and TRT-LLM test launches with `build_sglang_gpu_mem_args` and `build_trtllm_override_args`.
- Bumps under-profiled SGLang cases based on CI profiling:
  - SGLang same-GPU disaggregation: `profiled_vram_gib(13.0)`
  - SGLang router/unified-router single-GPU worker cases: `profiled_vram_gib(12.0)`
- Moves the final SGLang multiple-worker router test into the parallel bucket.

#### Sequential bucket comparison, using baseline run `25943372915` and PR run `26193253178`:

| Engine | Baseline GPU-parallel bucket | PR GPU-parallel bucket | Baseline runnable sequential | PR runnable sequential |
| --- | ---: | ---: | ---: | ---: |
| vLLM | 95 | 217 | 123 | 0 |
| SGLang | 46 | 198 | 189 | 4 |
| TRT-LLM | 6 | 91 | 97 | 0 |

#### Sequential-stage runtime impact on the compared amd64 jobs:

| Engine | Baseline sequential stage | PR sequential stage | Notes |
| --- | ---: | ---: | --- |
| vLLM | ~23s | ~20s | No runnable sequential tests remain; the old leftovers were already very fast. |
| SGLang | ~14m | ~6m | Runnable sequential tests dropped from 189 to 4. |
| TRT-LLM | ~11m42s | ~26s | No runnable sequential tests remain; only skipped selections remain. |

#### Tests intentionally left sequential:

- `tests/frontend/test_tool_calling_sglang.py::test_tool_calling_sglang_all[chat_processor_frontend]`
- `tests/frontend/test_tool_calling_sglang.py::test_tool_calling_sglang_all[rust_parsers]`
- `tests/serve/test_sglang.py::test_sglang_deployment[multimodal_e_pd_qwen-2]`
- `tests/serve/test_sglang.py::test_sglang_deployment[video_e_pd_qwen-2]`

The SGLang tool-calling umbrella cases pass reliably in sequential, but the fixture still does broad SGLang/frontend process cleanup and needs a scoped cleanup refactor before it is safe to pack with other parallel tests. The SGLang E/P/D multimodal and video cases can trip UCX `mm` transport initialization when packed with other tests, so they remain unprofiled for now.

vLLM `omni_audio` and TRT-LLM multimodal E/P/D cases still appear in the sequential selection only as skipped tests. Moving skipped tests out would not materially speed CI because the workflow still initializes the sequential stage.

#### Validation:

- GitHub Actions backend/pre-merge runtime checks passed on the PR run used for the comparison.
- `python3 -m py_compile` on changed Python files
- `bash -n examples/backends/trtllm/launch/agg_router.sh`
- `ruff check` on changed Python files
- `git diff --check`

## Where should the reviewer start?

- `tests/utils/gpu_args.py`: shared helper for passing scheduler memory limits into backend launches.
- `tests/serve/test_sglang.py`: SGLang profile bumps and intentionally unprofiled E/P/D cases.
- `tests/frontend/test_tool_calling_sglang.py`: SGLang tool-calling umbrella that remains sequential.
- `tests/router/test_router_e2e_with_sglang.py` and `tests/router/test_router_e2e_with_unified.py`: SGLang router profile markers and final parallelized router case.
- `tests/router/test_router_e2e_with_trtllm.py`, `tests/serve/test_trtllm.py`, and `tests/mm_router/test_mm_router_e2e.py`: TRT-LLM profile markers and override plumbing.
- `components/src/dynamo/sglang/tests/test_sglang_engine.py` and `components/src/dynamo/trtllm/tests/test_trtllm_engine.py`: backend engine umbrella tests.

## Related Issues:

- Relates to #9634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated integration tests for SGLang and TRT-LLM engines, consolidating multiple scenario checks into single test runs.
  * Added GPU VRAM profiling markers across test suite for improved resource tracking.

* **Chores**
  * Refactored GPU memory argument handling utilities for consistent worker startup configuration.
  * Updated test module configurations with profiling markers for better CI test selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->