### PR TITLE
fix: preserve tool_calls for tool_choice=required with reasoning

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1540,17 +1540,20 @@ impl OpenAIPreprocessor {
                 Some("kimi_k25")
             );
 
-        // tool_choice=required/named forces the backend into guided decoding,
-        // which constrains output to a bare JSON shape with no reasoning
-        // wrapper. Running the reasoning parser on that output is both
-        // pointless (nothing to extract) and actively harmful for parsers
-        // that inject a `<think>` prefix unconditionally (e.g. MiniMax
-        // append-think), because the prefix would contaminate the
-        // tool-call JSON fed into the jail.
-        let tool_choice_forces_guided_json = matches!(
+        // Under guided-decoding (tool_choice=required/named), only force-
+        // reasoning parsers must skip — they treat the bare JSON output as
+        // reasoning_content and starve the jail. Non-force-reasoning parsers
+        // (qwen3, deepseek_v4, glm45, etc.) are safe to run: vLLM's
+        // reasoner-gate allows free generation during `<think>...</think>`
+        // before clamping to the guided grammar, so the model emits
+        // `<reasoning></think><JSON>` and the parser strips the prefix so the
+        // jail sees pure JSON.
+        let skip_reasoning_for_guided_json = matches!(
             request.inner.tool_choice,
             Some(ChatCompletionToolChoiceOption::Required)
                 | Some(ChatCompletionToolChoiceOption::Named(_))
+        ) && Self::is_force_reasoning_parser(
+            self.runtime_config.reasoning_parser.as_deref(),
         );
 
         let reasoning_disabled_by_request = Self::is_reasoning_disabled_by_request(
@@ -1562,11 +1565,11 @@ impl OpenAIPreprocessor {
         let should_parse_reasoning = self.runtime_config.reasoning_parser.is_some()
             && !reasoning_disabled_by_request
             && !suppress_reasoning_after_tool
-            && !tool_choice_forces_guided_json;
+            && !skip_reasoning_for_guided_json;
         let should_strip_disabled_reasoning_start = reasoning_disabled_by_request
             && Self::is_nemotron_force_reasoning(self.runtime_config.reasoning_parser.as_deref())
             && !suppress_reasoning_after_tool
-            && !tool_choice_forces_guided_json;
+            && !skip_reasoning_for_guided_json;
 
         // Reasoning Content Parsing Transformation Step
         // Current Solution:
@@ -2060,6 +2063,26 @@ impl OpenAIPreprocessor {
         matches!(
             reasoning_parser,
             Some("nemotron_nano" | "nemotron3" | "nemotron_v3")
+        )
+    }
+
+    /// Parsers that begin streaming in reasoning mode (force_reasoning=true).
+    /// These swallow any leading text without an open `<think>` tag as
+    /// reasoning_content, so they cannot run on guided-decoding output where
+    /// the model emits bare JSON from token 0.
+    fn is_force_reasoning_parser(reasoning_parser: Option<&str>) -> bool {
+        matches!(
+            reasoning_parser,
+            Some(
+                "deepseek_r1"
+                    | "step3"
+                    | "kimi_k25"
+                    | "mistral"
+                    | "minimax_append_think"
+                    | "nemotron_nano"
+                    | "nemotron3"
+                    | "nemotron_v3"
+            )
         )
     }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1548,13 +1548,12 @@ impl OpenAIPreprocessor {
         // before clamping to the guided grammar, so the model emits
         // `<reasoning></think><JSON>` and the parser strips the prefix so the
         // jail sees pure JSON.
-        let skip_reasoning_for_guided_json = matches!(
-            request.inner.tool_choice,
-            Some(ChatCompletionToolChoiceOption::Required)
-                | Some(ChatCompletionToolChoiceOption::Named(_))
-        ) && Self::is_force_reasoning_parser(
-            self.runtime_config.reasoning_parser.as_deref(),
-        );
+        let skip_reasoning_for_guided_json =
+            matches!(
+                request.inner.tool_choice,
+                Some(ChatCompletionToolChoiceOption::Required)
+                    | Some(ChatCompletionToolChoiceOption::Named(_))
+            ) && Self::is_force_reasoning_parser(self.runtime_config.reasoning_parser.as_deref());
 
         let reasoning_disabled_by_request = Self::is_reasoning_disabled_by_request(
             self.runtime_config.reasoning_parser.as_deref(),

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -563,6 +563,11 @@ impl JailedStream {
         JailedStreamBuilder::new()
     }
 
+    /// Whether the jail starts already-jailed (tool_choice=required/named path).
+    fn is_immediate(&self) -> bool {
+        matches!(self.jail_mode, JailMode::Immediate { .. })
+    }
+
     /// Apply jail stream transformation with finish_reason fix
     /// This is a convenience method that applies both apply() and fix_finish_reason()
     pub fn apply_with_finish_reason<S>(
@@ -630,8 +635,8 @@ impl JailedStream {
                             };
 
                             if let Some(text) = text_content {
-                                let starts_jailed = matches!(self.jail_mode, JailMode::Immediate { .. });
-                                let choice_state = choice_states.get_or_create_state(choice.index, starts_jailed);
+                                let choice_state = choice_states
+                                    .get_or_create_state(choice.index, self.is_immediate());
 
                                 if let Some(reasoning_content) = &choice.delta.reasoning_content {
                                     let pending = choice_state
@@ -663,10 +668,17 @@ impl JailedStream {
                             }
                             // For multimodal content, pass through unchanged (no jailing)
                         } else {
-                            // Handle choices without content (e.g., final chunks with finish_reason)
-                            // Only filter out if this choice was ever jailed and lacks role
-                            // (to avoid aggregator issues with deltas missing role after unjail)
-                            let choice_state = choice_states.get_or_create_state(choice.index, false);
+                            // Handle choices without content (final chunks with finish_reason,
+                            // role-only chunks, or chunks where the upstream reasoning parser
+                            // stripped all content into `reasoning_content`).
+                            //
+                            // `starts_jailed` must reflect the configured jail_mode: if Immediate
+                            // mode is initialized via this branch (e.g., a reasoning-only first
+                            // chunk), hardcoding `false` here silently disables it for the rest
+                            // of the stream — `get_or_create_state` ignores the argument on
+                            // subsequent calls.
+                            let choice_state = choice_states
+                                .get_or_create_state(choice.index, self.is_immediate());
                             // Also track stream finish reason from content-less final chunks
                             // (e.g. finish_reason=Stop arriving in a chunk with content=None) so
                             // the Immediate-mode finalize path can emit the correct finish_reason.
@@ -675,9 +687,12 @@ impl JailedStream {
                             }
                             let was_ever_jailed = !choice_state.accumulated_content.is_empty() || choice_state.is_jailed;
 
+                            // Reasoning-only chunks must pass through even when jailed; only
+                            // `content` is subject to accumulation.
                             let should_emit = choice.delta.role.is_some()
                                 || choice.delta.tool_calls.is_some()
-                                || !was_ever_jailed; // Always pass through if never jailed
+                                || choice.delta.reasoning_content.is_some()
+                                || !was_ever_jailed;
 
                             if should_emit {
                                 let pass_through_choice = ChatChoiceStream {

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -80,7 +80,7 @@ fn get_text(content: &ChatCompletionMessageContent) -> &str {
 }
 
 /// Accumulates streamed tool call deltas into complete tool calls for assertion.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 struct MergedToolCall {
     id: Option<String>,
     r#type: Option<String>,
@@ -337,6 +337,45 @@ fn mock_multi_choice_content_chunk(
         inner: CreateChatCompletionStreamResponse {
             id: "test-id".to_string(),
             choices,
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        },
+        nvext: None,
+    }
+}
+
+/// Construct a chunk that carries only `reasoning_content` (no text delta).
+/// Mirrors what upstream `parse_reasoning_content_from_stream` emits while the
+/// model is still inside `<think>...</think>` — used by the DIS-2061 matrix
+/// to exercise the jail's `Immediate` mode initialization when the first
+/// chunk for a choice has `delta.content=None`.
+fn mock_reasoning_only_chunk(reasoning: &str) -> NvCreateChatCompletionStreamResponse {
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
+        Role,
+    };
+    #[allow(deprecated)]
+    let choice = ChatChoiceStream {
+        index: 0,
+        delta: ChatCompletionStreamResponseDelta {
+            role: Some(Role::Assistant),
+            content: None,
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: Some(reasoning.to_string()),
+        },
+        finish_reason: None,
+        logprobs: None,
+    };
+    NvCreateChatCompletionStreamResponse {
+        inner: CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices: vec![choice],
             created: 0,
             model: "test-model".to_string(),
             system_fingerprint: None,
@@ -1154,4 +1193,325 @@ async fn postprocessor_parsing_stream_minimax_named_bare_parameters() {
         args,
         serde_json::json!({"location": "Paris", "unit": "celsius"})
     );
+}
+
+// ===== DIS-2061 matrix tests =====
+//
+// Cross-cuts guided tool-choice × reasoning-parser family × prompt injection
+// × backend output shape. See the PR review for the matrix design. Each row
+// asserts: (a) tool_calls extracted with the expected arguments, (b) raw
+// JSON / `<think>` markers don't leak into client-visible `content`, and
+// (c) `reasoning_content` contains only the reasoning text (or is empty
+// when no reasoning is expected).
+
+/// Tools list used by all matrix rows. Single `get_weather(location)` tool
+/// so we can vary inputs without redefining the schema each time.
+fn matrix_tools() -> Vec<dynamo_protocols::types::ChatCompletionTool> {
+    serde_json::from_value(serde_json::json!([{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"]
+            }
+        }
+    }]))
+    .unwrap()
+}
+
+/// Build a minimal streaming request preconfigured with tools and
+/// `tool_choice`. Used by every matrix row.
+fn matrix_request(
+    tool_choice: ChatCompletionToolChoiceOption,
+) -> NvCreateChatCompletionRequest {
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "What's the weather in San Francisco?"}],
+        "stream": true,
+        "temperature": 0.0
+    }))
+    .unwrap();
+    request.inner.tools = Some(matrix_tools());
+    request.inner.tool_choice = Some(tool_choice);
+    request
+}
+
+/// Drain a postprocessed stream into `(reasoning, content, tool_calls,
+/// finish_reasons)`. The matrix rows assert against these four buckets.
+async fn drain_stream(
+    output_stream: impl futures::Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
+) -> (String, String, Vec<MergedToolCall>, Vec<FinishReason>) {
+    let output_chunks: Vec<_> = Box::pin(output_stream).collect().await;
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    let mut merged: BTreeMap<u32, MergedToolCall> = BTreeMap::new();
+    let mut finish_reasons = Vec::new();
+
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+            if let Some(tcs) = &choice.delta.tool_calls {
+                for tc in tcs {
+                    merged.entry(tc.index).or_default().merge_from(tc);
+                }
+            }
+            if let Some(fr) = choice.finish_reason {
+                finish_reasons.push(fr);
+            }
+        }
+    }
+    let tool_calls: Vec<MergedToolCall> = merged.values().cloned().collect();
+    (reasoning, content, tool_calls, finish_reasons)
+}
+
+/// Assert the standard "tool call extracted, nothing leaks" success shape
+/// shared by every matrix row that expects a successful extraction.
+fn assert_clean_tool_call(
+    case: &str,
+    content: &str,
+    tool_calls: &[MergedToolCall],
+    expected_location: &str,
+) {
+    assert!(
+        !content.contains("get_weather"),
+        "{case}: tool-call JSON must not leak into content, got: {content:?}"
+    );
+    assert!(
+        !content.contains("<think>") && !content.contains("</think>"),
+        "{case}: think markers must not leak into content, got: {content:?}"
+    );
+    assert_eq!(tool_calls.len(), 1, "{case}: expected one tool call");
+    assert_eq!(
+        tool_calls[0].name.as_deref(),
+        Some("get_weather"),
+        "{case}: wrong tool name"
+    );
+    let args: Value = serde_json::from_str(&tool_calls[0].arguments)
+        .unwrap_or_else(|e| panic!("{case}: arguments not valid JSON: {e}"));
+    assert_eq!(
+        args,
+        serde_json::json!({"location": expected_location}),
+        "{case}: wrong arguments"
+    );
+}
+
+/// CASE 1a + 1b — force-reasoning parser + tool_choice=required + bare JSON,
+/// with both `prompt_injected_reasoning` values. The gate skips the reasoning
+/// parser regardless, so the bare JSON reaches the jail unmolested.
+#[tokio::test]
+async fn dis2061_matrix_force_reasoning_required_bare_json() {
+    let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+
+    for (case, prompt_injected) in [
+        ("1a: force-reasoning + required + prompt_injected=false", false),
+        ("1b: force-reasoning + required + prompt_injected=true", true),
+    ] {
+        let preprocessor = build_preprocessor(Some("nemotron_nano"), Some("nemotron_nano"));
+        let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(bare_json), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_stream = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, prompt_injected)
+            .expect("postprocessor_parsing_stream should build");
+        let (reasoning, content, tool_calls, finish_reasons) = drain_stream(output_stream).await;
+
+        assert!(
+            reasoning.is_empty(),
+            "{case}: reasoning_content must be empty when parser is skipped, got: {reasoning:?}"
+        );
+        assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+        assert!(
+            finish_reasons.contains(&FinishReason::ToolCalls),
+            "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+        );
+    }
+}
+
+/// CASE 2 — force-reasoning parser + tool_choice=named + bare JSON.
+/// Same skip-the-parser logic as `Required`, exercised through the `Named`
+/// arm of the gate.
+#[tokio::test]
+async fn dis2061_matrix_force_reasoning_named_bare_json() {
+    use dynamo_protocols::types::{ChatCompletionNamedToolChoice, FunctionName};
+
+    let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let preprocessor = build_preprocessor(Some("nemotron_nano"), Some("nemotron_nano"));
+    let request = matrix_request(ChatCompletionToolChoiceOption::Named(
+        ChatCompletionNamedToolChoice {
+            r#type: dynamo_protocols::types::ChatCompletionToolType::Function,
+            function: FunctionName {
+                name: "get_weather".to_string(),
+            },
+        },
+    ));
+
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(bare_json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true)
+        .expect("postprocessor_parsing_stream should build");
+    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+
+    let case = "2: force-reasoning + named + bare JSON";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: reasoning_content must be empty, got: {reasoning:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+}
+
+/// CASE 3 — non-force parser + required + `prompt_injected_reasoning=false`
+/// + bare JSON. Parser runs but stays in non-reasoning mode (no `<think>`
+/// start token in the stream), so the bare JSON flows through as
+/// `normal_text` and reaches the jail intact.
+#[tokio::test]
+async fn dis2061_matrix_non_force_required_no_injection_bare_json() {
+    let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
+    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(bare_json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false)
+        .expect("postprocessor_parsing_stream should build");
+    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+
+    let case = "3: non-force + required + prompt_injected=false + bare JSON";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: parser must not produce reasoning when no <think> seen, got: {reasoning:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+}
+
+/// CASE 4 — non-force parser + required + `prompt_injected_reasoning=true`
+/// + `<reasoning></think>[json]` (the Qwen3.x production shape). Parser
+/// strips the reasoning prefix into `reasoning_content`; the JSON after
+/// `</think>` reaches the jail. Verified end-to-end against
+/// Qwen3.6-35B-A3B-FP8 — this is the case DIS-2061 set out to fix.
+#[tokio::test]
+async fn dis2061_matrix_non_force_required_prompt_injected_with_close_marker() {
+    let stream_text = r#"Let me check.</think>[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
+    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(stream_text), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true)
+        .expect("postprocessor_parsing_stream should build");
+    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+
+    let case = "4: non-force + required + prompt_injected=true + reasoning</think>JSON";
+    assert_eq!(
+        reasoning.trim(),
+        "Let me check.",
+        "{case}: reasoning_content should hold only the pre-</think> text, got: {reasoning:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+}
+
+/// CASE 5 — non-force parser + required + `prompt_injected_reasoning=true`
+/// + bare JSON (no `</think>`). Documents the **backend contract** rather
+/// than asserting recovery: when `--dyn-reasoning-parser X` is set, vLLM's
+/// auto-forward in `components/src/dynamo/vllm/main.py:506-507` instantiates
+/// a reasoner whose `should_fill_bitmask` gate (vLLM
+/// `v1/structured_output/__init__.py:301`) keeps the xgrammar bitmask off
+/// until `</think>` appears in the output. Consequently any "bare guided
+/// JSON" emitted before `</think>` was never grammar-constrained — it's a
+/// backend-bug shape, not a normal production output.
+///
+/// This test pins the current behavior so future regressions are loud: if
+/// we later add an EOF fallback to `BasicReasoningParser` to flush
+/// accumulated reasoning as content, this assertion needs to flip.
+#[tokio::test]
+async fn dis2061_matrix_non_force_required_prompt_injected_bare_json_contract() {
+    let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
+    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(bare_json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true)
+        .expect("postprocessor_parsing_stream should build");
+    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+
+    let case = "5 (contract): non-force + required + prompt_injected=true + bare JSON";
+    // Backend contract: this shape shouldn't happen with a properly configured
+    // vLLM reasoner. If it does, the parser consumes the bare JSON as reasoning,
+    // tool_calls comes out empty, and content is empty. Pinning this so an EOF
+    // fallback (future) consciously updates the expectations.
+    assert!(
+        tool_calls.is_empty(),
+        "{case}: contract case currently extracts no tool_calls (backend bug shape), got: {tool_calls:?}"
+    );
+    assert!(
+        content.is_empty(),
+        "{case}: content must remain empty (no leak), got: {content:?}"
+    );
+    assert!(
+        reasoning.contains("get_weather"),
+        "{case}: parser pins the JSON in reasoning_content under the broken contract, got: {reasoning:?}"
+    );
+}
+
+/// CASE 6 — Immediate jail mode + first chunk has only `reasoning_content`
+/// (no text delta) + JSON arrives in a later chunk. Regression for the
+/// `jail.rs:678` fix: before the fix, the else branch hardcoded
+/// `starts_jailed=false`, silently disabling Immediate mode whenever the
+/// first chunk for a choice initialized through the no-content path. After
+/// the fix, the state respects `JailMode::Immediate` and the JSON in the
+/// later chunk is captured by the jail.
+#[tokio::test]
+async fn dis2061_matrix_immediate_jail_reasoning_only_first_chunk() {
+    let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
+    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![
+            mock_reasoning_only_chunk("thinking briefly"),
+            mock_content_chunk(bare_json),
+            mock_final_chunk(),
+        ]
+        .into_iter()
+        .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false)
+        .expect("postprocessor_parsing_stream should build");
+    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+
+    let case = "6: Immediate jail + reasoning-only first chunk + JSON later";
+    assert!(
+        reasoning.contains("thinking briefly"),
+        "{case}: reasoning_content from the first chunk must reach the client, got: {reasoning:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
 }

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -868,13 +868,19 @@ async fn postprocessor_parsing_stream_minimax_required_bypasses_reasoning() {
 /// Mirrors dynamo-deploy smoke_test.py::case_completions_tool_call_required:
 /// "What is the weather in San Francisco?" with `tool_choice="required"` and
 /// the `get_weather` tool. The backend emits a bare guided-decoding JSON
-/// payload, so the postprocessor must bypass reasoning extraction even when
-/// both a Nemotron reasoning parser and a Nemotron tool parser are configured.
-/// The JSON must be consumed by the tool jail, not surfaced as content or
-/// `reasoning_content`.
+/// payload; the JSON must be consumed by the tool jail, not surfaced as
+/// content or `reasoning_content`. Two parser families:
+///   * `nemotron_nano` is force-reasoning, so the preprocessor skips reasoning
+///     parsing entirely under `tool_choice=required`. `prompt_injected_reasoning`
+///     is moot.
+///   * `nemotron_deci` is non-force-reasoning (alias for the basic_parser shape
+///     also used by `glm45`).
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_required_smoke_case() {
-    for (case, parser) in [("nano", "nemotron_nano"), ("super/deci", "nemotron_deci")] {
+    for (case, parser, prompt_injected_reasoning) in [
+        ("nano", "nemotron_nano", true),
+        ("super/deci", "nemotron_deci", false),
+    ] {
         let preprocessor = build_preprocessor(Some(parser), Some(parser));
 
         let mut request: NvCreateChatCompletionRequest =
@@ -914,7 +920,7 @@ async fn postprocessor_parsing_stream_nemotron_required_smoke_case() {
 
         let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
         let output_stream = preprocessor
-            .postprocessor_parsing_stream(input_stream, &request, true)
+            .postprocessor_parsing_stream(input_stream, &request, prompt_injected_reasoning)
             .expect("postprocessor_parsing_stream should build");
 
         let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -12,7 +12,8 @@ use dynamo_llm::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
 };
 use dynamo_protocols::types::{
-    ChatCompletionMessageContent, ChatCompletionToolChoiceOption, FinishReason,
+    ChatCompletionMessageContent, ChatCompletionNamedToolChoice, ChatCompletionTool,
+    ChatCompletionToolChoiceOption, ChatCompletionToolType, FinishReason, FunctionName,
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{StreamExt, stream};
@@ -350,9 +351,9 @@ fn mock_multi_choice_content_chunk(
 
 /// Construct a chunk that carries only `reasoning_content` (no text delta).
 /// Mirrors what upstream `parse_reasoning_content_from_stream` emits while the
-/// model is still inside `<think>...</think>` — used by the DIS-2061 matrix
-/// to exercise the jail's `Immediate` mode initialization when the first
-/// chunk for a choice has `delta.content=None`.
+/// model is still inside `<think>...</think>`; exercises the jail's
+/// `Immediate` mode initialization when the first chunk for a choice has
+/// `delta.content=None`.
 fn mock_reasoning_only_chunk(reasoning: &str) -> NvCreateChatCompletionStreamResponse {
     use dynamo_protocols::types::{
         ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
@@ -1195,18 +1196,12 @@ async fn postprocessor_parsing_stream_minimax_named_bare_parameters() {
     );
 }
 
-// ===== DIS-2061 matrix tests =====
-//
-// Cross-cuts guided tool-choice × reasoning-parser family × prompt injection
-// × backend output shape. See the PR review for the matrix design. Each row
-// asserts: (a) tool_calls extracted with the expected arguments, (b) raw
-// JSON / `<think>` markers don't leak into client-visible `content`, and
-// (c) `reasoning_content` contains only the reasoning text (or is empty
-// when no reasoning is expected).
+// Guided tool-choice × reasoning-parser family × prompt injection × backend
+// output shape. Each row asserts: tool_calls extracted correctly, no JSON
+// or <think> leakage into content, reasoning_content holds only reasoning.
 
-/// Tools list used by all matrix rows. Single `get_weather(location)` tool
-/// so we can vary inputs without redefining the schema each time.
-fn matrix_tools() -> Vec<dynamo_protocols::types::ChatCompletionTool> {
+/// Single `get_weather(location)` tool shared by every matrix row.
+fn single_weather_tool() -> Vec<ChatCompletionTool> {
     serde_json::from_value(serde_json::json!([{
         "type": "function",
         "function": {
@@ -1224,9 +1219,8 @@ fn matrix_tools() -> Vec<dynamo_protocols::types::ChatCompletionTool> {
     .unwrap()
 }
 
-/// Build a minimal streaming request preconfigured with tools and
-/// `tool_choice`. Used by every matrix row.
-fn matrix_request(
+/// Streaming chat completion request preconfigured with the matrix tool.
+fn streaming_tool_request(
     tool_choice: ChatCompletionToolChoiceOption,
 ) -> NvCreateChatCompletionRequest {
     let mut request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
@@ -1236,16 +1230,21 @@ fn matrix_request(
         "temperature": 0.0
     }))
     .unwrap();
-    request.inner.tools = Some(matrix_tools());
+    request.inner.tools = Some(single_weather_tool());
     request.inner.tool_choice = Some(tool_choice);
     request
 }
 
-/// Drain a postprocessed stream into `(reasoning, content, tool_calls,
-/// finish_reasons)`. The matrix rows assert against these four buckets.
+struct DrainOutput {
+    reasoning: String,
+    content: String,
+    tool_calls: Vec<MergedToolCall>,
+    finish_reasons: Vec<FinishReason>,
+}
+
 async fn drain_stream(
     output_stream: impl futures::Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
-) -> (String, String, Vec<MergedToolCall>, Vec<FinishReason>) {
+) -> DrainOutput {
     let output_chunks: Vec<_> = Box::pin(output_stream).collect().await;
     let mut reasoning = String::new();
     let mut content = String::new();
@@ -1273,8 +1272,12 @@ async fn drain_stream(
             }
         }
     }
-    let tool_calls: Vec<MergedToolCall> = merged.values().cloned().collect();
-    (reasoning, content, tool_calls, finish_reasons)
+    DrainOutput {
+        reasoning,
+        content,
+        tool_calls: merged.values().cloned().collect(),
+        finish_reasons,
+    }
 }
 
 /// Assert the standard "tool call extracted, nothing leaks" success shape
@@ -1308,11 +1311,10 @@ fn assert_clean_tool_call(
     );
 }
 
-/// CASE 1a + 1b — force-reasoning parser + tool_choice=required + bare JSON,
-/// with both `prompt_injected_reasoning` values. The gate skips the reasoning
-/// parser regardless, so the bare JSON reaches the jail unmolested.
+/// Force-reasoning parser + required + bare JSON, both prompt_injected values.
+/// Gate skips reasoning regardless; jail extracts the tool call.
 #[tokio::test]
-async fn dis2061_matrix_force_reasoning_required_bare_json() {
+async fn tool_choice_matrix_force_reasoning_required_bare_json() {
     let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
 
     for (case, prompt_injected) in [
@@ -1320,7 +1322,7 @@ async fn dis2061_matrix_force_reasoning_required_bare_json() {
         ("1b: force-reasoning + required + prompt_injected=true", true),
     ] {
         let preprocessor = build_preprocessor(Some("nemotron_nano"), Some("nemotron_nano"));
-        let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+        let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
         let input_stream = stream::iter(
             vec![mock_content_chunk(bare_json), mock_final_chunk()]
                 .into_iter()
@@ -1329,7 +1331,12 @@ async fn dis2061_matrix_force_reasoning_required_bare_json() {
         let output_stream = preprocessor
             .postprocessor_parsing_stream(input_stream, &request, prompt_injected)
             .expect("postprocessor_parsing_stream should build");
-        let (reasoning, content, tool_calls, finish_reasons) = drain_stream(output_stream).await;
+        let DrainOutput {
+            reasoning,
+            content,
+            tool_calls,
+            finish_reasons,
+        } = drain_stream(output_stream).await;
 
         assert!(
             reasoning.is_empty(),
@@ -1343,18 +1350,14 @@ async fn dis2061_matrix_force_reasoning_required_bare_json() {
     }
 }
 
-/// CASE 2 — force-reasoning parser + tool_choice=named + bare JSON.
-/// Same skip-the-parser logic as `Required`, exercised through the `Named`
-/// arm of the gate.
+/// Force-reasoning parser + named + bare JSON; same skip path as Required.
 #[tokio::test]
-async fn dis2061_matrix_force_reasoning_named_bare_json() {
-    use dynamo_protocols::types::{ChatCompletionNamedToolChoice, FunctionName};
-
+async fn tool_choice_matrix_force_reasoning_named_bare_json() {
     let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
     let preprocessor = build_preprocessor(Some("nemotron_nano"), Some("nemotron_nano"));
-    let request = matrix_request(ChatCompletionToolChoiceOption::Named(
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Named(
         ChatCompletionNamedToolChoice {
-            r#type: dynamo_protocols::types::ChatCompletionToolType::Function,
+            r#type: ChatCompletionToolType::Function,
             function: FunctionName {
                 name: "get_weather".to_string(),
             },
@@ -1369,7 +1372,12 @@ async fn dis2061_matrix_force_reasoning_named_bare_json() {
     let output_stream = preprocessor
         .postprocessor_parsing_stream(input_stream, &request, true)
         .expect("postprocessor_parsing_stream should build");
-    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
 
     let case = "2: force-reasoning + named + bare JSON";
     assert!(
@@ -1379,15 +1387,13 @@ async fn dis2061_matrix_force_reasoning_named_bare_json() {
     assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
 }
 
-/// CASE 3 — non-force parser + required + `prompt_injected_reasoning=false`
-/// + bare JSON. Parser runs but stays in non-reasoning mode (no `<think>`
-/// start token in the stream), so the bare JSON flows through as
-/// `normal_text` and reaches the jail intact.
+/// Non-force parser + required + no prompt injection + bare JSON: parser
+/// runs in non-reasoning mode and passes JSON through.
 #[tokio::test]
-async fn dis2061_matrix_non_force_required_no_injection_bare_json() {
+async fn tool_choice_matrix_non_force_required_no_injection_bare_json() {
     let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
     let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
-    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
     let input_stream = stream::iter(
         vec![mock_content_chunk(bare_json), mock_final_chunk()]
             .into_iter()
@@ -1396,7 +1402,12 @@ async fn dis2061_matrix_non_force_required_no_injection_bare_json() {
     let output_stream = preprocessor
         .postprocessor_parsing_stream(input_stream, &request, false)
         .expect("postprocessor_parsing_stream should build");
-    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
 
     let case = "3: non-force + required + prompt_injected=false + bare JSON";
     assert!(
@@ -1406,16 +1417,14 @@ async fn dis2061_matrix_non_force_required_no_injection_bare_json() {
     assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
 }
 
-/// CASE 4 — non-force parser + required + `prompt_injected_reasoning=true`
-/// + `<reasoning></think>[json]` (the Qwen3.x production shape). Parser
-/// strips the reasoning prefix into `reasoning_content`; the JSON after
-/// `</think>` reaches the jail. Verified end-to-end against
-/// Qwen3.6-35B-A3B-FP8 — this is the case DIS-2061 set out to fix.
+/// Non-force parser + required + reasoning</think>JSON (the Qwen3.x production
+/// shape; verified end-to-end against Qwen3.6-35B-A3B-FP8). Parser strips
+/// reasoning, jail gets JSON.
 #[tokio::test]
-async fn dis2061_matrix_non_force_required_prompt_injected_with_close_marker() {
+async fn tool_choice_matrix_non_force_required_prompt_injected_with_close_marker() {
     let stream_text = r#"Let me check.</think>[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
     let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
-    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
     let input_stream = stream::iter(
         vec![mock_content_chunk(stream_text), mock_final_chunk()]
             .into_iter()
@@ -1424,7 +1433,12 @@ async fn dis2061_matrix_non_force_required_prompt_injected_with_close_marker() {
     let output_stream = preprocessor
         .postprocessor_parsing_stream(input_stream, &request, true)
         .expect("postprocessor_parsing_stream should build");
-    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
 
     let case = "4: non-force + required + prompt_injected=true + reasoning</think>JSON";
     assert_eq!(
@@ -1449,10 +1463,10 @@ async fn dis2061_matrix_non_force_required_prompt_injected_with_close_marker() {
 /// we later add an EOF fallback to `BasicReasoningParser` to flush
 /// accumulated reasoning as content, this assertion needs to flip.
 #[tokio::test]
-async fn dis2061_matrix_non_force_required_prompt_injected_bare_json_contract() {
+async fn tool_choice_matrix_non_force_required_prompt_injected_bare_json_contract() {
     let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
     let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
-    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
     let input_stream = stream::iter(
         vec![mock_content_chunk(bare_json), mock_final_chunk()]
             .into_iter()
@@ -1461,13 +1475,14 @@ async fn dis2061_matrix_non_force_required_prompt_injected_bare_json_contract() 
     let output_stream = preprocessor
         .postprocessor_parsing_stream(input_stream, &request, true)
         .expect("postprocessor_parsing_stream should build");
-    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
 
     let case = "5 (contract): non-force + required + prompt_injected=true + bare JSON";
-    // Backend contract: this shape shouldn't happen with a properly configured
-    // vLLM reasoner. If it does, the parser consumes the bare JSON as reasoning,
-    // tool_calls comes out empty, and content is empty. Pinning this so an EOF
-    // fallback (future) consciously updates the expectations.
     assert!(
         tool_calls.is_empty(),
         "{case}: contract case currently extracts no tool_calls (backend bug shape), got: {tool_calls:?}"
@@ -1490,10 +1505,10 @@ async fn dis2061_matrix_non_force_required_prompt_injected_bare_json_contract() 
 /// the fix, the state respects `JailMode::Immediate` and the JSON in the
 /// later chunk is captured by the jail.
 #[tokio::test]
-async fn dis2061_matrix_immediate_jail_reasoning_only_first_chunk() {
+async fn tool_choice_matrix_immediate_jail_reasoning_only_first_chunk() {
     let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
     let preprocessor = build_preprocessor(Some("qwen3"), Some("hermes"));
-    let request = matrix_request(ChatCompletionToolChoiceOption::Required);
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
     let input_stream = stream::iter(
         vec![
             mock_reasoning_only_chunk("thinking briefly"),
@@ -1506,7 +1521,12 @@ async fn dis2061_matrix_immediate_jail_reasoning_only_first_chunk() {
     let output_stream = preprocessor
         .postprocessor_parsing_stream(input_stream, &request, false)
         .expect("postprocessor_parsing_stream should build");
-    let (reasoning, content, tool_calls, _) = drain_stream(output_stream).await;
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
 
     let case = "6: Immediate jail + reasoning-only first chunk + JSON later";
     assert!(

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1318,8 +1318,14 @@ async fn tool_choice_matrix_force_reasoning_required_bare_json() {
     let bare_json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
 
     for (case, prompt_injected) in [
-        ("1a: force-reasoning + required + prompt_injected=false", false),
-        ("1b: force-reasoning + required + prompt_injected=true", true),
+        (
+            "1a: force-reasoning + required + prompt_injected=false",
+            false,
+        ),
+        (
+            "1b: force-reasoning + required + prompt_injected=true",
+            true,
+        ),
     ] {
         let preprocessor = build_preprocessor(Some("nemotron_nano"), Some("nemotron_nano"));
         let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);


### PR DESCRIPTION
#### Overview:

As title
#### Details:

#### Where should the reviewer start?
Two interlocking bugs caused tool_choice=required to leak the entire model output as text (tool_calls=None) when paired with a reasoning parser:

  1. preprocessor.rs gated the reasoning parser off for every required/named request regardless of parser type. The assumption only holds for force-reasoning parsers (MiniMax append-think, nemotron force-reasoning aliases, etc.) which would otherwise consume the bare JSON as reasoning_content. Non-force-reasoning parsers (qwen3, deepseek_v4, glm45, gemma4, granite, gpt_oss, kimi original) must keep running to strip the \`<think>...</think>\` prefix that vLLM's reasoner-gate allows during guided decoding.

  2. jail.rs hardcoded starts_jailed=false in the else branch that handles chunks without delta.content. Once the reasoning parser strips content into delta.reasoning_content, the first chunk initializing the choice state went through that branch, silently disabling Immediate jail mode for the rest of the stream — get_or_create_state ignores the argument on subsequent calls. Also widen should_emit so reasoning-only chunks aren't dropped while jailed.

  Fixes DIS-2061.

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

Test Plan:
Start worker with
`python -m dynamo.vllm     --model Qwen/Qwen3.6-35B-A3B-FP8     --trust-remote-code     --dyn-tool-call-parser qwen3_coder     --dyn-reasoning-parser qwen3     --mamba-cache-mode align  --reasoning-parser qwen3   --is-decode-worker     --no-enable-prefix-caching     --tensor-parallel-size 1     --max-model-len 8192     --gpu-memory-utilization 0.95
`
Send request
`python repro.py --base-url http://localhost:8000 --model "Qwen/Qwen3.6-35B-A3B-FP8" --runs 20`

Before:
0/20 Pass

After:
20/20 Pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined reasoning content handling to distinguish between different reasoning parser types when using guided decoding with required or named tool choices.
  * Improved consistency in jail state initialization for immediate modes.
  * Enhanced reasoning content emission in constrained output scenarios.

* **Tests**
  * Updated regression tests to validate parser-specific behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->