### PR TITLE
test(parsers): add streaming parser parity harness

### DIFF
--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2283,6 +2283,7 @@ dependencies = [
  "dynamo-llm",
  "dynamo-mocker",
  "dynamo-parsers",
+ "dynamo-protocols",
  "dynamo-runtime",
  "futures",
  "once_cell",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -40,6 +40,7 @@ lightseek-mm = ["dynamo-llm/lightseek-mm"]
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
 dynamo-parsers = { path = "../../parsers" }
+dynamo-protocols = { path = "../../protocols" }
 dynamo-backend-common = { path = "../../backend-common" }
 
 anyhow = { version = "1" }

--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -1,14 +1,27 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use dynamo_llm::preprocessor::OpenAIPreprocessor;
+use dynamo_llm::protocols::Annotated;
+use dynamo_llm::protocols::openai::ParsingOptions;
+use dynamo_llm::protocols::openai::chat_completions::{
+    DeltaAggregator, NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse,
+};
 use dynamo_parsers::reasoning::get_available_reasoning_parsers;
 use dynamo_parsers::tool_calling::ToolDefinition;
 use dynamo_parsers::tool_calling::parsers::{
     detect_and_parse_tool_call_with_recovery, get_available_tool_parsers,
 };
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+    CreateChatCompletionStreamResponse, FinishReason, Role,
+};
+use futures::{Stream, stream};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::pin::Pin;
 
 /// Get list of available tool parser names
 #[pyfunction]
@@ -47,7 +60,7 @@ pub fn get_reasoning_parser_names() -> Vec<&'static str> {
 ///     ValueError on parser failure or malformed `tools_json`.
 #[pyfunction]
 #[pyo3(signature = (parser_name, message, tools_json=None))]
-pub fn parse_tool_call<'py>(
+pub fn parse_tool_calls_batch<'py>(
     py: Python<'py>,
     parser_name: String,
     message: String,
@@ -75,6 +88,159 @@ pub fn parse_tool_call<'py>(
         });
         Ok(result.to_string())
     })
+}
+
+#[derive(Debug, Deserialize)]
+struct CaptureChunk {
+    #[serde(default)]
+    delta_text: String,
+    finish_reason: Option<FinishReason>,
+}
+
+#[derive(Debug, Serialize)]
+struct CaptureOutput {
+    calls: Vec<CaptureOutputCall>,
+    normal_text: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CaptureOutputCall {
+    name: String,
+    arguments: Value,
+}
+
+/// Parse streamed tool-call chunks through Dynamo's Rust streaming jail.
+///
+/// Args:
+///     parser_name: Parser name (e.g. "kimi_k2"). Empty string falls back to default.
+///     chunks_json: JSON-serialized list of `{"delta_text": str, "finish_reason": str?}` chunks.
+///     tools_json:  Optional JSON-serialized list of tool definitions.
+///
+/// Returns (awaited):
+///     JSON-serialized string `{"calls": [{"name", "arguments"}], "normal_text": str}`.
+///
+/// Raises:
+///     ValueError on parser failure or malformed JSON.
+#[pyfunction]
+#[pyo3(signature = (parser_name, chunks_json, tools_json=None))]
+pub fn parse_tool_calls_stream<'py>(
+    py: Python<'py>,
+    parser_name: String,
+    chunks_json: String,
+    tools_json: Option<String>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let chunks: Vec<CaptureChunk> = serde_json::from_str(&chunks_json)
+        .map_err(|e| PyValueError::new_err(format!("invalid chunks_json: {e}")))?;
+    let tools = parse_tools_json(tools_json.as_deref())?;
+    let parser_str = if parser_name.is_empty() {
+        None
+    } else {
+        Some(parser_name)
+    };
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let input_chunks = chunks
+            .iter()
+            .map(make_stream_chunk)
+            .collect::<Vec<Annotated<NvCreateChatCompletionStreamResponse>>>();
+        let output = parse_response_stream(stream::iter(input_chunks), parser_str, tools).await?;
+        serde_json::to_string(&output)
+            .map_err(|e| PyValueError::new_err(format!("failed to serialize stream output: {e}")))
+    })
+}
+
+async fn parse_response_stream(
+    stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    tool_parser: Option<String>,
+    tool_definitions: Option<Vec<ToolDefinition>>,
+) -> PyResult<CaptureOutput> {
+    let stream: Pin<
+        Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>,
+    > = Box::pin(OpenAIPreprocessor::apply_tool_calling_jail(
+        tool_parser,
+        None,
+        tool_definitions,
+        stream,
+    ));
+
+    let response = DeltaAggregator::apply(stream, ParsingOptions::default())
+        .await
+        .map_err(|e| PyValueError::new_err(format!("failed to aggregate stream output: {e}")))?;
+    Ok(capture_output_from_response(&response))
+}
+
+fn make_stream_chunk(chunk: &CaptureChunk) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    let choice = ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            // The tool-calling jail may suppress early input chunks. Keep the
+            // synthetic role on each chunk so DeltaAggregator still sees a
+            // role on the first emitted chunk.
+            role: Some(Role::Assistant),
+            content: Some(ChatCompletionMessageContent::Text(chunk.delta_text.clone())),
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: chunk.finish_reason,
+        logprobs: None,
+    };
+    Annotated {
+        id: Some("parser-stream-capture".to_string()),
+        data: Some(NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "parser-stream-capture".to_string(),
+                choices: vec![choice],
+                created: 1234567890,
+                model: "parser-stream-capture".to_string(),
+                service_tier: None,
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+            },
+            nvext: None,
+        }),
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+fn capture_output_from_response(response: &NvCreateChatCompletionResponse) -> CaptureOutput {
+    let mut normal_text = String::new();
+    let mut calls = Vec::new();
+
+    for choice in &response.inner.choices {
+        if let Some(content) = &choice.message.content {
+            normal_text.push_str(get_text(content));
+        }
+        if let Some(tool_calls) = &choice.message.tool_calls {
+            for tool_call in tool_calls {
+                calls.push(CaptureOutputCall {
+                    name: tool_call.function.name.clone(),
+                    arguments: decode_arguments(&tool_call.function.arguments),
+                });
+            }
+        }
+    }
+
+    CaptureOutput { calls, normal_text }
+}
+
+fn get_text(content: &ChatCompletionMessageContent) -> &str {
+    match content {
+        ChatCompletionMessageContent::Text(text) => text.as_str(),
+        ChatCompletionMessageContent::Parts(_) => "",
+    }
+}
+
+fn decode_arguments(arguments: &str) -> Value {
+    if arguments.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str(arguments).unwrap_or_else(|_| Value::String(arguments.to_string()))
+    }
 }
 
 /// Convert OpenAI-style or flat tools JSON into `Vec<ToolDefinition>`.
@@ -115,6 +281,7 @@ fn parse_tools_json(tools_json: Option<&str>) -> PyResult<Option<Vec<ToolDefinit
 pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_tool_parser_names, m)?)?;
     m.add_function(wrap_pyfunction!(get_reasoning_parser_names, m)?)?;
-    m.add_function(wrap_pyfunction!(parse_tool_call, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_tool_calls_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_tool_calls_stream, m)?)?;
     Ok(())
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -33,7 +33,7 @@ def get_reasoning_parser_names() -> list[str]:
     """Get list of available reasoning parser names."""
     ...
 
-async def parse_tool_call(
+async def parse_tool_calls_batch(
     parser_name: str,
     message: str,
     tools_json: Optional[str] = None,
@@ -55,6 +55,26 @@ async def parse_tool_call(
 
     Raises:
         ValueError on parser failure or malformed `tools_json`.
+    """
+    ...
+
+async def parse_tool_calls_stream(
+    parser_name: str,
+    chunks_json: str,
+    tools_json: Optional[str] = None,
+) -> str:
+    """Parse streamed tool-call chunks using the specified parser.
+
+    Args:
+        parser_name: Parser name (e.g. "kimi_k2"). Empty string falls back to default.
+        chunks_json: JSON-serialized list of chunks with `delta_text` and optional `finish_reason`.
+        tools_json: Optional JSON-serialized list of tool definitions.
+
+    Returns:
+        JSON-serialized string `{"calls": [{"name", "arguments"}], "normal_text": str}`.
+
+    Raises:
+        ValueError on parser failure or malformed JSON.
     """
     ...
 

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1232,8 +1232,8 @@ mod tests {
         );
     }
 
-    /// Single tool call, thinking mode (direct V4 analog of the V3 tool fixture).
-    /// `PARSER.1` + `PARSER.8` + `PARSER.9` — single tool call, streaming assembly, paired with reasoning. Also validates `PARSER.12` finish_reason=tool_calls.
+    /// `PARSER.stream.1` — single tool call over the streaming pipeline,
+    /// paired with reasoning. Also validates finish_reason=tool_calls passthrough.
     #[tokio::test]
     async fn test_deepseek_v4_e2e_with_tools_vllm() {
         let file_path = format!(
@@ -1243,8 +1243,8 @@ mod tests {
         run_deepseek_v4_tool_call_fixture(&file_path).await;
     }
 
-    /// No tool call — thinking + plain body; finish_reason=stop.
-    /// `PARSER.3` + `PARSER.10` — no tool call + reasoning only. Also validates `PARSER.12` finish_reason=stop.
+    /// `PARSER.batch.3` over the streaming pipeline — no tool call,
+    /// reasoning plus plain body, and finish_reason=stop passthrough.
     #[tokio::test]
     async fn test_deepseek_v4_e2e_with_no_tools_vllm() {
         let file_path = format!(
@@ -1283,8 +1283,7 @@ mod tests {
         );
     }
 
-    /// Two parallel tool calls inside one DSML block.
-    /// `PARSER.2` — parallel tool calls in one DSML block.
+    /// `PARSER.stream.2` — two parallel tool calls inside one DSML block.
     #[tokio::test]
     async fn test_deepseek_v4_e2e_multi_tool_vllm() {
         let file_path = format!(
@@ -1296,7 +1295,8 @@ mod tests {
 
     /// string="true" vs string="false" — numbers, booleans, arrays, objects must
     /// round-trip as their proper JSON types inside arguments.
-    /// `PARSER.7` — complex args (mixed string="true|false" → strings / numbers / bools / arrays / objects round-trip).
+    /// `PARSER.batch.7.a` over the streaming pipeline — complex args
+    /// (mixed string="true|false" to strings / numbers / bools / arrays / objects).
     #[tokio::test]
     async fn test_deepseek_v4_e2e_mixed_param_types_vllm() {
         let file_path = format!(
@@ -1308,7 +1308,8 @@ mod tests {
 
     /// Body text emitted before the DSML block — parser must populate both
     /// normal_content and tool_calls.
-    /// `PARSER.13` — normal text interleaved before the DSML block.
+    /// `PARSER.batch.8.a` over the streaming pipeline — normal text
+    /// interleaved before the DSML block.
     #[tokio::test]
     async fn test_deepseek_v4_e2e_content_before_tool_vllm() {
         let file_path = format!(
@@ -1321,7 +1322,8 @@ mod tests {
     /// Parameter value containing unicode, emoji, embedded quotes/newlines/tabs,
     /// and fragments that look like sentinels but aren't — must not confuse the
     /// parser, which anchors only on the exact </｜DSML｜parameter> token.
-    /// `PARSER.7` — Unicode / special characters inside argument values. (`PARSER.xml1` is N/A for DSML — no entity decoding.)
+    /// `PARSER.batch.7.b` over the streaming pipeline — Unicode / special
+    /// characters inside argument values. (`PARSER.xml.1` is N/A for DSML.)
     #[tokio::test]
     async fn test_deepseek_v4_e2e_special_chars_vllm() {
         let file_path = format!(
@@ -1333,7 +1335,8 @@ mod tests {
 
     /// Adversarial streaming: every DSML character is its own delta (~200 chunks).
     /// Exercises buffer accumulation across chunk boundaries.
-    /// `PARSER.8` — streaming chunk-boundary splits (tokens straddle chunks).
+    /// `PARSER.stream.3` — streaming chunk-boundary splits
+    /// (grammar tokens straddle chunks).
     #[tokio::test]
     async fn test_deepseek_v4_e2e_fragmented_tokens_vllm() {
         let file_path = format!(
@@ -1389,8 +1392,8 @@ mod tests {
         }
     }
 
-    /// Repro: complete Kimi K2 tool call stream, section_end present → should work.
-    /// This is the baseline / control test.
+    /// `PARSER.stream.1.b` — complete Kimi K2 tool call stream split
+    /// across parser-significant boundaries; section_end present.
     #[tokio::test]
     async fn test_kimi_k2_streaming_complete_section() {
         let chunks = vec![
@@ -1420,7 +1423,7 @@ mod tests {
         );
     }
 
-    /// Repro for DIS-1765: model hits max_tokens BEFORE emitting section_end.
+    /// `PARSER.stream.4.a` — model hits max_tokens before emitting section_end.
     /// Individual tool call is complete (call_begin + args + call_end), but
     /// section_end is missing. The jail should still extract the tool call at
     /// finalize time instead of emitting raw marker text.
@@ -1459,7 +1462,8 @@ mod tests {
         );
     }
 
-    /// Repro: multiple complete tool calls, no section_end (max_tokens).
+    /// `PARSER.stream.4.a` plus `PARSER.stream.2` — multiple complete tool
+    /// calls, no section_end (max_tokens).
     #[tokio::test]
     async fn test_kimi_k2_streaming_multiple_calls_missing_section_end() {
         let chunks = vec![
@@ -1493,9 +1497,9 @@ mod tests {
         assert_eq!(aggregated.tool_calls.len(), 2);
     }
 
-    /// `PARSER.5` + `PARSER.8` (PR #8208) — kimi-k2 truncated mid-argument
-    /// (no `<|tool_call_end|>`), streaming, customer regression. Also
-    /// validates `PARSER.12` finish_reason=stop passthrough.
+    /// `PARSER.stream.4.b` — Kimi K2 truncated mid-argument (no
+    /// `<|tool_call_end|>`), customer regression. Also validates
+    /// finish_reason=stop passthrough.
     ///
     /// Repro for the production leak observed against kimi-k2-6: the
     /// model stops mid-argument with

--- a/lib/parsers/PARSER_CASES.md
+++ b/lib/parsers/PARSER_CASES.md
@@ -37,6 +37,8 @@ White-box helper unit tests of `detect_tool_call_start_*` /
 carry a numbered category since they have no cross-impl analogue and
 exist to pin internal Rust function behavior only.
 
+"Happy path" is used deliberately: it means a valid, well-formed parser flow where the parser should emit the expected calls/text without truncation recovery, malformed-input fallback, unknown-tool handling, or expected errors. If a category or sub-case is the happy case for that axis, the label says so explicitly.
+
 ## Quick reference
 
 ### Parser, batch mode
@@ -45,12 +47,12 @@ Universal behavior contract. Applies to every tool-call parser when
 fed the full model output as a single string.
 
 - **`PARSER.batch.1`** Single tool call — happy path (one complete, well-formed call).
-- **`PARSER.batch.2`** Multiple tool calls — sequential or parallel (2+ in one response).
+- **`PARSER.batch.2`** Multiple tool calls — multi-call happy path, sequential or parallel (2+ complete, well-formed calls in one response).
 - **`PARSER.batch.3`** No tool call (response is text only).
 - **`PARSER.batch.4`** Malformed / partial JSON args (truncated, missing close brace, invalid syntax). Recovery contract is impl-defined; document divergences rather than asserting one truth.
 - **`PARSER.batch.5`** Missing end-token recovery (recover calls when the closing fence is absent due to `max_tokens` / EOS).
-- **`PARSER.batch.6`** Empty args (`arguments={}` / no-arg call).
-- **`PARSER.batch.7`** Complex arg types (nested objects, arrays, bool, number, Unicode / newlines in values).
+- **`PARSER.batch.6`** Empty args — no-arg happy path (`arguments={}` / no-arg call).
+- **`PARSER.batch.7`** Complex arg types — typed-args happy path (nested objects, arrays, bool, number, Unicode / newlines in values).
 - **`PARSER.batch.8`** Normal text interleaved with tool calls.
 - **`PARSER.batch.9`** Empty content / empty `tool_calls` array / null response.
 - **`PARSER.batch.10`** Duplicate tool calls (same name twice, possibly with same args).
@@ -65,10 +67,16 @@ as batch mode, but driven through `parse_streaming_increment(delta)`.
 This requires a separate test harness; case numbers are independent
 of batch.
 
-- **`PARSER.stream.1`** Single tool call across N chunks (any chunk boundary).
-- **`PARSER.stream.2`** Multiple tool calls, each spanning multiple chunks.
+- **`PARSER.stream.1`** Single tool call across N chunks — streaming happy-path family (one complete, well-formed call with any legal chunk boundary).
+- **`PARSER.stream.1.a`** Single complete tool-call payload delivered in one content chunk — one-chunk streaming happy path.
+- **`PARSER.stream.1.b`** Single complete tool call split across parser-significant boundaries — buffering streaming happy path.
+- **`PARSER.stream.2`** Multiple tool calls, each spanning multiple chunks — multi-call streaming happy path.
 - **`PARSER.stream.3`** Partial-token chunking (chunk boundary splits a grammar token mid-string). Partial-token matching must return `keep buffering`, not flush as plain text.
 - **`PARSER.stream.4`** Streaming termination — final chunk arrives with `finish_reason=tool_calls` / EOS; parser flushes any in-flight call.
+- **`PARSER.stream.4.a`** Truncated before tool-call end — non-happy path where arguments are complete but the model omits `tool_call_end` / section end; recovery is implementation-defined and may diverge.
+- **`PARSER.stream.4.b`** Truncated mid-call body — non-happy path where the stream terminates before the in-flight argument payload is complete; recovery is implementation-defined and may diverge.
+
+Stream fixtures may include `delta_token_ids` on each chunk. Text-only chunks are enough for most parser families, but token-ID-dependent streaming parsers (currently vLLM's Harmony / `openai` parser) must record `delta_token_ids`; capture should mark those cases unavailable rather than inventing IDs.
 
 ### Format-conditional (scope narrower than "all parsers")
 
@@ -127,7 +135,7 @@ One complete, well-formed call in the response.
   see `PARSER.fmt.5` for the broader argument-shape contract.
   Reference: vLLM Kimi K2 PR #32768.
 
-## `PARSER.batch.2` — Multiple tool calls (sequential or parallel)
+## `PARSER.batch.2` — Multiple tool calls, multi-call happy path
 
 Two or more calls in one response, in the same block or back-to-back.
 
@@ -238,7 +246,7 @@ Five distinct truncation shapes with different recovery contracts:
   calls remain recoverable while the partial trailing call is dropped,
   preserved as text, or surfaced as an impl-defined error.
 
-## `PARSER.batch.6` — Empty args
+## `PARSER.batch.6` — Empty args, no-arg happy path
 
 Tool call with `arguments={}`, or a no-parameter invoke.
 
@@ -262,7 +270,7 @@ the API but exercise different parser code paths.
   `arguments` key is absent entirely (vs explicit `{}`). Tests that
   the parser treats missing-key as "no args" rather than "invalid".
 
-## `PARSER.batch.7` — Complex argument types
+## `PARSER.batch.7` — Complex argument types, typed-args happy path
 
 Nested objects, arrays, booleans, numbers, mixed types, Unicode
 values, and newlines inside argument values.
@@ -323,9 +331,9 @@ The `b8` column of the cross-impl parity matrix shows broad divergence
 families; Dynamo preserves it). The sub-cases pin which positional
 shape is being exercised so divergences land on a precise row.
 
-- **`PARSER.batch.8.a`** Narration **before** the tool call only —
+- **`PARSER.batch.8.a`** Narration **before** the tool call only — historical interleaved-text happy path.
   model emits text, then a single tool call, then nothing else. Most
-  parsers handle this; it's the historical happy path.
+  parsers handle this.
 - **`PARSER.batch.8.b`** Narration **after** the tool call only —
   model emits the tool call, then trailing text. Common divergence
   point: vLLM and SGLang typically truncate at the wrapper close.
@@ -460,14 +468,19 @@ separator-looking character before the real call separator.
 
 ---
 
-## `PARSER.stream.1` — Single tool call across N chunks
+## `PARSER.stream.1` — Single tool call across N chunks, streaming happy path
 
 One complete tool call delivered across multiple SSE chunks of any
 sizing. Parser incrementally reconstructs the call.
 
 - Applies to every tool-call parser. Dominant production path.
 
-## `PARSER.stream.2` — Multiple tool calls, each across N chunks
+### Sub-cases
+
+- **`PARSER.stream.1.a`** One-chunk streaming happy path. Single complete tool-call payload delivered in one content chunk, with stream termination handled separately. This protects the streaming path's non-buffered happy path, which is easy to regress when the jail only handles accumulated multi-chunk state.
+- **`PARSER.stream.1.b`** Buffering streaming happy path. Single complete tool call split across parser-significant boundaries such as start fence, function name, arguments, and end fence. This is the default buffering happy path for streaming parsers.
+
+## `PARSER.stream.2` — Multiple tool calls, each across N chunks, multi-call streaming happy path
 
 Two or more calls in the response, each spanning multiple chunks.
 Parser must emit each call as its complete invocation lands; must not
@@ -491,6 +504,11 @@ Final chunk arrives with `finish_reason=tool_calls` (or `length` /
 explicitly per `PARSER.batch.5`).
 
 - Applies to every tool-call parser.
+
+### Sub-cases
+
+- **`PARSER.stream.4.a`** Truncated before tool-call end. The model emits a start fence, function name, argument-begin marker, and complete JSON arguments, then terminates before `tool_call_end` / section end. This is a non-happy path: Dynamo currently treats the call as incomplete and emits no tool call, while vLLM/SGLang may recover the call from the complete argument JSON.
+- **`PARSER.stream.4.b`** Truncated mid-call body. The model emits a start fence and begins the argument payload, then terminates before the JSON/value body is complete. This is a non-happy path: parsers may drop the in-flight call, preserve residual markup as normal text, emit an error, or surface a raw partial argument string.
 
 ---
 
@@ -634,7 +652,7 @@ mirrored by `<|channel|>analysis<|message|>...<|end|>` for reasoning.
 The parser must walk the envelope correctly across its legal
 variations:
 
-- **Complete envelope** — all tags present (the happy path).
+- **Complete envelope happy path** — all tags present.
 - **Missing `<|start|>` / assistant prefix** — model output lands
   inside an existing turn.
 - **Missing `<|call|>` (truncation recovery)** — engine hit

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -142,7 +142,7 @@ pub fn try_tool_call_parse_gemma4(
     //     return empty — Dynamo intentionally diverges from vLLM's
     //     exception-fallback (which echoes raw bytes) so tool-call markup
     //     never leaks into normal_text on malformed / truncated / orphan-
-    //     close / no-body inputs. Cases flagged by the parity chart's `↯`:
+    //     close / no-body inputs. Cases flagged by the parity table's `↯`:
     //     PARSER.batch.{4.a, 4.b, 4.c, 4.d, 5.a, 5.b, 5.c, 6.c}.
     //   - Plain-text path (zero calls AND no markup): return the message
     //     as-is.

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -21,11 +21,13 @@ tests/parity/
 ├── README.md                       (this file)
 ├── conftest.py                     ← session-scoped fixtures (server boots, etc.)
 ├── common.py                       ← ParseResult, canonical-JSON diff, decode_arguments
+├── generate_parity_table.py        ← common table CLI: parser
+├── parity_table.html.j2            ← shared HTML template
 └── parser/
     ├── fixtures/                   ← static YAML, generated from Dynamo as oracle
     │   └── <family>/PARSER.batch.yaml         (and per-top-level-case files like PARSER.batch.8.yaml; see Fixture file schema)
     ├── capture_parser_outputs.py     ← drift-check (default) or merge any impl's output into `expected.{dynamo,vllm,sglang}`
-    ├── generate_parity_chart.py    ← print the parity-status table (run on demand; not checked in)
+    ├── table.py                    ← parser table adapter
     │
     ├── dynamo.py                   ← M2 in-process wrapper (PyO3 binding)
     ├── vllm.py                     ← M2 in-process wrapper (ToolParserManager)
@@ -66,8 +68,9 @@ which bug class each method can catch:
 
 ```python
 # Dynamo Rust side (via PyO3 binding)
-from dynamo._core import parse_tool_call
-result = await parse_tool_call("kimi_k2", text, tools_json)
+from dynamo._core import parse_tool_calls_batch, parse_tool_calls_stream
+batch_result = await parse_tool_calls_batch("kimi_k2", text, tools_json)
+stream_result = await parse_tool_calls_stream("kimi_k2", chunks_json, tools_json)
 
 # vLLM side (native Python class)
 from vllm.tool_parsers import ToolParserManager
@@ -82,6 +85,24 @@ result = KimiK2Detector().detect_and_parse(text, tools)
 **What it surfaces:** parser-logic divergences between Dynamo's Rust parser class and upstream's Python parser classes. The bug class isolated from everything else in the request lifecycle.
 
 **File:** `tests/parity/parser/test_parity_parser.py`.
+
+#### Batch vs stream mode inside M2
+
+Batch fixtures are one-shot: the fixture provides `model_text`, the wrapper calls the implementation's batch parser once, and the harness compares the final `ParseResult`:
+
+```text
+model_text -> parse_tool_calls_batch() -> final calls/text
+```
+
+Stream fixtures are stateful: the fixture provides ordered `chunks`, the wrapper feeds each chunk through the implementation's streaming API, the implementation keeps parser state between chunks, and the wrapper aggregates emitted deltas into the same final `ParseResult` shape used by batch tests:
+
+```text
+chunk N -> parser state -> maybe content/tool delta -> aggregate -> next chunk
+```
+
+That stateful middle is the thing stream parity is trying to test. Concatenating `chunks[*].delta_text` and calling the batch parser would miss boundary bugs: partial start markers, partial argument payloads, tool-call deltas split across chunks, finish-reason timing, and vLLM cases that require `delta_token_ids`.
+
+`tests/parity/common.py` deliberately stays at the final comparison boundary (`ParseResult`, argument decoding, canonical JSON). It can host small shared helpers for aggregating stream tool-call deltas, but it cannot replace the implementation-specific stream state machine. Dynamo stream parity enters Rust through the PyO3 binding; runtime-image pytest must not compile helper binaries with `cargo run`.
 
 ### Method 3 — end-to-end HTTP test *(upcoming, next step — sibling PR #9189)*
 
@@ -159,11 +180,11 @@ somewhere you can browse:
 
 ```bash
 # Markdown — paste into a PR description or browse in any editor.
-python3 tests/parity/parser/generate_parity_chart.py > PARITY.md
+python3 tests/parity/generate_parity_table.py parser > PARITY.md
 
-# HTML — clickable cells link to the source fixture YAML; hover over any
+# HTML table — clickable cells link to the source fixture YAML; hover over any
 # non-= cell to see the case description and the divergence reason.
-python3 tests/parity/parser/generate_parity_chart.py --html > PARITY.html
+python3 tests/parity/generate_parity_table.py parser --html > PARITY.html
 ```
 
 Run from the repo root so the HTML's relative `<a href=...>` links to
@@ -300,7 +321,7 @@ side is wrong. Worked example: `kimi_k2 / PARSER.batch.8.b → V`
 
 ### 1. Pick a cell
 
-Run `generate_parity_chart.py`; pick any `V` / `S` / `VS` cell from the
+Run `generate_parity_table.py`; pick any `V` / `S` / `VS` cell from the
 output.
 
 ### 2. Look up the side-by-side diff in the YAML
@@ -490,7 +511,7 @@ PARSER.batch.8.b:
 Then regenerate the table so the cell flips:
 
 ```bash
-python3 tests/parity/parser/generate_parity_chart.py > PARITY.md
+python3 tests/parity/generate_parity_table.py parser > PARITY.md
 ```
 
 Pytest should now be fully green; the table cell flips to `=`.
@@ -584,7 +605,7 @@ cases:
   Test skips with the message.
 
 The `ref` field is required on per-sub-case files
-(`PARSER.<mode>.<n>.yaml`) and takes one of two forms:
+(`PARSER.<mode>.<n>.yaml`) and takes one of three forms:
 
 - **`ref: originated from <url>`** — there's an upstream test exercising
   this same shape on this same family. The fixture's `model_text` may
@@ -595,8 +616,9 @@ The `ref` field is required on per-sub-case files
 - **`ref: dynamo`** — authored fresh in this repo, no upstream peer.
   Most sub-case taxonomy fillers (`.b` post-only, `.d` between-calls)
   land here because vLLM/SGLang don't test those shapes.
+- **`ref: derived from PARSER.<mode>.<n>[.<sub>]`** — authored in this repo by transforming an existing parity case into a new surface. Streaming fixtures commonly use this when the same `model_text` shape is split into `chunks` or truncated at a stream boundary.
 
-Every sub-case carries one of these two states; there's no "no
+Every sub-case carries one of these three states; there's no "no
 provenance" state. The legacy flat `PARSER.<mode>.yaml` (cases without
 sub-cases) does NOT carry `ref` — those entries predate the convention.
 
@@ -653,7 +675,7 @@ Open any two family files side-by-side and the case shells look
 nearly identical: same `description` strings, same `tools` schemas,
 same case keys `"PARSER.batch.1"`–`"PARSER.batch.10"`. **That's by
 design** — `PARSER.batch.N` is the same logical scenario across every
-family (run `generate_parity_chart.py` for the full list).
+family (run `generate_parity_table.py` for the full list).
 
 So a reviewer can grep `PARSER.batch.4` across all 10 families and
 immediately see how each parser handles the same scenario. The
@@ -841,4 +863,4 @@ real value-add is the cross-impl half (vLLM and SGLang).
    rather than the full volatile message. Add a `reason:` field to
    intentional divergences so they show as `V`/`S` not `V?`/`S?` in the
    table.
-6. Regenerate the table: `python3 tests/parity/parser/generate_parity_chart.py > PARITY.md`.
+6. Regenerate the table: `python3 tests/parity/generate_parity_table.py parser > PARITY.md`.

--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -77,3 +77,19 @@ def decode_arguments(args: Any) -> Any:
         return json.loads(args)
     except (json.JSONDecodeError, TypeError):
         return args
+
+
+def decode_stream_calls(
+    stream_calls: dict[int, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    calls = []
+    for _, call in sorted(stream_calls.items()):
+        if not call.get("name") and not call.get("arguments"):
+            continue
+        calls.append(
+            {
+                "name": call.get("name") or "",
+                "arguments": decode_arguments(call.get("arguments") or ""),
+            }
+        )
+    return calls

--- a/tests/parity/generate_parity_table.py
+++ b/tests/parity/generate_parity_table.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate parity tables for parser stages from one common entrypoint.
+
+Examples:
+    python3 tests/parity/generate_parity_table.py parser --html > tests/parity/parser/PARITY.html
+    python3 tests/parity/generate_parity_table.py parser --mode stream > tests/parity/parser/PARITY.stream.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate Dynamo parity tables.",
+    )
+    parser.add_argument(
+        "stage",
+        choices=("parser",),
+        help="Parity stage to render.",
+    )
+    args, rest = parser.parse_known_args(argv)
+
+    if args.stage == "parser":
+        from tests.parity.parser import table
+
+    table.main(rest)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -36,6 +36,11 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .stats span { font-family: ui-monospace, monospace; font-weight: bold; }
 .generated { color: #888; font-size: 12px; margin-top: -0.5em; }
 .versions { color: #555; font-size: 12px; margin-top: 0.2em; }
+.tabs { display: flex; gap: 4px; border-bottom: 1px solid #ccc; margin: 1em 0; }
+.tab-button { appearance: none; border: 1px solid #ccc; border-bottom: 0; background: #f5f5f5; color: #222; padding: 6px 10px; font: inherit; cursor: pointer; border-radius: 4px 4px 0 0; }
+.tab-button.active { background: #fff; font-weight: 600; position: relative; top: 1px; }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
 .column-control { padding: 2px; }
 .column-control.col-collapsed { background: #eef2f7; min-width: 20px; width: 20px; }
 .col-toggle { border: 1px solid transparent; background: transparent; color: inherit; padding: 2px 5px; border-radius: 4px; font: inherit; cursor: pointer; }
@@ -117,13 +122,22 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   Auto-generated on {{ stamp|e }}{% if sha %} on commit <a href="https://github.com/ai-dynamo/dynamo/commit/{{ sha|e }}"><code>{{ short_sha|e }}</code></a>{% endif %}:
   <code>{{ command|e }} &gt; {{ output|e }}</code>
 </p>
-<table>
+{% if tabs|length > 1 %}
+<div class="tabs" role="tablist">
+{% for tab in tabs %}
+{{ tab|safe }}
+{% endfor %}
+</div>
+{% endif %}
+{% for panel in panels %}
+<section id="{{ panel.id|e }}" class="tab-panel{% if panel.active %} active{% endif %}" role="tabpanel"{% if tabs|length > 1 %} aria-labelledby="{{ panel.id|e }}-button"{% endif %}>
+<table data-parity-table>
 <thead>
-<tr>{{ group_headers|safe }}</tr>
-<tr>{{ sub_headers|safe }}</tr>
+<tr>{{ panel.group_headers|safe }}</tr>
+<tr>{{ panel.sub_headers|safe }}</tr>
 </thead>
 <tbody>
-{% for row in body_rows %}
+{% for row in panel.body_rows %}
 {{ row|safe }}
 {% endfor %}
 </tbody>
@@ -156,43 +170,45 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <strong>Peer parser versions</strong> pinned in
   <a href="../../../pyproject.toml">pyproject.toml</a>:
   {% for name, version in peer_versions %}{% if not loop.first %} · {% endif %}{{ name|e }} <code>{{ version|e }}</code>{% endfor %}.
-  {% endif %}
+{% endif %}
 </p>
 <p class="stats">
-  Stats: {{ stats.families }} families × {{ stats.sub_cases }} sub-cases
-  = {{ stats.slots }} grid slots ({{ stats.na }} n/a, {{ stats.missing }} missing).
-  <strong>{{ stats.real }}</strong> real cases:
-  <span style="color:#0a7d2c">{{ stats.parity }} full parity</span> ·
-  <span style="color:#555">{{ stats.documented }} documented divergences</span>
+  Stats: {{ panel.stats.families }} families × {{ panel.stats.sub_cases }} sub-cases
+  = {{ panel.stats.slots }} grid slots ({{ panel.stats.na }} n/a, {{ panel.stats.missing }} missing).
+  <strong>{{ panel.stats.real }}</strong> real cases:
+  <span style="color:#0a7d2c">{{ panel.stats.parity }} full parity</span> ·
+  <span style="color:#555">{{ panel.stats.documented }} documented divergences</span>
   (have <code>reason:</code>) ·
-  <span style="color:#c63">{{ stats.research }} research-needed</span>
+  <span style="color:#c63">{{ panel.stats.research }} research-needed</span>
   (no <code>reason:</code> yet) ·
-  <span style="color:#b00">{{ stats.errors }} expected-errors</span>.
+  <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
 </p>
-{% if glossary_groups %}
-<h2 id="case-descriptions">Case descriptions</h2>
+{% if panel.glossary_groups %}
+<h2 id="case-descriptions-{{ panel.mode|e }}">Case descriptions</h2>
 <p>Full case definitions:
 <a href="../../../lib/parsers/PARSER_CASES.md">lib/parsers/PARSER_CASES.md</a>.</p>
 <table class="glossary">
 <tbody>
-{% for group in glossary_groups %}
+{% for group in panel.glossary_groups %}
 <tr class="category"><td colspan="2">{{ group.label|e }}</td></tr>
 {% for sub, desc in group.rows %}
-<tr><td class="sub">PARSER.batch.{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
+<tr><td class="sub">PARSER.{{ panel.mode|e }}.{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
 {% endfor %}
 {% endfor %}
 </tbody>
 </table>
 {% endif %}
+</section>
+{% endfor %}
 <script>
 (function () {
   const margin = 8;
   const showDelayMs = 750;
   const hideDelayMs = 750;
   const columnButtons = Array.from(document.querySelectorAll('[data-col-toggle]'));
-  const columnKeys = columnButtons.map(function (button) {
+  const columnKeys = Array.from(new Set(columnButtons.map(function (button) {
     return button.dataset.colToggle;
-  });
+  })));
 
   function defaultVisibleColumns() {
     const visible = new Set();
@@ -278,14 +294,16 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
         el.classList.toggle('col-hidden', isVisible);
       });
     });
-    let visibleColumnCount = 0;
-    columnButtons.forEach(function (button) {
-      const key = button.dataset.colToggle;
-      const span = Number(button.dataset.colSpan || '1');
-      visibleColumnCount += visible.has(key) ? span : 1;
-    });
-    document.querySelectorAll('[data-section-span]').forEach(function (el) {
-      el.colSpan = visibleColumnCount;
+    document.querySelectorAll('table[data-parity-table]').forEach(function (table) {
+      let visibleColumnCount = 0;
+      table.querySelectorAll('[data-col-toggle]').forEach(function (button) {
+        const key = button.dataset.colToggle;
+        const span = Number(button.dataset.colSpan || '1');
+        visibleColumnCount += visible.has(key) ? span : 1;
+      });
+      table.querySelectorAll('[data-section-span]').forEach(function (el) {
+        el.colSpan = visibleColumnCount;
+      });
     });
     if (shouldUpdateUrl) {
       updateUrl(visible);
@@ -307,6 +325,24 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
         visibleColumns.add(key);
       }
       applyColumnState(visibleColumns, true);
+    });
+  });
+
+  const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
+  const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+  function activateTab(id) {
+    tabButtons.forEach(function (button) {
+      const selected = button.dataset.tabTarget === id;
+      button.classList.toggle('active', selected);
+      button.setAttribute('aria-selected', selected ? 'true' : 'false');
+    });
+    tabPanels.forEach(function (panel) {
+      panel.classList.toggle('active', panel.id === id);
+    });
+  }
+  tabButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      activateTab(button.dataset.tabTarget);
     });
   });
 

--- a/tests/parity/parser/capture_parser_outputs.py
+++ b/tests/parity/parser/capture_parser_outputs.py
@@ -12,10 +12,11 @@ Default — DRIFT CHECK (read-only):
     python3 -m tests.parity.parser.capture_parser_outputs --impl dynamo
     python3 -m tests.parity.parser.capture_parser_outputs --impl vllm
     python3 -m tests.parity.parser.capture_parser_outputs --impl sglang
+    python3 -m tests.parity.parser.capture_parser_outputs --impl sglang --mode stream
 
   Compares the parser's live output against the recorded `expected.<impl>`
   block. Exits non-zero on any drift. Use this as a CI gate / pre-flight
-  after a `model_text` edit or an upstream parser bump.
+  after a `model_text` / `chunks` edit or an upstream parser bump.
 
 `--merge` — POPULATE FIXTURES (destructive):
     python3 -m tests.parity.parser.capture_parser_outputs --impl dynamo --merge
@@ -41,6 +42,7 @@ Default — DRIFT CHECK (read-only):
 
 Run inside a container where the target impl is installed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -76,6 +78,11 @@ _ap.add_argument(
     ),
 )
 _ap.add_argument(
+    "--mode",
+    choices=("batch", "stream"),
+    help="Limit capture to fixture mode. Default checks both batch and stream fixtures.",
+)
+_ap.add_argument(
     "--merge",
     action="store_true",
     help=(
@@ -105,6 +112,7 @@ IMPL = _args.impl
 MERGE_MODE = _args.merge
 OVERWRITE = _args.overwrite_if_exists
 FAMILY_FILTER = set(_args.family or [])
+MODE_FILTER = _args.mode
 
 if OVERWRITE and not MERGE_MODE:
     _ap.error("--overwrite-if-exists requires --merge")
@@ -159,10 +167,28 @@ def is_na_stub(case: dict[str, Any]) -> bool:
     )
 
 
-def run_parser(family: str, case: dict) -> dict:
+def run_parser(family: str, mode: str, case: dict) -> dict:
     """Run the parser wrapper. Returns {calls, normal_text, error}."""
     try:
-        got = wrapper.parse(family, case["model_text"], case.get("tools"))
+        if mode == "stream":
+            parse_tool_calls_stream = getattr(wrapper, "parse_tool_calls_stream", None)
+            if parse_tool_calls_stream is None:
+                return {
+                    "calls": None,
+                    "normal_text": None,
+                    "error": f"UNAVAILABLE: {IMPL} wrapper has no parse_tool_calls_stream",
+                }
+            got = parse_tool_calls_stream(family, case["chunks"], case.get("tools"))
+        elif mode == "batch":
+            got = wrapper.parse_tool_calls_batch(
+                family, case["model_text"], case.get("tools")
+            )
+        else:
+            return {
+                "calls": None,
+                "normal_text": None,
+                "error": f"PYTHON_EXC: unsupported parser mode {mode!r}",
+            }
         return {
             "calls": [serialize(c) for c in (got.calls or [])],
             "normal_text": got.normal_text,
@@ -295,6 +321,16 @@ def _emit_yaml(fp: Path, doc: dict[str, Any]) -> None:
     fp.write_text(header + "\n" + body, encoding="utf-8")
 
 
+def _build_output_block(got: dict) -> dict | None:
+    """Translate one parser output into a standalone YAML expected block."""
+    err = got.get("error")
+    if err and err.startswith("UNAVAILABLE:"):
+        return {"unavailable": err[len("UNAVAILABLE:") :].strip()}
+    if err:
+        return None
+    return normalize_output(got)
+
+
 def _build_merged_block(got: dict, dyn: dict) -> dict | None:
     """Translate parser output into a YAML-ready expected.<impl> block.
 
@@ -303,11 +339,11 @@ def _build_merged_block(got: dict, dyn: dict) -> dict | None:
     `{error: <substring>}` block; auto-generating one would bake a
     fragile substring into the fixture).
     """
-    err = got.get("error")
-    if err and err.startswith("UNAVAILABLE:"):
-        return {"unavailable": err[len("UNAVAILABLE:") :].strip()}
-    if err:
+    block = _build_output_block(got)
+    if block is None:
         return None
+    if "unavailable" in block:
+        return block
     n_got = normalize_output(got)
     n_dyn = normalize_output(dyn)
     if n_got == n_dyn:
@@ -330,6 +366,8 @@ def merge_into_fixtures(
         family = doc["family"]
         if FAMILY_FILTER and family not in FAMILY_FILTER:
             continue
+        if MODE_FILTER and doc.get("mode") != MODE_FILTER:
+            continue
         cases = doc.get("cases") or {}
         changed = False
         for case_id, case in cases.items():
@@ -342,17 +380,20 @@ def merge_into_fixtures(
             existing = (
                 case.get("expected") if isinstance(case.get("expected"), dict) else {}
             )
+            if IMPL in existing and not overwrite:
+                n_skipped_existing += 1
+                continue
             dyn = existing.get("dynamo")
-            if not isinstance(dyn, dict):
+            if IMPL == "dynamo":
+                block = _build_output_block(got)
+            elif isinstance(dyn, dict):
+                block = _build_merged_block(got, dyn)
+            else:
                 print(
                     f"  SKIP {key}: no `expected.dynamo` to compare against",
                     file=sys.stderr,
                 )
                 continue
-            if IMPL in existing and not overwrite:
-                n_skipped_existing += 1
-                continue
-            block = _build_merged_block(got, dyn)
             if block is None:
                 print(
                     f"  SKIP {key}: parser errored — record "
@@ -387,13 +428,15 @@ def main() -> int:
         family = doc["family"]
         if FAMILY_FILTER and family not in FAMILY_FILTER:
             continue
+        if MODE_FILTER and doc.get("mode") != MODE_FILTER:
+            continue
         for case_id, case in doc["cases"].items():
             key = f"{family}/{case_id}"
             if is_na_stub(case):
                 n_skipped_na += 1
                 continue
             n_total += 1
-            got = run_parser(family, case)
+            got = run_parser(family, doc["mode"], case)
             all_outputs[key] = got
             if got["error"]:
                 if got["error"].startswith("PYTHON_EXC:"):
@@ -408,8 +451,11 @@ def main() -> int:
                     drift.append((key, d))
 
     if FAMILY_FILTER and n_total == 0:
+        scope = f"family={', '.join(sorted(FAMILY_FILTER))}"
+        if MODE_FILTER:
+            scope += f" mode={MODE_FILTER}"
         print(
-            f"ERROR: --family matched no cases: {', '.join(sorted(FAMILY_FILTER))}",
+            f"ERROR: filter matched no cases: {scope}",
             file=sys.stderr,
         )
         return 2

--- a/tests/parity/parser/dynamo.py
+++ b/tests/parity/parser/dynamo.py
@@ -6,25 +6,49 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
+import importlib.util
 import json
 from typing import Any
 
-from dynamo._core import parse_tool_call
 from tests.parity.common import ParseResult, decode_arguments
 
+_DYNAMO_CORE_SPEC = (
+    importlib.util.find_spec("dynamo._core")
+    if importlib.util.find_spec("dynamo") is not None
+    else None
+)
 
-def parse(
+
+def _load_dynamo_core() -> Any | None:
+    if _DYNAMO_CORE_SPEC is None:
+        return None
+    try:
+        return importlib.import_module("dynamo._core")
+    except (ImportError, OSError):
+        return None
+
+
+_DYNAMO_CORE = _load_dynamo_core()
+
+
+def parse_tool_calls_batch(
     parser_family: str,
     raw_text: str,
     tools: list[dict[str, Any]] | None,
 ) -> ParseResult:
+    if _DYNAMO_CORE is None:
+        return ParseResult(error="UNAVAILABLE: dynamo._core is not installed")
+
     tools_json = json.dumps(tools) if tools else None
 
     try:
         # The PyO3 binding returns a future that registers with a running
         # event loop, so we must call it from inside an async context.
         async def _run() -> str:
-            return await parse_tool_call(parser_family, raw_text, tools_json)
+            return await _DYNAMO_CORE.parse_tool_calls_batch(
+                parser_family, raw_text, tools_json
+            )
 
         result_json: str = asyncio.run(_run())
         raw = json.loads(result_json)
@@ -35,6 +59,38 @@ def parse(
         {
             "name": c["function"]["name"],
             "arguments": decode_arguments(c["function"]["arguments"]),
+        }
+        for c in raw.get("calls") or []
+    ]
+    return ParseResult(calls=calls, normal_text=raw.get("normal_text"))
+
+
+def parse_tool_calls_stream(
+    parser_family: str,
+    chunks: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    if _DYNAMO_CORE is None:
+        return ParseResult(error="UNAVAILABLE: dynamo._core is not installed")
+
+    tools_json = json.dumps(tools) if tools else None
+
+    try:
+
+        async def _run() -> str:
+            return await _DYNAMO_CORE.parse_tool_calls_stream(
+                parser_family, json.dumps(chunks), tools_json
+            )
+
+        result_json: str = asyncio.run(_run())
+        raw = json.loads(result_json)
+    except Exception as e:
+        return ParseResult(error=f"{type(e).__name__}: {e}")
+
+    calls = [
+        {
+            "name": c["name"],
+            "arguments": decode_arguments(c["arguments"]),
         }
         for c in raw.get("calls") or []
     ]

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -52,7 +52,7 @@ from sglang.srt.function_call.qwen25_detector import (
     Qwen25Detector,  # type: ignore[import-untyped]
 )
 
-from tests.parity.common import ParseResult, decode_arguments
+from tests.parity.common import ParseResult, decode_arguments, decode_stream_calls
 
 # Maps parser_family → SGLang detector class. SGLang doesn't have a registry-by-name
 # like vLLM; the class is imported directly.
@@ -77,7 +77,7 @@ _FAMILY_TO_SGLANG_DETECTOR = {
 # deepseek_v4, jamba, phi4.
 
 
-def parse(
+def parse_tool_calls_batch(
     parser_family: str,
     raw_text: str,
     tools: list[dict[str, Any]] | None,
@@ -110,6 +110,50 @@ def parse(
         for tc in info.calls or []
     ]
     return ParseResult(calls=calls, normal_text=info.normal_text)
+
+
+def parse_tool_calls_stream(
+    parser_family: str,
+    chunks: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    detector_cls = _FAMILY_TO_SGLANG_DETECTOR.get(parser_family)
+    if detector_cls is None:
+        return ParseResult(
+            error=f"UNAVAILABLE: SGLang has no detector for family={parser_family!r}"
+        )
+
+    normal_text_parts: list[str] = []
+    stream_calls: dict[int, dict[str, Any]] = {}
+
+    try:
+        detector = detector_cls()
+        sg_tools = _build_tools(tools)
+        for chunk in chunks:
+            info = detector.parse_streaming_increment(
+                chunk.get("delta_text") or "", sg_tools
+            )
+            if info.normal_text:
+                normal_text_parts.append(info.normal_text)
+            for position, tool_call in enumerate(info.calls or []):
+                index = int(getattr(tool_call, "tool_index", position) or 0)
+                call = stream_calls.setdefault(index, {"name": None, "arguments": ""})
+                if tool_call.name:
+                    call["name"] = tool_call.name
+                arguments = getattr(tool_call, "parameters", None) or getattr(
+                    tool_call, "arguments", None
+                )
+                if isinstance(arguments, str):
+                    call["arguments"] += arguments
+                elif arguments:
+                    call["arguments"] = arguments
+    except Exception as e:
+        return ParseResult(error=f"{type(e).__name__}: {e}")
+
+    return ParseResult(
+        calls=decode_stream_calls(stream_calls),
+        normal_text="".join(normal_text_parts),
+    )
 
 
 def _build_tools(tools: list[dict[str, Any]] | None) -> list[Any] | None:

--- a/tests/parity/parser/table.py
+++ b/tests/parity/parser/table.py
@@ -37,13 +37,15 @@ from `expected.<impl>.unavailable` across each family's cases.
 
 Run:
     # Markdown table to stdout
-    python3 tests/parity/parser/generate_parity_chart.py \
+    python3 tests/parity/generate_parity_table.py parser \
         > tests/parity/parser/PARITY.md
+    python3 tests/parity/generate_parity_table.py parser --mode stream \
+        > tests/parity/parser/PARITY.stream.md
 
-    # HTML table with clickable YAML links + hover tooltips. Write next
+    # HTML table with tabs, clickable YAML links, and hover tooltips. Write next
     # to this script so `<a href="fixtures/<family>/PARSER.batch.N.yaml">`
     # resolves when opened in a browser.
-    python3 tests/parity/parser/generate_parity_chart.py --html \
+    python3 tests/parity/generate_parity_table.py parser --html \
         > tests/parity/parser/PARITY.html
 
 PARITY.{md,html} are for local viewing only; don't check them in.
@@ -67,14 +69,14 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests/parity/parser/fixtures"
 PARSER_CASES_MD = REPO_ROOT / "lib/parsers/PARSER_CASES.md"
 PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
-SCRIPT_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = REPO_ROOT / "tests/parity"
 
 RUST_TOOL_CALLING_DIR = REPO_ROOT / "lib/parsers/src/tool_calling"
 
 
 def _make_jinja_env() -> Environment:
     return Environment(
-        loader=FileSystemLoader(SCRIPT_DIR),
+        loader=FileSystemLoader(TEMPLATE_DIR),
         trim_blocks=False,
         lstrip_blocks=True,
         undefined=StrictUndefined,
@@ -304,7 +306,7 @@ TOP_N_FAMILIES = [
     "qwen3_coder",
 ]
 
-SUB_CASE_GROUPS = [
+BATCH_SUB_CASE_GROUPS = [
     ("Core", ("1", "3", "9", "9.a", "9.b")),
     ("Multi-call", ("2.a", "2.b", "2.c", "2.d", "10")),
     (
@@ -342,30 +344,54 @@ SPLIT_PARENT_SUBCASES = {
     "13": ("13.a",),
 }
 
-_SUB_CASE_GROUP_KEY_BY_LABEL = {
-    label: re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
-    for label, _subs in SUB_CASE_GROUPS
+STREAM_SUB_CASE_GROUPS = [
+    ("Single-call", ("1.a", "1.b")),
+    ("Multi-call", ("2",)),
+    ("Partial-token", ("3",)),
+    ("Termination", ("4.a", "4.b")),
+]
+
+SUB_CASE_GROUPS_BY_MODE = {
+    "batch": BATCH_SUB_CASE_GROUPS,
+    "stream": STREAM_SUB_CASE_GROUPS,
 }
 
-_SUB_CASE_DISPLAY_ORDER = {
-    sub: (group_idx, sub_idx)
-    for group_idx, (_label, subs) in enumerate(SUB_CASE_GROUPS)
-    for sub_idx, sub in enumerate(subs)
+_SUB_CASE_GROUP_KEY_BY_LABEL_BY_MODE = {
+    mode: {
+        label: re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
+        for label, _subs in groups
+    }
+    for mode, groups in SUB_CASE_GROUPS_BY_MODE.items()
 }
 
-_SUB_CASE_GROUP_INDEX_BY_SUB = {
-    sub: group_idx
-    for group_idx, (_label, subs) in enumerate(SUB_CASE_GROUPS)
-    for sub in subs
+_SUB_CASE_GROUP_KEY_BY_SUB_BY_MODE = {
+    mode: {
+        sub: _SUB_CASE_GROUP_KEY_BY_LABEL_BY_MODE[mode][label]
+        for label, subs in groups
+        for sub in subs
+    }
+    for mode, groups in SUB_CASE_GROUPS_BY_MODE.items()
 }
 
-_SUB_CASE_GROUP_BY_SUB = {sub: label for label, subs in SUB_CASE_GROUPS for sub in subs}
 
-_SUB_CASE_GROUP_KEY_BY_SUB = {
-    sub: _SUB_CASE_GROUP_KEY_BY_LABEL[label]
-    for label, subs in SUB_CASE_GROUPS
-    for sub in subs
-}
+def _display_order(mode: str) -> dict[str, tuple[int, int]]:
+    return {
+        sub: (group_idx, sub_idx)
+        for group_idx, (_label, subs) in enumerate(SUB_CASE_GROUPS_BY_MODE[mode])
+        for sub_idx, sub in enumerate(subs)
+    }
+
+
+def _group_index_by_sub(mode: str) -> dict[str, int]:
+    return {
+        sub: group_idx
+        for group_idx, (_label, subs) in enumerate(SUB_CASE_GROUPS_BY_MODE[mode])
+        for sub in subs
+    }
+
+
+def _group_by_sub(mode: str) -> dict[str, str]:
+    return {sub: label for label, subs in SUB_CASE_GROUPS_BY_MODE[mode] for sub in subs}
 
 
 def _natural_sub_sort_key(sub: str) -> tuple[int, str]:
@@ -374,9 +400,9 @@ def _natural_sub_sort_key(sub: str) -> tuple[int, str]:
     return (int(parts[0]), parts[1] if len(parts) > 1 else "")
 
 
-def _sub_sort_key(sub: str) -> tuple[int, int, int, str]:
+def _sub_sort_key(mode: str, sub: str) -> tuple[int, int, int, str]:
     """Sort known cases by semantic display group, future cases naturally last."""
-    display_order = _SUB_CASE_DISPLAY_ORDER.get(sub)
+    display_order = _display_order(mode).get(sub)
     if display_order is not None:
         group_idx, sub_idx = display_order
         return (0, group_idx, sub_idx, "")
@@ -384,18 +410,20 @@ def _sub_sort_key(sub: str) -> tuple[int, int, int, str]:
     return (1, num, 0, suffix)
 
 
-def _subcase_band_class(sub: str) -> str:
-    group_idx = _SUB_CASE_GROUP_INDEX_BY_SUB.get(sub, len(SUB_CASE_GROUPS))
+def _subcase_band_class(mode: str, sub: str) -> str:
+    group_idx = _group_index_by_sub(mode).get(sub, len(SUB_CASE_GROUPS_BY_MODE[mode]))
     return f"case-band-{group_idx % 2}"
 
 
-def _subcase_group_key(sub: str) -> str:
-    return _SUB_CASE_GROUP_KEY_BY_SUB.get(sub, "other")
+def _subcase_group_key(mode: str, sub: str) -> str:
+    return _SUB_CASE_GROUP_KEY_BY_SUB_BY_MODE[mode].get(sub, "other")
 
 
-def _discover_sub_cases(cases: dict) -> list[str]:
+def _discover_sub_cases(mode: str, cases: dict) -> list[str]:
     """Union of sub-case IDs across all loaded fixtures, in stable order."""
-    return sorted({sub for _fam, sub in cases.keys()}, key=_sub_sort_key)
+    return sorted(
+        {sub for _fam, sub in cases.keys()}, key=lambda s: _sub_sort_key(mode, s)
+    )
 
 
 def _normalize_split_parent_cases(cases: dict) -> dict:
@@ -475,8 +503,8 @@ def family_suffix(fam: str, no_vllm: set[str], no_sglang: set[str]) -> str:
     return suff
 
 
-def load_all_cases() -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
-    """Load every batch fixture YAML.
+def load_all_cases(mode: str) -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
+    """Load every fixture YAML for one parser mode.
 
     Returns `(cases, labels)`:
       cases  — `{(family, sub_case_id): case_data}`; each case dict gets
@@ -489,17 +517,17 @@ def load_all_cases() -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
     cases: dict[tuple[str, str], dict] = {}
     labels: dict[str, str] = {}
     script_dir = Path(__file__).resolve().parent
-    for fp in sorted(FIXTURES.glob("*/PARSER.batch*.yaml")):
+    for fp in sorted(FIXTURES.glob(f"*/PARSER.{mode}*.yaml")):
         doc = yaml.safe_load(fp.read_text())
-        if doc.get("mode", "batch") != "batch":
+        if doc.get("mode") != mode:
             continue
         family = doc["family"]
         rel = str(fp.relative_to(script_dir))
         if "model_label" in doc:
             labels.setdefault(family, doc["model_label"])
         for cid, case in doc["cases"].items():
-            sub = cid.replace("PARSER.batch.", "")
             case["__family"] = family
+            sub = cid.replace(f"PARSER.{mode}.", "")
             case["__fixture_path"] = rel
             case["__case_id"] = cid
             cases[(family, sub)] = case
@@ -933,6 +961,22 @@ def _build_tooltip_html(case: dict, dyn) -> str:
         parts.append(
             f"<pre class=\"ttip-pre\">input_text='{_colorize_markup(model_text, family)}'</pre>"
         )
+    chunks = case.get("chunks")
+    if isinstance(chunks, list) and chunks:
+        parts.append('<div class="ttip-section">Input chunks:</div>')
+        chunk_lines = []
+        for i, chunk in enumerate(chunks):
+            if not isinstance(chunk, dict):
+                continue
+            delta = chunk.get("delta_text") or ""
+            suffix = ""
+            if chunk.get("finish_reason"):
+                suffix = " finish_reason=" + html_lib.escape(
+                    str(chunk["finish_reason"])
+                )
+            chunk_lines.append(f"{i}: delta_text='{_colorize_xml(delta)}'{suffix}")
+        chunk_text = "\n".join(chunk_lines)
+        parts.append(f'<pre class="ttip-pre">{chunk_text}</pre>')
 
     expected = case.get("expected") or {}
 
@@ -1055,14 +1099,14 @@ def _build_na_tooltip_html(case: dict) -> str:
     return "".join(parts)
 
 
-def _build_missing_tooltip_html(family: str, sub: str) -> str:
+def _build_missing_tooltip_html(mode: str, family: str, sub: str) -> str:
     """Tooltip for an absent fixture entry.
 
     This is intentionally distinct from an explicit n/a stub. Missing means
     the table has no fixture data for this family/case; explicit n/a means a
     fixture author recorded why the case does not apply.
     """
-    case_id = f"PARSER.batch.{sub}"
+    case_id = f"PARSER.{mode}.{sub}"
     parts = ['<div class="ttip">']
     parts.append(
         f'<div class="ttip-head">{html_lib.escape(case_id)} — '
@@ -1078,14 +1122,14 @@ def _build_missing_tooltip_html(family: str, sub: str) -> str:
     return "".join(parts)
 
 
-def render_cell_html(case: dict | None, family: str, sub: str) -> str:
+def render_cell_html(case: dict | None, mode: str, family: str, sub: str) -> str:
     text = cell_for(case)
     cls = _cell_class(text)
-    band_cls = _subcase_band_class(sub)
-    col_group = html_lib.escape(_subcase_group_key(sub))
+    band_cls = _subcase_band_class(mode, sub)
+    col_group = html_lib.escape(_subcase_group_key(mode, sub))
     td_open = f'<td class="cell {cls} {band_cls}" data-col-hide-group="{col_group}">'
     if case is None:
-        ttip = _build_missing_tooltip_html(family, sub)
+        ttip = _build_missing_tooltip_html(mode, family, sub)
         return f"{td_open}{text}{ttip}</td>"
 
     dyn = case.get("expected", {}).get("dynamo")
@@ -1278,6 +1322,7 @@ def _parser_cell_html(
 def render_row_html(
     model: str,
     family: str,
+    mode: str,
     cases: dict,
     sub_cases: list[str],
     refs: dict[str, tuple[str, int]],
@@ -1291,28 +1336,30 @@ def render_row_html(
         _parser_cell_html(family, refs, no_vllm, no_sglang, inheritance),
         _column_placeholder_html("parser"),
     ]
-    for run in _subcase_runs(sub_cases):
+    for run in _subcase_runs(mode, sub_cases):
         cells.extend(
-            render_cell_html(cases.get((family, sub)), family, sub) for sub in run
+            render_cell_html(cases.get((family, sub)), mode, family, sub) for sub in run
         )
-        cells.append(_column_placeholder_html(_subcase_group_key(run[0])))
+        cells.append(_column_placeholder_html(_subcase_group_key(mode, run[0])))
     cells.append("</tr>")
     return "".join(cells)
 
 
-def _parse_subcase_descriptions() -> dict[str, str]:
+def _parse_subcase_descriptions(mode: str) -> dict[str, str]:
     """Parse `lib/parsers/PARSER_CASES.md` for per-case descriptions.
 
     The Quick-reference section has one-liner bullets for top-level cases
-    (`PARSER.batch.1` … `PARSER.batch.10`); the deeper per-case sections
+    (`PARSER.<mode>.1` …); the deeper per-case sections
     contain multi-line bullets for sub-cases (`2.a`, `4.c`, etc.). Both
-    look like `- **`PARSER.batch.X`** <desc>`, where the bullet body may
+    look like `- **`PARSER.<mode>.X`** <desc>`, where the bullet body may
     wrap across indented continuation lines. Returns
     `{"1": "...", "2.a": "...", ...}`.
     """
     if not PARSER_CASES_MD.exists():
         return {}
-    pat = re.compile(r"\*\*`PARSER\.batch\.([0-9]+(?:\.[a-z])?)`\*\*\s+(.+)")
+    pat = re.compile(
+        rf"\*\*`PARSER\.{re.escape(mode)}\.([0-9]+(?:\.[a-z])?)`\*\*\s+(.+)"
+    )
     out: dict[str, str] = {}
     lines = PARSER_CASES_MD.read_text(encoding="utf-8").splitlines()
     i = 0
@@ -1341,29 +1388,31 @@ def _parse_subcase_descriptions() -> dict[str, str]:
     return out
 
 
-def _subcase_header_html(sub: str, descriptions: dict[str, str]) -> str:
+def _subcase_header_html(mode: str, sub: str, descriptions: dict[str, str]) -> str:
     desc = descriptions.get(sub) or descriptions.get(sub.split(".")[0]) or ""
     href = "../../../lib/parsers/PARSER_CASES.md"
     title = html_lib.escape(desc) if desc else ""
-    band_cls = _subcase_band_class(sub)
-    col_group = html_lib.escape(_subcase_group_key(sub))
+    band_cls = _subcase_band_class(mode, sub)
+    col_group = html_lib.escape(_subcase_group_key(mode, sub))
     return (
         f'<th class="case-sub {band_cls}" data-col-hide-group="{col_group}">'
         f'<a href="{href}" title="{title}">{html_lib.escape(sub)}</a></th>'
     )
 
 
-def _subcase_group_label(sub: str) -> str:
-    return _SUB_CASE_GROUP_BY_SUB.get(sub, "Other")
+def _subcase_group_label(mode: str, sub: str) -> str:
+    return _group_by_sub(mode).get(sub, "Other")
 
 
-def _subcase_runs(sub_cases: list[str]) -> list[list[str]]:
+def _subcase_runs(mode: str, sub_cases: list[str]) -> list[list[str]]:
     runs: list[list[str]] = []
     start = 0
     while start < len(sub_cases):
-        label = _subcase_group_label(sub_cases[start])
+        label = _subcase_group_label(mode, sub_cases[start])
         end = start + 1
-        while end < len(sub_cases) and _subcase_group_label(sub_cases[end]) == label:
+        while (
+            end < len(sub_cases) and _subcase_group_label(mode, sub_cases[end]) == label
+        ):
             end += 1
         runs.append(sub_cases[start:end])
         start = end
@@ -1408,16 +1457,16 @@ def _column_control_header_html(
     )
 
 
-def _subcase_group_headers_html(sub_cases: list[str]) -> str:
+def _subcase_group_headers_html(mode: str, sub_cases: list[str]) -> str:
     """Build semantic group headers spanning the displayed sub-case columns."""
     spans: list[str] = [
         _column_control_header_html("model", "Model", default_visible=False),
         _column_control_header_html("parser", "Parser", default_visible=True),
     ]
-    for run in _subcase_runs(sub_cases):
-        label = _subcase_group_label(run[0])
-        band_cls = _subcase_band_class(run[0])
-        col_group = html_lib.escape(_subcase_group_key(run[0]))
+    for run in _subcase_runs(mode, sub_cases):
+        label = _subcase_group_label(mode, run[0])
+        band_cls = _subcase_band_class(mode, run[0])
+        col_group = html_lib.escape(_subcase_group_key(mode, run[0]))
         spans.append(
             _column_control_header_html(
                 col_group,
@@ -1430,22 +1479,26 @@ def _subcase_group_headers_html(sub_cases: list[str]) -> str:
     return "".join(spans)
 
 
-def _subcase_headers_html(sub_cases: list[str], descriptions: dict[str, str]) -> str:
+def _subcase_headers_html(
+    mode: str, sub_cases: list[str], descriptions: dict[str, str]
+) -> str:
     headers: list[str] = []
-    for run in _subcase_runs(sub_cases):
-        headers.extend(_subcase_header_html(sub, descriptions) for sub in run)
-        headers.append(_column_placeholder_html(_subcase_group_key(run[0]), tag="th"))
+    for run in _subcase_runs(mode, sub_cases):
+        headers.extend(_subcase_header_html(mode, sub, descriptions) for sub in run)
+        headers.append(
+            _column_placeholder_html(_subcase_group_key(mode, run[0]), tag="th")
+        )
     return "".join(headers)
 
 
 def _glossary_groups(
-    descriptions: dict[str, str], sub_cases: list[str]
+    mode: str, descriptions: dict[str, str], sub_cases: list[str]
 ) -> list[dict[str, object]]:
     if not descriptions:
         return []
     return [
         {
-            "label": _subcase_group_label(run[0]),
+            "label": _subcase_group_label(mode, run[0]),
             "rows": [
                 (
                     sub,
@@ -1454,7 +1507,7 @@ def _glossary_groups(
                 for sub in run
             ],
         }
-        for run in _subcase_runs(sub_cases)
+        for run in _subcase_runs(mode, sub_cases)
     ]
 
 
@@ -1502,21 +1555,31 @@ def _compute_stats(
     return s
 
 
-def render_html(
+def _mode_label(mode: str) -> str:
+    if mode == "batch":
+        return "PARSER.batch.*"
+    if mode == "stream":
+        return "PARSER.stream.*"
+    return mode
+
+
+def render_html_panel(
+    mode: str,
     cases: dict,
     sub_cases: list[str],
     no_vllm: set[str],
     no_sglang: set[str],
     top_n: list[tuple[str, str]],
     others: list[tuple[str, str]],
-    family_filter: str | None = None,
-) -> str:
-    descriptions = _parse_subcase_descriptions()
+    active: bool = False,
+) -> dict[str, object]:
+    """Render one tab panel for one parser fixture mode."""
+    descriptions = _parse_subcase_descriptions(mode)
     refs = _build_family_to_rust_ref()
     inheritance = _build_family_inheritance(refs)
 
-    group_headers = _subcase_group_headers_html(sub_cases)
-    sub_headers = _subcase_headers_html(sub_cases, descriptions)
+    group_headers = _subcase_group_headers_html(mode, sub_cases)
+    sub_headers = _subcase_headers_html(mode, sub_cases, descriptions)
     n_cols = 2 + len(sub_cases)
 
     body_rows: list[str] = []
@@ -1528,7 +1591,15 @@ def render_html(
     for model, fam in top_n:
         body_rows.append(
             render_row_html(
-                model, fam, cases, sub_cases, refs, no_vllm, no_sglang, inheritance
+                model,
+                fam,
+                mode,
+                cases,
+                sub_cases,
+                refs,
+                no_vllm,
+                no_sglang,
+                inheritance,
             )
         )
     if others:
@@ -1539,21 +1610,84 @@ def render_html(
     for model, fam in others:
         body_rows.append(
             render_row_html(
-                model, fam, cases, sub_cases, refs, no_vllm, no_sglang, inheritance
+                model,
+                fam,
+                mode,
+                cases,
+                sub_cases,
+                refs,
+                no_vllm,
+                no_sglang,
+                inheritance,
             )
         )
 
     all_families = [fam for _, fam in top_n] + [fam for _, fam in others]
     stats = _compute_stats(cases, sub_cases, all_families)
 
+    panel_id = f"tab-{mode}"
+    return {
+        "id": panel_id,
+        "mode": mode,
+        "label": _mode_label(mode),
+        "active": active,
+        "group_headers": group_headers,
+        "sub_headers": sub_headers,
+        "body_rows": body_rows,
+        "stats": stats,
+        "glossary_groups": _glossary_groups(mode, descriptions, sub_cases),
+    }
+
+
+def _filter_family(
+    cases: dict[tuple[str, str], dict],
+    labels: dict[str, str],
+    family_filter: str | None,
+) -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
+    if family_filter is None:
+        return cases, labels
+    return (
+        {k: v for k, v in cases.items() if k[0] == family_filter},
+        {k: v for k, v in labels.items() if k == family_filter},
+    )
+
+
+def _load_html_panel(
+    mode: str,
+    active: bool = False,
+    family_filter: str | None = None,
+) -> tuple[str, dict[str, object], bool]:
+    cases, labels = load_all_cases(mode)
+    cases, labels = _filter_family(cases, labels, family_filter)
+    has_cases = bool(cases)
+    sub_cases = _discover_sub_cases(mode, cases)
+    no_vllm, no_sglang = _derive_no_peer_sets(cases)
+    top_n, others = _build_display_groups(cases, labels)
+    return (
+        mode,
+        render_html_panel(
+            mode, cases, sub_cases, no_vllm, no_sglang, top_n, others, active
+        ),
+        has_cases,
+    )
+
+
+def render_html(modes: list[str], family_filter: str | None = None) -> str:
+    panels = [
+        _load_html_panel(mode, active=(i == 0), family_filter=family_filter)
+        for i, mode in enumerate(modes)
+    ]
+    if family_filter and not any(has_cases for _mode, _panel, has_cases in panels):
+        raise SystemExit(f"no parser fixtures found for family={family_filter!r}")
+
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")
     title = (
-        f"Dynamo {family_filter} Parser Parity Table"
+        f"Dynamo {family_filter} Tool Call Parser - Parity Table"
         if family_filter
-        else "Dynamo Parser Parity Table"
+        else "Dynamo Tool Call Parser - Parity Table"
     )
-    command = "python3 tests/parity/parser/generate_parity_chart.py --html"
+    command = "python3 tests/parity/generate_parity_table.py parser --html"
     output = "tests/parity/parser/PARITY.html"
     if family_filter:
         command += f" --family {family_filter}"
@@ -1561,9 +1695,26 @@ def render_html(
 
     sha = _commit_sha()
 
+    if len(modes) == 1:
+        command += f" --mode {modes[0]}"
+        output = f"tests/parity/parser/PARITY.{modes[0]}.html"
+        if family_filter:
+            output = f"tests/parity/parser/PARITY.{family_filter}.{modes[0]}.html"
+
+    tabs = []
+    for i, (mode, _panel, _has_cases) in enumerate(panels):
+        panel_id = f"tab-{mode}"
+        active = " active" if i == 0 else ""
+        selected = "true" if i == 0 else "false"
+        tabs.append(
+            f'<button class="tab-button{active}" id="{panel_id}-button" '
+            f'type="button" role="tab" aria-selected="{selected}" '
+            f'data-tab-target="{panel_id}">{html_lib.escape(_mode_label(mode))}</button>'
+        )
+
     return (
         _make_jinja_env()
-        .get_template("parity_chart.html.j2")
+        .get_template("parity_table.html.j2")
         .render(
             title=title,
             stamp=stamp,
@@ -1571,17 +1722,14 @@ def render_html(
             short_sha=sha[:12] if sha else "",
             command=command,
             output=output,
-            group_headers=group_headers,
-            sub_headers=sub_headers,
-            body_rows=body_rows,
+            tabs=tabs,
+            panels=[panel for _mode, panel, _has_cases in panels],
             peer_versions=_peer_version_items(_peer_versions()),
-            stats=stats,
-            glossary_groups=_glossary_groups(descriptions, sub_cases),
         )
     )
 
 
-def main():
+def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     p.add_argument(
         "--html",
@@ -1592,31 +1740,33 @@ def main():
         "--family",
         help="Render only one parser family, e.g. harmony.",
     )
-    args = p.parse_args()
+    p.add_argument(
+        "--mode",
+        choices=("all", "batch", "stream"),
+        help=(
+            "Fixture mode to render. For HTML, default is all parser modes as "
+            "tabs. For Markdown, default is batch."
+        ),
+    )
+    args = p.parse_args(argv)
 
-    cases, labels = load_all_cases()
-    if args.family:
-        cases = {k: v for k, v in cases.items() if k[0] == args.family}
-        labels = {k: v for k, v in labels.items() if k == args.family}
-        if not cases:
-            raise SystemExit(f"no parser fixtures found for family={args.family!r}")
-    sub_cases = _discover_sub_cases(cases)
+    if args.html:
+        modes = ["batch", "stream"] if args.mode in (None, "all") else [args.mode]
+        print(render_html(modes, family_filter=args.family))
+        return
+
+    if args.mode == "all":
+        p.error("--mode all is only supported with --html")
+    mode = args.mode or "batch"
+
+    cases, labels = load_all_cases(mode)
+    cases, labels = _filter_family(cases, labels, args.family)
+    if args.family and not cases:
+        raise SystemExit(f"no parser fixtures found for family={args.family!r}")
+    sub_cases = _discover_sub_cases(mode, cases)
     no_vllm, no_sglang = _derive_no_peer_sets(cases)
     top_n, others = _build_display_groups(cases, labels)
-    if args.html:
-        print(
-            render_html(
-                cases,
-                sub_cases,
-                no_vllm,
-                no_sglang,
-                top_n,
-                others,
-                family_filter=args.family,
-            )
-        )
-    else:
-        print(render_markdown(cases, sub_cases, no_vllm, no_sglang, top_n, others))
+    print(render_markdown(cases, sub_cases, no_vllm, no_sglang, top_n, others))
 
 
 if __name__ == "__main__":

--- a/tests/parity/parser/test_generate_parity_table.py
+++ b/tests/parity/parser/test_generate_parity_table.py
@@ -18,7 +18,7 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-GENERATOR = REPO_ROOT / "tests/parity/parser/generate_parity_chart.py"
+GENERATOR = REPO_ROOT / "tests/parity/generate_parity_table.py"
 
 
 class LinkCollector(HTMLParser):
@@ -38,20 +38,9 @@ class LinkCollector(HTMLParser):
                 self.hrefs.append(value)
 
 
+@pytest.mark.timeout(60)
 def test_generate_parser_parity_table_html() -> None:
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(GENERATOR.relative_to(REPO_ROOT)),
-            "--html",
-        ],
-        cwd=REPO_ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    html = result.stdout
+    html = _render_html()
     links = LinkCollector()
     links.feed(html)
     fixture_links = [href for href in links.hrefs if href.startswith("fixtures/")]
@@ -59,11 +48,42 @@ def test_generate_parser_parity_table_html() -> None:
 
     assert "<html" in html.lower()
     assert "<table" in html.lower()
-    assert "Dynamo Parser Parity Table" in html
-    assert "generate_parity_chart.py --html" in html
+    assert "Dynamo Tool Call Parser - Parity Table" in html
+    assert "generate_parity_table.py parser --html" in html
+    assert "PARSER.batch.*" in html
+    assert "PARSER.stream.*" in html
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families
     assert "qwen3_coder" in fixture_families
+    assert any("/PARSER.batch" in href for href in fixture_links)
+    assert any("/PARSER.stream" in href for href in fixture_links)
+
+
+@pytest.mark.timeout(60)
+def test_generate_parser_parity_table_batch_mode_excludes_stream_links() -> None:
+    html = _render_html("--mode", "batch")
+    links = LinkCollector()
+    links.feed(html)
+    fixture_links = [href for href in links.hrefs if href.startswith("fixtures/")]
+
+    assert fixture_links
     assert all("/PARSER.batch" in href for href in fixture_links)
     assert all("PARSER.stream." not in href for href in fixture_links)
+
+
+def _render_html(*extra_args: str) -> str:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR.relative_to(REPO_ROOT)),
+            "parser",
+            "--html",
+            *extra_args,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -77,27 +77,23 @@ def _case_sort_key(case_id: str) -> tuple[int, str]:
     return (top, sub)
 
 
-def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
-    """Yields (family, case_id, case_dict) for every case across all families.
+def _load_fixtures() -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Yields (family, mode, case_id, case_dict) for every parser fixture.
 
     Two file layouts coexist:
       <family>/PARSER.<mode>.yaml       — legacy flat: holds 1, 2, ..., 10
       <family>/PARSER.<mode>.<n>.yaml   — per-top-level-case: holds n.a, n.b, ...
 
-    The batch harness ignores stream fixtures; those are exercised by the
-    streaming harness layered on top of this fixture corpus.
-
-    Both batch schemas are
-        {family: "...", mode: "batch", cases: {PARSER.batch.<id>: {...}, ...}}
+    `_run_parity_case` dispatches from the fixture-level `mode`, matching the
+    `PARSER.batch.*` / `PARSER.stream.*` taxonomy directly.
     """
     out = []
     for fp in sorted(FIXTURES_ROOT.glob("*/PARSER.*.yaml")):
         doc = yaml.safe_load(fp.read_text())
-        if doc.get("mode", "batch") != "batch":
-            continue
+        mode = doc["mode"]
         for case_id, case in doc["cases"].items():
-            out.append((doc["family"], case_id, case))
-    out.sort(key=lambda t: (t[0], *_case_sort_key(t[1])))
+            out.append((doc["family"], mode, case_id, case))
+    out.sort(key=lambda t: (t[0], t[1], *_case_sort_key(t[2])))
     return out
 
 
@@ -113,6 +109,7 @@ def _is_na_stub(fixture: dict[str, Any]) -> bool:
 
 def _run_parity_case(
     family: str,
+    mode: str,
     case_id: str,
     fixture: dict[str, Any],
     impl_name: str,
@@ -135,13 +132,25 @@ def _run_parity_case(
             f"{impl_name}/{family}/{case_id}: n/a stub (no expected: block): "
             f"{fixture['reason']}"
         )
-    parse_mod = importlib.import_module(f"tests.parity.parser.{impl_name}")
-    got = parse_mod.parse(family, fixture["model_text"], fixture.get("tools"))
-
     spec = fixture["expected"][impl_name]
 
     if "unavailable" in spec:
         pytest.skip(f"{impl_name} unavailable for {family}: {spec['unavailable']}")
+
+    parse_mod = importlib.import_module(f"tests.parity.parser.{impl_name}")
+    if mode == "stream":
+        parse_tool_calls_stream = getattr(parse_mod, "parse_tool_calls_stream", None)
+        if parse_tool_calls_stream is None:
+            pytest.fail(
+                f"{impl_name}/{family}/{case_id}: wrapper has no parse_tool_calls_stream"
+            )
+        got = parse_tool_calls_stream(family, fixture["chunks"], fixture.get("tools"))
+    elif mode == "batch":
+        got = parse_mod.parse_tool_calls_batch(
+            family, fixture["model_text"], fixture.get("tools")
+        )
+    else:
+        pytest.fail(f"{impl_name}/{family}/{case_id}: unsupported parser mode {mode!r}")
 
     if "error" in spec:
         if got.error and spec["error"] in got.error:
@@ -172,15 +181,16 @@ def _run_parity_case(
 # Dynamo-only entry. No engine marker → runs in the default (dynamo-runtime)
 # CI lane. vLLM and SGLang have their own dedicated test functions below.
 @pytest.mark.parametrize(
-    "family,case_id,fixture",
-    [pytest.param(f, c, fx, id=f"{f}/{c}") for (f, c, fx) in FIXTURES],
+    "family,mode,case_id,fixture",
+    [pytest.param(f, m, c, fx, id=f"{f}/{c}") for (f, m, c, fx) in FIXTURES],
 )
 def test_parity(
     family: str,
+    mode: str,
     case_id: str,
     fixture: dict[str, Any],
 ) -> None:
-    _run_parity_case(family, case_id, fixture, "dynamo")
+    _run_parity_case(family, mode, case_id, fixture, "dynamo")
 
 
 # vLLM-only entry: function-level `vllm` marker lets the vllm-runtime CI
@@ -189,26 +199,28 @@ def test_parity(
 # exercised here.
 @pytest.mark.vllm
 @pytest.mark.parametrize(
-    "family,case_id,fixture",
-    [pytest.param(f, c, fx, id=f"{f}/{c}") for (f, c, fx) in FIXTURES],
+    "family,mode,case_id,fixture",
+    [pytest.param(f, m, c, fx, id=f"{f}/{c}") for (f, m, c, fx) in FIXTURES],
 )
 def test_parity_vllm(
     family: str,
+    mode: str,
     case_id: str,
     fixture: dict[str, Any],
 ) -> None:
-    _run_parity_case(family, case_id, fixture, "vllm")
+    _run_parity_case(family, mode, case_id, fixture, "vllm")
 
 
 # SGLang-only entry (sibling of test_parity_vllm; same shape).
 @pytest.mark.sglang
 @pytest.mark.parametrize(
-    "family,case_id,fixture",
-    [pytest.param(f, c, fx, id=f"{f}/{c}") for (f, c, fx) in FIXTURES],
+    "family,mode,case_id,fixture",
+    [pytest.param(f, m, c, fx, id=f"{f}/{c}") for (f, m, c, fx) in FIXTURES],
 )
 def test_parity_sglang(
     family: str,
+    mode: str,
     case_id: str,
     fixture: dict[str, Any],
 ) -> None:
-    _run_parity_case(family, case_id, fixture, "sglang")
+    _run_parity_case(family, mode, case_id, fixture, "sglang")

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import json
 import re
-from types import SimpleNamespace
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, Protocol, cast
 
 # vLLM's tool-parser module path settled on `vllm.tool_parsers.*` in v0.6.x;
 # the older `vllm.entrypoints.openai.tool_parsers.*` location was retained as
@@ -24,10 +24,14 @@ except ImportError:
         ToolParserManager,
     )
 
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
 from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
+from vllm.tokenizers import TokenizerLike
 
-from tests.parity.common import ParseResult, decode_arguments
+from tests.parity.common import ParseResult, decode_arguments, decode_stream_calls
 
 _HARMONY_ASSISTANT_START = "<|start|>assistant"
 _HARMONY_COMMENTARY_CALL_RE = re.compile(
@@ -52,6 +56,16 @@ _HARMONY_RECIPIENT_RE = re.compile(r"\bto=(?P<recipient>functions\.[\w.\-]+)")
 
 class _HarmonyEncodingUnavailable(RuntimeError):
     pass
+
+
+class _TokenIdToolParser(Protocol):
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+        token_ids: Sequence[int] | None = None,
+    ) -> Any:
+        ...
 
 
 class _OmnivorousVocab(dict):
@@ -225,23 +239,13 @@ _FAMILY_TO_VLLM_KEY = {
     "gemma4": "gemma4",
 }
 
+_STREAM_TOKEN_ID_REQUIRED_FAMILIES = {
+    "harmony",
+}
 
-def parse(
-    parser_family: str,
-    raw_text: str,
-    tools: list[dict[str, Any]] | None,
-) -> ParseResult:
-    key = _FAMILY_TO_VLLM_KEY.get(parser_family)
-    if key is None:
-        return ParseResult(
-            error=f"UNAVAILABLE: vLLM has no parser for family={parser_family!r}"
-        )
 
-    # Wrap flat tool defs as real `ChatCompletionToolsParam` Pydantic instances —
-    # vLLM's schema-aware coercion paths gate on `hasattr(config, "type")` and
-    # `hasattr(config.function, "name")`, which the Pydantic model satisfies via
-    # attribute access (plain dicts would silently fall back to raw-string emission).
-    wrapped_tools = (
+def _wrap_tools(tools: list[dict[str, Any]] | None) -> list[Any] | None:
+    return (
         [
             ChatCompletionToolsParam.model_validate(
                 t if "function" in t else {"type": "function", "function": t}
@@ -251,21 +255,76 @@ def parse(
         if tools
         else None
     )
+
+
+def _make_request(tools: list[Any] | None) -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_construct(
+        model="parser-parity",
+        messages=[],
+        tools=tools,
+        tool_choice="auto" if tools else "none",
+    )
+
+
+def _make_parser(
+    parser_family: str,
+    tools: list[dict[str, Any]] | None,
+) -> tuple[ToolParser | None, list[Any] | None, str | None]:
+    key = _FAMILY_TO_VLLM_KEY.get(parser_family)
+    if key is None:
+        return (
+            None,
+            None,
+            f"UNAVAILABLE: vLLM has no parser for family={parser_family!r}",
+        )
+
+    # Wrap flat tool defs as real `ChatCompletionToolsParam` Pydantic instances —
+    # vLLM's schema-aware coercion paths gate on `hasattr(config, "type")` and
+    # `hasattr(config.function, "name")`, which the Pydantic model satisfies via
+    # attribute access (plain dicts would silently fall back to raw-string emission).
     try:
+        wrapped_tools = _wrap_tools(tools)
         parser_cls = ToolParserManager.get_tool_parser(key)
         # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
         # if falsy. None of the parsers we test actually call tokenizer methods inside
         # extract_tool_calls(), so a truthy stub satisfies the check.
-        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=wrapped_tools)
+        parser: ToolParser = parser_cls(
+            tokenizer=cast(TokenizerLike, _StubTokenizer()),
+            tools=wrapped_tools,
+        )
+        return parser, wrapped_tools, None
+    except Exception as e:
+        return None, None, f"{type(e).__name__}: {e}"
+
+
+def _field(obj: Any, name: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def parse_tool_calls_batch(
+    parser_family: str,
+    raw_text: str,
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    parser, wrapped_tools, error = _make_parser(parser_family, tools)
+    if error is not None:
+        return ParseResult(error=error)
+
+    assert parser is not None
+    key = _FAMILY_TO_VLLM_KEY[parser_family]
+    try:
         # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
-        # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
-        request = SimpleNamespace(tools=wrapped_tools)
+        # Build a real request object, but bypass validation because the parser only
+        # reads parser-relevant fields such as tools.
+        request = _make_request(wrapped_tools)
         if key == "openai":
             token_text, residual_normal_text = _harmony_token_text_and_normal_text(
                 raw_text
             )
             try:
-                info = parser.extract_tool_calls(
+                info = cast(_TokenIdToolParser, parser).extract_tool_calls(
                     token_text,
                     request,
                     token_ids=_harmony_token_ids(token_text),
@@ -293,4 +352,78 @@ def parse(
     return ParseResult(
         calls=calls,
         normal_text=_merge_normal_text(residual_normal_text, info.content),
+    )
+
+
+def parse_tool_calls_stream(
+    parser_family: str,
+    chunks: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    if parser_family in _STREAM_TOKEN_ID_REQUIRED_FAMILIES and any(
+        "delta_token_ids" not in chunk for chunk in chunks
+    ):
+        return ParseResult(
+            error=(
+                "UNAVAILABLE: vLLM streaming parser for "
+                f"family={parser_family!r} requires `delta_token_ids` in fixture chunks"
+            )
+        )
+
+    parser, wrapped_tools, error = _make_parser(parser_family, tools)
+    if error is not None:
+        return ParseResult(error=error)
+
+    assert parser is not None
+    request = _make_request(wrapped_tools)
+    previous_text = ""
+    current_text = ""
+    previous_token_ids: list[int] = []
+    current_token_ids: list[int] = []
+    normal_text_parts: list[str] = []
+    stream_calls: dict[int, dict[str, Any]] = {}
+
+    try:
+        for chunk in chunks:
+            delta_text = chunk.get("delta_text") or ""
+            delta_token_ids = [
+                int(token_id) for token_id in chunk.get("delta_token_ids", [])
+            ]
+            current_text = previous_text + delta_text
+            current_token_ids = previous_token_ids + delta_token_ids
+            delta = parser.extract_tool_calls_streaming(
+                previous_text,
+                current_text,
+                delta_text,
+                previous_token_ids,
+                current_token_ids,
+                delta_token_ids,
+                request,
+            )
+            previous_text = current_text
+            previous_token_ids = current_token_ids
+
+            if delta is None:
+                continue
+            content = _field(delta, "content")
+            if content:
+                normal_text_parts.append(content)
+            for tool_call in _field(delta, "tool_calls") or []:
+                index = int(_field(tool_call, "index") or 0)
+                call = stream_calls.setdefault(index, {"name": None, "arguments": ""})
+                function = _field(tool_call, "function") or {}
+                name = _field(function, "name")
+                if name:
+                    call["name"] = name
+                arguments = _field(function, "arguments")
+                if arguments:
+                    call["arguments"] += arguments
+    except NotImplementedError as e:
+        return ParseResult(error=f"UNAVAILABLE: {type(e).__name__}: {e}")
+    except Exception as e:
+        return ParseResult(error=f"{type(e).__name__}: {e}")
+
+    return ParseResult(
+        calls=decode_stream_calls(stream_calls),
+        normal_text="".join(normal_text_parts),
     )


### PR DESCRIPTION
#### Overview:

This PR adds streaming tool-call parser parity coverage across Dynamo, vLLM, and SGLang without changing parser behavior.

#### Details:

- **How is this fixed?** Add fixture-driven streaming capture and test dispatch so PARSER.stream.* cases run through the same parity path as batch cases.
- Add Dynamo streaming bindings and Python parity adapters for aggregating streaming deltas into final calls/text.
- Update the parity table generator to support parser batch/stream tabs from the shared tests/parity entry point.
- Move the Jinja template to tests/parity/parity_table.html.j2 so future parity tables can share it.
- No parser behavior changes; this PR adds tests, harness code, and table generation only.

#### Verification:

python3 -m pytest tests/parity/parser/test_generate_parity_table.py -q passed; python3 -m pytest tests/parity/parser/test_parity_parser.py -q passed (1273 passed, 1118 skipped); git diff --check passed.

#### Where should the reviewer start?

tests/parity/parser/test_parity_parser.py, then tests/parity/parser/dynamo.py and lib/llm/tests/test_streaming_tool_parsers.rs

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming mode for tool-call parsing to process incremental input chunks.

* **Refactor**
  * Updated tool-call parser API with improved batch and stream separation.

* **Documentation**
  * Refined parser test case taxonomy and parity testing methodology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->