### PR TITLE
test: add reasoning parser parity matrix (part 3)

### DIFF
--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -7,7 +7,8 @@ use dynamo_llm::protocols::openai::ParsingOptions;
 use dynamo_llm::protocols::openai::chat_completions::{
     DeltaAggregator, NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse,
 };
-use dynamo_parsers::reasoning::get_available_reasoning_parsers;
+use dynamo_parsers::ReasoningParser;
+use dynamo_parsers::reasoning::{ReasoningParserType, get_available_reasoning_parsers};
 use dynamo_parsers::tool_calling::ToolDefinition;
 use dynamo_parsers::tool_calling::parsers::{
     detect_and_parse_tool_call_with_recovery, get_available_tool_parsers,
@@ -243,6 +244,103 @@ fn decode_arguments(arguments: &str) -> Value {
     }
 }
 
+/// Parse reasoning from a complete model output string using the specified parser.
+///
+/// Args:
+///     parser_name: Parser name (e.g. "qwen3"). Empty string falls back to the
+///                  default reasoning parser.
+///     message:     Model output text to parse.
+///     token_ids:   Optional token IDs for parsers that need token-level markers.
+///     in_reasoning:
+///                  Start the parser in reasoning mode when the chat template
+///                  already injected the opening reasoning marker.
+///
+/// Returns:
+///     JSON-serialized string `{"reasoning_text": str, "normal_text": str}`.
+#[pyfunction]
+#[pyo3(signature = (parser_name, message, token_ids=None, in_reasoning=false))]
+pub fn parse_reasoning_batch(
+    parser_name: String,
+    message: String,
+    token_ids: Option<Vec<u32>>,
+    in_reasoning: bool,
+) -> PyResult<String> {
+    let mut parser = ReasoningParserType::get_reasoning_parser_from_name(&parser_name);
+    if in_reasoning {
+        parser.set_in_reasoning(true);
+    }
+
+    let token_ids = token_ids.unwrap_or_default();
+    let result = parser.detect_and_parse_reasoning(&message, &token_ids);
+    let out = serde_json::json!({
+        "reasoning_text": result.reasoning_text,
+        "normal_text": result.normal_text,
+    });
+    Ok(out.to_string())
+}
+
+/// Parse reasoning from streaming chunks using one stateful parser instance.
+///
+/// Args:
+///     parser_name: Parser name (e.g. "qwen3"). Empty string falls back to the
+///                  default reasoning parser.
+///     chunks:      Model output text chunks in stream order.
+///     token_chunks:
+///                  Optional token ID chunks aligned 1:1 with `chunks`.
+///     in_reasoning:
+///                  Start the parser in reasoning mode when the chat template
+///                  already injected the opening reasoning marker.
+///
+/// Returns:
+///     JSON-serialized string with accumulated `reasoning_text` and `normal_text`.
+#[pyfunction]
+#[pyo3(signature = (parser_name, chunks, token_chunks=None, in_reasoning=false))]
+pub fn parse_reasoning_stream(
+    parser_name: String,
+    chunks: Vec<String>,
+    token_chunks: Option<Vec<Vec<u32>>>,
+    in_reasoning: bool,
+) -> PyResult<String> {
+    if let Some(ref token_chunks) = token_chunks
+        && token_chunks.len() != chunks.len()
+    {
+        return Err(PyValueError::new_err(format!(
+            "token_chunks length ({}) must match chunks length ({})",
+            token_chunks.len(),
+            chunks.len()
+        )));
+    }
+
+    let mut parser = ReasoningParserType::get_reasoning_parser_from_name(&parser_name);
+    if in_reasoning {
+        parser.set_in_reasoning(true);
+    }
+
+    let mut reasoning_text = String::new();
+    let mut normal_text = String::new();
+    for (i, chunk) in chunks.iter().enumerate() {
+        let token_ids = token_chunks
+            .as_ref()
+            .map(|chunks| chunks[i].as_slice())
+            .unwrap_or(&[]);
+        let result = parser.parse_reasoning_streaming_incremental(chunk, token_ids);
+        reasoning_text.push_str(&result.reasoning_text);
+        normal_text.push_str(&result.normal_text);
+    }
+
+    // Flush delimiter prefixes held while waiting for the next chunk. At EOF,
+    // there is no next chunk that can complete the marker.
+    let result = parser.finish_reasoning_stream();
+    reasoning_text.push_str(&result.reasoning_text);
+    normal_text.push_str(&result.normal_text);
+
+    let out = serde_json::json!({
+        "reasoning_text": reasoning_text,
+        "normal_text": normal_text,
+    });
+    Ok(out.to_string())
+}
+
 /// Convert OpenAI-style or flat tools JSON into `Vec<ToolDefinition>`.
 ///
 /// Accepts either of these shapes per element:
@@ -283,5 +381,7 @@ pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_reasoning_parser_names, m)?)?;
     m.add_function(wrap_pyfunction!(parse_tool_calls_batch, m)?)?;
     m.add_function(wrap_pyfunction!(parse_tool_calls_stream, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_reasoning_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_reasoning_stream, m)?)?;
     Ok(())
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -78,6 +78,32 @@ async def parse_tool_calls_stream(
     """
     ...
 
+def parse_reasoning_batch(
+    parser_name: str,
+    message: str,
+    token_ids: Optional[List[int]] = None,
+    in_reasoning: bool = False,
+) -> str:
+    """Parse reasoning from a complete model output string using the specified parser.
+
+    Returns:
+        JSON-serialized string `{"reasoning_text": str, "normal_text": str}`.
+    """
+    ...
+
+def parse_reasoning_stream(
+    parser_name: str,
+    chunks: List[str],
+    token_chunks: Optional[List[List[int]]] = None,
+    in_reasoning: bool = False,
+) -> str:
+    """Parse reasoning from streaming chunks using one stateful parser instance.
+
+    Returns:
+        JSON-serialized string with accumulated `reasoning_text` and `normal_text`.
+    """
+    ...
+
 def run_kv_indexer(args: List[str]) -> None:
     """Run the KV indexer with the given arguments."""
     ...

--- a/lib/bindings/python/tests/test_parsers.py
+++ b/lib/bindings/python/tests/test_parsers.py
@@ -13,9 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 import pytest
 
-from dynamo._core import get_reasoning_parser_names, get_tool_parser_names
+from dynamo._core import (
+    get_reasoning_parser_names,
+    get_tool_parser_names,
+    parse_reasoning_batch,
+    parse_reasoning_stream,
+)
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -39,3 +46,54 @@ def test_get_reasoning_parser_names():
     # No Need to update this test when adding a new parser everytime
     assert parsers is not None
     assert len(parsers) > 0
+
+
+def test_parse_reasoning_batch():
+    parsed = json.loads(parse_reasoning_batch("qwen3", "<think>thinking</think>answer"))
+
+    assert parsed == {
+        "reasoning_text": "thinking",
+        "normal_text": "answer",
+    }
+
+
+def test_parse_reasoning_batch_in_reasoning_mode():
+    parsed = json.loads(
+        parse_reasoning_batch("qwen3", "thinking</think>answer", in_reasoning=True)
+    )
+
+    assert parsed == {
+        "reasoning_text": "thinking",
+        "normal_text": "answer",
+    }
+
+
+def test_parse_reasoning_stream():
+    parsed = json.loads(
+        parse_reasoning_stream("qwen3", ["<thi", "nk>thinking</think>", "answer"])
+    )
+
+    assert parsed == {
+        "reasoning_text": "thinking",
+        "normal_text": "answer",
+    }
+
+
+def test_parse_reasoning_stream_in_reasoning_mode():
+    parsed = json.loads(
+        parse_reasoning_stream(
+            "qwen3",
+            ["thinking", "</think>answer"],
+            in_reasoning=True,
+        )
+    )
+
+    assert parsed == {
+        "reasoning_text": "thinking",
+        "normal_text": "answer",
+    }
+
+
+def test_parse_reasoning_stream_rejects_mismatched_token_chunks():
+    with pytest.raises(ValueError, match="token_chunks length"):
+        parse_reasoning_stream("qwen3", ["a", "b"], [[1]])

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2051,7 +2051,8 @@ impl OpenAIPreprocessor {
         // decode the parsers silently produce empty reasoning_content /
         // tool_calls.
         //
-        // - gemma4: `<|think|>` markers (reasoning + tool-call).
+        // - gemma4: `<|think|>` prompt trigger plus parser-visible
+        //   `<|channel>` / `<channel|>` reasoning markers and tool-call markers.
         // - harmony / gpt_oss: `<|channel|>analysis<|message|>...<|end|>`.
         // - kimi_k2: `<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>`.
         // - kimi_k25: `</think>` (special token id 163607).

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -338,6 +338,25 @@ impl ReasoningParser for BasicReasoningParser {
             reasoning_text: accumulated_reasoning,
         }
     }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        if self._buffer.is_empty() {
+            return ParserResult::default();
+        }
+
+        let buffered = std::mem::take(&mut self._buffer);
+        if self._in_reasoning {
+            ParserResult {
+                normal_text: String::new(),
+                reasoning_text: buffered,
+            }
+        } else {
+            ParserResult {
+                normal_text: buffered,
+                reasoning_text: String::new(),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -268,6 +268,34 @@ impl ReasoningParser for Gemma4ReasoningParser {
             reasoning_text: reasoning_emit,
         }
     }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        if self.buffer.is_empty() {
+            return ParserResult::default();
+        }
+
+        let buffered = std::mem::take(&mut self.buffer);
+        if !self.in_reasoning {
+            return ParserResult {
+                normal_text: buffered,
+                reasoning_text: String::new(),
+            };
+        }
+
+        let reasoning_text = if self.prefix_resolved {
+            buffered
+        } else {
+            self.reasoning_accum.push_str(&buffered);
+            let (emit, resolved) = resolve_prefix(&self.reasoning_accum, &buffered);
+            self.prefix_resolved = resolved;
+            emit.to_string()
+        };
+        self.reset_span();
+        ParserResult {
+            normal_text: String::new(),
+            reasoning_text,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/parsers/src/reasoning/granite_parser.rs
+++ b/lib/parsers/src/reasoning/granite_parser.rs
@@ -176,6 +176,25 @@ impl ReasoningParser for GraniteReasoningParser {
             }
         }
     }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        if self.buffer.is_empty() {
+            return ParserResult::default();
+        }
+
+        let buffered = std::mem::take(&mut self.buffer);
+        if self.in_reasoning {
+            ParserResult {
+                normal_text: String::new(),
+                reasoning_text: buffered,
+            }
+        } else {
+            ParserResult {
+                normal_text: buffered,
+                reasoning_text: String::new(),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -28,6 +28,14 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
     REASONING_PARSER_MAP.get_or_init(|| {
         let mut map = HashMap::new();
         map.insert("deepseek_r1", ReasoningParserType::DeepseekR1);
+        // DeepSeek V3.x thinking mode uses the same output shape as R1:
+        // reasoning text is already in progress and the completion emits
+        // `</think>` before the final answer. The V3.x tool-call parsers are
+        // distinct because their tool-call wire formats differ, but reasoning
+        // shares this forced think-tag parser.
+        map.insert("deepseek_v3", ReasoningParserType::DeepseekR1);
+        map.insert("deepseek_v3_1", ReasoningParserType::DeepseekR1);
+        map.insert("deepseek_v3_2", ReasoningParserType::DeepseekR1);
         map.insert("basic", ReasoningParserType::Basic);
         map.insert("gpt_oss", ReasoningParserType::GptOss);
         map.insert("qwen3", ReasoningParserType::Qwen);
@@ -117,6 +125,17 @@ pub trait ReasoningParser: Send + std::fmt::Debug {
         token_ids: &[u32],
     ) -> ParserResult;
 
+    /// Finalizes a stream after the last chunk, before parser state is dropped.
+    ///
+    /// Incremental parsing may buffer a partial delimiter prefix instead of
+    /// emitting it immediately because the next chunk could complete a marker
+    /// like `<think>` or `</think>`. At EOF, no next chunk is coming, so the
+    /// parser must flush the undecided bytes as normal or reasoning text based
+    /// on its current state.
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        ParserResult::default()
+    }
+
     /// Override the parser's initial reasoning state. When called with `true`, the parser
     /// starts in reasoning mode without waiting for the start token in the completion stream.
     /// Use this when the chat template already injected the start token (e.g., `<think>`)
@@ -170,6 +189,10 @@ impl ReasoningParser for ReasoningParserWrapper {
     ) -> ParserResult {
         self.parser
             .parse_reasoning_streaming_incremental(text, token_ids)
+    }
+
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        self.parser.finish_reasoning_stream()
     }
 
     fn set_in_reasoning(&mut self, in_reasoning: bool) {
@@ -287,6 +310,9 @@ mod tests {
         // Update this list when adding a new parser
         let available_parsers = [
             "deepseek_r1",
+            "deepseek_v3",
+            "deepseek_v3_1",
+            "deepseek_v3_2",
             "basic",
             "gpt_oss",
             "qwen3",

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -193,6 +193,40 @@ Cell values show how each engine's recorded `expected.<impl>` block relates to D
 - `n/a` — **not applicable**: engine marked `unavailable` (no parser registered for that family), OR the sub-case shape doesn't apply to this grammar (e.g. attribute-encoded DSML families have no `4.b` because there's no embedded JSON to malform).
 - `—` — **missing fixture coverage**: no fixture entry exists for that family/case yet. If the case is intentionally not applicable, add an explicit table-only n/a stub with `description:` and `reason:` so the table can explain it.
 
+### Dashboard triage indicators
+
+Do not use `reason:` just to explain that outputs differ. A peer
+`reason:` means the divergence is intentionally classified and is not
+currently a Dynamo fix target. If the audit suggests the peer is more
+correct, or Dynamo is trimming, dropping, misrouting, or leaking text,
+remove the peer `reason:` so the dashboard renders a red `V?` / `S?`.
+That is the visible "fix Dynamo or decide the contract" queue.
+
+What to look for:
+
+- Red `V?` / `S?` — start here. A captured peer differs and the
+  divergence is not classified. If vLLM/SGLang appears more correct,
+  keep it red until Dynamo is fixed or the contract is explicitly
+  decided.
+- `↯` — Dynamo leaked parser-owned syntax into the wrong user-visible
+  field. For tool calling, this means tool call markup leaked into
+  `normal_text`; for reasoning, this means reasoning markup or final
+  answer text landed in the wrong split field.
+- `V` / `S` — documented divergence. Re-audit these when an upstream
+  version changes or when the reason says the peer preserves text that
+  Dynamo loses. If the peer now looks like the better target, delete
+  `reason:` and let the cell become red.
+- `n/a` — the case or peer does not apply. Do not use `n/a` for
+  behavior that is merely unknown.
+- `—` — missing fixture coverage. Add a real fixture, or add an
+  explicit `n/a` stub with a reason.
+
+For reasoning parity, the default contract is a lossless split:
+remove the reasoning delimiters, but preserve the text on each side of
+the delimiter or tool-boundary unless the fixture explicitly documents
+normalization. Tool call text in `normal_text` is not a reasoning leak;
+it is the downstream handoff to the tool calling parser.
+
 19 parsers total — split into the **Top-N models** we prioritize and
 **Others** wired into the harness for completeness. Both sections sorted
 alphabetically within themselves.

--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -9,9 +9,27 @@ harness can diff results uniformly.
 
 from __future__ import annotations
 
+import html as html_lib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any
+
+URL_RE = re.compile(r"https?://[^\s<>'\"]+")
+TRAILING_URL_PUNCTUATION = ".,;:)"
+
+# Curated featured-model order shared by the parser and reasoning parity tables.
+# The row labels still come from fixture metadata; this list only decides which
+# tool calling families lead the table and in what order.
+TOP_N_TOOL_CALLING_FAMILIES = [
+    "deepseek_v4",
+    "gemma4",
+    "glm47",
+    "harmony",
+    "kimi_k2",
+    "minimax_m2",
+    "qwen3_coder",
+]
 
 
 @dataclass
@@ -30,6 +48,22 @@ class ParseResult:
     def to_dict(self) -> dict[str, Any]:
         return {
             "calls": self.calls,
+            "normal_text": self.normal_text,
+            "error": self.error,
+        }
+
+
+@dataclass
+class ReasoningResult:
+    """Uniform shape returned by every reasoning impl wrapper."""
+
+    reasoning_text: str | None = None
+    normal_text: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reasoning_text": self.reasoning_text,
             "normal_text": self.normal_text,
             "error": self.error,
         }
@@ -54,9 +88,11 @@ def _normalize_normal_text(v: Any) -> Any:
 
 def canonical(d: dict[str, Any]) -> str:
     """Canonical JSON for diffing: sorted keys, no whitespace, with empty-string ↔ None
-    normalization applied to `normal_text`."""
+    normalization applied to parser text fields."""
     if "normal_text" in d:
         d = {**d, "normal_text": _normalize_normal_text(d["normal_text"])}
+    if "reasoning_text" in d:
+        d = {**d, "reasoning_text": _normalize_normal_text(d["reasoning_text"])}
     return json.dumps(d, sort_keys=True, separators=(",", ":"))
 
 
@@ -93,3 +129,104 @@ def decode_stream_calls(
             }
         )
     return calls
+
+
+def linkify_text_html(text: str) -> str:
+    """Escape plain text and turn embedded URLs into anchors."""
+
+    parts: list[str] = []
+    last = 0
+    for match in URL_RE.finditer(text):
+        raw_url = match.group(0)
+        url = raw_url.rstrip(TRAILING_URL_PUNCTUATION)
+        if not url:
+            continue
+        parts.append(html_lib.escape(text[last : match.start()]))
+        href = html_lib.escape(url, quote=True)
+        parts.append(
+            f'<a href="{href}" target="_blank" rel="noopener noreferrer">'
+            f"{html_lib.escape(url)}</a>"
+        )
+        parts.append(html_lib.escape(raw_url[len(url) :]))
+        last = match.end()
+    parts.append(html_lib.escape(text[last:]))
+    return "".join(parts)
+
+
+def parity_cell_class(marker: str) -> str:
+    if marker == "—":
+        return "missing"
+    if marker == "n/a":
+        return "na"
+    if marker == "D":
+        return "donly"
+    if "!" in marker:
+        return "err"
+    if "↯" in marker:
+        return "leak"
+    if "?" in marker:
+        return "research"
+    if marker == "=":
+        return "ok"
+    return "documented"
+
+
+def ref_text(value: Any) -> str:
+    if isinstance(value, list):
+        return "\n".join(str(item) for item in value)
+    if isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return str(value)
+
+
+def build_parity_tooltip_html(
+    *,
+    head: str,
+    description: str | None = None,
+    input_label: str | None = None,
+    input_html: str | None = None,
+    output_sections: list[tuple[str, str]] | None = None,
+    divergent_reasons: str | None = None,
+    leak_label: str | None = None,
+    leak_text: str | None = None,
+    extra_sections: list[tuple[str, str]] | None = None,
+    refs: list[tuple[str, Any]] | None = None,
+) -> str:
+    """Build the hover popup used by parser and reasoning parity tables.
+
+    The section order is intentional and shared across the two tables:
+    context, input, outputs, divergence explanation, leak warning, harness
+    details, and finally provenance refs.
+    """
+
+    parts = ['<div class="ttip">']
+    if head:
+        parts.append(f'<div class="ttip-head">{html_lib.escape(head)}</div>')
+    if description:
+        parts.append(f'<pre class="ttip-pre">{html_lib.escape(description)}</pre>')
+
+    def add_section(label: str, body_html: str) -> None:
+        parts.append(f'<div class="ttip-section">{html_lib.escape(label)}:</div>')
+        parts.append(f'<pre class="ttip-pre">{body_html}</pre>')
+
+    if input_label and input_html is not None:
+        add_section(input_label, input_html)
+
+    for label, body_html in output_sections or []:
+        add_section(label, body_html)
+
+    if divergent_reasons:
+        add_section("Divergent reasons", linkify_text_html(divergent_reasons))
+
+    if leak_label and leak_text:
+        add_section(leak_label, linkify_text_html(leak_text))
+
+    for label, body_html in extra_sections or []:
+        add_section(label, body_html)
+
+    for label, value in refs or []:
+        if value:
+            add_section(label, linkify_text_html(ref_text(value)))
+
+    parts.append("</div>")
+    return "".join(parts)

--- a/tests/parity/generate_parity_table.py
+++ b/tests/parity/generate_parity_table.py
@@ -7,6 +7,7 @@
 Examples:
     python3 tests/parity/generate_parity_table.py parser --html > tests/parity/parser/PARITY.html
     python3 tests/parity/generate_parity_table.py parser --mode stream > tests/parity/parser/PARITY.stream.md
+    python3 tests/parity/generate_parity_table.py reasoning --html > tests/parity/reasoning/PARITY.html
 """
 
 from __future__ import annotations
@@ -25,13 +26,15 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "stage",
-        choices=("parser",),
+        choices=("parser", "reasoning"),
         help="Parity stage to render.",
     )
     args, rest = parser.parse_known_args(argv)
 
     if args.stage == "parser":
         from tests.parity.parser import table
+    else:
+        from tests.parity.reasoning import table
 
     table.main(rest)
 

--- a/tests/parity/markup.py
+++ b/tests/parity/markup.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared markup colorization helpers for parity table tooltips."""
+
+from __future__ import annotations
+
+import html as html_lib
+import re
+from typing import Any
+
+# Matches both `<...>` and the Mistral-style `[NAME]`/`[/NAME]` form.
+# Brackets only match ALL-CAPS-underscore names so JSON arrays
+# (e.g. `[{...}]`, `[1, 2]`) don't get false-matched as tags.
+_TAG_RE = re.compile(r"<[^<>]+>|\[/?[A-Z][A-Z0-9_]*\]")
+
+# Two coloring schemes share one cycling palette:
+#   * Paired open/close: every matched pair gets a *fresh* palette index, so
+#     two `<tool_call>...</tool_call>` instances in the same input render as
+#     two different colors.
+#   * Singletons (e.g. harmony's `<|channel|>` section markers): stable
+#     by-role color so all `<|channel|>` tokens share one class everywhere.
+_PAIRED_PALETTE_SIZE = 8
+_color_seq = 0
+_singleton_classes: dict[str, str] = {}
+
+
+def _next_color_class() -> str:
+    global _color_seq
+    cls = f"tt-c{_color_seq % _PAIRED_PALETTE_SIZE}"
+    _color_seq += 1
+    return cls
+
+
+def _singleton_class_for(name: str) -> str:
+    cls = _singleton_classes.get(name)
+    if cls is None:
+        cls = _next_color_class()
+        _singleton_classes[name] = cls
+    return cls
+
+
+_PIPES = ("|", "｜")  # ASCII and FULLWIDTH VERTICAL LINE (U+FF5C)
+_BEGIN_SUFFIXES = (
+    "_begin",
+    "▁begin",
+)  # ASCII underscore and LOWER ONE EIGHTH BLOCK (U+2581)
+_END_SUFFIXES = ("_end", "▁end")
+
+# Harmony (gpt-oss) tokens are linear state-machine delimiters. Turn-boundary
+# tokens form pseudo-pairs: `<|start|>` opens a turn; `<|end|>`, `<|return|>`,
+# or `<|call|>` closes it. Each closer flavor gets its own paired color so a
+# tool call turn (start -> call) is visually distinct from a normal turn
+# (start -> end) or a final turn (start -> return). Section markers stay as
+# same-colored singletons.
+_HARMONY_TURN_OPEN = "start"
+_HARMONY_TURN_CLOSE = frozenset({"end", "return", "call"})
+_HARMONY_SECTION_MARKERS = frozenset({"channel", "constrain", "message"})
+_HARMONY_TOKEN_RE = re.compile(r"<\|([A-Za-z_]+)\|>")
+_HARMONY_SEGMENT_CLASS = {
+    "start": "tt-h-start",
+    "channel": "tt-h-channel",
+    "constrain": "tt-h-constrain",
+    "message": "tt-h-message",
+    "end": "tt-h-stop",
+    "return": "tt-h-stop",
+    "call": "tt-h-call",
+}
+
+
+def _colorize_harmony(text: str) -> str:
+    """Color Harmony's linear token segments as `<|token|>related-text`.
+
+    Harmony is not paired XML. Tokens such as `<|channel|>` and `<|message|>`
+    introduce the header/content span that follows, so each special token is
+    grouped with text up to the next Harmony token.
+    """
+    pieces: list[str] = []
+    last = 0
+    for m in _HARMONY_TOKEN_RE.finditer(text):
+        if m.start() > last:
+            pieces.append(html_lib.escape(text[last : m.start()]))
+        token_name = m.group(1)
+        if token_name in _HARMONY_TURN_CLOSE:
+            end = m.end()
+        else:
+            next_m = _HARMONY_TOKEN_RE.search(text, m.end())
+            end = next_m.start() if next_m else len(text)
+        cls = _HARMONY_SEGMENT_CLASS.get(token_name, "tt-h-other")
+        token = html_lib.escape(m.group(0))
+        related = html_lib.escape(text[m.end() : end])
+        pieces.append(
+            f'<span class="tt-h {cls}"><span class="tt-h-token">{token}</span>{related}</span>'
+        )
+        last = end
+    if last < len(text):
+        pieces.append(html_lib.escape(text[last:]))
+    return "".join(pieces)
+
+
+def colorize_markup(text: str, family: str | None = None) -> str:
+    if family == "harmony" and _HARMONY_TOKEN_RE.search(text):
+        return _colorize_harmony(text)
+    return _colorize_xml(text)
+
+
+def _strip_suffix(s: str, suffixes: tuple[str, ...]) -> str | None:
+    for suf in suffixes:
+        if s.endswith(suf) and len(s) > len(suf):
+            return s[: -len(suf)]
+    return None
+
+
+def _tag_kind_and_name(inner: str) -> tuple[str | None, str, str | None]:
+    """Classify `<...>` tag inner text into an open/close/singleton kind.
+
+    Returns (kind, pair_id, color_override):
+      * kind: 'open' | 'close' | 'singleton' | None
+      * pair_id: name used to match open against close on the stack
+      * color_override: when set, the paired span uses this name for the
+        color class instead of pair_id (lets `<|start|>...<|call|>` color
+        differently from `<|start|>...<|end|>` despite sharing pair_id).
+    """
+
+    def _name_of(s: str) -> str:
+        # Split on whitespace, slash, `>`, OR `=` so that
+        # `<function=book_flight>` pairs with `</function>` and
+        # `<parameter=destination>` pairs with `</parameter>`.
+        if not s:
+            return ""
+        return re.split(r"[\s/>=]", s, 1)[0].rstrip("|")
+
+    if inner.startswith("/"):
+        return ("close", _name_of(inner[1:]), None)
+    starts_pipe = inner[:1] in _PIPES
+    ends_pipe = inner[-1:] in _PIPES
+    if starts_pipe and ends_pipe and len(inner) >= 2:
+        middle = inner[1:-1]
+        stripped = _strip_suffix(middle, _BEGIN_SUFFIXES)
+        if stripped is not None:
+            return ("open", stripped, None)
+        stripped = _strip_suffix(middle, _END_SUFFIXES)
+        if stripped is not None:
+            return ("close", stripped, None)
+        if middle == _HARMONY_TURN_OPEN:
+            return ("open", "__harmony_turn", None)
+        if middle in _HARMONY_TURN_CLOSE:
+            # Color the pair by which closer flavor was used.
+            return ("close", "__harmony_turn", f"__harmony_pair_{middle}")
+        if middle in _HARMONY_SECTION_MARKERS:
+            return ("singleton", "__harmony_section", None)
+        return (None, "", None)
+    if starts_pipe and inner[:1] == "|":
+        return ("open", _name_of(inner[1:]), None)
+    if ends_pipe and inner[-1:] == "|":
+        return ("close", _name_of(inner[:-1]), None)
+    return ("open", _name_of(inner), None)
+
+
+def _colorize_xml(text: str) -> str:
+    """HTML-escape `text` and wrap each `<...>` token in a span.
+    Paired open/close (stack match by tag name) -> class 'tt-paired'.
+    Unmatched close, or open that never closes -> class 'tt-orphan'.
+
+    Pairs standard XML (`<X>...</X>`) AND alt pipe-marker conventions:
+      `<|X>...<X|>`          (boundary ASCII pipes)
+      `<|X_begin|>...<|X_end|>`  (both-side pipes with _begin/_end suffix)
+    Lenient pop-through: a close looks down the stack for the nearest
+    name-match; anything un-closed above it is marked orphan. Lets
+    no-close singletons (e.g. `<|tool_call_argument_begin|>`) localize
+    their orphan-ness without poisoning the surrounding pairs.
+    """
+    pieces: list[str] = []
+    stack: list[tuple[str, int]] = []
+    last = 0
+    for m in _TAG_RE.finditer(text):
+        if m.start() > last:
+            pieces.append(html_lib.escape(text[last : m.start()]))
+        tok = m.group(0)
+        kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
+        esc = html_lib.escape(tok)
+        if kind is None:
+            pieces.append(f'<span class="tt-orphan">{esc}</span>')
+        elif kind == "singleton":
+            cls = _singleton_class_for(pair_id)
+            pieces.append(f'<span class="{cls}">{esc}</span>')
+        elif kind == "close":
+            match_at = -1
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i][0] == pair_id:
+                    match_at = i
+                    break
+            if match_at >= 0:
+                for _, unmatched_idx in stack[match_at + 1 :]:
+                    pieces[
+                        unmatched_idx
+                    ] = f'<span class="tt-orphan">{pieces[unmatched_idx]}</span>'
+                open_idx = stack[match_at][1]
+                # Per-instance color: every matched pair gets a fresh palette
+                # index, so two `<tool_call>...</tool_call>` (or two
+                # `<|start|>...<|call|>`) blocks in the same input render as
+                # different colors. (color_override unused on the paired
+                # path — kept on the singleton-flavor branch only.)
+                _ = color_override
+                cls = _next_color_class()
+                pieces[open_idx] = f'<span class="{cls}">{pieces[open_idx]}</span>'
+                pieces.append(f'<span class="{cls}">{esc}</span>')
+                del stack[match_at:]
+            else:
+                pieces.append(f'<span class="tt-orphan">{esc}</span>')
+        else:
+            pieces.append(esc)
+            stack.append((pair_id, len(pieces) - 1))
+        last = m.end()
+    for _, idx in stack:
+        pieces[idx] = f'<span class="tt-orphan">{pieces[idx]}</span>'
+    if last < len(text):
+        pieces.append(html_lib.escape(text[last:]))
+    return "".join(pieces)
+
+
+def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
+    intervals: list[dict[str, Any]] = []
+    stack: list[tuple[str, int]] = []
+    for match in _TAG_RE.finditer(text):
+        idx = len(intervals)
+        tok = match.group(0)
+        kind, pair_id, _color_override = _tag_kind_and_name(tok[1:-1])
+        intervals.append({"start": match.start(), "end": match.end(), "class": None})
+        if kind is None:
+            intervals[idx]["class"] = "tt-orphan"
+        elif kind == "singleton":
+            intervals[idx]["class"] = _singleton_class_for(pair_id)
+        elif kind == "close":
+            match_at = -1
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i][0] == pair_id:
+                    match_at = i
+                    break
+            if match_at >= 0:
+                for _, unmatched_idx in stack[match_at + 1 :]:
+                    intervals[unmatched_idx]["class"] = "tt-orphan"
+                cls = _next_color_class()
+                intervals[stack[match_at][1]]["class"] = cls
+                intervals[idx]["class"] = cls
+                del stack[match_at:]
+            else:
+                intervals[idx]["class"] = "tt-orphan"
+        else:
+            stack.append((pair_id, idx))
+    for _, idx in stack:
+        intervals[idx]["class"] = "tt-orphan"
+    return intervals
+
+
+def _harmony_intervals(text: str) -> list[dict[str, Any]]:
+    intervals: list[dict[str, Any]] = []
+    for match in _HARMONY_TOKEN_RE.finditer(text):
+        token_name = match.group(1)
+        if token_name in _HARMONY_TURN_CLOSE:
+            end = match.end()
+        else:
+            next_match = _HARMONY_TOKEN_RE.search(text, match.end())
+            end = next_match.start() if next_match else len(text)
+        intervals.append(
+            {
+                "start": match.start(),
+                "end": end,
+                "class": _HARMONY_SEGMENT_CLASS.get(token_name, "tt-h-other"),
+                "token_start": match.start(),
+                "token_end": match.end(),
+                "harmony": True,
+            }
+        )
+    return intervals
+
+
+def _markup_intervals(text: str, family: str | None) -> list[dict[str, Any]]:
+    if family == "harmony" and _HARMONY_TOKEN_RE.search(text):
+        return _harmony_intervals(text)
+    return _xml_token_intervals(text)
+
+
+def _render_harmony_interval_slice(
+    text: str, interval: dict[str, Any], start: int, end: int
+) -> str:
+    token_start = interval["token_start"]
+    token_end = interval["token_end"]
+    parts: list[str] = []
+    cursor = start
+    token_slice_start = max(start, token_start)
+    token_slice_end = min(end, token_end)
+    if cursor < token_slice_start:
+        parts.append(html_lib.escape(text[cursor:token_slice_start]))
+        cursor = token_slice_start
+    if token_slice_start < token_slice_end:
+        parts.append(
+            '<span class="tt-h-token">'
+            f"{html_lib.escape(text[token_slice_start:token_slice_end])}</span>"
+        )
+        cursor = token_slice_end
+    if cursor < end:
+        parts.append(html_lib.escape(text[cursor:end]))
+    return f'<span class="tt-h {interval["class"]}">{"".join(parts)}</span>'
+
+
+def _render_interval_slice(
+    text: str, interval: dict[str, Any], start: int, end: int
+) -> str:
+    if interval.get("harmony"):
+        return _render_harmony_interval_slice(text, interval, start, end)
+    return (
+        f'<span class="{interval["class"] or "tt-orphan"}">'
+        f"{html_lib.escape(text[start:end])}</span>"
+    )
+
+
+def _colorize_markup_slice(
+    text: str, intervals: list[dict[str, Any]], start: int, end: int
+) -> str:
+    pieces: list[str] = []
+    cursor = start
+    for interval in intervals:
+        istart = interval["start"]
+        iend = interval["end"]
+        if iend <= start:
+            continue
+        if istart >= end:
+            break
+        overlap_start = max(start, istart)
+        overlap_end = min(end, iend)
+        if cursor < overlap_start:
+            pieces.append(html_lib.escape(text[cursor:overlap_start]))
+        pieces.append(
+            _render_interval_slice(text, interval, overlap_start, overlap_end)
+        )
+        cursor = overlap_end
+    if cursor < end:
+        pieces.append(html_lib.escape(text[cursor:end]))
+    return "".join(pieces)
+
+
+def colorize_stream_deltas(chunks: list[Any], family: str | None) -> list[str]:
+    deltas = [
+        str(chunk.get("delta_text") or "") if isinstance(chunk, dict) else ""
+        for chunk in chunks
+    ]
+    text = "".join(deltas)
+    intervals = _markup_intervals(text, family)
+    rendered: list[str] = []
+    cursor = 0
+    for delta in deltas:
+        end = cursor + len(delta)
+        rendered.append(_colorize_markup_slice(text, intervals, cursor, end))
+        cursor = end
+    return rendered

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -22,9 +22,10 @@ td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
 td.cell { text-align: center; min-width: 24px; }
 td.cell.ok         { color: #0a7d2c; }
-td.cell.documented { color: #0a7d2c; }
-td.cell.research   { color: #c63;    font-weight: bold; }
-td.cell.leak       { color: #555;    font-weight: bold; }
+td.cell.donly      { color: #555; }
+td.cell.documented { color: #555; }
+td.cell.research   { color: #b00;    font-weight: bold; }
+td.cell.leak       { color: #b00;    font-weight: bold; }
 td.cell.err        { color: #b00;    font-weight: bold; }
 td.cell.na         { color: #aaa; }
 td.cell.missing    { color: #8a6d3b; }
@@ -56,11 +57,25 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 table.glossary { margin-top: 0.5em; }
 table.glossary td.sub { white-space: nowrap; font-weight: bold; }
 table.glossary tr.category td { background: #eef; font-family: -apple-system, system-ui, sans-serif; font-weight: bold; }
+.info-panel { border: 1px solid #d0d7de; background: #f8fafc; padding: 12px 14px; margin: 1em 0; border-radius: 6px; max-width: 1200px; }
+.info-panel h2 { margin: 0 0 0.35em 0; font-size: 18px; }
+.info-panel h3 { margin: 0.9em 0 0.35em 0; font-size: 14px; color: #174a86; }
+.info-panel p { margin: 0 0 0.8em 0; font-size: 13px; color: #333; }
+.info-panel ul { margin: 0.35em 0 0 1.2em; padding: 0; font-size: 12px; color: #333; }
+.info-panel li { margin: 0.18em 0; }
+.flow-grid { display: grid; grid-template-columns: repeat(5, minmax(130px, 1fr)); gap: 8px; }
+.flow-step { position: relative; border: 1px solid #ccd6e0; background: #fff; padding: 8px 10px; border-radius: 4px; font-size: 12px; color: #333; }
+.flow-step-title { font-weight: 700; color: #174a86; margin-bottom: 3px; }
+.flow-step:not(:last-child)::after { content: "→"; position: absolute; right: -9px; top: 50%; transform: translateY(-50%); color: #667085; font-weight: 700; }
+@media (max-width: 900px) {
+    .flow-grid { grid-template-columns: 1fr; }
+    .flow-step:not(:last-child)::after { content: "↓"; right: 50%; top: auto; bottom: -12px; transform: translateX(50%); }
+}
 
 /* JS-managed hover tooltip on cells (replaces native title= for cells).
  * 750ms delay on appear; 750ms grace period before hiding after the cursor leaves.
- * `td.parser` participates so the parser-column inheritance tooltip
- * uses the same styling as data-cell tooltips. */
+ * `td.parser` participates so parser metadata tooltips use the same styling
+ * as data-cell tooltips. */
 td.cell, td.parser { position: relative; }
 .ttip {
     visibility: hidden;
@@ -122,6 +137,9 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   Auto-generated on {{ stamp|e }}{% if sha %} on commit <a href="https://github.com/ai-dynamo/dynamo/commit/{{ sha|e }}"><code>{{ short_sha|e }}</code></a>{% endif %}:
   <code>{{ command|e }} &gt; {{ output|e }}</code>
 </p>
+{% if intro_html is defined and intro_html %}
+{{ intro_html|safe }}
+{% endif %}
 {% if tabs|length > 1 %}
 <div class="tabs" role="tablist">
 {% for tab in tabs %}
@@ -143,24 +161,28 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 </tbody>
 </table>
 <p class="legend">
+{% if legend_html is defined and legend_html %}
+  {{ legend_html|safe }}
+{% else %}
   <strong>Legend:</strong>
-  <span style="color:#0a7d2c">=</span> full parity
-  (Dynamo, vLLM, and SGLang produce the same results) ·
-  <span style="color:#0a7d2c">V/S</span> divergence
+  <span style="color:#0a7d2c">=</span> all captured peers match Dynamo ·
+  <span style="color:#555">D</span> Dynamo-only fixture
+  (both peers unavailable) ·
+  <span style="color:#555">V/S</span> divergence
   (V = vLLM, S = SGLang; intentional, has <code>reason:</code>) ·
-  <span style="color:#c63">?</span> more research needed
+  <span style="color:#b00">?</span> more research needed
   (e.g. V?, S? — diverges with no <code>reason:</code> yet) ·
-  <span style="color:#555">↯</span> Dynamo leaks tool call markup into <code>normal_text</code>
+  <span style="color:#b00">↯</span> Dynamo leaks tool call markup into <code>normal_text</code>
   (<code>expected.dynamo.reason:</code> carries the explanation) ·
   <span style="color:#b00">!</span> expected-error suffix
   (e.g. V!, S! — engine crashes by design) ·
   <span style="color:#aaa">n/a</span> not applicable ·
   <span style="color:#8a6d3b">—</span> missing fixture coverage ·
-  <span class="parser-suffix">†</span> = no vLLM peer parser for this family ·
-  <span class="parser-suffix">§</span> = no SGLang peer parser for this family.
+  <span class="parser-suffix">†</span> = no vLLM peer tool calling parser for this family ·
+  <span class="parser-suffix">§</span> = no SGLang peer tool calling parser for this family.
   <br><br>
   <strong>Tooltip fields:</strong>
-  <code>input_text</code>=raw model output fed into the parser ·
+  <code>input_text</code>=raw model output fed into the tool calling parser ·
   <code>normal_text</code>=the <em>residual</em> prose left after stripping tool calls and reasoning blocks
   (<em>not</em> all of the model's output — "normal" as in "non-structured", to distinguish it from the structured
   <code>calls</code> and reasoning_content) ·
@@ -170,29 +192,35 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <strong>Peer parser versions</strong> pinned in
   <a href="../../../pyproject.toml">pyproject.toml</a>:
   {% for name, version in peer_versions %}{% if not loop.first %} · {% endif %}{{ name|e }} <code>{{ version|e }}</code>{% endfor %}.
+  {% endif %}
 {% endif %}
 </p>
 <p class="stats">
   Stats: {{ panel.stats.families }} families × {{ panel.stats.sub_cases }} sub-cases
   = {{ panel.stats.slots }} grid slots ({{ panel.stats.na }} n/a, {{ panel.stats.missing }} missing).
   <strong>{{ panel.stats.real }}</strong> real cases:
-  <span style="color:#0a7d2c">{{ panel.stats.parity }} full parity</span> ·
-  <span style="color:#0a7d2c">{{ panel.stats.documented }} documented divergences</span>
+  <span style="color:#0a7d2c">{{ panel.stats.parity }} captured-peer parity</span> ·
+  <span style="color:#555">{{ panel.stats.dynamo_only }} Dynamo-only</span> ·
+  <span style="color:#555">{{ panel.stats.documented }} documented divergences</span>
   (have <code>reason:</code>) ·
-  <span style="color:#c63">{{ panel.stats.research }} research-needed</span>
+  <span style="color:#b00">{{ panel.stats.research }} research-needed</span>
   (no <code>reason:</code> yet) ·
   <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
 </p>
 {% if panel.glossary_groups %}
 <h2 id="case-descriptions-{{ panel.mode|e }}">Case descriptions</h2>
 <p>Full case definitions:
-<a href="../../../lib/parsers/PARSER_CASES.md">lib/parsers/PARSER_CASES.md</a>.</p>
+<a href="{{ case_docs_href|default('../../../lib/parsers/PARSER_CASES.md') }}">{{ case_docs_label|default('lib/parsers/PARSER_CASES.md') }}</a>.</p>
 <table class="glossary">
 <tbody>
 {% for group in panel.glossary_groups %}
 <tr class="category"><td colspan="2">{{ group.label|e }}</td></tr>
 {% for sub, desc in group.rows %}
+{% if case_prefix is defined and case_prefix %}
+<tr><td class="sub">{{ case_prefix|e }}{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
+{% else %}
 <tr><td class="sub">PARSER.{{ panel.mode|e }}.{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
+{% endif %}
 {% endfor %}
 {% endfor %}
 </tbody>

--- a/tests/parity/parser/table.py
+++ b/tests/parity/parser/table.py
@@ -23,13 +23,13 @@ the table referenced in `tests/parity/README.md`.
 
 Cell markers (per peer, vllm + sglang):
   =     peer block is `*d_<case>` anchor ref to dynamo (matches)
-  V/S   peer is a concrete inline block AND has `reason:` (intentional —
-        rendered same color as =, since the divergence is accounted for)
+  V/S   peer is a concrete inline block AND has `reason:` (intentional)
   V?/S? peer is a concrete inline block AND has no `reason:` yet
         (research-needed; we observed it but haven't classified it)
   V!/S! peer has `error: <substring>` (expected to crash)
   VS, V?S, VS!, etc. — combinations
-  n/a   peer marked `unavailable`, or family/case doesn't apply
+  D     Dynamo-only fixture; both peer blocks are `unavailable`
+  n/a   family/case doesn't apply
   —     no fixture entry exists for this family/case yet
 
 Footnote markers `†` (no vLLM peer) and `§` (no SGLang peer) are auto-derived
@@ -50,6 +50,7 @@ Run:
 
 PARITY.{md,html} are for local viewing only; don't check them in.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -64,6 +65,14 @@ from pathlib import Path
 
 import yaml
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from tests.parity.common import TOP_N_TOOL_CALLING_FAMILIES as TOP_N_FAMILIES
+from tests.parity.common import (
+    build_parity_tooltip_html,
+    linkify_text_html,
+    parity_cell_class,
+)
+from tests.parity.markup import colorize_markup, colorize_stream_deltas
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests/parity/parser/fixtures"
@@ -285,30 +294,10 @@ def _build_family_to_rust_ref() -> dict[str, tuple[str, int]]:
     return out
 
 
-# Curated featured-model order. The only hand-maintained list left in the
-# script: it picks WHICH families lead the table and IN WHAT ORDER. The
-# human-readable label for each (e.g. "DeepSeek V4") is sourced from the
-# fixture YAML's `model_label:` field, so the label travels with the
-# family definition, not with this script.
-#
-# Source of truth: the tracked Top-N model mapping used by the parity
-# planning notes. When that list changes, this list and the corresponding
-# `model_label:` fields under `fixtures/<family>/PARSER.batch.yaml` must
-# be updated together.
-# Alphabetical-by-family-id within the list (matches the table row order).
-TOP_N_FAMILIES = [
-    "deepseek_v4",
-    "gemma4",
-    "glm47",
-    "harmony",
-    "kimi_k2",
-    "minimax_m2",
-    "qwen3_coder",
-]
-
 BATCH_SUB_CASE_GROUPS = [
+    ("Single-call", ("1.a", "1.b", "1.c", "1.d")),
     ("Core", ("1", "3", "9", "9.a", "9.b")),
-    ("Multi-call", ("2.a", "2.b", "2.c", "2.d", "10")),
+    ("Multi-call", ("2.a", "2.b", "2.c", "2.d", "2.e", "10")),
     (
         "Malformed / recovery",
         ("4.a", "4.b", "4.c", "4.d", "4.e", "5.a", "5.b", "5.c", "5.d", "5.e"),
@@ -339,6 +328,7 @@ SPLIT_PARENT_SUBCASES = {
     # Once a taxonomy bucket has leaf cases, the matrix should render only the
     # leaves. Existing parent fixtures still carry useful expectations/reasons
     # for parser families that have not been rewritten to leaf IDs yet.
+    "1": ("1.a",),
     "9": ("9.a",),
     "30": ("30.a", "30.b", "30.c"),
     "31": ("31.a", "31.b"),
@@ -595,6 +585,22 @@ def peer_status(case: dict, dyn: dict, impl: str) -> tuple[str, bool]:
     return ("na", False)
 
 
+_TOOL_CALL_MARKUP_RE = re.compile(
+    r"</?tool_call|</?tool_calls|<\|tool_call|<\|tool_calls|"
+    r"</?TOOLCALL|TOOL_CALLS|<｜(?:DSML｜)?(?:tool|tool▁call|tool▁calls)|"
+    r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value"
+)
+
+
+def _dynamo_tool_call_leak(dyn: dict) -> str | None:
+    normal_text = dyn.get("normal_text")
+    if not dyn.get("reason") or not isinstance(normal_text, str):
+        return None
+    if not _TOOL_CALL_MARKUP_RE.search(normal_text):
+        return None
+    return str(dyn["reason"])
+
+
 def cell_for(case: dict | None) -> str:
     if case is None:
         return "—"
@@ -618,7 +624,9 @@ def cell_for(case: dict | None) -> str:
     # leaking tool call markup only when Dynamo also leaves residual
     # `normal_text`. Dynamo can have non-leak reasons for dropped malformed
     # markup, so don't mark those as `↯`.
-    if isinstance(dyn, dict) and dyn.get("reason") and bool(dyn.get("normal_text")):
+    if isinstance(dyn, dict) and _dynamo_tool_call_leak(dyn):
+        if v_kind == "unavail" and s_kind == "unavail":
+            return "↯D"
         if parts:
             return "↯" + "".join(parts)
         return "↯"
@@ -626,7 +634,7 @@ def cell_for(case: dict | None) -> str:
     if parts:
         return "".join(parts)
     if v_kind == "unavail" and s_kind == "unavail":
-        return "n/a"
+        return "D"
     return "="
 
 
@@ -637,15 +645,17 @@ def render_row(
     sub_cases: list[str],
     no_vllm: set[str],
     no_sglang: set[str],
+    inheritance: dict[str, dict],
 ) -> str:
     cells = [cell_for(cases.get((family, sub))) for sub in sub_cases]
-    suff = family_suffix(family, no_vllm, no_sglang)
-    return f"| {model} | {family}{suff} | " + " | ".join(cells) + " |"
+    parser_label = _parser_label_markdown(family, no_vllm, no_sglang, inheritance)
+    return f"| {model} | {parser_label} | " + " | ".join(cells) + " |"
 
 
 _LEGEND_MD = (
     "**Legend:** "
-    "`=` full parity (Dynamo, vLLM, and SGLang produce the same results) · "
+    "`=` all captured peers match Dynamo · "
+    "`D` Dynamo-only fixture (both peers unavailable) · "
     "`V`/`S` divergence (V = vLLM, S = SGLang; intentional, has `reason:`) · "
     "`?` research-needed suffix (e.g. V?, S? — diverges with no `reason:` yet) · "
     "`↯` Dynamo leaks tool call markup into `normal_text` "
@@ -653,8 +663,8 @@ _LEGEND_MD = (
     "`!` expected-error suffix (e.g. V!, S! — engine crashes by design) · "
     "`n/a` not applicable · "
     "`—` missing fixture coverage · "
-    "`†` (parser column) = no vLLM peer parser for this family · "
-    "`§` (parser column) = no SGLang peer parser for this family."
+    "`†` (tool calling parser column) = no vLLM peer parser for this family · "
+    "`§` (tool calling parser column) = no SGLang peer parser for this family."
 )
 
 
@@ -666,44 +676,26 @@ def render_markdown(
     top_n: list[tuple[str, str]],
     others: list[tuple[str, str]],
 ) -> str:
-    header = "| model | parser | " + " | ".join(sub_cases) + " |"
+    inheritance = _build_family_inheritance(_build_family_to_rust_ref())
+    header = "| model | Tool calling parser | " + " | ".join(sub_cases) + " |"
     sep = "|---|---|" + ":-:|" * len(sub_cases)
     lines = [header, sep]
     lines.append("| **Top-N models** |   |" + "   |" * len(sub_cases))
     for model, fam in top_n:
-        lines.append(render_row(model, fam, cases, sub_cases, no_vllm, no_sglang))
+        lines.append(
+            render_row(model, fam, cases, sub_cases, no_vllm, no_sglang, inheritance)
+        )
     lines.append("| **Others** |   |" + "   |" * len(sub_cases))
     for model, fam in others:
-        lines.append(render_row(model, fam, cases, sub_cases, no_vllm, no_sglang))
+        lines.append(
+            render_row(model, fam, cases, sub_cases, no_vllm, no_sglang, inheritance)
+        )
     lines.append("")
     lines.append(_LEGEND_MD)
     return "\n".join(lines)
 
 
 _IMPL_DISPLAY = {"dynamo": "Dynamo", "vllm": "vLLM", "sglang": "SGLang"}
-_URL_RE = re.compile(r"https?://[^\s<>'\"]+")
-_TRAILING_URL_PUNCTUATION = ".,;:)"
-
-
-def _linkify_text_html(text: str) -> str:
-    """Escape plain text and turn embedded URLs into anchors."""
-    parts: list[str] = []
-    last = 0
-    for match in _URL_RE.finditer(text):
-        raw_url = match.group(0)
-        url = raw_url.rstrip(_TRAILING_URL_PUNCTUATION)
-        if not url:
-            continue
-        parts.append(html_lib.escape(text[last : match.start()]))
-        href = html_lib.escape(url, quote=True)
-        parts.append(
-            f'<a href="{href}" target="_blank" rel="noopener noreferrer">'
-            f"{html_lib.escape(url)}</a>"
-        )
-        parts.append(html_lib.escape(raw_url[len(url) :]))
-        last = match.end()
-    parts.append(html_lib.escape(text[last:]))
-    return "".join(parts)
 
 
 def _format_output_block_html(block, family: str | None = None) -> str:
@@ -726,258 +718,42 @@ def _format_output_block_html(block, family: str | None = None) -> str:
         calls_line = html_lib.escape(f"calls=[{rendered}]")
     else:
         calls_line = "calls=[]"
-    nt_line = f"normal_text='{_colorize_markup(nt, family)}'"
+    nt_line = f"normal_text='{colorize_markup(nt, family)}'"
     return f"{nt_line}\n{calls_line}"
-
-
-# Matches both `<...>` and the Mistral-style `[NAME]`/`[/NAME]` form.
-# Brackets only match ALL-CAPS-underscore names so JSON arrays
-# (e.g. `[{...}]`, `[1, 2]`) don't get false-matched as tags.
-_TAG_RE = re.compile(r"<[^<>]+>|\[/?[A-Z][A-Z0-9_]*\]")
-
-# Two coloring schemes share one cycling palette:
-#   * Paired open/close: every matched pair gets a *fresh* palette index, so
-#     two `<tool_call>...</tool_call>` instances in the same input render as
-#     two different colors.
-#   * Singletons (e.g. harmony's `<|channel|>` section markers): stable
-#     by-role color so all `<|channel|>` tokens share one class everywhere.
-_PAIRED_PALETTE_SIZE = 8
-_color_seq = 0
-_singleton_classes: dict[str, str] = {}
-
-
-def _next_color_class() -> str:
-    global _color_seq
-    cls = f"tt-c{_color_seq % _PAIRED_PALETTE_SIZE}"
-    _color_seq += 1
-    return cls
-
-
-def _singleton_class_for(name: str) -> str:
-    cls = _singleton_classes.get(name)
-    if cls is None:
-        cls = _next_color_class()
-        _singleton_classes[name] = cls
-    return cls
-
-
-_PIPES = ("|", "｜")  # ASCII and FULLWIDTH VERTICAL LINE (U+FF5C)
-_BEGIN_SUFFIXES = (
-    "_begin",
-    "▁begin",
-)  # ASCII underscore and LOWER ONE EIGHTH BLOCK (U+2581)
-_END_SUFFIXES = ("_end", "▁end")
-
-# Harmony (gpt-oss) tokens are linear state-machine delimiters. Turn-boundary
-# tokens form pseudo-pairs: `<|start|>` opens a turn; `<|end|>`, `<|return|>`,
-# or `<|call|>` closes it. Each closer flavor gets its own paired color so a
-# tool-call turn (start→call) is visually distinct from a normal turn (start→end)
-# or a final turn (start→return). Section markers stay as same-colored singletons.
-_HARMONY_TURN_OPEN = "start"
-_HARMONY_TURN_CLOSE = frozenset({"end", "return", "call"})
-_HARMONY_SECTION_MARKERS = frozenset({"channel", "constrain", "message"})
-_HARMONY_TOKEN_RE = re.compile(r"<\|([A-Za-z_]+)\|>")
-_HARMONY_SEGMENT_CLASS = {
-    "start": "tt-h-start",
-    "channel": "tt-h-channel",
-    "constrain": "tt-h-constrain",
-    "message": "tt-h-message",
-    "end": "tt-h-stop",
-    "return": "tt-h-stop",
-    "call": "tt-h-call",
-}
-
-
-def _colorize_harmony(text: str) -> str:
-    """Color Harmony's linear token segments as `<|token|>related-text`.
-
-    Harmony is not paired XML. Tokens such as `<|channel|>` and `<|message|>`
-    introduce the header/content span that follows, so each special token is
-    grouped with text up to the next Harmony token.
-    """
-    pieces: list[str] = []
-    last = 0
-    for m in _HARMONY_TOKEN_RE.finditer(text):
-        if m.start() > last:
-            pieces.append(html_lib.escape(text[last : m.start()]))
-        token_name = m.group(1)
-        if token_name in _HARMONY_TURN_CLOSE:
-            end = m.end()
-        else:
-            next_m = _HARMONY_TOKEN_RE.search(text, m.end())
-            end = next_m.start() if next_m else len(text)
-        cls = _HARMONY_SEGMENT_CLASS.get(token_name, "tt-h-other")
-        token = html_lib.escape(m.group(0))
-        related = html_lib.escape(text[m.end() : end])
-        pieces.append(
-            f'<span class="tt-h {cls}"><span class="tt-h-token">{token}</span>{related}</span>'
-        )
-        last = end
-    if last < len(text):
-        pieces.append(html_lib.escape(text[last:]))
-    return "".join(pieces)
-
-
-def _colorize_markup(text: str, family: str | None = None) -> str:
-    if family == "harmony" and _HARMONY_TOKEN_RE.search(text):
-        return _colorize_harmony(text)
-    return _colorize_xml(text)
-
-
-def _strip_suffix(s: str, suffixes: tuple[str, ...]) -> str | None:
-    for suf in suffixes:
-        if s.endswith(suf) and len(s) > len(suf):
-            return s[: -len(suf)]
-    return None
-
-
-def _tag_kind_and_name(inner: str) -> tuple[str | None, str, str | None]:
-    """Classify `<...>` tag inner text into an open/close/singleton kind.
-
-    Returns (kind, pair_id, color_override):
-      * kind: 'open' | 'close' | 'singleton' | None
-      * pair_id: name used to match open against close on the stack
-      * color_override: when set, the paired span uses this name for the
-        color class instead of pair_id (lets `<|start|>...<|call|>` color
-        differently from `<|start|>...<|end|>` despite sharing pair_id).
-    """
-
-    def _name_of(s: str) -> str:
-        # Split on whitespace, slash, `>`, OR `=` so that
-        # `<function=book_flight>` pairs with `</function>` and
-        # `<parameter=destination>` pairs with `</parameter>`.
-        if not s:
-            return ""
-        return re.split(r"[\s/>=]", s, 1)[0].rstrip("|")
-
-    if inner.startswith("/"):
-        return ("close", _name_of(inner[1:]), None)
-    starts_pipe = inner[:1] in _PIPES
-    ends_pipe = inner[-1:] in _PIPES
-    if starts_pipe and ends_pipe and len(inner) >= 2:
-        middle = inner[1:-1]
-        stripped = _strip_suffix(middle, _BEGIN_SUFFIXES)
-        if stripped is not None:
-            return ("open", stripped, None)
-        stripped = _strip_suffix(middle, _END_SUFFIXES)
-        if stripped is not None:
-            return ("close", stripped, None)
-        if middle == _HARMONY_TURN_OPEN:
-            return ("open", "__harmony_turn", None)
-        if middle in _HARMONY_TURN_CLOSE:
-            # Color the pair by which closer flavor was used.
-            return ("close", "__harmony_turn", f"__harmony_pair_{middle}")
-        if middle in _HARMONY_SECTION_MARKERS:
-            return ("singleton", "__harmony_section", None)
-        return (None, "", None)
-    if starts_pipe and inner[:1] == "|":
-        return ("open", _name_of(inner[1:]), None)
-    if ends_pipe and inner[-1:] == "|":
-        return ("close", _name_of(inner[:-1]), None)
-    return ("open", _name_of(inner), None)
-
-
-def _colorize_xml(text: str) -> str:
-    """HTML-escape `text` and wrap each `<...>` token in a span.
-    Paired open/close (stack match by tag name) → class 'tt-paired'.
-    Unmatched close, or open that never closes → class 'tt-orphan'.
-
-    Pairs standard XML (`<X>...</X>`) AND alt pipe-marker conventions:
-      `<|X>...<X|>`          (boundary ASCII pipes)
-      `<|X_begin|>...<|X_end|>`  (both-side pipes with _begin/_end suffix)
-    Lenient pop-through: a close looks down the stack for the nearest
-    name-match; anything un-closed above it is marked orphan. Lets
-    no-close singletons (e.g. `<|tool_call_argument_begin|>`) localize
-    their orphan-ness without poisoning the surrounding pairs.
-    """
-    pieces: list[str] = []
-    stack: list[tuple[str, int]] = []
-    last = 0
-    for m in _TAG_RE.finditer(text):
-        if m.start() > last:
-            pieces.append(html_lib.escape(text[last : m.start()]))
-        tok = m.group(0)
-        kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
-        esc = html_lib.escape(tok)
-        if kind is None:
-            pieces.append(f'<span class="tt-orphan">{esc}</span>')
-        elif kind == "singleton":
-            cls = _singleton_class_for(pair_id)
-            pieces.append(f'<span class="{cls}">{esc}</span>')
-        elif kind == "close":
-            match_at = -1
-            for i in range(len(stack) - 1, -1, -1):
-                if stack[i][0] == pair_id:
-                    match_at = i
-                    break
-            if match_at >= 0:
-                for _, unmatched_idx in stack[match_at + 1 :]:
-                    pieces[
-                        unmatched_idx
-                    ] = f'<span class="tt-orphan">{pieces[unmatched_idx]}</span>'
-                open_idx = stack[match_at][1]
-                # Per-instance color: every matched pair gets a fresh palette
-                # index, so two `<tool_call>...</tool_call>` (or two
-                # `<|start|>...<|call|>`) blocks in the same input render as
-                # different colors. (color_override unused on the paired
-                # path — kept on the singleton-flavor branch only.)
-                _ = color_override
-                cls = _next_color_class()
-                pieces[open_idx] = f'<span class="{cls}">{pieces[open_idx]}</span>'
-                pieces.append(f'<span class="{cls}">{esc}</span>')
-                del stack[match_at:]
-            else:
-                pieces.append(f'<span class="tt-orphan">{esc}</span>')
-        else:
-            pieces.append(esc)
-            stack.append((pair_id, len(pieces) - 1))
-        last = m.end()
-    for _, idx in stack:
-        pieces[idx] = f'<span class="tt-orphan">{pieces[idx]}</span>'
-    if last < len(text):
-        pieces.append(html_lib.escape(text[last:]))
-    return "".join(pieces)
 
 
 def _build_tooltip_html(case: dict, dyn) -> str:
     """Rich HTML hover tooltip: head, input (colorized), per-engine output,
     divergence reasons. Returns the full `<div class="ttip">...</div>`."""
     case_id = case.get("__case_id", "")
+    family = case.get("__family")
     desc = case.get("description") or ""
-    head = f"{case_id} — {desc}" if (case_id and desc) else (case_id or desc)
+    if case_id and family:
+        head = f"{case_id} — {family}"
+    else:
+        head = case_id or str(family or "")
 
-    parts: list[str] = ['<div class="ttip">']
-    if head:
-        parts.append(f'<div class="ttip-head">{html_lib.escape(head)}</div>')
-
-    ref = case.get("ref")
-    if isinstance(ref, str) and ref:
-        parts.append('<div class="ttip-section">Ref:</div>')
-        parts.append(f'<pre class="ttip-pre">{_linkify_text_html(ref)}</pre>')
-
+    input_label = None
+    input_html = None
     model_text = case.get("model_text")
     if isinstance(model_text, str) and model_text:
-        family = case.get("__family")
-        parts.append('<div class="ttip-section">Input:</div>')
-        parts.append(
-            f"<pre class=\"ttip-pre\">input_text='{_colorize_markup(model_text, family)}'</pre>"
-        )
+        input_label = "Input"
+        input_html = f"input_text='{colorize_markup(model_text, family)}'"
     chunks = case.get("chunks")
     if isinstance(chunks, list) and chunks:
-        parts.append('<div class="ttip-section">Input chunks:</div>')
         chunk_lines = []
+        chunk_html = colorize_stream_deltas(chunks, family)
         for i, chunk in enumerate(chunks):
             if not isinstance(chunk, dict):
                 continue
-            delta = chunk.get("delta_text") or ""
             suffix = ""
             if chunk.get("finish_reason"):
                 suffix = " finish_reason=" + html_lib.escape(
                     str(chunk["finish_reason"])
                 )
-            chunk_lines.append(f"{i}: delta_text='{_colorize_xml(delta)}'{suffix}")
-        chunk_text = "\n".join(chunk_lines)
-        parts.append(f'<pre class="ttip-pre">{chunk_text}</pre>')
+            chunk_lines.append(f"{i}: delta_text='{chunk_html[i]}'{suffix}")
+        input_label = "Input chunks"
+        input_html = "\n".join(chunk_lines)
 
     expected = case.get("expected") or {}
 
@@ -988,7 +764,7 @@ def _build_tooltip_html(case: dict, dyn) -> str:
         }
 
     n_dyn = _norm(dyn) if isinstance(dyn, dict) else None
-    all_parity = isinstance(dyn, dict) and all(
+    all_engines_parity = isinstance(dyn, dict) and all(
         isinstance(expected.get(i), dict)
         and not expected[i].get("unavailable")
         and "error" not in expected[i]
@@ -996,35 +772,32 @@ def _build_tooltip_html(case: dict, dyn) -> str:
         for i in ("dynamo", "vllm", "sglang")
     )
 
-    if all_parity:
-        parts.append('<div class="ttip-section">All engines parity:</div>')
-        parts.append(
-            f'<pre class="ttip-pre">{_format_output_block_html(dyn, case.get("__family"))}</pre>'
+    output_sections: list[tuple[str, str]] = []
+    if all_engines_parity:
+        output_sections.append(
+            ("All engines parity", _format_output_block_html(dyn, family))
         )
     else:
         for impl in ("dynamo", "vllm", "sglang"):
             block = expected.get(impl)
-            parts.append(f'<div class="ttip-section">{_IMPL_DISPLAY[impl]}:</div>')
-            parts.append(
-                f'<pre class="ttip-pre">{_format_output_block_html(block, case.get("__family"))}</pre>'
+            output_sections.append(
+                (_IMPL_DISPLAY[impl], _format_output_block_html(block, family))
             )
 
     reasons = _tooltip_for(case, dyn) if isinstance(dyn, dict) else ""
-    if reasons:
-        parts.append('<div class="ttip-section">Divergence reason:</div>')
-        parts.append(f'<pre class="ttip-pre">{_linkify_text_html(reasons)}</pre>')
 
-    dyn_leak = (
-        dyn.get("reason")
-        if isinstance(dyn, dict) and bool(dyn.get("normal_text"))
-        else None
+    dyn_leak = _dynamo_tool_call_leak(dyn) if isinstance(dyn, dict) else None
+    return build_parity_tooltip_html(
+        head=head,
+        description=desc,
+        input_label=input_label,
+        input_html=input_html,
+        output_sections=output_sections,
+        divergent_reasons=reasons or None,
+        leak_label="↯ Dynamo tool call leaks",
+        leak_text=str(dyn_leak) if dyn_leak else None,
+        refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
     )
-    if dyn_leak:
-        parts.append('<div class="ttip-section">↯ Dynamo tool call leaks:</div>')
-        parts.append(f'<pre class="ttip-pre">{_linkify_text_html(str(dyn_leak))}</pre>')
-
-    parts.append("</div>")
-    return "".join(parts)
 
 
 def _tooltip_for(case: dict, dyn: dict) -> str:
@@ -1065,24 +838,6 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
     return "\n".join(parts)
 
 
-def _cell_class(text: str) -> str:
-    if text == "—":
-        return "missing"
-    if text == "n/a":
-        return "na"
-    if "!" in text:
-        return "err"
-    if "↯" in text:
-        return "leak"
-    if "?" in text:
-        return "research"
-    if text == "=":
-        return "ok"
-    # V / S / VS with a documented `reason:` — accepted divergence, but
-    # NOT parity, so don't color it green.
-    return "documented"
-
-
 def _build_na_tooltip_html(case: dict) -> str:
     """Tooltip for an n/a stub case (only `reason:` in YAML, no `expected:`
     block). Renders case id + description + the reason. Used when the cell
@@ -1091,13 +846,11 @@ def _build_na_tooltip_html(case: dict) -> str:
     desc = case.get("description") or ""
     head = f"{case_id} — {desc}" if (case_id and desc) else (case_id or desc)
     reason = case.get("reason") or "n/a (no reason given)"
-    parts = ['<div class="ttip">']
-    if head:
-        parts.append(f'<div class="ttip-head">{html_lib.escape(head)}</div>')
-    parts.append('<div class="ttip-section">Why n/a:</div>')
-    parts.append(f'<pre class="ttip-pre">{_linkify_text_html(str(reason))}</pre>')
-    parts.append("</div>")
-    return "".join(parts)
+    return build_parity_tooltip_html(
+        head=head,
+        extra_sections=[("Why n/a", linkify_text_html(str(reason)))],
+        refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
+    )
 
 
 def _build_missing_tooltip_html(mode: str, family: str, sub: str) -> str:
@@ -1108,24 +861,24 @@ def _build_missing_tooltip_html(mode: str, family: str, sub: str) -> str:
     fixture author recorded why the case does not apply.
     """
     case_id = f"PARSER.{mode}.{sub}"
-    parts = ['<div class="ttip">']
-    parts.append(
-        f'<div class="ttip-head">{html_lib.escape(case_id)} — '
-        f"{html_lib.escape(family)}</div>"
+    return build_parity_tooltip_html(
+        head=f"{case_id} — {family}",
+        extra_sections=[
+            (
+                "Missing fixture",
+                html_lib.escape(
+                    "No fixture entry exists for this family/case. If the case "
+                    "is intentionally not applicable, add an explicit n/a stub "
+                    "with description: and reason: so the table can explain it."
+                ),
+            )
+        ],
     )
-    parts.append('<div class="ttip-section">Missing fixture:</div>')
-    parts.append(
-        '<pre class="ttip-pre">No fixture entry exists for this family/case. '
-        "If the case is intentionally not applicable, add an explicit n/a "
-        "stub with description: and reason: so the table can explain it.</pre>"
-    )
-    parts.append("</div>")
-    return "".join(parts)
 
 
 def render_cell_html(case: dict | None, mode: str, family: str, sub: str) -> str:
     text = cell_for(case)
-    cls = _cell_class(text)
+    cls = parity_cell_class(text)
     band_cls = _subcase_band_class(mode, sub)
     col_group = html_lib.escape(_subcase_group_key(mode, sub))
     td_open = f'<td class="cell {cls} {band_cls}" data-col-hide-group="{col_group}">'
@@ -1160,12 +913,13 @@ def _parser_inheritance_tooltip_html(
     no_vllm: set[str] | None = None,
     no_sglang: set[str] | None = None,
 ) -> str:
-    """Rich `.ttip` tooltip rendering the parser inheritance as an ASCII
-    tree localized to the target family: variant header, siblings sharing
-    the same backend, the target marked with `← THIS`, aliases nested under
-    the target, and a warning when filed under `xml/` but bypassing the
-    shared XML base. `ctor_ref` is unused here (was for older field-based
-    layout) — kept for API stability with `_parser_cell_html`."""
+    """Rich `.ttip` tooltip for the tool calling parser column.
+
+    Keep this field-list shape aligned with the reasoning parser column tooltip
+    so both tables explain "effective parser/backend -> row family" the same
+    way. `ctor_ref` is unused here (was for older field-based layout) — kept
+    for API stability with `_parser_cell_html`.
+    """
     del ctor_ref
 
     variant = info["variant"] or "?"
@@ -1174,93 +928,61 @@ def _parser_inheritance_tooltip_html(
     factory = info["factory"]
     alias_of = info.get("alias_of")  # set when this family is an alias-only entry
 
-    # Header: ParserConfig::<Variant>[::<Sub>] → <backend file>  [(factory: <name>)]
     head_parts = [f"ParserConfig::{variant}"]
     if sub_variant:
         head_parts[-1] = f"ParserConfig::{variant}::{sub_variant}"
     bf_href = html_lib.escape(f"../../../lib/parsers/src/tool_calling/{backend_file}")
     bf_link = f'<a href="{bf_href}">{html_lib.escape(backend_file)}</a>'
-    header_html = f"{html_lib.escape(head_parts[0])} → {bf_link}"
+
+    anchor = alias_of or family
+    shared_family = sorted([anchor] + info["shared_with"])
+    effective_backend = _shared_backend_short(info) or family
+
+    implementation = f"{html_lib.escape(head_parts[0])} -> {bf_link}"
     if factory:
         factory_name = factory.split("(", 1)[0]
-        header_html += html_lib.escape(f"  (factory: {factory_name})")
+        implementation += html_lib.escape(f" (factory: {factory_name})")
 
-    # Body: anchor + siblings, alphabetical, target marked with ← THIS.
-    # Anchor is the family whose entry "owns" this backend. If `family` is
-    # an alias-only entry, the anchor is its target and the marker drops
-    # to the alias's leaf row under that target.
-    anchor = alias_of or family
-    siblings = info["shared_with"]
-    fam_list = sorted([anchor] + siblings)
-    body_lines: list[str] = []
-    for i, fam in enumerate(fam_list):
-        is_last_fam = i == len(fam_list) - 1
-        branch = "└── " if is_last_fam else "├── "
-        # block="..." suffix only renders for the anchor row, since we only
-        # have factory args for the current entry (not for siblings).
-        suffix = ""
-        if fam == anchor and info["factory"]:
-            fm = re.search(r'\("([^"]+)"\)', info["factory"])
-            if fm:
-                suffix = f'  block="{fm.group(1)}"'
-        # ← THIS goes on the target family's line only when the table cell
-        # IS the target (not an alias).
-        marker_html = (
-            "  <strong>← THIS</strong>" if (fam == family and not alias_of) else ""
+    tooltip_lines = [
+        "Tool calling parser family from fixture YAML.",
+        f"Tool calling parser row: {html_lib.escape(family)}",
+        f"Effective parser/backend: {html_lib.escape(effective_backend)}",
+        f"Dynamo implementation: {implementation}",
+    ]
+    if info["shared_with"]:
+        tooltip_lines.append(
+            "Shared implementation family: " + html_lib.escape(", ".join(shared_family))
         )
-        body_lines.append(
-            f"{branch}{html_lib.escape(fam)}{html_lib.escape(suffix)}{marker_html}"
+    if alias_of:
+        tooltip_lines.append(f"Alias of: {html_lib.escape(alias_of)}")
+    if info["aliases"]:
+        tooltip_lines.append(
+            "Registered aliases: " + html_lib.escape(", ".join(info["aliases"]))
         )
 
-        # Aliases nested under the anchor. If we're rendering the alias's
-        # own tooltip, the alias's row carries the ← THIS marker.
-        if fam == anchor and info["aliases"]:
-            cont = "    " if is_last_fam else "│   "
-            for j, alias in enumerate(info["aliases"]):
-                alast = j == len(info["aliases"]) - 1
-                ab = "└── " if alast else "├── "
-                a_marker = (
-                    "  <strong>← THIS</strong>"
-                    if (alias_of and alias == family)
-                    else ""
-                )
-                body_lines.append(
-                    f"{cont}{ab}{html_lib.escape(alias)}  (alias){a_marker}"
-                )
-
-    # Peer-availability footnote (†/§) — embedded here so symbols don't need
-    # their own native tooltip. Anchored on the table-cell family, so an
-    # alias inherits its target's peer markers (they share the same fixture
-    # YAMLs and the same `expected.<impl>.unavailable` flags).
     peer_notes: list[str] = []
     if no_vllm and family in no_vllm:
-        peer_notes.append(
-            '<span class="parser-suffix">†</span> no vLLM peer parser for this family'
-        )
+        peer_notes.append("no vLLM peer parser")
     if no_sglang and family in no_sglang:
-        peer_notes.append(
-            '<span class="parser-suffix">§</span> no SGLang peer parser for this family'
-        )
-    peer_html = ("\n\n" + "\n".join(peer_notes)) if peer_notes else ""
+        peer_notes.append("no SGLang peer parser")
+    if peer_notes:
+        tooltip_lines.append("Peer availability: " + ", ".join(peer_notes))
 
-    # Misleading-location warning appended as a separate paragraph below the tree.
-    warn_html = ""
     if info["filed_under_xml_misleading"]:
-        warn_html = (
-            "\n\n⚠ Filed under xml/ but does NOT use the shared xml::parser.\n"
-            f"   Has its own ParserConfig::{html_lib.escape(variant)} variant."
+        tooltip_lines.append(
+            "Note: filed under xml/ but does not use the shared xml::parser; "
+            f"it has its own ParserConfig::{html_lib.escape(variant)} variant."
         )
+    tooltip_lines.extend(_tool_parser_tree_lines(family, info, effective_backend))
 
-    tree_html = header_html + "\n" + "\n".join(body_lines) + peer_html + warn_html
-
-    if alias_of:
-        head_text = f"{family} — alias of {alias_of}; inherits {info['base_label']}"
+    if effective_backend == family:
+        head_text = f"`{family}`"
     else:
-        head_text = f"{family} — inherits {info['base_label']}"
+        head_text = f"`{effective_backend}` (row: `{family}`)"
     return (
         '<div class="ttip">'
         f'<div class="ttip-head">{html_lib.escape(head_text)}</div>'
-        f'<pre class="ttip-pre">{tree_html}</pre>'
+        f'<pre class="ttip-pre">{"".join(line + chr(10) for line in tooltip_lines).rstrip()}</pre>'
         "</div>"
     )
 
@@ -1272,6 +994,64 @@ _SHARED_BACKEND_SHORT = {
 }
 
 
+def _tool_parser_tree_lines(
+    family: str,
+    info: dict,
+    effective_backend: str,
+) -> list[str]:
+    alias_of = info.get("alias_of")
+    anchor = alias_of or family
+    aliases = info["aliases"]
+    if not info["shared_with"] and not aliases and effective_backend == family:
+        return []
+
+    fam_list = sorted([anchor] + info["shared_with"])
+    lines = ["", "Shared implementation tree:"]
+    root_label = html_lib.escape(effective_backend)
+    if effective_backend == family:
+        root_label = f"<strong>{root_label}</strong>"
+    lines.append(f"{root_label} (effective parser/backend)")
+
+    for i, fam in enumerate(fam_list):
+        is_last_fam = i == len(fam_list) - 1
+        branch = "└── " if is_last_fam else "├── "
+        fam_label = html_lib.escape(fam)
+        if fam == family and not alias_of:
+            fam_label = f"<strong>{fam_label}</strong>"
+        lines.append(f"{branch}{fam_label}")
+
+        if fam == anchor and aliases:
+            cont = "    " if is_last_fam else "│   "
+            for j, alias in enumerate(aliases):
+                alast = j == len(aliases) - 1
+                ab = "└── " if alast else "├── "
+                alias_label = html_lib.escape(alias)
+                if alias_of and alias == family:
+                    alias_label = f"<strong>{alias_label}</strong>"
+                lines.append(f"{cont}{ab}{alias_label} (alias)")
+
+    return lines
+
+
+def _shared_backend_short(info: dict | None) -> str | None:
+    if info and info["shared_with"]:
+        return _SHARED_BACKEND_SHORT.get(info["key"])
+    return None
+
+
+def _parser_label_markdown(
+    family: str,
+    no_vllm: set[str],
+    no_sglang: set[str],
+    inheritance: dict[str, dict],
+) -> str:
+    suff = family_suffix(family, no_vllm, no_sglang)
+    short = _shared_backend_short(inheritance.get(family))
+    if short:
+        return f"{short} -> {family}{suff}"
+    return f"{family}{suff}"
+
+
 def _parser_cell_html(
     family: str,
     refs: dict[str, tuple[str, int]],
@@ -1280,9 +1060,9 @@ def _parser_cell_html(
     inheritance: dict[str, dict],
 ) -> str:
     suff = family_suffix(family, no_vllm, no_sglang)
-    label = html_lib.escape(family)
+    row_label = html_lib.escape(family)
     if suff:
-        label += f'<span class="parser-suffix">{html_lib.escape(suff)}</span>'
+        row_label += f'<span class="parser-suffix">{html_lib.escape(suff)}</span>'
     ref = refs.get(family)
     info = inheritance.get(family)
     ttip = (
@@ -1291,14 +1071,16 @@ def _parser_cell_html(
         else ""
     )
 
-    # Shared-base suffix: only show when 2+ families share this backend, so
-    # the column calls out the consolidation rows without adding noise to
-    # standalone parsers (pythonic, gemma4, glm47, kimi_k2, harmony, ...).
-    base_suffix = ""
-    if info and info["shared_with"]:
-        short = _SHARED_BACKEND_SHORT.get(info["key"])
-        if short:
-            base_suffix = f'<span class="parser-base">→ {html_lib.escape(short)}</span>'
+    # Shared-backend rows should read as implementation -> fixture family,
+    # e.g. `xml -> minimax_m2` and `xml -> qwen3_coder`. Standalone parsers
+    # keep the public family name as the primary label.
+    short = _shared_backend_short(info)
+    if short:
+        label = html_lib.escape(short)
+        base_suffix = f'<span class="parser-base">→ {row_label}</span>'
+    else:
+        label = row_label
+        base_suffix = ""
 
     # Family-name link points to the **actual parser code** (backend_file from
     # the inheritance map), not to the config-ctor location in config.rs. The
@@ -1462,7 +1244,9 @@ def _subcase_group_headers_html(mode: str, sub_cases: list[str]) -> str:
     """Build semantic group headers spanning the displayed sub-case columns."""
     spans: list[str] = [
         _column_control_header_html("model", "Model", default_visible=False),
-        _column_control_header_html("parser", "Parser", default_visible=True),
+        _column_control_header_html(
+            "parser", "Tool calling parser", default_visible=True
+        ),
     ]
     for run in _subcase_runs(mode, sub_cases):
         label = _subcase_group_label(mode, run[0])
@@ -1526,6 +1310,7 @@ def _compute_stats(
         "slots": len(families) * len(sub_cases),
         "real": 0,
         "parity": 0,
+        "dynamo_only": 0,
         "documented": 0,
         "research": 0,
         "errors": 0,
@@ -1545,6 +1330,8 @@ def _compute_stats(
             s["real"] += 1
             if text == "=":
                 s["parity"] += 1
+            elif text == "D":
+                s["dynamo_only"] += 1
             elif "!" in text:
                 s["errors"] += 1
             elif "↯" in text:
@@ -1684,9 +1471,9 @@ def render_html(modes: list[str], family_filter: str | None = None) -> str:
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")
     title = (
-        f"Dynamo {family_filter} Tool Call Parser - Parity Table"
+        f"Dynamo {family_filter} Tool Calling Parser - Parity Table"
         if family_filter
-        else "Dynamo Tool Call Parser - Parity Table"
+        else "Dynamo Tool Calling Parser - Parity Table"
     )
     command = "python3 tests/parity/generate_parity_table.py parser --html"
     output = "tests/parity/parser/PARITY.html"

--- a/tests/parity/parser/test_generate_parity_table.py
+++ b/tests/parity/parser/test_generate_parity_table.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from html.parser import HTMLParser
@@ -48,7 +49,7 @@ def test_generate_parser_parity_table_html() -> None:
 
     assert "<html" in html.lower()
     assert "<table" in html.lower()
-    assert "Dynamo Tool Call Parser - Parity Table" in html
+    assert "Dynamo Tool Calling Parser - Parity Table" in html
     assert "generate_parity_table.py parser --html" in html
     assert "PARSER.batch.*" in html
     assert "PARSER.stream.*" in html
@@ -72,12 +73,48 @@ def test_generate_parser_parity_table_batch_mode_excludes_stream_links() -> None
     assert all("PARSER.stream." not in href for href in fixture_links)
 
 
+@pytest.mark.timeout(60)
+def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> None:
+    html = _render_html_for("reasoning")
+
+    assert "Dynamo Reasoning - Parity Table" in html
+    assert re.search(
+        r'<td class="cell na[^"]*"[^>]*><a href="fixtures/qwen3/REASONING\.batch\.yaml">n/a</a>'
+        r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.b — qwen3',
+        html,
+    )
+    assert re.search(
+        r'<td class="cell leak[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">↯D</a>'
+        r'<div class="ttip"><div class="ttip-head">REASONING\.stream\.3\.b — gpt_oss',
+        html,
+    )
+    assert re.search(
+        r'<td class="cell research[^"]*"[^>]*><a href="fixtures/kimi_k25/REASONING\.batch\.yaml">V\?</a>'
+        r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.b — kimi_k25',
+        html,
+    )
+    assert re.search(
+        r'<td class="cell research[^"]*"[^>]*><a href="fixtures/granite/REASONING\.batch\.yaml">V\?</a>'
+        r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.2\.a — granite',
+        html,
+    )
+    assert re.search(
+        r'<td class="cell ok[^"]*"[^>]*><a href="fixtures/minimax_append_think/REASONING\.batch\.yaml">=</a>'
+        r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.a — minimax_append_think',
+        html,
+    )
+
+
 def _render_html(*extra_args: str) -> str:
+    return _render_html_for("parser", *extra_args)
+
+
+def _render_html_for(table: str, *extra_args: str) -> str:
     result = subprocess.run(
         [
             sys.executable,
             str(GENERATOR.relative_to(REPO_ROOT)),
-            "parser",
+            table,
             "--html",
             *extra_args,
         ],

--- a/tests/parity/reasoning/__init__.py
+++ b/tests/parity/reasoning/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/parity/reasoning/dynamo.py
+++ b/tests/parity/reasoning/dynamo.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning parity wrapper for Dynamo's Rust parsers, via the PyO3 binding."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from dynamo._core import parse_reasoning_batch, parse_reasoning_stream
+from tests.parity.common import ReasoningResult
+
+
+def parse(
+    parser_family: str,
+    fixture: dict[str, Any],
+    mode: str,
+) -> ReasoningResult:
+    try:
+        if mode == "stream":
+            raw_json = parse_reasoning_stream(
+                parser_family,
+                fixture["chunks"],
+                fixture.get("token_chunks"),
+                fixture.get("in_reasoning", False),
+            )
+        elif mode == "batch":
+            raw_json = parse_reasoning_batch(
+                parser_family,
+                fixture["model_text"],
+                fixture.get("token_ids"),
+                fixture.get("in_reasoning", False),
+            )
+        else:
+            raise ValueError(f"unsupported reasoning mode: {mode!r}")
+        raw = json.loads(raw_json)
+    except Exception as e:
+        return ReasoningResult(error=f"{type(e).__name__}: {e}")
+
+    return ReasoningResult(
+        reasoning_text=raw.get("reasoning_text"),
+        normal_text=raw.get("normal_text"),
+    )

--- a/tests/parity/reasoning/sglang.py
+++ b/tests/parity/reasoning/sglang.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning parity wrapper for SGLang's reasoning parser."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+
+from tests.parity.common import ReasoningResult
+
+_FAMILY_TO_SGLANG_REASONING = {
+    "deepseek_r1": "deepseek-r1",
+    "gpt_oss": "gpt-oss",
+    "kimi": "kimi",
+    "qwen3": "qwen3",
+}
+
+
+def _make_parser(parser_name: str, fixture: dict[str, Any]) -> ReasoningParser:
+    return ReasoningParser(
+        model_type=parser_name,
+        stream_reasoning=True,
+        force_reasoning=fixture.get("force_reasoning", False),
+    )
+
+
+def parse(
+    parser_family: str,
+    fixture: dict[str, Any],
+    mode: str,
+) -> ReasoningResult:
+    parser_name = fixture.get("sglang_parser") or _FAMILY_TO_SGLANG_REASONING.get(
+        parser_family
+    )
+    if not parser_name:
+        return ReasoningResult(
+            error=f"UNAVAILABLE: SGLang has no reasoning parser for family={parser_family!r}"
+        )
+
+    try:
+        parser = _make_parser(parser_name, fixture)
+        if mode == "stream":
+            chunks = fixture["chunks"]
+        elif mode == "batch":
+            chunks = [fixture["model_text"]]
+        else:
+            raise ValueError(f"unsupported reasoning mode: {mode!r}")
+        reasoning_text = ""
+        normal_text = ""
+        for chunk in chunks:
+            reasoning_delta, normal_delta = parser.parse_stream_chunk(chunk)
+            reasoning_text += reasoning_delta or ""
+            normal_text += normal_delta or ""
+    except Exception as e:
+        return ReasoningResult(error=f"{type(e).__name__}: {e}")
+
+    return ReasoningResult(reasoning_text=reasoning_text, normal_text=normal_text)

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -1,0 +1,2091 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate the REASONING.* parity table from YAML fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import html as html_lib
+import json
+import re
+import subprocess
+import zoneinfo
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from tests.parity.common import TOP_N_TOOL_CALLING_FAMILIES as TOP_N_FAMILIES
+from tests.parity.common import (
+    build_parity_tooltip_html,
+    linkify_text_html,
+    parity_cell_class,
+)
+from tests.parity.markup import colorize_markup
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURES = REPO_ROOT / "tests/parity/reasoning/fixtures"
+PARSER_FIXTURES = REPO_ROOT / "tests/parity/parser/fixtures"
+REASONING_CASES_MD = REPO_ROOT / "lib/parsers/REASONING_CASES.md"
+SCRIPT_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = REPO_ROOT / "tests/parity"
+
+DisplayRow = dict[str, str | None]
+_IMPL_DISPLAY = {"dynamo": "Dynamo", "vllm": "vLLM", "sglang": "SGLang"}
+
+CASE_GROUPS = [
+    (
+        "Core",
+        ("batch.1.a", "batch.1.b"),
+    ),
+    (
+        "Reasoning extraction",
+        (
+            "batch.2.a",
+            "batch.2.b",
+            "batch.2.c",
+            "batch.2.d",
+            "batch.2.e",
+            "batch.2.f",
+        ),
+    ),
+    ("Tool call boundary", ("batch.3.a", "batch.3.b")),
+    ("Malformed / recovery", ("batch.4", "batch.5")),
+    ("Multi-span", ("batch.6.a", "batch.6.b")),
+    (
+        "Core",
+        ("stream.1.a", "stream.1.b"),
+    ),
+    ("Reasoning extraction", ("stream.2.a",)),
+    ("Multi-span", ("stream.2.b",)),
+    ("Chunk boundaries", ("stream.3.a", "stream.3.b", "stream.3.c")),
+]
+_CASE_GROUP_BY_CASE = {
+    case_id: label for label, case_ids in CASE_GROUPS for case_id in case_ids
+}
+_CASE_GROUP_INDEX_BY_CASE = {
+    case_id: group_idx
+    for group_idx, (_, case_ids) in enumerate(CASE_GROUPS)
+    for case_id in case_ids
+}
+_CASE_DISPLAY_ORDER = {
+    case_id: (group_idx, case_idx)
+    for group_idx, (_, case_ids) in enumerate(CASE_GROUPS)
+    for case_idx, case_id in enumerate(case_ids)
+}
+
+# Public tool-calling parser rows can share a reasoning implementation. Keep this
+# map in user-facing parser-family names, not Rust enum names: `deepseek_v3`
+# currently routes to `ReasoningParserType::DeepseekR1`, but the parity table
+# should still display `deepseek_v3` because that is the public reasoning parser
+# family and fixture directory.
+PARSER_TO_REASONING_FAMILY = {
+    "deepseek_v3": "deepseek_v3",
+    "deepseek_v3_1": "deepseek_v3",
+    "deepseek_v3_2": "deepseek_v3",
+    "deepseek_v4": "deepseek_v4",
+    "gemma4": "gemma4",
+    "glm47": "nemotron_deci",
+    "harmony": "gpt_oss",
+    "kimi_k2": "kimi_k25",
+    "minimax_m2": "minimax_append_think",
+    "mistral": "mistral",
+    "nemotron_deci": "nemotron_deci",
+    "nemotron_nano": "deepseek_r1",
+    "qwen3_coder": "qwen3",
+}
+
+_FAMILY_METADATA = {
+    "basic": {
+        "models": ["Generic CoT models"],
+        "rust_enum": "ReasoningParserType::Basic",
+        "implementation": "BasicReasoningParser `<think>` / `</think>`",
+        "shared_with": ["qwen3", "deepseek_v4", "nemotron_deci", "glm45"],
+    },
+    "qwen3": {
+        "models": ["Qwen3.5", "QwQ-32B", "Qwen3-Think", "Qwen3-Coder"],
+        "rust_enum": "ReasoningParserType::Qwen",
+        "implementation": "BasicReasoningParser `<think>` / `</think>`",
+        "shared_with": ["basic", "deepseek_v4", "nemotron_deci", "glm45"],
+    },
+    "deepseek_v4": {
+        "models": ["DeepSeek V4 Pro", "DeepSeek V4 Flash"],
+        "rust_enum": "ReasoningParserType::DeepSeekV4",
+        "implementation": "BasicReasoningParser `<think>` / `</think>`",
+        "shared_with": ["basic", "qwen3", "nemotron_deci", "glm45"],
+        "aliases": ["deepseek-v4", "deepseekv4"],
+    },
+    "nemotron_deci": {
+        "models": [
+            "Nemotron-Super / -Ultra / -Deci",
+            "Llama-Nemotron",
+            "GLM-4.5 / GLM-4.7 via glm45 alias",
+        ],
+        "rust_enum": "ReasoningParserType::NemotronDeci",
+        "implementation": "BasicReasoningParser `<think>` / `</think>`",
+        "shared_with": ["basic", "qwen3", "deepseek_v4", "glm45"],
+        "aliases": ["glm45"],
+    },
+    "deepseek_r1": {
+        "models": [
+            "DeepSeek R1",
+            "DeepSeek V3.x aliases",
+            "Nemotron force-reasoning aliases",
+        ],
+        "rust_enum": "ReasoningParserType::DeepseekR1",
+        "implementation": (
+            "BasicReasoningParser `<think>` / `</think>`, force_reasoning=true"
+        ),
+        "shared_with": [
+            "deepseek_v3",
+            "step3",
+            "nemotron_nano",
+            "nemotron3",
+            "nemotron_v3",
+        ],
+    },
+    "deepseek_v3": {
+        "models": ["DeepSeek V3", "DeepSeek V3.1", "DeepSeek V3.2"],
+        "rust_enum": "ReasoningParserType::DeepseekR1",
+        "implementation": (
+            "BasicReasoningParser `<think>` / `</think>`, force_reasoning=true"
+        ),
+        "shared_with": [
+            "deepseek_r1",
+            "step3",
+            "nemotron_nano",
+            "nemotron3",
+            "nemotron_v3",
+        ],
+        "aliases": ["deepseek_v3_1", "deepseek_v3_2"],
+    },
+    "kimi": {
+        "models": ["Kimi K2 Instruct / Thinking using Unicode think delimiters"],
+        "rust_enum": "ReasoningParserType::Kimi",
+        "implementation": "BasicReasoningParser `◁think▷` / `◁/think▷`",
+    },
+    "kimi_k25": {
+        "models": ["Kimi K2.5 / Kimi K2.6 style `<think>` force-reasoning models"],
+        "rust_enum": "ReasoningParserType::KimiK25",
+        "implementation": (
+            "BasicReasoningParser `<think>` / `</think>`, "
+            "force_reasoning=true, Kimi tool-section exit"
+        ),
+    },
+    "mistral": {
+        "models": ["Magistral"],
+        "rust_enum": "ReasoningParserType::Mistral",
+        "implementation": (
+            "BasicReasoningParser `[THINK]` / `[/THINK]`, force_reasoning=true"
+        ),
+    },
+    "granite": {
+        "models": ["IBM Granite 3.x", "IBM Granite 3.2 language models"],
+        "rust_enum": "ReasoningParserType::Granite",
+        "implementation": "GraniteReasoningParser",
+    },
+    "gpt_oss": {
+        "models": ["gpt-oss-20b", "gpt-oss-120b"],
+        "rust_enum": "ReasoningParserType::GptOss",
+        "implementation": "GptOssReasoningParser / Harmony StreamableParser",
+    },
+    "minimax_append_think": {
+        "models": ["MiniMax M2", "MiniMax M2.1"],
+        "rust_enum": "ReasoningParserType::MiniMaxAppendThink",
+        "implementation": "MiniMaxAppendThinkParser",
+    },
+    "gemma4": {
+        "models": ["Google Gemma 4 thinking models"],
+        "rust_enum": "ReasoningParserType::Gemma4",
+        "implementation": "Gemma4ReasoningParser",
+        "aliases": ["gemma-4"],
+    },
+}
+
+_REASONING_MODE_METADATA = {
+    "basic": {
+        "label": "explicit markers",
+        "control": "mostly static",
+        "summary": (
+            "Reasoning starts only after an opening `<think>` marker or a "
+            "prompt-injected start state."
+        ),
+        "static": [
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=false",
+            "stream_reasoning=true",
+        ],
+    },
+    "qwen3": {
+        "label": "explicit markers",
+        "control": "frontend-tunable",
+        "summary": (
+            "Qwen-style reasoning uses explicit `<think>` markers; templates "
+            "may inject the opening marker."
+        ),
+        "static": [
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=false",
+            "stream_reasoning=true",
+        ],
+    },
+    "deepseek_v4": {
+        "label": "explicit markers",
+        "control": "frontend-tunable",
+        "summary": (
+            "DeepSeek V4 uses `<think>` markers, but the prompt formatter "
+            "controls whether thinking is enabled."
+        ),
+        "static": [
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=false",
+            "stream_reasoning=true",
+        ],
+    },
+    "nemotron_deci": {
+        "label": "explicit markers",
+        "control": "frontend-tunable",
+        "summary": "GLM/Nemotron-Deci style parsing uses explicit `<think>` markers.",
+        "static": [
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=false",
+            "stream_reasoning=true",
+        ],
+    },
+    "deepseek_r1": {
+        "label": "force reasoning",
+        "control": "frontend-tunable",
+        "summary": (
+            "Generation may begin already inside reasoning; marker-free text "
+            "can be reasoning until an end marker."
+        ),
+        "static": [
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=true",
+            "stream_reasoning=true",
+        ],
+    },
+    "deepseek_v3": {
+        "label": "force reasoning",
+        "control": "frontend-tunable",
+        "summary": "DeepSeek V3.x routes to the R1 force-reasoning implementation in Dynamo.",
+        "static": [
+            "Rust enum: ReasoningParserType::DeepseekR1",
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=true",
+            "stream_reasoning=true",
+        ],
+    },
+    "kimi": {
+        "label": "explicit unicode",
+        "control": "mostly static",
+        "summary": "Kimi legacy reasoning uses Unicode delimiters instead of `<think>`.",
+        "static": [
+            "BasicReasoningParser `◁think▷` / `◁/think▷`",
+            "force_reasoning=false",
+            "stream_reasoning=true",
+        ],
+    },
+    "kimi_k25": {
+        "label": "force reasoning",
+        "control": "frontend-tunable",
+        "summary": (
+            "Kimi K2.5 can start in reasoning and uses the tool call section "
+            "marker as a reasoning escape boundary."
+        ),
+        "static": [
+            "BasicReasoningParser `<think>` / `</think>`",
+            "force_reasoning=true",
+            "stream_reasoning=true",
+            "tool_start_token=`<|tool_calls_section_begin|>`",
+        ],
+    },
+    "mistral": {
+        "label": "force reasoning",
+        "control": "mostly static",
+        "summary": (
+            "Mistral/Magistral reasoning uses bracket markers and starts in "
+            "force-reasoning mode."
+        ),
+        "static": [
+            "BasicReasoningParser `[THINK]` / `[/THINK]`",
+            "force_reasoning=true",
+            "stream_reasoning=true",
+        ],
+    },
+    "granite": {
+        "label": "phrase markers",
+        "control": "mostly static",
+        "summary": "Granite reasoning is split by natural-language phrase markers.",
+        "static": [
+            "GraniteReasoningParser",
+            "`Here is my thought process:` / `Here is my response:`",
+        ],
+    },
+    "gpt_oss": {
+        "label": "Harmony channels",
+        "control": "mostly static",
+        "summary": (
+            "GPT-OSS reasoning is the Harmony `analysis` channel, parsed by "
+            "the Harmony stream parser."
+        ),
+        "static": [
+            "GptOssReasoningParser / Harmony StreamableParser",
+            "requires special tokens to remain visible in decoded text",
+        ],
+    },
+    "minimax_append_think": {
+        "label": "append-think",
+        "control": "mostly static",
+        "summary": (
+            "MiniMax append-think has its own contract instead of normal "
+            "reasoning extraction."
+        ),
+        "static": [
+            "MiniMaxAppendThinkParser",
+            "parser-specific content wrapper behavior",
+        ],
+    },
+    "gemma4": {
+        "label": "Gemma channels",
+        "control": "frontend-tunable",
+        "summary": "Gemma 4 reasoning is wrapped by channel markers with a `thought` role label.",
+        "static": [
+            "Gemma4ReasoningParser",
+            "requires special tokens to remain visible in decoded text",
+        ],
+    },
+}
+
+_FAMILY_TO_VLLM_REASONING = {
+    "deepseek_r1": "deepseek_r1",
+    "deepseek_v3": "deepseek_v3",
+    "deepseek_v4": "deepseek_v4",
+    "gemma4": "gemma4",
+    "gpt_oss": "openai_gptoss",
+    "granite": "granite",
+    "kimi_k25": "kimi_k2",
+    "mistral": "mistral",
+    "minimax_append_think": "minimax_m2_append_think",
+    "nemotron_deci": "glm45",
+    "qwen3": "qwen3",
+}
+
+_FAMILY_TO_SGLANG_REASONING = {
+    "deepseek_r1": "deepseek-r1",
+    "gpt_oss": "gpt-oss",
+    "kimi": "kimi",
+    "qwen3": "qwen3",
+}
+
+
+def _make_jinja_env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(TEMPLATE_DIR),
+        trim_blocks=False,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+    )
+
+
+def _commit_sha() -> str | None:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def _case_sort_key(case_id: str) -> tuple[int, int, int, str]:
+    doc_id = case_id.replace("REASONING.", "", 1)
+    order = _CASE_DISPLAY_ORDER.get(doc_id)
+    if order is not None:
+        group_idx, case_idx = order
+        return (0, group_idx, case_idx, "")
+    parts = doc_id.split(".")
+    mode = 0 if parts[0] == "batch" else 1
+    top = int(parts[1])
+    sub = parts[2] if len(parts) > 2 else ""
+    return (1, mode, top, sub)
+
+
+def _normalize_text(v: Any) -> Any:
+    if v is None:
+        return None
+    if isinstance(v, str) and v.strip() == "":
+        return None
+    return v
+
+
+def _canonical(d: dict[str, Any]) -> str:
+    d = {
+        **d,
+        "normal_text": _normalize_text(d.get("normal_text")),
+        "reasoning_text": _normalize_text(d.get("reasoning_text")),
+    }
+    d.pop("reason", None)
+    return json.dumps(d, sort_keys=True, separators=(",", ":"))
+
+
+_DEFAULT_REASONING_MARKUP_RE = re.compile(r"</?think>")
+_NO_AUTO_REASONING_MARKUP_RE = re.compile(r"(?!)")
+_REASONING_MARKUP_BY_FAMILY: dict[str, re.Pattern[str]] = {
+    "deepseek_r1": re.compile(r"</?think>"),
+    "deepseek_v3": re.compile(r"</?think>"),
+    "deepseek_v4": re.compile(r"</?think>"),
+    "gemma4": re.compile(r"<\|channel>|<channel\|>"),
+    "gpt_oss": re.compile(r"<\|(?:start|end|return|channel|message)\|>"),
+    "granite": re.compile(
+        r"Here is my thought process:|Here is my response:|Here's my response:"
+    ),
+    "kimi": re.compile(r"◁/?think▷"),
+    "kimi_k25": re.compile(r"</?think>"),
+    "minimax_append_think": _NO_AUTO_REASONING_MARKUP_RE,
+    "mistral": re.compile(r"\[/?THINK\]"),
+    "nemotron_deci": re.compile(r"</?think>"),
+    "qwen3": re.compile(r"</?think>"),
+}
+
+
+def _reasoning_markup_re(family: str | None) -> re.Pattern[str]:
+    return _REASONING_MARKUP_BY_FAMILY.get(family or "", _DEFAULT_REASONING_MARKUP_RE)
+
+
+def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | None:
+    dynamo = expected.get("dynamo", {})
+    if not isinstance(dynamo, dict):
+        return None
+    marker_re = _reasoning_markup_re(family)
+    for field in ("reasoning_text", "normal_text"):
+        value = dynamo.get(field)
+        if isinstance(value, str) and marker_re.search(value):
+            return str(
+                dynamo.get("reason")
+                or f"Dynamo {field} contains reasoning parser markup."
+            )
+    return None
+
+
+def _has_dynamo_leak(case: dict[str, Any], family: str | None) -> bool:
+    if case.get("dynamo_leak"):
+        return True
+    expected = case.get("expected")
+    return (
+        isinstance(expected, dict) and _dynamo_leak_reason(expected, family) is not None
+    )
+
+
+def _load() -> tuple[dict[str, dict[str, Any]], list[str], dict[tuple[str, str], Path]]:
+    rows: dict[str, dict[str, Any]] = {}
+    columns = set()
+    refs = {}
+    for fp in sorted(FIXTURES.glob("*/REASONING.*.yaml")):
+        doc = yaml.safe_load(fp.read_text())
+        family = doc["family"]
+        row = rows.setdefault(
+            family,
+            {
+                "family": family,
+                "model_label": doc.get("model_label", family),
+                "cases": {},
+            },
+        )
+        for case_id, case in doc["cases"].items():
+            columns.add(case_id)
+            row["cases"][case_id] = case
+            refs[(family, case_id)] = fp
+    return rows, sorted(columns, key=_case_sort_key), refs
+
+
+def _load_parser_labels() -> dict[str, str]:
+    labels = {}
+    for fp in sorted(PARSER_FIXTURES.glob("*/PARSER.batch.yaml")):
+        doc = yaml.safe_load(fp.read_text())
+        labels[doc["family"]] = doc.get("model_label", doc["family"])
+    return labels
+
+
+def _build_display_groups(
+    rows: dict[str, dict[str, Any]],
+) -> tuple[list[DisplayRow], list[DisplayRow], list[DisplayRow]]:
+    parser_labels = _load_parser_labels()
+    parser_families = set(parser_labels)
+
+    def make_row(tool_family: str) -> dict[str, str | None]:
+        return {
+            "model_label": parser_labels.get(tool_family, tool_family),
+            "tool_family": tool_family,
+            "reasoning_family": PARSER_TO_REASONING_FAMILY.get(tool_family),
+        }
+
+    def has_reasoning_fixture(tool_family: str) -> bool:
+        reasoning_family = PARSER_TO_REASONING_FAMILY.get(tool_family)
+        return reasoning_family in rows
+
+    top_n = [
+        make_row(tool_family)
+        for tool_family in TOP_N_FAMILIES
+        if tool_family in parser_families and has_reasoning_fixture(tool_family)
+    ]
+    other_tool_families = sorted(
+        (
+            tool_family
+            for tool_family in parser_families - set(TOP_N_FAMILIES)
+            if has_reasoning_fixture(tool_family)
+        ),
+        key=lambda family: parser_labels.get(family, family).lower(),
+    )
+    others = [make_row(tool_family) for tool_family in other_tool_families]
+
+    mapped_reasoning = {
+        family for family in PARSER_TO_REASONING_FAMILY.values() if family in rows
+    }
+    reasoning_only = [
+        {
+            "model_label": rows[family]["model_label"],
+            "tool_family": None,
+            "reasoning_family": family,
+        }
+        for family in sorted(set(rows) - mapped_reasoning)
+    ]
+    return top_n, others, reasoning_only
+
+
+def _derive_no_peer_sets(rows: dict[str, dict[str, Any]]) -> tuple[set[str], set[str]]:
+    """Reasoning families where every expected case marks the peer unavailable."""
+
+    def all_unavailable(cases: dict[str, dict[str, Any]], impl: str) -> bool:
+        expected_cases = [
+            case for case in cases.values() if isinstance(case.get("expected"), dict)
+        ]
+        if not expected_cases:
+            return False
+        for case in expected_cases:
+            block = case.get("expected", {}).get(impl)
+            if not isinstance(block, dict) or "unavailable" not in block:
+                return False
+        return True
+
+    no_vllm = {
+        family
+        for family, row in rows.items()
+        if family not in _FAMILY_TO_VLLM_REASONING
+        and all_unavailable(row["cases"], "vllm")
+    }
+    no_sglang = {
+        family
+        for family, row in rows.items()
+        if family not in _FAMILY_TO_SGLANG_REASONING
+        and all_unavailable(row["cases"], "sglang")
+    }
+    return no_vllm, no_sglang
+
+
+def family_suffix(
+    reasoning_family: str | None,
+    no_vllm: set[str],
+    no_sglang: set[str],
+) -> str:
+    if reasoning_family is None:
+        return ""
+    suffix = ""
+    if reasoning_family in no_vllm:
+        suffix += "†"
+    if reasoning_family in no_sglang:
+        suffix += "§"
+    return suffix
+
+
+def _columns_for_mode(columns: list[str], mode: str) -> list[str]:
+    return [case_id for case_id in columns if case_id.startswith(f"REASONING.{mode}.")]
+
+
+def _is_na_stub(case: dict[str, Any]) -> bool:
+    return (
+        set(case) <= {"description", "reason", "ref", "spec_ref"} and "reason" in case
+    )
+
+
+def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, str]:
+    if case is None:
+        return "—", "missing fixture coverage"
+    if "expected" not in case:
+        if _is_na_stub(case):
+            return "n/a", case["reason"]
+        return "?", "fixture has no expected block"
+
+    expected = case["expected"]
+    dynamo = expected["dynamo"]
+    dynamo_leak = _has_dynamo_leak(case, family)
+    markers = []
+    unavailable = 0
+    tooltip_parts = [case.get("description", "")]
+
+    for impl, letter in (("vllm", "V"), ("sglang", "S")):
+        spec = expected[impl]
+        if "unavailable" in spec:
+            unavailable += 1
+            tooltip_parts.append(f"{impl}: unavailable — {spec['unavailable']}")
+            continue
+        if "error" in spec:
+            markers.append(f"{letter}!")
+            tooltip_parts.append(f"{impl}: expected error — {spec['error']}")
+            continue
+        if _canonical(spec) == _canonical(dynamo):
+            tooltip_parts.append(f"{impl}: matches Dynamo")
+            continue
+        suffix = "?" if dynamo_leak or not spec.get("reason") else ""
+        markers.append(f"{letter}{suffix}")
+        reason = (
+            "research-needed" if dynamo_leak else spec.get("reason", "research-needed")
+        )
+        tooltip_parts.append(f"{impl}: diverges — {reason}")
+
+    if unavailable == 2:
+        if dynamo_leak:
+            return "↯D", "\n".join(p for p in tooltip_parts if p)
+        return "D", "\n".join(p for p in tooltip_parts if p)
+    if dynamo_leak:
+        return "↯" + ("".join(markers) or "?"), "\n".join(p for p in tooltip_parts if p)
+    if markers:
+        return "".join(markers), "\n".join(p for p in tooltip_parts if p)
+    if unavailable:
+        return "=", "\n".join(p for p in tooltip_parts if p)
+    return "=", "\n".join(p for p in tooltip_parts if p)
+
+
+def _render_markdown_row(
+    row: dict[str, str | None],
+    rows: dict[str, dict[str, Any]],
+    columns: list[str],
+    no_vllm: set[str],
+    no_sglang: set[str],
+) -> str:
+    reasoning_family = row["reasoning_family"]
+    tool_family = row["tool_family"]
+    parser_label = _parser_label_text(tool_family, reasoning_family, no_vllm, no_sglang)
+    cells = [str(row["model_label"]), parser_label]
+    for case_id in columns:
+        if reasoning_family is None:
+            marker = "n/a"
+        else:
+            marker, _ = _cell(
+                rows[reasoning_family]["cases"].get(case_id),
+                reasoning_family,
+            )
+        cells.append(marker)
+    return "| " + " | ".join(cells) + " |"
+
+
+def _markdown(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
+    out = []
+    top_n, others, reasoning_only = _build_display_groups(rows)
+    no_vllm, no_sglang = _derive_no_peer_sets(rows)
+    header = [
+        "model",
+        "Reasoning Parser Family",
+        *[_display_case_id(c) for c in columns],
+    ]
+    out.append("| " + " | ".join(header) + " |")
+    out.append("|---|---|" + "|".join([":-:" for _ in columns]) + "|")
+    out.append("| **Top-N models** |   |" + "   |" * len(columns))
+    for row in top_n:
+        out.append(_render_markdown_row(row, rows, columns, no_vllm, no_sglang))
+    out.append("| **Others** |   |" + "   |" * len(columns))
+    for row in others:
+        out.append(_render_markdown_row(row, rows, columns, no_vllm, no_sglang))
+    if reasoning_only:
+        out.append("| **Reasoning-only** |   |" + "   |" * len(columns))
+        for row in reasoning_only:
+            out.append(_render_markdown_row(row, rows, columns, no_vllm, no_sglang))
+    return "\n".join(out)
+
+
+def _display_case_id(case_id: str) -> str:
+    parts = case_id.split(".")
+    return ".".join(parts[2:])
+
+
+def _case_doc_id(case_id: str) -> str:
+    return case_id.replace("REASONING.", "", 1)
+
+
+def _case_mode(case_id: str) -> str:
+    return _case_doc_id(case_id).split(".", 1)[0]
+
+
+def _case_group_label(case_id: str) -> str:
+    return _CASE_GROUP_BY_CASE.get(_case_doc_id(case_id), "Other")
+
+
+def _case_group_key(case_id: str) -> str:
+    label_key = re.sub(r"[^a-z0-9]+", "_", _case_group_label(case_id).lower())
+    return f"{_case_mode(case_id)}_{label_key.strip('_')}"
+
+
+def _case_band_class(case_id: str) -> str:
+    group_idx = _CASE_GROUP_INDEX_BY_CASE.get(_case_doc_id(case_id), len(CASE_GROUPS))
+    return f"case-band-{group_idx % 2}"
+
+
+def _case_runs(columns: list[str]) -> list[list[str]]:
+    runs = []
+    start = 0
+    while start < len(columns):
+        group_key = _case_group_key(columns[start])
+        end = start + 1
+        while end < len(columns) and _case_group_key(columns[end]) == group_key:
+            end += 1
+        runs.append(columns[start:end])
+        start = end
+    return runs
+
+
+def _column_placeholder_html(key: str, tag: str = "td") -> str:
+    key_attr = html_lib.escape(key)
+    return (
+        f'<{tag} class="col-placeholder col-hidden" '
+        f'data-col-placeholder-group="{key_attr}"></{tag}>'
+    )
+
+
+def _column_control_header_html(
+    key: str,
+    label: str,
+    *,
+    default_visible: bool,
+    css_class: str = "",
+    colspan: int | None = None,
+) -> str:
+    key_attr = html_lib.escape(key)
+    visible = "true" if default_visible else "false"
+    classes = " ".join(part for part in ("column-control", css_class) if part)
+    span_size = colspan if colspan is not None else 1
+    if colspan is not None:
+        span_attr = f'colspan="{colspan}" data-expanded-colspan="{colspan}"'
+    else:
+        span_attr = 'rowspan="2"'
+    action = "Collapse" if default_visible else "Expand"
+    return (
+        f'<th class="{html_lib.escape(classes)}" data-col-control-group="{key_attr}" '
+        f"{span_attr}>"
+        f'<button type="button" class="col-toggle" data-col-toggle="{key_attr}" '
+        f'data-col-label="{html_lib.escape(label)}" data-col-span="{span_size}" '
+        f'data-default-visible="{visible}" aria-pressed="{visible}" '
+        f'aria-label="{action} {html_lib.escape(label)} column">'
+        '<span class="col-toggle-symbol" aria-hidden="true"></span>'
+        f'<span class="col-toggle-label">{html_lib.escape(label)}</span>'
+        "</button></th>"
+    )
+
+
+def _case_group_headers_html(columns: list[str]) -> str:
+    headers = [
+        _column_control_header_html("model", "Model", default_visible=False),
+        _column_control_header_html(
+            "parser", "Reasoning Parser Family", default_visible=True
+        ),
+    ]
+    for run in _case_runs(columns):
+        label = _case_group_label(run[0])
+        group_key = _case_group_key(run[0])
+        headers.append(
+            _column_control_header_html(
+                group_key,
+                label,
+                default_visible=True,
+                css_class=f"case-group {_case_band_class(run[0])}",
+                colspan=len(run),
+            )
+        )
+    return "".join(headers)
+
+
+def _parse_case_descriptions() -> dict[str, str]:
+    if not REASONING_CASES_MD.exists():
+        return {}
+    pat = re.compile(
+        r"\*\*`REASONING\.(batch|stream)\.([0-9]+(?:\.[a-z])?)`\*\*\s+(.+)"
+    )
+    out = {}
+    lines = REASONING_CASES_MD.read_text(encoding="utf-8").splitlines()
+    i = 0
+    while i < len(lines):
+        match = pat.search(lines[i])
+        if not match:
+            i += 1
+            continue
+        mode, sub, desc = match.groups()
+        body_parts = [desc.strip()]
+        j = i + 1
+        while j < len(lines):
+            nxt = lines[j]
+            if not nxt.strip() or not nxt.startswith(" "):
+                break
+            if pat.search(nxt):
+                break
+            body_parts.append(nxt.strip())
+            j += 1
+        out.setdefault(f"{mode}.{sub}", " ".join(body_parts).rstrip("."))
+        i = j
+    return out
+
+
+def _case_header_html(case_id: str, descriptions: dict[str, str]) -> str:
+    display = _display_case_id(case_id)
+    desc = descriptions.get(_case_doc_id(case_id)) or ""
+    href = "../../../lib/parsers/REASONING_CASES.md"
+    return (
+        f'<th class="case-sub {_case_band_class(case_id)}" '
+        f'data-col-hide-group="{html_lib.escape(_case_group_key(case_id))}">'
+        f'<a href="{href}" title="{html_lib.escape(desc)}">'
+        f"{html_lib.escape(display)}</a></th>"
+    )
+
+
+def _case_headers_html(columns: list[str], descriptions: dict[str, str]) -> str:
+    headers = []
+    for run in _case_runs(columns):
+        headers.extend(_case_header_html(case_id, descriptions) for case_id in run)
+        headers.append(_column_placeholder_html(_case_group_key(run[0]), tag="th"))
+    return "".join(headers)
+
+
+def _glossary_groups(
+    descriptions: dict[str, str], columns: list[str]
+) -> list[dict[str, object]]:
+    if not descriptions:
+        return []
+    return [
+        {
+            "label": _case_group_label(run[0]),
+            "rows": [
+                (
+                    _case_doc_id(case_id),
+                    descriptions.get(_case_doc_id(case_id), ""),
+                )
+                for case_id in run
+            ],
+        }
+        for run in _case_runs(columns)
+    ]
+
+
+def _markup_family(family: str | None) -> str | None:
+    if family == "gpt_oss":
+        return "harmony"
+    return family
+
+
+def _colorize_kimi(text: str) -> str:
+    pieces = []
+    for part in re.split(r"(◁/?think▷)", text):
+        if part == "◁think▷" or part == "◁/think▷":
+            pieces.append(f'<span class="tt-c0">{html_lib.escape(part)}</span>')
+        else:
+            pieces.append(html_lib.escape(part))
+    return "".join(pieces)
+
+
+def _colorize_granite(text: str) -> str:
+    replacements = {
+        "Here is my thought process:": "tt-c0",
+        "Here is my response:": "tt-c1",
+        "Here's my thought process:": "tt-c0",
+        "Here's my response:": "tt-c1",
+    }
+    pattern = re.compile("|".join(re.escape(k) for k in replacements))
+    pieces = []
+    last = 0
+    for match in pattern.finditer(text):
+        pieces.append(html_lib.escape(text[last : match.start()]))
+        marker = match.group(0)
+        cls = replacements[marker]
+        pieces.append(f'<span class="{cls}">{html_lib.escape(marker)}</span>')
+        last = match.end()
+    pieces.append(html_lib.escape(text[last:]))
+    return "".join(pieces)
+
+
+_STREAM_TAG_RE = re.compile(r"<[^<>]+>|\[/?[A-Z][A-Z0-9_]*\]")
+_HARMONY_TOKEN_RE = re.compile(r"<\|([A-Za-z_]+)\|>")
+_HARMONY_TURN_CLOSE = frozenset({"end", "return", "call"})
+_HARMONY_SEGMENT_CLASS = {
+    "start": "tt-h-start",
+    "channel": "tt-h-channel",
+    "constrain": "tt-h-constrain",
+    "message": "tt-h-message",
+    "end": "tt-h-stop",
+    "return": "tt-h-stop",
+    "call": "tt-h-call",
+}
+_GEMMA4_CHANNEL_RE = re.compile(r"<\|channel>[A-Za-z_]+(?:\n)?|<channel\|>")
+_PIPES = ("|", "｜")
+_BEGIN_SUFFIXES = ("_begin", "▁begin")
+_END_SUFFIXES = ("_end", "▁end")
+
+
+def _split_name(value: str) -> str:
+    return re.split(r"[\s/>=]", value, 1)[0].rstrip("|")
+
+
+def _strip_marker_suffix(value: str, suffixes: tuple[str, ...]) -> str | None:
+    for suffix in suffixes:
+        if value.endswith(suffix) and len(value) > len(suffix):
+            return value[: -len(suffix)]
+    return None
+
+
+def _stream_tag_kind(token: str) -> tuple[str | None, str]:
+    if token.startswith("[/"):
+        return "close", token[2:-1]
+    if token.startswith("["):
+        return "open", token[1:-1]
+
+    inner = token[1:-1]
+    if inner.startswith("/"):
+        return "close", _split_name(inner[1:])
+    starts_pipe = inner[:1] in _PIPES
+    ends_pipe = inner[-1:] in _PIPES
+    if starts_pipe and ends_pipe and len(inner) >= 2:
+        middle = inner[1:-1]
+        stripped = _strip_marker_suffix(middle, _BEGIN_SUFFIXES)
+        if stripped is not None:
+            return "open", stripped
+        stripped = _strip_marker_suffix(middle, _END_SUFFIXES)
+        if stripped is not None:
+            return "close", stripped
+        return "singleton", middle
+    if starts_pipe and inner[:1] == "|":
+        return "open", _split_name(inner[1:])
+    if ends_pipe and inner[-1:] == "|":
+        return "close", _split_name(inner[:-1])
+    return "open", _split_name(inner)
+
+
+def _tag_intervals(text: str) -> list[dict[str, Any]]:
+    intervals: list[dict[str, Any]] = []
+    stack: list[tuple[str, int]] = []
+    color_seq = 0
+
+    def next_class() -> str:
+        nonlocal color_seq
+        cls = f"tt-c{color_seq % 8}"
+        color_seq += 1
+        return cls
+
+    for match in _STREAM_TAG_RE.finditer(text):
+        idx = len(intervals)
+        token = match.group(0)
+        kind, name = _stream_tag_kind(token)
+        intervals.append({"start": match.start(), "end": match.end(), "class": None})
+        if kind == "singleton":
+            intervals[idx]["class"] = next_class()
+        elif kind == "close":
+            match_at = -1
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i][0] == name:
+                    match_at = i
+                    break
+            if match_at >= 0:
+                for _, unmatched_idx in stack[match_at + 1 :]:
+                    intervals[unmatched_idx]["class"] = "tt-orphan"
+                cls = next_class()
+                intervals[stack[match_at][1]]["class"] = cls
+                intervals[idx]["class"] = cls
+                del stack[match_at:]
+            else:
+                intervals[idx]["class"] = "tt-orphan"
+        elif kind == "open":
+            stack.append((name, idx))
+        else:
+            intervals[idx]["class"] = "tt-orphan"
+    for _, idx in stack:
+        intervals[idx]["class"] = "tt-orphan"
+    return intervals
+
+
+def _simple_marker_intervals(
+    text: str, markers: dict[str, str]
+) -> list[dict[str, Any]]:
+    pattern = re.compile("|".join(re.escape(marker) for marker in markers))
+    return [
+        {"start": m.start(), "end": m.end(), "class": markers[m.group(0)]}
+        for m in pattern.finditer(text)
+    ]
+
+
+def _harmony_intervals(text: str) -> list[dict[str, Any]]:
+    intervals = []
+    for match in _HARMONY_TOKEN_RE.finditer(text):
+        token_name = match.group(1)
+        if token_name in _HARMONY_TURN_CLOSE:
+            end = match.end()
+        else:
+            next_match = _HARMONY_TOKEN_RE.search(text, match.end())
+            end = next_match.start() if next_match else len(text)
+        intervals.append(
+            {
+                "start": match.start(),
+                "end": end,
+                "class": _HARMONY_SEGMENT_CLASS.get(token_name, "tt-h-other"),
+                "token_start": match.start(),
+                "token_end": match.end(),
+                "harmony": True,
+            }
+        )
+    return intervals
+
+
+def _gemma4_channel_intervals(text: str) -> list[dict[str, Any]]:
+    intervals: list[dict[str, Any]] = []
+    stack: list[int] = []
+    color_seq = 0
+
+    def next_class() -> str:
+        nonlocal color_seq
+        cls = f"tt-c{color_seq % 8}"
+        color_seq += 1
+        return cls
+
+    for match in _GEMMA4_CHANNEL_RE.finditer(text):
+        token = match.group(0)
+        idx = len(intervals)
+        intervals.append({"start": match.start(), "end": match.end(), "class": None})
+        if token.startswith("<|channel>"):
+            stack.append(idx)
+        elif stack:
+            open_idx = stack.pop()
+            cls = next_class()
+            intervals[open_idx]["class"] = cls
+            intervals[idx]["class"] = cls
+        else:
+            intervals[idx]["class"] = "tt-orphan"
+
+    for idx in stack:
+        intervals[idx]["class"] = "tt-orphan"
+    return intervals
+
+
+def _stream_intervals(text: str, family: str | None) -> list[dict[str, Any]]:
+    if family == "gpt_oss":
+        return _harmony_intervals(text)
+    if family == "gemma4":
+        return _gemma4_channel_intervals(text)
+    if family == "kimi":
+        return _simple_marker_intervals(
+            text,
+            {"◁think▷": "tt-c0", "◁/think▷": "tt-c0"},
+        )
+    if family == "granite":
+        return _simple_marker_intervals(
+            text,
+            {
+                "Here is my thought process:": "tt-c0",
+                "Here is my response:": "tt-c1",
+                "Here's my thought process:": "tt-c0",
+                "Here's my response:": "tt-c1",
+            },
+        )
+    return _tag_intervals(text)
+
+
+def _render_harmony_interval_slice(
+    text: str, interval: dict[str, Any], start: int, end: int
+) -> str:
+    token_start = interval["token_start"]
+    token_end = interval["token_end"]
+    parts = []
+    cursor = start
+    token_slice_start = max(start, token_start)
+    token_slice_end = min(end, token_end)
+    if cursor < token_slice_start:
+        parts.append(html_lib.escape(text[cursor:token_slice_start]))
+        cursor = token_slice_start
+    if token_slice_start < token_slice_end:
+        parts.append(
+            '<span class="tt-h-token">'
+            f"{html_lib.escape(text[token_slice_start:token_slice_end])}</span>"
+        )
+        cursor = token_slice_end
+    if cursor < end:
+        parts.append(html_lib.escape(text[cursor:end]))
+    return f'<span class="tt-h {interval["class"]}">{"".join(parts)}</span>'
+
+
+def _render_interval_slice(
+    text: str, interval: dict[str, Any], start: int, end: int
+) -> str:
+    if interval.get("harmony"):
+        return _render_harmony_interval_slice(text, interval, start, end)
+    return (
+        f'<span class="{interval["class"]}">{html_lib.escape(text[start:end])}</span>'
+    )
+
+
+def _colorize_chunk_slice(
+    text: str, intervals: list[dict[str, Any]], start: int, end: int
+) -> str:
+    pieces = []
+    cursor = start
+    for interval in intervals:
+        istart = interval["start"]
+        iend = interval["end"]
+        if iend <= start:
+            continue
+        if istart >= end:
+            break
+        overlap_start = max(start, istart)
+        overlap_end = min(end, iend)
+        if cursor < overlap_start:
+            pieces.append(html_lib.escape(text[cursor:overlap_start]))
+        pieces.append(
+            _render_interval_slice(text, interval, overlap_start, overlap_end)
+        )
+        cursor = overlap_end
+    if cursor < end:
+        pieces.append(html_lib.escape(text[cursor:end]))
+    return "".join(pieces)
+
+
+def _colorize_stream_chunks(chunks: list[Any], family: str) -> list[str]:
+    raw_chunks = [str(chunk) for chunk in chunks]
+    text = "".join(raw_chunks)
+    intervals = _stream_intervals(text, family)
+    rendered = []
+    cursor = 0
+    for chunk in raw_chunks:
+        end = cursor + len(chunk)
+        rendered.append(_colorize_chunk_slice(text, intervals, cursor, end))
+        cursor = end
+    return rendered
+
+
+def _colorize_gemma4(text: str) -> str:
+    return _colorize_chunk_slice(text, _gemma4_channel_intervals(text), 0, len(text))
+
+
+def _colorize_reasoning_markup(value: str, family: str | None) -> str:
+    if family == "gemma4":
+        return _colorize_gemma4(value)
+    if family == "kimi":
+        return _colorize_kimi(value)
+    if family == "granite":
+        return _colorize_granite(value)
+    return colorize_markup(value, _markup_family(family))
+
+
+def _format_value_html(name: str, value: Any, family: str | None = None) -> str:
+    if isinstance(value, str):
+        return f'{html_lib.escape(name)}="{_colorize_reasoning_markup(value, family)}"'
+    rendered = html_lib.escape(json.dumps(value, ensure_ascii=False))
+    return f"{html_lib.escape(name)}={rendered}"
+
+
+def _display_family_mapping_note(family: str, display_family: str | None) -> str:
+    if display_family and display_family != family:
+        return f"{display_family!r} (fixture: {family!r})"
+    return repr(family)
+
+
+def _format_unavailable_html(
+    message: Any,
+    family: str,
+    display_family: str | None,
+) -> str:
+    rendered = str(message)
+    if display_family and display_family != family:
+        replacement = f"{display_family!r} (fixture: {family!r})"
+        replaced = rendered.replace(repr(family), replacement)
+        if replaced == rendered:
+            replaced = f"{rendered} (row family: {replacement})"
+        rendered = replaced
+    return html_lib.escape(f"unavailable: {rendered}")
+
+
+def _format_output_block_html(
+    block: dict[str, Any] | None,
+    family: str,
+    *,
+    display_family: str | None = None,
+) -> str:
+    if block is None:
+        return html_lib.escape("(no expectation)")
+    if "unavailable" in block:
+        return _format_unavailable_html(block["unavailable"], family, display_family)
+    if "error" in block:
+        return html_lib.escape(f"error matching {block['error']!r}")
+
+    lines = [
+        _format_value_html("reasoning_text", block.get("reasoning_text"), family),
+        _format_value_html("normal_text", block.get("normal_text"), family),
+    ]
+    return "\n".join(lines)
+
+
+def _input_text_html(case: dict[str, Any], family: str) -> str:
+    if "chunks" in case:
+        chunk_lines = ["chunks=["]
+        for i, chunk_html in enumerate(_colorize_stream_chunks(case["chunks"], family)):
+            chunk_lines.append(f'  {i}: "{chunk_html}"')
+        chunk_lines.append("]")
+        return "\n".join(chunk_lines)
+    return _format_value_html("input_text", case.get("model_text", ""), family)
+
+
+def _vllm_parser_name(family: str, case: dict[str, Any]) -> str | None:
+    return case.get("vllm_parser") or _FAMILY_TO_VLLM_REASONING.get(family)
+
+
+def _vllm_chat_template_kwargs(
+    parser_name: str | None, case: dict[str, Any]
+) -> dict[str, Any]:
+    if not parser_name:
+        return {}
+    kwargs: dict[str, Any] = {}
+    if parser_name == "deepseek_v4":
+        kwargs["enable_thinking"] = True
+    if parser_name == "deepseek_v3":
+        kwargs["thinking"] = True
+    kwargs.update(case.get("chat_template_kwargs", {}))
+    return kwargs
+
+
+def _sglang_parser_name(family: str, case: dict[str, Any]) -> str | None:
+    return case.get("sglang_parser") or _FAMILY_TO_SGLANG_REASONING.get(family)
+
+
+def _flag_value(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _presence(value: Any) -> str:
+    return "provided" if value else "none"
+
+
+def _harness_flags_html(
+    case_id: str,
+    family: str,
+    case: dict[str, Any],
+    *,
+    display_family: str | None = None,
+) -> str:
+    vllm_parser = _vllm_parser_name(family, case)
+    vllm_kwargs = _vllm_chat_template_kwargs(vllm_parser, case)
+    sglang_parser = _sglang_parser_name(family, case)
+
+    mode = _case_mode(case_id)
+    if mode == "stream":
+        dynamo_token_flag = f"token_chunks={_presence(case.get('token_chunks'))}"
+        if case.get("token_chunks"):
+            vllm_token_flag = "delta_token_ids=fixture token_chunks"
+        elif vllm_parser == "openai_gptoss":
+            vllm_token_flag = "delta_token_ids=derived from Harmony tokenizer"
+        else:
+            vllm_token_flag = "delta_token_ids=derived from stub tokenizer"
+    else:
+        dynamo_token_flag = f"token_ids={_presence(case.get('token_ids'))}"
+        vllm_token_flag = "request.skip_special_tokens=false"
+
+    family_flag = (
+        f"parser_family={display_family}; fixture_family={family}"
+        if display_family and display_family != family
+        else f"parser_family={family}"
+    )
+    lines = [
+        "Parity harness flags used for this result:",
+        (
+            "dynamo: "
+            f"{family_flag}; "
+            f"in_reasoning={_flag_value(case.get('in_reasoning', False))}; "
+            f"{dynamo_token_flag}"
+        ),
+    ]
+
+    if vllm_parser:
+        lines.append(
+            "vllm: "
+            f"reasoning_parser={vllm_parser}; "
+            f"chat_template_kwargs={_flag_value(vllm_kwargs)}; "
+            f"{vllm_token_flag}"
+        )
+    else:
+        lines.append(
+            "vllm: unavailable for Dynamo parser family "
+            f"{_display_family_mapping_note(family, display_family)}"
+        )
+
+    if sglang_parser:
+        lines.append(
+            "sglang: "
+            f"model_type={sglang_parser}; "
+            "stream_reasoning=true; "
+            f"force_reasoning={_flag_value(case.get('force_reasoning', False))}"
+        )
+    else:
+        lines.append(
+            "sglang: unavailable for Dynamo parser family "
+            f"{_display_family_mapping_note(family, display_family)}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "Not set by this parser-level parity harness:",
+            "- frontend `tool_choice`",
+            "- SGLang `separate_reasoning`",
+            "- request `enable_thinking` / `thinking` / `thinking_mode` "
+            "unless shown in vLLM chat_template_kwargs above",
+        ]
+    )
+    return html_lib.escape("\n".join(lines))
+
+
+def _tooltip_for(
+    case: dict[str, Any],
+    dyn: dict[str, Any],
+    family: str | None,
+) -> str:
+    """Build the peer-divergence explanation used by hover popups."""
+
+    parts: list[str] = []
+    dynamo_leak = _has_dynamo_leak(case, family)
+    expected = case.get("expected", {})
+    for impl in ("vllm", "sglang"):
+        block = expected.get(impl)
+        if not isinstance(block, dict) or block is dyn:
+            continue
+        if "unavailable" in block:
+            continue
+        name = _IMPL_DISPLAY.get(impl, impl)
+        if "error" in block:
+            parts.append(f"{name}: expected error matching {block['error']!r}")
+            continue
+        if _canonical(block) == _canonical(dyn):
+            continue
+        if "reason" in block and not dynamo_leak:
+            parts.append(f"{name}: {block['reason']}")
+        elif "reasoning_text" in block or "normal_text" in block:
+            parts.append(f"{name}: (research-needed — no `reason:` field yet)")
+    return "\n".join(parts)
+
+
+def _tooltip_html(
+    case_id: str,
+    family: str,
+    case: dict[str, Any],
+    *,
+    display_family: str | None = None,
+) -> str:
+    head_family = display_family or family
+    head = f"{case_id} — {head_family}"
+    description = case.get("description")
+    extra_sections: list[tuple[str, str]] = [
+        (
+            "Harness flags",
+            _harness_flags_html(
+                case_id,
+                family,
+                case,
+                display_family=display_family,
+            ),
+        )
+    ]
+    if display_family and display_family != family:
+        extra_sections.append(
+            (
+                "Family mapping",
+                html_lib.escape(
+                    "This row uses the public GLM/Nemotron reasoning parser "
+                    f"family {display_family!r}; fixtures are shared with "
+                    f"{family!r} because GLM and Nemotron use the same "
+                    "parser implementation here."
+                ),
+            )
+        )
+    if "expected" not in case:
+        reason = case.get("reason", "fixture has no expected block")
+        return build_parity_tooltip_html(
+            head=head,
+            description=str(description) if description else None,
+            extra_sections=[("Why n/a", linkify_text_html(str(reason)))],
+            refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
+        )
+
+    expected = case["expected"]
+    dyn = expected.get("dynamo")
+    all_engines_parity = isinstance(dyn, dict) and all(
+        isinstance(expected.get(i), dict)
+        and not expected[i].get("unavailable")
+        and "error" not in expected[i]
+        and _canonical(expected[i]) == _canonical(dyn)
+        for i in ("dynamo", "vllm", "sglang")
+    )
+
+    output_sections: list[tuple[str, str]] = []
+    if all_engines_parity:
+        output_sections.append(
+            (
+                "All engines parity",
+                _format_output_block_html(
+                    dyn,
+                    family,
+                    display_family=display_family,
+                ),
+            )
+        )
+    else:
+        for impl in ("dynamo", "vllm", "sglang"):
+            output_sections.append(
+                (
+                    _IMPL_DISPLAY[impl],
+                    _format_output_block_html(
+                        expected.get(impl),
+                        family,
+                        display_family=display_family,
+                    ),
+                )
+            )
+
+    dynamo_leak = (
+        _dynamo_leak_reason(expected, family)
+        if _has_dynamo_leak(case, family)
+        else None
+    )
+    return build_parity_tooltip_html(
+        head=head,
+        description=str(description) if description else None,
+        input_label="Input chunks" if "chunks" in case else "Input",
+        input_html=_input_text_html(case, family),
+        output_sections=output_sections,
+        divergent_reasons=_tooltip_for(case, dyn, family)
+        if isinstance(dyn, dict)
+        else None,
+        leak_label="↯ Dynamo reasoning leaks",
+        leak_text=dynamo_leak
+        or ("unresolved" if _has_dynamo_leak(case, family) else None),
+        extra_sections=extra_sections,
+        refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
+    )
+
+
+def _missing_tooltip_html(
+    case_id: str,
+    family: str,
+    *,
+    display_family: str | None = None,
+) -> str:
+    head_family = display_family or family
+    return build_parity_tooltip_html(
+        head=f"{case_id} — {head_family}",
+        extra_sections=[
+            ("Missing fixture", html_lib.escape("missing fixture coverage"))
+        ],
+    )
+
+
+def _no_reasoning_tooltip_html(case_id: str, tool_family: str) -> str:
+    return build_parity_tooltip_html(
+        head=f"{case_id} — {tool_family}",
+        extra_sections=[
+            (
+                "Why n/a",
+                html_lib.escape(
+                    "This tool calling parser row has no mapped Dynamo reasoning "
+                    "parser fixture."
+                ),
+            )
+        ],
+    )
+
+
+def _render_cell_html(
+    case: dict[str, Any] | None,
+    family: str,
+    case_id: str,
+    refs: dict[tuple[str, str], Path],
+    *,
+    display_family: str | None = None,
+) -> str:
+    if case is None:
+        marker = "—"
+        href = ""
+        tooltip = _missing_tooltip_html(
+            case_id,
+            family,
+            display_family=display_family,
+        )
+    else:
+        marker, _ = _cell(case, family)
+        href = str(refs[(family, case_id)].relative_to(SCRIPT_DIR))
+        tooltip = _tooltip_html(
+            case_id,
+            family,
+            case,
+            display_family=display_family,
+        )
+
+    classes = f"cell {parity_cell_class(marker)} {_case_band_class(case_id)}"
+    group_key = html_lib.escape(_case_group_key(case_id))
+    label = html_lib.escape(marker)
+    if href:
+        body = f'<a href="{html_lib.escape(href)}">{label}</a>'
+    else:
+        body = label
+    return (
+        f'<td class="{classes}" data-col-hide-group="{group_key}">'
+        f"{body}{tooltip}</td>"
+    )
+
+
+def _render_no_reasoning_cell_html(tool_family: str, case_id: str) -> str:
+    classes = f"cell na {_case_band_class(case_id)}"
+    group_key = html_lib.escape(_case_group_key(case_id))
+    tooltip = _no_reasoning_tooltip_html(case_id, tool_family)
+    return (
+        f'<td class="{classes}" data-col-hide-group="{group_key}">' f"n/a{tooltip}</td>"
+    )
+
+
+def _implementation_label(reasoning_family: str | None) -> str:
+    if reasoning_family is None:
+        return "n/a"
+    meta = _FAMILY_METADATA.get(reasoning_family, {})
+    implementation = str(meta.get("implementation") or reasoning_family)
+    class_name = implementation.split(" ", 1)[0]
+    marker = re.search(r"`([^`]+)`", implementation)
+    if class_name == "BasicReasoningParser" and marker:
+        return f"{class_name} {marker.group(1)}"
+    return class_name
+
+
+def _display_reasoning_family(
+    tool_family: str | None,
+    reasoning_family: str | None,
+) -> str | None:
+    if tool_family == "glm47" and reasoning_family == "nemotron_deci":
+        return "glm45"
+    return reasoning_family
+
+
+def _parser_label_text(
+    tool_family: str | None,
+    reasoning_family: str | None,
+    no_vllm: set[str] | None = None,
+    no_sglang: set[str] | None = None,
+) -> str:
+    if reasoning_family is None:
+        return "n/a"
+    suffix = family_suffix(reasoning_family, no_vllm or set(), no_sglang or set())
+    return f"`{_implementation_label(reasoning_family)}`{suffix}"
+
+
+def _reasoning_mode_meta(
+    tool_family: str | None,
+    reasoning_family: str | None,
+) -> dict[str, Any]:
+    if reasoning_family is None:
+        return {
+            "label": "n/a",
+            "control": "not configured",
+            "summary": (
+                "This tool calling parser row has no mapped Dynamo reasoning "
+                "parser fixture."
+            ),
+            "static": [],
+        }
+
+    meta = dict(_REASONING_MODE_METADATA.get(reasoning_family, {}))
+    if not meta:
+        meta = {
+            "label": "custom",
+            "control": "mostly static",
+            "summary": "Custom reasoning parser family.",
+            "static": [],
+        }
+
+    row_notes = []
+    if tool_family and tool_family != reasoning_family:
+        row_notes.append(
+            f"Tool calling parser row `{tool_family}` maps to reasoning "
+            f"family `{reasoning_family}`."
+        )
+    if tool_family in {"deepseek_v3_1", "deepseek_v3_2"}:
+        row_notes.append(
+            "DeepSeek V3.1/V3.2 aliases share the DeepSeek V3.x reasoning fixtures."
+        )
+    if tool_family == "glm47":
+        row_notes.append(
+            "GLM tool rows use the public `glm45` reasoning alias; that alias "
+            "maps to the `nemotron_deci` implementation and fixtures."
+        )
+    if tool_family == "harmony":
+        row_notes.append(
+            "Tool calling parser `harmony` pairs with `gpt_oss` reasoning."
+        )
+    if tool_family == "kimi_k2":
+        row_notes.append(
+            "Tool calling parser `kimi_k2` pairs with `kimi_k25` reasoning."
+        )
+
+    if row_notes:
+        meta["row_notes"] = row_notes
+    return meta
+
+
+def _reasoning_parser_tree_lines(
+    tool_family: str | None,
+    reasoning_family: str | None,
+    meta: dict[str, Any],
+) -> list[str]:
+    if reasoning_family is None:
+        return []
+
+    implementation = _implementation_label(reasoning_family)
+    shared = [name for name in meta.get("shared_with", []) if name != reasoning_family]
+    aliases = [
+        name
+        for name in meta.get("aliases", [])
+        if name != reasoning_family and name not in shared
+    ]
+    known_children = {*shared, *aliases}
+    row_only = (
+        [tool_family]
+        if tool_family
+        and tool_family != reasoning_family
+        and tool_family not in known_children
+        else []
+    )
+    children = [
+        (reasoning_family, ""),
+        *[(name, "") for name in sorted(row_only)],
+        *[(name, "") for name in sorted(shared)],
+        *[(name, " (alias)") for name in sorted(aliases)],
+    ]
+
+    lines = [
+        "",
+        "Shared implementation tree:",
+        html_lib.escape(implementation),
+    ]
+    for i, (name, suffix) in enumerate(children):
+        branch = "└── " if i == len(children) - 1 else "├── "
+        name_label = html_lib.escape(name)
+        if tool_family == name:
+            name_label = f"<strong>{name_label}</strong>"
+        elif tool_family is None and name == reasoning_family:
+            name_label = f"<strong>{name_label}</strong>"
+        lines.append(f"{branch}{name_label}{html_lib.escape(suffix)}")
+    return lines
+
+
+def _parser_cell_html(
+    tool_family: str | None,
+    reasoning_family: str | None,
+    no_vllm: set[str],
+    no_sglang: set[str],
+) -> str:
+    meta = _FAMILY_METADATA.get(reasoning_family or "", {})
+    display_family = _display_reasoning_family(tool_family, reasoning_family)
+    implementation_label = _implementation_label(reasoning_family)
+    mode_meta = _reasoning_mode_meta(tool_family, reasoning_family)
+    activation_name = display_family or "n/a"
+    tooltip_lines = [
+        html_lib.escape(
+            f'This is activated via "--dyn-reasoning-parser {activation_name}".'
+        ),
+    ]
+    if display_family:
+        tooltip_lines.append(f"Parser family: {html_lib.escape(display_family)}")
+    if tool_family and tool_family != display_family:
+        tooltip_lines.append(f"Tool calling row: {html_lib.escape(tool_family)}")
+    if display_family:
+        if display_family != reasoning_family:
+            tooltip_lines.append(
+                f"Fixture family: {html_lib.escape(reasoning_family or '')}"
+            )
+    else:
+        tooltip_lines.append(html_lib.escape("Reasoning parser family: n/a"))
+    if meta.get("models"):
+        tooltip_lines.append(
+            "Models: "
+            + html_lib.escape(", ".join(str(model) for model in meta["models"]))
+        )
+    if meta.get("rust_enum"):
+        tooltip_lines.append(f"Rust enum: {html_lib.escape(meta['rust_enum'])}")
+    if meta.get("implementation"):
+        tooltip_lines.append(
+            f"Implementation: {html_lib.escape(meta['implementation'])}"
+        )
+    peer_notes = []
+    if reasoning_family in no_vllm:
+        peer_notes.append("no vLLM peer reasoning parser")
+    if reasoning_family in no_sglang:
+        peer_notes.append("no SGLang peer reasoning parser")
+    if peer_notes:
+        tooltip_lines.append(
+            "Peer availability: " + html_lib.escape(", ".join(peer_notes))
+        )
+    tooltip_lines.extend(
+        [
+            "",
+            "Mode:",
+            f"- {html_lib.escape(f'{mode_meta['label']} / {mode_meta['control']}')}",
+        ]
+    )
+    static_config = mode_meta.get("static", [])
+    config_lines = [
+        str(line)
+        for line in static_config
+        if not str(line).startswith(
+            (
+                "BasicReasoningParser",
+                "Gemma4ReasoningParser",
+                "GptOssReasoningParser",
+                "GraniteReasoningParser",
+                "MiniMaxAppendThinkParser",
+            )
+        )
+    ]
+    if config_lines:
+        tooltip_lines.extend(
+            ["", "Config:"] + [f"- {html_lib.escape(line)}" for line in config_lines]
+        )
+    tooltip_lines.extend(
+        _reasoning_parser_tree_lines(tool_family, reasoning_family, meta)
+    )
+    parser_label = _parser_label_text(tool_family, reasoning_family, no_vllm, no_sglang)
+    tooltip = (
+        f'<div class="ttip-head">{html_lib.escape(parser_label)}</div>'
+        f'<pre class="ttip-pre">{chr(10).join(tooltip_lines)}</pre>'
+    )
+    suffix = family_suffix(reasoning_family, no_vllm, no_sglang)
+    suffix_html = (
+        f'<span class="parser-suffix">{html_lib.escape(suffix)}</span>'
+        if suffix
+        else ""
+    )
+    if tool_family is None:
+        label = f"<code>{html_lib.escape(implementation_label)}</code>"
+    elif reasoning_family is None:
+        label = "<code>n/a</code>"
+    elif tool_family == reasoning_family:
+        label = f"<code>{html_lib.escape(implementation_label)}</code>"
+    else:
+        label = f"<code>{html_lib.escape(implementation_label)}</code>"
+    return (
+        '<td class="parser" data-col-hide-group="parser">'
+        f'{label}{suffix_html}<div class="ttip">{tooltip}</div></td>'
+    )
+
+
+def _render_row_html(
+    row: dict[str, str | None],
+    rows: dict[str, dict[str, Any]],
+    columns: list[str],
+    refs: dict[tuple[str, str], Path],
+    no_vllm: set[str],
+    no_sglang: set[str],
+) -> str:
+    tool_family = row["tool_family"]
+    reasoning_family = row["reasoning_family"]
+    cells = [
+        f'<tr><td class="model" data-col-hide-group="model">'
+        f"{html_lib.escape(str(row['model_label']))}</td>",
+        _column_placeholder_html("model"),
+        _parser_cell_html(tool_family, reasoning_family, no_vllm, no_sglang),
+        _column_placeholder_html("parser"),
+    ]
+    for run in _case_runs(columns):
+        if reasoning_family is None:
+            cells.extend(
+                _render_no_reasoning_cell_html(str(tool_family), case_id)
+                for case_id in run
+            )
+        else:
+            cases = rows[reasoning_family]["cases"]
+            display_family = _display_reasoning_family(tool_family, reasoning_family)
+            cells.extend(
+                _render_cell_html(
+                    cases.get(case_id),
+                    reasoning_family,
+                    case_id,
+                    refs,
+                    display_family=display_family,
+                )
+                for case_id in run
+            )
+        cells.append(_column_placeholder_html(_case_group_key(run[0])))
+    cells.append("</tr>")
+    return "".join(cells)
+
+
+def _compute_stats(
+    rows: dict[str, dict[str, Any]],
+    columns: list[str],
+    display_rows: list[dict[str, str | None]],
+) -> dict[str, int]:
+    stats = {
+        "families": len(display_rows),
+        "sub_cases": len(columns),
+        "slots": len(display_rows) * len(columns),
+        "real": 0,
+        "parity": 0,
+        "dynamo_only": 0,
+        "documented": 0,
+        "research": 0,
+        "errors": 0,
+        "na": 0,
+        "missing": 0,
+    }
+    for row in display_rows:
+        family = row["reasoning_family"]
+        for case_id in columns:
+            if family is None:
+                marker = "n/a"
+            else:
+                marker, _ = _cell(rows[family]["cases"].get(case_id), family)
+            if marker == "—":
+                stats["missing"] += 1
+            elif marker == "n/a":
+                stats["na"] += 1
+            else:
+                stats["real"] += 1
+                if marker == "=":
+                    stats["parity"] += 1
+                elif marker == "D":
+                    stats["dynamo_only"] += 1
+                elif "!" in marker:
+                    stats["errors"] += 1
+                elif "?" in marker:
+                    stats["research"] += 1
+                else:
+                    stats["documented"] += 1
+    return stats
+
+
+def _omitted_tool_calling_rows_html(rows: dict[str, dict[str, Any]]) -> str:
+    parser_labels = _load_parser_labels()
+    omitted = []
+    for tool_family, label in parser_labels.items():
+        reasoning_family = PARSER_TO_REASONING_FAMILY.get(tool_family)
+        if reasoning_family not in rows:
+            omitted.append((label, tool_family))
+    if not omitted:
+        return ""
+
+    omitted.sort(key=lambda item: item[0].lower())
+    rendered = ", ".join(
+        f"{html_lib.escape(label)} (<code>{html_lib.escape(family)}</code>)"
+        for label, family in omitted
+    )
+    return (
+        "<br><br>"
+        "<strong>Omitted tool calling parser rows:</strong> "
+        "no corresponding Dynamo reasoning parser fixture for "
+        f"{rendered}."
+    )
+
+
+def _has_missing_cells(rows: dict[str, dict[str, Any]], columns: list[str]) -> bool:
+    top_n, others, reasoning_only = _build_display_groups(rows)
+    for row in [*top_n, *others, *reasoning_only]:
+        reasoning_family = row["reasoning_family"]
+        if reasoning_family is None:
+            continue
+        cases = rows[reasoning_family]["cases"]
+        if any(case_id not in cases for case_id in columns):
+            return True
+    return False
+
+
+def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
+    missing_text = ""
+    if _has_missing_cells(rows, columns):
+        missing_text = (
+            " · " '<span style="color:#8a6d3b">—</span> missing fixture coverage'
+        )
+    legend = (
+        "<strong>Legend:</strong> "
+        '<span style="color:#0a7d2c">=</span> all captured peers match Dynamo · '
+        '<span style="color:#555">D</span> Dynamo-only fixture '
+        "(both peers unavailable) · "
+        '<span style="color:#555">V/S</span> divergence '
+        "(V = vLLM, S = SGLang; intentional, has <code>reason:</code>) · "
+        '<span style="color:#b00">?</span> more research needed '
+        "(e.g. V?, S? — diverges with no <code>reason:</code> yet) · "
+        '<span style="color:#b00">↯</span> Dynamo leaks reasoning markup '
+        "or final-answer text into the wrong field · "
+        '<span style="color:#b00">!</span> expected-error suffix '
+        "(e.g. V!, S! — engine crashes by design) · "
+        '<span style="color:#aaa">n/a</span> not applicable'
+        f"{missing_text}."
+        "<br>"
+        '<span class="parser-suffix">†</span> = no vLLM peer reasoning parser '
+        "for this family · "
+        '<span class="parser-suffix">§</span> = no SGLang peer reasoning parser '
+        "for this family."
+        "<br><br>"
+        "<strong>Tooltip fields:</strong> "
+        "<code>input_text</code>=raw model output or stream chunks fed into "
+        "the reasoning parser · "
+        "<code>reasoning_text</code>=hidden reasoning content extracted by "
+        "the parser · "
+        "<code>normal_text</code>=residual text passed onward to response "
+        "assembly or downstream parsers · "
+        "<code>harness flags</code>=the exact parser-level arguments used for "
+        "the parity result."
+    )
+    return legend + _omitted_tool_calling_rows_html(rows)
+
+
+def _mode_label(mode: str) -> str:
+    if mode == "batch":
+        return "REASONING.batch.*"
+    if mode == "stream":
+        return "REASONING.stream.*"
+    return mode
+
+
+def _html_panel(
+    rows: dict[str, dict[str, Any]],
+    columns: list[str],
+    refs: dict[tuple[str, str], Path],
+    no_vllm: set[str],
+    no_sglang: set[str],
+    *,
+    mode: str,
+    active: bool,
+) -> dict[str, object]:
+    descriptions = _parse_case_descriptions()
+    top_n, others, reasoning_only = _build_display_groups(rows)
+    display_rows = [*top_n, *others, *reasoning_only]
+    body_rows = []
+    sections = [
+        ("Top-N models", top_n),
+        ("Others", others),
+        ("Reasoning-only", reasoning_only),
+    ]
+    for label, section_rows in sections:
+        if not section_rows:
+            continue
+        body_rows.append(
+            f'<tr class="section"><td data-section-span colspan="{2 + len(columns)}">'
+            f"{html_lib.escape(label)}</td></tr>"
+        )
+        for row in section_rows:
+            body_rows.append(
+                _render_row_html(row, rows, columns, refs, no_vllm, no_sglang)
+            )
+
+    return {
+        "id": f"tab-{mode}",
+        "mode": mode,
+        "label": _mode_label(mode),
+        "active": active,
+        "group_headers": _case_group_headers_html(columns),
+        "sub_headers": _case_headers_html(columns, descriptions),
+        "body_rows": body_rows,
+        "stats": _compute_stats(rows, columns, display_rows),
+        "glossary_groups": _glossary_groups(descriptions, columns),
+    }
+
+
+def _html(
+    rows: dict[str, dict[str, Any]],
+    columns: list[str],
+    refs: dict[tuple[str, str], Path],
+    modes: list[str],
+) -> str:
+    generated = datetime.datetime.now(
+        zoneinfo.ZoneInfo("America/Los_Angeles")
+    ).strftime("%Y-%m-%d %H:%M %Z")
+    sha = _commit_sha()
+    no_vllm, no_sglang = _derive_no_peer_sets(rows)
+    panels = [
+        _html_panel(
+            rows,
+            _columns_for_mode(columns, mode),
+            refs,
+            no_vllm,
+            no_sglang,
+            mode=mode,
+            active=i == 0,
+        )
+        for i, mode in enumerate(modes)
+    ]
+    command = "python3 tests/parity/generate_parity_table.py reasoning --html"
+    output = "tests/parity/reasoning/PARITY.html"
+    if len(modes) == 1:
+        command += f" --mode {modes[0]}"
+        output = f"tests/parity/reasoning/PARITY.{modes[0]}.html"
+    tabs = []
+    for i, mode in enumerate(modes):
+        panel_id = f"tab-{mode}"
+        active = " active" if i == 0 else ""
+        selected = "true" if i == 0 else "false"
+        tabs.append(
+            f'<button class="tab-button{active}" id="{panel_id}-button" '
+            f'type="button" role="tab" aria-selected="{selected}" '
+            f'data-tab-target="{panel_id}">'
+            f"{html_lib.escape(_mode_label(mode))}</button>"
+        )
+
+    return (
+        _make_jinja_env()
+        .get_template("parity_table.html.j2")
+        .render(
+            title="Dynamo Reasoning - Parity Table",
+            stamp=generated,
+            sha=sha,
+            short_sha=sha[:12] if sha else "",
+            command=command,
+            output=output,
+            tabs=tabs,
+            panels=panels,
+            peer_versions=[],
+            intro_html="",
+            legend_html=_legend_html(rows, columns),
+            case_docs_href="../../../lib/parsers/REASONING_CASES.md",
+            case_docs_label="lib/parsers/REASONING_CASES.md",
+            case_prefix="REASONING.",
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--html", action="store_true", help="emit HTML instead of Markdown")
+    ap.add_argument(
+        "--mode",
+        choices=("all", "batch", "stream"),
+        help=(
+            "Fixture mode to render. For HTML, default is all reasoning modes as "
+            "tabs. For Markdown, default is batch."
+        ),
+    )
+    args = ap.parse_args(argv)
+
+    rows, columns, refs = _load()
+    if args.html:
+        modes = ["batch", "stream"] if args.mode in (None, "all") else [args.mode]
+        print(_html(rows, columns, refs, modes))
+    else:
+        if args.mode == "all":
+            ap.error("--mode all is only supported with --html")
+        mode = args.mode or "batch"
+        print(_markdown(rows, _columns_for_mode(columns, mode)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parity/reasoning/test_parity_reasoning.py
+++ b/tests/parity/reasoning/test_parity_reasoning.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning parser parity tests.
+
+For each fixture, run the same model text through Dynamo's Rust reasoning
+parser and peer reasoning parser implementations from vLLM / SGLang when
+available. The YAML fixture is the contract:
+
+    expected:
+      dynamo: &d_1
+        reasoning_text: "..."
+        normal_text: "..."
+      vllm: *d_1
+      sglang:
+        unavailable: "..."
+
+Run:
+    python3 -m pytest tests/parity/reasoning/test_parity_reasoning.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from tests.parity import common
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures"
+
+_PACKAGE: dict[str, str] = {
+    "dynamo": "dynamo._core",
+    "vllm": "vllm",
+    "sglang": "sglang",
+}
+
+
+def _case_sort_key(case_id: str) -> tuple[int, int, str]:
+    parts = case_id.split(".")
+    mode = 0 if parts[1] == "batch" else 1
+    top = int(parts[2])
+    sub = parts[3] if len(parts) > 3 else ""
+    return (mode, top, sub)
+
+
+def _load_fixtures() -> list[tuple[str, str, str, dict[str, Any]]]:
+    out = []
+    for fp in sorted(FIXTURES_ROOT.glob("*/REASONING.*.yaml")):
+        doc = yaml.safe_load(fp.read_text())
+        mode = doc["mode"]
+        for case_id, case in doc["cases"].items():
+            out.append((doc["family"], mode, case_id, case))
+    out.sort(key=lambda t: (t[0], *_case_sort_key(t[2])))
+    return out
+
+
+FIXTURES = tuple(_load_fixtures())
+
+
+def _is_na_stub(fixture: dict[str, Any]) -> bool:
+    return set(fixture) <= {"description", "reason", "ref", "spec_ref"} and all(
+        isinstance(fixture[key], str) and fixture[key].strip()
+        for key in ("description", "reason")
+    )
+
+
+def _run_parity_case(
+    family: str,
+    mode: str,
+    case_id: str,
+    fixture: dict[str, Any],
+    impl_name: str,
+) -> None:
+    pytest.importorskip(_PACKAGE[impl_name])
+    if "expected" not in fixture:
+        if not _is_na_stub(fixture):
+            pytest.fail(
+                f"{impl_name}/{family}/{case_id}: fixture is missing expected: "
+                "but is not an explicit n/a stub"
+            )
+        pytest.skip(
+            f"{impl_name}/{family}/{case_id}: n/a stub (no expected block): "
+            f"{fixture['reason']}"
+        )
+
+    spec = fixture["expected"][impl_name]
+    if "unavailable" in spec:
+        pytest.skip(f"{impl_name} unavailable for {family}: {spec['unavailable']}")
+
+    parse_mod = importlib.import_module(f"tests.parity.reasoning.{impl_name}")
+    got = parse_mod.parse(family, fixture, mode)
+
+    if "error" in spec:
+        if got.error and spec["error"] in got.error:
+            return
+        pytest.fail(
+            f"{impl_name}/{family}/{case_id}: expected error {spec['error']!r}, "
+            f"got {got.error!r}"
+        )
+
+    if got.error:
+        pytest.fail(f"{impl_name} crashed on {family}/{case_id}: {got.error}")
+
+    expected = common.ReasoningResult(
+        reasoning_text=spec.get("reasoning_text"),
+        normal_text=spec.get("normal_text"),
+    )
+    got_canonical = common.canonical(got.to_dict())
+    expected_canonical = common.canonical(expected.to_dict())
+    assert got_canonical == expected_canonical, (
+        f"\nimpl:     {impl_name}\n"
+        f"family:   {family}\n"
+        f"mode:     {mode}\n"
+        f"case:     {case_id}\n"
+        f"expected: {expected_canonical}\n"
+        f"got:      {got_canonical}\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "family,mode,case_id,fixture",
+    [pytest.param(f, m, c, fx, id=f"{f}/{c}") for (f, m, c, fx) in FIXTURES],
+)
+def test_reasoning_parity(
+    family: str,
+    mode: str,
+    case_id: str,
+    fixture: dict[str, Any],
+) -> None:
+    _run_parity_case(family, mode, case_id, fixture, "dynamo")
+
+
+@pytest.mark.vllm
+@pytest.mark.parametrize(
+    "family,mode,case_id,fixture",
+    [pytest.param(f, m, c, fx, id=f"{f}/{c}") for (f, m, c, fx) in FIXTURES],
+)
+def test_reasoning_parity_vllm(
+    family: str,
+    mode: str,
+    case_id: str,
+    fixture: dict[str, Any],
+) -> None:
+    _run_parity_case(family, mode, case_id, fixture, "vllm")
+
+
+@pytest.mark.sglang
+@pytest.mark.parametrize(
+    "family,mode,case_id,fixture",
+    [pytest.param(f, m, c, fx, id=f"{f}/{c}") for (f, m, c, fx) in FIXTURES],
+)
+def test_reasoning_parity_sglang(
+    family: str,
+    mode: str,
+    case_id: str,
+    fixture: dict[str, Any],
+) -> None:
+    _run_parity_case(family, mode, case_id, fixture, "sglang")

--- a/tests/parity/reasoning/vllm.py
+++ b/tests/parity/reasoning/vllm.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from vllm.entrypoints.openai.parser.harmony_utils import get_encoding, parse_chat_output
@@ -12,6 +13,32 @@ from vllm.reasoning import ReasoningParserManager
 from vllm.tokenizers.mistral import MistralTokenizer
 
 from tests.parity.common import ReasoningResult
+
+# Harmony text-level fallback regexes. Mirror tests/parity/parser/vllm.py so the
+# behavior matches when get_encoding() can't load the tiktoken vocab (e.g. CI
+# runners with no reach to openaipublic.blob.core.windows.net).
+_HARMONY_MESSAGE_RE = re.compile(
+    r"(?:<\|start\|>assistant)?"
+    r"<\|channel\|>(?P<channel>\w+)"
+    r"(?P<header>.*?)"
+    r"<\|message\|>(?P<body>.*?)"
+    r"(?P<stop><\|call\|>|<\|end\|>|<\|return\|>|$)",
+    re.DOTALL,
+)
+_HARMONY_RECIPIENT_RE = re.compile(r"\bto=(?P<recipient>functions\.[\w.\-]+)")
+_HARMONY_FINAL_MARKER = "<|channel|>final<|message|>"
+
+
+class _HarmonyEncodingUnavailable(RuntimeError):
+    """Raised when openai-harmony's tiktoken vocab can't be loaded.
+
+    The Rust extension behind openai-harmony downloads `o200k_base.tiktoken`
+    from openaipublic.blob.core.windows.net on first use. CI runners without
+    reach to that CDN fail with HarmonyError. The reasoning fixtures fall back
+    to a text-level harmony state machine when this happens — mirrors what
+    tests/parity/parser/vllm.py already does for the tool-calling parity path.
+    """
+
 
 _FAMILY_TO_VLLM_REASONING = {
     "deepseek_r1": "deepseek_r1",
@@ -92,7 +119,10 @@ class _StubTokenizer:
 
 class _HarmonyTokenizer:
     def __init__(self) -> None:
-        self.encoding = get_encoding()
+        try:
+            self.encoding = get_encoding()
+        except Exception as e:
+            raise _HarmonyEncodingUnavailable(f"{type(e).__name__}: {e}") from e
 
     def encode(self, text: str, *args: Any, **kwargs: Any) -> list[int]:
         return list(self.encoding.encode(text, allowed_special="all"))
@@ -227,8 +257,96 @@ def _run_batch(parser: Any, fixture: dict[str, Any]) -> ReasoningResult:
 
 
 def _run_gptoss_batch(fixture: dict[str, Any]) -> ReasoningResult:
-    token_ids = _HarmonyTokenizer().encode(fixture["model_text"])
-    reasoning_text, normal_text, _ = parse_chat_output(token_ids)
+    try:
+        token_ids = _HarmonyTokenizer().encode(fixture["model_text"])
+        reasoning_text, normal_text, _ = parse_chat_output(token_ids)
+    except _HarmonyEncodingUnavailable:
+        return _harmony_reasoning_parse_batch(fixture["model_text"])
+    except Exception as e:
+        # parse_chat_output() reaches into get_encoding() too — raw HarmonyError
+        # surfaces here, not _HarmonyEncodingUnavailable. Catch and route the
+        # same way so the fallback runs.
+        if _looks_like_harmony_vocab_error(e):
+            return _harmony_reasoning_parse_batch(fixture["model_text"])
+        raise
+    return ReasoningResult(reasoning_text=reasoning_text, normal_text=normal_text)
+
+
+def _looks_like_harmony_vocab_error(exc: Exception) -> bool:
+    msg = str(exc)
+    return "vocab file" in msg or "tiktoken" in msg
+
+
+def _harmony_parse_messages(text: str) -> tuple[list[str], list[str]]:
+    """Return (analysis_bodies, normal_bodies) extracted from harmony markup.
+
+    Mirrors openai-harmony's parse_chat_output() at the text level:
+    - `analysis` channel bodies → reasoning_text contributors
+    - `final` channel bodies → normal_text contributors
+    - `commentary` channel bodies WITHOUT `to=functions.*` → normal_text contributors
+    - `commentary` channel bodies WITH a `to=functions.*` recipient → dropped
+      (tool-call payload; the tool-call parser handles it separately)
+    """
+    analysis_bodies: list[str] = []
+    normal_bodies: list[str] = []
+    for match in _HARMONY_MESSAGE_RE.finditer(text):
+        channel = match.group("channel")
+        header = match.group("header")
+        body = match.group("body")
+        recipient_match = _HARMONY_RECIPIENT_RE.search(header)
+        recipient = recipient_match.group("recipient") if recipient_match else None
+        if channel == "analysis":
+            analysis_bodies.append(body)
+        elif channel == "final":
+            normal_bodies.append(body)
+        elif channel == "commentary" and recipient is None:
+            normal_bodies.append(body)
+    return analysis_bodies, normal_bodies
+
+
+def _harmony_reasoning_parse_batch(model_text: str) -> ReasoningResult:
+    """Text-level mirror of parse_chat_output() for batch mode."""
+    analysis_bodies, normal_bodies = _harmony_parse_messages(model_text)
+    return ReasoningResult(
+        reasoning_text="\n".join(analysis_bodies),
+        normal_text="\n".join(normal_bodies),
+    )
+
+
+def _harmony_reasoning_parse_stream(chunks: list[str]) -> ReasoningResult:
+    """Text-level mirror of extract_reasoning_streaming() across all chunks.
+
+    Re-parses the accumulated text on every chunk and emits the delta vs the
+    previous chunk's parse. Once we've passed `<|channel|>final<|message|>`
+    the harness convention is to raw-append subsequent chunks to normal_text
+    (matches what _run_stream does when is_reasoning_end_streaming flips).
+    """
+    reasoning_text = ""
+    normal_text = ""
+    accumulated = ""
+    prev_reasoning = ""
+    prev_normal = ""
+    reasoning_done = False
+    for chunk in chunks:
+        if reasoning_done:
+            normal_text += chunk
+            continue
+        accumulated += chunk
+        analysis_bodies, normal_bodies = _harmony_parse_messages(accumulated)
+        cur_reasoning = "\n".join(analysis_bodies)
+        cur_normal = "\n".join(normal_bodies)
+        if cur_reasoning.startswith(prev_reasoning):
+            reasoning_text += cur_reasoning[len(prev_reasoning) :]
+        else:
+            reasoning_text = cur_reasoning
+        if cur_normal.startswith(prev_normal):
+            normal_text += cur_normal[len(prev_normal) :]
+        else:
+            normal_text = cur_normal
+        prev_reasoning = cur_reasoning
+        prev_normal = cur_normal
+        if _HARMONY_FINAL_MARKER in accumulated:
+            reasoning_done = True
     return ReasoningResult(reasoning_text=reasoning_text, normal_text=normal_text)
 
 
@@ -251,7 +369,12 @@ def parse(
     try:
         if parser_name == "openai_gptoss" and mode == "batch":
             return _run_gptoss_batch(fixture)
-        parser = _make_parser(parser_name, fixture)
+        try:
+            parser = _make_parser(parser_name, fixture)
+        except _HarmonyEncodingUnavailable:
+            if parser_name == "openai_gptoss" and mode == "stream":
+                return _harmony_reasoning_parse_stream(fixture["chunks"])
+            raise
         if mode == "stream":
             chunks = fixture["chunks"]
             return _run_stream(parser, fixture, chunks)
@@ -259,5 +382,16 @@ def parse(
             return _run_batch(parser, fixture)
         else:
             raise ValueError(f"unsupported reasoning mode: {mode!r}")
+    except _HarmonyEncodingUnavailable:
+        if parser_name == "openai_gptoss" and mode == "batch":
+            return _harmony_reasoning_parse_batch(fixture["model_text"])
+        if parser_name == "openai_gptoss" and mode == "stream":
+            return _harmony_reasoning_parse_stream(fixture["chunks"])
+        raise
     except Exception as e:
+        if parser_name == "openai_gptoss" and _looks_like_harmony_vocab_error(e):
+            if mode == "batch":
+                return _harmony_reasoning_parse_batch(fixture["model_text"])
+            if mode == "stream":
+                return _harmony_reasoning_parse_stream(fixture["chunks"])
         return ReasoningResult(error=f"{type(e).__name__}: {e}")

--- a/tests/parity/reasoning/vllm.py
+++ b/tests/parity/reasoning/vllm.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning parity wrapper for vLLM's reasoning parser classes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm.entrypoints.openai.parser.harmony_utils import get_encoding, parse_chat_output
+from vllm.reasoning import ReasoningParserManager
+from vllm.tokenizers.mistral import MistralTokenizer
+
+from tests.parity.common import ReasoningResult
+
+_FAMILY_TO_VLLM_REASONING = {
+    "deepseek_r1": "deepseek_r1",
+    "deepseek_v3": "deepseek_v3",
+    "deepseek_v4": "deepseek_v4",
+    "gemma4": "gemma4",
+    "gpt_oss": "openai_gptoss",
+    "granite": "granite",
+    "kimi_k25": "kimi_k2",
+    "mistral": "mistral",
+    "minimax_append_think": "minimax_m2_append_think",
+    "nemotron_deci": "glm45",
+    "qwen3": "qwen3",
+}
+
+_SPECIAL_TOKEN_IDS = {
+    "<think>": 1_000_001,
+    "</think>": 1_000_002,
+    "<tool_call>": 1_000_003,
+    "</tool_call>": 1_000_004,
+    "<|channel>": 1_000_005,
+    "<channel|>": 1_000_006,
+    "<|turn>": 1_000_007,
+    "<|tool_call>": 1_000_008,
+    "<|tool_response>": 1_000_009,
+    "[THINK]": 1_000_010,
+    "[/THINK]": 1_000_011,
+    "<|start|>": 1_000_012,
+    "<|channel|>": 1_000_013,
+    "<|constrain|>": 1_000_014,
+    "<|message|>": 1_000_015,
+    "<|end|>": 1_000_016,
+    "<|call|>": 1_000_017,
+    "<|return|>": 1_000_018,
+    "<|tool_calls_section_begin|>": 1_000_019,
+}
+_ID_TO_SPECIAL_TOKEN = {v: k for k, v in _SPECIAL_TOKEN_IDS.items()}
+_SPECIAL_TOKENS_BY_LENGTH = sorted(
+    _SPECIAL_TOKEN_IDS,
+    key=len,
+    reverse=True,
+)
+
+_HARMONY_SPECIAL_TOKENS = (
+    "<|channel|>",
+    "<|constrain|>",
+    "<|end|>",
+    "<|message|>",
+    "<|start|>",
+    "<|call|>",
+    "<|return|>",
+)
+
+
+class _StubTokenizer:
+    all_special_tokens = tuple(_SPECIAL_TOKEN_IDS)
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(_SPECIAL_TOKEN_IDS)
+
+    def encode(self, text: str, *args: Any, **kwargs: Any) -> list[int]:
+        token_ids: list[int] = []
+        i = 0
+        while i < len(text):
+            for token in _SPECIAL_TOKENS_BY_LENGTH:
+                if text.startswith(token, i):
+                    token_ids.append(_SPECIAL_TOKEN_IDS[token])
+                    i += len(token)
+                    break
+            else:
+                token_ids.append(ord(text[i]))
+                i += 1
+        return token_ids
+
+    def decode(self, token_ids: list[int], *args: Any, **kwargs: Any) -> str:
+        return "".join(_ID_TO_SPECIAL_TOKEN.get(t, chr(t)) for t in token_ids)
+
+
+class _HarmonyTokenizer:
+    def __init__(self) -> None:
+        self.encoding = get_encoding()
+
+    def encode(self, text: str, *args: Any, **kwargs: Any) -> list[int]:
+        return list(self.encoding.encode(text, allowed_special="all"))
+
+    def decode(self, token_ids: list[int], *args: Any, **kwargs: Any) -> str:
+        return self.encoding.decode(token_ids)
+
+    def get_vocab(self) -> dict[str, int]:
+        return {token: self.encode(token)[0] for token in _HARMONY_SPECIAL_TOKENS}
+
+
+class _StubMistralInnerTokenizer:
+    def get_special_token(self, token: Any) -> int | None:
+        key = getattr(token, "value", token)
+        return _SPECIAL_TOKEN_IDS.get(str(key))
+
+
+class _StubMistralTokenizer(MistralTokenizer):
+    all_special_tokens = tuple(_SPECIAL_TOKEN_IDS)
+
+    def __init__(self) -> None:
+        self.tokenizer = _StubMistralInnerTokenizer()
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(_SPECIAL_TOKEN_IDS)
+
+    def encode(self, text: str, *args: Any, **kwargs: Any) -> list[int]:
+        return _StubTokenizer().encode(text, *args, **kwargs)
+
+    def decode(self, token_ids: list[int], *args: Any, **kwargs: Any) -> str:
+        return _StubTokenizer().decode(token_ids, *args, **kwargs)
+
+    def __len__(self) -> int:
+        return len(_SPECIAL_TOKEN_IDS)
+
+
+class _Request:
+    skip_special_tokens = False
+
+
+def _make_parser(parser_name: str, fixture: dict[str, Any]) -> Any:
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    if parser_name == "openai_gptoss":
+        tokenizer = _HarmonyTokenizer()
+    elif parser_name == "mistral":
+        tokenizer = _StubMistralTokenizer()
+    else:
+        tokenizer = _StubTokenizer()
+    chat_template_kwargs = {}
+    if parser_name == "deepseek_v4":
+        chat_template_kwargs["enable_thinking"] = True
+    if parser_name == "deepseek_v3":
+        chat_template_kwargs["thinking"] = True
+    chat_template_kwargs.update(fixture.get("chat_template_kwargs", {}))
+
+    attempts = (
+        lambda: parser_cls(tokenizer, chat_template_kwargs=chat_template_kwargs),
+        lambda: parser_cls(tokenizer),
+        lambda: parser_cls(),
+    )
+    last_error: Exception | None = None
+    for attempt in attempts:
+        try:
+            return attempt()
+        except TypeError as e:
+            last_error = e
+    raise TypeError(f"could not initialize vLLM reasoning parser: {last_error}")
+
+
+def _message_field(message: Any, *names: str) -> str:
+    if message is None:
+        return ""
+    for name in names:
+        if isinstance(message, dict):
+            value = message.get(name)
+        else:
+            value = getattr(message, name, None)
+        if value:
+            return value
+    return ""
+
+
+def _run_stream(
+    parser: Any, fixture: dict[str, Any], chunks: list[str]
+) -> ReasoningResult:
+    token_chunks = fixture.get("token_chunks")
+    previous_text = ""
+    previous_token_ids: list[int] = []
+    reasoning_text = ""
+    normal_text = ""
+    reasoning_done = False
+    tokenizer = parser.model_tokenizer
+
+    for i, chunk in enumerate(chunks):
+        current_text = previous_text + chunk
+        current_token_ids = tokenizer.encode(current_text)
+        if token_chunks:
+            delta_token_ids = token_chunks[i]
+        elif current_token_ids[: len(previous_token_ids)] == previous_token_ids:
+            delta_token_ids = current_token_ids[len(previous_token_ids) :]
+        else:
+            delta_token_ids = tokenizer.encode(chunk)
+
+        if reasoning_done:
+            normal_text += chunk
+        else:
+            message = parser.extract_reasoning_streaming(
+                previous_text,
+                current_text,
+                chunk,
+                previous_token_ids,
+                current_token_ids,
+                delta_token_ids,
+            )
+            reasoning_text += _message_field(message, "reasoning", "reasoning_content")
+            normal_text += _message_field(message, "content")
+            if parser.is_reasoning_end_streaming(current_token_ids, delta_token_ids):
+                reasoning_done = True
+
+        previous_text = current_text
+        previous_token_ids = current_token_ids
+
+    return ReasoningResult(reasoning_text=reasoning_text, normal_text=normal_text)
+
+
+def _run_batch(parser: Any, fixture: dict[str, Any]) -> ReasoningResult:
+    reasoning_text, normal_text = parser.extract_reasoning(
+        fixture["model_text"],
+        _Request(),
+    )
+    return ReasoningResult(reasoning_text=reasoning_text, normal_text=normal_text)
+
+
+def _run_gptoss_batch(fixture: dict[str, Any]) -> ReasoningResult:
+    token_ids = _HarmonyTokenizer().encode(fixture["model_text"])
+    reasoning_text, normal_text, _ = parse_chat_output(token_ids)
+    return ReasoningResult(reasoning_text=reasoning_text, normal_text=normal_text)
+
+
+def parse(
+    parser_family: str,
+    fixture: dict[str, Any],
+    mode: str,
+) -> ReasoningResult:
+    parser_name = fixture.get("vllm_parser") or _FAMILY_TO_VLLM_REASONING.get(
+        parser_family
+    )
+    if not parser_name:
+        return ReasoningResult(
+            error=(
+                "UNAVAILABLE: vLLM has no reasoning parser for "
+                f"family={parser_family!r}"
+            )
+        )
+
+    try:
+        if parser_name == "openai_gptoss" and mode == "batch":
+            return _run_gptoss_batch(fixture)
+        parser = _make_parser(parser_name, fixture)
+        if mode == "stream":
+            chunks = fixture["chunks"]
+            return _run_stream(parser, fixture, chunks)
+        elif mode == "batch":
+            return _run_batch(parser, fixture)
+        else:
+            raise ValueError(f"unsupported reasoning mode: {mode!r}")
+    except Exception as e:
+        return ReasoningResult(error=f"{type(e).__name__}: {e}")


### PR DESCRIPTION
#### Overview:

This PR adds the reasoning parity table harness for part 3 of the reasoning parity work.

#### Details:

<img width="890" height="529" alt="image" src="https://github.com/user-attachments/assets/4a1ca5d2-b4c6-4e24-8396-c79587c9d8b5" />

- **How is this fixed?** Add Python parity runners plus Rust/Python parser helpers so the YAML reasoning fixtures from #9891 can run against Dynamo, vLLM, and SGLang peers.
- Extend the common parity table generator and HTML template so reasoning and tool calling tables share the same layout/style.
- Add reasoning parser stream finalization so buffered partial delimiters are flushed at EOF.
- Keep the fixture contracts and reference docs in #9891; this PR is the code/test/table layer.

#### Verification:

`cargo fmt`, pre-commit hooks in the Dynamo devcontainer, and `HF_HUB_OFFLINE=1 python3 -m pytest -q tests/parity/reasoning/test_parity_reasoning.py tests/parity/parser/test_generate_parity_table.py --basetemp=/tmp/pytest_temp_part2` passed; parser and reasoning HTML tables regenerated locally.

#### Where should the reviewer start?

`tests/parity/reasoning/table.py`, then `tests/parity/reasoning/test_parity_reasoning.py`, then `lib/bindings/python/rust/parsers.rs`

#### Related Issues:

Depends on #9891; DIS-2063

/coderabbit profile chill
