### PR TITLE
chore: bump aiperf to 0.8.0 and aiconfigurator to release/0.9.0 tip (#9777)

### DIFF
--- a/benchmarks/frontend/scripts/README.md
+++ b/benchmarks/frontend/scripts/README.md
@@ -116,7 +116,7 @@ When `--num-models` is 1, the served model name matches the HF model path (e.g.,
 |------|----------|---------|
 | etcd | Yes | `apt install etcd` or [releases](https://github.com/etcd-io/etcd/releases) |
 | nats-server | Yes | `apt install nats-server` or [nats.io](https://nats.io/download/) |
-| aiperf | Yes | `uv pip install "git+https://github.com/ai-dynamo/aiperf.git@main"` (in dynamo venv) |
+| aiperf | Yes | `uv pip install "aiperf==0.8.0"` (in dynamo venv) |
 | jq | Yes | `apt install jq` |
 | perf | Optional | `apt install linux-tools-$(uname -r)` |
 | bpftrace | Optional | `apt install bpftrace` (needs root or CAP_BPF + CAP_PERFMON) |

--- a/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/aiperf.py
@@ -61,7 +61,17 @@ def _build_aiperf_script(
 
     return f"""set -e
 apt-get update -qq && apt-get install -y -qq curl jq git procps 2>/dev/null
-pip install --quiet git+https://github.com/ai-dynamo/aiperf.git@54cd6dc820bff8bfebc875da104e59d745e14f75
+# aiperf 0.8.0 pulls crick==0.0.8 which has no manylinux aarch64 wheel; on
+# arm64 nodes pip falls back to sdist and needs a C compiler. python:3.12-slim
+# bundles Python headers at /usr/local/include/python3.12/, but libc headers
+# (stdlib.h, etc.) come from libc6-dev — and on Debian libc6-dev is only a
+# Recommends of gcc, not a Depends, so we install it explicitly to stay
+# resilient if this apt-get ever gets --no-install-recommends. Skip on amd64
+# where the prebuilt wheel exists on PyPI.
+if [ "$(uname -m)" = "aarch64" ]; then
+    apt-get install -y -qq gcc libc6-dev 2>/dev/null
+fi
+pip install --quiet aiperf==0.8.0
 echo "aiperf installed"
 
 # Wait for model

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,8 +40,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b33a136e78f9351a7ad17db1e2a1abd7b295cc6a",
-    "aiperf==0.6.0",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9",
+    "aiperf==0.8.0",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.benchmark.txt
+++ b/container/deps/requirements.benchmark.txt
@@ -3,4 +3,4 @@
 
 # Benchmark and profiling tool dependencies.
 
-aiperf==0.6.0
+aiperf==0.8.0

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,7 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@79eb16034f37e7211dd4f556448794603c3bdea3
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -8,6 +8,36 @@
 ##############################################
 FROM ${EPP_IMAGE} AS epp
 
+# Build `crick` as a wheel in an isolated stage so the C toolchain never
+# reaches the final frontend image. aiperf 0.8.0 depends on crick==0.0.8,
+# which publishes no manylinux aarch64 wheel — without this, arm64 builds
+# fall back to sdist and fail in the final stage where gcc is intentionally
+# absent. amd64 has a prebuilt manylinux_x86_64 wheel on PyPI, so the build
+# is gated on TARGETARCH=arm64; amd64 ships an empty /wheels and uv pulls
+# crick straight from PyPI in the final stage. /wheels is created either
+# way so the COPY --from=crick_builder in the final stage always succeeds.
+FROM ${FRONTEND_IMAGE} AS crick_builder
+ARG PYTHON_VERSION
+ARG TARGETARCH
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    mkdir -p /wheels \
+    && if [ "$TARGETARCH" = "arm64" ]; then \
+        apt-get update -y \
+        && apt-get install -y --no-install-recommends \
+            ca-certificates \
+            gcc \
+            libc6-dev \
+            python${PYTHON_VERSION}-dev \
+            python${PYTHON_VERSION}-venv \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        python${PYTHON_VERSION} -m venv /tmp/buildenv \
+        && /tmp/buildenv/bin/pip install --no-cache-dir --upgrade pip wheel \
+        && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels; \
+    fi
+
 FROM ${FRONTEND_IMAGE} AS frontend
 
 ARG PYTHON_VERSION
@@ -65,6 +95,8 @@ COPY --chown=dynamo: --from=dynamo_base /bin/uv /bin/uvx /bin/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
+# crick wheel pre-built in the crick_builder stage; see comment near the top.
+COPY --chown=dynamo: --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
 
 # Create virtual environment
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
@@ -86,8 +118,10 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
+# UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
+# uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
-    export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -13,17 +13,32 @@
 FROM ${PLANNER_BUILD_IMAGE}:${PLANNER_BUILD_IMAGE_TAG} AS planner_builder
 
 ARG PYTHON_VERSION
+ARG TARGETARCH
 
 # Install only the packages needed to resolve and install the planner runtime
 # dependencies in the builder stage. git/git-lfs are only needed because
 # aiconfigurator is currently installed from a Git URL with LFS-backed assets.
+# On arm64, gcc + libc6-dev are added so aiperf's `crick` dep can compile
+# from sdist (crick==0.0.8 publishes no manylinux aarch64 wheel); on amd64
+# the prebuilt wheel from PyPI is used and the toolchain is skipped
+# entirely. Python headers come from the base image's
+# /usr/local/include/python${PYTHON_VERSION} (python:3.X-slim bundles them
+# directly — no apt python*-dev needed, and python${PYTHON_VERSION}-dev is
+# not available in this base's apt index anyway). libc6-dev is required
+# explicitly because on Debian it's a Recommends of gcc, not a Depends, so
+# --no-install-recommends would otherwise skip it and the build fails with
+# "fatal error: stdlib.h: No such file or directory". The toolchain stays
+# in this builder stage and never reaches the final image.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
+    EXTRA_PKGS=""; \
+    if [ "$TARGETARCH" = "arm64" ]; then EXTRA_PKGS="gcc libc6-dev"; fi; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         git \
         git-lfs \
-        libgomp1 && \
+        libgomp1 \
+        $EXTRA_PKGS && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -450,7 +450,7 @@ spec:
           - -lc
           - |
             apt-get update -qq && apt-get install -y -qq tmux > /dev/null 2>&1
-            pip install -q aiperf==0.5.0
+            pip install -q aiperf==0.8.0
             echo "Benchmark pod ready (tmux + aiperf installed)."
             sleep infinity
         imagePullPolicy: IfNotPresent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator>=0.7.0",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
Cherry Pick of PR #9777 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-5167, OPS-5168

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->