### PR TITLE
fix(release): correct frontend ECR source tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,9 +328,12 @@ jobs:
             copy_image "${SOURCE}" "${TARGET}" "tensorrtllm-runtime:${NGC_VERSION_TAG}-efa"
 
             # ---- Frontend image (already multi-arch from build-frontend-image workflow) ----
+            # post-merge tags the frontend ECR image as <sha>-dynamo-frontend
+            # (framework=dynamo, target=frontend → tag builder "dynamo-frontend"),
+            # NOT <sha>-frontend.
             echo ""
             echo "=== Frontend Image ==="
-            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-frontend"
+            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-dynamo-frontend"
             TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/dynamo-frontend:${NGC_VERSION_TAG}"
             copy_image "${SOURCE}" "${TARGET}" "dynamo-frontend:${NGC_VERSION_TAG}"
 


### PR DESCRIPTION
Relates to OPS-5418.

## Summary

Fixes the frontend container source tag in `.github/workflows/release.yml` so the RC publish job actually copies the frontend image to NGC instead of failing on a non-existent ECR tag.

## What was broken

The release workflow was sourcing:

```
${ECR_HOSTNAME}/ai-dynamo/dynamo:${COMMIT_SHA}-frontend
```

But `post-merge-ci.yml` builds the frontend image with `framework: dynamo` and `target: frontend`, which `shared-build-image.yml` composes into the tag builder `dynamo-frontend` — so the actual ECR tag that gets pushed is:

```
${ECR_HOSTNAME}/ai-dynamo/dynamo:${COMMIT_SHA}-dynamo-frontend
```

`<sha>-frontend` never existed in ECR, so the frontend copy step has been a no-op failure on every RC run.

## Fix

One-line source tag correction: `<sha>-frontend` → `<sha>-dynamo-frontend`. Same diff that landed on `main` as part of the larger release-pipeline overhaul (#9798); pulled out here as a minimal cherry so `release/1.2.0` RCs can ship frontend without taking the full restructure.

## Scope

- **Only the RC path is touched.** Nightly behavior on this branch is unchanged.
- All other source tags in the workflow already match the post-merge tag scheme on this branch (verified by grepping `post-merge-ci.yml` for `framework:` / `target:` combos and `image_tag` strings).

## Test plan

- [ ] Trigger `workflow_dispatch` on `release/1.2.0` against a recent post-merge commit SHA.
- [ ] Confirm the "Frontend Image" step in the `Publish to NGC` job succeeds and produces `nvcr.io/<NGC_ORG>/ai-dynamo/dynamo-frontend:<TAG>`.
- [ ] Confirm the other 10 images still copy successfully (no regression to runtimes / EFA / operator / planner / snapshot-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->