### PR TITLE
fix(kv-router): seed lower-tier query from primary-only MatchDetails

### DIFF
--- a/lib/kv-router/src/indexer/lower_tier_indexers.rs
+++ b/lib/kv-router/src/indexer/lower_tier_indexers.rs
@@ -159,6 +159,14 @@ pub fn query_lower_tiers(
     sequence: &[LocalBlockHash],
     device_matches: &MatchDetails,
 ) -> HashMap<StorageTier, LowerTierMatchDetails> {
+    // No lower-tier indexers are allocated, so there is no continuation
+    // work to perform. Return before validating device score/hash lockstep;
+    // that invariant only matters when a lower tier will consume the
+    // continuations.
+    if indexers.indexers.read().unwrap().is_empty() {
+        return HashMap::new();
+    }
+
     let mut continuations = LowerTierMatchDetails::default().next_continuations;
     for (worker, matched_blocks) in &device_matches.overlap_scores.scores {
         let Some(last_hash) = device_matches.last_matched_hashes.get(worker).copied() else {
@@ -206,4 +214,31 @@ pub fn query_lower_tiers(
     }
 
     lower_tier_matches
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::{LocalBlockHash, OverlapScores, WorkerWithDpRank};
+
+    #[test]
+    fn query_lower_tiers_returns_empty_when_no_tiers_allocated() {
+        let indexers = LowerTierIndexers::new(1, 4);
+
+        // Mismatched device_matches: a score entry with no paired
+        // `last_matched_hashes` entry. Would `debug_assert!`-panic in the
+        // old body; the early-return must skip the seeding loop entirely.
+        let mut overlap_scores = OverlapScores::new();
+        overlap_scores
+            .scores
+            .insert(WorkerWithDpRank::new(99, 0), 3);
+        let device_matches = MatchDetails {
+            overlap_scores,
+            last_matched_hashes: Default::default(),
+        };
+
+        let sequence = vec![LocalBlockHash(1), LocalBlockHash(2)];
+        let result = query_lower_tiers(&indexers, &sequence, &device_matches);
+        assert!(result.is_empty());
+    }
 }

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -339,9 +339,35 @@ impl Indexer {
         sequence: Vec<LocalBlockHash>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         match self {
-            Self::KvIndexer { lower_tier, .. } | Self::Concurrent { lower_tier, .. } => {
-                let device = self.find_match_details(sequence.clone()).await?;
-                let lt = query_lower_tiers(lower_tier, &sequence, &device);
+            Self::KvIndexer {
+                lower_tier, approx, ..
+            }
+            | Self::Concurrent {
+                lower_tier, approx, ..
+            } => {
+                // Seed lower-tier continuations from confirmed primary matches
+                // only. Predict-on-route side scores are unconfirmed; using
+                // them as lower-tier anchors would over-credit host/disk cache
+                // hits and break the score/hash lockstep `query_lower_tiers`
+                // expects.
+                let primary_device = self.find_primary_match_details(sequence.clone()).await?;
+                let lt = query_lower_tiers(lower_tier, &sequence, &primary_device);
+
+                let device = if let Some(approx) = approx.as_ref() {
+                    match approx.find_matches(sequence).await {
+                        Ok(side) => merge_overlap_scores(primary_device, side),
+                        Err(error) => {
+                            tracing::warn!(
+                                error = %error,
+                                "predict-on-route side indexer query failed; using primary only"
+                            );
+                            primary_device
+                        }
+                    }
+                } else {
+                    primary_device
+                };
+
                 Ok(TieredMatchDetails {
                     device,
                     lower_tier: lt,
@@ -647,6 +673,14 @@ impl Indexer {
 /// we use whichever indexer saw the longer prefix. `last_matched_hashes`,
 /// `frequencies`, and `tree_sizes` come from the primary — the side
 /// indexer's short-TTL view isn't meaningful for those signals.
+///
+/// IMPORTANT: the returned `MatchDetails` is no longer guaranteed to satisfy
+/// `overlap_scores.scores` <-> `last_matched_hashes` lockstep — side-only
+/// workers gain a score with no paired hash by design. The result is safe
+/// for scheduling / cache-hit signal but MUST NOT be used to seed
+/// `query_lower_tiers`, which assumes the lockstep invariant. The local
+/// arm of `find_matches_by_tier` enforces this by running the lower-tier
+/// query against primary-only `MatchDetails` before merging side scores.
 fn merge_overlap_scores(mut primary: MatchDetails, side: OverlapScores) -> MatchDetails {
     for (worker, side_score) in side.scores {
         primary
@@ -1008,6 +1042,139 @@ mod tests {
 
         let matches = indexer.find_matches_by_tier(block_hashes).await.unwrap();
         assert_eq!(matches.device.overlap_scores.scores.get(&worker), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn side_only_worker_scored_but_not_used_as_lower_tier_anchor() {
+        // Build an Indexer::Concurrent with a real side indexer so
+        // `record_hashed_routing_decision` populates only the side path.
+        let primary = Arc::new(ThreadPoolIndexer::new(
+            ConcurrentRadixTreeCompressed::new(),
+            2,
+            4,
+        ));
+        // PruneConfig is required to enable routing-decision recording on the
+        // side indexer; without it the routing-decision path is a no-op.
+        let side = Arc::new(ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTreeCompressed::new(),
+            1,
+            4,
+            PruneConfig {
+                ttl: Duration::from_secs(60),
+            },
+        ));
+        let side_for_flush = side.clone();
+        let indexer = Indexer::Concurrent {
+            primary,
+            lower_tier: LowerTierIndexers::new(2, 4),
+            approx: Some(super::SideIndexer::Concurrent(side)),
+        };
+
+        let primary_worker = WorkerWithDpRank::new(10, 0);
+        let side_only_worker = WorkerWithDpRank::new(20, 0);
+
+        // Primary sees blocks [11, 12, 13] on Device for primary_worker;
+        // extension block [14] on HostPinned for primary_worker.
+        indexer
+            .apply_event(store_event(
+                10,
+                0,
+                1,
+                &[],
+                &[11, 12, 13],
+                StorageTier::Device,
+            ))
+            .await;
+        indexer
+            .apply_event(store_event(
+                10,
+                0,
+                2,
+                &[11, 12, 13],
+                &[14],
+                StorageTier::HostPinned,
+            ))
+            .await;
+        // Crucially, also give side_only_worker a HostPinned extension at
+        // block 14 anchored on the same prefix [11, 12, 13]. If the lower
+        // tier were seeded from the side-merged device score, the host walk
+        // would find this and credit a hit; with the reorder it should not.
+        indexer
+            .apply_event(store_event(
+                20,
+                0,
+                3,
+                &[11, 12, 13],
+                &[14],
+                StorageTier::HostPinned,
+            ))
+            .await;
+
+        // Side-only: route a decision so the side indexer learns
+        // side_only_worker for the same device prefix. Primary never sees it.
+        let block_hashes: Vec<LocalBlockHash> =
+            [11, 12, 13].iter().copied().map(LocalBlockHash).collect();
+        let sequence_hashes = compute_seq_hash_for_block(&block_hashes);
+        indexer
+            .record_hashed_routing_decision(side_only_worker, block_hashes.clone(), sequence_hashes)
+            .await
+            .unwrap();
+
+        flush_indexer(&indexer).await;
+        side_for_flush.flush().await;
+
+        let matches = indexer
+            .find_matches_by_tier(vec![
+                LocalBlockHash(11),
+                LocalBlockHash(12),
+                LocalBlockHash(13),
+                LocalBlockHash(14),
+            ])
+            .await
+            .unwrap();
+
+        // Merge worked: both workers carry device scores.
+        assert_eq!(
+            matches
+                .device
+                .overlap_scores
+                .scores
+                .get(&primary_worker)
+                .copied(),
+            Some(3)
+        );
+        assert_eq!(
+            matches
+                .device
+                .overlap_scores
+                .scores
+                .get(&side_only_worker)
+                .copied(),
+            Some(3),
+            "side-only worker should appear in merged device scores"
+        );
+
+        // Reorder enforced: lower-tier was seeded from primary only.
+        // primary_worker still extends into HostPinned via its own device
+        // anchor. side_only_worker's HostPinned extension exists in the
+        // host tier, but because the side score wasn't used as a device
+        // anchor, the host walk does not start for it and its host hit is
+        // not credited.
+        let host = matches
+            .lower_tier
+            .get(&StorageTier::HostPinned)
+            .expect("host-pinned tier should have been allocated");
+        assert_eq!(host.hits.get(&primary_worker).copied(), Some(1));
+        assert_eq!(
+            host.hits.get(&side_only_worker).copied().unwrap_or(0),
+            0,
+            "side-only worker's host extension must not be credited \
+             when lower-tier seeding is primary-only"
+        );
+        assert!(
+            !host.next_continuations.contains_key(&side_only_worker),
+            "side-only worker must not appear in lower-tier continuations"
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -293,20 +293,7 @@ impl Indexer {
             | Self::Remote { approx, .. } => approx.as_ref(),
             Self::None => None,
         };
-
-        let Some(approx) = approx else {
-            return Ok(primary_details);
-        };
-        match approx.find_matches(sequence).await {
-            Ok(side) => Ok(merge_overlap_scores(primary_details, side)),
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    "predict-on-route side indexer query failed; using primary only"
-                );
-                Ok(primary_details)
-            }
-        }
+        Ok(merge_side_or_warn(approx, primary_details, sequence).await)
     }
 
     pub(crate) async fn find_primary_match_details(
@@ -352,21 +339,7 @@ impl Indexer {
                 // expects.
                 let primary_device = self.find_primary_match_details(sequence.clone()).await?;
                 let lt = query_lower_tiers(lower_tier, &sequence, &primary_device);
-
-                let device = if let Some(approx) = approx.as_ref() {
-                    match approx.find_matches(sequence).await {
-                        Ok(side) => merge_overlap_scores(primary_device, side),
-                        Err(error) => {
-                            tracing::warn!(
-                                error = %error,
-                                "predict-on-route side indexer query failed; using primary only"
-                            );
-                            primary_device
-                        }
-                    }
-                } else {
-                    primary_device
-                };
+                let device = merge_side_or_warn(approx.as_ref(), primary_device, sequence).await;
 
                 Ok(TieredMatchDetails {
                     device,
@@ -381,19 +354,7 @@ impl Indexer {
                         tracing::warn!(error = %e, "Remote indexer tiered query failed");
                         KvRouterError::IndexerOffline
                     })?;
-                if let Some(approx) = approx {
-                    match approx.find_matches(sequence).await {
-                        Ok(side) => {
-                            tiered.device = merge_overlap_scores(tiered.device, side);
-                        }
-                        Err(error) => {
-                            tracing::warn!(
-                                error = %error,
-                                "predict-on-route side indexer query failed; using remote primary only"
-                            );
-                        }
-                    }
-                }
+                tiered.device = merge_side_or_warn(approx.as_ref(), tiered.device, sequence).await;
                 Ok(tiered)
             }
             Self::None => Ok(TieredMatchDetails::default()),
@@ -675,7 +636,7 @@ impl Indexer {
 /// indexer's short-TTL view isn't meaningful for those signals.
 ///
 /// IMPORTANT: the returned `MatchDetails` is no longer guaranteed to satisfy
-/// `overlap_scores.scores` <-> `last_matched_hashes` lockstep — side-only
+/// `overlap_scores.scores` <-> `last_matched_hashes` lockstep. Side-only
 /// workers gain a score with no paired hash by design. The result is safe
 /// for scheduling / cache-hit signal but MUST NOT be used to seed
 /// `query_lower_tiers`, which assumes the lockstep invariant. The local
@@ -695,6 +656,37 @@ fn merge_overlap_scores(mut primary: MatchDetails, side: OverlapScores) -> Match
             .or_insert(side_score);
     }
     primary
+}
+
+/// Query the predict-on-route side indexer (if present) and merge its scores
+/// into `primary`. On query error, log a warning and return `primary` unchanged
+/// so the caller still has a usable scheduling signal. See
+/// [`merge_overlap_scores`] for the lockstep caveat on the returned shape.
+///
+/// NOTE: when this merged `MatchDetails` is combined with lower-tier hits
+/// seeded from the primary-only anchor (e.g. in `find_matches_by_tier`), the
+/// total cached-token signal can in theory overcount: the device score is
+/// raised by the side indexer but the lower-tier walk used the lower primary
+/// depth. Accepted as edge for now since side scores are short-TTL
+/// approximations and the overcount is bounded and rare in practice.
+async fn merge_side_or_warn(
+    approx: Option<&SideIndexer>,
+    primary: MatchDetails,
+    sequence: Vec<LocalBlockHash>,
+) -> MatchDetails {
+    let Some(approx) = approx else {
+        return primary;
+    };
+    match approx.find_matches(sequence).await {
+        Ok(side) => merge_overlap_scores(primary, side),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "predict-on-route side indexer query failed; using primary only"
+            );
+            primary
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`Indexer::find_matches_by_tier` (local arm) was seeding `query_lower_tiers` with a side-merged `MatchDetails`. `merge_overlap_scores` writes scores but leaves `last_matched_hashes` empty for side-only workers — that violates the score/hash lockstep invariant `query_lower_tiers` assumes:

- **Debug builds:** the `debug_assert!(false, ...)` in `lower_tier_indexers.rs:165` panics on the first side-only worker.
- **Release builds:** the assert becomes a silent `continue;`, so the side-only worker's device-block credit is dropped from the lower-tier walk and host/disk cache-hit math is under-counted.

## Fix

- `find_matches_by_tier` (KvIndexer / Concurrent arms): run `query_lower_tiers` against **primary-only** `MatchDetails`, then merge side-indexer scores into the device output afterwards. Scheduler-facing scores are unchanged; lower-tier walks see only confirmed (event-driven) anchors.
- `query_lower_tiers`: early-return when no lower-tier indexers are allocated. Saves wasted work in the common no-offload deployment and makes the function immune to non-lockstep `device_matches` when no consumer exists.
- Add a warning paragraph to `merge_overlap_scores` documenting that its output is non-lockstep by design and must not seed `query_lower_tiers`.
- `Remote` arm of `find_matches_by_tier` is unchanged — it already had the right ordering (remote primary handles its tier query, then side merges locally).
- The `debug_assert!` stays as-is — after the reorder, anything that triggers it is a genuine producer bug, so it remains a useful regression tripwire.

## Test plan

- [x] `query_lower_tiers_returns_empty_when_no_tiers_allocated` — passes a deliberately mismatched `MatchDetails` (score with no paired hash) and asserts the early-return short-circuits before the assert would fire.
- [x] `side_only_worker_scored_but_not_used_as_lower_tier_anchor` — builds an indexer where a side-only worker has HostPinned data on the same extension block as the primary worker. If the side score were used as a device anchor, the host walk would credit a hit; the test asserts `host.hits[side_only_worker] == 0` while `device.overlap_scores[side_only_worker] == 3` (merge ran).
- [x] `cargo fmt` clean
- [x] Full `kv_router::indexer::tests` suite — 9/9 passing
- [x] Full `lib/kv-router` indexer test suite — 283/283 passing
- [ ] Benchmark deferred (no algorithmic change on lookup path; happy to run a Mooncake bench on `find_matches_by_tier` with approx enabled if reviewer requests)

## Notes for reviewers

Drafted while waiting for @PeaBrane to confirm the design framing: **predict-on-route side scores are scheduling-only signal, not confirmed anchors for cross-tier extension.** If that framing changes, the fix shape would too — moving out of draft once that's settled.

Refs: DYN-3074


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query behavior when lower-tier indexers are not configured.

* **Tests**
  * Added unit test for lower-tier query handling.
  * Added regression test for overlap score merging behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->