### PR TITLE
test(sglang): replace hardcoded ports in migration test

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -96,6 +96,8 @@ class DynamoWorkerProcess(ManagedProcess):
     ):
         self.worker_id = worker_id
         self.system_port = allocate_port(9100)
+        self.bootstrap_port: int | None = None
+        self.prefill_port: int | None = None
         self.disagg_mode = disagg_mode
 
         command = [
@@ -121,12 +123,13 @@ class DynamoWorkerProcess(ManagedProcess):
             command.append("--skip-tokenizer-init")
         else:
             # Disaggregated
+            self.bootstrap_port = allocate_port(12340)
             command.extend(
                 [
                     "--disaggregation-mode",
                     disagg_mode,
                     "--disaggregation-bootstrap-port",
-                    f"1234{worker_id[-1]}",
+                    str(self.bootstrap_port),
                     "--host",
                     "0.0.0.0",
                     "--disaggregation-transfer-backend",
@@ -134,7 +137,8 @@ class DynamoWorkerProcess(ManagedProcess):
                 ]
             )
             if disagg_mode == "prefill":
-                command.extend(["--port", "40000"])
+                self.prefill_port = allocate_port(20000)
+                command.extend(["--port", str(self.prefill_port)])
 
         # Set environment variables
         env = os.environ.copy()
@@ -187,12 +191,14 @@ class DynamoWorkerProcess(ManagedProcess):
         )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Release allocated port when worker exits."""
-        try:
-            # system_port is a required parameter, always set in __init__
-            deallocate_port(self.system_port)
-        except Exception as e:
-            logging.warning(f"Failed to release SGLang worker port: {e}")
+        """Release allocated ports when worker exits."""
+        for port in (self.system_port, self.bootstrap_port, self.prefill_port):
+            if port is None:
+                continue
+            try:
+                deallocate_port(port)
+            except Exception as e:
+                logging.warning(f"Failed to release SGLang worker port {port}: {e}")
 
         return super().__exit__(exc_type, exc_val, exc_tb)
 


### PR DESCRIPTION
#### Overview

`DynamoWorkerProcess.__init__` in the sglang fault-tolerance migration test was building its subprocess command with two hardcoded port values: `f"1234{worker_id[-1]}"` for `--disaggregation-bootstrap-port` and the literal `"40000"` for the prefill worker's `--port`. Two pytest invocations on the same host with overlapping worker IDs collide on those ports.

Pulled both ports through the existing `allocate_port` / `deallocate_port` helper, the same one already used for `self.system_port` in this file and elsewhere across the migration / cancellation tests.

**Repro**

Two parallel pytest invocations on one host. On `main`, both `worker0` processes try to bind 12340 + 40000 and the second loses.

```bash
cd /workspace
pytest tests/fault_tolerance/migration/test_sglang.py::test_request_migration_sglang_decode \
  -k "migration_enabled and tcp and stream and chat" &
pytest tests/fault_tolerance/migration/test_sglang.py::test_request_migration_sglang_decode \
  -k "migration_enabled and tcp and stream and chat" &
wait
```

**Before** (observed in sglang config dumps on `main`):

```
worker0 (prefill):  bootstrap 12340,  --port 40000
worker1 (decode):   bootstrap 12341
worker2 (decode):   bootstrap 12342
```

**After** (two consecutive runs on this branch):

```
run 1:  bootstrap 12393 / 12415 / 12433,  --port 20028
run 2:  bootstrap 12354 / 12385 / 12394,  --port 20049
```

Every value is picked by the registry-backed allocator. Cross-process safety comes from the helper's flock + `bind()` probe + 100-slot random offset, not from the hint.

#### Details

Three small edits in one file.

Initialize `self.bootstrap_port` and `self.prefill_port` to `None` next to the existing `self.system_port = allocate_port(9100)`. They stay `None` for aggregated workers.

In the disaggregated branch, allocate the bootstrap port up front and inline it into the command list. For prefill workers, also allocate the HTTP port and inline it. The `worker_id[-1]` coupling is gone; `worker_id` is now purely a log-dir and display label.

Collapsed `__exit__` into a single loop over all three ports, skipping `None` and wrapping each `deallocate_port` in a per-port `try/except` so one failure does not skip the others.

One thing worth flagging up front: `allocate_port`'s `start_port` argument validates against `[1024, 32767]` (i16 cap in the Rust backend, with a TODO to lift it), so the original literal `40000` cannot be reused even as a search hint. Picked `20000` for the prefill port: well above `system_port=9100` and `bootstrap=12340`, comfortably below the cap.

The same "two ports per `ManagedProcess` subclass" shape already lives in `tests/vllm_self_benchmark/test_self_benchmark_gpu.py:156-165` (`system_port` + `fpm_port`) and was added for the same second-worker-bind-collision reason. The vllm migration test still has matching TODO markers at `test_vllm.py:121,143` for the same anti-pattern; out of scope here, but a natural follow-up.

#### Related Issues

Closes #8073
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Tests**
* Improved dynamic port allocation for disaggregated worker testing, replacing hardcoded port values with runtime allocation
* Enhanced worker process resource management to ensure all allocated network ports are properly released during shutdown

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->