### PR TITLE
fix(cargo): remove broken readme references blocking publication

### DIFF
--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -9,7 +9,6 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
 description = "Dynamo LLM Library"
 
 [features]

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -17,7 +17,6 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [dependencies]
 # Upstream OpenAI types (types-only, no HTTP client)

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -3,7 +3,6 @@
 
 [package]
 name = "dynamo-runtime"
-readme = "README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
- `dynamo-runtime` declared `readme = "README.md"` but the file does not exist in `lib/runtime/`, which makes `cargo package`/`cargo publish` fail before upload.
- `dynamo-llm` and `dynamo-protocols` declared `readme.workspace = true`, but the workspace root `Cargo.toml` does not define a `readme` in `[workspace.package]` — the same failure mode.
- This PR drops all three references so the affected crates can be packaged. `dynamo-mocker` and `dynamo-kv-router` already point at real README files and are untouched.

## Test plan
- [ ] `cargo metadata --format-version 1 --no-deps` parses without errors.
- [ ] `cargo package -p dynamo-runtime --no-verify --allow-dirty` produces a `.crate` artifact.
- [ ] `cargo package -p dynamo-llm --no-verify --allow-dirty` produces a `.crate` artifact.
- [ ] `cargo package -p dynamo-protocols --no-verify --allow-dirty` produces a `.crate` artifact.

Relates to OPS-6619

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package configuration across multiple modules.

**Note:** No user-facing changes in this release. These updates involve internal build and packaging configuration adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->