### PR TITLE
fix: remove broken Cargo readme references blocking publication (#9809)

### DIFF
--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -9,7 +9,6 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
 description = "Dynamo LLM Library"
 
 [features]

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -17,7 +17,6 @@ edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [dependencies]
 # Upstream OpenAI types (types-only, no HTTP client)

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -3,7 +3,6 @@
 
 [package]
 name = "dynamo-runtime"
-readme = "README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
(cherry picked from commit 11e9f37596f22869ea8d164f5b21339f02bd65e6)

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-6619
