### PR TITLE
feat(operator): inject worker topology Downward API volume

### DIFF
--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -86,6 +86,11 @@ const (
 	EnvKvTransferEnforcement     = "DYN_KV_TRANSFER_ENFORCEMENT"
 	EnvKvTransferPreferredWeight = "DYN_KV_TRANSFER_PREFERRED_WEIGHT"
 
+	// Topology env vars (worker) injected when
+	// spec.experimental.kvTransferPolicy is configured.
+	EnvTopologyEnabled   = "DYN_TOPOLOGY_ENABLED"
+	EnvTopologyMountPath = "DYN_TOPOLOGY_MOUNT_PATH"
+
 	DynamoDeploymentConfigEnvVar      = "DYN_DEPLOYMENT_CONFIG"
 	DynamoNamespaceEnvVar             = "DYN_NAMESPACE"
 	DynamoNamespacePrefixEnvVar       = "DYN_NAMESPACE_PREFIX"

--- a/deploy/operator/internal/dynamo/component_worker.go
+++ b/deploy/operator/internal/dynamo/component_worker.go
@@ -8,6 +8,7 @@ package dynamo
 import (
 	"fmt"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -123,4 +124,39 @@ func (w *WorkerDefaults) GetBaseContainer(context ComponentContext) (corev1.Cont
 	}
 
 	return container, nil
+}
+
+const (
+	topologyVolumeName = "topology-labels"
+	topologyMountPath  = "/etc/dynamo/topology"
+)
+
+// TopologyLabelVolume returns a Downward API volume that projects a pod label
+// into a file. The volume updates dynamically when the label is added or
+// changed, so the runtime can poll until the file has content.
+func TopologyLabelVolume(policy *v1beta1.KvTransferPolicy) corev1.Volume {
+	return corev1.Volume{
+		Name: topologyVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			DownwardAPI: &corev1.DownwardAPIVolumeSource{
+				Items: []corev1.DownwardAPIVolumeFile{
+					{
+						Path: string(policy.Domain),
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: fmt.Sprintf("metadata.labels['%s']", policy.LabelKey),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TopologyLabelVolumeMount returns the volume mount for the topology label volume.
+func TopologyLabelVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      topologyVolumeName,
+		MountPath: topologyMountPath,
+		ReadOnly:  true,
+	}
 }

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1755,18 +1755,19 @@ func applyDGDTemplateDefaults(
 		main.Env = MergeEnvs(dynamoDeployment.Spec.Env, main.Env)
 	}
 
-	// Bake KV transfer policy env vars into worker pod templates so they
-	// survive DGD → DCD materialization (the DCD controller lacks the parent DGD).
-	// Workers publish these in their MDC so the router reads policy per-worker.
-	if shouldApplyKvTransferPolicyEnvVarsToWorkerComponent(component, dynamoDeployment) {
-		applyKvTransferPolicyEnvVarsToWorkerComponent(component, dynamoDeployment.Spec.Experimental.KvTransferPolicy)
+	// Bake KV transfer policy env vars and topology projection into worker pod
+	// templates so they survive DGD -> DCD materialization (the DCD controller
+	// lacks the parent DGD). Workers publish these in their MDC so the router
+	// reads policy per-worker.
+	if shouldApplyKvTransferPolicyToWorkerComponent(component, dynamoDeployment) {
+		applyKvTransferPolicyToWorkerComponent(component, dynamoDeployment.Spec.Experimental.KvTransferPolicy)
 	}
 
 	propagateDGDAnnotations(dynamoDeployment.GetAnnotations(), component)
 	propagateDGDSpecMetadata(dynamoDeployment.Spec.Annotations, dynamoDeployment.Spec.Labels, component)
 }
 
-func shouldApplyKvTransferPolicyEnvVarsToWorkerComponent(
+func shouldApplyKvTransferPolicyToWorkerComponent(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	dynamoDeployment *v1beta1.DynamoGraphDeployment,
 ) bool {
@@ -1777,7 +1778,7 @@ func shouldApplyKvTransferPolicyEnvVarsToWorkerComponent(
 		IsWorkerComponent(string(component.ComponentType))
 }
 
-func applyKvTransferPolicyEnvVarsToWorkerComponent(
+func applyKvTransferPolicyToWorkerComponent(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	kvt *v1beta1.KvTransferPolicy,
 ) {
@@ -1786,6 +1787,12 @@ func applyKvTransferPolicyEnvVarsToWorkerComponent(
 	}
 	podTemplate := ensurePodTemplate(component)
 	main := ensureMainContainer(podTemplate)
+	main.Env = MergeEnvs(removeWorkerKvTransferPolicyEnvVars(main.Env), workerKvTransferPolicyEnvVars(kvt))
+	main.VolumeMounts = appendTopologyLabelVolumeMount(main.VolumeMounts, TopologyLabelVolumeMount())
+	podTemplate.Spec.Volumes = appendTopologyLabelVolume(podTemplate.Spec.Volumes, TopologyLabelVolume(kvt))
+}
+
+func workerKvTransferPolicyEnvVars(kvt *v1beta1.KvTransferPolicy) []corev1.EnvVar {
 	enforcement := string(kvt.Enforcement)
 	if enforcement == "" {
 		enforcement = string(v1beta1.KvTransferEnforcementRequired)
@@ -1793,6 +1800,8 @@ func applyKvTransferPolicyEnvVarsToWorkerComponent(
 	policyEnvs := []corev1.EnvVar{
 		{Name: commonconsts.EnvKvTransferDomain, Value: string(kvt.Domain)},
 		{Name: commonconsts.EnvKvTransferEnforcement, Value: enforcement},
+		{Name: commonconsts.EnvTopologyEnabled, Value: "true"},
+		{Name: commonconsts.EnvTopologyMountPath, Value: topologyMountPath},
 	}
 	if kvt.PreferredWeight != nil {
 		policyEnvs = append(policyEnvs, corev1.EnvVar{
@@ -1800,16 +1809,16 @@ func applyKvTransferPolicyEnvVarsToWorkerComponent(
 			Value: strconv.FormatFloat(float64(*kvt.PreferredWeight), 'f', -1, 32),
 		})
 	}
-	main.Env = MergeEnvs(removeKvTransferPolicyEnvVars(main.Env), policyEnvs)
+	return policyEnvs
 }
 
-func removeKvTransferPolicyEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
+func removeWorkerKvTransferPolicyEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
 	if len(envs) == 0 {
 		return envs
 	}
 	filtered := make([]corev1.EnvVar, 0, len(envs))
 	for _, env := range envs {
-		if isKvTransferPolicyEnvVar(env.Name) {
+		if isWorkerKvTransferPolicyEnvVar(env.Name) {
 			continue
 		}
 		filtered = append(filtered, env)
@@ -1817,15 +1826,39 @@ func removeKvTransferPolicyEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
 	return filtered
 }
 
-func isKvTransferPolicyEnvVar(name string) bool {
+func isWorkerKvTransferPolicyEnvVar(name string) bool {
 	switch name {
 	case commonconsts.EnvKvTransferDomain,
 		commonconsts.EnvKvTransferEnforcement,
-		commonconsts.EnvKvTransferPreferredWeight:
+		commonconsts.EnvKvTransferPreferredWeight,
+		commonconsts.EnvTopologyEnabled,
+		commonconsts.EnvTopologyMountPath:
 		return true
 	default:
 		return false
 	}
+}
+
+func appendTopologyLabelVolumeMount(mounts []corev1.VolumeMount, mount corev1.VolumeMount) []corev1.VolumeMount {
+	filtered := make([]corev1.VolumeMount, 0, len(mounts)+1)
+	for _, existing := range mounts {
+		if existing.Name == mount.Name || existing.MountPath == mount.MountPath {
+			continue
+		}
+		filtered = append(filtered, existing)
+	}
+	return append(filtered, mount)
+}
+
+func appendTopologyLabelVolume(volumes []corev1.Volume, vol corev1.Volume) []corev1.Volume {
+	filtered := make([]corev1.Volume, 0, len(volumes)+1)
+	for _, v := range volumes {
+		if v.Name == vol.Name {
+			continue
+		}
+		filtered = append(filtered, v)
+	}
+	return append(filtered, vol)
 }
 
 // dgdPropagatedAnnotationKeys lists DGD metadata annotations that are propagated

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -9074,13 +9074,14 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		assert.Equal(t, "0.85", envMap[commonconsts.EnvKvTransferPreferredWeight])
 	})
 
-	t.Run("worker policy env vars override user-supplied transfer env vars", func(t *testing.T) {
+	t.Run("worker policy env vars override user-supplied transfer and topology env vars", func(t *testing.T) {
 		dgd := &v1beta1.DynamoGraphDeployment{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
 			Spec: v1beta1.DynamoGraphDeploymentSpec{
 				BackendFramework: "vllm",
 				Env: []corev1.EnvVar{
 					{Name: commonconsts.EnvKvTransferPreferredWeight, Value: "1"},
+					{Name: commonconsts.EnvTopologyEnabled, Value: "false"},
 					{Name: "GLOBAL_ENV", Value: "global"},
 				},
 				Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
@@ -9095,6 +9096,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 										Env: []corev1.EnvVar{
 											{Name: commonconsts.EnvKvTransferDomain, Value: "wrong-domain"},
 											{Name: commonconsts.EnvKvTransferEnforcement, Value: "preferred"},
+											{Name: commonconsts.EnvTopologyMountPath, Value: "/tmp/wrong-topology"},
 											{Name: "USER_ENV", Value: "user"},
 										},
 									},
@@ -9123,6 +9125,8 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		assert.Equal(t, "zone", envMap[commonconsts.EnvKvTransferDomain])
 		assert.Equal(t, "required", envMap[commonconsts.EnvKvTransferEnforcement])
 		assert.NotContains(t, envMap, commonconsts.EnvKvTransferPreferredWeight)
+		assert.Equal(t, "true", envMap[commonconsts.EnvTopologyEnabled])
+		assert.Equal(t, "/etc/dynamo/topology", envMap[commonconsts.EnvTopologyMountPath])
 		assert.Equal(t, "global", envMap["GLOBAL_ENV"])
 		assert.Equal(t, "user", envMap["USER_ENV"])
 	})
@@ -9241,4 +9245,219 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		assert.Equal(t, "required", envMap[commonconsts.EnvKvTransferEnforcement],
 			"omitted enforcement should default to required")
 	})
+}
+
+func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
+	secretsRetriever := &mockSecretsRetriever{}
+	controllerConfig := &configv1alpha1.OperatorConfiguration{}
+
+	t.Run("worker gets topology env vars and volume", func(t *testing.T) {
+		dgd := &v1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+			Spec: v1beta1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+					{
+						ComponentName: "worker",
+						ComponentType: v1beta1.ComponentTypeWorker,
+						PodTemplate: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Volumes: []corev1.Volume{
+									{
+										Name: "topology-labels",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+									{
+										Name: "keep-me",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name: v1beta1.MainContainerName,
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "topology-labels",
+												MountPath: "/tmp/wrong-topology",
+											},
+											{
+												Name:      "wrong-volume",
+												MountPath: "/etc/dynamo/topology",
+											},
+											{
+												Name:      "keep-me",
+												MountPath: "/mnt/keep-me",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &v1beta1.KvTransferPolicy{
+						LabelKey:    "topology.kubernetes.io/zone",
+						Domain:      "zone",
+						Enforcement: v1beta1.KvTransferEnforcementRequired,
+					},
+				},
+			},
+		}
+		component := dgd.Spec.Components[0].DeepCopy()
+		podSpec, err := GeneratePodSpecForComponent(
+			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+		)
+		require.NoError(t, err)
+
+		envMap := envVarsToMap(podSpec.Containers[0].Env)
+		assert.Equal(t, "true", envMap[commonconsts.EnvTopologyEnabled])
+		assert.Equal(t, "/etc/dynamo/topology", envMap[commonconsts.EnvTopologyMountPath])
+		assert.NotContains(t, envMap, "DYN_TOPOLOGY_DOMAIN")
+
+		// Downward API volume
+		var topologyVolumes int
+		assert.True(t, hasVolumeNamed(podSpec.Volumes, "keep-me"))
+		for _, v := range podSpec.Volumes {
+			if v.Name == "topology-labels" {
+				topologyVolumes++
+				require.NotNil(t, v.DownwardAPI)
+				require.Len(t, v.DownwardAPI.Items, 1)
+				assert.Equal(t, "zone", v.DownwardAPI.Items[0].Path)
+				assert.Equal(t, "metadata.labels['topology.kubernetes.io/zone']", v.DownwardAPI.Items[0].FieldRef.FieldPath)
+			}
+		}
+		assert.Equal(t, 1, topologyVolumes, "topology-labels volume should be operator-owned")
+
+		// Volume mount
+		var topologyMounts int
+		assert.True(t, hasVolumeMountNamed(podSpec.Containers[0].VolumeMounts, "keep-me"))
+		for _, m := range podSpec.Containers[0].VolumeMounts {
+			if m.Name == "topology-labels" {
+				topologyMounts++
+				assert.Equal(t, "/etc/dynamo/topology", m.MountPath)
+				assert.True(t, m.ReadOnly)
+			}
+			assert.NotEqual(t, "wrong-volume", m.Name)
+		}
+		assert.Equal(t, 1, topologyMounts, "topology-labels mount should be operator-owned")
+	})
+
+	t.Run("frontend does NOT get topology env vars", func(t *testing.T) {
+		dgd := &v1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+			Spec: v1beta1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+					{ComponentName: "frontend", ComponentType: v1beta1.ComponentTypeFrontend},
+				},
+				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &v1beta1.KvTransferPolicy{
+						LabelKey:    "topology.kubernetes.io/zone",
+						Domain:      "zone",
+						Enforcement: v1beta1.KvTransferEnforcementRequired,
+					},
+				},
+			},
+		}
+		component := dgd.Spec.Components[0].DeepCopy()
+		podSpec, err := GeneratePodSpecForComponent(
+			component, BackendFrameworkSGLang, secretsRetriever, dgd, RoleMain, 1,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "frontend", nil, nil,
+		)
+		require.NoError(t, err)
+
+		envMap := envVarsToMap(podSpec.Containers[0].Env)
+		assert.NotContains(t, envMap, commonconsts.EnvTopologyEnabled)
+		assert.False(t, hasTopologyLabelVolume(podSpec.Volumes))
+		assert.False(t, hasTopologyLabelVolumeMount(podSpec.Containers[0].VolumeMounts))
+	})
+
+	t.Run("worker without policy has no topology", func(t *testing.T) {
+		dgd := &v1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+			Spec: v1beta1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+					{ComponentName: "worker", ComponentType: v1beta1.ComponentTypeWorker},
+				},
+			},
+		}
+		component := dgd.Spec.Components[0].DeepCopy()
+		podSpec, err := GeneratePodSpecForComponent(
+			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+		)
+		require.NoError(t, err)
+
+		envMap := envVarsToMap(podSpec.Containers[0].Env)
+		assert.NotContains(t, envMap, commonconsts.EnvTopologyEnabled)
+		assert.False(t, hasTopologyLabelVolume(podSpec.Volumes))
+		assert.False(t, hasTopologyLabelVolumeMount(podSpec.Containers[0].VolumeMounts))
+	})
+
+	t.Run("worker with experimental but without policy has no topology", func(t *testing.T) {
+		dgd := &v1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+			Spec: v1beta1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+					{ComponentName: "worker", ComponentType: v1beta1.ComponentTypeWorker},
+				},
+				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{},
+			},
+		}
+		component := dgd.Spec.Components[0].DeepCopy()
+		podSpec, err := GeneratePodSpecForComponent(
+			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+		)
+		require.NoError(t, err)
+
+		envMap := envVarsToMap(podSpec.Containers[0].Env)
+		assert.NotContains(t, envMap, commonconsts.EnvTopologyEnabled)
+		assert.False(t, hasTopologyLabelVolume(podSpec.Volumes))
+		assert.False(t, hasTopologyLabelVolumeMount(podSpec.Containers[0].VolumeMounts))
+	})
+}
+
+func hasTopologyLabelVolume(volumes []corev1.Volume) bool {
+	for _, v := range volumes {
+		if v.Name == topologyVolumeName {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTopologyLabelVolumeMount(mounts []corev1.VolumeMount) bool {
+	for _, m := range mounts {
+		if m.Name == topologyVolumeName {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeNamed(volumes []corev1.Volume, name string) bool {
+	for _, v := range volumes {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeMountNamed(mounts []corev1.VolumeMount, name string) bool {
+	for _, m := range mounts {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
#### Overview:

Inject topology metadata into worker pod templates when `spec.experimental.kvTransferPolicy` is configured. Workers get a Downward API volume at `/etc/dynamo/topology/{domain}` plus runtime topology env vars; frontend pods and workers without a policy stay unchanged.

#### Details:

- `deploy/operator/internal/consts/consts.go`: adds worker topology env var constants.
- `deploy/operator/internal/dynamo/component_worker.go`: adds helpers for the topology Downward API volume, read-only mount, and topology env vars.
- `deploy/operator/internal/dynamo/graph.go`: applies topology projection alongside the existing worker KV transfer policy env injection.
- `deploy/operator/internal/dynamo/graph_test.go`: covers worker injection, preferred/required transfer policy preservation, frontend exclusion, and no-policy cases.

#### Follow-up:

- PR4c / DYN-3070 will add the controller that copies the configured node label onto scheduled worker pods so the Downward API volume can project the label value into `/etc/dynamo/topology/{domain}`. This PR only wires the worker pod env vars, volume, and mount.

#### Where should the reviewer start?

`deploy/operator/internal/dynamo/graph.go` around `applyDGDTemplateDefaults`, then the new worker helpers in `deploy/operator/internal/dynamo/component_worker.go`.

#### Verification:

- `cd deploy/operator && go test ./internal/dynamo -run 'TestGeneratePodSpecForComponent_(KvTransferPolicyEnvVars|WorkerTopologyEnvVars)'`
- `cd deploy/operator && go test ./internal/dynamo`

#### Related Issues:

- Closes DYN-2990
- Relates to DYN-3070: https://linear.app/nvidia/issue/DYN-3070/tar-pr4c-topology-label-controller-for-nodepod-label-copy
- Relates to ai-dynamo/dynamo#9118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added topology labeling configuration support for worker components when KV transfer policy is enabled
  * Enhanced environment variable injection for topology-aware KV transfer deployments

* **Chores**
  * Refactored internal functions for improved KV transfer policy application
  * Expanded test coverage to validate topology environment variables and Kubernetes resource configuration for worker pods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->