### PR TITLE
feat: add standalone resource observability

### DIFF
--- a/dev/observability/README.md
+++ b/dev/observability/README.md
@@ -2,4 +2,4 @@
 
 For detailed documentation on Observability (Prometheus metrics, tracing, and logging), please refer to [docs/observability/](../../docs/observability/).
 
-For the per-process resource exporter (`dynamo_local_resource_monitor.py`) that ships with this stack, see [docs/observability/local-resource-monitor.md](../../docs/observability/local-resource-monitor.md).
+For the per-process resource monitor (`dynamo_local_resource_monitor.py`) that ships with this stack, see [docs/observability/local-resource-monitor.md](../../docs/observability/local-resource-monitor.md).

--- a/dev/observability/dynamo_local_resource_monitor.html.j2
+++ b/dev/observability/dynamo_local_resource_monitor.html.j2
@@ -6,39 +6,40 @@
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
 <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <style>
-  * { box-sizing: border-box; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
-    margin: 0;
     background: #0d0d14;
     color: #e0e0e0;
     font-family: monospace;
     overflow: hidden;
   }
   #toolbar {
-    height: 52px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 16px;
-    border-bottom: 1px solid #2a2a3c;
+    padding: 12px 20px;
   }
-  h1 { margin: 0; font-size: 20px; font-weight: 700; }
+  #toolbar h1 { font-size: 22px; }
   .btn {
-    border: 1px solid #444466;
-    padding: 6px 12px;
+    border: none;
+    padding: 6px 14px;
     cursor: pointer;
     font-family: monospace;
-    font-weight: 700;
+    font-weight: bold;
+    margin-left: 4px;
     border-radius: 4px;
     font-size: 13px;
+  }
+  .range-btn {
     background: #2a2a3c;
     color: #e0e0e0;
+    border: 1px solid #444;
   }
-  .btn.active { background: #55557a; }
-  #pause-btn { background: #ffcc00; color: #0d0d14; border-color: #ffcc00; }
-  #snapshot-btn { background: #00e676; color: #0d0d14; border-color: #00e676; }
-  #chart { width: 100vw; height: calc(100vh - 74px); }
-  #status { height: 22px; padding-left: 16px; font-size: 11px; color: #9a9aaa; }
+  .range-btn.active { background: #444466; }
+  #pause-btn { background: #ffcc00; color: #0d0d14; margin-left: 12px; }
+  #snapshot-btn { background: #00e676; color: #0d0d14; }
+  #chart { width: 100%; height: calc(100vh - 50px); }
+  #status { position: fixed; bottom: 8px; left: 20px; font-size: 11px; color: #666; }
 </style>
 </head>
 <body>
@@ -48,6 +49,7 @@
     <button class="btn range-btn" data-sec="60">1m</button>
     <button class="btn range-btn active" data-sec="120">2m</button>
     <button class="btn range-btn" data-sec="300">5m</button>
+    <button class="btn range-btn" data-sec="600">10m</button>
     <button class="btn range-btn" data-sec="900">15m</button>
     <button class="btn" id="pause-btn">Pause</button>
     <button class="btn" id="snapshot-btn">Snapshot</button>
@@ -66,6 +68,9 @@
   let paused = false;
   let renderScheduled = false;
   let lastCounters = {main: 0, disk: 0, pcie: []};
+  let rateSnapshot = {main: 0, disk: 0, pcie: [], time: Date.now()};
+  let sampleRates = {main: "0.0", disk: "0.0", pcie: [], pcieAvg: "0.0"};
+  const MEM_PATTERNS = ["/", "\\", "x", "+", "-", "|", "."];
   const status = document.getElementById("status");
   const chart = document.getElementById("chart");
 
@@ -80,7 +85,13 @@
   socket.on("connect", function() {
     status.textContent = "Connected. Waiting for data...";
     socket.emit("view_minutes", Math.max(1, Math.round(viewSeconds / 60)));
-    socket.emit("request_init");
+    if (state) {
+      socket.emit("request_init");
+    } else {
+      setTimeout(function() {
+        if (!state) socket.emit("request_init");
+      }, 3000);
+    }
   });
 
   socket.on("disconnect", function() {
@@ -94,6 +105,13 @@
       disk: msg.counter_disk || 0,
       pcie: msg.counter_pcie || []
     };
+    rateSnapshot = {
+      main: lastCounters.main,
+      disk: lastCounters.disk,
+      pcie: lastCounters.pcie.slice(),
+      time: Date.now()
+    };
+    sampleRates = zeroRates(lastCounters.pcie);
     if (msg.hostname) {
       const gpuTag = msg.gpu_summary ? " " + msg.gpu_summary : "";
       const title = "Dynamo Local Resource Monitor - " + msg.hostname + gpuTag;
@@ -166,9 +184,9 @@
       appendTrim(state.pcie_rx[gi] || [], (msg.pcie_rx || [])[gi] || []);
     }
     lastCounters = {
-      main: msg.counter_main || lastCounters.main,
-      disk: msg.counter_disk || lastCounters.disk,
-      pcie: msg.counter_pcie || lastCounters.pcie
+      main: typeof msg.counter_main === "number" ? msg.counter_main : lastCounters.main,
+      disk: typeof msg.counter_disk === "number" ? msg.counter_disk : lastCounters.disk,
+      pcie: Array.isArray(msg.counter_pcie) ? msg.counter_pcie : lastCounters.pcie
     };
   }
 
@@ -181,7 +199,12 @@
     renderScheduled = true;
     requestAnimationFrame(function() {
       renderScheduled = false;
-      render();
+      try {
+        render();
+      } catch (err) {
+        status.textContent = "Render error: " + (err && err.message ? err.message : err);
+        throw err;
+      }
     });
   }
 
@@ -197,131 +220,388 @@
     const traces = [];
     const timesMain = toDates(state.ts_main);
     const timesDisk = toDates(state.ts_disk);
-    const colors = [
-      "#00e5ff", "#ff1744", "#76ff03", "#448aff", "#ff9100",
-      "#d500f9", "#ffea00", "#f50057", "#00e676", "#ff6d00"
-    ];
+    const gpuCount = state.gpu_count || 0;
+    const gpuRows = Array.from({length: gpuCount}, (_, gi) => ({mem: gi * 2 + 1, util: gi * 2 + 2}));
+    const cpuRow = gpuCount * 2 + 1;
+    const ioRow = cpuRow + 1;
+    const nRows = ioRow;
+    const rowWeights = gpuRows.flatMap(() => [7, 3]).concat([3, 3]);
+    const rowGaps = gpuRows.flatMap((_, gi) => [gi > 0 ? 0.04 : 0, 0.002]).concat([gpuCount ? 0.04 : 0, 0.02]);
 
-    for (let gi = 0; gi < (state.gpu_count || 0); gi++) {
+    const domains = computeDomains(rowWeights, rowGaps);
+    let secondaryY = nRows + 1;
+    const pcieY = [];
+    const tempY = [];
+    for (let gi = 0; gi < gpuCount; gi++) {
+      if (state.has_pcie) pcieY[gi] = yRef(secondaryY++);
+      tempY[gi] = yRef(secondaryY++);
+    }
+    const netY = yRef(secondaryY++);
+
+    const systemLegend = gpuCount > 0 ? (gpuCount === 1 ? "legend2" : "legend" + (gpuCount + 1)) : "legend";
+
+    for (let gi = 0; gi < gpuCount; gi++) {
+      const memRow = gpuRows[gi].mem;
+      const utilRow = gpuRows[gi].util;
+      const gpuLegend = gi === 0 ? "legend" : "legend" + (gi + 1);
       const memSeries = state.gpu_mem[gi] || [];
+      const memColors = memSeries.map(proc => proc.color || "#999999");
+      const similarSet = findSimilarColors(memColors, 30);
       for (let i = memSeries.length - 1; i >= 0; i--) {
         const proc = memSeries[i];
-        traces.push({
-          x: timesMain, y: proc.vals, name: "GPU " + gi + " " + proc.name + " (" + proc.pid + ")",
+        const procColor = proc.color || "#999999";
+        const trace = {
+          x: timesMain, y: proc.vals, name: proc.name,
           type: "scatter", mode: "none", stackgroup: "gpu_mem_" + gi,
-          fillcolor: hexToRgba(proc.color || colors[i % colors.length], 0.55),
-          line: {width: 0, color: proc.color || colors[i % colors.length]},
-          xaxis: "x", yaxis: "y", legendgroup: "gpu_mem_" + gi
+          fillcolor: hexToRgba(procColor, 0.6),
+          line: {width: 0, color: procColor},
+          xaxis: xRef(memRow), yaxis: yRef(memRow), legendgroup: "gpu_mem_" + gi,
+          legendgrouptitle: {text: "GPU " + gi + " Mem"}, legend: gpuLegend
+        };
+        if (similarSet.has(i)) {
+          const pattern = MEM_PATTERNS[Math.abs(proc.pid || 0) % MEM_PATTERNS.length];
+          trace.fillpattern = {
+            shape: pattern,
+            solidity: 0.15,
+            size: 8,
+            bgcolor: hexToRgba(procColor, 0.6),
+            fgcolor: "rgba(13,13,20,0.4)"
+          };
+        }
+        traces.push(trace);
+      }
+      if (memSeries.length === 0) {
+        traces.push({
+          x: timesMain, y: timesMain.map(() => 0), name: "GPU " + gi + " Mem: 0",
+          type: "scatter", mode: "lines", line: {width: 1, color: "#555"},
+          xaxis: xRef(memRow), yaxis: yRef(memRow), legendgroup: "gpu_mem_" + gi, legend: gpuLegend
         });
       }
-      traces.push({
-        x: timesMain,
-        y: timesMain.map(() => (state.gpu_mem_total_gib || [])[gi] || 0),
-        name: "GPU " + gi + " total",
-        type: "scatter", mode: "lines", line: {color: "#ff5252", width: 1, dash: "dot"},
-        xaxis: "x", yaxis: "y", legendgroup: "gpu_total"
-      });
-      traces.push({
-        x: timesMain, y: (state.gpu_util || [])[gi] || [], name: "GPU " + gi + " util",
-        type: "scatter", mode: "lines", line: {color: "#76b900", width: 2},
-        fill: "tozeroy", fillcolor: "rgba(118,185,0,0.25)", xaxis: "x2", yaxis: "y2"
-      });
-      traces.push({
-        x: timesMain, y: (state.gpu_temp || [])[gi] || [], name: "GPU " + gi + " temp",
-        type: "scatter", mode: "lines", line: {color: "#ff6e40", width: 1, dash: "dot"},
-        xaxis: "x2", yaxis: "y2"
-      });
       if (state.has_pcie) {
         const timesPcie = toDates((state.ts_pcie || [])[gi] || []);
         traces.push({
-          x: timesPcie, y: (state.pcie_tx || [])[gi] || [], name: "GPU " + gi + " PCIe TX",
-          type: "scatter", mode: "lines", line: {color: "#ef5350", width: 1}, xaxis: "x4", yaxis: "y4"
+          x: timesPcie, y: (state.pcie_tx || [])[gi] || [], name: "PCIe W (GPU " + gi + ")",
+          type: "scatter", mode: "lines", line: {color: "#ef5350", width: 0.5}, xaxis: xRef(memRow), yaxis: pcieY[gi],
+          legendgroup: "pcie_" + gi, legendgrouptitle: {text: "GPU " + gi + " PCIe"}, legend: gpuLegend
         });
         traces.push({
-          x: timesPcie, y: (state.pcie_rx || [])[gi] || [], name: "GPU " + gi + " PCIe RX",
-          type: "scatter", mode: "lines", line: {color: "#69f0ae", width: 1, dash: "dot"}, xaxis: "x4", yaxis: "y4"
+          x: timesPcie, y: (state.pcie_rx || [])[gi] || [], name: "PCIe R (GPU " + gi + ")",
+          type: "scatter", mode: "lines", line: {color: "#69f0ae", width: 0.5, dash: "dot"}, xaxis: xRef(memRow), yaxis: pcieY[gi],
+          legendgroup: "pcie_" + gi, legend: gpuLegend
         });
       }
+      traces.push({
+        x: timesMain, y: (state.gpu_util || [])[gi] || [], name: "GPU " + gi + " Util",
+        type: "scatter", mode: "lines", line: {color: "#76b900", width: 2},
+        fill: "tozeroy", fillcolor: hexToRgba("#76b900", 0.65), xaxis: xRef(utilRow), yaxis: yRef(utilRow),
+        legendgroup: "util_" + gi, legendgrouptitle: {text: "GPU " + gi + " Util"}, legend: gpuLegend
+      });
+      traces.push({
+        x: timesMain, y: (state.gpu_temp || [])[gi] || [], name: "GPU " + gi + " Temp",
+        type: "scatter", mode: "lines", line: {color: "#ff6e40", width: 1.5, dash: "dot"},
+        xaxis: xRef(utilRow), yaxis: tempY[gi], legendgroup: "util_" + gi, legend: gpuLegend
+      });
     }
 
-    for (const proc of state.cpu_procs || []) {
+    const cpuProcs = state.cpu_procs || [];
+    for (let i = cpuProcs.length - 1; i >= 0; i--) {
+      const proc = cpuProcs[i];
       traces.push({
         x: timesMain, y: proc.vals, name: proc.name, type: "scatter", mode: "none",
-        stackgroup: "cpu", fillcolor: hexToRgba(proc.color || "#8888ff", 0.45),
-        line: {width: 0, color: proc.color || "#8888ff"}, xaxis: "x3", yaxis: "y3"
+        stackgroup: "cpu", fillcolor: hexToRgba(proc.color || "#8888ff", 0.55),
+        line: {width: 0, color: proc.color || "#8888ff"}, xaxis: xRef(cpuRow), yaxis: yRef(cpuRow),
+        legendgroup: "cpu", legendgrouptitle: {text: "CPU"}, legend: systemLegend
       });
     }
     traces.push({
       x: timesMain, y: state.cpu || [], name: "CPU total", type: "scatter", mode: "lines",
-      line: {color: "#ffcc00", width: 1.5, dash: "dot"}, xaxis: "x3", yaxis: "y3"
+      line: {color: "#ffcc00", width: 1.5, dash: "dot"}, xaxis: xRef(cpuRow), yaxis: yRef(cpuRow),
+      legendgroup: "cpu", legend: systemLegend
     });
+    const diskTotal = (state.disk_read || []).map((v, i) => v + (state.disk_write || [])[i]);
     traces.push({
-      x: timesDisk, y: state.disk_read || [], name: "Disk read", type: "scatter", mode: "lines",
-      line: {color: "#ff9800", width: 1}, xaxis: "x4", yaxis: "y4"
-    });
-    traces.push({
-      x: timesDisk, y: state.disk_write || [], name: "Disk write", type: "scatter", mode: "lines",
-      line: {color: "#ffd740", width: 1}, xaxis: "x4", yaxis: "y4"
+      x: timesDisk, y: diskTotal, name: "Disk I/O", type: "scatter", mode: "lines",
+      line: {color: "#ff9800", width: 1, shape: "spline", smoothing: 0.8},
+      fill: "tozeroy", fillcolor: hexToRgba("#ff9800", 0.35), xaxis: xRef(ioRow), yaxis: yRef(ioRow),
+      legendgroup: "disk_io", legendgrouptitle: {text: "Disk I/O"}, legend: systemLegend
     });
     traces.push({
       x: timesMain, y: state.net_sent || [], name: "Net TX", type: "scatter", mode: "lines",
-      line: {color: "#18ffff", width: 1}, xaxis: "x4", yaxis: "y4"
+      line: {color: "#18ffff", width: 0.5, shape: "spline", smoothing: 1.3},
+      xaxis: xRef(ioRow), yaxis: netY, legendgroup: "net", legendgrouptitle: {text: "Network"}, legend: systemLegend
     });
     traces.push({
       x: timesMain, y: state.net_recv || [], name: "Net RX", type: "scatter", mode: "lines",
-      line: {color: "#ff80ab", width: 1}, xaxis: "x4", yaxis: "y4"
+      line: {color: "#ff80ab", width: 0.5, shape: "spline", smoothing: 1.3},
+      xaxis: xRef(ioRow), yaxis: netY, legendgroup: "net", legend: systemLegend
     });
 
     const range = visibleRange();
     const baseAxis = {gridcolor: "#262640", zerolinecolor: "#444466"};
-    const xAxis = {gridcolor: "#262640", type: "date"};
-    if (range) xAxis.range = range;
+    const xBase = {domain: [0, 0.92], gridcolor: "#262640", type: "date"};
+    if (range) xBase.range = range;
+    const legendStyle = {
+      orientation: "v",
+      xanchor: "left",
+      x: 1.01,
+      font: {size: 10},
+      bgcolor: "rgba(13,13,20,0.8)",
+      tracegroupgap: 1,
+      itemsizing: "constant",
+      valign: "top"
+    };
     const layout = {
       paper_bgcolor: "#0d0d14", plot_bgcolor: "#141420",
       font: {family: "monospace", color: "#e0e0e0", size: 11},
-      margin: {l: 68, r: 20, t: 20, b: 34},
-      hovermode: "x unified",
-      legend: {orientation: "v", x: 1.01, y: 1, bgcolor: "rgba(13,13,20,0.75)", font: {size: 10}},
-      grid: {rows: 4, columns: 1, pattern: "independent", roworder: "top to bottom"},
-      xaxis: Object.assign({}, xAxis),
-      xaxis2: Object.assign({}, xAxis),
-      xaxis3: Object.assign({}, xAxis),
-      xaxis4: Object.assign({}, xAxis),
-      yaxis: Object.assign({title: "GPU VRAM GiB", domain: [0.76, 1.0], rangemode: "tozero"}, baseAxis),
-      yaxis2: Object.assign({title: "GPU % / C", domain: [0.52, 0.72], range: [0, 105]}, baseAxis),
-      yaxis3: Object.assign({title: "CPU %", domain: [0.28, 0.48], range: [0, 105]}, baseAxis),
-      yaxis4: Object.assign({title: "I/O", domain: [0.0, 0.24], rangemode: "tozero"}, baseAxis),
-      annotations: [
-        label("GPU VRAM by process", 0.995),
-        label("GPU utilization + temperature", 0.715),
-        label("CPU total + top process groups", 0.475),
-        label("Disk, network, PCIe", 0.235)
-      ]
+      margin: {l: 70, r: 20, t: 10, b: 35},
+      hovermode: false,
+      showlegend: true,
+      grid: {rows: nRows, columns: 1, pattern: "independent", roworder: "top to bottom"},
+      shapes: rowBackgrounds(nRows),
+      annotations: []
     };
-    Plotly.react(chart, traces, layout, {responsive: true, displayModeBar: true, scrollZoom: true});
-    const gpuText = state.gpu_count ? state.gpu_count + " GPU" + (state.gpu_count === 1 ? "" : "s") : "CPU-only";
+
+    for (let r = 1; r <= nRows; r++) {
+      layout[xLayout(r)] = Object.assign(
+        {showticklabels: r === nRows, anchor: yRef(r)},
+        xBase
+      );
+      layout[yLayout(r)] = Object.assign({domain: domains[r - 1]}, baseAxis);
+    }
+
+    for (let gi = 0; gi < gpuCount; gi++) {
+      const memRow = gpuRows[gi].mem;
+      const utilRow = gpuRows[gi].util;
+      const gpuLegend = gi === 0 ? "legend" : "legend" + (gi + 1);
+      layout[gpuLegend] = Object.assign({}, legendStyle, {
+        yanchor: "top",
+        y: domains[memRow - 1][1]
+      });
+      layout[yLayout(memRow)].title = {
+        text: "<span style=\"color:#76b900\">GPU " + gi + " GiB</span>",
+        font: {size: 10}
+      };
+      layout[yLayout(memRow)].rangemode = "tozero";
+      layout[yLayout(utilRow)].title = {
+        text: "<span style=\"color:#76b900\">GPU " + gi + " %-util</span>",
+        font: {size: 10}
+      };
+      layout[yLayout(utilRow)].range = [0, 105];
+      layout[yLayoutByRef(tempY[gi])] = {
+        domain: domains[utilRow - 1],
+        title: {text: "GPU &deg;C", font: {color: "#ff6e40", size: 10}},
+        overlaying: yRef(utilRow),
+        side: "right",
+        showgrid: false,
+        autorange: true,
+        minallowed: 30
+      };
+      if (state.has_pcie) {
+        layout[yLayoutByRef(pcieY[gi])] = {
+          domain: domains[memRow - 1],
+          title: {text: "PCIe GB/s (log)", font: {color: "#999", size: 10}},
+          overlaying: yRef(memRow),
+          side: "right",
+          showgrid: false,
+          type: "log",
+          autorange: true
+        };
+      }
+      layout.annotations.push(rowLabel(
+        memRow,
+        state.has_pcie ? "GPU " + gi + " Memory (GiB) + PCIe (GB/s)" : "GPU " + gi + " Memory (GiB)",
+        state.has_pcie ? mainPcieRateText(gi) : mainRateText()
+      ));
+      layout.annotations.push(rowLabel(
+        utilRow,
+        "GPU " + gi + " %-util + GPU &deg;C",
+        mainRateText()
+      ));
+      const maxGib = (state.gpu_mem_total_gib || [])[gi] || 0;
+      if (!maxGib) continue;
+      layout.shapes.push({
+        type: "line", x0: 0, x1: 1, y0: maxGib, y1: maxGib,
+        xref: xRef(memRow) + " domain", yref: yRef(memRow), line: {color: "#ff5252", width: 2}
+      });
+      layout.annotations.push({
+        text: maxGib.toFixed(1) + " GiB", x: 1, y: maxGib,
+        xref: xRef(memRow) + " domain", yref: yRef(memRow), showarrow: false,
+        font: {size: 10, color: "#ff5252"}, xanchor: "right"
+      });
+    }
+
+    layout[systemLegend] = Object.assign({}, legendStyle, {
+      yanchor: "top",
+      y: domains[cpuRow - 1][1]
+    });
+    layout[yLayout(cpuRow)].title = {
+      text: "<span style=\"color:#ffcc00\">CPU %</span>",
+      font: {size: 10}
+    };
+    layout[yLayout(cpuRow)].range = [0, 105];
+    layout[yLayout(ioRow)].title = {
+      text: "<span style=\"color:#ff9800\">Disk I/O MB/s</span>",
+      font: {size: 10}
+    };
+    layout[yLayout(ioRow)].rangemode = "tozero";
+    layout[yLayoutByRef(netY)] = {
+      domain: domains[ioRow - 1],
+      title: {text: "Net MB/s (log)", font: {color: "#18ffff", size: 10}},
+      overlaying: yRef(ioRow),
+      side: "right",
+      showgrid: false,
+      type: "log",
+      autorange: true
+    };
+    layout.annotations.push(rowLabel(
+      cpuRow,
+      "CPU Usage (%)",
+      mainRateText()
+    ));
+    layout.annotations.push(rowLabel(
+      ioRow,
+      "Disk I/O (MB/s) + Network (MB/s)",
+      diskRateText()
+    ));
+
+    Plotly.react(chart, traces, layout, {
+      responsive: true,
+      displayModeBar: true,
+      scrollZoom: true,
+      toImageButtonOptions: {format: "png", filename: "resource_monitor", height: 1080, width: 1920, scale: 2}
+    });
+    const gpuText = gpuCount ? gpuCount + " GPU" + (gpuCount === 1 ? "" : "s") : "CPU-only";
+    const pcieText = sampleRates.pcie.length
+      ? " pcie [" + sampleRates.pcie.map((rate, gi) => "gpu" + gi + " " + rate).join(", ") + "]/s"
+      : "";
     status.textContent = (paused ? "Paused" : "Live") +
       " | " + gpuText +
-      " | main " + lastCounters.main +
-      " disk " + lastCounters.disk;
+      " | main " + sampleRates.main + "/s" +
+      pcieText +
+      " disk " + sampleRates.disk + "/s";
   }
 
-  function label(text, y) {
+  function zeroRates(pcieCounters) {
     return {
-      text: "  " + text + "  ",
+      main: "0.0",
+      disk: "0.0",
+      pcie: (pcieCounters || []).map(() => "0.0"),
+      pcieAvg: "0.0"
+    };
+  }
+
+  function updateSampleRates() {
+    if (!state) return;
+    const now = Date.now();
+    const elapsed = (now - rateSnapshot.time) / 1000;
+    if (elapsed <= 0) return;
+    const currentPcie = Array.isArray(lastCounters.pcie) ? lastCounters.pcie : [];
+    const pcieRates = currentPcie.map((counter, gi) => {
+      const previous = rateSnapshot.pcie[gi] || 0;
+      return Math.max(0, (counter - previous) / elapsed);
+    });
+    const pcieAvg = pcieRates.length
+      ? pcieRates.reduce((total, rate) => total + rate, 0) / pcieRates.length
+      : 0;
+    sampleRates = {
+      main: Math.max(0, (lastCounters.main - rateSnapshot.main) / elapsed).toFixed(1),
+      disk: Math.max(0, (lastCounters.disk - rateSnapshot.disk) / elapsed).toFixed(1),
+      pcie: pcieRates.map(rate => rate.toFixed(1)),
+      pcieAvg: pcieAvg.toFixed(1)
+    };
+    rateSnapshot = {
+      main: lastCounters.main,
+      disk: lastCounters.disk,
+      pcie: currentPcie.slice(),
+      time: now
+    };
+  }
+
+  function mainRateText() {
+    return sampleRates.main + " samples/s";
+  }
+
+  function mainPcieRateText(gpuIndex) {
+    const pcieRate = sampleRates.pcie[gpuIndex] || sampleRates.pcieAvg || "0.0";
+    return sampleRates.main + " samples/s, " + pcieRate + " samples/s";
+  }
+
+  function diskRateText() {
+    return sampleRates.disk + " samples/s";
+  }
+
+  function xRef(row) {
+    return row === 1 ? "x" : "x" + row;
+  }
+
+  function yRef(row) {
+    return row === 1 ? "y" : "y" + row;
+  }
+
+  function xLayout(row) {
+    return row === 1 ? "xaxis" : "xaxis" + row;
+  }
+
+  function yLayout(row) {
+    return row === 1 ? "yaxis" : "yaxis" + row;
+  }
+
+  function yLayoutByRef(ref) {
+    return ref === "y" ? "yaxis" : "yaxis" + ref.slice(1);
+  }
+
+  function computeDomains(weights, gaps) {
+    const totalWeight = weights.reduce((a, b) => a + b, 0);
+    const totalGap = gaps.reduce((a, b) => a + b, 0);
+    const usable = 1 - totalGap;
+    let top = 1;
+    return weights.map((weight, i) => {
+      top -= gaps[i] || 0;
+      const height = (weight / totalWeight) * usable;
+      const domain = [top - height, top];
+      top -= height;
+      return domain;
+    });
+  }
+
+  function rowBackgrounds(rowCount) {
+    const colors = ["#101020", "#181830"];
+    return Array.from({length: rowCount}, (_, i) => ({
+      type: "rect", x0: 0, x1: 1, y0: 0, y1: 1,
+      xref: xRef(i + 1) + " domain",
+      yref: yRef(i + 1) + " domain",
+      fillcolor: colors[i % colors.length],
+      line: {width: 0}, layer: "below"
+    }));
+  }
+
+  function label(text, xref, yref, rateText) {
+    const displayText = rateText ? text + "<br>" + rateText : text;
+    return {
+      text: "  " + displayText + "  ",
       x: 0,
-      y: y,
-      xref: "paper",
-      yref: "paper",
+      y: 0.97,
+      xref: xref,
+      yref: yref,
       showarrow: false,
       xanchor: "left",
       yanchor: "top",
       bgcolor: "rgba(30,30,50,0.92)",
       bordercolor: "#444466",
       borderwidth: 1,
+      borderpad: 3,
       font: {size: 11, color: "#c0c0d0"}
     };
   }
+
+  function rowLabel(row, text, rateText) {
+    return label(text, xRef(row) + " domain", yRef(row) + " domain", rateText);
+  }
+
+  setInterval(function() {
+    updateSampleRates();
+    if (state) scheduleRender();
+  }, 5000);
 
   function hexToRgba(hex, alpha) {
     const h = (hex || "#999999").replace("#", "");
@@ -329,6 +609,40 @@
     const g = parseInt(h.substring(2, 4), 16);
     const b = parseInt(h.substring(4, 6), 16);
     return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
+  }
+
+  function hexToHue(hex) {
+    const h = (hex || "#999999").replace("#", "");
+    const r = parseInt(h.substring(0, 2), 16) / 255;
+    const g = parseInt(h.substring(2, 4), 16) / 255;
+    const b = parseInt(h.substring(4, 6), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const delta = max - min;
+    if (delta === 0) return {hue: 0, sat: 0};
+    let hue;
+    if (max === r) hue = ((g - b) / delta + 6) % 6;
+    else if (max === g) hue = (b - r) / delta + 2;
+    else hue = (r - g) / delta + 4;
+    return {hue: hue * 60, sat: delta / max};
+  }
+
+  function findSimilarColors(colors, threshold) {
+    const needs = new Set();
+    const hsv = colors.map(color => hexToHue(color));
+    for (let i = 0; i < hsv.length; i++) {
+      if (hsv[i].sat < 0.15) continue;
+      for (let j = i + 1; j < hsv.length; j++) {
+        if (hsv[j].sat < 0.15) continue;
+        let hueDelta = Math.abs(hsv[i].hue - hsv[j].hue);
+        if (hueDelta > 180) hueDelta = 360 - hueDelta;
+        if (hueDelta < threshold) {
+          needs.add(i);
+          needs.add(j);
+        }
+      }
+    }
+    return needs;
   }
 
   document.querySelectorAll(".range-btn").forEach(btn => {

--- a/dev/observability/dynamo_local_resource_monitor.html.j2
+++ b/dev/observability/dynamo_local_resource_monitor.html.j2
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Dynamo Local Resource Monitor</title>
+<script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+<script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: #0d0d14;
+    color: #e0e0e0;
+    font-family: monospace;
+    overflow: hidden;
+  }
+  #toolbar {
+    height: 52px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 16px;
+    border-bottom: 1px solid #2a2a3c;
+  }
+  h1 { margin: 0; font-size: 20px; font-weight: 700; }
+  .btn {
+    border: 1px solid #444466;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-family: monospace;
+    font-weight: 700;
+    border-radius: 4px;
+    font-size: 13px;
+    background: #2a2a3c;
+    color: #e0e0e0;
+  }
+  .btn.active { background: #55557a; }
+  #pause-btn { background: #ffcc00; color: #0d0d14; border-color: #ffcc00; }
+  #snapshot-btn { background: #00e676; color: #0d0d14; border-color: #00e676; }
+  #chart { width: 100vw; height: calc(100vh - 74px); }
+  #status { height: 22px; padding-left: 16px; font-size: 11px; color: #9a9aaa; }
+</style>
+</head>
+<body>
+<div id="toolbar">
+  <h1>Dynamo Local Resource Monitor</h1>
+  <div>
+    <button class="btn range-btn" data-sec="60">1m</button>
+    <button class="btn range-btn active" data-sec="120">2m</button>
+    <button class="btn range-btn" data-sec="300">5m</button>
+    <button class="btn range-btn" data-sec="900">15m</button>
+    <button class="btn" id="pause-btn">Pause</button>
+    <button class="btn" id="snapshot-btn">Snapshot</button>
+  </div>
+</div>
+<div id="chart"></div>
+<div id="status">Connecting...</div>
+
+<script>
+(function() {
+  "use strict";
+
+  const MAX_POINTS = 5000;
+  let state = null;
+  let viewSeconds = 120;
+  let paused = false;
+  let renderScheduled = false;
+  let lastCounters = {main: 0, disk: 0, pcie: []};
+  const status = document.getElementById("status");
+  const chart = document.getElementById("chart");
+
+  const socket = io({
+    transports: ["websocket", "polling"],
+    reconnection: true,
+    reconnectionDelay: 500,
+    reconnectionAttempts: Infinity,
+    timeout: 60000
+  });
+
+  socket.on("connect", function() {
+    status.textContent = "Connected. Waiting for data...";
+    socket.emit("view_minutes", Math.max(1, Math.round(viewSeconds / 60)));
+    socket.emit("request_init");
+  });
+
+  socket.on("disconnect", function() {
+    status.textContent = "Disconnected -- reconnecting...";
+  });
+
+  socket.on("init", function(msg) {
+    state = msg;
+    lastCounters = {
+      main: msg.counter_main || 0,
+      disk: msg.counter_disk || 0,
+      pcie: msg.counter_pcie || []
+    };
+    if (msg.hostname) {
+      const gpuTag = msg.gpu_summary ? " " + msg.gpu_summary : "";
+      const title = "Dynamo Local Resource Monitor - " + msg.hostname + gpuTag;
+      document.querySelector("h1").textContent = title;
+      document.title = title;
+    }
+    scheduleRender();
+  });
+
+  socket.on("delta", function(msg) {
+    if (!state) {
+      socket.emit("request_init");
+      return;
+    }
+    if (keysChanged(msg)) {
+      socket.emit("request_init");
+      return;
+    }
+    mergeDelta(msg);
+    scheduleRender();
+  });
+
+  function keysChanged(msg) {
+    if (!msg.gpu_mem_keys || !state.gpu_mem) return false;
+    const currentGpu = state.gpu_mem.map(group => group.map(p => p.pid));
+    if (!sameKeySet(currentGpu, msg.gpu_mem_keys)) return true;
+    const currentCpu = (state.cpu_procs || []).map(p => p.id);
+    if (!sameKeySet([currentCpu], [msg.cpu_proc_keys || []])) return true;
+    return false;
+  }
+
+  function sameKeySet(a, b) {
+    if (!a || !b || a.length !== b.length) return false;
+    const normalize = groups => groups.map(group => {
+      if (!Array.isArray(group)) return group;
+      return group.map(value => String(value)).sort();
+    });
+    return JSON.stringify(normalize(a)) === JSON.stringify(normalize(b));
+  }
+
+  function appendTrim(arr, vals) {
+    if (!vals || vals.length === 0) return;
+    arr.push.apply(arr, vals);
+    if (arr.length > MAX_POINTS) arr.splice(0, arr.length - MAX_POINTS);
+  }
+
+  function appendById(existing, incoming, key) {
+    const byKey = new Map(existing.map(item => [item[key], item]));
+    for (const item of incoming || []) {
+      const target = byKey.get(item[key]);
+      if (target) appendTrim(target.vals, item.vals || []);
+    }
+  }
+
+  function mergeDelta(msg) {
+    appendTrim(state.ts_main, msg.ts_main || []);
+    appendTrim(state.ts_disk, msg.ts_disk || []);
+    appendTrim(state.cpu, msg.cpu || []);
+    appendById(state.cpu_procs || [], msg.cpu_procs || [], "id");
+    appendTrim(state.net_sent, msg.net_sent || []);
+    appendTrim(state.net_recv, msg.net_recv || []);
+    appendTrim(state.disk_read, msg.disk_read || []);
+    appendTrim(state.disk_write, msg.disk_write || []);
+    for (let gi = 0; gi < (state.gpu_count || 0); gi++) {
+      appendById(state.gpu_mem[gi] || [], (msg.gpu_mem || [])[gi] || [], "pid");
+      appendTrim(state.gpu_util[gi], (msg.gpu_util || [])[gi] || []);
+      appendTrim(state.gpu_temp[gi], (msg.gpu_temp || [])[gi] || []);
+      appendTrim(state.ts_pcie[gi] || [], (msg.ts_pcie || [])[gi] || []);
+      appendTrim(state.pcie_tx[gi] || [], (msg.pcie_tx || [])[gi] || []);
+      appendTrim(state.pcie_rx[gi] || [], (msg.pcie_rx || [])[gi] || []);
+    }
+    lastCounters = {
+      main: msg.counter_main || lastCounters.main,
+      disk: msg.counter_disk || lastCounters.disk,
+      pcie: msg.counter_pcie || lastCounters.pcie
+    };
+  }
+
+  function toDates(values) {
+    return (values || []).map(v => new Date(v * 1000));
+  }
+
+  function scheduleRender() {
+    if (renderScheduled) return;
+    renderScheduled = true;
+    requestAnimationFrame(function() {
+      renderScheduled = false;
+      render();
+    });
+  }
+
+  function visibleRange() {
+    if (paused || viewSeconds <= 0) return null;
+    const end = new Date();
+    const start = new Date(end.getTime() - viewSeconds * 1000);
+    return [start, end];
+  }
+
+  function render() {
+    if (!state) return;
+    const traces = [];
+    const timesMain = toDates(state.ts_main);
+    const timesDisk = toDates(state.ts_disk);
+    const colors = [
+      "#00e5ff", "#ff1744", "#76ff03", "#448aff", "#ff9100",
+      "#d500f9", "#ffea00", "#f50057", "#00e676", "#ff6d00"
+    ];
+
+    for (let gi = 0; gi < (state.gpu_count || 0); gi++) {
+      const memSeries = state.gpu_mem[gi] || [];
+      for (let i = memSeries.length - 1; i >= 0; i--) {
+        const proc = memSeries[i];
+        traces.push({
+          x: timesMain, y: proc.vals, name: "GPU " + gi + " " + proc.name + " (" + proc.pid + ")",
+          type: "scatter", mode: "none", stackgroup: "gpu_mem_" + gi,
+          fillcolor: hexToRgba(proc.color || colors[i % colors.length], 0.55),
+          line: {width: 0, color: proc.color || colors[i % colors.length]},
+          xaxis: "x", yaxis: "y", legendgroup: "gpu_mem_" + gi
+        });
+      }
+      traces.push({
+        x: timesMain,
+        y: timesMain.map(() => (state.gpu_mem_total_gib || [])[gi] || 0),
+        name: "GPU " + gi + " total",
+        type: "scatter", mode: "lines", line: {color: "#ff5252", width: 1, dash: "dot"},
+        xaxis: "x", yaxis: "y", legendgroup: "gpu_total"
+      });
+      traces.push({
+        x: timesMain, y: (state.gpu_util || [])[gi] || [], name: "GPU " + gi + " util",
+        type: "scatter", mode: "lines", line: {color: "#76b900", width: 2},
+        fill: "tozeroy", fillcolor: "rgba(118,185,0,0.25)", xaxis: "x2", yaxis: "y2"
+      });
+      traces.push({
+        x: timesMain, y: (state.gpu_temp || [])[gi] || [], name: "GPU " + gi + " temp",
+        type: "scatter", mode: "lines", line: {color: "#ff6e40", width: 1, dash: "dot"},
+        xaxis: "x2", yaxis: "y2"
+      });
+      if (state.has_pcie) {
+        const timesPcie = toDates((state.ts_pcie || [])[gi] || []);
+        traces.push({
+          x: timesPcie, y: (state.pcie_tx || [])[gi] || [], name: "GPU " + gi + " PCIe TX",
+          type: "scatter", mode: "lines", line: {color: "#ef5350", width: 1}, xaxis: "x4", yaxis: "y4"
+        });
+        traces.push({
+          x: timesPcie, y: (state.pcie_rx || [])[gi] || [], name: "GPU " + gi + " PCIe RX",
+          type: "scatter", mode: "lines", line: {color: "#69f0ae", width: 1, dash: "dot"}, xaxis: "x4", yaxis: "y4"
+        });
+      }
+    }
+
+    for (const proc of state.cpu_procs || []) {
+      traces.push({
+        x: timesMain, y: proc.vals, name: proc.name, type: "scatter", mode: "none",
+        stackgroup: "cpu", fillcolor: hexToRgba(proc.color || "#8888ff", 0.45),
+        line: {width: 0, color: proc.color || "#8888ff"}, xaxis: "x3", yaxis: "y3"
+      });
+    }
+    traces.push({
+      x: timesMain, y: state.cpu || [], name: "CPU total", type: "scatter", mode: "lines",
+      line: {color: "#ffcc00", width: 1.5, dash: "dot"}, xaxis: "x3", yaxis: "y3"
+    });
+    traces.push({
+      x: timesDisk, y: state.disk_read || [], name: "Disk read", type: "scatter", mode: "lines",
+      line: {color: "#ff9800", width: 1}, xaxis: "x4", yaxis: "y4"
+    });
+    traces.push({
+      x: timesDisk, y: state.disk_write || [], name: "Disk write", type: "scatter", mode: "lines",
+      line: {color: "#ffd740", width: 1}, xaxis: "x4", yaxis: "y4"
+    });
+    traces.push({
+      x: timesMain, y: state.net_sent || [], name: "Net TX", type: "scatter", mode: "lines",
+      line: {color: "#18ffff", width: 1}, xaxis: "x4", yaxis: "y4"
+    });
+    traces.push({
+      x: timesMain, y: state.net_recv || [], name: "Net RX", type: "scatter", mode: "lines",
+      line: {color: "#ff80ab", width: 1}, xaxis: "x4", yaxis: "y4"
+    });
+
+    const range = visibleRange();
+    const baseAxis = {gridcolor: "#262640", zerolinecolor: "#444466"};
+    const xAxis = {gridcolor: "#262640", type: "date"};
+    if (range) xAxis.range = range;
+    const layout = {
+      paper_bgcolor: "#0d0d14", plot_bgcolor: "#141420",
+      font: {family: "monospace", color: "#e0e0e0", size: 11},
+      margin: {l: 68, r: 20, t: 20, b: 34},
+      hovermode: "x unified",
+      legend: {orientation: "v", x: 1.01, y: 1, bgcolor: "rgba(13,13,20,0.75)", font: {size: 10}},
+      grid: {rows: 4, columns: 1, pattern: "independent", roworder: "top to bottom"},
+      xaxis: Object.assign({}, xAxis),
+      xaxis2: Object.assign({}, xAxis),
+      xaxis3: Object.assign({}, xAxis),
+      xaxis4: Object.assign({}, xAxis),
+      yaxis: Object.assign({title: "GPU VRAM GiB", domain: [0.76, 1.0], rangemode: "tozero"}, baseAxis),
+      yaxis2: Object.assign({title: "GPU % / C", domain: [0.52, 0.72], range: [0, 105]}, baseAxis),
+      yaxis3: Object.assign({title: "CPU %", domain: [0.28, 0.48], range: [0, 105]}, baseAxis),
+      yaxis4: Object.assign({title: "I/O", domain: [0.0, 0.24], rangemode: "tozero"}, baseAxis),
+      annotations: [
+        label("GPU VRAM by process", 0.995),
+        label("GPU utilization + temperature", 0.715),
+        label("CPU total + top process groups", 0.475),
+        label("Disk, network, PCIe", 0.235)
+      ]
+    };
+    Plotly.react(chart, traces, layout, {responsive: true, displayModeBar: true, scrollZoom: true});
+    const gpuText = state.gpu_count ? state.gpu_count + " GPU" + (state.gpu_count === 1 ? "" : "s") : "CPU-only";
+    status.textContent = (paused ? "Paused" : "Live") +
+      " | " + gpuText +
+      " | main " + lastCounters.main +
+      " disk " + lastCounters.disk;
+  }
+
+  function label(text, y) {
+    return {
+      text: "  " + text + "  ",
+      x: 0,
+      y: y,
+      xref: "paper",
+      yref: "paper",
+      showarrow: false,
+      xanchor: "left",
+      yanchor: "top",
+      bgcolor: "rgba(30,30,50,0.92)",
+      bordercolor: "#444466",
+      borderwidth: 1,
+      font: {size: 11, color: "#c0c0d0"}
+    };
+  }
+
+  function hexToRgba(hex, alpha) {
+    const h = (hex || "#999999").replace("#", "");
+    const r = parseInt(h.substring(0, 2), 16);
+    const g = parseInt(h.substring(2, 4), 16);
+    const b = parseInt(h.substring(4, 6), 16);
+    return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
+  }
+
+  document.querySelectorAll(".range-btn").forEach(btn => {
+    btn.addEventListener("click", function() {
+      document.querySelectorAll(".range-btn").forEach(b => b.classList.remove("active"));
+      this.classList.add("active");
+      viewSeconds = parseInt(this.dataset.sec);
+      paused = false;
+      document.getElementById("pause-btn").textContent = "Pause";
+      document.getElementById("pause-btn").style.backgroundColor = "#ffcc00";
+      socket.emit("view_minutes", Math.max(1, Math.round(viewSeconds / 60)));
+      scheduleRender();
+    });
+  });
+
+  document.getElementById("pause-btn").addEventListener("click", function() {
+    paused = !paused;
+    this.textContent = paused ? "Resume" : "Pause";
+    this.style.backgroundColor = paused ? "#ff5252" : "#ffcc00";
+    if (!paused) socket.emit("view_minutes", Math.max(1, Math.round(viewSeconds / 60)));
+    scheduleRender();
+  });
+
+  document.getElementById("snapshot-btn").addEventListener("click", function() {
+    if (!state) return;
+    const d = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const fname = d.getFullYear() + "-" +
+      pad(d.getMonth() + 1) + "-" +
+      pad(d.getDate()) + "_" +
+      pad(d.getHours()) +
+      pad(d.getMinutes()) +
+      pad(d.getSeconds()) +
+      "_resource_monitor";
+    Plotly.downloadImage(chart, {format: "png", width: 1920, height: 1080, scale: 2, filename: fname});
+  });
+})();
+</script>
+</body>
+</html>

--- a/dev/observability/dynamo_local_resource_monitor.html.j2
+++ b/dev/observability/dynamo_local_resource_monitor.html.j2
@@ -136,7 +136,7 @@
 
   function appendTrim(arr, vals) {
     if (!vals || vals.length === 0) return;
-    arr.push.apply(arr, vals);
+    for (const val of vals) arr.push(val);
     if (arr.length > MAX_POINTS) arr.splice(0, arr.length - MAX_POINTS);
   }
 

--- a/dev/observability/dynamo_local_resource_monitor.py
+++ b/dev/observability/dynamo_local_resource_monitor.py
@@ -187,6 +187,7 @@ def _resolve_process_name(pid: int) -> str:
                 parts.append(test)
             elif script:
                 parts.append(script)
+            parts.append(f"PID={pid}")
             return ", ".join(parts)
 
         # SGLang, TRT-LLM, mpi4py, orted — walk ancestry for context
@@ -212,7 +213,16 @@ def _resolve_process_name(pid: int) -> str:
                 parts.append(test)
             elif script:
                 parts.append(script)
+            parts.append(f"PID={pid}")
             return ", ".join(parts)
+
+        if cmdline and os.path.basename(cmdline[0]) == "node":
+            label = _classify_node_process(full_cmd)
+            if label:
+                return f"{label}:{pid}"
+        if cmdline and cmdline[0] == "docker" and "exec" in cmdline:
+            if "node" in full_cmd:
+                return f"Docker/Cursor:{pid}"
 
         # Python with dynamo module: extract module + model + test context
         if cmdline and os.path.basename(cmdline[0]).startswith("python"):
@@ -230,19 +240,20 @@ def _resolve_process_name(pid: int) -> str:
                         parts.append(short_model)
                     if test:
                         parts.append(test)
+                    parts.append(f"PID={pid}")
                     return ", ".join(parts)
             if len(cmdline) > 1:
                 script = os.path.basename(cmdline[1])
                 if len(script) > 25:
                     script = script[:22] + "..."
-                return script
+                return f"{script}, PID={pid}"
 
         if cmdline:
             base = os.path.basename(cmdline[0])
             if len(base) > 25:
                 base = base[:22] + "..."
-            return base
-        return proc_name
+            return f"{base}:{pid}"
+        return f"{proc_name}:{pid}"
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         return f"pid:{pid}"
 
@@ -298,6 +309,33 @@ def _extract_arg(cmdline: list[str], flag: str) -> str:
     return ""
 
 
+def _classify_node_process(full_cmd: str) -> str:
+    lower_cmd = full_cmd.lower()
+    markers = (
+        ("--type=extensionhost", "ExtHost"),
+        ("cursorpyright", "Pylance"),
+        ("pyright", "Pylance"),
+        ("pylance", "Pylance"),
+        ("--type=filewatcher", "FileWatcher"),
+        ("--type=ptyhost", "PtyHost"),
+        ("server-main.js", "CursorServer"),
+        ("multiplex-server", "Multiplex"),
+        ("forwarder.js", "PortFwd"),
+        ("markdown-language-features", "Markdown"),
+        ("rust-analyzer", "RustAnalyzer"),
+        ("gitlens", "GitLens"),
+        ("typescript", "TSServer"),
+        ("eslint", "ESLint"),
+        ("bootstrap-fork", "CursorWorker"),
+    )
+    for marker, label in markers:
+        if marker in lower_cmd:
+            return label
+    if ".cursor-server" in lower_cmd or ".vscode-server" in lower_cmd:
+        return "CursorNode"
+    return ""
+
+
 class ProcessTracker:
     """Track rolling per-process series with stable colors for the dashboard UI."""
 
@@ -322,14 +360,13 @@ class ProcessTracker:
         timestamp: float = 0,
         pre_resolved: dict[int, str] | None = None,
     ):
+        pre_resolved = pre_resolved or {}
+        self.names.update(pre_resolved)
         for pid in data:
             if pid not in self.series:
                 backfill = min(self._len, self.maxlen)
                 self.series[pid] = deque([0.0] * backfill, maxlen=self.maxlen)
-                if pre_resolved and pid in pre_resolved:
-                    self.names[pid] = pre_resolved[pid]
-                else:
-                    self.names[pid] = name_resolver(pid)
+                self.names[pid] = pre_resolved.get(pid) or name_resolver(pid)
                 self.first_seen[pid] = timestamp
                 if self._free_slots:
                     slot = self._free_slots.pop(0)
@@ -604,7 +641,7 @@ class MetricsCollector:
                 self.gpu_names.append(name)
                 mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
                 self.gpu_mem_total_gib.append(mem.total / (1024**3))
-                self.proc_gpu_mem.append(ProcessTracker(maxlen_main, prune=True))
+                self.proc_gpu_mem.append(ProcessTracker(maxlen_main, prune=False))
                 self.gpu_util.append(deque(maxlen=maxlen_main))
                 self.gpu_temp.append(deque(maxlen=maxlen_main))
                 self.gpu_pcie_tx.append(deque(maxlen=maxlen_pcie))
@@ -754,8 +791,18 @@ class MetricsCollector:
     ):
         gpu_names: list[dict[int, str]] = []
         for i, (gpu_proc_mem, _, _) in enumerate(gpu_data):
-            new_pids = self.proc_gpu_mem[i].new_pids(gpu_proc_mem)
-            gpu_names.append({pid: _resolve_process_name(pid) for pid in new_pids})
+            tracker = self.proc_gpu_mem[i]
+            new_pids = tracker.new_pids(gpu_proc_mem)
+            stale_label_pids = {
+                pid
+                for pid in gpu_proc_mem
+                if f"PID={pid}" not in tracker.names.get(pid, "")
+                and f":{pid}" not in tracker.names.get(pid, "")
+            }
+            pids_to_resolve = new_pids | stale_label_pids
+            gpu_names.append(
+                {pid: _resolve_process_name(pid) for pid in pids_to_resolve}
+            )
 
         cpu_id_data: dict[int, float] = {}
         cpu_id_names: dict[int, str] = {}

--- a/dev/observability/dynamo_local_resource_monitor.py
+++ b/dev/observability/dynamo_local_resource_monitor.py
@@ -604,7 +604,7 @@ class MetricsCollector:
                 self.gpu_names.append(name)
                 mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
                 self.gpu_mem_total_gib.append(mem.total / (1024**3))
-                self.proc_gpu_mem.append(ProcessTracker(maxlen_main, prune=False))
+                self.proc_gpu_mem.append(ProcessTracker(maxlen_main, prune=True))
                 self.gpu_util.append(deque(maxlen=maxlen_main))
                 self.gpu_temp.append(deque(maxlen=maxlen_main))
                 self.gpu_pcie_tx.append(deque(maxlen=maxlen_pcie))
@@ -1285,6 +1285,8 @@ def build_monitor_server(collector: MetricsCollector):
     )
 
     ui_state = {"view_minutes": 2}
+    client_cursors: dict[str, dict] = {}
+    client_lock = threading.Lock()
 
     @app.route("/")
     def index():
@@ -1300,6 +1302,12 @@ def build_monitor_server(collector: MetricsCollector):
     @socketio.on("connect")
     def handle_connect():
         sid = flask.request.sid
+        with client_lock:
+            client_cursors[sid] = {
+                "main": 0,
+                "pcie": [0] * collector.gpu_count,
+                "disk": 0,
+            }
 
         def send_init():
             for _ in range(50):
@@ -1307,13 +1315,33 @@ def build_monitor_server(collector: MetricsCollector):
                     if len(collector.ts_main) > 5:
                         break
                 time.sleep(0.1)
-            socketio.emit("init", collector.snapshot_full(), to=sid)
+            snapshot = collector.snapshot_full()
+            with client_lock:
+                client_cursors[sid] = {
+                    "main": snapshot["counter_main"],
+                    "pcie": list(snapshot["counter_pcie"]),
+                    "disk": snapshot["counter_disk"],
+                }
+            socketio.emit("init", snapshot, to=sid)
 
         threading.Thread(target=send_init, daemon=True).start()
 
+    @socketio.on("disconnect")
+    def handle_disconnect():
+        with client_lock:
+            client_cursors.pop(flask.request.sid, None)
+
     @socketio.on("request_init")
     def handle_request_init():
-        socketio.emit("init", collector.snapshot_full(), to=flask.request.sid)
+        sid = flask.request.sid
+        snapshot = collector.snapshot_full()
+        with client_lock:
+            client_cursors[sid] = {
+                "main": snapshot["counter_main"],
+                "pcie": list(snapshot["counter_pcie"]),
+                "disk": snapshot["counter_disk"],
+            }
+        socketio.emit("init", snapshot, to=sid)
 
     @socketio.on("view_minutes")
     def handle_view_minutes(view_minutes):
@@ -1328,9 +1356,6 @@ def build_monitor_server(collector: MetricsCollector):
     }
 
     def push_loop():
-        last_main = 0
-        last_pcie: list[int] = [0] * collector.gpu_count
-        last_disk = 0
         while True:
             view_minutes = ui_state.get("view_minutes", 2)
             push_sec, step = push_policy.get(view_minutes, (0.100, 1))
@@ -1339,17 +1364,31 @@ def build_monitor_server(collector: MetricsCollector):
                 counter_main = collector.counter_main
                 counter_pcie = list(collector.counter_pcie)
                 counter_disk = collector.counter_disk
-            if (
-                counter_main <= last_main
-                and counter_pcie == last_pcie
-                and counter_disk <= last_disk
-            ):
-                continue
-            delta = collector.snapshot_delta(last_main, last_pcie, last_disk, step=step)
-            last_main = counter_main
-            last_pcie = counter_pcie
-            last_disk = counter_disk
-            socketio.emit("delta", delta)
+            with client_lock:
+                cursors = list(client_cursors.items())
+
+            for sid, cursor in cursors:
+                last_main = cursor["main"]
+                last_pcie = cursor["pcie"]
+                last_disk = cursor["disk"]
+                if (
+                    counter_main <= last_main
+                    and counter_pcie == last_pcie
+                    and counter_disk <= last_disk
+                ):
+                    continue
+                delta = collector.snapshot_delta(
+                    last_main, last_pcie, last_disk, step=step
+                )
+                with client_lock:
+                    if sid not in client_cursors:
+                        continue
+                    client_cursors[sid] = {
+                        "main": counter_main,
+                        "pcie": counter_pcie,
+                        "disk": counter_disk,
+                    }
+                socketio.emit("delta", delta, to=sid)
 
     return socketio, app, push_loop
 

--- a/dev/observability/dynamo_local_resource_monitor.py
+++ b/dev/observability/dynamo_local_resource_monitor.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Dynamo Local Resource Monitor — per-process resource metrics exporter for Prometheus.
+Dynamo Local Resource Monitor — per-process resource metrics and local dashboard.
 
 Tracks VRAM, GPU utilization, PCIe bandwidth, CPU, disk I/O, and network I/O
 for Dynamo inference processes, labeled by model name and process identity.
@@ -30,9 +30,11 @@ Architecture (multiprocess, bypasses GIL):
   - 1 subprocess per GPU: PCIe TX/RX sampling at 10/s
   - 1 subprocess: CPU + GPU mem/util/temp + network at 5/s
   - 1 subprocess: aggregate disk I/O at 1/s
-  - Main process: polls pipes, updates Prometheus gauges
+  - Main process: polls pipes, updates Prometheus gauges or pushes UI deltas
 
-Exposes a /metrics endpoint in Prometheus exposition format.
+The HTTP endpoint serves /metrics for Prometheus. When the dashboard packages
+are installed, the same endpoint also serves a local Plotly dashboard at / and
+pushes deltas over Socket.IO.
 
 Usage:
     python3 dynamo_local_resource_monitor.py [--port 8051] [--host 0.0.0.0]
@@ -40,17 +42,27 @@ Usage:
 
 import argparse
 import importlib.util
+import json
 import multiprocessing
 import os
 import signal
+import socketserver
 import sys
 import threading
 import time
+from collections import Counter, deque
+from pathlib import Path
+from wsgiref.simple_server import WSGIRequestHandler, WSGIServer, make_server
 
 _REQUIRED_PACKAGES = {
     "psutil": "psutil",
     "pynvml": "nvidia-ml-py",
     "prometheus_client": "prometheus-client",
+}
+_DASHBOARD_PACKAGES = {
+    "flask": "flask",
+    "flask_socketio": "flask-socketio",
+    "simple_websocket": "simple-websocket",
 }
 _missing = [
     pypi
@@ -68,7 +80,7 @@ if _missing:
 
 import psutil  # noqa: E402
 import pynvml  # noqa: E402
-from prometheus_client import Gauge, start_http_server  # noqa: E402
+from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest  # noqa: E402
 
 HAS_NVML = False
 try:
@@ -77,11 +89,35 @@ try:
 except pynvml.NVMLError as e:
     print(f"NVML init failed ({e}) -- GPU monitoring disabled")
 
+PROCESS_COLORS = [
+    "#00e5ff",
+    "#ff1744",
+    "#76ff03",
+    "#448aff",
+    "#ff9100",
+    "#d500f9",
+    "#ffea00",
+    "#f50057",
+    "#00e676",
+    "#ff6d00",
+    "#18ffff",
+    "#ea80fc",
+    "#b2ff59",
+    "#ff80ab",
+    "#64ffda",
+    "#ffd740",
+    "#e040fb",
+    "#ff9e80",
+    "#a7ffeb",
+    "#ff8a80",
+]
+OTHER_COLOR = "#9e9e9e"
+CACHE_DIR = Path.home() / ".cache" / "dynamo_local_resource_monitor"
+CACHE_FILE = CACHE_DIR / "metrics.json"
+
 
 def parse_args():
-    p = argparse.ArgumentParser(
-        description="GPU/CPU/Disk/Network Prometheus metrics exporter"
-    )
+    p = argparse.ArgumentParser(description="GPU/CPU/Disk/Network resource monitor")
     p.add_argument("--port", type=int, default=8051)
     p.add_argument("--host", default="0.0.0.0")
     p.add_argument(
@@ -96,7 +132,42 @@ def parse_args():
         default=1000,
         help="Disk I/O collection interval ms (1/s)",
     )
+    p.add_argument(
+        "--window",
+        type=int,
+        default=900,
+        help="Dashboard rolling window seconds (default 900 = 15min)",
+    )
+    p.add_argument(
+        "--top-n",
+        type=int,
+        default=12,
+        help="Dashboard process series limit per chart",
+    )
     return p.parse_args()
+
+
+def _missing_dashboard_packages():
+    return [
+        pypi
+        for mod, pypi in _DASHBOARD_PACKAGES.items()
+        if importlib.util.find_spec(mod) is None
+    ]
+
+
+def _load_dashboard_server_deps():
+    missing = _missing_dashboard_packages()
+    if missing:
+        print(
+            f"dynamo_local_resource_monitor: missing dashboard server packages: {', '.join(missing)}\n"
+            f"Install with:\n\n  pip install {' '.join(missing)}\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    flask = importlib.import_module("flask")
+    flask_socketio = importlib.import_module("flask_socketio")
+    return flask, flask_socketio
 
 
 def _resolve_process_name(pid: int) -> str:
@@ -227,6 +298,137 @@ def _extract_arg(cmdline: list[str], flag: str) -> str:
     return ""
 
 
+class ProcessTracker:
+    """Track rolling per-process series with stable colors for the dashboard UI."""
+
+    def __init__(self, maxlen: int, prune: bool = True):
+        self.maxlen = maxlen
+        self._prune_enabled = prune
+        self._len = 0
+        self.series: dict[int, deque[float]] = {}
+        self.names: dict[int, str] = {}
+        self.first_seen: dict[int, float] = {}
+        self._pid_slot: dict[int, int] = {}
+        self._free_slots: list[int] = []
+        self._next_slot = 0
+
+    def new_pids(self, data: dict[int, float]) -> set[int]:
+        return set(data.keys()) - set(self.series.keys())
+
+    def record(
+        self,
+        data: dict[int, float],
+        name_resolver,
+        timestamp: float = 0,
+        pre_resolved: dict[int, str] | None = None,
+    ):
+        for pid in data:
+            if pid not in self.series:
+                backfill = min(self._len, self.maxlen)
+                self.series[pid] = deque([0.0] * backfill, maxlen=self.maxlen)
+                if pre_resolved and pid in pre_resolved:
+                    self.names[pid] = pre_resolved[pid]
+                else:
+                    self.names[pid] = name_resolver(pid)
+                self.first_seen[pid] = timestamp
+                if self._free_slots:
+                    slot = self._free_slots.pop(0)
+                else:
+                    slot = self._next_slot
+                    self._next_slot += 1
+                self._pid_slot[pid] = slot
+
+        for pid, dq in self.series.items():
+            dq.append(data.get(pid, 0.0))
+        self._len += 1
+        if self._prune_enabled:
+            self._prune_dead()
+
+    def _prune_dead(self):
+        window = min(200, self._len)
+        dead = [
+            pid
+            for pid, dq in self.series.items()
+            if all(v == 0.0 for v in list(dq)[-window:])
+        ]
+        for pid in dead:
+            del self.series[pid]
+            del self.names[pid]
+            if pid in self._pid_slot:
+                self._free_slots.append(self._pid_slot.pop(pid))
+
+    def to_dict(self) -> dict:
+        return {
+            "maxlen": self.maxlen,
+            "_prune_enabled": self._prune_enabled,
+            "_len": self._len,
+            "series": {str(k): list(v) for k, v in self.series.items()},
+            "names": {str(k): v for k, v in self.names.items()},
+            "first_seen": {str(k): v for k, v in self.first_seen.items()},
+            "_pid_slot": {str(k): v for k, v in self._pid_slot.items()},
+            "_free_slots": self._free_slots,
+            "_next_slot": self._next_slot,
+        }
+
+    def load_dict(self, data: dict):
+        self._len = data.get("_len", 0)
+        for key, values in data.get("series", {}).items():
+            pid = int(key)
+            self.series[pid] = deque(values, maxlen=self.maxlen)
+        self.names = {int(k): v for k, v in data.get("names", {}).items()}
+        self.first_seen = {int(k): v for k, v in data.get("first_seen", {}).items()}
+        self._pid_slot = {int(k): v for k, v in data.get("_pid_slot", {}).items()}
+        self._free_slots = data.get("_free_slots", [])
+        self._next_slot = data.get("_next_slot", 0)
+
+    def _color_for(self, pid: int) -> str:
+        slot = self._pid_slot.get(pid, 0)
+        return PROCESS_COLORS[slot % len(PROCESS_COLORS)]
+
+    def get_top_sorted(
+        self, n: int = 20, sort_by: str = "recency"
+    ) -> list[tuple[int, str, str, list[float]]]:
+        if not self.series:
+            return []
+
+        if sort_by == "recency":
+
+            def _key(p):
+                series = self.series[p]
+                last_active = -1
+                for i in range(len(series) - 1, -1, -1):
+                    if series[i] > 0:
+                        last_active = i
+                        break
+                return (last_active, max(series) if series else 0)
+
+        else:
+
+            def _key(p):
+                return sum(self.series[p])
+
+        sorted_pids = sorted(self.series.keys(), key=_key, reverse=True)
+        top = sorted_pids[:n]
+        rest = sorted_pids[n:]
+        result = [
+            (pid, self.names[pid], self._color_for(pid), list(self.series[pid]))
+            for pid in top
+            if max(self.series[pid]) > 0
+        ]
+        if rest:
+            length = len(next(iter(self.series.values())))
+            rest_vals = [0.0] * length
+            has_data = False
+            for pid in rest:
+                for i, value in enumerate(self.series[pid]):
+                    rest_vals[i] += value
+                    if value > 0:
+                        has_data = True
+            if has_data:
+                result.append((-1, "Other", OTHER_COLOR, rest_vals))
+        return result
+
+
 # ---------------------------------------------------------------------------
 # Multiprocess workers (each gets its own GIL)
 # ---------------------------------------------------------------------------
@@ -344,6 +546,485 @@ def _disk_worker(conn, interval_sec):
         last_mono = mono
         conn.send(("disk", now, read_mbps, write_mbps))
         time.sleep(interval_sec)
+
+
+class MetricsCollector:
+    """Rolling time-series state for the WebSocket dashboard."""
+
+    def __init__(
+        self,
+        window_sec: int,
+        main_interval_ms: int = 200,
+        disk_interval_ms: int = 1000,
+        pcie_rate_hz: int = 10,
+        top_n: int = 12,
+    ):
+        self.lock = threading.Lock()
+        maxlen_main = int(window_sec * 1000 / main_interval_ms)
+        maxlen_pcie = window_sec * pcie_rate_hz
+        maxlen_disk = int(window_sec * 1000 / disk_interval_ms)
+        self.top_n = top_n
+
+        self.ts_main: deque[float] = deque(maxlen=maxlen_main)
+        self.counter_main = 0
+        self.cpu_pct: deque[float] = deque(maxlen=maxlen_main)
+        self.proc_gpu_mem: list[ProcessTracker] = []
+        self.gpu_util: list[deque[float]] = []
+        self.gpu_temp: list[deque[float]] = []
+        self.net_sent_mbps: deque[float] = deque(maxlen=maxlen_main)
+        self.net_recv_mbps: deque[float] = deque(maxlen=maxlen_main)
+
+        self.ts_pcie: list[deque[float]] = []
+        self.counter_pcie: list[int] = []
+        self.gpu_pcie_tx: list[deque[float]] = []
+        self.gpu_pcie_rx: list[deque[float]] = []
+        self.has_pcie = False
+
+        self.proc_cpu = ProcessTracker(maxlen_main, prune=True)
+        self._cpu_name_to_id: dict[str, int] = {}
+        self._cpu_next_id = 1
+        self._cpu_top_n = 5
+
+        self.ts_disk: deque[float] = deque(maxlen=maxlen_disk)
+        self.counter_disk = 0
+        self.disk_read_mbps: deque[float] = deque(maxlen=maxlen_disk)
+        self.disk_write_mbps: deque[float] = deque(maxlen=maxlen_disk)
+
+        self.gpu_count = 0
+        self.gpu_names: list[str] = []
+        self.gpu_mem_total_gib: list[float] = []
+        if HAS_NVML:
+            self.gpu_count = pynvml.nvmlDeviceGetCount()
+            for i in range(self.gpu_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                name = pynvml.nvmlDeviceGetName(handle)
+                if isinstance(name, bytes):
+                    name = name.decode("utf-8")
+                self.gpu_names.append(name)
+                mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                self.gpu_mem_total_gib.append(mem.total / (1024**3))
+                self.proc_gpu_mem.append(ProcessTracker(maxlen_main, prune=False))
+                self.gpu_util.append(deque(maxlen=maxlen_main))
+                self.gpu_temp.append(deque(maxlen=maxlen_main))
+                self.gpu_pcie_tx.append(deque(maxlen=maxlen_pcie))
+                self.gpu_pcie_rx.append(deque(maxlen=maxlen_pcie))
+                self.ts_pcie.append(deque(maxlen=maxlen_pcie))
+                self.counter_pcie.append(0)
+            if self.gpu_count > 0:
+                try:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+                    pynvml.nvmlDeviceGetPcieThroughput(
+                        handle, pynvml.NVML_PCIE_UTIL_TX_BYTES
+                    )
+                    self.has_pcie = True
+                except pynvml.NVMLError:
+                    self.has_pcie = False
+
+    def save_state(self):
+        """Persist the rolling window so restarting the dashboard keeps context."""
+        with self.lock:
+            state = {
+                "ts_main": list(self.ts_main),
+                "counter_main": self.counter_main,
+                "cpu_pct": list(self.cpu_pct),
+                "proc_cpu": self.proc_cpu.to_dict(),
+                "_cpu_name_to_id": self._cpu_name_to_id,
+                "_cpu_next_id": self._cpu_next_id,
+                "net_sent_mbps": list(self.net_sent_mbps),
+                "net_recv_mbps": list(self.net_recv_mbps),
+                "ts_pcie": [list(d) for d in self.ts_pcie],
+                "counter_pcie": self.counter_pcie[:],
+                "gpu_pcie_tx": [list(d) for d in self.gpu_pcie_tx],
+                "gpu_pcie_rx": [list(d) for d in self.gpu_pcie_rx],
+                "ts_disk": list(self.ts_disk),
+                "counter_disk": self.counter_disk,
+                "disk_read_mbps": list(self.disk_read_mbps),
+                "disk_write_mbps": list(self.disk_write_mbps),
+                "gpu_util": [list(d) for d in self.gpu_util],
+                "gpu_temp": [list(d) for d in self.gpu_temp],
+                "proc_gpu_mem": [t.to_dict() for t in self.proc_gpu_mem],
+                "gpu_count": self.gpu_count,
+                "saved_at": time.time(),
+            }
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = CACHE_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state))
+        tmp.rename(CACHE_FILE)
+        print(f"[save] metrics saved to {CACHE_FILE}", flush=True)
+
+    def load_state(self):
+        """Restore the previous rolling window, if it matches the local GPUs."""
+        if not CACHE_FILE.exists():
+            return
+        try:
+            state = json.loads(CACHE_FILE.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"[load] failed to read cache: {exc}", flush=True)
+            return
+        cached_gpu_count = state.get("gpu_count")
+        if cached_gpu_count != self.gpu_count:
+            print(
+                f"[load] GPU count mismatch (cached={cached_gpu_count}, "
+                f"current={self.gpu_count}), ignoring cache",
+                flush=True,
+            )
+            return
+        age = time.time() - state.get("saved_at", 0)
+        print(
+            f"[load] restoring metrics from {CACHE_FILE} (saved {age:.0f}s ago)",
+            flush=True,
+        )
+
+        def state_list(name: str, index: int, default):
+            values = state.get(name, [])
+            if isinstance(values, list) and index < len(values):
+                return values[index]
+            return default
+
+        with self.lock:
+            maxlen_main = self.ts_main.maxlen
+            maxlen_pcie = self.ts_pcie[0].maxlen if self.ts_pcie else 0
+            maxlen_disk = self.ts_disk.maxlen
+            self.ts_main = deque(state.get("ts_main", []), maxlen=maxlen_main)
+            self.counter_main = state.get("counter_main", 0)
+            self.cpu_pct = deque(state.get("cpu_pct", []), maxlen=maxlen_main)
+            if "proc_cpu" in state:
+                self.proc_cpu.load_dict(state["proc_cpu"])
+                self._cpu_name_to_id = state.get("_cpu_name_to_id", {})
+                self._cpu_next_id = state.get("_cpu_next_id", 1)
+            self.net_sent_mbps = deque(
+                state.get("net_sent_mbps", []), maxlen=maxlen_main
+            )
+            self.net_recv_mbps = deque(
+                state.get("net_recv_mbps", []), maxlen=maxlen_main
+            )
+            for gi in range(self.gpu_count):
+                self.ts_pcie[gi] = deque(
+                    state_list("ts_pcie", gi, []), maxlen=maxlen_pcie
+                )
+                self.counter_pcie[gi] = state_list("counter_pcie", gi, 0)
+                self.gpu_pcie_tx[gi] = deque(
+                    state_list("gpu_pcie_tx", gi, []), maxlen=maxlen_pcie
+                )
+                self.gpu_pcie_rx[gi] = deque(
+                    state_list("gpu_pcie_rx", gi, []), maxlen=maxlen_pcie
+                )
+                self.gpu_util[gi] = deque(
+                    state_list("gpu_util", gi, []), maxlen=maxlen_main
+                )
+                self.gpu_temp[gi] = deque(
+                    state_list("gpu_temp", gi, []), maxlen=maxlen_main
+                )
+                self.proc_gpu_mem[gi].load_dict(state_list("proc_gpu_mem", gi, {}))
+            self.ts_disk = deque(state.get("ts_disk", []), maxlen=maxlen_disk)
+            self.counter_disk = state.get("counter_disk", 0)
+            self.disk_read_mbps = deque(
+                state.get("disk_read_mbps", []), maxlen=maxlen_disk
+            )
+            self.disk_write_mbps = deque(
+                state.get("disk_write_mbps", []), maxlen=maxlen_disk
+            )
+        print(
+            f"[load] restored {len(self.ts_main)} main samples, {len(self.ts_disk)} disk samples",
+            flush=True,
+        )
+
+    def ingest_pcie(self, now: float, gpu_idx: int, tx_val: float, rx_val: float):
+        with self.lock:
+            self.ts_pcie[gpu_idx].append(now)
+            self.counter_pcie[gpu_idx] += 1
+            self.gpu_pcie_tx[gpu_idx].append(tx_val)
+            self.gpu_pcie_rx[gpu_idx].append(rx_val)
+
+    def _cpu_name_id(self, name: str) -> int:
+        if name not in self._cpu_name_to_id:
+            self._cpu_name_to_id[name] = self._cpu_next_id
+            self._cpu_next_id += 1
+        return self._cpu_name_to_id[name]
+
+    def ingest_main(
+        self,
+        now: float,
+        cpu: float,
+        gpu_data: list[tuple[dict, float, float]],
+        sent_rate: float,
+        recv_rate: float,
+        cpu_by_name: dict[str, float] | None = None,
+    ):
+        gpu_names: list[dict[int, str]] = []
+        for i, (gpu_proc_mem, _, _) in enumerate(gpu_data):
+            new_pids = self.proc_gpu_mem[i].new_pids(gpu_proc_mem)
+            gpu_names.append({pid: _resolve_process_name(pid) for pid in new_pids})
+
+        cpu_id_data: dict[int, float] = {}
+        cpu_id_names: dict[int, str] = {}
+        if cpu_by_name:
+            for name, pct in cpu_by_name.items():
+                sid = self._cpu_name_id(name)
+                cpu_id_data[sid] = pct
+                cpu_id_names[sid] = name
+
+        with self.lock:
+            self.ts_main.append(now)
+            self.counter_main += 1
+            self.cpu_pct.append(cpu)
+            self.proc_cpu.record(
+                cpu_id_data,
+                lambda sid: cpu_id_names.get(sid, f"pid:{sid}"),
+                now,
+                pre_resolved=cpu_id_names,
+            )
+            for i, (gpu_proc_mem, util, temp) in enumerate(gpu_data):
+                self.proc_gpu_mem[i].record(
+                    gpu_proc_mem,
+                    _resolve_process_name,
+                    now,
+                    pre_resolved=gpu_names[i],
+                )
+                self.gpu_util[i].append(util)
+                self.gpu_temp[i].append(temp)
+            alpha_net = 0.15
+            prev_sent = self.net_sent_mbps[-1] if self.net_sent_mbps else 0.0
+            prev_recv = self.net_recv_mbps[-1] if self.net_recv_mbps else 0.0
+            self.net_sent_mbps.append(
+                alpha_net * sent_rate + (1 - alpha_net) * prev_sent
+            )
+            self.net_recv_mbps.append(
+                alpha_net * recv_rate + (1 - alpha_net) * prev_recv
+            )
+
+    def ingest_disk(self, now: float, read_mbps: float, write_mbps: float):
+        with self.lock:
+            self.ts_disk.append(now)
+            self.counter_disk += 1
+            self.disk_read_mbps.append(read_mbps)
+            self.disk_write_mbps.append(write_mbps)
+
+    @staticmethod
+    def _downsample_init(times, arrays, max_recent=1000, max_total=1500):
+        n = len(times)
+        if n <= max_total:
+            return times, arrays
+        older_count = n - max_recent
+        older_target = max_total - max_recent
+        step = max(1, older_count // older_target)
+        indices = list(range(0, older_count, step)) + list(range(older_count, n))
+        ds_times = [times[i] for i in indices]
+        ds_arrays = [
+            [arr[i] for i in indices] if len(arr) == n else arr for arr in arrays
+        ]
+        return ds_times, ds_arrays
+
+    def snapshot_full(self) -> dict:
+        with self.lock:
+            main_vals = [list(self.cpu_pct)]
+            cpu_procs_full = self.proc_cpu.get_top_sorted(
+                self._cpu_top_n, sort_by="total"
+            )
+            for _, _, _, values in cpu_procs_full:
+                main_vals.append(values)
+
+            gpu_mem_per_gpu_full = []
+            for gi in range(self.gpu_count):
+                procs = self.proc_gpu_mem[gi].get_top_sorted(self.top_n)
+                gpu_mem_per_gpu_full.append(procs)
+                for _, _, _, values in procs:
+                    main_vals.append(values)
+
+            gpu_util = [list(self.gpu_util[i]) for i in range(self.gpu_count)]
+            gpu_temp = [list(self.gpu_temp[i]) for i in range(self.gpu_count)]
+            main_vals.extend(gpu_util)
+            main_vals.extend(gpu_temp)
+            main_vals.append(list(self.net_sent_mbps))
+            main_vals.append(list(self.net_recv_mbps))
+            ts_main_ds, main_ds = self._downsample_init(list(self.ts_main), main_vals)
+
+            midx = 0
+            ds_cpu = main_ds[midx] if main_ds else []
+            midx += 1
+            cpu_procs = []
+            for proc_id, name, color, _ in cpu_procs_full:
+                cpu_procs.append(
+                    {
+                        "id": proc_id,
+                        "name": name,
+                        "color": color,
+                        "vals": main_ds[midx],
+                    }
+                )
+                midx += 1
+
+            gpu_mem_per_gpu = []
+            for gi in range(self.gpu_count):
+                ds_procs = []
+                for pid, name, color, _ in gpu_mem_per_gpu_full[gi]:
+                    ds_procs.append(
+                        {
+                            "pid": pid,
+                            "name": name,
+                            "color": color,
+                            "vals": main_ds[midx],
+                            "first_seen": self.proc_gpu_mem[gi].first_seen.get(pid, 0),
+                        }
+                    )
+                    midx += 1
+                gpu_mem_per_gpu.append(ds_procs)
+
+            ds_gpu_util = [main_ds[midx + i] for i in range(self.gpu_count)]
+            midx += self.gpu_count
+            ds_gpu_temp = [main_ds[midx + i] for i in range(self.gpu_count)]
+            midx += self.gpu_count
+            ds_net_sent = main_ds[midx] if midx < len(main_ds) else []
+            ds_net_recv = main_ds[midx + 1] if midx + 1 < len(main_ds) else []
+
+            ds_pcie_tx = []
+            ds_pcie_rx = []
+            ts_pcie_per_gpu = []
+            if self.has_pcie:
+                for gi in range(self.gpu_count):
+                    ts_raw = list(self.ts_pcie[gi])
+                    tx_raw = list(self.gpu_pcie_tx[gi])
+                    rx_raw = list(self.gpu_pcie_rx[gi])
+                    ts_ds, vals_ds = self._downsample_init(ts_raw, [tx_raw, rx_raw])
+                    ts_pcie_per_gpu.append(ts_ds)
+                    ds_pcie_tx.append(vals_ds[0])
+                    ds_pcie_rx.append(vals_ds[1])
+
+            disk_vals = [list(self.disk_read_mbps), list(self.disk_write_mbps)]
+            ts_disk_ds, disk_ds = self._downsample_init(list(self.ts_disk), disk_vals)
+            ds_disk_read = disk_ds[0] if disk_ds else []
+            ds_disk_write = disk_ds[1] if len(disk_ds) > 1 else []
+
+            gpu_summary = ""
+            if self.gpu_names:
+                parts = []
+                for name, count in Counter(self.gpu_names).items():
+                    short = name.replace("NVIDIA ", "").replace("Generation", "")
+                    short = short.strip()
+                    parts.append(f"{count}x {short}" if count > 1 else short)
+                gpu_summary = "[" + ", ".join(parts) + "]"
+
+            return {
+                "type": "init",
+                "counter_main": self.counter_main,
+                "counter_pcie": list(self.counter_pcie),
+                "counter_disk": self.counter_disk,
+                "ts_main": ts_main_ds,
+                "ts_pcie": ts_pcie_per_gpu,
+                "ts_disk": ts_disk_ds,
+                "hostname": os.uname().nodename,
+                "gpu_summary": gpu_summary,
+                "gpu_count": self.gpu_count,
+                "gpu_names": self.gpu_names,
+                "gpu_mem_total_gib": self.gpu_mem_total_gib,
+                "has_pcie": self.has_pcie,
+                "gpu_mem": gpu_mem_per_gpu,
+                "gpu_util": ds_gpu_util,
+                "gpu_temp": ds_gpu_temp,
+                "pcie_tx": ds_pcie_tx,
+                "pcie_rx": ds_pcie_rx,
+                "cpu": ds_cpu,
+                "cpu_procs": cpu_procs,
+                "net_sent": ds_net_sent,
+                "net_recv": ds_net_recv,
+                "disk_read": ds_disk_read,
+                "disk_write": ds_disk_write,
+            }
+
+    def snapshot_delta(
+        self,
+        since_main: int,
+        since_pcie: list[int],
+        since_disk: int,
+        step: int = 1,
+    ) -> dict:
+        with self.lock:
+            new_main = self.counter_main - since_main
+            main_len = len(self.ts_main)
+            main_idx = max(0, main_len - new_main) if new_main > 0 else main_len
+            sl_m = slice(main_idx, None, step)
+            new_ts_main = list(self.ts_main)[sl_m]
+            cpu = list(self.cpu_pct)[sl_m]
+
+            cpu_procs = self.proc_cpu.get_top_sorted(self._cpu_top_n, sort_by="total")
+            cpu_procs_delta = [
+                {
+                    "id": proc_id,
+                    "name": name,
+                    "color": color,
+                    "vals": values[sl_m] if main_idx < len(values) else [],
+                }
+                for proc_id, name, color, values in cpu_procs
+            ]
+            cpu_proc_keys = [proc_id for proc_id, _, _, _ in cpu_procs]
+
+            gpu_mem_per_gpu = []
+            gpu_mem_keys_per_gpu = []
+            for gi in range(self.gpu_count):
+                gpu_mem = self.proc_gpu_mem[gi].get_top_sorted(self.top_n)
+                gpu_mem_per_gpu.append(
+                    [
+                        {
+                            "pid": pid,
+                            "name": name,
+                            "color": color,
+                            "vals": values[sl_m] if main_idx < len(values) else [],
+                        }
+                        for pid, name, color, values in gpu_mem
+                    ]
+                )
+                gpu_mem_keys_per_gpu.append([pid for pid, _, _, _ in gpu_mem])
+
+            gpu_util = [list(self.gpu_util[i])[sl_m] for i in range(self.gpu_count)]
+            gpu_temp = [list(self.gpu_temp[i])[sl_m] for i in range(self.gpu_count)]
+            net_sent = list(self.net_sent_mbps)[sl_m]
+            net_recv = list(self.net_recv_mbps)[sl_m]
+
+            pcie_step = max(step, 2)
+            pcie_tx = []
+            pcie_rx = []
+            new_ts_pcie = []
+            if self.has_pcie:
+                for gi in range(self.gpu_count):
+                    sp = since_pcie[gi] if gi < len(since_pcie) else 0
+                    new_pcie = self.counter_pcie[gi] - sp
+                    pcie_len = len(self.ts_pcie[gi])
+                    pcie_idx = max(0, pcie_len - new_pcie) if new_pcie > 0 else pcie_len
+                    sl_p = slice(pcie_idx, None, pcie_step)
+                    new_ts_pcie.append(list(self.ts_pcie[gi])[sl_p])
+                    pcie_tx.append(list(self.gpu_pcie_tx[gi])[sl_p])
+                    pcie_rx.append(list(self.gpu_pcie_rx[gi])[sl_p])
+
+            new_disk = self.counter_disk - since_disk
+            disk_len = len(self.ts_disk)
+            disk_idx = max(0, disk_len - new_disk) if new_disk > 0 else disk_len
+            sl_d = slice(disk_idx, None, step)
+            new_ts_disk = list(self.ts_disk)[sl_d]
+            disk_read = list(self.disk_read_mbps)[sl_d]
+            disk_write = list(self.disk_write_mbps)[sl_d]
+
+            return {
+                "type": "delta",
+                "counter_main": self.counter_main,
+                "counter_pcie": list(self.counter_pcie),
+                "counter_disk": self.counter_disk,
+                "ts_main": new_ts_main,
+                "ts_pcie": new_ts_pcie,
+                "ts_disk": new_ts_disk,
+                "gpu_mem": gpu_mem_per_gpu,
+                "gpu_mem_keys": gpu_mem_keys_per_gpu,
+                "gpu_util": gpu_util,
+                "gpu_temp": gpu_temp,
+                "pcie_tx": pcie_tx,
+                "pcie_rx": pcie_rx,
+                "cpu": cpu,
+                "cpu_procs": cpu_procs_delta,
+                "cpu_proc_keys": cpu_proc_keys,
+                "net_sent": net_sent,
+                "net_recv": net_recv,
+                "disk_read": disk_read,
+                "disk_write": disk_write,
+            }
 
 
 # ---------------------------------------------------------------------------
@@ -484,12 +1165,202 @@ class PrometheusUpdater:
         DISK_WRITE_MBPS.set(write_mbps)
 
 
+DASHBOARD_TEMPLATE = Path(__file__).with_name("dynamo_local_resource_monitor.html.j2")
+
+
+class ThreadingWSGIServer(socketserver.ThreadingMixIn, WSGIServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class QuietWSGIRequestHandler(WSGIRequestHandler):
+    def log_message(self, _format, *args):
+        return
+
+
+def _method_not_allowed(start_response):
+    body = b"Method Not Allowed\n"
+    start_response(
+        "405 Method Not Allowed",
+        [
+            ("Allow", "GET, OPTIONS"),
+            ("Content-Type", "text/plain; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+        ],
+    )
+    return [body]
+
+
+def _dashboard_install_html(missing: list[str]) -> bytes:
+    install_cmd = f"pip install {' '.join(missing)}"
+    body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Dynamo Local Resource Monitor</title>
+<style>
+  body {{ margin: 32px; font-family: monospace; line-height: 1.5; }}
+  code {{ background: #f3f3f3; padding: 2px 4px; }}
+</style>
+</head>
+<body>
+<h1>Dynamo Local Resource Monitor</h1>
+<p>You need to install the dashboard packages to use this page:</p>
+<pre>{install_cmd}</pre>
+<p>Prometheus metrics are still available at <code>/metrics</code>.</p>
+</body>
+</html>
+"""
+    return body.encode("utf-8")
+
+
+def start_metrics_only_server(port: int, addr: str, dashboard_missing: list[str]):
+    install_html = _dashboard_install_html(dashboard_missing)
+
+    def app(environ, start_response):
+        method = environ["REQUEST_METHOD"]
+        path = environ.get("PATH_INFO", "/")
+        if method == "OPTIONS":
+            start_response("200 OK", [("Allow", "OPTIONS,GET")])
+            return [b""]
+        if method != "GET":
+            return _method_not_allowed(start_response)
+
+        if path == "/metrics":
+            output = generate_latest()
+            start_response(
+                "200 OK",
+                [
+                    ("Content-Type", CONTENT_TYPE_LATEST),
+                    ("Content-Length", str(len(output))),
+                ],
+            )
+            return [output]
+
+        if path == "/favicon.ico":
+            start_response("200 OK", [("Content-Length", "0")])
+            return [b""]
+
+        if path == "/":
+            start_response(
+                "200 OK",
+                [
+                    ("Content-Type", "text/html; charset=utf-8"),
+                    ("Content-Length", str(len(install_html))),
+                ],
+            )
+            return [install_html]
+
+        body = b"Not Found\n"
+        start_response(
+            "404 Not Found",
+            [
+                ("Content-Type", "text/plain; charset=utf-8"),
+                ("Content-Length", str(len(body))),
+            ],
+        )
+        return [body]
+
+    return make_server(
+        addr,
+        port,
+        app,
+        server_class=ThreadingWSGIServer,
+        handler_class=QuietWSGIRequestHandler,
+    )
+
+
+def build_monitor_server(collector: MetricsCollector):
+    flask, flask_socketio = _load_dashboard_server_deps()
+    app = flask.Flask(__name__, template_folder=str(DASHBOARD_TEMPLATE.parent))
+    app.config["SECRET_KEY"] = "dynamo_local_resource_monitor"
+    socketio = flask_socketio.SocketIO(
+        app,
+        cors_allowed_origins="*",
+        async_mode="threading",
+        ping_timeout=60,
+        ping_interval=25,
+        max_http_buffer_size=50 * 1024 * 1024,
+    )
+
+    ui_state = {"view_minutes": 2}
+
+    @app.route("/")
+    def index():
+        return flask.render_template(DASHBOARD_TEMPLATE.name)
+
+    @app.route("/metrics")
+    def metrics():
+        return flask.Response(
+            generate_latest(),
+            headers={"Content-Type": CONTENT_TYPE_LATEST},
+        )
+
+    @socketio.on("connect")
+    def handle_connect():
+        sid = flask.request.sid
+
+        def send_init():
+            for _ in range(50):
+                with collector.lock:
+                    if len(collector.ts_main) > 5:
+                        break
+                time.sleep(0.1)
+            socketio.emit("init", collector.snapshot_full(), to=sid)
+
+        threading.Thread(target=send_init, daemon=True).start()
+
+    @socketio.on("request_init")
+    def handle_request_init():
+        socketio.emit("init", collector.snapshot_full(), to=flask.request.sid)
+
+    @socketio.on("view_minutes")
+    def handle_view_minutes(view_minutes):
+        ui_state["view_minutes"] = int(view_minutes)
+
+    push_policy = {
+        1: (0.075, 1),
+        2: (0.100, 1),
+        5: (0.200, 2),
+        10: (0.500, 4),
+        15: (1.000, 8),
+    }
+
+    def push_loop():
+        last_main = 0
+        last_pcie: list[int] = [0] * collector.gpu_count
+        last_disk = 0
+        while True:
+            view_minutes = ui_state.get("view_minutes", 2)
+            push_sec, step = push_policy.get(view_minutes, (0.100, 1))
+            time.sleep(push_sec)
+            with collector.lock:
+                counter_main = collector.counter_main
+                counter_pcie = list(collector.counter_pcie)
+                counter_disk = collector.counter_disk
+            if (
+                counter_main <= last_main
+                and counter_pcie == last_pcie
+                and counter_disk <= last_disk
+            ):
+                continue
+            delta = collector.snapshot_delta(last_main, last_pcie, last_disk, step=step)
+            last_main = counter_main
+            last_pcie = counter_pcie
+            last_disk = counter_disk
+            socketio.emit("delta", delta)
+
+    return socketio, app, push_loop
+
+
 def main():
     args = parse_args()
     gpu_count = 0
     if HAS_NVML:
         gpu_count = pynvml.nvmlDeviceGetCount()
 
+    dashboard_missing = _missing_dashboard_packages()
+    dashboard_enabled = not dashboard_missing
     main_sec = args.main_interval / 1000.0
     disk_sec = args.disk_interval / 1000.0
     print(
@@ -499,6 +1370,15 @@ def main():
         f"PCIe collect : 10/s ({gpu_count} subprocess{'es' if gpu_count != 1 else ''})"
     )
     print(f"Disk collect : {args.disk_interval}ms (aggregate disk I/O)")
+    if dashboard_enabled:
+        print("Server mode  : shared endpoint (/ and /metrics)")
+        print("Push interval: dynamic (75ms@1m .. 1000ms@15m)")
+        print(
+            f"Rolling window: {args.window}s ({args.window // 60}m {args.window % 60}s)"
+        )
+    else:
+        print("Server mode  : Prometheus /metrics exporter")
+        print(f"Dashboard    : disabled (missing: {', '.join(dashboard_missing)})")
 
     if HAS_NVML:
         for i in range(gpu_count):
@@ -514,7 +1394,20 @@ def main():
         print("No NVIDIA GPUs detected -- CPU + Disk only")
     print()
 
+    collector = None
     updater = PrometheusUpdater(gpu_count)
+    socketio = None
+    app = None
+    push_loop = None
+    if dashboard_enabled:
+        collector = MetricsCollector(
+            window_sec=args.window,
+            main_interval_ms=args.main_interval,
+            disk_interval_ms=args.disk_interval,
+            top_n=args.top_n,
+        )
+        collector.load_state()
+        socketio, app, push_loop = build_monitor_server(collector)
 
     workers: list[multiprocessing.Process] = []
     pipes: list[multiprocessing.connection.Connection] = []
@@ -564,33 +1457,48 @@ def main():
                 tag = msg[0]
                 if tag == "pcie":
                     updater.ingest_pcie(msg[2], msg[3], msg[4])
+                    if collector is not None:
+                        collector.ingest_pcie(msg[1], msg[2], msg[3], msg[4])
                 elif tag == "main":
                     updater.ingest_main(msg[2], msg[3], msg[4], msg[5], msg[6])
+                    if collector is not None:
+                        collector.ingest_main(
+                            msg[1], msg[2], msg[3], msg[4], msg[5], msg[6]
+                        )
                 elif tag == "disk":
                     updater.ingest_disk(msg[2], msg[3])
+                    if collector is not None:
+                        collector.ingest_disk(msg[1], msg[2], msg[3])
 
     for w in workers:
         w.start()
     threading.Thread(target=_poll_pipes, daemon=True).start()
 
-    # Start Prometheus HTTP server
-    start_http_server(args.port, addr=args.host)
-    print(f"Prometheus metrics at http://{args.host}:{args.port}/metrics")
-
     def _shutdown(signum, _frame):
         name = signal.Signals(signum).name
-        print(f"\n[{name}] shutting down.", flush=True)
+        if collector is not None:
+            print(f"\n[{name}] saving metrics before exit.", flush=True)
+            collector.save_state()
+        else:
+            print(f"\n[{name}] shutting down.", flush=True)
         raise SystemExit(0)
 
     signal.signal(signal.SIGINT, _shutdown)
     signal.signal(signal.SIGTERM, _shutdown)
 
-    # Block main thread (workers and HTTP server are in background threads)
-    try:
-        while True:
-            time.sleep(3600)
-    except SystemExit:
-        pass
+    if dashboard_enabled:
+        threading.Thread(target=push_loop, daemon=True).start()
+        socketserver.TCPServer.allow_reuse_address = True
+        print(f"Dashboard at http://{args.host}:{args.port}/")
+        print(f"Prometheus metrics at http://{args.host}:{args.port}/metrics")
+        socketio.run(app, host=args.host, port=args.port, allow_unsafe_werkzeug=True)
+    else:
+        httpd = start_metrics_only_server(args.port, args.host, dashboard_missing)
+        print(f"Prometheus metrics at http://{args.host}:{args.port}/metrics")
+        try:
+            httpd.serve_forever()
+        except SystemExit:
+            pass
 
 
 if __name__ == "__main__":

--- a/dev/observability/dynamo_local_resource_monitor.py
+++ b/dev/observability/dynamo_local_resource_monitor.py
@@ -1331,9 +1331,17 @@ def build_monitor_server(collector: MetricsCollector):
         max_http_buffer_size=50 * 1024 * 1024,
     )
 
-    ui_state = {"view_minutes": 2}
     client_cursors: dict[str, dict] = {}
     client_lock = threading.Lock()
+
+    def new_client_cursor() -> dict:
+        return {
+            "main": 0,
+            "pcie": [0] * collector.gpu_count,
+            "disk": 0,
+            "view_minutes": 2,
+            "next_push": 0.0,
+        }
 
     @app.route("/")
     def index():
@@ -1350,11 +1358,7 @@ def build_monitor_server(collector: MetricsCollector):
     def handle_connect():
         sid = flask.request.sid
         with client_lock:
-            client_cursors[sid] = {
-                "main": 0,
-                "pcie": [0] * collector.gpu_count,
-                "disk": 0,
-            }
+            client_cursors[sid] = new_client_cursor()
 
         def send_init():
             for _ in range(50):
@@ -1364,11 +1368,16 @@ def build_monitor_server(collector: MetricsCollector):
                 time.sleep(0.1)
             snapshot = collector.snapshot_full()
             with client_lock:
-                client_cursors[sid] = {
-                    "main": snapshot["counter_main"],
-                    "pcie": list(snapshot["counter_pcie"]),
-                    "disk": snapshot["counter_disk"],
-                }
+                cursor = client_cursors.get(sid)
+                if cursor is None:
+                    return
+                cursor.update(
+                    {
+                        "main": snapshot["counter_main"],
+                        "pcie": list(snapshot["counter_pcie"]),
+                        "disk": snapshot["counter_disk"],
+                    }
+                )
             socketio.emit("init", snapshot, to=sid)
 
         threading.Thread(target=send_init, daemon=True).start()
@@ -1383,16 +1392,24 @@ def build_monitor_server(collector: MetricsCollector):
         sid = flask.request.sid
         snapshot = collector.snapshot_full()
         with client_lock:
-            client_cursors[sid] = {
-                "main": snapshot["counter_main"],
-                "pcie": list(snapshot["counter_pcie"]),
-                "disk": snapshot["counter_disk"],
-            }
+            cursor = client_cursors.get(sid)
+            if cursor is None:
+                return
+            cursor.update(
+                {
+                    "main": snapshot["counter_main"],
+                    "pcie": list(snapshot["counter_pcie"]),
+                    "disk": snapshot["counter_disk"],
+                }
+            )
         socketio.emit("init", snapshot, to=sid)
 
     @socketio.on("view_minutes")
     def handle_view_minutes(view_minutes):
-        ui_state["view_minutes"] = int(view_minutes)
+        with client_lock:
+            cursor = client_cursors.get(flask.request.sid)
+            if cursor is not None:
+                cursor["view_minutes"] = int(view_minutes)
 
     push_policy = {
         1: (0.075, 1),
@@ -1404,37 +1421,56 @@ def build_monitor_server(collector: MetricsCollector):
 
     def push_loop():
         while True:
-            view_minutes = ui_state.get("view_minutes", 2)
-            push_sec, step = push_policy.get(view_minutes, (0.100, 1))
-            time.sleep(push_sec)
-            with collector.lock:
-                counter_main = collector.counter_main
-                counter_pcie = list(collector.counter_pcie)
-                counter_disk = collector.counter_disk
+            time.sleep(0.075)
+            now = time.monotonic()
             with client_lock:
-                cursors = list(client_cursors.items())
+                cursors = [
+                    (sid, cursor.copy())
+                    for sid, cursor in client_cursors.items()
+                    if now >= cursor.get("next_push", 0.0)
+                ]
 
             for sid, cursor in cursors:
                 last_main = cursor["main"]
                 last_pcie = cursor["pcie"]
                 last_disk = cursor["disk"]
+                push_sec, step = push_policy.get(
+                    cursor.get("view_minutes", 2), (0.100, 1)
+                )
+                delta = collector.snapshot_delta(
+                    last_main, last_pcie, last_disk, step=step
+                )
+                counter_main = delta["counter_main"]
+                counter_pcie = list(delta["counter_pcie"])
+                counter_disk = delta["counter_disk"]
                 if (
                     counter_main <= last_main
                     and counter_pcie == last_pcie
                     and counter_disk <= last_disk
                 ):
+                    with client_lock:
+                        live_cursor = client_cursors.get(sid)
+                        if live_cursor is not None:
+                            live_cursor["next_push"] = now + push_sec
                     continue
-                delta = collector.snapshot_delta(
-                    last_main, last_pcie, last_disk, step=step
-                )
                 with client_lock:
-                    if sid not in client_cursors:
+                    live_cursor = client_cursors.get(sid)
+                    if live_cursor is None:
                         continue
-                    client_cursors[sid] = {
-                        "main": counter_main,
-                        "pcie": counter_pcie,
-                        "disk": counter_disk,
-                    }
+                    if (
+                        live_cursor["main"] != last_main
+                        or live_cursor["pcie"] != last_pcie
+                        or live_cursor["disk"] != last_disk
+                    ):
+                        continue
+                    live_cursor.update(
+                        {
+                            "main": counter_main,
+                            "pcie": counter_pcie,
+                            "disk": counter_disk,
+                            "next_push": now + push_sec,
+                        }
+                    )
                 socketio.emit("delta", delta, to=sid)
 
     return socketio, app, push_loop

--- a/dev/observability/dynamo_local_resource_monitor.py
+++ b/dev/observability/dynamo_local_resource_monitor.py
@@ -354,6 +354,7 @@ class ProcessTracker:
         for pid in dead:
             del self.series[pid]
             del self.names[pid]
+            self.first_seen.pop(pid, None)
             if pid in self._pid_slot:
                 self._free_slots.append(self._pid_slot.pop(pid))
 

--- a/docs/observability/local-resource-monitor.md
+++ b/docs/observability/local-resource-monitor.md
@@ -17,7 +17,7 @@ Design context lives in [DEP #9065](https://github.com/ai-dynamo/dynamo/issues/9
 - **Nsight Systems** is a 980 MB profile-then-analyze tool — right for one-off deep dives, wrong for an always-on CI signal.
 - **aiperf** is client-side load + latency, not server-side per-process telemetry, and runs *after* the engine is up.
 
-This exporter samples at 200 ms (PCIe internally at 10/s), groups subprocesses into one logical worker per engine, and labels each per-engine PID with framework + model + test name (e.g. `VLLM::EngineCore, Qwen3-0.6B, test_serve_deployment[aggregated_unified]`) — so Grafana renders parallel engines bin-packed onto one GPU as separate side-by-side series instead of one summed line. That's what makes flaky one-of-N-tests failures diagnosable.
+This monitor samples at 200 ms (PCIe internally at 10/s), groups subprocesses into one logical worker per engine, and labels each per-engine PID with framework + model + test name (e.g. `VLLM::EngineCore, Qwen3-0.6B, test_serve_deployment[aggregated_unified]`) — so Grafana renders parallel engines bin-packed onto one GPU as separate side-by-side series instead of one summed line. That's what makes flaky one-of-N-tests failures diagnosable.
 
 ## Prometheus + Grafana
 

--- a/docs/observability/local-resource-monitor.md
+++ b/docs/observability/local-resource-monitor.md
@@ -3,9 +3,9 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Dynamo Local Resource Monitor (Prometheus Exporter)
+# Dynamo Local Resource Monitor
 
-[`dynamo_local_resource_monitor.py`](../../dev/observability/dynamo_local_resource_monitor.py) is a Dynamo-specific Prometheus exporter that tracks per-process resource usage (VRAM, GPU utilization, PCIe bandwidth, CPU, disk I/O, network I/O) for Dynamo inference processes — labeled by model name, process identity, and PID.
+[`dynamo_local_resource_monitor.py`](../../dev/observability/dynamo_local_resource_monitor.py) is a Dynamo-specific resource monitor that tracks per-process resource usage (VRAM, GPU utilization, PCIe bandwidth, CPU, disk I/O, network I/O) for Dynamo inference processes — labeled by model name, process identity, and PID. It always exposes Prometheus metrics at `/metrics`; when the dashboard dependencies are installed, the same endpoint also serves a WebSocket dashboard at `/`.
 
 ## Why this and not the existing observability tools?
 
@@ -19,7 +19,7 @@ Design context lives in [DEP #9065](https://github.com/ai-dynamo/dynamo/issues/9
 
 This exporter samples at 200 ms (PCIe internally at 10/s), groups subprocesses into one logical worker per engine, and labels each per-engine PID with framework + model + test name (e.g. `VLLM::EngineCore, Qwen3-0.6B, test_serve_deployment[aggregated_unified]`) — so Grafana renders parallel engines bin-packed onto one GPU as separate side-by-side series instead of one summed line. That's what makes flaky one-of-N-tests failures diagnosable.
 
-## Enabling the exporter
+## Prometheus + Grafana
 
 The Prometheus instance that scrapes this exporter is gated behind the `resource-monitor` Docker Compose profile, so the main observability stack comes up without it. To enable it, pass `--profile resource-monitor`:
 
@@ -38,7 +38,7 @@ python3 dev/observability/dynamo_local_resource_monitor.py --host 0.0.0.0 --port
 
 Then verify metrics at `http://<host>:8051/metrics`.
 
-If any dependencies are missing, the script prints the exact `pip install` command needed and exits.
+If any required dependencies are missing, the script prints the exact `pip install` command needed and exits.
 
 > **Firewall note:** If your host runs UFW (or similar), you must allow port 8051 from the Docker Compose bridge network for `dynamo-resource-monitor` to scrape the exporter:
 >
@@ -48,3 +48,16 @@ If any dependencies are missing, the script prints the exact `pip install` comma
 > ```
 >
 > Verify the scrape target is healthy with `curl -s http://localhost:9091/api/v1/targets | jq '.data.activeTargets[] | {job, health}'`.
+
+## WebSocket Dashboard
+
+For one-off profiling without Grafana, install the dashboard dependencies too. The same command then starts a Flask-SocketIO server, serves a Plotly dashboard at `/`, and keeps Prometheus metrics available at `/metrics`:
+
+```bash
+pip install psutil nvidia-ml-py prometheus-client flask flask-socketio simple-websocket
+python3 dev/observability/dynamo_local_resource_monitor.py --host 0.0.0.0 --port 8051
+```
+
+Open `http://<host>:8051/` in a browser. The dashboard keeps a rolling window in memory, saves it under `~/.cache/dynamo_local_resource_monitor/metrics.json` on shutdown, and restores it on restart when the GPU count still matches.
+
+Without the dashboard packages, the monitor still starts the Prometheus `/metrics` exporter. Visiting `/` shows the `pip install` command needed to enable the dashboard.


### PR DESCRIPTION
#### Overview:

On dlcluster, bringing up Grafana/docker compose is too heavy for quick resource debugging, so this PR adds a standalone optional WebSocket dashboard at `/` while keeping `/metrics` available on the same endpoint.

#### Details:

<img width="2308" height="1297" alt="image" src="https://github.com/user-attachments/assets/af112ef1-ad38-427c-b29b-79a613552f5f" />

- **How is this fixed?** Share the existing host resource monitor between Prometheus gauges and a STANDALONE Flask-SocketIO dashboard.
- Move the dashboard HTML into `dev/observability/dynamo_local_resource_monitor.html.j2`.
- If dashboard packages are missing, `/` shows the install command and `/metrics` still works.
- Update observability docs for lightweight host usage.

#### Verification:

`python3 -m py_compile`, `--help`, pre-commit, and host smoke checks for `/` plus `/metrics` passed.

#### Where should the reviewer start?

`dev/observability/dynamo_local_resource_monitor.py`, then `dev/observability/dynamo_local_resource_monitor.html.j2`

#### Related Issues:

Relates to [DEP #9065](https://github.com/ai-dynamo/dynamo/issues/9065); follows [#9055](https://github.com/ai-dynamo/dynamo/pull/9055) and [#7968](https://github.com/ai-dynamo/dynamo/pull/7968); internal tracking [Linear DIS-1921](https://linear.app/nvidia/issue/DIS-1921).

/coderabbit profile chill