### PR TITLE
fix: hide Harmony analysis from normal text

### DIFF
--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -122,10 +122,7 @@ fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> 
         .replace_all(&cleaned, |caps: &Captures<'_>| {
             record_special_tokens(&caps[0], &mut stripped);
             push_unique(&mut stripped, "analysis_envelope".to_string());
-            caps.name("body")
-                .map(|m| m.as_str())
-                .unwrap_or_default()
-                .to_string()
+            ""
         })
         .into_owned();
 
@@ -418,7 +415,7 @@ pub async fn parse_tool_calls_harmony_complete(
             {
                 push_harmony_text(&mut normal_text, &message.content);
             }
-        } else if matches!(channel, Some("analysis" | "final")) {
+        } else if channel == Some("final") {
             push_harmony_text(&mut normal_text, &message.content);
         }
     }
@@ -529,10 +526,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 0);
     }
 
@@ -544,10 +538,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -563,10 +554,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -599,17 +587,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_harmony_tool_only_keeps_analysis_and_final_as_normal_text() {
+    async fn test_parse_harmony_tool_only_keeps_final_as_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to check weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>final<|message|>I checked the weather.<|return|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
         assert_eq!(tool_calls.len(), 1);
-        assert_eq!(
-            normal_content,
-            Some("Need to check weather.I checked the weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("I checked the weather.".to_string()));
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_weather");
         assert_eq!(args["location"], "NYC");
@@ -719,8 +704,8 @@ mod tests {
         assert_eq!(normal, Some("".to_string()));
     }
 
-    // The regex fallback must preserve any non-tool spans (prose before
-    // the call, analysis, suffix after `<|call|>`) as `normal_text`, not zero them.
+    // The regex fallback must preserve non-tool user-visible spans (prose before
+    // the call and suffix after `<|call|>`) as `normal_text`, not zero them.
     #[tokio::test]
     async fn test_parse_harmony_regex_fallback_preserves_residual_text() {
         let text = r#"PREFIX <|channel|>analysis<|message|>Need a tool.<|end|><|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
@@ -745,8 +730,8 @@ mod tests {
             "normal must keep suffix: {normal:?}"
         );
         assert!(
-            normal.contains("Need a tool."),
-            "normal must keep analysis when only tool parsing is active: {normal:?}"
+            !normal.contains("Need a tool."),
+            "normal must not expose Harmony analysis text: {normal:?}"
         );
         assert!(
             !normal.contains("<|start|>"),
@@ -787,7 +772,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_parse_harmony_parse_failure_preserves_analysis_body() {
+    async fn test_parse_harmony_parse_failure_strips_analysis_body() {
         let text = r#"Before <|channel|>analysis<|message|>Need to call get_weather.<|end|><|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
         let (tool_calls, normal) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
@@ -795,10 +780,14 @@ mod tests {
                 .unwrap();
         assert!(tool_calls.is_empty());
         let normal = normal.unwrap_or_default();
-        assert_eq!(normal, "Before Need to call get_weather. After");
+        assert_eq!(normal, "Before  After");
         assert!(
             !normal.contains("<|channel|>"),
             "normal_text must not leak Harmony protocol tokens: {normal:?}"
+        );
+        assert!(
+            !normal.contains("Need to call get_weather."),
+            "normal_text must not expose Harmony analysis text: {normal:?}"
         );
     }
 
@@ -810,13 +799,7 @@ mod tests {
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some(
-                r#"We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function."#
-                    .to_string()
-            )
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert!(tool_calls.is_empty());
     }
 

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -1737,10 +1737,7 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
         let (result, content) = detect_and_parse_tool_call(input, Some("harmony"), None)
             .await
             .unwrap();
-        assert_eq!(
-            content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());
         assert_eq!(name, "get_current_weather");

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
@@ -23,7 +23,7 @@ cases:
         - arguments:
             location: NYC
           name: get_weather
-        normal_text: I will check the weather. Need to use function get_weather.
+        normal_text: I will check the weather.
       vllm:
         calls:
         - arguments:
@@ -49,7 +49,7 @@ cases:
         - arguments:
             location: NYC
           name: get_weather
-        normal_text: Need to use function get_weather. Let me know if you need more.
+        normal_text: Let me know if you need more.
       vllm:
         calls:
         - arguments:
@@ -64,7 +64,7 @@ cases:
         normal_text: Let me know if you need more.
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: "OpenAI Harmony channels plus Dynamo tool-only parser fallback: analysis is normally separated by a reasoning parser, but when only tool parsing is configured Dynamo preserves it in normal_text; originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220; spec https://developers.openai.com/cookbook/articles/openai-harmony#channels"
+    ref: "OpenAI Harmony: analysis is hidden and preambles should be commentary messages; originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220; spec https://developers.openai.com/cookbook/articles/openai-harmony#channels"
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
     tools:
@@ -75,7 +75,7 @@ cases:
         - arguments:
             location: NYC
           name: get_weather
-        normal_text: I will check the weather. Need to use function get_weather. Let me know if you need more.
+        normal_text: I will check the weather.  Let me know if you need more.
       vllm:
         calls:
         - arguments:
@@ -91,7 +91,7 @@ cases:
         reason: "No spec-correct winner on whitespace: analysis is correctly hidden and the same call is extracted; surrounding prose is outside Harmony messages, so whitespace is recovery-only"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
-    ref: "OpenAI Harmony channels plus Dynamo tool-only parser fallback: analysis is normally separated by a reasoning parser, but when only tool parsing is configured Dynamo preserves it in normal_text: https://developers.openai.com/cookbook/articles/openai-harmony#channels"
+    ref: "OpenAI Harmony: analysis is hidden and preambles should be commentary messages: https://developers.openai.com/cookbook/articles/openai-harmony#channels"
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Then check LA weather. <|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
@@ -106,7 +106,7 @@ cases:
         - arguments:
             location: LA
           name: get_weather
-        normal_text: I will check the weather. Need to use function get_weather. Then check LA weather.
+        normal_text: I will check the weather.  Then check LA weather.
       vllm:
         calls:
         - arguments:


### PR DESCRIPTION
#### Overview:

This PR hides Harmony `analysis` channel text from `normal_text` so batch 8 parser fixtures match the user-visible output from vLLM and SGLang.

#### Details:

- **How is this fixed?** Treat Harmony `analysis` as internal reasoning in `parse_tool_calls_harmony_complete` and in parse-failure cleanup; keep `final` channel text user-visible.
- Update Harmony parser unit expectations so tool-only and fallback cases no longer expose analysis text.
- Update `tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml` so Dynamo expected output matches the peer hidden-analysis behavior for `8.a` through `8.d`.
- Concrete failure mode: Dynamo returned `Need to use function get_weather.` inside `normal_text`, while vLLM/SGLang returned only the surrounding user-visible prose.

#### Verification:

`cargo test --locked -p dynamo-parsers harmony_parser -- --nocapture` passed in the dynamo2 devcontainer; `PYTHONPATH=lib/bindings/python/src python3 -m pytest tests/parity/parser/test_parity_parser.py -q -k "harmony and PARSER.batch.8"` passed with 8 passed / 4 skipped because SGLang is not installed; `python3 -m pytest tests/parity/parser/test_generate_parity_chart.py -q` passed in the devcontainer.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/harmony/harmony_parser.rs`, then `tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml`

#### Related Issues:

Relates to OPS-6052, OPS-6053, OPS-6054, OPS-6055

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Harmony parser now correctly excludes analysis protocol content from normal text output. The parser has been updated to process only final message content, preventing analysis metadata and explanatory text from appearing in extracted results. This provides cleaner and more focused text output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->