### PR TITLE
chore: bump aiperf to 0.8.0 and aiconfigurator to release/0.9.0 tip

### DIFF
--- a/benchmarks/frontend/scripts/README.md
+++ b/benchmarks/frontend/scripts/README.md
@@ -116,7 +116,7 @@ When `--num-models` is 1, the served model name matches the HF model path (e.g.,
 |------|----------|---------|
 | etcd | Yes | `apt install etcd` or [releases](https://github.com/etcd-io/etcd/releases) |
 | nats-server | Yes | `apt install nats-server` or [nats.io](https://nats.io/download/) |
-| aiperf | Yes | `uv pip install "git+https://github.com/ai-dynamo/aiperf.git@main"` (in dynamo venv) |
+| aiperf | Yes | `uv pip install "aiperf==0.8.0"` (in dynamo venv) |
 | jq | Yes | `apt install jq` |
 | perf | Optional | `apt install linux-tools-$(uname -r)` |
 | bpftrace | Optional | `apt install bpftrace` (needs root or CAP_BPF + CAP_PERFMON) |

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -61,7 +61,7 @@ def _build_aiperf_script(
 
     return f"""set -e
 apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
-pip install --quiet git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
+pip install --quiet aiperf==0.8.0
 echo "aiperf installed"
 
 # Wait for model

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -61,6 +61,13 @@ def _build_aiperf_script(
 
     return f"""set -e
 apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
+# aiperf 0.8.0 pulls crick==0.0.8 which has no manylinux aarch64 wheel; on
+# arm64 nodes pip falls back to sdist and needs a C compiler. python:3.12-slim
+# ships Python headers under /usr/local/include so just `gcc` (which pulls
+# libc6-dev transitively) is enough. Skip on amd64 where the wheel exists.
+if [ "$(uname -m)" = "aarch64" ]; then
+    apt-get install -y -qq gcc 2>/dev/null
+fi
 pip install --quiet aiperf==0.8.0
 echo "aiperf installed"
 

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -63,10 +63,13 @@ def _build_aiperf_script(
 apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
 # aiperf 0.8.0 pulls crick==0.0.8 which has no manylinux aarch64 wheel; on
 # arm64 nodes pip falls back to sdist and needs a C compiler. python:3.12-slim
-# ships Python headers under /usr/local/include so just `gcc` (which pulls
-# libc6-dev transitively) is enough. Skip on amd64 where the wheel exists.
+# bundles Python headers at /usr/local/include/python3.12/, but libc headers
+# (stdlib.h, etc.) come from libc6-dev — and on Debian libc6-dev is only a
+# Recommends of gcc, not a Depends, so we install it explicitly to stay
+# resilient if this apt-get ever gets --no-install-recommends. Skip on amd64
+# where the prebuilt wheel exists on PyPI.
 if [ "$(uname -m)" = "aarch64" ]; then
-    apt-get install -y -qq gcc 2>/dev/null
+    apt-get install -y -qq gcc libc6-dev 2>/dev/null
 fi
 pip install --quiet aiperf==0.8.0
 echo "aiperf installed"

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,8 +40,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b33a136e78f9351a7ad17db1e2a1abd7b295cc6a",
-    "aiperf==0.6.0",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9",
+    "aiperf==0.8.0",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.benchmark.txt
+++ b/container/deps/requirements.benchmark.txt
@@ -3,4 +3,4 @@
 
 # Benchmark and profiling tool dependencies.
 
-aiperf==0.6.0
+aiperf==0.8.0

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,7 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@79eb16034f37e7211dd4f556448794603c3bdea3
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -12,22 +12,30 @@ FROM ${EPP_IMAGE} AS epp
 # reaches the final frontend image. aiperf 0.8.0 depends on crick==0.0.8,
 # which publishes no manylinux aarch64 wheel — without this, arm64 builds
 # fall back to sdist and fail in the final stage where gcc is intentionally
-# absent. The produced wheel lands in /opt/dynamo/wheelhouse/extra and uv
-# picks it up via UV_FIND_LINKS.
+# absent. amd64 has a prebuilt manylinux_x86_64 wheel on PyPI, so the build
+# is gated on TARGETARCH=arm64; amd64 ships an empty /wheels and uv pulls
+# crick straight from PyPI in the final stage. /wheels is created either
+# way so the COPY --from=crick_builder in the final stage always succeeds.
 FROM ${FRONTEND_IMAGE} AS crick_builder
 ARG PYTHON_VERSION
+ARG TARGETARCH
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gcc \
-        python${PYTHON_VERSION}-dev \
-        python${PYTHON_VERSION}-venv \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN python${PYTHON_VERSION} -m venv /tmp/buildenv \
-    && /tmp/buildenv/bin/pip install --no-cache-dir --upgrade pip wheel \
-    && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels
+    mkdir -p /wheels \
+    && if [ "$TARGETARCH" = "arm64" ]; then \
+        apt-get update -y \
+        && apt-get install -y --no-install-recommends \
+            ca-certificates \
+            gcc \
+            python${PYTHON_VERSION}-dev \
+            python${PYTHON_VERSION}-venv \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        python${PYTHON_VERSION} -m venv /tmp/buildenv \
+        && /tmp/buildenv/bin/pip install --no-cache-dir --upgrade pip wheel \
+        && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels; \
+    fi
 
 FROM ${FRONTEND_IMAGE} AS frontend
 

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -26,6 +26,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
             gcc \
+            libc6-dev \
             python${PYTHON_VERSION}-dev \
             python${PYTHON_VERSION}-venv \
         && apt-get clean \

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -8,6 +8,27 @@
 ##############################################
 FROM ${EPP_IMAGE} AS epp
 
+# Build `crick` as a wheel in an isolated stage so the C toolchain never
+# reaches the final frontend image. aiperf 0.8.0 depends on crick==0.0.8,
+# which publishes no manylinux aarch64 wheel — without this, arm64 builds
+# fall back to sdist and fail in the final stage where gcc is intentionally
+# absent. The produced wheel lands in /opt/dynamo/wheelhouse/extra and uv
+# picks it up via UV_FIND_LINKS.
+FROM ${FRONTEND_IMAGE} AS crick_builder
+ARG PYTHON_VERSION
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN python${PYTHON_VERSION} -m venv /tmp/buildenv \
+    && /tmp/buildenv/bin/pip install --no-cache-dir --upgrade pip wheel \
+    && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels
+
 FROM ${FRONTEND_IMAGE} AS frontend
 
 ARG PYTHON_VERSION
@@ -66,6 +87,8 @@ COPY --chown=dynamo: --from=dynamo_base /bin/uv /bin/uvx /bin/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
+# crick wheel pre-built in the crick_builder stage; see comment near the top.
+COPY --chown=dynamo: --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
 
 # Create virtual environment
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
@@ -87,8 +110,10 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
+# UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
+# uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
-    export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -17,13 +17,18 @@ ARG PYTHON_VERSION
 # Install only the packages needed to resolve and install the planner runtime
 # dependencies in the builder stage. git/git-lfs are only needed because
 # aiconfigurator is currently installed from a Git URL with LFS-backed assets.
+# gcc + python3-dev are needed to compile aiperf's `crick` dep from sdist on
+# arm64 (no manylinux aarch64 wheel published); the toolchain is confined to
+# this builder stage and never reaches the final image.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
+        gcc \
         git \
         git-lfs \
-        libgomp1 && \
+        libgomp1 \
+        python${PYTHON_VERSION}-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -13,22 +13,29 @@
 FROM ${PLANNER_BUILD_IMAGE}:${PLANNER_BUILD_IMAGE_TAG} AS planner_builder
 
 ARG PYTHON_VERSION
+ARG TARGETARCH
 
 # Install only the packages needed to resolve and install the planner runtime
 # dependencies in the builder stage. git/git-lfs are only needed because
 # aiconfigurator is currently installed from a Git URL with LFS-backed assets.
-# gcc + python3-dev are needed to compile aiperf's `crick` dep from sdist on
-# arm64 (no manylinux aarch64 wheel published); the toolchain is confined to
-# this builder stage and never reaches the final image.
+# On arm64, gcc is added so aiperf's `crick` dep can compile from sdist
+# (crick==0.0.8 publishes no manylinux aarch64 wheel); on amd64 the prebuilt
+# wheel from PyPI is used and the toolchain is skipped entirely. Python
+# headers come from the base image's /usr/local/include/python${PYTHON_VERSION}
+# (python:3.X-slim bundles them directly — no apt python*-dev needed, and
+# python${PYTHON_VERSION}-dev is not available in this base's apt index
+# anyway). The toolchain stays in this builder stage and never reaches the
+# final image.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
+    EXTRA_PKGS=""; \
+    if [ "$TARGETARCH" = "arm64" ]; then EXTRA_PKGS="gcc"; fi; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
-        gcc \
         git \
         git-lfs \
         libgomp1 \
-        python${PYTHON_VERSION}-dev && \
+        $EXTRA_PKGS && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -18,18 +18,21 @@ ARG TARGETARCH
 # Install only the packages needed to resolve and install the planner runtime
 # dependencies in the builder stage. git/git-lfs are only needed because
 # aiconfigurator is currently installed from a Git URL with LFS-backed assets.
-# On arm64, gcc is added so aiperf's `crick` dep can compile from sdist
-# (crick==0.0.8 publishes no manylinux aarch64 wheel); on amd64 the prebuilt
-# wheel from PyPI is used and the toolchain is skipped entirely. Python
-# headers come from the base image's /usr/local/include/python${PYTHON_VERSION}
-# (python:3.X-slim bundles them directly — no apt python*-dev needed, and
-# python${PYTHON_VERSION}-dev is not available in this base's apt index
-# anyway). The toolchain stays in this builder stage and never reaches the
-# final image.
+# On arm64, gcc + libc6-dev are added so aiperf's `crick` dep can compile
+# from sdist (crick==0.0.8 publishes no manylinux aarch64 wheel); on amd64
+# the prebuilt wheel from PyPI is used and the toolchain is skipped
+# entirely. Python headers come from the base image's
+# /usr/local/include/python${PYTHON_VERSION} (python:3.X-slim bundles them
+# directly — no apt python*-dev needed, and python${PYTHON_VERSION}-dev is
+# not available in this base's apt index anyway). libc6-dev is required
+# explicitly because on Debian it's a Recommends of gcc, not a Depends, so
+# --no-install-recommends would otherwise skip it and the build fails with
+# "fatal error: stdlib.h: No such file or directory". The toolchain stays
+# in this builder stage and never reaches the final image.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
     EXTRA_PKGS=""; \
-    if [ "$TARGETARCH" = "arm64" ]; then EXTRA_PKGS="gcc"; fi; \
+    if [ "$TARGETARCH" = "arm64" ]; then EXTRA_PKGS="gcc libc6-dev"; fi; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         git \

--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -450,7 +450,7 @@ spec:
           - -lc
           - |
             apt-get update -qq && apt-get install -y -qq tmux > /dev/null 2>&1
-            pip install -q aiperf==0.5.0
+            pip install -q aiperf==0.8.0
             echo "Benchmark pod ready (tmux + aiperf installed)."
             sleep infinity
         imagePullPolicy: IfNotPresent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator>=0.7.0",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
## Summary

- Bump `aiperf` from `0.6.0` to `0.8.0` (PyPI release) in `benchmarks/pyproject.toml`, `container/deps/requirements.benchmark.txt`, `benchmarks/frontend/scripts/sweep_k8s/aiperf.py`, `benchmarks/frontend/scripts/README.md`, and the example pod in `docs/benchmarks/kv-router-ab-testing.md`. The benchmarks pyproject and the sweep_k8s installer previously pulled aiperf from a transient main SHA — both now use the official 0.8.0 PyPI release.
- Bump `aiconfigurator` to the tip of `release/0.9.0` (`2103aa286a822d112ea83781ad14e3e022b603d9`) in `container/deps/requirements.planner.txt` and `benchmarks/pyproject.toml`. The root `pyproject.toml` `mocker` optional-deps group is converted from `aiconfigurator>=0.7.0` to the same git+SHA pin since `0.9.0` is not yet on PyPI.
- Leaves the two recipes with intentional non-standard aiperf pins untouched: `recipes/qwen3.6-35b/perf.yaml` (`AIPERF_GIT_REF` env var pinned to a PR-specific SHA) and `recipes/gpt-oss-120b/trtllm/disagg/perf.yaml` (pinned to `4d3fa294...`).

## Container build fix: handling crick on arm64

`aiperf 0.8.0` introduced a new transitive dep on `crick==0.0.8`. PyPI publishes crick wheels for `manylinux_x86_64`, `musllinux`, `i686`, `macOS arm64`, and Windows — but **no `manylinux_aarch64` wheel**. The initial CI run on this PR failed on the `planner` and `frontend` multi-arch builds: on arm64, uv fell back to the crick sdist and tried to compile the C extension, but the container images don't ship a C toolchain:

```
error: command 'aarch64-linux-gnu-gcc' failed: No such file or directory
help: `crick` (v0.0.8) was included because `aiperf` (v0.8.0) depends on `crick`
```

The fix in each container is targeted at keeping the toolchain *out* of the final runtime image:

- **Planner** (`container/templates/planner.Dockerfile`): the Dockerfile already has a two-stage `planner_builder` → `planner` layout. Added `gcc` + `python${PYTHON_VERSION}-dev` to the apt install in the builder stage only. crick compiles in the builder, the resulting `crick.tdigest.so` lands in `/opt/dynamo/venv`, and the final stage's existing `COPY --from=planner_builder /opt/dynamo/venv` brings it across. The final image never sees gcc.
- **Frontend** (`container/templates/frontend.Dockerfile`): single-stage today, so a full builder/runtime split would be invasive. Instead, added a dedicated `crick_builder` stage that installs `gcc` + `python3-dev`, builds the wheel via `pip wheel --no-deps crick==0.0.8`, and emits it to `/wheels`. The final `frontend` stage `COPY --from=crick_builder`s the wheel into `/opt/dynamo/wheelhouse/extra/` and sets `UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra` so uv prefers the prebuilt wheel over the sdist. The existing single-stage flow (base image, apt list, user setup, EPP copy, workspace copies, conditional KVBM/GMS installs) is otherwise untouched — minimizing the surface area for "did we forget to copy something" regressions.

If a future aiperf bump pulls another no-aarch64-wheel sdist dep, we'll need to either add it to the `crick_builder` pip wheel list (frontend) or rely on the planner_builder's gcc to handle it transparently.

## Test plan

- [ ] CI passes on the branch (in particular the `planner / Build multi-arch cpu` and `frontend / Build multi-arch cpu` jobs that failed on the first run)
- [ ] `uv sync` (or equivalent) resolves cleanly in the root project and in `benchmarks/`
- [ ] Planner container build succeeds with the new `aiconfigurator` SHA and no gcc in the final image (`docker run --rm planner:<tag> which gcc` returns non-zero)
- [ ] Frontend container build succeeds and no gcc in the final image
- [ ] Spot-check a benchmark run via `benchmarks/frontend/scripts/sweep_k8s` to confirm `aiperf==0.8.0` installs and profiles successfully

Relates to OPS-5167, OPS-5168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
