### PR TITLE
feat: autodetect agent behavior in agent traces

### DIFF
--- a/benchmarks/agent_trace/README.md
+++ b/benchmarks/agent_trace/README.md
@@ -24,6 +24,9 @@ glob pattern. The converter emits Chrome Trace Event JSON:
 - one tool slice per harness `tool_end`/`tool_error`; explicit
   `started_at_unix_ms`/`ended_at_unix_ms` are preferred, then `duration_ms`,
   then paired `tool_start` timing when both records are present
+- finish metadata on request slices, including final finish reason, backend
+  finish reason, stop reason, per-choice finish summaries, and complete
+  tool-call names
 - optional first-token markers with `--include-markers`
 
 Use `--no-stages` for a compact request-only view. Use
@@ -51,6 +54,11 @@ emits one independent Mooncake request row per Dynamo `request_end`, with an
 absolute `timestamp` from Dynamo's request-arrival time and no `session_id`.
 Stable trace `input_sequence_hashes` are compacted to Mooncake `hash_ids`
 during conversion.
+
+Mooncake replay intentionally ignores non-replay request fields such as
+`finish_reason_metadata`. Use the Perfetto converter when you want to inspect
+whether a request stopped for tool calls, hit a backend stop reason, or emitted
+complete tool-call metadata.
 
 For what replay covers today and what remains on the roadmap (cache movement
 fidelity, output token reconstruction, causal tool/turn dependencies, end-to-end

--- a/benchmarks/agent_trace/convert_to_perfetto.py
+++ b/benchmarks/agent_trace/convert_to_perfetto.py
@@ -148,6 +148,37 @@ def _flatten_args(
         for key, value in worker.items():
             args[f"worker.{key}"] = value
 
+    finish = request.get("finish_reason_metadata")
+    if isinstance(finish, dict):
+        args["finish_reason_metadata"] = finish
+        for key in ("finish_reason", "backend_finish_reason", "stop_reason"):
+            if key in finish:
+                args[f"finish.{key}"] = finish[key]
+
+        tool_calls = finish.get("tool_calls")
+        if isinstance(tool_calls, list):
+            args["finish.tool_call_count"] = len(tool_calls)
+            names = [
+                str(call["name"])
+                for call in tool_calls
+                if isinstance(call, dict) and call.get("name")
+            ]
+            if names:
+                args["finish.tool_call_names"] = ", ".join(names)
+
+        choices = finish.get("choices")
+        if isinstance(choices, list):
+            args["finish.choice_count"] = len(choices)
+            finish_reasons = [
+                f"{choice.get('choice_index')}:{choice.get('finish_reason')}"
+                for choice in choices
+                if isinstance(choice, dict)
+                and choice.get("choice_index") is not None
+                and choice.get("finish_reason") is not None
+            ]
+            if finish_reasons:
+                args["finish.choice_finish_reasons"] = ", ".join(finish_reasons)
+
     return {key: value for key, value in args.items() if value is not None}
 
 

--- a/benchmarks/agent_trace/validate_convert_to_perfetto.py
+++ b/benchmarks/agent_trace/validate_convert_to_perfetto.py
@@ -41,6 +41,27 @@ def check_convert_records_emits_request_stages_and_metadata():
                         "avg_itl_ms": 4.2,
                         "kv_hit_rate": 0.8,
                         "queue_depth": 2,
+                        "finish_reason_metadata": {
+                            "finish_reason": "tool_calls",
+                            "backend_finish_reason": "stop",
+                            "stop_reason": "END",
+                            "tool_calls": [
+                                {
+                                    "choice_index": 0,
+                                    "tool_call_index": 0,
+                                    "id": "call-1",
+                                    "name": "web_search",
+                                }
+                            ],
+                            "choices": [
+                                {
+                                    "choice_index": 0,
+                                    "finish_reason": "tool_calls",
+                                    "backend_finish_reason": "stop",
+                                    "stop_reason": "END",
+                                }
+                            ],
+                        },
                         "worker": {
                             "prefill_worker_id": 1,
                             "prefill_dp_rank": 0,
@@ -67,6 +88,13 @@ def check_convert_records_emits_request_stages_and_metadata():
     assert request["dur"] == 50_000
     assert request["args"]["x_request_id"] == "caller-1"
     assert request["args"]["worker.decode_worker_id"] == 2
+    assert request["args"]["finish.finish_reason"] == "tool_calls"
+    assert request["args"]["finish.backend_finish_reason"] == "stop"
+    assert request["args"]["finish.stop_reason"] == "END"
+    assert request["args"]["finish.tool_call_count"] == 1
+    assert request["args"]["finish.tool_call_names"] == "web_search"
+    assert request["args"]["finish.choice_count"] == 1
+    assert request["args"]["finish.choice_finish_reasons"] == "0:tool_calls"
 
     stage_events = [event for event in events if event.get("cat") == "dynamo.llm.stage"]
     assert {event["tid"] for event in stage_events} == {request["tid"]}

--- a/docs/agents/agent-tracing.md
+++ b/docs/agents/agent-tracing.md
@@ -191,7 +191,8 @@ Top-level finish fields summarize the common single-choice case; `choices`
 keeps per-choice finish fields when `n > 1`. Tool-call metadata includes ids and
 names only; arguments are intentionally not stored in agent traces.
 For chat streams, final finish metadata is recorded after parser/jail rewrites;
-completion streams currently record backend finish and stop metadata only.
+completion streams record the final OpenAI-compatible completion finish reason
+from the completion response choices.
 
 By default we do not save the input/ouput payloads. In order to view these, use the built in Dynamo `audit_sink` functionality.
 

--- a/docs/agents/agent-tracing.md
+++ b/docs/agents/agent-tracing.md
@@ -154,6 +154,27 @@ Emitted after the response stream finishes or is dropped. Omitted keys were not 
     "x_request_id": "llm-call-42",
     "model": "my-model",
     "output_tokens": 16,
+    "finish_reason_metadata": {
+      "finish_reason": "tool_calls",
+      "backend_finish_reason": "stop",
+      "stop_reason": "END",
+      "tool_calls": [
+        {
+          "choice_index": 0,
+          "tool_call_index": 0,
+          "id": "call-abc",
+          "name": "web_search"
+        }
+      ],
+      "choices": [
+        {
+          "choice_index": 0,
+          "finish_reason": "tool_calls",
+          "backend_finish_reason": "stop",
+          "stop_reason": "END"
+        }
+      ]
+    },
     "replay": {
       "trace_block_size": 64,
       "input_length": 128,
@@ -162,6 +183,15 @@ Emitted after the response stream finishes or is dropped. Omitted keys were not 
   }
 }
 ```
+
+`finish_reason_metadata` is optional. `backend_finish_reason` and `stop_reason`
+come from the backend/token stop path; `finish_reason` is the final
+OpenAI-compatible finish reason after parser rewrites, such as `tool_calls`.
+Top-level finish fields summarize the common single-choice case; `choices`
+keeps per-choice finish fields when `n > 1`. Tool-call metadata includes ids and
+names only; arguments are intentionally not stored in agent traces.
+For chat streams, final finish metadata is recorded after parser/jail rewrites;
+completion streams currently record backend finish and stop metadata only.
 
 By default we do not save the input/ouput payloads. In order to view these, use the built in Dynamo `audit_sink` functionality.
 
@@ -208,12 +238,20 @@ uv run --no-project python benchmarks/agent_trace/convert_to_perfetto.py \
 
 Open in [Perfetto UI](https://ui.perfetto.dev/). Flags: `--include-markers`, `--no-stages`, `--separate-stage-tracks`.
 
+Request slices include flattened finish metadata when present, such as `finish.finish_reason`,
+`finish.backend_finish_reason`, `finish.stop_reason`, `finish.tool_call_count`,
+`finish.tool_call_names`, and per-choice summaries like `finish.choice_finish_reasons`.
+
 ## [Experimental] Replaying agent traces using agentic Mooncake replay
 
 You can convert a collected agent trace into an **agentic Mooncake** trace and replay it with
 `python -m dynamo.replay`. The converter uses Dynamo `request_end` rows for request timing, token
 lengths, worker placement, and replay hashes. It also uses terminal harness tool rows
 (`tool_end` / `tool_error`) to preserve tool-wait time between dependent LLM requests.
+
+Replay ignores non-replay request fields such as `finish_reason_metadata`; use the
+Perfetto view above when you want to inspect final finish reasons, backend stop
+signals, or complete tool-call metadata inside the trace.
 
 ```bash
 cargo run -p dynamo-bench --bin agent_trace_to_mooncake -- \

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -31,6 +31,7 @@ media-ffmpeg = ["dep:video-rs", "dep:ffmpeg-next", "dep:memfile"]
 bench = ["dynamo-kv-router/bench"]
 kv-router-stress = ["dep:clap", "dep:indicatif", "bench"]
 lightseek-mm = ["dep:llm-multimodal", "dep:llm-tokenizer"]
+agent-trace-bench = []
 
 [[bench]]
 name = "tokenizer_simple"
@@ -49,6 +50,11 @@ required-features = ["block-manager", "testing-cuda"]
 name = "kv_router_bench"
 harness = false
 required-features = ["kv-router-stress"]
+
+[[bench]]
+name = "agent_trace_finish_metadata"
+harness = false
+required-features = ["agent-trace-bench"]
 
 [dependencies]
 # repo

--- a/lib/llm/benches/README.md
+++ b/lib/llm/benches/README.md
@@ -59,3 +59,12 @@ RUN_BENCH=1 BATCH_SIZE=64 cargo bench --bench tokenizer_dataset -p dynamo-llm
 | `DATASET` | `zai-org/LongBench-v2` | HuggingFace dataset name (`zai-org/LongBench-v2` or `RyokoAI/ShareGPT52K`) |
 | `MAX_SAMPLES` | `503` | Maximum number of samples to process |
 | `BATCH_SIZE` | unset | If set, runs batched mode instead of sequential |
+
+## agent_trace_finish_metadata
+
+Measures request finish metadata overhead with tracing disabled/enabled, plus
+tool-call metadata recording across increasing numbers of calls.
+
+```bash
+cargo bench --bench agent_trace_finish_metadata -p dynamo-llm --features agent-trace-bench
+```

--- a/lib/llm/benches/agent_trace_finish_metadata.rs
+++ b/lib/llm/benches/agent_trace_finish_metadata.rs
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::hint::black_box;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use dynamo_llm::agents::trace::SharedFinishReasonMetadata;
+use dynamo_llm::preprocessor::OpenAIPreprocessor;
+use dynamo_llm::protocols::common::llm_backend::{
+    BackendOutput, FinishReason as BackendFinishReason,
+};
+use dynamo_llm::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
+use dynamo_protocols::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
+    ChatCompletionRequestUserMessageContent, CreateChatCompletionRequest,
+};
+use dynamo_runtime::engine::{AsyncEngineContext, AsyncEngineStream, ResponseStream};
+use dynamo_runtime::protocols::annotated::Annotated;
+use futures::StreamExt;
+use futures::stream;
+
+const STREAM_CHUNKS: usize = 256;
+const TOOL_CALL_SIZES: &[usize] = &[1, 8, 64, 512, 4096];
+
+#[derive(Debug)]
+struct MockContext {
+    id: String,
+    stopped: AtomicBool,
+    killed: AtomicBool,
+}
+
+impl MockContext {
+    fn new() -> Self {
+        Self {
+            id: "agent-trace-finish-metadata-bench".to_string(),
+            stopped: AtomicBool::new(false),
+            killed: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncEngineContext for MockContext {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn stop_generating(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.stopped.load(Ordering::SeqCst)
+    }
+
+    fn is_killed(&self) -> bool {
+        self.killed.load(Ordering::SeqCst)
+    }
+
+    async fn stopped(&self) {}
+
+    async fn killed(&self) {}
+
+    fn stop(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+    }
+
+    fn kill(&self) {
+        self.killed.store(true, Ordering::SeqCst);
+    }
+
+    fn link_child(&self, _: Arc<dyn AsyncEngineContext>) {}
+}
+
+fn chat_request() -> NvCreateChatCompletionRequest {
+    NvCreateChatCompletionRequest {
+        inner: CreateChatCompletionRequest {
+            model: "bench-model".to_string(),
+            messages: vec![ChatCompletionRequestMessage::User(
+                ChatCompletionRequestUserMessage {
+                    content: ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
+                    name: None,
+                },
+            )],
+            stream: Some(true),
+            ..Default::default()
+        },
+        common: Default::default(),
+        nvext: None,
+        chat_template_args: None,
+        media_io_kwargs: None,
+        return_tokens_as_token_ids: None,
+        unsupported_fields: Default::default(),
+    }
+}
+
+fn backend_outputs(count: usize) -> Vec<BackendOutput> {
+    (0..count)
+        .map(|index| BackendOutput {
+            token_ids: vec![index as u32],
+            tokens: vec![Some("x".to_string())],
+            text: Some("x".to_string()),
+            cum_log_probs: None,
+            log_probs: None,
+            top_logprobs: None,
+            finish_reason: (index + 1 == count).then_some(BackendFinishReason::Stop),
+            stop_reason: None,
+            index: Some(0),
+            completion_usage: None,
+            disaggregated_params: None,
+            worker_trace_link: None,
+            engine_data: None,
+        })
+        .collect()
+}
+
+fn backend_stream(
+    ctx: Arc<dyn AsyncEngineContext>,
+    count: usize,
+) -> Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>> {
+    let stream = stream::iter(backend_outputs(count).into_iter().map(Annotated::from_data));
+    ResponseStream::new(Box::pin(stream), ctx)
+}
+
+async fn consume_postprocessor_stream(trace_finish_metadata: bool) -> usize {
+    let request = chat_request();
+    let generator = Box::new(request.response_generator("bench-request".to_string()));
+    let ctx = Arc::new(MockContext::new());
+    let stream = OpenAIPreprocessor::transform_postprocessor_stream(
+        backend_stream(ctx.clone(), STREAM_CHUNKS),
+        generator,
+        ctx,
+        false,
+        trace_finish_metadata.then(SharedFinishReasonMetadata::default),
+    );
+
+    stream.collect::<Vec<_>>().await.len()
+}
+
+fn tool_call_chunks(count: usize) -> Vec<(u32, Option<String>, Option<String>)> {
+    (0..count)
+        .map(|index| {
+            (
+                index as u32,
+                Some(format!("call-{index}")),
+                Some("lookup".to_string()),
+            )
+        })
+        .collect()
+}
+
+fn argument_only_chunks(count: usize) -> Vec<(u32, Option<String>, Option<String>)> {
+    (0..count)
+        .map(|index| {
+            (
+                0,
+                (index == 0).then(|| "call-0".to_string()),
+                (index == 0).then(|| "lookup".to_string()),
+            )
+        })
+        .collect()
+}
+
+fn bench_postprocessor_finish_metadata(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime should build");
+    let mut group = c.benchmark_group("agent_trace_finish_metadata/postprocessor");
+    group.throughput(Throughput::Elements(STREAM_CHUNKS as u64));
+
+    group.bench_function("finish_metadata_off", |b| {
+        b.iter(|| {
+            black_box(runtime.block_on(consume_postprocessor_stream(false)));
+        });
+    });
+
+    group.bench_function("finish_metadata_on", |b| {
+        b.iter(|| {
+            black_box(runtime.block_on(consume_postprocessor_stream(true)));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_tool_call_metadata(c: &mut Criterion) {
+    let mut group = c.benchmark_group("agent_trace_finish_metadata/tool_calls");
+
+    for &count in TOOL_CALL_SIZES {
+        group.throughput(Throughput::Elements(count as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("record_unique", count),
+            &count,
+            |b, &count| {
+                b.iter_batched(
+                    || tool_call_chunks(count),
+                    |chunks| {
+                        let metadata = SharedFinishReasonMetadata::default();
+                        for (index, id, name) in chunks {
+                            metadata.record_tool_call_chunk_for_bench(
+                                0,
+                                index,
+                                id.as_deref(),
+                                name.as_deref(),
+                            );
+                        }
+                        black_box(metadata.snapshot_for_bench().unwrap().tool_calls.len());
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("skip_argument_only_chunks", count),
+            &count,
+            |b, &count| {
+                b.iter_batched(
+                    || argument_only_chunks(count),
+                    |chunks| {
+                        let metadata = SharedFinishReasonMetadata::default();
+                        for (index, id, name) in chunks {
+                            metadata.record_tool_call_chunk_for_bench(
+                                0,
+                                index,
+                                id.as_deref(),
+                                name.as_deref(),
+                            );
+                        }
+                        black_box(metadata.snapshot_for_bench().unwrap().tool_calls.len());
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_postprocessor_finish_metadata,
+    bench_tool_call_metadata
+);
+criterion_main!(benches);

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -120,17 +120,17 @@ impl FinishReasonMetadataState {
             .entry((choice_index, tool_call_index))
             .or_default();
         let mut changed = false;
-        if let Some(id) = id {
-            if pending.id.as_deref() != Some(id) {
-                pending.id = Some(id.to_string());
-                changed = true;
-            }
+        if let Some(id) = id
+            && pending.id.as_deref() != Some(id)
+        {
+            pending.id = Some(id.to_string());
+            changed = true;
         }
-        if let Some(name) = name {
-            if pending.name.as_deref() != Some(name) {
-                pending.name = Some(name.to_string());
-                changed = true;
-            }
+        if let Some(name) = name
+            && pending.name.as_deref() != Some(name)
+        {
+            pending.name = Some(name.to_string());
+            changed = true;
         }
 
         if !changed {

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -3,6 +3,7 @@
 
 //! Dynamo LLM integration helpers for agent trace records.
 
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,16 +12,102 @@ use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::pipeline::Context;
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::transports::event_plane::EventSubscriber;
-use futures::Stream;
+use futures::{Stream, StreamExt};
+use parking_lot::Mutex;
 
 use crate::agents::context::AgentContext;
 use crate::agents::trace::{
     AgentReplayMetrics, AgentRequestMetrics, AgentToolEventRelay, AgentTracePolicy,
-    AgentTraceRecord, DEFAULT_TOOL_EVENTS_TOPIC, WorkerInfo,
+    AgentTraceRecord, DEFAULT_TOOL_EVENTS_TOPIC, FinishReasonMetadata, ToolCallMetadata,
+    WorkerInfo,
 };
 use crate::local_model::LocalModel;
+use crate::protocols::common::FinishReason as BackendFinishReason;
 use crate::protocols::common::preprocessor::PreprocessedRequest;
 use crate::protocols::common::timing::RequestTracker;
+use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+
+pub(crate) type SharedFinishReasonMetadata = Arc<Mutex<FinishReasonMetadataState>>;
+
+#[derive(Debug, Default)]
+pub(crate) struct FinishReasonMetadataState {
+    metadata: FinishReasonMetadata,
+    pending_tool_calls: HashMap<(u32, u32), PendingToolCallMetadata>,
+}
+
+#[derive(Debug, Default)]
+struct PendingToolCallMetadata {
+    id: Option<String>,
+    name: Option<String>,
+    has_arguments: bool,
+}
+
+impl FinishReasonMetadataState {
+    fn record_backend_finish_reason(
+        &mut self,
+        choice_index: Option<u32>,
+        backend_finish_reason: Option<String>,
+        stop_reason: Option<dynamo_protocols::types::StopReason>,
+    ) {
+        if let Some(backend_finish_reason) = backend_finish_reason.as_ref() {
+            self.metadata.backend_finish_reason = Some(backend_finish_reason.clone());
+        }
+        if let Some(stop_reason) = stop_reason.as_ref() {
+            self.metadata.stop_reason = Some(stop_reason.clone());
+        }
+        if let Some(choice_index) = choice_index {
+            self.metadata.record_choice_backend_finish_reason(
+                choice_index,
+                backend_finish_reason,
+                stop_reason,
+            );
+        }
+    }
+
+    fn record_choice_finish_reason(
+        &mut self,
+        choice_index: u32,
+        finish_reason: dynamo_protocols::types::FinishReason,
+    ) {
+        self.metadata.finish_reason = Some(finish_reason.clone());
+        self.metadata
+            .record_choice_finish_reason(choice_index, finish_reason);
+    }
+
+    fn record_tool_call_chunk(
+        &mut self,
+        choice_index: u32,
+        tool_call_index: u32,
+        id: Option<&str>,
+        name: Option<&str>,
+        arguments_present: bool,
+    ) {
+        let pending = self
+            .pending_tool_calls
+            .entry((choice_index, tool_call_index))
+            .or_default();
+        if let Some(id) = id {
+            pending.id = Some(id.to_string());
+        }
+        if let Some(name) = name {
+            pending.name = Some(name.to_string());
+        }
+        pending.has_arguments |= arguments_present;
+
+        if pending.name.is_some() && pending.has_arguments {
+            self.metadata.record_tool_call(ToolCallMetadata {
+                choice_index,
+                tool_call_index,
+                id: pending.id.clone(),
+                name: pending.name.clone(),
+            });
+        }
+    }
+
+    fn snapshot(&self) -> Option<FinishReasonMetadata> {
+        (!self.metadata.is_empty()).then_some(self.metadata.clone())
+    }
+}
 
 /// Record token counts needed by agent trace request-end records.
 ///
@@ -88,6 +175,7 @@ pub(crate) fn request_metrics(
             .and_then(|timing| timing.router_queue_depth.map(|v| v as u64)),
         worker,
         replay: None,
+        finish_reason_metadata: None,
     }
 }
 
@@ -97,6 +185,7 @@ pub(crate) struct AgentTraceRequestEndState {
     pub request_tracker: Option<Arc<RequestTracker>>,
     pub x_request_id: Option<String>,
     pub replay_metrics: Option<AgentReplayMetrics>,
+    pub finish_reason_metadata: SharedFinishReasonMetadata,
 }
 
 pub(crate) fn build_agent_trace_request_end_state(
@@ -123,7 +212,72 @@ pub(crate) fn build_agent_trace_request_end_state(
         request_tracker: tracker.clone(),
         x_request_id,
         replay_metrics: super::request_replay_metrics(&common_request.token_ids, trace_block_size),
+        finish_reason_metadata: Arc::new(Mutex::new(FinishReasonMetadataState::default())),
     })
+}
+
+pub(crate) fn finish_reason_metadata_handle(
+    trace_state: &Option<AgentTraceRequestEndState>,
+) -> Option<SharedFinishReasonMetadata> {
+    trace_state
+        .as_ref()
+        .map(|state| state.finish_reason_metadata.clone())
+}
+
+pub(crate) fn record_backend_finish_reason_metadata(
+    finish_reason_metadata: Option<&SharedFinishReasonMetadata>,
+    choice_index: Option<u32>,
+    finish_reason: Option<&BackendFinishReason>,
+    stop_reason: Option<&dynamo_protocols::types::StopReason>,
+) {
+    if finish_reason.is_none() && stop_reason.is_none() {
+        return;
+    }
+    let Some(finish_reason_metadata) = finish_reason_metadata else {
+        return;
+    };
+
+    finish_reason_metadata.lock().record_backend_finish_reason(
+        choice_index,
+        finish_reason.map(ToString::to_string),
+        stop_reason.cloned(),
+    );
+}
+
+fn record_chat_finish_reason_metadata(
+    finish_reason_metadata: &SharedFinishReasonMetadata,
+    response: &Annotated<NvCreateChatCompletionStreamResponse>,
+) {
+    let Some(data) = response.data.as_ref() else {
+        return;
+    };
+
+    let mut metadata = finish_reason_metadata.lock();
+    for choice in &data.inner.choices {
+        if let Some(finish_reason) = choice.finish_reason.as_ref() {
+            metadata.record_choice_finish_reason(choice.index, finish_reason.clone());
+        }
+
+        let Some(tool_calls) = choice.delta.tool_calls.as_ref() else {
+            continue;
+        };
+        for tool_call in tool_calls {
+            let function = tool_call.function.as_ref();
+            metadata.record_tool_call_chunk(
+                choice.index,
+                tool_call.index,
+                tool_call.id.as_deref(),
+                function.and_then(|function| function.name.as_deref()),
+                function.is_some_and(|function| function.arguments.is_some()),
+            );
+        }
+    }
+}
+
+fn snapshot_finish_reason_metadata(
+    finish_reason_metadata: &SharedFinishReasonMetadata,
+) -> Option<FinishReasonMetadata> {
+    finish_reason_metadata.lock().snapshot()
 }
 
 pub(crate) fn wrap_agent_trace_request_end_stream<Resp>(
@@ -140,6 +294,7 @@ where
         request_tracker,
         x_request_id,
         replay_metrics,
+        finish_reason_metadata,
     }) = trace_state
     else {
         return stream;
@@ -161,9 +316,26 @@ where
             request_tracker.as_deref(),
         );
         metrics.replay = replay_metrics;
+        metrics.finish_reason_metadata = snapshot_finish_reason_metadata(&finish_reason_metadata);
         super::emit_request_end(agent_context, metrics);
     });
     stream
+}
+
+pub(crate) fn wrap_agent_trace_chat_request_end_stream(
+    stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
+    trace_state: Option<AgentTraceRequestEndState>,
+    request_id: String,
+) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
+    let Some(finish_reason_metadata) = finish_reason_metadata_handle(&trace_state) else {
+        return wrap_agent_trace_request_end_stream(stream, trace_state, request_id);
+    };
+
+    let stream = stream.map(move |response| {
+        record_chat_finish_reason_metadata(&finish_reason_metadata, &response);
+        response
+    });
+    wrap_agent_trace_request_end_stream(Box::pin(stream), trace_state, request_id)
 }
 
 pub(crate) async fn start_tool_event_ingest_from_policy(
@@ -300,11 +472,29 @@ fn tool_events_namespace(local_model: &LocalModel) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{thread, time::Duration};
+    use std::{sync::Arc, thread, time::Duration};
 
-    use crate::protocols::common::timing::{RequestTracker, WORKER_TYPE_DECODE};
+    use dynamo_runtime::protocols::annotated::Annotated;
+    use futures::StreamExt;
+    use parking_lot::Mutex;
 
-    use super::request_metrics;
+    use crate::agents::context::AgentContext;
+    use crate::agents::trace::TraceEventType;
+    use crate::protocols::common::{
+        self,
+        timing::{RequestTracker, WORKER_TYPE_DECODE},
+    };
+    use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
+        CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, StopReason,
+    };
+
+    use super::{
+        AgentTraceRequestEndState, FinishReasonMetadataState,
+        record_backend_finish_reason_metadata, request_metrics,
+        wrap_agent_trace_chat_request_end_stream,
+    };
 
     #[test]
     fn test_request_metrics_from_tracker() {
@@ -345,6 +535,7 @@ mod tests {
         assert_eq!(metrics.kv_hit_rate, Some(0.5));
         assert!(metrics.kv_transfer_estimated_latency_ms.is_some());
         assert_eq!(metrics.queue_depth, Some(3));
+        assert!(metrics.finish_reason_metadata.is_none());
         let worker = metrics.worker.expect("worker info should be set");
         assert_eq!(worker.prefill_worker_id, Some(17));
         assert_eq!(worker.prefill_dp_rank, Some(2));
@@ -376,6 +567,153 @@ mod tests {
         assert_eq!(metrics.kv_hit_rate, None);
         assert_eq!(metrics.kv_transfer_estimated_latency_ms, None);
         assert_eq!(metrics.queue_depth, None);
+        assert!(metrics.finish_reason_metadata.is_none());
         assert!(metrics.worker.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_chat_request_end_records_finish_reason_metadata() {
+        super::super::BUS.init(16);
+        let mut rx = super::super::BUS.subscribe();
+
+        let finish_reason_metadata = Arc::new(Mutex::new(FinishReasonMetadataState::default()));
+        record_backend_finish_reason_metadata(
+            Some(&finish_reason_metadata),
+            Some(0),
+            Some(&common::FinishReason::Stop),
+            Some(&StopReason::String("END".to_string())),
+        );
+
+        let trace_state = AgentTraceRequestEndState {
+            agent_context: AgentContext {
+                session_type_id: "ms_agent".to_string(),
+                session_id: "run-finish".to_string(),
+                trajectory_id: "run-finish:agent".to_string(),
+                parent_trajectory_id: None,
+            },
+            request_model: "test-model".to_string(),
+            request_tracker: None,
+            x_request_id: Some("llm-call-1".to_string()),
+            replay_metrics: None,
+            finish_reason_metadata,
+        };
+
+        let stream = futures::stream::iter(vec![
+            Annotated::from_data(NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "chatcmpl-1".to_string(),
+                    choices: vec![ChatChoiceStream {
+                        index: 0,
+                        delta: ChatCompletionStreamResponseDelta {
+                            content: None,
+                            function_call: None,
+                            tool_calls: Some(vec![ChatCompletionMessageToolCallChunk {
+                                index: 0,
+                                id: Some("call-1".to_string()),
+                                r#type: None,
+                                function: Some(FunctionCallStream {
+                                    name: Some("web_search".to_string()),
+                                    arguments: None,
+                                }),
+                            }]),
+                            role: None,
+                            refusal: None,
+                            reasoning_content: None,
+                        },
+                        finish_reason: None,
+                        logprobs: None,
+                    }],
+                    created: 0,
+                    model: "test-model".to_string(),
+                    service_tier: None,
+                    system_fingerprint: None,
+                    object: "chat.completion.chunk".to_string(),
+                    usage: None,
+                },
+                nvext: None,
+            }),
+            Annotated::from_data(NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "chatcmpl-1".to_string(),
+                    choices: vec![ChatChoiceStream {
+                        index: 0,
+                        delta: ChatCompletionStreamResponseDelta {
+                            content: None,
+                            function_call: None,
+                            tool_calls: Some(vec![ChatCompletionMessageToolCallChunk {
+                                index: 0,
+                                id: None,
+                                r#type: None,
+                                function: Some(FunctionCallStream {
+                                    name: None,
+                                    arguments: Some(r#"{"q":"weather"}"#.to_string()),
+                                }),
+                            }]),
+                            role: None,
+                            refusal: None,
+                            reasoning_content: None,
+                        },
+                        finish_reason: Some(FinishReason::ToolCalls),
+                        logprobs: None,
+                    }],
+                    created: 0,
+                    model: "test-model".to_string(),
+                    service_tier: None,
+                    system_fingerprint: None,
+                    object: "chat.completion.chunk".to_string(),
+                    usage: None,
+                },
+                nvext: None,
+            }),
+        ]);
+
+        let wrapped = wrap_agent_trace_chat_request_end_stream(
+            Box::pin(stream),
+            Some(trace_state),
+            "req-finish".to_string(),
+        );
+        let responses: Vec<_> = wrapped.collect().await;
+        assert_eq!(responses.len(), 2);
+
+        let record = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let record = rx.recv().await.expect("trace record should publish");
+                if record.event_type == TraceEventType::RequestEnd
+                    && record
+                        .request
+                        .as_ref()
+                        .is_some_and(|request| request.request_id == "req-finish")
+                {
+                    break record;
+                }
+            }
+        })
+        .await
+        .expect("trace record for req-finish should publish");
+        let request = record.request.expect("request metrics should be present");
+        let metadata = request
+            .finish_reason_metadata
+            .expect("finish metadata should be recorded");
+        assert_eq!(metadata.backend_finish_reason.as_deref(), Some("stop"));
+        assert_eq!(metadata.finish_reason, Some(FinishReason::ToolCalls));
+        assert_eq!(
+            metadata.stop_reason,
+            Some(StopReason::String("END".to_string()))
+        );
+        assert_eq!(metadata.tool_calls.len(), 1);
+        assert_eq!(metadata.tool_calls[0].choice_index, 0);
+        assert_eq!(metadata.tool_calls[0].tool_call_index, 0);
+        assert_eq!(metadata.tool_calls[0].id.as_deref(), Some("call-1"));
+        assert_eq!(metadata.tool_calls[0].name.as_deref(), Some("web_search"));
+        assert_eq!(metadata.choices.len(), 1);
+        assert_eq!(metadata.choices[0].choice_index, 0);
+        assert_eq!(
+            metadata.choices[0].backend_finish_reason.as_deref(),
+            Some("stop")
+        );
+        assert_eq!(
+            metadata.choices[0].finish_reason,
+            Some(FinishReason::ToolCalls)
+        );
     }
 }

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -29,10 +29,13 @@ use crate::protocols::openai::{
     chat_completions::NvCreateChatCompletionStreamResponse, completions::NvCreateCompletionResponse,
 };
 
-pub(crate) type SharedFinishReasonMetadata = Arc<Mutex<FinishReasonMetadataState>>;
+#[derive(Clone, Debug, Default)]
+pub struct SharedFinishReasonMetadata {
+    state: Arc<Mutex<FinishReasonMetadataState>>,
+}
 
 #[derive(Debug, Default)]
-pub(crate) struct FinishReasonMetadataState {
+struct FinishReasonMetadataState {
     metadata: FinishReasonMetadata,
     pending_tool_calls: HashMap<(u32, u32), PendingToolCallMetadata>,
 }
@@ -41,7 +44,12 @@ pub(crate) struct FinishReasonMetadataState {
 struct PendingToolCallMetadata {
     id: Option<String>,
     name: Option<String>,
-    has_arguments: bool,
+}
+
+impl SharedFinishReasonMetadata {
+    fn lock(&self) -> parking_lot::MutexGuard<'_, FinishReasonMetadataState> {
+        self.state.lock()
+    }
 }
 
 impl FinishReasonMetadataState {
@@ -82,7 +90,6 @@ impl FinishReasonMetadataState {
         tool_call_index: u32,
         id: Option<&str>,
         name: Option<&str>,
-        arguments_present: bool,
     ) {
         let pending = self
             .pending_tool_calls
@@ -94,9 +101,8 @@ impl FinishReasonMetadataState {
         if let Some(name) = name {
             pending.name = Some(name.to_string());
         }
-        pending.has_arguments |= arguments_present;
 
-        if pending.name.is_some() && pending.has_arguments {
+        if pending.id.is_some() || pending.name.is_some() {
             self.metadata.record_tool_call(ToolCallMetadata {
                 choice_index,
                 tool_call_index,
@@ -214,7 +220,7 @@ pub(crate) fn build_agent_trace_request_end_state(
         request_tracker: tracker.clone(),
         x_request_id,
         replay_metrics: super::request_replay_metrics(&common_request.token_ids, trace_block_size),
-        finish_reason_metadata: Arc::new(Mutex::new(FinishReasonMetadataState::default())),
+        finish_reason_metadata: SharedFinishReasonMetadata::default(),
     })
 }
 
@@ -270,7 +276,6 @@ fn record_chat_finish_reason_metadata(
                 tool_call.index,
                 tool_call.id.as_deref(),
                 function.and_then(|function| function.name.as_deref()),
-                function.is_some_and(|function| function.arguments.is_some()),
             );
         }
     }
@@ -525,11 +530,10 @@ fn tool_events_namespace(local_model: &LocalModel) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, thread, time::Duration};
+    use std::{thread, time::Duration};
 
     use dynamo_runtime::protocols::annotated::Annotated;
     use futures::StreamExt;
-    use parking_lot::Mutex;
 
     use crate::agents::context::AgentContext;
     use crate::agents::trace::TraceEventType;
@@ -548,7 +552,7 @@ mod tests {
     };
 
     use super::{
-        AgentTraceRequestEndState, FinishReasonMetadataState,
+        AgentTraceRequestEndState, SharedFinishReasonMetadata,
         record_backend_finish_reason_metadata, request_metrics,
         wrap_agent_trace_chat_request_end_stream, wrap_agent_trace_completion_request_end_stream,
     };
@@ -633,7 +637,7 @@ mod tests {
         super::super::BUS.init(16);
         let mut rx = super::super::BUS.subscribe();
 
-        let finish_reason_metadata = Arc::new(Mutex::new(FinishReasonMetadataState::default()));
+        let finish_reason_metadata = SharedFinishReasonMetadata::default();
         record_backend_finish_reason_metadata(
             Some(&finish_reason_metadata),
             Some(0),
@@ -697,15 +701,7 @@ mod tests {
                         delta: ChatCompletionStreamResponseDelta {
                             content: None,
                             function_call: None,
-                            tool_calls: Some(vec![ChatCompletionMessageToolCallChunk {
-                                index: 0,
-                                id: None,
-                                r#type: None,
-                                function: Some(FunctionCallStream {
-                                    name: None,
-                                    arguments: Some(r#"{"q":"weather"}"#.to_string()),
-                                }),
-                            }]),
+                            tool_calls: None,
                             role: None,
                             refusal: None,
                             reasoning_content: None,
@@ -779,7 +775,7 @@ mod tests {
         super::super::BUS.init(16);
         let mut rx = super::super::BUS.subscribe();
 
-        let finish_reason_metadata = Arc::new(Mutex::new(FinishReasonMetadataState::default()));
+        let finish_reason_metadata = SharedFinishReasonMetadata::default();
         record_backend_finish_reason_metadata(
             Some(&finish_reason_metadata),
             Some(0),

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -38,6 +38,7 @@ pub struct SharedFinishReasonMetadata {
 struct FinishReasonMetadataState {
     metadata: FinishReasonMetadata,
     pending_tool_calls: HashMap<(u32, u32), PendingToolCallMetadata>,
+    tool_call_positions: HashMap<(u32, u32), usize>,
 }
 
 #[derive(Debug, Default)]
@@ -49,6 +50,25 @@ struct PendingToolCallMetadata {
 impl SharedFinishReasonMetadata {
     fn lock(&self) -> parking_lot::MutexGuard<'_, FinishReasonMetadataState> {
         self.state.lock()
+    }
+
+    #[cfg(feature = "agent-trace-bench")]
+    #[doc(hidden)]
+    pub fn record_tool_call_chunk_for_bench(
+        &self,
+        choice_index: u32,
+        tool_call_index: u32,
+        id: Option<&str>,
+        name: Option<&str>,
+    ) {
+        self.lock()
+            .record_tool_call_chunk(choice_index, tool_call_index, id, name);
+    }
+
+    #[cfg(feature = "agent-trace-bench")]
+    #[doc(hidden)]
+    pub fn snapshot_for_bench(&self) -> Option<FinishReasonMetadata> {
+        self.lock().snapshot()
     }
 }
 
@@ -91,19 +111,45 @@ impl FinishReasonMetadataState {
         id: Option<&str>,
         name: Option<&str>,
     ) {
+        if id.is_none() && name.is_none() {
+            return;
+        }
+
         let pending = self
             .pending_tool_calls
             .entry((choice_index, tool_call_index))
             .or_default();
+        let mut changed = false;
         if let Some(id) = id {
-            pending.id = Some(id.to_string());
+            if pending.id.as_deref() != Some(id) {
+                pending.id = Some(id.to_string());
+                changed = true;
+            }
         }
         if let Some(name) = name {
-            pending.name = Some(name.to_string());
+            if pending.name.as_deref() != Some(name) {
+                pending.name = Some(name.to_string());
+                changed = true;
+            }
         }
 
-        if pending.id.is_some() || pending.name.is_some() {
-            self.metadata.record_tool_call(ToolCallMetadata {
+        if !changed {
+            return;
+        }
+
+        let key = (choice_index, tool_call_index);
+        if let Some(position) = self.tool_call_positions.get(&key).copied() {
+            let existing = &mut self.metadata.tool_calls[position];
+            if existing.id.is_none() {
+                existing.id = pending.id.clone();
+            }
+            if existing.name.is_none() {
+                existing.name = pending.name.clone();
+            }
+        } else {
+            let position = self.metadata.tool_calls.len();
+            self.tool_call_positions.insert(key, position);
+            self.metadata.tool_calls.push(ToolCallMetadata {
                 choice_index,
                 tool_call_index,
                 id: pending.id.clone(),

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -79,7 +79,7 @@ impl FinishReasonMetadataState {
         choice_index: u32,
         finish_reason: dynamo_protocols::types::FinishReason,
     ) {
-        self.metadata.finish_reason = Some(finish_reason.clone());
+        self.metadata.finish_reason = Some(finish_reason);
         self.metadata
             .record_choice_finish_reason(choice_index, finish_reason);
     }
@@ -263,7 +263,7 @@ fn record_chat_finish_reason_metadata(
     let mut metadata = finish_reason_metadata.lock();
     for choice in &data.inner.choices {
         if let Some(finish_reason) = choice.finish_reason.as_ref() {
-            metadata.record_choice_finish_reason(choice.index, finish_reason.clone());
+            metadata.record_choice_finish_reason(choice.index, *finish_reason);
         }
 
         let Some(tool_calls) = choice.delta.tool_calls.as_ref() else {

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -25,7 +25,9 @@ use crate::local_model::LocalModel;
 use crate::protocols::common::FinishReason as BackendFinishReason;
 use crate::protocols::common::preprocessor::PreprocessedRequest;
 use crate::protocols::common::timing::RequestTracker;
-use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+use crate::protocols::openai::{
+    chat_completions::NvCreateChatCompletionStreamResponse, completions::NvCreateCompletionResponse,
+};
 
 pub(crate) type SharedFinishReasonMetadata = Arc<Mutex<FinishReasonMetadataState>>;
 
@@ -274,6 +276,41 @@ fn record_chat_finish_reason_metadata(
     }
 }
 
+fn completion_finish_reason_to_finish_reason(
+    finish_reason: dynamo_protocols::types::CompletionFinishReason,
+) -> dynamo_protocols::types::FinishReason {
+    match finish_reason {
+        dynamo_protocols::types::CompletionFinishReason::Stop => {
+            dynamo_protocols::types::FinishReason::Stop
+        }
+        dynamo_protocols::types::CompletionFinishReason::Length => {
+            dynamo_protocols::types::FinishReason::Length
+        }
+        dynamo_protocols::types::CompletionFinishReason::ContentFilter => {
+            dynamo_protocols::types::FinishReason::ContentFilter
+        }
+    }
+}
+
+fn record_completion_finish_reason_metadata(
+    finish_reason_metadata: &SharedFinishReasonMetadata,
+    response: &Annotated<NvCreateCompletionResponse>,
+) {
+    let Some(data) = response.data.as_ref() else {
+        return;
+    };
+
+    let mut metadata = finish_reason_metadata.lock();
+    for choice in &data.inner.choices {
+        if let Some(finish_reason) = choice.finish_reason {
+            metadata.record_choice_finish_reason(
+                choice.index,
+                completion_finish_reason_to_finish_reason(finish_reason),
+            );
+        }
+    }
+}
+
 fn snapshot_finish_reason_metadata(
     finish_reason_metadata: &SharedFinishReasonMetadata,
 ) -> Option<FinishReasonMetadata> {
@@ -333,6 +370,22 @@ pub(crate) fn wrap_agent_trace_chat_request_end_stream(
 
     let stream = stream.map(move |response| {
         record_chat_finish_reason_metadata(&finish_reason_metadata, &response);
+        response
+    });
+    wrap_agent_trace_request_end_stream(Box::pin(stream), trace_state, request_id)
+}
+
+pub(crate) fn wrap_agent_trace_completion_request_end_stream(
+    stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>,
+    trace_state: Option<AgentTraceRequestEndState>,
+    request_id: String,
+) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>> {
+    let Some(finish_reason_metadata) = finish_reason_metadata_handle(&trace_state) else {
+        return wrap_agent_trace_request_end_stream(stream, trace_state, request_id);
+    };
+
+    let stream = stream.map(move |response| {
+        record_completion_finish_reason_metadata(&finish_reason_metadata, &response);
         response
     });
     wrap_agent_trace_request_end_stream(Box::pin(stream), trace_state, request_id)
@@ -484,16 +537,20 @@ mod tests {
         self,
         timing::{RequestTracker, WORKER_TYPE_DECODE},
     };
-    use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+    use crate::protocols::openai::{
+        chat_completions::NvCreateChatCompletionStreamResponse,
+        completions::NvCreateCompletionResponse,
+    };
     use dynamo_protocols::types::{
         ChatChoiceStream, ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
-        CreateChatCompletionStreamResponse, FinishReason, FunctionCallStream, StopReason,
+        Choice, CompletionFinishReason, CreateChatCompletionStreamResponse,
+        CreateCompletionResponse, FinishReason, FunctionCallStream, StopReason,
     };
 
     use super::{
         AgentTraceRequestEndState, FinishReasonMetadataState,
         record_backend_finish_reason_metadata, request_metrics,
-        wrap_agent_trace_chat_request_end_stream,
+        wrap_agent_trace_chat_request_end_stream, wrap_agent_trace_completion_request_end_stream,
     };
 
     #[test]
@@ -714,6 +771,98 @@ mod tests {
         assert_eq!(
             metadata.choices[0].finish_reason,
             Some(FinishReason::ToolCalls)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_completion_request_end_records_finish_reason_metadata() {
+        super::super::BUS.init(16);
+        let mut rx = super::super::BUS.subscribe();
+
+        let finish_reason_metadata = Arc::new(Mutex::new(FinishReasonMetadataState::default()));
+        record_backend_finish_reason_metadata(
+            Some(&finish_reason_metadata),
+            Some(0),
+            Some(&common::FinishReason::Stop),
+            Some(&StopReason::String("END".to_string())),
+        );
+
+        let trace_state = AgentTraceRequestEndState {
+            agent_context: AgentContext {
+                session_type_id: "ms_agent".to_string(),
+                session_id: "run-completion-finish".to_string(),
+                trajectory_id: "run-completion-finish:agent".to_string(),
+                parent_trajectory_id: None,
+            },
+            request_model: "test-model".to_string(),
+            request_tracker: None,
+            x_request_id: Some("completion-call-1".to_string()),
+            replay_metrics: None,
+            finish_reason_metadata,
+        };
+
+        let stream =
+            futures::stream::iter(vec![Annotated::from_data(NvCreateCompletionResponse {
+                inner: CreateCompletionResponse {
+                    id: "cmpl-1".to_string(),
+                    object: "text_completion".to_string(),
+                    created: 0,
+                    model: "test-model".to_string(),
+                    system_fingerprint: None,
+                    choices: vec![Choice {
+                        text: "".to_string(),
+                        index: 0,
+                        logprobs: None,
+                        finish_reason: Some(CompletionFinishReason::Length),
+                    }],
+                    usage: None,
+                },
+                nvext: None,
+            })]);
+
+        let wrapped = wrap_agent_trace_completion_request_end_stream(
+            Box::pin(stream),
+            Some(trace_state),
+            "req-completion-finish".to_string(),
+        );
+        let responses: Vec<_> = wrapped.collect().await;
+        assert_eq!(responses.len(), 1);
+
+        let record = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let record = rx.recv().await.expect("trace record should publish");
+                if record.event_type == TraceEventType::RequestEnd
+                    && record
+                        .request
+                        .as_ref()
+                        .is_some_and(|request| request.request_id == "req-completion-finish")
+                {
+                    break record;
+                }
+            }
+        })
+        .await
+        .expect("trace record for req-completion-finish should publish");
+        let request = record.request.expect("request metrics should be present");
+        let metadata = request
+            .finish_reason_metadata
+            .expect("finish metadata should be recorded");
+        assert_eq!(metadata.backend_finish_reason.as_deref(), Some("stop"));
+        assert_eq!(metadata.finish_reason, Some(FinishReason::Length));
+        assert_eq!(
+            metadata.stop_reason,
+            Some(StopReason::String("END".to_string()))
+        );
+        assert!(metadata.tool_calls.is_empty());
+        assert_eq!(metadata.choices.len(), 1);
+        assert_eq!(metadata.choices[0].choice_index, 0);
+        assert_eq!(
+            metadata.choices[0].backend_finish_reason.as_deref(),
+            Some("stop")
+        );
+        assert_eq!(
+            metadata.choices[0].finish_reason,
+            Some(FinishReason::Length)
         );
     }
 }

--- a/lib/llm/src/agents/trace/mod.rs
+++ b/lib/llm/src/agents/trace/mod.rs
@@ -15,8 +15,10 @@ use crate::telemetry::bus::TelemetryBus;
 
 pub use config::{AgentTracePolicy, is_enabled, policy};
 pub(crate) use integration::{
-    build_agent_trace_request_end_state, record_llm_metric_tokens, request_metrics,
-    start_tool_event_ingest_from_policy, wrap_agent_trace_request_end_stream,
+    SharedFinishReasonMetadata, build_agent_trace_request_end_state, finish_reason_metadata_handle,
+    record_backend_finish_reason_metadata, record_llm_metric_tokens, request_metrics,
+    start_tool_event_ingest_from_policy, wrap_agent_trace_chat_request_end_stream,
+    wrap_agent_trace_request_end_stream,
 };
 pub(crate) use record::validate_tool_record;
 pub use record::{emit_request_end, publish_tool_record};
@@ -24,7 +26,8 @@ pub use relay::AgentToolEventRelay;
 pub(crate) use replay::request_replay_metrics;
 pub use types::{
     AgentReplayMetrics, AgentRequestMetrics, AgentToolEvent, AgentToolStatus, AgentTraceRecord,
-    TraceEventSource, TraceEventType, TraceSchema, WorkerInfo,
+    ChoiceFinishReasonMetadata, FinishReasonMetadata, ToolCallMetadata, TraceEventSource,
+    TraceEventType, TraceSchema, WorkerInfo,
 };
 
 pub const DEFAULT_TOOL_EVENTS_TOPIC: &str = "agent-tool-events";

--- a/lib/llm/src/agents/trace/mod.rs
+++ b/lib/llm/src/agents/trace/mod.rs
@@ -14,11 +14,12 @@ use tokio_util::sync::CancellationToken;
 use crate::telemetry::bus::TelemetryBus;
 
 pub use config::{AgentTracePolicy, is_enabled, policy};
+pub use integration::SharedFinishReasonMetadata;
 pub(crate) use integration::{
-    SharedFinishReasonMetadata, build_agent_trace_request_end_state, finish_reason_metadata_handle,
+    build_agent_trace_request_end_state, finish_reason_metadata_handle,
     record_backend_finish_reason_metadata, record_llm_metric_tokens, request_metrics,
     start_tool_event_ingest_from_policy, wrap_agent_trace_chat_request_end_stream,
-    wrap_agent_trace_completion_request_end_stream, wrap_agent_trace_request_end_stream,
+    wrap_agent_trace_completion_request_end_stream,
 };
 pub(crate) use record::validate_tool_record;
 pub use record::{emit_request_end, publish_tool_record};

--- a/lib/llm/src/agents/trace/mod.rs
+++ b/lib/llm/src/agents/trace/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use integration::{
     SharedFinishReasonMetadata, build_agent_trace_request_end_state, finish_reason_metadata_handle,
     record_backend_finish_reason_metadata, record_llm_metric_tokens, request_metrics,
     start_tool_event_ingest_from_policy, wrap_agent_trace_chat_request_end_stream,
-    wrap_agent_trace_request_end_stream,
+    wrap_agent_trace_completion_request_end_stream, wrap_agent_trace_request_end_stream,
 };
 pub(crate) use record::validate_tool_record;
 pub use record::{emit_request_end, publish_tool_record};

--- a/lib/llm/src/agents/trace/record.rs
+++ b/lib/llm/src/agents/trace/record.rs
@@ -124,6 +124,7 @@ mod tests {
                 queue_depth: None,
                 worker: None,
                 replay: None,
+                finish_reason_metadata: None,
             },
         );
 

--- a/lib/llm/src/agents/trace/sink.rs
+++ b/lib/llm/src/agents/trace/sink.rs
@@ -267,6 +267,7 @@ mod tests {
                 queue_depth: None,
                 worker: None,
                 replay: None,
+                finish_reason_metadata: None,
             }),
             tool: None,
         }

--- a/lib/llm/src/agents/trace/types.rs
+++ b/lib/llm/src/agents/trace/types.rs
@@ -84,6 +84,8 @@ pub struct AgentRequestMetrics {
     pub worker: Option<WorkerInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub replay: Option<AgentReplayMetrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason_metadata: Option<FinishReasonMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -103,6 +105,125 @@ pub struct WorkerInfo {
     pub decode_worker_id: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decode_dp_rank: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct FinishReasonMetadata {
+    /// Final OpenAI-compatible finish reason after parser/post-processing rewrites.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<dynamo_protocols::types::FinishReason>,
+
+    /// Raw backend finish reason before parser/post-processing rewrites.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_finish_reason: Option<String>,
+
+    /// Backend-provided stop condition that caused `finish_reason=stop`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<dynamo_protocols::types::StopReason>,
+
+    /// Complete tool calls emitted by the model. Arguments are intentionally
+    /// omitted so agent traces remain metadata, not payload logs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<ToolCallMetadata>,
+
+    /// Per-choice finish metadata for multi-choice requests. The top-level
+    /// fields remain as a compact summary for the common single-choice case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub choices: Vec<ChoiceFinishReasonMetadata>,
+}
+
+impl FinishReasonMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.finish_reason.is_none()
+            && self.backend_finish_reason.is_none()
+            && self.stop_reason.is_none()
+            && self.tool_calls.is_empty()
+            && self.choices.is_empty()
+    }
+
+    pub fn record_tool_call(&mut self, tool_call: ToolCallMetadata) {
+        if let Some(existing) = self.tool_calls.iter_mut().find(|existing| {
+            (existing.choice_index == tool_call.choice_index
+                && existing.tool_call_index == tool_call.tool_call_index)
+                || tool_call
+                    .id
+                    .as_ref()
+                    .is_some_and(|id| existing.id.as_ref() == Some(id))
+        }) {
+            if existing.id.is_none() {
+                existing.id = tool_call.id;
+            }
+            if existing.name.is_none() {
+                existing.name = tool_call.name;
+            }
+        } else {
+            self.tool_calls.push(tool_call);
+        }
+    }
+
+    pub fn record_choice_finish_reason(
+        &mut self,
+        choice_index: u32,
+        finish_reason: dynamo_protocols::types::FinishReason,
+    ) {
+        self.choice_metadata_mut(choice_index).finish_reason = Some(finish_reason);
+    }
+
+    pub fn record_choice_backend_finish_reason(
+        &mut self,
+        choice_index: u32,
+        backend_finish_reason: Option<String>,
+        stop_reason: Option<dynamo_protocols::types::StopReason>,
+    ) {
+        let choice = self.choice_metadata_mut(choice_index);
+        if let Some(backend_finish_reason) = backend_finish_reason {
+            choice.backend_finish_reason = Some(backend_finish_reason);
+        }
+        if let Some(stop_reason) = stop_reason {
+            choice.stop_reason = Some(stop_reason);
+        }
+    }
+
+    fn choice_metadata_mut(&mut self, choice_index: u32) -> &mut ChoiceFinishReasonMetadata {
+        if let Some(position) = self
+            .choices
+            .iter()
+            .position(|choice| choice.choice_index == choice_index)
+        {
+            return &mut self.choices[position];
+        }
+
+        self.choices.push(ChoiceFinishReasonMetadata {
+            choice_index,
+            finish_reason: None,
+            backend_finish_reason: None,
+            stop_reason: None,
+        });
+        self.choices
+            .last_mut()
+            .expect("choice metadata was just pushed")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolCallMetadata {
+    pub choice_index: u32,
+    pub tool_call_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChoiceFinishReasonMetadata {
+    pub choice_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<dynamo_protocols::types::FinishReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_finish_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<dynamo_protocols::types::StopReason>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/llm/src/agents/trace/types.rs
+++ b/lib/llm/src/agents/trace/types.rs
@@ -141,26 +141,6 @@ impl FinishReasonMetadata {
             && self.choices.is_empty()
     }
 
-    pub fn record_tool_call(&mut self, tool_call: ToolCallMetadata) {
-        if let Some(existing) = self.tool_calls.iter_mut().find(|existing| {
-            (existing.choice_index == tool_call.choice_index
-                && existing.tool_call_index == tool_call.tool_call_index)
-                || tool_call
-                    .id
-                    .as_ref()
-                    .is_some_and(|id| existing.id.as_ref() == Some(id))
-        }) {
-            if existing.id.is_none() {
-                existing.id = tool_call.id;
-            }
-            if existing.name.is_none() {
-                existing.name = tool_call.name;
-            }
-        } else {
-            self.tool_calls.push(tool_call);
-        }
-    }
-
     pub fn record_choice_finish_reason(
         &mut self,
         choice_index: u32,

--- a/lib/llm/src/agents/trace/types.rs
+++ b/lib/llm/src/agents/trace/types.rs
@@ -193,15 +193,14 @@ impl FinishReasonMetadata {
             return &mut self.choices[position];
         }
 
+        let position = self.choices.len();
         self.choices.push(ChoiceFinishReasonMetadata {
             choice_index,
             finish_reason: None,
             backend_finish_reason: None,
             stop_reason: None,
         });
-        self.choices
-            .last_mut()
-            .expect("choice metadata was just pushed")
+        &mut self.choices[position]
     }
 }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2843,7 +2843,7 @@ impl
             trace_finish_reason_metadata,
         );
 
-        let stream = crate::agents::trace::wrap_agent_trace_request_end_stream(
+        let stream = crate::agents::trace::wrap_agent_trace_completion_request_end_stream(
             Box::pin(stream),
             trace_state,
             request_id,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1800,6 +1800,7 @@ impl OpenAIPreprocessor {
         generator: Box<dyn DeltaGeneratorExt<Resp>>,
         context: Arc<dyn AsyncEngineContext>,
         trace_tokens_enabled: bool,
+        trace_finish_reason_metadata: Option<crate::agents::trace::SharedFinishReasonMetadata>,
     ) -> impl Stream<Item = Annotated<Resp>> + Send
     where
         S: Stream<Item = Annotated<BackendOutput>> + Send + 'static,
@@ -1818,6 +1819,7 @@ impl OpenAIPreprocessor {
             usage_chunk_sent: bool,
             finished: bool,
             trace_tokens_enabled: bool,
+            trace_finish_reason_metadata: Option<crate::agents::trace::SharedFinishReasonMetadata>,
         }
 
         let state = State {
@@ -1830,6 +1832,7 @@ impl OpenAIPreprocessor {
             usage_chunk_sent: false,
             finished: false,
             trace_tokens_enabled,
+            trace_finish_reason_metadata,
         };
 
         // transform the common response stream into a chat response stream
@@ -1869,6 +1872,13 @@ impl OpenAIPreprocessor {
                         inner.cumulative_output_tokens += chunk_tokens;
 
                         let isl = inner.response_generator.get_isl().map(|isl| isl as usize);
+
+                        crate::agents::trace::record_backend_finish_reason_metadata(
+                            inner.trace_finish_reason_metadata.as_ref(),
+                            backend_output.index,
+                            backend_output.finish_reason.as_ref(),
+                            backend_output.stop_reason.as_ref(),
+                        );
 
                         (chunk_tokens, isl)
                     } else {
@@ -2631,6 +2641,8 @@ impl
             self.kv_cache_block_size,
         );
         let trace_tokens_enabled = trace_state.is_some();
+        let trace_finish_reason_metadata =
+            crate::agents::trace::finish_reason_metadata_handle(&trace_state);
 
         // Attach the timing tracker to the request so downstream components can record metrics
         common_request.tracker = tracker;
@@ -2664,6 +2676,7 @@ impl
             response_generator,
             context.clone(),
             trace_tokens_enabled,
+            trace_finish_reason_metadata,
         );
 
         let transformed_stream = self.postprocessor_parsing_stream(
@@ -2706,7 +2719,7 @@ impl
             &self.tokenizer,
         );
 
-        let final_stream = crate::agents::trace::wrap_agent_trace_request_end_stream(
+        let final_stream = crate::agents::trace::wrap_agent_trace_chat_request_end_stream(
             final_stream,
             trace_state,
             request_id,
@@ -2790,6 +2803,8 @@ impl
             self.kv_cache_block_size,
         );
         let trace_tokens_enabled = trace_state.is_some();
+        let trace_finish_reason_metadata =
+            crate::agents::trace::finish_reason_metadata_handle(&trace_state);
 
         // Attach the timing tracker to the request so downstream components can record metrics
         common_request.tracker = tracker;
@@ -2825,6 +2840,7 @@ impl
             response_generator,
             context.clone(),
             trace_tokens_enabled,
+            trace_finish_reason_metadata,
         );
 
         let stream = crate::agents::trace::wrap_agent_trace_request_end_stream(

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -219,6 +219,7 @@ async fn test_streaming_without_usage() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     // Collect all chunks
@@ -279,6 +280,7 @@ async fn test_streaming_with_usage_compliance() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     // Collect all chunks
@@ -353,6 +355,7 @@ async fn test_streaming_with_continuous_usage() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     // Collect all chunks
@@ -445,6 +448,7 @@ async fn test_streaming_with_usage_false() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     // Collect all chunks
@@ -570,6 +574,7 @@ async fn test_nonstreaming_has_usage_field() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     // Aggregate the streaming chunks into a single non-streaming response
@@ -627,6 +632,7 @@ async fn test_cmpl_streaming_with_usage_true_no_backend_usage() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     let chunks: Vec<_> = transformed_stream.collect().await;
@@ -692,6 +698,7 @@ async fn test_cmpl_streaming_with_cached_tokens_propagation() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
     let chunks: Vec<_> = transformed_stream.collect().await;
 
@@ -737,6 +744,7 @@ async fn test_chat_streaming_with_cached_tokens_propagation() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
     let chunks: Vec<_> = transformed_stream.collect().await;
 
@@ -782,6 +790,7 @@ async fn test_cmpl_nonstreaming_has_usage_and_cached_tokens() {
         response_generator,
         ctx.clone(),
         false,
+        None,
     );
 
     // Aggregate into a single non-streaming response


### PR DESCRIPTION
## Summary
- add optional finish_reason_metadata to agent request traces
- record backend stop metadata plus final chat and completions finish metadata
- record chat tool-call metadata without storing arguments
- surface finish metadata in Perfetto conversion and document replay limitations

## Review feedback incorporated
- accumulate split streaming tool-call chunks before recording metadata
- preserve per-choice finish metadata for multi-choice requests
- filter async trace tests by request id to avoid shared-bus races
- use parking_lot::Mutex for short metadata critical sections
- keep argument-only tool-call chunks on the cheap path after id/name metadata has been captured

## Follow-up
- wired /v1/completions through a completion-specific trace wrapper so final completion finish reasons are captured from response choices
- did not change parser semantics: live /v1/completions does not currently run the chat tool-call/reasoning parser path

## Performance / benchmark notes
- added Criterion benchmark `agent_trace_finish_metadata` for finish metadata stream overhead and tool-call metadata scaling
- short local run: `finish_metadata_off` ~251 us vs `finish_metadata_on` ~275 us for 256 synthetic chunks, about 23 us total overhead (~90 ns/chunk)
- stress case: `record_unique/4096` records 4,096 distinct tool calls into one trace metadata object; ~2.34 ms total, about 570 ns per unique tool call
- argument-only chunk fast path: `skip_argument_only_chunks/4096` ~89.9 us total after id/name have already been captured
- the 4,096-call number is an intentional scaling stress case, not normal request overhead
- matched local high-concurrency A/B found no meaningful throughput regression with tracing enabled: `76.78 rps` off vs `76.29 rps` on for the same request count, concurrency, and completion-token count

## Validation
- cargo fmt --package dynamo-llm
- cargo bench --bench agent_trace_finish_metadata -p dynamo-llm --features agent-trace-bench --no-run
- cargo test -p dynamo-llm finish_reason_metadata --lib
- cargo bench --bench agent_trace_finish_metadata -p dynamo-llm --features agent-trace-bench -- --sample-size 10 --warm-up-time 1 --measurement-time 1
- local SGLang smoke: `Qwen/Qwen3-0.6B` worker with `--dyn-tool-call-parser hermes --dyn-reasoning-parser qwen3`; streaming `tool_choice=required` request returned `finish_reason: tool_calls`, and JSONL agent trace recorded `finish_reason_metadata.tool_calls[0].name == "get_weather"` with backend finish `stop`
- local high-concurrency perf A/B: warm `Qwen/Qwen3-0.6B` SGLang worker, 384 unary chat requests at concurrency 64, `nvext.agent_context` on every request, `DYN_LOG=warn`, identical 2,112 completion tokens; tracing off `76.78 rps` / p95 `1242.92 ms`, tracing on JSONL with default 1s flush `76.29 rps` / p95 `1174.18 ms`; trace file emitted 448/448 records including warmup
- python3 benchmarks/agent_trace/validate_convert_to_perfetto.py
- PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile benchmarks/agent_trace/convert_to_perfetto.py benchmarks/agent_trace/validate_convert_to_perfetto.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced agent trace records now capture detailed finish metadata including tool-call names, per-choice finish reasons, and backend stop reasons.
  * Perfetto trace conversion now extracts and flattens this metadata for better visibility into tool calls and response completion details.

* **Documentation**
  * Updated agent tracing documentation to clarify finish metadata content and conversion behavior between Perfetto and Mooncake replay formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

