### PR TITLE
ci: Use Ubuntu 24.04 vLLM runtime images

### DIFF
--- a/container/compliance/README.md
+++ b/container/compliance/README.md
@@ -126,8 +126,8 @@ python container/compliance/process_results.py \
 
 | Framework | CUDA | Base image |
 |-----------|------|------------|
-| `vllm` | 12.9 | `vllm/vllm-openai:v0.21.0-cu129` |
-| `vllm` | 13.0 | `vllm/vllm-openai:v0.21.0` |
+| `vllm` | 12.9 | `vllm/vllm-openai:v0.21.0-cu129-ubuntu2404` |
+| `vllm` | 13.0 | `vllm/vllm-openai:v0.21.0-ubuntu2404` |
 | `sglang` | 12.9 | `lmsysorg/sglang:v0.5.11-cu129-runtime` |
 | `sglang` | 13.0 | `lmsysorg/sglang:v0.5.11-cu130-runtime` |
 | `trtllm` | 13.1 | `nvcr.io/nvidia/cuda-dl-base:25.12-cuda13.1-runtime-ubuntu24.04` |

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -45,12 +45,12 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.06-cuda12.9-devel-ubuntu24.04
-    runtime_image_tag: v0.21.0-cu129
+    runtime_image_tag: v0.21.0-cu129-ubuntu2404
   cuda13.0:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.21.0
+    runtime_image_tag: v0.21.0-ubuntu2404
   xpu:
     base_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
     runtime_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo


### PR DESCRIPTION
## Summary
- switch Dynamo's vLLM CUDA 12.9 runtime base to `vllm/vllm-openai:v0.21.0-cu129-ubuntu2404`
- switch Dynamo's vLLM CUDA 13.0 runtime base to `vllm/vllm-openai:v0.21.0-ubuntu2404`
- update the container compliance reference table to match `container/context.yaml`

## Why
The upstream vLLM Docker Hub repository publishes explicit Ubuntu 24.04 runtime tags for v0.21.0, and Dynamo should consume those tags directly instead of the non-OS-suffixed v0.21.0 tags.

## Validation
- `list_backend_images(backend="vllm", tag_contains="v0.21.0", count=100)`
- `python3 container/compliance/resolve_base_image.py --framework vllm --cuda-version 12.9`
- `python3 container/compliance/resolve_base_image.py --framework vllm --cuda-version 13.0`
- `python3 container/render.py --framework vllm --target runtime --cuda-version 12.9 --platform linux/amd64 --output-short-filename`
- `python3 container/render.py --framework vllm --target runtime --cuda-version 13.0 --platform linux/amd64 --output-short-filename`
- `git diff --check`
- pre-commit hooks except `pytest-marker-report`; that hook failed in the local Python 3.10 pre-commit env because current `main` imports Python 3.11 typing symbols (`Self`/`Required`) during collection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image configurations and documentation for vllm framework to support Ubuntu 24.04 with CUDA 12.9 and 13.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->