### PR TITLE
fix(parsers): restrict chart to batch fixtures

### DIFF
--- a/tests/parity/parser/generate_parity_chart.py
+++ b/tests/parity/parser/generate_parity_chart.py
@@ -18,7 +18,7 @@ EXAMPLE OUTPUT (truncated; illustrative, NOT a snapshot of current fixtures
 
 ================================================================================
 
-Reads every `tests/parity/parser/fixtures/<family>/PARSER.*.yaml` and emits
+Reads every `tests/parity/parser/fixtures/<family>/PARSER.batch*.yaml` and emits
 the table referenced in `tests/parity/README.md`.
 
 Cell markers (per peer, vllm + sglang):
@@ -476,7 +476,7 @@ def family_suffix(fam: str, no_vllm: set[str], no_sglang: set[str]) -> str:
 
 
 def load_all_cases() -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
-    """Load every fixture YAML.
+    """Load every batch fixture YAML.
 
     Returns `(cases, labels)`:
       cases  — `{(family, sub_case_id): case_data}`; each case dict gets
@@ -489,8 +489,10 @@ def load_all_cases() -> tuple[dict[tuple[str, str], dict], dict[str, str]]:
     cases: dict[tuple[str, str], dict] = {}
     labels: dict[str, str] = {}
     script_dir = Path(__file__).resolve().parent
-    for fp in sorted(FIXTURES.glob("*/PARSER.*.yaml")):
+    for fp in sorted(FIXTURES.glob("*/PARSER.batch*.yaml")):
         doc = yaml.safe_load(fp.read_text())
+        if doc.get("mode", "batch") != "batch":
+            continue
         family = doc["family"]
         rel = str(fp.relative_to(script_dir))
         if "model_label" in doc:

--- a/tests/parity/parser/test_generate_parity_chart.py
+++ b/tests/parity/parser/test_generate_parity_chart.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GENERATOR = REPO_ROOT / "tests/parity/parser/generate_parity_chart.py"
+
+
+class LinkCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        if tag != "a":
+            return
+        for name, value in attrs:
+            if name == "href" and value is not None:
+                self.hrefs.append(value)
+
+
+def test_generate_parser_parity_table_html() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR.relative_to(REPO_ROOT)),
+            "--html",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    html = result.stdout
+    links = LinkCollector()
+    links.feed(html)
+    fixture_links = [href for href in links.hrefs if href.startswith("fixtures/")]
+    fixture_families = {href.split("/")[1] for href in fixture_links}
+
+    assert "<html" in html.lower()
+    assert "<table" in html.lower()
+    assert "Dynamo Parser Parity Table" in html
+    assert "generate_parity_chart.py --html" in html
+    assert fixture_links
+    assert len(fixture_families) > 10
+    assert "deepseek_v3" in fixture_families
+    assert "qwen3_coder" in fixture_families
+    assert all("/PARSER.batch" in href for href in fixture_links)
+    assert all("PARSER.stream." not in href for href in fixture_links)


### PR DESCRIPTION
#### Overview:

This PR fixes parser parity chart generation by keeping the chart scoped to parser batch fixtures.

#### Details:

- **How is this fixed?** `generate_parity_chart.py` loads only `PARSER.batch*.yaml` and keeps the batch-mode guard before sorting.
- Adds a pre-merge pytest that generates the full HTML chart and asserts fixture links stay batch-only.
- Concrete failure mode: `PARSER.stream.1.a` reached the batch numeric sorter and raised `ValueError: invalid literal for int() with base 10: 'PARSER'`.

#### Verification:

`python3 -m pytest tests/parity/parser/test_generate_parity_chart.py -q` passed; `python3 tests/parity/parser/generate_parity_chart.py --html` generated `PARITY.871617eed87.html`.

#### Where should the reviewer start?

`tests/parity/parser/generate_parity_chart.py`, then `tests/parity/parser/test_generate_parity_chart.py`

/coderabbit profile chill
