### PR TITLE
fix(mocker): preserve zero-duration replay progress

### DIFF
--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -248,9 +248,7 @@ impl EngineComponent {
             };
 
             if executed.end_ms == now_ms {
-                if payload.has_completion_effects() {
-                    effects.immediate_completions.push(payload);
-                }
+                effects.immediate_completions.push(payload);
                 return Ok(effects);
             }
 

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -21,12 +21,6 @@ pub(super) struct WorkerCompletionPayload {
     pub kv_events: Vec<RouterEvent>,
 }
 
-impl WorkerCompletionPayload {
-    pub(super) fn has_completion_effects(&self) -> bool {
-        self.completed_requests > 0 || !self.output_signals.is_empty() || !self.kv_events.is_empty()
-    }
-}
-
 pub(super) fn next_timestamp(
     next_arrival_ms: Option<f64>,
     next_event_ms: Option<f64>,


### PR DESCRIPTION
Fix a regression `Exception: offline disagg replay reached a dead end with 1 in-flight requests remaining`

That change comes from https://github.com/ai-dynamo/dynamo/pull/9337 filtered out zero-duration immediate completions when the completion payload had no externally visible effects. That looked like a harmless no-op cleanup, but offline replay also uses immediate completions as a progress signal for same-timestamp engine passes.

Some vLLM disaggregated decode passes can take 0ms and only advance internal state, such as computed-token progress, before producing output or request completion. Dropping those empty immediate completions made the replay loop think no progress was possible while a request was still in flight.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker completion handling to ensure all completion payloads are properly processed during offline replay operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->