### PR TITLE
fix: auto-enable SGLang memory saver for GMS (#9647)

### DIFF
--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -56,6 +56,7 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
 
+    server_args.enable_memory_saver = True
     # Resolve lock mode from model_loader_extra_config before patches fire
     global _gms_lock_mode
     extra = getattr(server_args, "model_loader_extra_config", None)


### PR DESCRIPTION
Cherry-pick of #9647 to `release/1.2.0`.

Original PR: https://github.com/ai-dynamo/dynamo/pull/9647
Main merge commit: 517c44b8a7a93496c2514e9cf58ec0fd1a3a3b85
Cherry-pick commit: 9d751a22a35a973dcbcf1b81f71ee5960882e67d

Notes:
- Used `git cherry-pick --signoff 517c44b8a7a93496c2514e9cf58ec0fd1a3a3b85`.
- Resolved a trivial context conflict in `lib/gpu_memory_service/integrations/sglang/__init__.py` because `release/1.2.0` does not include the RO reconnect timeout context from main. The effective backport is the intended one-line change: `server_args.enable_memory_saver = True`.
- No known PR dependencies.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
