### PR TITLE
fix(parsers): Qwen3-Coder large int overflow in XML tool parsing

### DIFF
--- a/lib/parsers/PARSER_CASES.md
+++ b/lib/parsers/PARSER_CASES.md
@@ -311,6 +311,9 @@ splits along four type-handling axes:
   empty nested objects, and duplicate-key / last-key-wins policy when
   a grammar can represent it. Chunk-boundary versions of these shapes
   belong under `PARSER.stream.3`, not here.
+- **`PARSER.batch.7.f`** Numeric precision edges. Integer-like number
+  literals above `f64`'s exact integer range must preserve the original
+  value rather than round through float parsing.
 
 ## `PARSER.batch.8` — Normal text interleaved with tool calls
 

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -6,13 +6,44 @@
 
 use std::collections::HashMap;
 
+use num_traits::ToPrimitive;
 use regex::Regex;
+use serde::Serialize;
 use serde_json::Value;
+use serde_json::value::RawValue;
 use uuid::Uuid;
 
 use super::super::ToolDefinition;
 use super::super::config::XmlParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
+
+enum ParsedParamValue {
+    Json(Value),
+    RawNumber(Box<RawValue>),
+}
+
+impl From<Value> for ParsedParamValue {
+    fn from(value: Value) -> Self {
+        Self::Json(value)
+    }
+}
+
+impl Serialize for ParsedParamValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Json(value) => value.serialize(serializer),
+            Self::RawNumber(raw) => raw.serialize(serializer),
+        }
+    }
+}
+
+fn is_integer_literal(value: &str) -> bool {
+    let value = value.strip_prefix('-').unwrap_or(value);
+    !value.is_empty() && value.bytes().all(|b| b.is_ascii_digit())
+}
 
 /// Build a `<start>name>(body)<end>` regex pattern. When `strict` is false,
 /// missing `<end>` falls back to end-of-block so truncated input still parses
@@ -277,7 +308,7 @@ fn parse_tool_call_block(
         let param_config = get_arguments_config(function_name, tools);
 
         // Parse parameters from the function body.
-        let mut parameters: HashMap<String, serde_json::Value> = HashMap::new();
+        let mut parameters: HashMap<String, ParsedParamValue> = HashMap::new();
 
         for param_cap in parameter_regex.captures_iter(function_body) {
             let param_name_raw = param_cap.get(1).map(|m| m.as_str().trim()).unwrap_or("");
@@ -435,13 +466,13 @@ fn convert_param_value(
     param_name: &str,
     param_config: &HashMap<String, Value>,
     func_name: &str,
-) -> Value {
+) -> ParsedParamValue {
     // HTML unescape and trim
     let param_value = html_unescape(param_value.trim());
 
     // Handle null
     if param_value.to_lowercase() == "null" {
-        return Value::Null;
+        return Value::Null.into();
     }
 
     // Check if parameter is in config
@@ -451,7 +482,7 @@ fn convert_param_value(
             param_name,
             func_name
         );
-        return Value::String(param_value);
+        return Value::String(param_value).into();
     }
 
     // Get the type from schema.
@@ -481,7 +512,9 @@ fn convert_param_value(
     // If parsing fails, we log a warning and fall back to returning the value as a string.
     match param_type.as_str() {
         // String types: Return value as-is (already HTML-unescaped above)
-        "string" | "str" | "text" | "varchar" | "char" | "enum" => Value::String(param_value),
+        "string" | "str" | "text" | "varchar" | "char" | "enum" => {
+            Value::String(param_value).into()
+        }
 
         // Integer types: Parse as i64, fall back to string on error.
         // Matches: "int", "integer", "int32", "uint", "unsigned", "long", "short", etc.
@@ -492,7 +525,7 @@ fn convert_param_value(
             || t.starts_with("unsigned") =>
         {
             match param_value.parse::<i64>() {
-                Ok(int_val) => Value::Number(int_val.into()),
+                Ok(int_val) => Value::Number(int_val.into()).into(),
                 Err(_) => {
                     tracing::warn!(
                         "Parsed value '{}' of parameter '{}' is not an integer in tool '{}', degenerating to string.",
@@ -500,40 +533,58 @@ fn convert_param_value(
                         param_name,
                         func_name
                     );
-                    Value::String(param_value)
+                    Value::String(param_value).into()
                 }
             }
         }
 
-        // Float/Number types: Parse as f64.
+        // Float/Number types: Parse integer-looking tokens before f64 to avoid
+        // precision loss above f64's exact integer range.
         // Matches: "number", "num", "float", "float32", "float64", "double", etc.
-        // Note: Whole numbers (e.g., 42.0) are stored as integers for better JSON compatibility.
+        // Note: Whole numbers (e.g., 42.0) are stored as integers for better JSON compatibility
+        // when they fit in i64. Larger finite whole numbers must not be cast with `as i64`,
+        // which saturates to i64::MIN/MAX and corrupts model-emitted arguments.
         t if t.starts_with("num") || t.starts_with("float") => {
-            match param_value.parse::<f64>() {
-                Ok(float_val) => {
-                    // Return int if it's a whole number, otherwise float.
-                    if float_val.fract() == 0.0 && float_val.is_finite() {
-                        Value::Number((float_val as i64).into())
-                    } else if let Some(num) = serde_json::Number::from_f64(float_val) {
-                        Value::Number(num)
-                    } else {
+            if is_integer_literal(&param_value) {
+                if let Ok(int_val) = param_value.parse::<i64>() {
+                    Value::Number(int_val.into()).into()
+                } else if let Ok(raw) = RawValue::from_string(param_value.clone()) {
+                    ParsedParamValue::RawNumber(raw)
+                } else {
+                    Value::String(param_value).into()
+                }
+            } else {
+                match param_value.parse::<f64>() {
+                    Ok(float_val) => {
+                        if float_val.fract() == 0.0 && float_val.is_finite() {
+                            if let Some(int_val) = float_val.to_i64() {
+                                Value::Number(int_val.into()).into()
+                            } else if let Ok(raw) = RawValue::from_string(param_value.clone()) {
+                                ParsedParamValue::RawNumber(raw)
+                            } else {
+                                Value::String(param_value).into()
+                            }
+                        } else if let Some(num) = serde_json::Number::from_f64(float_val) {
+                            Value::Number(num).into()
+                        } else {
+                            tracing::warn!(
+                                "Parsed value '{}' of parameter '{}' is not a valid float in tool '{}', degenerating to string.",
+                                param_value,
+                                param_name,
+                                func_name
+                            );
+                            Value::String(param_value).into()
+                        }
+                    }
+                    Err(_) => {
                         tracing::warn!(
-                            "Parsed value '{}' of parameter '{}' is not a valid float in tool '{}', degenerating to string.",
+                            "Parsed value '{}' of parameter '{}' is not a float in tool '{}', degenerating to string.",
                             param_value,
                             param_name,
                             func_name
                         );
-                        Value::String(param_value)
+                        Value::String(param_value).into()
                     }
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        "Parsed value '{}' of parameter '{}' is not a float in tool '{}', degenerating to string.",
-                        param_value,
-                        param_name,
-                        func_name
-                    );
-                    Value::String(param_value)
                 }
             }
         }
@@ -550,7 +601,7 @@ fn convert_param_value(
                     func_name
                 );
             }
-            Value::Bool(lower_val == "true")
+            Value::Bool(lower_val == "true").into()
         }
 
         // Complex types (objects/arrays): Try JSON parsing, then fall back to Python-style
@@ -566,7 +617,7 @@ fn convert_param_value(
         {
             // Try JSON parsing first (standard JSON with double quotes).
             if let Ok(json_val) = serde_json::from_str::<Value>(&param_value) {
-                return json_val;
+                return json_val.into();
             }
 
             tracing::warn!(
@@ -578,7 +629,7 @@ fn convert_param_value(
 
             // Try `ast.literal_eval` equivalent (handles Python-style single quotes, etc.).
             if let Ok(json_val) = try_literal_eval(&param_value) {
-                return json_val;
+                return json_val.into();
             }
 
             tracing::warn!(
@@ -587,7 +638,7 @@ fn convert_param_value(
                 param_name,
                 func_name
             );
-            Value::String(param_value)
+            Value::String(param_value).into()
         }
 
         // Unknown/custom types: Attempt best-effort parsing via `literal_eval`.
@@ -595,7 +646,7 @@ fn convert_param_value(
         _ => {
             // Unknown type, try `literal_eval`.
             if let Ok(json_val) = try_literal_eval(&param_value) {
-                return json_val;
+                return json_val.into();
             }
 
             tracing::warn!(
@@ -604,7 +655,7 @@ fn convert_param_value(
                 param_name,
                 func_name
             );
-            Value::String(param_value)
+            Value::String(param_value).into()
         }
     }
 }
@@ -742,6 +793,36 @@ mod tests {
             pos_inc, first_end,
             "should stop at end of first complete call when second is incomplete"
         );
+    }
+
+    #[test]
+    fn test_number_coercion_does_not_saturate_large_whole_values() {
+        let input = r#"<tool_call>
+<function=set_limit>
+<parameter=count>100000000000000000000</parameter>
+<parameter=precise_count>9007199254740993</parameter>
+</function>
+</tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "set_limit".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "count": {"type": "number"},
+                    "precise_count": {"type": "number"}
+                }
+            })),
+        }];
+
+        let (calls, normal) =
+            try_tool_call_parse_xml(input, &XmlParserConfig::default(), Some(&tools)).unwrap();
+        let args: HashMap<String, Box<RawValue>> =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+
+        assert_eq!(normal, Some("".to_string()));
+        assert_eq!(calls[0].function.name, "set_limit");
+        assert_eq!(args["count"].get(), "100000000000000000000");
+        assert_eq!(args["precise_count"].get(), "9007199254740993");
     }
 
     #[rstest] // helper

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
@@ -195,3 +195,6 @@ cases:
                 retry: null
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for deepseek_v3; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
@@ -172,3 +172,6 @@ cases:
                 retry: null
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for deepseek_v3_1; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
@@ -73,3 +73,6 @@ cases:
   PARSER.batch.7.e:
     description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
     reason: Large/deep JSON-edge payload test 7.e not yet authored for deepseek_v3_2; existing batch.7 coverage remains in 7.a-d.
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for deepseek_v3_2; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
@@ -75,3 +75,6 @@ cases:
   PARSER.batch.7.e:
     description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
     reason: Large/deep JSON-edge payload test 7.e not yet authored for deepseek_v4; existing batch.7 coverage remains in 7.a-d.
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for deepseek_v4; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -173,3 +173,6 @@ cases:
                 retry: 'null'
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for gemma4; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
@@ -61,3 +61,6 @@ cases:
   PARSER.batch.7.e:
     description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
     reason: Large/deep JSON-edge payload test 7.e not yet authored for glm47; existing batch.7 coverage remains in 7.a-d.
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for glm47; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -194,3 +194,6 @@ cases:
         calls: []
         normal_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"payload":{"regions":[{"name":"west","scores":[1,2,3]},{"name":"east","scores":[4,5,6]}],"flags":{"enabled":true,"retry":null},"empty":{}}}<|call|>
         reason: "Dynamo/vLLM are more spec-correct for completion-body parsing: the first assistant message may start at '<|channel|>'; SGLang requires a redundant '<|start|>assistant' prefix and leaks raw markup"
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for harmony; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
@@ -174,3 +174,6 @@ cases:
                 retry: null
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for hermes; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
@@ -159,3 +159,6 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for jamba; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
@@ -173,3 +173,6 @@ cases:
                 retry: null
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for kimi_k2; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -174,3 +174,6 @@ cases:
                 retry: null
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for llama3_json; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
@@ -73,3 +73,6 @@ cases:
   PARSER.batch.7.e:
     description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
     reason: Large/deep JSON-edge payload test 7.e not yet authored for minimax_m2; existing batch.7 coverage remains in 7.a-d.
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for minimax_m2; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
@@ -164,3 +164,6 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for mistral; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
@@ -144,3 +144,6 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for nemotron_deci; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
@@ -85,3 +85,6 @@ cases:
   PARSER.batch.7.e:
     description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
     reason: Large/deep JSON-edge payload test 7.e not yet authored for nemotron_nano; existing batch.7 coverage remains in 7.a-d.
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for nemotron_nano; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
@@ -142,3 +142,6 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for phi4; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
@@ -172,3 +172,6 @@ cases:
                 retry: null
               empty: {}
         normal_text: ''
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for pythonic; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
@@ -151,3 +151,6 @@ cases:
         calls: []
         normal_text: '<tool_call>{"name": "process_data", "arguments": {"payload": {"regions": [{"name": "west", "scores": [1,
           2, 3]}, {"name": "east", "scores": [4, 5, 6]}], "flags": {"enabled": true, "retry": null}, "empty": {}}}}</tool_call>'
+  PARSER.batch.7.f:
+    description: Numeric precision edge test 7.f — not yet authored for this family
+    reason: Numeric precision edge test 7.f not yet authored for qwen25; Qwen3-Coder coverage is provided by qwen3_coder 7.f.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
@@ -81,3 +81,34 @@ cases:
   PARSER.batch.7.e:
     description: Large / deep JSON-edge payload test 7.e — not yet authored for this family
     reason: Large/deep JSON-edge payload test 7.e not yet authored for qwen3_coder; existing batch.7 coverage remains in 7.a-d.
+  PARSER.batch.7.f:
+    description: Numeric precision edge preserves integer-like number literal
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=set_limit>
+      <parameter=count>9007199254740993</parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: set_limit
+      parameters:
+        type: object
+        properties:
+          count:
+            type: number
+    expected:
+      dynamo: &id003
+        calls:
+        - name: set_limit
+          arguments:
+            count: 9007199254740993
+        normal_text: ''
+      vllm: &id004
+        reason: Dynamo preserves integer-like number literals before the f64 path; vLLM/SGLang round through f64 and lose precision above 2^53.
+        calls:
+        - name: set_limit
+          arguments:
+            count: 9007199254740992
+        normal_text:
+      sglang: *id004

--- a/tests/parity/parser/table.py
+++ b/tests/parity/parser/table.py
@@ -324,6 +324,7 @@ BATCH_SUB_CASE_GROUPS = [
             "7.c",
             "7.d",
             "7.e",
+            "7.f",
         ),
     ),
     ("Text interleaving", ("8.a", "8.b", "8.c", "8.d")),


### PR DESCRIPTION

#### Overview:

Fix Qwen3-Coder XML tool-call parsing so large whole-number arguments are not saturated to `i64::MAX`.

Dynamo previously parsed schema-aware `number` values through `f64`, then cast whole values to `i64`. For large integers such as `100000000000000000000`, that cast saturated to `9223372036854775807`, changing the tool argument.

#### Details:

Observed raw model output from locally served `Qwen/Qwen3-Coder-30B-A3B-Instruct`:

```xml
<tool_call>
<function=set_limit>
<parameter=count>100000000000000000000</parameter>
</function>
</tool_call>
```

Dynamo parser output before this fix:

```json
{"calls":[{"name":"set_limit","arguments":{"count":9223372036854775807}}],"normal_text":""}
```

Dynamo parser output after this fix:

```json
{"calls":[{"name":"set_limit","arguments":{"count":100000000000000000000}}],"normal_text":""}
```

- Preserve large numeric literals when a schema-declared `number` / `float` value is finite and whole but does not fit in `i64`.
- Keep existing `i64` behavior for values that fit.
- Fall back to string preservation if the numeric literal cannot be represented as a JSON number.
- Enable `serde_json` `arbitrary_precision` for the parser crate so large numeric tokens can round-trip without lossy exponent formatting.
- Add a Qwen3-Coder XML parser regression test for a large integer tool argument.


#### Where should the reviewer start?

Start with:

- `lib/parsers/src/tool_calling/xml/parser.rs`
  - `convert_param_value`
  - `test_number_coercion_does_not_saturate_large_whole_values`
- `lib/parsers/Cargo.toml`


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where large whole-number values in tool-calling arguments were being incorrectly saturated to limits, corrupting the intended values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->