### PR TITLE
fix(metrics): preserve original model casing on frontend lifecycle guards

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -2508,6 +2508,14 @@ mod tests {
         collector.observe_response(100, 1);
         let _queue = metrics.clone().create_http_queue_guard(model);
 
+        // Drop the lifecycle guards so their Drop impls record
+        // completion-time metrics (request_counter, request_duration,
+        // detokenize observations) before we gather. Without this the
+        // regression only covers constructor-time labels.
+        drop(_inflight);
+        drop(collector);
+        drop(_queue);
+
         let metric_families = registry.gather();
         let observed: Vec<String> = metric_families
             .iter()

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1042,7 +1042,7 @@ impl Metrics {
 
         InflightGuard::new(
             self.clone(),
-            model.to_string().to_lowercase(),
+            model.to_string(),
             endpoint,
             request_type,
             request_id.to_string(),
@@ -1051,7 +1051,7 @@ impl Metrics {
 
     /// Create a new [`ResponseMetricCollector`] for collecting per-response metrics (i.e., TTFT, ITL)
     pub fn create_response_collector(self: Arc<Self>, model: &str) -> ResponseMetricCollector {
-        ResponseMetricCollector::new(self, model.to_string().to_lowercase())
+        ResponseMetricCollector::new(self, model.to_string())
     }
 
     /// Create a new [`HttpQueueGuard`] for tracking HTTP processing queue
@@ -1059,7 +1059,7 @@ impl Metrics {
     /// This guard tracks requests from HTTP handler start until first token generation,
     /// providing visibility into HTTP processing queue time before actual LLM processing begins.
     pub fn create_http_queue_guard(self: Arc<Self>, model: &str) -> HttpQueueGuard {
-        HttpQueueGuard::new(self, model.to_string().to_lowercase())
+        HttpQueueGuard::new(self, model.to_string())
     }
 }
 
@@ -2488,6 +2488,45 @@ mod tests {
                 .get(),
             0
         );
+    }
+
+    #[test]
+    fn test_lifecycle_constructors_preserve_model_label_casing() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "Llama-3.1-8B-Instruct";
+
+        let _inflight = metrics.clone().create_inflight_guard(
+            model,
+            Endpoint::ChatCompletions,
+            true,
+            "req-case",
+        );
+        let mut collector = metrics.clone().create_response_collector(model);
+        collector.observe_response(100, 1);
+        let _queue = metrics.clone().create_http_queue_guard(model);
+
+        let metric_families = registry.gather();
+        let observed: Vec<String> = metric_families
+            .iter()
+            .flat_map(|mf| mf.get_metric())
+            .flat_map(|m| m.get_label())
+            .filter(|l| l.name() == "model")
+            .map(|l| l.value().to_string())
+            .collect();
+
+        assert!(
+            !observed.is_empty(),
+            "expected at least one metric to carry a model label"
+        );
+        for value in &observed {
+            assert_eq!(
+                value, model,
+                "model label was modified; expected original casing to be preserved"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The HTTP frontend's request-lifecycle metric guards — `InflightGuard`,
`ResponseMetricCollector`, and `HttpQueueGuard` — were lowercasing the
`model` label when they were constructed. Other `dynamo_frontend_*`
metric families (model-config gauges, migration / cancellation /
rejection counters) passed the model through unchanged. Result:
dashboards filtering by `model="$model"` saw matches only on half of
the metric families for the same logical model.

This PR removes the three `.to_lowercase()` calls in
`lib/llm/src/http/service/metrics.rs` so all frontend metric families
emit the same casing — the casing the model card was registered under.

## Why preserve rather than normalize?

The frontend's `ModelManager` lookup is case-sensitive
(`DashMap<String, _>` keyed on the raw model name). Requests whose
`model` field doesn't exactly match a registered model card are rejected
upstream of the metric setters with `ModelUnavailable`. So the only
casings that can ever reach these callsites are the registered ones —
preservation is sufficient to keep label values consistent across
metric families. No upstream canonicalization is needed.

## Test plan

- New regression test
  `test_lifecycle_constructors_preserve_model_label_casing` registers
  `Llama-3.1-8B-Instruct`, drives each of the three lifecycle paths
  (`create_inflight_guard`, `create_response_collector` +
  `observe_response`, `create_http_queue_guard`), and asserts every
  `model` label emitted across the registry equals the original
  mixed-case input.
- Existing metrics module tests (26 total) pass locally.

Refs: DYN-3073