### PR TITLE
fix(trtllm): Remove diffusion image counts restriction. Best effort return number of images (DYN-3056)

### DIFF
--- a/components/src/dynamo/trtllm/engines/diffusion_engine.py
+++ b/components/src/dynamo/trtllm/engines/diffusion_engine.py
@@ -259,7 +259,9 @@ class DiffusionEngine:
 
         logger.info(
             f"Generating: prompt='{prompt[:50]}...', "
-            f"size={width}x{height}, frames={num_frames}, steps={num_inference_steps}"
+            f"size={width}x{height}, frames={num_frames}, "
+            f"num_images_per_prompt={num_images_per_prompt}, "
+            f"steps={num_inference_steps}"
         )
 
         # Use TRT-LLM's DiffusionRequest dataclass so that all defaults
@@ -308,6 +310,13 @@ class DiffusionEngine:
                 logger.info(f"Generated video output with shape {output.video.shape}")
             elif output.image is not None:
                 logger.info(f"Generated image output with shape {output.image.shape}")
+                actual_num_images = output.image.shape[0]
+                if actual_num_images != num_images_per_prompt:
+                    logger.warning(
+                        f"Pipeline returned {actual_num_images} image(s) but "
+                        f"{num_images_per_prompt} were requested; the caller will "
+                        f"receive the pipeline's actual output unchanged."
+                    )
 
         return output
 

--- a/components/src/dynamo/trtllm/engines/diffusion_engine.py
+++ b/components/src/dynamo/trtllm/engines/diffusion_engine.py
@@ -314,8 +314,7 @@ class DiffusionEngine:
                 if actual_num_images != num_images_per_prompt:
                     logger.warning(
                         f"Pipeline returned {actual_num_images} image(s) but "
-                        f"{num_images_per_prompt} were requested; the caller will "
-                        f"receive the pipeline's actual output unchanged."
+                        f"{num_images_per_prompt} were requested."
                     )
 
         return output

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
@@ -206,10 +206,8 @@ class ImageGenerationHandler(BaseGenerativeHandler):
             assert (
                 images.ndim == 4 and images.shape[3] == 3
             ), f"Expected image shape (B, H, W, C), got {images.shape}"
-            # Bound the response to what the caller asked for. The engine
-            # separately warns when the pipeline's actual batch differs from
-            # num_images_per_prompt; the handler does not synthesize missing
-            # images and does not forward extras beyond the requested count.
+            # Engine warns on batch mismatch; here we clamp to the caller's
+            # requested count without padding or synthesizing.
             emit_count = min(images.shape[0], num_images_per_prompt)
             data_items: list[ImageData] = []
             for i in range(emit_count):

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
@@ -158,6 +158,11 @@ class ImageGenerationHandler(BaseGenerativeHandler):
         num_images_per_prompt = (
             req.n if req.n is not None else self.config.default_num_images_per_prompt
         )
+        if not 1 <= num_images_per_prompt <= 10:
+            raise ValueError(
+                f"num_images_per_prompt must be in [1, 10], got "
+                f"{num_images_per_prompt}."
+            )
         num_inference_steps = (
             nvext.num_inference_steps
             if nvext.num_inference_steps is not None

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
@@ -155,10 +155,6 @@ class ImageGenerationHandler(BaseGenerativeHandler):
 
         # Parse parameters
         width, height = self._parse_size(req.size)
-        if req.n is not None and req.n > 1:
-            raise ValueError(
-                f"Requested {req.n} images, but this handler currently supports n=1 only."
-            )
         num_images_per_prompt = (
             req.n if req.n is not None else self.config.default_num_images_per_prompt
         )
@@ -205,19 +201,36 @@ class ImageGenerationHandler(BaseGenerativeHandler):
 
         # Encode media based on what the pipeline returned
         if output.image is not None:
-            # MediaOutput.image is (B, H, W, C) uint8 since TRT-LLM rc9;
+            # MediaOutput.image is (B, H, W, C) uint8 since TRT-LLM rc9.
             images = output.image
             assert (
                 images.ndim == 4 and images.shape[3] == 3
             ), f"Expected image shape (B, H, W, C), got {images.shape}"
-            # [gluo FIXME] currently only take the first image but the protocol supports multiple images
-            # verify if TRT-LLM will generate multiple images, relax this constraint if that's the case
-            image_np = images[0].cpu().numpy()
-            logger.debug(
-                f"Request {request_id}: encoding image output "
-                f"(shape={image_np.shape}) to PNG"
-            )
-            image_bytes = await asyncio.to_thread(encode_to_png_bytes, image_np)
+            # Bound the response to what the caller asked for. The engine
+            # separately warns when the pipeline's actual batch differs from
+            # num_images_per_prompt; the handler does not synthesize missing
+            # images and does not forward extras beyond the requested count.
+            emit_count = min(images.shape[0], num_images_per_prompt)
+            data_items: list[ImageData] = []
+            for i in range(emit_count):
+                image_np = images[i].cpu().numpy()
+                logger.debug(
+                    f"Request {request_id}: encoding image {i + 1}/{emit_count} "
+                    f"(shape={image_np.shape}) to PNG"
+                )
+                image_bytes = await asyncio.to_thread(encode_to_png_bytes, image_np)
+                if response_format == "url":
+                    storage_path = f"images/{request_id}_{i}.png"
+                    image_url = await upload_to_fs(
+                        self.media_output_fs,
+                        storage_path,
+                        image_bytes,
+                        self.media_output_http_url,
+                    )
+                    data_items.append(ImageData(url=image_url))
+                else:
+                    b64_image = base64.b64encode(image_bytes).decode("utf-8")
+                    data_items.append(ImageData(b64_json=b64_image))
 
         elif output.video is not None:
             raise RuntimeError(
@@ -239,25 +252,11 @@ class ImageGenerationHandler(BaseGenerativeHandler):
                 f"image={output.image is not None}, audio={output.audio is not None}"
             )
 
-        # Return media via URL or base64
-        if response_format == "url":
-            storage_path = f"images/{request_id}.png"
-            image_url = await upload_to_fs(
-                self.media_output_fs,
-                storage_path,
-                image_bytes,
-                self.media_output_http_url,
-            )
-            image_data = ImageData(url=image_url)
-        else:
-            b64_image = base64.b64encode(image_bytes).decode("utf-8")
-            image_data = ImageData(b64_json=b64_image)
-
         inference_time = time.time() - start_time
 
         response = NvImagesResponse(
             created=int(time.time()),
-            data=[image_data],
+            data=data_items,
         )
 
         logger.debug(f"Request {request_id} completed in {inference_time:.2f}s")

--- a/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py
@@ -214,8 +214,8 @@ class ImageGenerationHandler(BaseGenerativeHandler):
             # Engine warns on batch mismatch; here we clamp to the caller's
             # requested count without padding or synthesizing.
             emit_count = min(images.shape[0], num_images_per_prompt)
-            data_items: list[ImageData] = []
-            for i in range(emit_count):
+
+            async def _encode_one(i: int) -> ImageData:
                 image_np = images[i].cpu().numpy()
                 logger.debug(
                     f"Request {request_id}: encoding image {i + 1}/{emit_count} "
@@ -230,10 +230,13 @@ class ImageGenerationHandler(BaseGenerativeHandler):
                         image_bytes,
                         self.media_output_http_url,
                     )
-                    data_items.append(ImageData(url=image_url))
-                else:
-                    b64_image = base64.b64encode(image_bytes).decode("utf-8")
-                    data_items.append(ImageData(b64_json=b64_image))
+                    return ImageData(url=image_url)
+                b64_image = base64.b64encode(image_bytes).decode("utf-8")
+                return ImageData(b64_json=b64_image)
+
+            data_items: list[ImageData] = list(
+                await asyncio.gather(*(_encode_one(i) for i in range(emit_count)))
+            )
 
         elif output.video is not None:
             raise RuntimeError(

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -390,7 +390,7 @@ class TestVideoHandlerConcurrency:
           one thread is ever inside generate() → ``max_concurrent == 1``.
     """
 
-    def _make_handler(self):
+    def _make_handler(self, tmp_path):
         """Create a ImageGenerationHandler with mock engine and config."""
         from dynamo.trtllm.request_handlers.diffusion.image_handler import (
             ImageGenerationHandler,
@@ -402,7 +402,7 @@ class TestVideoHandlerConcurrency:
         mock_engine.generate = tracker.generate
 
         config = DiffusionConfig(
-            media_output_fs_url="file:///tmp/test_media",
+            media_output_fs_url=(tmp_path / "test_media").as_uri(),
             default_fps=24,
             default_seconds=4,
         )
@@ -431,7 +431,7 @@ class TestVideoHandlerConcurrency:
             pass
 
     @pytest.mark.timeout(5)
-    def test_concurrent_requests_are_serialized(self):
+    def test_concurrent_requests_are_serialized(self, tmp_path):
         """Fires 3 concurrent requests and asserts only one thread enters
         engine.generate() at a time (max_concurrent == 1).
 
@@ -441,7 +441,7 @@ class TestVideoHandlerConcurrency:
         """
 
         async def run():
-            handler, tracker = self._make_handler()
+            handler, tracker = self._make_handler(tmp_path)
 
             requests = [self._make_request() for _ in range(3)]
 
@@ -474,10 +474,13 @@ class TestVideoHandlerConcurrency:
 class TestImageHandlerResponseFormats:
     """Tests for ImageGenerationHandler generate() response format branching."""
 
-    def _make_handler(self, engine_output_batch: int = 1, **config_overrides):
+    def _make_handler(self, tmp_path, engine_output_batch: int = 1, **config_overrides):
         """Create a handler with mocked engine and fs.
 
         Args:
+            tmp_path: pytest-provided per-test temporary directory used as the
+                handler's ``media_output_fs_url`` so tests stay hermetic and
+                parallel-safe.
             engine_output_batch: First dim of the synthetic image tensor the mock
                 engine returns. Lets tests exercise the handler's batch-iteration
                 and clamping behavior without needing the real engine.
@@ -498,7 +501,7 @@ class TestImageHandlerResponseFormats:
         mock_engine.generate = MagicMock(return_value=mock_output)
 
         config_kwargs = dict(
-            media_output_fs_url="file:///tmp/test_media",
+            media_output_fs_url=(tmp_path / "test_media").as_uri(),
             media_output_http_url="https://cdn.example.com/media",
             default_fps=24,
             default_seconds=4,
@@ -518,9 +521,9 @@ class TestImageHandlerResponseFormats:
         return handler
 
     @pytest.mark.asyncio
-    async def test_url_response_format(self):
+    async def test_url_response_format(self, tmp_path):
         """Test generate() with url response format calls upload_to_fs."""
-        handler = self._make_handler()
+        handler = self._make_handler(tmp_path)
 
         request = {
             "prompt": "a test image",
@@ -549,9 +552,9 @@ class TestImageHandlerResponseFormats:
         mock_upload.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_b64_response_format(self):
+    async def test_b64_response_format(self, tmp_path):
         """Test generate() with b64_json response format returns base64 encoded image."""
-        handler = self._make_handler()
+        handler = self._make_handler(tmp_path)
 
         request = {
             "prompt": "a test image",
@@ -580,9 +583,9 @@ class TestImageHandlerResponseFormats:
         assert decoded == b"fake_image_bytes"
 
     @pytest.mark.asyncio
-    async def test_default_response_format_is_url(self):
+    async def test_default_response_format_is_url(self, tmp_path):
         """Test that generate() defaults to url response format."""
-        handler = self._make_handler()
+        handler = self._make_handler(tmp_path)
 
         request = {
             "prompt": "a test image",
@@ -607,13 +610,13 @@ class TestImageHandlerResponseFormats:
         assert results[0]["data"][0]["url"] is not None
 
     @pytest.mark.asyncio
-    async def test_error_response_on_failure(self):
+    async def test_error_response_on_failure(self, tmp_path):
         """
         Test that generate() raises exception on engine failure. This is different from video generation.
         In video generation where the error is embedded in the response, but in image generation,
         the response doesn't contain the error, so the handler doesn't suppress it and let it propagate.
         """
-        handler = self._make_handler()
+        handler = self._make_handler(tmp_path)
         handler.engine.generate = MagicMock(side_effect=RuntimeError("GPU OOM"))
 
         request = {
@@ -628,11 +631,12 @@ class TestImageHandlerResponseFormats:
         assert "GPU OOM" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_url_response_format_batch_n(self):
+    async def test_url_response_format_batch_n(self, tmp_path):
         """Engine returns batch=2 with default_num_images_per_prompt=2 and no
         request-level n -> response carries two ImageData entries, each from a
         separate upload with a distinct storage path."""
         handler = self._make_handler(
+            tmp_path,
             engine_output_batch=2,
             default_num_images_per_prompt=2,
         )
@@ -668,10 +672,11 @@ class TestImageHandlerResponseFormats:
         ), f"Expected distinct storage paths per image, got {storage_paths}"
 
     @pytest.mark.asyncio
-    async def test_request_n_overrides_default(self):
+    async def test_request_n_overrides_default(self, tmp_path):
         """Per-request n takes precedence over config default. Default=1,
         request n=2, engine returns batch=2 -> two entries."""
         handler = self._make_handler(
+            tmp_path,
             engine_output_batch=2,
             default_num_images_per_prompt=1,
         )
@@ -695,9 +700,10 @@ class TestImageHandlerResponseFormats:
         assert len(results[0]["data"]) == 2
 
     @pytest.mark.asyncio
-    async def test_n_gt_1_is_accepted(self):
+    async def test_n_gt_1_is_accepted(self, tmp_path):
         """Requests with n > 1 are accepted and reach the engine."""
         handler = self._make_handler(
+            tmp_path,
             engine_output_batch=2,
             default_num_images_per_prompt=1,
         )
@@ -717,11 +723,12 @@ class TestImageHandlerResponseFormats:
                 pass
 
     @pytest.mark.asyncio
-    async def test_handler_emits_fewer_when_engine_shortchanges(self):
+    async def test_handler_emits_fewer_when_engine_shortchanges(self, tmp_path):
         """Engine returns batch=1 when request asks for n=2 -> response has 1
         entry. The handler does not synthesize, pad, or error; it faithfully
         reports what the engine produced."""
         handler = self._make_handler(
+            tmp_path,
             engine_output_batch=1,
             default_num_images_per_prompt=1,
         )
@@ -750,10 +757,10 @@ class TestImageHandlerResponseFormats:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [0, -1, 11, 100])
-    async def test_n_out_of_range_is_rejected(self, n):
+    async def test_n_out_of_range_is_rejected(self, tmp_path, n):
         """Requests with n < 1 or n > 10 (OpenAI's documented range) raise
         ValueError before the engine is called."""
-        handler = self._make_handler(default_num_images_per_prompt=1)
+        handler = self._make_handler(tmp_path, default_num_images_per_prompt=1)
         handler.engine.generate = MagicMock()  # Should never be called.
 
         request = {
@@ -771,11 +778,12 @@ class TestImageHandlerResponseFormats:
         handler.engine.generate.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_handler_clamps_when_engine_overproduces(self):
+    async def test_handler_clamps_when_engine_overproduces(self, tmp_path):
         """Engine returns batch=3 when request asks for n=2 -> response is
         truncated to 2 entries. Defensive: bounds the handler's iteration by
         what the caller asked for, even if the pipeline ever over-produces."""
         handler = self._make_handler(
+            tmp_path,
             engine_output_batch=3,
             default_num_images_per_prompt=1,
         )

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -754,16 +754,3 @@ class TestDiffusionEngineMismatchWarning:
             f"Expected no WARNING when pipeline returns the requested batch size, "
             f"got {[r.getMessage() for r in warnings]}"
         )
-
-    def test_silent_for_num_images_per_prompt_1(self, caplog, stub_trtllm_modules):
-        """The common N=1 case stays silent (pipeline returns 1, request is 1)."""
-        engine = self._make_engine(self._make_pipeline(returned_batch=1))
-
-        with caplog.at_level(logging.WARNING, logger=_DIFFUSION_ENGINE_LOGGER):
-            engine.generate(prompt="a test prompt", num_images_per_prompt=1)
-
-        warnings = self._warning_records(caplog)
-        assert warnings == [], (
-            f"Expected no WARNING in the N=1 common case, "
-            f"got {[r.getMessage() for r in warnings]}"
-        )

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -749,6 +749,28 @@ class TestImageHandlerResponseFormats:
         assert mock_upload.call_count == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [0, -1, 11, 100])
+    async def test_n_out_of_range_is_rejected(self, n):
+        """Requests with n < 1 or n > 10 (OpenAI's documented range) raise
+        ValueError before the engine is called."""
+        handler = self._make_handler(default_num_images_per_prompt=1)
+        handler.engine.generate = MagicMock()  # Should never be called.
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "n": n,
+        }
+
+        with pytest.raises(
+            ValueError, match=r"num_images_per_prompt must be in \[1, 10\]"
+        ):
+            async for _ in handler.generate(request, MagicMock()):
+                pass
+
+        handler.engine.generate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_handler_clamps_when_engine_overproduces(self):
         """Engine returns batch=3 when request asks for n=2 -> response is
         truncated to 2 entries. Defensive: bounds the handler's iteration by
@@ -875,11 +897,11 @@ class TestDiffusionEngineMismatchWarning:
         )
         return pipeline
 
-    def _make_engine(self, pipeline):
+    def _make_engine(self, pipeline, tmp_path):
         """Construct a DiffusionEngine with the given mock pipeline already loaded."""
         from dynamo.trtllm.engines.diffusion_engine import DiffusionEngine
 
-        config = DiffusionConfig(media_output_fs_url="file:///tmp/test_media")
+        config = DiffusionConfig(media_output_fs_url=(tmp_path / "test_media").as_uri())
         engine = DiffusionEngine(config)
         engine._initialized = True
         engine._pipeline = pipeline
@@ -892,9 +914,9 @@ class TestDiffusionEngineMismatchWarning:
             if r.name == _DIFFUSION_ENGINE_LOGGER and r.levelno >= logging.WARNING
         ]
 
-    def test_warns_on_count_mismatch(self, caplog, stub_trtllm_modules):
+    def test_warns_on_count_mismatch(self, tmp_path, caplog, stub_trtllm_modules):
         """Pipeline returns 1 image when 2 were requested -> WARNING naming both values."""
-        engine = self._make_engine(self._make_pipeline(returned_batch=1))
+        engine = self._make_engine(self._make_pipeline(returned_batch=1), tmp_path)
 
         with caplog.at_level(logging.WARNING, logger=_DIFFUSION_ENGINE_LOGGER):
             engine.generate(prompt="a test prompt", num_images_per_prompt=2)
@@ -910,9 +932,9 @@ class TestDiffusionEngineMismatchWarning:
             f"counts; got: {msg!r}"
         )
 
-    def test_silent_when_count_matches(self, caplog, stub_trtllm_modules):
+    def test_silent_when_count_matches(self, tmp_path, caplog, stub_trtllm_modules):
         """Pipeline returns 2 images when 2 were requested -> no WARNING."""
-        engine = self._make_engine(self._make_pipeline(returned_batch=2))
+        engine = self._make_engine(self._make_pipeline(returned_batch=2), tmp_path)
 
         with caplog.at_level(logging.WARNING, logger=_DIFFUSION_ENGINE_LOGGER):
             engine.generate(prompt="a test prompt", num_images_per_prompt=2)

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -10,8 +10,11 @@ These tests do NOT require visual_gen, torch, or GPU - they test logic only.
 """
 
 import asyncio
+import logging
+import sys
 import threading
 import time
+import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -612,3 +615,155 @@ class TestImageHandlerResponseFormats:
                 pass
 
         assert "GPU OOM" in str(exc_info.value)
+
+
+# =============================================================================
+# Part 7: DiffusionEngine Mismatch Warning Tests
+# =============================================================================
+
+
+_DIFFUSION_ENGINE_LOGGER = "dynamo.trtllm.engines.diffusion_engine"
+
+
+class _StubVisualGenParams:
+    """Minimal stand-in for tensorrt_llm.visual_gen.params.VisualGenParams.
+
+    Accepts the same keyword arguments DiffusionEngine.generate() passes and
+    exposes them as attributes, so the engine's `_merge_defaults` mirror code
+    can read/set them. extra_params defaults to None (matches real behavior).
+    """
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        if not hasattr(self, "extra_params"):
+            self.extra_params = None
+
+
+class _StubDiffusionRequest:
+    """Minimal stand-in for tensorrt_llm._torch.visual_gen.executor.DiffusionRequest."""
+
+    def __init__(self, request_id, prompt, params):
+        self.request_id = request_id
+        self.prompt = prompt
+        self.params = params
+
+
+@pytest.fixture
+def stub_trtllm_modules(monkeypatch):
+    """Install minimal tensorrt_llm stubs so DiffusionEngine.generate() can run
+    in unit tests without TRT-LLM installed.
+
+    DiffusionEngine.generate() does two lazy imports inside its body:
+        from tensorrt_llm._torch.visual_gen.executor import DiffusionRequest
+        from tensorrt_llm.visual_gen.params import VisualGenParams
+    The unit-test environment doesn't ship TRT-LLM (see this file's header
+    docstring), so we substitute minimal classes that match the surface the
+    engine uses.
+    """
+    params_mod = types.ModuleType("tensorrt_llm.visual_gen.params")
+    params_mod.VisualGenParams = _StubVisualGenParams
+
+    executor_mod = types.ModuleType("tensorrt_llm._torch.visual_gen.executor")
+    executor_mod.DiffusionRequest = _StubDiffusionRequest
+
+    parent_modules = [
+        "tensorrt_llm",
+        "tensorrt_llm._torch",
+        "tensorrt_llm._torch.visual_gen",
+        "tensorrt_llm.visual_gen",
+    ]
+    for name in parent_modules:
+        if name not in sys.modules:
+            monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    monkeypatch.setitem(
+        sys.modules, "tensorrt_llm._torch.visual_gen.executor", executor_mod
+    )
+    monkeypatch.setitem(sys.modules, "tensorrt_llm.visual_gen.params", params_mod)
+
+
+class TestDiffusionEngineMismatchWarning:
+    """Tests for DiffusionEngine.generate()'s pipeline-output mismatch warning.
+
+    The underlying TRT-LLM Flux2Pipeline (and likely FluxPipeline) silently
+    returns batch=1 regardless of the requested num_images_per_prompt.
+    DiffusionEngine.generate() stays a thin pass-through over pipeline.infer()
+    but logs a WARNING when output.image.shape[0] != num_images_per_prompt so
+    operators can see the mismatch in production logs. The pipeline output is
+    not mutated, padded, or looped — the engine is observability, not workaround.
+    """
+
+    def _make_pipeline(self, returned_batch: int):
+        """Mock pipeline that returns an image tensor with the given batch size."""
+        pipeline = MagicMock()
+        pipeline.default_generation_params = {}
+        pipeline.extra_param_specs = {}
+        pipeline.infer = MagicMock(
+            return_value=SimpleNamespace(
+                video=None,
+                image=torch.zeros((returned_batch, 64, 64, 3), dtype=torch.uint8),
+                audio=None,
+            )
+        )
+        return pipeline
+
+    def _make_engine(self, pipeline):
+        """Construct a DiffusionEngine with the given mock pipeline already loaded."""
+        from dynamo.trtllm.engines.diffusion_engine import DiffusionEngine
+
+        config = DiffusionConfig(media_output_fs_url="file:///tmp/test_media")
+        engine = DiffusionEngine(config)
+        engine._initialized = True
+        engine._pipeline = pipeline
+        return engine
+
+    def _warning_records(self, caplog):
+        return [
+            r
+            for r in caplog.records
+            if r.name == _DIFFUSION_ENGINE_LOGGER and r.levelno >= logging.WARNING
+        ]
+
+    def test_warns_on_count_mismatch(self, caplog, stub_trtllm_modules):
+        """Pipeline returns 1 image when 2 were requested -> WARNING naming both values."""
+        engine = self._make_engine(self._make_pipeline(returned_batch=1))
+
+        with caplog.at_level(logging.WARNING, logger=_DIFFUSION_ENGINE_LOGGER):
+            engine.generate(prompt="a test prompt", num_images_per_prompt=2)
+
+        warnings = self._warning_records(caplog)
+        assert len(warnings) == 1, (
+            f"Expected exactly one WARNING for the 2-vs-1 mismatch, "
+            f"got {[r.getMessage() for r in warnings]}"
+        )
+        msg = warnings[0].getMessage()
+        assert "2" in msg and "1" in msg, (
+            f"WARNING message should name both requested (2) and actual (1) "
+            f"counts; got: {msg!r}"
+        )
+
+    def test_silent_when_count_matches(self, caplog, stub_trtllm_modules):
+        """Pipeline returns 2 images when 2 were requested -> no WARNING."""
+        engine = self._make_engine(self._make_pipeline(returned_batch=2))
+
+        with caplog.at_level(logging.WARNING, logger=_DIFFUSION_ENGINE_LOGGER):
+            engine.generate(prompt="a test prompt", num_images_per_prompt=2)
+
+        warnings = self._warning_records(caplog)
+        assert warnings == [], (
+            f"Expected no WARNING when pipeline returns the requested batch size, "
+            f"got {[r.getMessage() for r in warnings]}"
+        )
+
+    def test_silent_for_num_images_per_prompt_1(self, caplog, stub_trtllm_modules):
+        """The common N=1 case stays silent (pipeline returns 1, request is 1)."""
+        engine = self._make_engine(self._make_pipeline(returned_batch=1))
+
+        with caplog.at_level(logging.WARNING, logger=_DIFFUSION_ENGINE_LOGGER):
+            engine.generate(prompt="a test prompt", num_images_per_prompt=1)
+
+        warnings = self._warning_records(caplog)
+        assert warnings == [], (
+            f"Expected no WARNING in the N=1 common case, "
+            f"got {[r.getMessage() for r in warnings]}"
+        )

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -668,35 +668,6 @@ class TestImageHandlerResponseFormats:
         ), f"Expected distinct storage paths per image, got {storage_paths}"
 
     @pytest.mark.asyncio
-    async def test_b64_response_format_batch_n(self):
-        """Engine returns batch=2 with default_num_images_per_prompt=2 -> two
-        b64_json entries in response.data."""
-        handler = self._make_handler(
-            engine_output_batch=2,
-            default_num_images_per_prompt=2,
-        )
-
-        request = {
-            "prompt": "a test image",
-            "model": "test-model",
-            "response_format": "b64_json",
-        }
-
-        with patch(
-            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
-            return_value=b"fake_image_bytes",
-        ):
-            results = []
-            async for result in handler.generate(request, MagicMock()):
-                results.append(result)
-
-        assert len(results) == 1
-        assert len(results[0]["data"]) == 2
-        for entry in results[0]["data"]:
-            assert entry["b64_json"] is not None
-            assert entry.get("url") is None
-
-    @pytest.mark.asyncio
     async def test_request_n_overrides_default(self):
         """Per-request n takes precedence over config default. Default=1,
         request n=2, engine returns batch=2 -> two entries."""

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -724,9 +724,8 @@ class TestImageHandlerResponseFormats:
         assert len(results[0]["data"]) == 2
 
     @pytest.mark.asyncio
-    async def test_n_gt_1_no_longer_rejected(self):
-        """Pre-fix handler raised ValueError for n>1; the fix removes that
-        rejection so n=2 requests reach the engine and produce a response."""
+    async def test_n_gt_1_is_accepted(self):
+        """Requests with n > 1 are accepted and reach the engine."""
         handler = self._make_handler(
             engine_output_batch=2,
             default_num_images_per_prompt=1,
@@ -743,7 +742,6 @@ class TestImageHandlerResponseFormats:
             "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
             return_value=b"fake_image_bytes",
         ):
-            # The pre-fix handler raised ValueError("Requested 2 images, ...").
             async for _ in handler.generate(request, MagicMock()):
                 pass
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py
@@ -474,26 +474,37 @@ class TestVideoHandlerConcurrency:
 class TestImageHandlerResponseFormats:
     """Tests for ImageGenerationHandler generate() response format branching."""
 
-    def _make_handler(self):
-        """Create a handler with mocked engine and fs."""
+    def _make_handler(self, engine_output_batch: int = 1, **config_overrides):
+        """Create a handler with mocked engine and fs.
+
+        Args:
+            engine_output_batch: First dim of the synthetic image tensor the mock
+                engine returns. Lets tests exercise the handler's batch-iteration
+                and clamping behavior without needing the real engine.
+            **config_overrides: Extra DiffusionConfig kwargs (e.g.,
+                ``default_num_images_per_prompt=2``) merged on top of the
+                default test config.
+        """
         from dynamo.trtllm.request_handlers.diffusion.image_handler import (
             ImageGenerationHandler,
         )
 
         mock_output = SimpleNamespace(
             video=None,
-            image=torch.zeros((1, 64, 64, 3), dtype=torch.uint8),
+            image=torch.zeros((engine_output_batch, 64, 64, 3), dtype=torch.uint8),
             audio=None,
         )
         mock_engine = MagicMock()
         mock_engine.generate = MagicMock(return_value=mock_output)
 
-        config = DiffusionConfig(
+        config_kwargs = dict(
             media_output_fs_url="file:///tmp/test_media",
             media_output_http_url="https://cdn.example.com/media",
             default_fps=24,
             default_seconds=4,
         )
+        config_kwargs.update(config_overrides)
+        config = DiffusionConfig(**config_kwargs)
 
         with patch(
             "dynamo.trtllm.request_handlers.diffusion.image_handler.get_fs",
@@ -615,6 +626,194 @@ class TestImageHandlerResponseFormats:
                 pass
 
         assert "GPU OOM" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_url_response_format_batch_n(self):
+        """Engine returns batch=2 with default_num_images_per_prompt=2 and no
+        request-level n -> response carries two ImageData entries, each from a
+        separate upload with a distinct storage path."""
+        handler = self._make_handler(
+            engine_output_batch=2,
+            default_num_images_per_prompt=2,
+        )
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "response_format": "url",
+        }
+
+        upload_urls = [
+            "https://cdn.example.com/media/images/test_0.png",
+            "https://cdn.example.com/media/images/test_1.png",
+        ]
+        with patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
+            return_value=b"fake_image_bytes",
+        ), patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.upload_to_fs",
+            side_effect=upload_urls,
+        ) as mock_upload:
+            results = []
+            async for result in handler.generate(request, MagicMock()):
+                results.append(result)
+
+        assert len(results) == 1
+        assert len(results[0]["data"]) == 2
+        assert mock_upload.call_count == 2
+
+        storage_paths = [call.args[1] for call in mock_upload.call_args_list]
+        assert (
+            len(set(storage_paths)) == 2
+        ), f"Expected distinct storage paths per image, got {storage_paths}"
+
+    @pytest.mark.asyncio
+    async def test_b64_response_format_batch_n(self):
+        """Engine returns batch=2 with default_num_images_per_prompt=2 -> two
+        b64_json entries in response.data."""
+        handler = self._make_handler(
+            engine_output_batch=2,
+            default_num_images_per_prompt=2,
+        )
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "response_format": "b64_json",
+        }
+
+        with patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
+            return_value=b"fake_image_bytes",
+        ):
+            results = []
+            async for result in handler.generate(request, MagicMock()):
+                results.append(result)
+
+        assert len(results) == 1
+        assert len(results[0]["data"]) == 2
+        for entry in results[0]["data"]:
+            assert entry["b64_json"] is not None
+            assert entry.get("url") is None
+
+    @pytest.mark.asyncio
+    async def test_request_n_overrides_default(self):
+        """Per-request n takes precedence over config default. Default=1,
+        request n=2, engine returns batch=2 -> two entries."""
+        handler = self._make_handler(
+            engine_output_batch=2,
+            default_num_images_per_prompt=1,
+        )
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "n": 2,
+            "response_format": "b64_json",
+        }
+
+        with patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
+            return_value=b"fake_image_bytes",
+        ):
+            results = []
+            async for result in handler.generate(request, MagicMock()):
+                results.append(result)
+
+        assert len(results) == 1
+        assert len(results[0]["data"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_n_gt_1_no_longer_rejected(self):
+        """Pre-fix handler raised ValueError for n>1; the fix removes that
+        rejection so n=2 requests reach the engine and produce a response."""
+        handler = self._make_handler(
+            engine_output_batch=2,
+            default_num_images_per_prompt=1,
+        )
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "n": 2,
+            "response_format": "b64_json",
+        }
+
+        with patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
+            return_value=b"fake_image_bytes",
+        ):
+            # The pre-fix handler raised ValueError("Requested 2 images, ...").
+            async for _ in handler.generate(request, MagicMock()):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_handler_emits_fewer_when_engine_shortchanges(self):
+        """Engine returns batch=1 when request asks for n=2 -> response has 1
+        entry. The handler does not synthesize, pad, or error; it faithfully
+        reports what the engine produced."""
+        handler = self._make_handler(
+            engine_output_batch=1,
+            default_num_images_per_prompt=1,
+        )
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "n": 2,
+            "response_format": "url",
+        }
+
+        with patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
+            return_value=b"fake_image_bytes",
+        ), patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.upload_to_fs",
+            return_value="https://cdn.example.com/media/images/test_0.png",
+        ) as mock_upload:
+            results = []
+            async for result in handler.generate(request, MagicMock()):
+                results.append(result)
+
+        assert len(results) == 1
+        assert len(results[0]["data"]) == 1
+        assert mock_upload.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_handler_clamps_when_engine_overproduces(self):
+        """Engine returns batch=3 when request asks for n=2 -> response is
+        truncated to 2 entries. Defensive: bounds the handler's iteration by
+        what the caller asked for, even if the pipeline ever over-produces."""
+        handler = self._make_handler(
+            engine_output_batch=3,
+            default_num_images_per_prompt=1,
+        )
+
+        request = {
+            "prompt": "a test image",
+            "model": "test-model",
+            "n": 2,
+            "response_format": "url",
+        }
+
+        upload_urls = [
+            "https://cdn.example.com/media/images/test_0.png",
+            "https://cdn.example.com/media/images/test_1.png",
+        ]
+        with patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.encode_to_png_bytes",
+            return_value=b"fake_image_bytes",
+        ), patch(
+            "dynamo.trtllm.request_handlers.diffusion.image_handler.upload_to_fs",
+            side_effect=upload_urls,
+        ) as mock_upload:
+            results = []
+            async for result in handler.generate(request, MagicMock()):
+                results.append(result)
+
+        assert len(results) == 1
+        assert len(results[0]["data"]) == 2
+        assert mock_upload.call_count == 2
 
 
 # =============================================================================


### PR DESCRIPTION
#### Overview:

DYN-3056: the TRT-LLM image-diffusion path silently truncated multi-image batches to a single image and rejected per-request `n > 1`, so a worker configured with `--default-num-images-per-prompt N` would return one image regardless of the configured default or the request's `n`. This PR makes the response faithful: the handler emits one `ImageData` per image the pipeline produced (bounded by what the caller asked for), and the engine emits a `WARNING` when the pipeline's actual batch differs from the requested count, so the mismatch is observable in production logs.

#### Details:

Two layers, both small:

- **Handler** (`request_handlers/diffusion/image_handler.py`):
  - Removes the `ValueError("Requested {n} images, but this handler currently supports n=1 only.")` rejection.
  - Replaces the `images[0]` + hardcoded one-element `data=[image_data]` response with a loop iterating `range(min(images.shape[0], num_images_per_prompt))`, building one `ImageData` per emitted image. The clamp bounds the response to what the caller asked for, so a defensively over-producing pipeline can't run away with the request.
  - Switches the per-image storage path from `images/{request_id}.png` to `images/{request_id}_{i}.png` to avoid collisions when more than one image is uploaded.

- **Engine** (`engines/diffusion_engine.py`):
  - Extends the existing `Generating:` log line to include `num_images_per_prompt` so the value reaching the pipeline is observable alongside the existing `prompt / size / frames / steps` fields.
  - After `pipeline.infer()` returns, checks `output.image.shape[0]` against the requested count and emits `logger.warning(...)` on mismatch. The engine stays a thin pass-through — no loop, no stacking — the warning is observability only.

**What this PR does not deliver:** the original ticket's "`response.data` length == N" outcome is not guaranteed. TRT-LLM 1.3.0rc14's `Flux2Pipeline` ignores `num_images_per_prompt` and always returns batch=1; this PR surfaces that as a visible warning rather than papering over the upstream limitation with a per-image loop. Operators hitting the warning are responsible for chasing the underlying TRT-LLM behavior.

#### Where should the reviewer start?

- `components/src/dynamo/trtllm/request_handlers/diffusion/image_handler.py` — three surgical changes around lines 156-235 (drop n>1 rejection, replace single-image extraction with clamped loop, distinct storage paths).
- `components/src/dynamo/trtllm/engines/diffusion_engine.py` — `Generating:` log extension at 259-264 and the new mismatch warning right after `pipeline.infer()` at 313-318.
- `components/src/dynamo/trtllm/tests/test_trtllm_image_diffusion.py` — `TestImageHandlerResponseFormats` extended with five batch / clamp / accept-n cases; new `TestDiffusionEngineMismatchWarning` class with two engine-warning cases. `_make_handler()` extended with `engine_output_batch` and config-override kwargs.

#### Verification:

Verified in `nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.2.0-post.1-rc.4-cuda13` against `black-forest-labs/FLUX.2-klein-4B` on an RTX 5880 Ada with the ticket's repro (no `n` field, `--default-num-images-per-prompt 2`, 256x256, 4 inference steps):

```
INFO  diffusion_engine.generate: Generating: prompt='A red apple on a wooden table...',
      size=256x256, frames=81, num_images_per_prompt=2, steps=4
INFO  diffusion_engine.generate: Generated image output with shape torch.Size([1, 256, 256, 3])
WARN  diffusion_engine.generate: Pipeline returned 1 image(s) but 2 were requested.
HTTP 200, response.data length = 1
```

Compared to the pre-fix behavior (HTTP 200, `data length = 1`, no warning, no visibility into what `num_images_per_prompt` actually reached the engine), the response is now self-describing.

#### Related Issues:

Relates to: DYN-3056
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation now accepts requests for multiple images (`n > 1`)
  * All generated images are returned in a single response instead of just the first image

* **Improvements**
  * Enhanced logging includes additional generation parameters
  * Added validation warnings for image count mismatches

* **Tests**
  * Expanded test coverage for multi-image generation and response formatting scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->