### PR TITLE
fix(operator): Avoid imagePullSecrets drift during operator startup

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -476,7 +476,7 @@ func main() {
 		"istio", runtimeConfig.IstioAvailable,
 	)
 
-	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetClient())
+	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader())
 	// refresh whenever a secret is created/deleted/updated
 	// Set up informer
 	var factory informers.SharedInformerFactory
@@ -541,12 +541,13 @@ func main() {
 		setupLog.Error(err, "unable to add event handler to secret informer")
 		os.Exit(1)
 	}
+	if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
+		setupLog.Error(err, "initial docker secrets index refresh failed")
+		os.Exit(1)
+	}
+	setupLog.Info("initial docker secrets index refreshed")
 	// launch a goroutine to refresh the docker secret indexer in any case every minute
 	go func() {
-		// Initial refresh
-		if err := dockerSecretRetriever.RefreshIndex(context.Background()); err != nil {
-			setupLog.Error(err, "initial docker secrets index refresh failed")
-		}
 		ticker := time.NewTicker(60 * time.Second)
 		defer ticker.Stop()
 		for {

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -180,20 +180,24 @@ func SyncResource[T client.Object](ctx context.Context, r Reconciler, parentReso
 				"lastAppliedGeneration", getAnnotation(oldResource, NvidiaAnnotationGenerationKey))
 		}
 
-		// Generate and log diff before updating
-		diff, diffErr := generateSpecDiff(oldResource, resource)
-		if diffErr != nil {
-			logs.V(1).Info(fmt.Sprintf("Failed to generate diff for %s: %v", resourceType, diffErr))
-		} else if diff != "" {
-			logs.Info(fmt.Sprintf("%s spec changes detected", resourceType), "diff", diff)
-		}
+		if changeResult.SpecNeedsUpdate {
+			// Generate and log diff before updating
+			diff, diffErr := generateSpecDiff(oldResource, resource)
+			if diffErr != nil {
+				logs.V(1).Info(fmt.Sprintf("Failed to generate diff for %s: %v", resourceType, diffErr))
+			} else if diff != "" {
+				logs.Info(fmt.Sprintf("%s spec changes detected", resourceType), "diff", diff)
+			}
 
-		// Update the spec of the current object with the desired spec
-		err = CopySpec(resource, oldResource)
-		if err != nil {
-			logs.Error(err, fmt.Sprintf("Failed to copy spec for %s.", resourceType))
-			r.GetRecorder().Eventf(oldResource, corev1.EventTypeWarning, fmt.Sprintf("CopySpec%s", resourceType), "Failed to copy spec for %s %s: %s", resourceType, resourceNamespace, err)
-			return
+			// Update the spec of the current object with the desired spec
+			err = CopySpec(resource, oldResource)
+			if err != nil {
+				logs.Error(err, fmt.Sprintf("Failed to copy spec for %s.", resourceType))
+				r.GetRecorder().Eventf(oldResource, corev1.EventTypeWarning, fmt.Sprintf("CopySpec%s", resourceType), "Failed to copy spec for %s %s: %s", resourceType, resourceNamespace, err)
+				return
+			}
+		} else {
+			logs.Info(fmt.Sprintf("%s spec is equivalent. Updating bookkeeping annotations only.", resourceType))
 		}
 
 		updateAnnotations(oldResource, *changeResult.NewHash, changeResult.NewGeneration)
@@ -303,6 +307,10 @@ type SpecChangeResult struct {
 	NewGeneration int64
 	// NeedsUpdate indicates whether the resource needs to be updated
 	NeedsUpdate bool
+	// SpecNeedsUpdate indicates whether the desired spec/content must be copied.
+	// When false with NeedsUpdate=true, only operator bookkeeping annotations need
+	// repair and the resource spec should be left untouched.
+	SpecNeedsUpdate bool
 	// ManualChangeDetected indicates whether a manual change was detected
 	ManualChangeDetected bool
 }
@@ -318,64 +326,76 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 	if err != nil {
 		return SpecChangeResult{}, err
 	}
+	currentHash, err := GetSpecHash(current)
+	if err != nil {
+		return SpecChangeResult{}, err
+	}
 
 	lastAppliedHash := getAnnotation(current, NvidiaAnnotationHashKey)
 	lastAppliedGenStr := getAnnotation(current, NvidiaAnnotationGenerationKey)
 	currentGen := current.GetGeneration()
+	annotationOnlyChange := func() SpecChangeResult {
+		return SpecChangeResult{
+			NewHash:       &desiredHash,
+			NewGeneration: currentGen,
+			NeedsUpdate:   true,
+		}
+	}
+	specChange := func(manual bool) SpecChangeResult {
+		return SpecChangeResult{
+			NewHash:              &desiredHash,
+			NewGeneration:        currentGen + 1,
+			NeedsUpdate:          true,
+			SpecNeedsUpdate:      true,
+			ManualChangeDetected: manual,
+		}
+	}
 
 	// Case 1: Hash annotation missing (external create or pre-upgrade resource)
 	// Note: This is not first-time CREATE (handled separately in SyncResource with generation=1).
-	// This handles existing resources without our annotations - we're about to update them,
-	// so NewGeneration = currentGen + 1 is correct.
+	// If the live spec already matches the desired spec, only backfill the operator
+	// bookkeeping annotations. This avoids rewriting API-server-defaulted fields
+	// during upgrades.
 	if lastAppliedHash == "" {
-		return SpecChangeResult{
-			NewHash:       &desiredHash,
-			NewGeneration: currentGen + 1,
-			NeedsUpdate:   true,
-		}, nil
+		if currentHash == desiredHash {
+			return annotationOnlyChange(), nil
+		}
+		return specChange(false), nil
 	}
 
 	// Case 2: Hash different (spec changed)
 	if desiredHash != lastAppliedHash {
-		return SpecChangeResult{
-			NewHash:       &desiredHash,
-			NewGeneration: currentGen + 1,
-			NeedsUpdate:   true,
-		}, nil
+		if currentHash == desiredHash {
+			return annotationOnlyChange(), nil
+		}
+		return specChange(false), nil
 	}
 
 	// Case 3: Hash same, but generation annotation missing (upgrade scenario)
-	// Do a full update to ensure spec is exactly what we want - there could have been
-	// manual edits before we added generation tracking. The cost is one extra Update
-	// per resource during upgrade, but on next reconcile generations will match.
 	if lastAppliedGenStr == "" {
-		return SpecChangeResult{
-			NewHash:       &desiredHash,
-			NewGeneration: currentGen + 1,
-			NeedsUpdate:   true,
-		}, nil
+		if currentHash == desiredHash {
+			return annotationOnlyChange(), nil
+		}
+		return specChange(false), nil
 	}
 
 	// Case 4: Both annotations exist, check for manual changes
 	lastAppliedGen, err := strconv.ParseInt(lastAppliedGenStr, 10, 64)
 	if err != nil {
 		// Corrupted annotation, force update to fix
-		return SpecChangeResult{
-			NewHash:       &desiredHash,
-			NewGeneration: currentGen + 1,
-			NeedsUpdate:   true,
-		}, nil
+		if currentHash == desiredHash {
+			return annotationOnlyChange(), nil
+		}
+		return specChange(false), nil
 	}
 
 	// Detect manual changes: if current generation > last applied generation,
 	// someone else modified the resource after our last update
 	if currentGen > 0 && currentGen > lastAppliedGen {
-		return SpecChangeResult{
-			NewHash:              &desiredHash,
-			NewGeneration:        currentGen + 1,
-			NeedsUpdate:          true,
-			ManualChangeDetected: true,
-		}, nil
+		if currentHash == desiredHash {
+			return annotationOnlyChange(), nil
+		}
+		return specChange(true), nil
 	}
 
 	// No update needed

--- a/deploy/operator/internal/controller_common/resource.go
+++ b/deploy/operator/internal/controller_common/resource.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -326,7 +327,7 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 	if err != nil {
 		return SpecChangeResult{}, err
 	}
-	currentHash, err := GetSpecHash(current)
+	currentMatchesDesired, err := specContentEqualPreserveListOrder(current, desired)
 	if err != nil {
 		return SpecChangeResult{}, err
 	}
@@ -357,7 +358,7 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 	// bookkeeping annotations. This avoids rewriting API-server-defaulted fields
 	// during upgrades.
 	if lastAppliedHash == "" {
-		if currentHash == desiredHash {
+		if currentMatchesDesired {
 			return annotationOnlyChange(), nil
 		}
 		return specChange(false), nil
@@ -365,7 +366,7 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 
 	// Case 2: Hash different (spec changed)
 	if desiredHash != lastAppliedHash {
-		if currentHash == desiredHash {
+		if currentMatchesDesired {
 			return annotationOnlyChange(), nil
 		}
 		return specChange(false), nil
@@ -373,7 +374,7 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 
 	// Case 3: Hash same, but generation annotation missing (upgrade scenario)
 	if lastAppliedGenStr == "" {
-		if currentHash == desiredHash {
+		if currentMatchesDesired {
 			return annotationOnlyChange(), nil
 		}
 		return specChange(false), nil
@@ -383,7 +384,7 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 	lastAppliedGen, err := strconv.ParseInt(lastAppliedGenStr, 10, 64)
 	if err != nil {
 		// Corrupted annotation, force update to fix
-		if currentHash == desiredHash {
+		if currentMatchesDesired {
 			return annotationOnlyChange(), nil
 		}
 		return specChange(false), nil
@@ -392,7 +393,7 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 	// Detect manual changes: if current generation > last applied generation,
 	// someone else modified the resource after our last update
 	if currentGen > 0 && currentGen > lastAppliedGen {
-		if currentHash == desiredHash {
+		if currentMatchesDesired {
 			return annotationOnlyChange(), nil
 		}
 		return specChange(true), nil
@@ -402,6 +403,18 @@ func GetSpecChangeResult(current client.Object, desired client.Object) (SpecChan
 	return SpecChangeResult{
 		NeedsUpdate: false,
 	}, nil
+}
+
+func specContentEqualPreserveListOrder(current, desired client.Object) (bool, error) {
+	currentSpec, err := getSpec(current)
+	if err != nil {
+		return false, err
+	}
+	desiredSpec, err := getSpec(desired)
+	if err != nil {
+		return false, err
+	}
+	return equality.Semantic.DeepEqual(currentSpec, desiredSpec), nil
 }
 
 // getAnnotation safely retrieves an annotation value from an object

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -421,14 +421,53 @@ func TestGetSpecChangeResult(t *testing.T) {
 	}
 }
 
+func TestGetSpecChangeResult_AnnotationOnlyForEquivalentSpec(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	current := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "worker",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "worker",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+	current.SetGeneration(7)
+
+	result, err := GetSpecChangeResult(current, desired)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(result.NeedsUpdate).To(gomega.BeTrue())
+	g.Expect(result.SpecNeedsUpdate).To(gomega.BeFalse())
+	g.Expect(result.NewGeneration).To(gomega.Equal(int64(7)))
+	g.Expect(result.NewHash).ToNot(gomega.BeNil())
+}
+
 func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 	tests := []struct {
 		name                       string
 		currentGeneration          int64
 		lastAppliedGeneration      string // empty string means annotation not set
-		lastAppliedHash            string // empty string means annotation not set, "match" means compute from desired
+		lastAppliedHash            string // empty string means annotation not set, "match" means compute from current
 		desiredReplicas            int64  // different from current (2) means hash will differ
 		expectNeedsUpdate          bool
+		expectSpecNeedsUpdate      bool
 		expectManualChangeDetected bool
 		expectNewGeneration        int64 // 0 means don't check
 	}{
@@ -441,35 +480,33 @@ func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 			expectNeedsUpdate:     false,
 		},
 		{
-			name:                       "manual change detected - generation increased",
+			name:                       "generation increased but spec is equivalent - annotations only",
 			currentGeneration:          7,
 			lastAppliedGeneration:      "5",
 			lastAppliedHash:            "match",
 			desiredReplicas:            2,
 			expectNeedsUpdate:          true,
-			expectManualChangeDetected: true,
-			expectNewGeneration:        8, // current(7) + 1
+			expectManualChangeDetected: false,
+			expectNewGeneration:        7,
 		},
 		{
 			// Upgrade scenario: hash matches but no generation annotation yet.
-			// We do a full update to ensure spec is correct (could have been manual edits
-			// before we added generation tracking).
-			name:                  "missing generation annotation - full update for safety",
+			name:                  "missing generation annotation - annotations only when spec is equivalent",
 			currentGeneration:     5,
 			lastAppliedGeneration: "", // missing
 			lastAppliedHash:       "match",
 			desiredReplicas:       2,
 			expectNeedsUpdate:     true,
-			expectNewGeneration:   6, // current + 1
+			expectNewGeneration:   5,
 		},
 		{
-			name:                  "missing hash annotation - needs full update",
+			name:                  "missing hash annotation - annotations only when spec is equivalent",
 			currentGeneration:     5,
 			lastAppliedGeneration: "5",
 			lastAppliedHash:       "", // missing
 			desiredReplicas:       2,
 			expectNeedsUpdate:     true,
-			expectNewGeneration:   6, // current(5) + 1
+			expectNewGeneration:   5,
 		},
 		{
 			name:                  "hash changed - needs full update",
@@ -478,25 +515,26 @@ func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 			lastAppliedHash:       "match",
 			desiredReplicas:       3, // different from current (2)
 			expectNeedsUpdate:     true,
+			expectSpecNeedsUpdate: true,
 			expectNewGeneration:   6, // current(5) + 1
 		},
 		{
-			name:                  "corrupted generation annotation - needs full update",
+			name:                  "corrupted generation annotation - annotations only when spec is equivalent",
 			currentGeneration:     5,
 			lastAppliedGeneration: "invalid",
 			lastAppliedHash:       "match",
 			desiredReplicas:       2,
 			expectNeedsUpdate:     true,
-			expectNewGeneration:   6, // current(5) + 1
+			expectNewGeneration:   5,
 		},
 		{
-			name:                  "both annotations missing - needs full update",
+			name:                  "both annotations missing - annotations only when spec is equivalent",
 			currentGeneration:     5,
 			lastAppliedGeneration: "",
 			lastAppliedHash:       "",
 			desiredReplicas:       2,
 			expectNeedsUpdate:     true,
-			expectNewGeneration:   6, // current(5) + 1
+			expectNewGeneration:   5,
 		},
 		{
 			name:                       "manual change with hash also changed",
@@ -505,6 +543,7 @@ func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 			lastAppliedHash:            "match",
 			desiredReplicas:            3, // different
 			expectNeedsUpdate:          true,
+			expectSpecNeedsUpdate:      true,
 			expectManualChangeDetected: false, // hash change takes precedence
 			expectNewGeneration:        8,
 		},
@@ -578,6 +617,7 @@ func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 			result, err := GetSpecChangeResult(current, desired)
 			g.Expect(err).To(gomega.BeNil())
 			g.Expect(result.NeedsUpdate).To(gomega.Equal(tt.expectNeedsUpdate), "NeedsUpdate mismatch")
+			g.Expect(result.SpecNeedsUpdate).To(gomega.Equal(tt.expectSpecNeedsUpdate), "SpecNeedsUpdate mismatch")
 			g.Expect(result.ManualChangeDetected).To(gomega.Equal(tt.expectManualChangeDetected), "ManualChangeDetected mismatch")
 			if tt.expectNewGeneration != 0 {
 				g.Expect(result.NewGeneration).To(gomega.Equal(tt.expectNewGeneration), "NewGeneration mismatch")

--- a/deploy/operator/internal/controller_common/resource_test.go
+++ b/deploy/operator/internal/controller_common/resource_test.go
@@ -459,6 +459,55 @@ func TestGetSpecChangeResult_AnnotationOnlyForEquivalentSpec(t *testing.T) {
 	g.Expect(result.NewHash).ToNot(gomega.BeNil())
 }
 
+func TestGetSpecChangeResult_OrderOnlyManualDriftNeedsSpecUpdate(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	desired := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "worker",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"initContainers": []interface{}{
+							map[string]interface{}{"name": "setup", "image": "busybox"},
+							map[string]interface{}{"name": "migrate", "image": "busybox"},
+						},
+						"containers": []interface{}{
+							map[string]interface{}{"name": "main", "image": "worker:v1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	current := desired.DeepCopy()
+	current.SetGeneration(6)
+	current.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["initContainers"] = []interface{}{
+		map[string]interface{}{"name": "migrate", "image": "busybox"},
+		map[string]interface{}{"name": "setup", "image": "busybox"},
+	}
+	desiredHash, err := GetSpecHash(desired)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	currentHash, err := GetSpecHash(current)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(currentHash).To(gomega.Equal(desiredHash), "canonical hash must reproduce the historical blind spot")
+	current.SetAnnotations(map[string]string{
+		NvidiaAnnotationHashKey:       desiredHash,
+		NvidiaAnnotationGenerationKey: "5",
+	})
+
+	result, err := GetSpecChangeResult(current, desired)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(result.NeedsUpdate).To(gomega.BeTrue())
+	g.Expect(result.SpecNeedsUpdate).To(gomega.BeTrue())
+	g.Expect(result.ManualChangeDetected).To(gomega.BeTrue())
+	g.Expect(result.NewGeneration).To(gomega.Equal(int64(7)))
+}
+
 func TestGetSpecChangeResult_GenerationTracking(t *testing.T) {
 	tests := []struct {
 		name                       string

--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"sort"
 	"sync"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
@@ -14,11 +16,11 @@ import (
 type DockerSecretIndexer struct {
 	// maps for a namespace, a docker registry server to a list of secret names
 	secrets map[string]map[string][]string
-	client  client.Client
+	client  client.Reader
 	mu      sync.RWMutex
 }
 
-func NewDockerSecretIndexer(client client.Client) *DockerSecretIndexer {
+func NewDockerSecretIndexer(client client.Reader) *DockerSecretIndexer {
 	return &DockerSecretIndexer{
 		secrets: make(map[string]map[string][]string),
 		client:  client,
@@ -31,6 +33,12 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	if err := i.client.List(ctx, secrets); err != nil {
 		return fmt.Errorf("unable to list secrets: %w", err)
 	}
+	sort.Slice(secrets.Items, func(a, b int) bool {
+		if secrets.Items[a].Namespace != secrets.Items[b].Namespace {
+			return secrets.Items[a].Namespace < secrets.Items[b].Namespace
+		}
+		return secrets.Items[a].Name < secrets.Items[b].Name
+	})
 	tmpSecrets := make(map[string]map[string][]string)
 	for _, secret := range secrets.Items {
 		if secret.Type == corev1.SecretTypeDockerConfigJson {
@@ -55,6 +63,12 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 			}
 		}
 	}
+	for namespace := range tmpSecrets {
+		for registry, secretNames := range tmpSecrets[namespace] {
+			sort.Strings(secretNames)
+			tmpSecrets[namespace][registry] = slices.Compact(secretNames)
+		}
+	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.secrets = tmpSecrets
@@ -68,5 +82,5 @@ func (i *DockerSecretIndexer) GetSecrets(namespace, registry string) ([]string, 
 	}
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	return i.secrets[namespace][registry], nil
+	return append([]string(nil), i.secrets[namespace][registry]...), nil
 }

--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
-	"sort"
 	"sync"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
@@ -33,11 +32,20 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	if err := i.client.List(ctx, secrets); err != nil {
 		return fmt.Errorf("unable to list secrets: %w", err)
 	}
-	sort.Slice(secrets.Items, func(a, b int) bool {
-		if secrets.Items[a].Namespace != secrets.Items[b].Namespace {
-			return secrets.Items[a].Namespace < secrets.Items[b].Namespace
+	slices.SortFunc(secrets.Items, func(a, b corev1.Secret) int {
+		if a.Namespace != b.Namespace {
+			if a.Namespace < b.Namespace {
+				return -1
+			}
+			return 1
 		}
-		return secrets.Items[a].Name < secrets.Items[b].Name
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
 	})
 	tmpSecrets := make(map[string]map[string][]string)
 	for _, secret := range secrets.Items {
@@ -65,7 +73,7 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	}
 	for namespace := range tmpSecrets {
 		for registry, secretNames := range tmpSecrets[namespace] {
-			sort.Strings(secretNames)
+			slices.Sort(secretNames)
 			tmpSecrets[namespace][registry] = slices.Compact(secretNames)
 		}
 	}

--- a/deploy/operator/internal/secrets/docker_test.go
+++ b/deploy/operator/internal/secrets/docker_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -132,7 +133,7 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
 	}
-	if got, want := secrets, []string{"secret-a", "secret-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+	if got, want := secrets, []string{"secret-a", "secret-b"}; !slices.Equal(got, want) {
 		t.Fatalf("DockerSecretIndexer.GetSecrets() = %v, want %v", got, want)
 	}
 
@@ -141,7 +142,7 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
 	}
-	if got, want := secrets, []string{"secret-a", "secret-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+	if got, want := secrets, []string{"secret-a", "secret-b"}; !slices.Equal(got, want) {
 		t.Fatalf("DockerSecretIndexer.GetSecrets() after caller mutation = %v, want %v", got, want)
 	}
 }

--- a/deploy/operator/internal/secrets/docker_test.go
+++ b/deploy/operator/internal/secrets/docker_test.go
@@ -93,3 +93,55 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		t.Errorf("DockerSecretIndexer.GetSecrets() = %v, want %v", secrets[0], "secret3")
 	}
 }
+
+func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
+	mockSecrets := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-b",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"my-registry.com/team-a":{}, "my-registry.com/team-b":{}}}`),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-a",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"my-registry.com/team-a":{}}}`),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&mockSecrets[0], &mockSecrets[1]).
+		Build()
+
+	i := NewDockerSecretIndexer(fakeClient)
+	if err := i.RefreshIndex(context.Background()); err != nil {
+		t.Fatalf("DockerSecretIndexer.RefreshIndex() error = %v", err)
+	}
+
+	secrets, err := i.GetSecrets("default", "my-registry.com")
+	if err != nil {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
+	}
+	if got, want := secrets, []string{"secret-a", "secret-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() = %v, want %v", got, want)
+	}
+
+	secrets[0] = "mutated"
+	secrets, err = i.GetSecrets("default", "my-registry.com")
+	if err != nil {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
+	}
+	if got, want := secrets, []string{"secret-a", "secret-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() after caller mutation = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes spurious Deployment rollouts during operator startup/upgrade caused by transient or non-deterministic docker image pull secret discovery.

## Changes

- Warm the docker secret index synchronously before controllers are registered, using the direct API reader.
- Make discovered docker secrets deterministic by sorting and compacting secret names per registry.
- Return a copy from `DockerSecretIndexer.GetSecrets()` to avoid caller-side mutation of cached state.
- Avoid copying specs when only operator bookkeeping annotations need repair and the live spec already exactly matches desired.
Closes DYN-3086

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during operator startup; initialization failures now terminate gracefully.
  * Docker secret indexer now returns deterministic ordering for consistent behavior.

* **Refactor**
  * Optimized resource synchronization to efficiently distinguish between annotation-only updates and full spec updates, reducing unnecessary writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->