### PR TITLE
fix(planner): skip disagg load scaling during active scale

### DIFF
--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -701,6 +701,8 @@ class NativePlannerBase:
             ready_num_decode=num_d if self.require_decode else None,
             expected_num_prefill=expected_p if self.require_prefill else None,
             expected_num_decode=expected_d if self.require_decode else None,
+            prefill_scaling_in_progress=self.require_prefill and not is_stable,
+            decode_scaling_in_progress=self.require_decode and not is_stable,
         )
 
     # ------------------------------------------------------------------

--- a/components/src/dynamo/planner/core/load_scaling.py
+++ b/components/src/dynamo/planner/core/load_scaling.py
@@ -127,6 +127,12 @@ class LoadScalingMixin:
             self._diag_load_reason_prefill = "no_fpm_data"
             self._diag_load_reason_decode = "no_fpm_data"
             return None
+        if self._scaling_in_progress("prefill") or self._scaling_in_progress("decode"):
+            logger.info("Scaling in progress for disagg deployment, observing only")
+            self._diag_load_reason = "scaling_in_progress"
+            self._diag_load_reason_prefill = "scaling_in_progress"
+            self._diag_load_reason_decode = "scaling_in_progress"
+            return None
         if p_stats and not self._reconcile_fpm_worker_count(
             p_stats, self._num_p_workers, "prefill"
         ):

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -107,6 +107,8 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
         self._num_d_workers: int = 0
         self._expected_num_p: Optional[int] = None
         self._expected_num_d: Optional[int] = None
+        self._prefill_scaling_in_progress: bool = False
+        self._decode_scaling_in_progress: bool = False
 
         self._throughput_lower_bound_p: int = 1
         self._throughput_lower_bound_d: int = 1
@@ -319,15 +321,19 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
             self._num_d_workers = counts.ready_num_decode
         self._expected_num_p = counts.expected_num_prefill
         self._expected_num_d = counts.expected_num_decode
+        self._prefill_scaling_in_progress = counts.prefill_scaling_in_progress
+        self._decode_scaling_in_progress = counts.decode_scaling_in_progress
 
     def _scaling_in_progress(self, component: str) -> bool:
         if component == "prefill":
             return (
-                self._expected_num_p is not None
+                self._prefill_scaling_in_progress
+                or self._expected_num_p is not None
                 and self._expected_num_p != self._num_p_workers
             )
         return (
-            self._expected_num_d is not None
+            self._decode_scaling_in_progress
+            or self._expected_num_d is not None
             and self._expected_num_d != self._num_d_workers
         )
 

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -328,13 +328,17 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
         if component == "prefill":
             return (
                 self._prefill_scaling_in_progress
-                or self._expected_num_p is not None
-                and self._expected_num_p != self._num_p_workers
+                or (
+                    self._expected_num_p is not None
+                    and self._expected_num_p != self._num_p_workers
+                )
             )
         return (
             self._decode_scaling_in_progress
-            or self._expected_num_d is not None
-            and self._expected_num_d != self._num_d_workers
+            or (
+                self._expected_num_d is not None
+                and self._expected_num_d != self._num_d_workers
+            )
         )
 
     # ------------------------------------------------------------------

--- a/components/src/dynamo/planner/core/state_machine.py
+++ b/components/src/dynamo/planner/core/state_machine.py
@@ -326,19 +326,13 @@ class PlannerStateMachine(LoadScalingMixin, ThroughputScalingMixin):
 
     def _scaling_in_progress(self, component: str) -> bool:
         if component == "prefill":
-            return (
-                self._prefill_scaling_in_progress
-                or (
-                    self._expected_num_p is not None
-                    and self._expected_num_p != self._num_p_workers
-                )
+            return self._prefill_scaling_in_progress or (
+                self._expected_num_p is not None
+                and self._expected_num_p != self._num_p_workers
             )
-        return (
-            self._decode_scaling_in_progress
-            or (
-                self._expected_num_d is not None
-                and self._expected_num_d != self._num_d_workers
-            )
+        return self._decode_scaling_in_progress or (
+            self._expected_num_d is not None
+            and self._expected_num_d != self._num_d_workers
         )
 
     # ------------------------------------------------------------------

--- a/components/src/dynamo/planner/core/types.py
+++ b/components/src/dynamo/planner/core/types.py
@@ -59,6 +59,8 @@ class WorkerCounts:
     ready_num_decode: Optional[int] = None
     expected_num_prefill: Optional[int] = None
     expected_num_decode: Optional[int] = None
+    prefill_scaling_in_progress: bool = False
+    decode_scaling_in_progress: bool = False
 
 
 @dataclass

--- a/components/src/dynamo/planner/tests/unit/test_easy_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_easy_scaling.py
@@ -821,9 +821,7 @@ class TestScalingInProgress:
         effects = core.on_tick(_tick_for(tick), tick)
         assert effects.scale_to is None
         assert effects.diagnostics.load_decision_reason == "scaling_in_progress"
-        assert (
-            effects.diagnostics.load_decision_reason_prefill == "scaling_in_progress"
-        )
+        assert effects.diagnostics.load_decision_reason_prefill == "scaling_in_progress"
         assert effects.diagnostics.load_decision_reason_decode == "scaling_in_progress"
 
 

--- a/components/src/dynamo/planner/tests/unit/test_easy_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_easy_scaling.py
@@ -802,6 +802,30 @@ class TestScalingInProgress:
         assert effects.scale_to is None
         assert effects.diagnostics.load_decision_reason == "scaling_in_progress"
 
+    def test_disagg_no_decision_when_status_unstable(self):
+        core = _make_core(mode="disagg", optimization_target="latency")
+        p_fpm = _make_fpm(queued_prefill_tokens=CONTEXT_LENGTH * 2)
+        d_fpm = _make_fpm(sum_decode_kv_tokens=MAX_KV_TOKENS, queued_decode_kv_tokens=0)
+        tick = TickInput(
+            now_s=5.0,
+            fpm_observations=FpmObservations(
+                prefill={("w1", 0): p_fpm},
+                decode={("w1", 0): d_fpm},
+            ),
+            worker_counts=WorkerCounts(
+                ready_num_prefill=1,
+                ready_num_decode=1,
+                prefill_scaling_in_progress=True,
+            ),
+        )
+        effects = core.on_tick(_tick_for(tick), tick)
+        assert effects.scale_to is None
+        assert effects.diagnostics.load_decision_reason == "scaling_in_progress"
+        assert (
+            effects.diagnostics.load_decision_reason_prefill == "scaling_in_progress"
+        )
+        assert effects.diagnostics.load_decision_reason_decode == "scaling_in_progress"
+
 
 # ── Budget clamping ──────────────────────────────────────────────────
 

--- a/components/src/dynamo/planner/tests/unit/test_easy_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_easy_scaling.py
@@ -824,6 +824,38 @@ class TestScalingInProgress:
         assert effects.diagnostics.load_decision_reason_prefill == "scaling_in_progress"
         assert effects.diagnostics.load_decision_reason_decode == "scaling_in_progress"
 
+    def test_disagg_resumes_decisions_when_status_stable(self):
+        core = _make_core(mode="disagg", optimization_target="latency")
+        p_fpm = _make_fpm(queued_prefill_tokens=CONTEXT_LENGTH * 2)
+        d_fpm = _make_fpm(sum_decode_kv_tokens=MAX_KV_TOKENS, queued_decode_kv_tokens=0)
+        unstable_tick = TickInput(
+            now_s=5.0,
+            fpm_observations=FpmObservations(
+                prefill={("w1", 0): p_fpm},
+                decode={("w1", 0): d_fpm},
+            ),
+            worker_counts=WorkerCounts(
+                ready_num_prefill=1,
+                ready_num_decode=1,
+                prefill_scaling_in_progress=True,
+            ),
+        )
+        unstable_effects = core.on_tick(_tick_for(unstable_tick), unstable_tick)
+        assert unstable_effects.scale_to is None
+
+        stable_tick = TickInput(
+            now_s=10.0,
+            fpm_observations=FpmObservations(
+                prefill={("w1", 0): p_fpm},
+                decode={("w1", 0): d_fpm},
+            ),
+            worker_counts=WorkerCounts(ready_num_prefill=1, ready_num_decode=1),
+        )
+        stable_effects = core.on_tick(_tick_for(stable_tick), stable_tick)
+        assert stable_effects.scale_to is not None
+        assert stable_effects.scale_to.num_prefill == 2
+        assert stable_effects.diagnostics.load_decision_reason == "scale_up"
+
 
 # ── Budget clamping ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Prevent disagg load scaling from issuing new scale decisions while a previous scale operation is still in progress.

## Details

- Adds explicit per-component scaling-in-progress flags to `WorkerCounts`.
- Propagates unstable worker status from the connector into Planner inventory.
- Updates `_scaling_in_progress()` to honor unstable status even when expected replica counts are unavailable.
- Applies the scaling-in-progress guard to disagg load scaling, matching single/agg behavior.
- Adds regression coverage for disagg easy-mode scaling while status is unstable.


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability by detecting when scaling operations are already underway. The planner now avoids issuing new scaling decisions when operations are in progress, preventing conflicting actions during load adjustments.

* **Tests**
  * Added test coverage for scenarios with ongoing scaling operations in disaggregated deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->