### PR TITLE
fix: bump etcd to v3.5.30 for runtime containers

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -25,7 +25,7 @@ dynamo:
   python_version: "3.12"
 
   nats_version: v2.10.28
-  etcd_version: v3.5.21
+  etcd_version: v3.5.30
 
   nixl_ref: 0.10.1
   nixl_ucx_ref: v1.20.x


### PR DESCRIPTION
Bumps etcd from v3.5.21 to v3.5.30 in container/context.yaml. This is picked up by the sglang-runtime and vllm-runtime images, which embed the pre-built etcd binary (downloaded in templates/dynamo_base.Dockerfile and COPY'd into the runtime stage). The bump moves the statically linked google.golang.org/grpc dependency from v1.59.0 to v1.79.3.

closes: OPS-4216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core containerized infrastructure component to version v3.5.30, replacing the previously used v3.5.21 release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->