### PR TITLE
fix: accept PEP 440 suffixes when determining next RC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,9 @@ jobs:
           # Base version pinned in pyproject.toml at the source SHA. Same value
           # cargo and maturin stamp into the wheel filename / METADATA.
           BASE_VERSION=$(awk '/^version = / {gsub(/"/, "", $3); print $3; exit}' pyproject.toml)
-          if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          # Accept X.Y.Z or X.Y.Z + one PEP 440 suffix: .postN, .devN, aN, bN, rcN.
+          # The SEMVER_BASE sed below must stay in lockstep with this regex.
+          if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+|\.dev[0-9]+|a[0-9]+|b[0-9]+|rc[0-9]+)?$ ]]; then
             echo "Error: cannot parse base version from pyproject.toml (got '${BASE_VERSION}')"
             exit 1
           fi
@@ -173,14 +175,33 @@ jobs:
             fi
           fi
 
-          # Normalize version for Helm SemVer: X.Y.Z.suffix → X.Y.Z-suffix
-          SEMVER_VERSION=$(echo "${VERSION}" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)\.(.+)/\1-\2/')
-          HELM_CHART_VERSION="${SEMVER_VERSION}-rc${NEXT_RC}"
+          # Convert PEP 440 suffix on BASE_VERSION to SemVer pre-release so the
+          # Helm chart and NGC tag stay valid SemVer. Mapping:
+          #   .postN → -post.N    .devN → -dev.N
+          #   aN     → -alpha.N   bN    → -beta.N    rcN → -rc.N
+          # The auto-incremented RC counter is appended as -rc.NEXT_RC even when
+          # BASE_VERSION already contains rcN — those stack (e.g. 1.2.0-rc.1-rc.0).
+          SEMVER_BASE=$(echo "${BASE_VERSION}" | sed -E \
+            -e 's/^([0-9]+\.[0-9]+\.[0-9]+)\.post([0-9]+)$/\1-post.\2/' \
+            -e 's/^([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)$/\1-dev.\2/' \
+            -e 's/^([0-9]+\.[0-9]+\.[0-9]+)a([0-9]+)$/\1-alpha.\2/' \
+            -e 's/^([0-9]+\.[0-9]+\.[0-9]+)b([0-9]+)$/\1-beta.\2/' \
+            -e 's/^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$/\1-rc.\2/')
+
+          if [[ "${SEMVER_BASE}" == *-* ]]; then
+            # Suffixed base: dotted SemVer form, identical for Helm and NGC.
+            HELM_CHART_VERSION="${SEMVER_BASE}-rc.${NEXT_RC}"
+            NGC_VERSION_TAG="${SEMVER_BASE}-rc.${NEXT_RC}"
+          else
+            # Plain X.Y.Z: preserve the existing tag shape exactly.
+            HELM_CHART_VERSION="${SEMVER_BASE}-rc${NEXT_RC}"
+            NGC_VERSION_TAG="${VERSION}rc${NEXT_RC}"
+          fi
 
           WHEEL_VERSION="${BASE_VERSION}"
 
           echo "rc_number=${NEXT_RC}" >> $GITHUB_OUTPUT
-          echo "ngc_version_tag=${VERSION}rc${NEXT_RC}" >> $GITHUB_OUTPUT
+          echo "ngc_version_tag=${NGC_VERSION_TAG}" >> $GITHUB_OUTPUT
           echo "helm_chart_version=${HELM_CHART_VERSION}" >> $GITHUB_OUTPUT
           echo "wheel_version=${WHEEL_VERSION}" >> $GITHUB_OUTPUT
           echo "RC number: ${NEXT_RC}"


### PR DESCRIPTION
The "Determine next RC number" step in the release workflow rejected `pyproject.toml` versions like `1.2.0.post1` against a strict three-segment regex, breaking every workflow_dispatch on release/1.2.0 after the post1 bump.

Broaden the base-version regex to also accept .postN / .devN / aN / bN / rcN suffixes, and convert each to a dotted-SemVer pre-release identifier when assembling the Helm chart version and NGC image tag so both stay valid SemVer (e.g. `1.2.0.post1` -> `1.2.0-post.1-rc.0`). Plain X.Y.Z keeps the existing tag shape unchanged.

Closes OPS-5418
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->