### PR TITLE
ci(docs): ungate safe docs metadata checks

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -13,21 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Consolidated Fern Documentation Workflow
+# Trusted Fern Documentation Workflow
 #
-# This workflow handles all Fern documentation automation:
+# This workflow handles trusted Fern documentation automation:
 #
-# 1. LINT (PRs): Validates Fern configuration and checks for broken links
-#    - Triggers on PRs when docs/** files change
-#    - Runs `fern check` and `fern docs broken-links`
+# Safe pre-merge Fern lint runs in pre-merge.yml on normal pull_request events.
 #
-# 2. SYNC & PUBLISH/PREVIEW: Syncs docs/ from source branch to fern/ on docs-website
-#    - Triggers on push to main or PRs when docs/** files change
+# 1. SYNC & PUBLISH/PREVIEW: Syncs docs/ from source branch to fern/ on docs-website
+#    - Triggers on trusted pushes to main or pull-request/N when docs-site files change
 #    - On main: commits and pushes to docs-website, then publishes via `fern generate --docs`
-#    - On PRs: generates a preview URL via `fern generate --docs --preview` and comments on PR
+#    - On gated PR branches: generates a preview URL via `fern generate --docs --preview` and comments on PR
 #    - Preserves versioned documentation (products[0]) from docs-website's docs.yml
 #
-# 3. VERSION RELEASE (tags): Creates versioned documentation snapshot
+# 2. VERSION RELEASE (tags): Creates versioned documentation snapshot
 #    - Triggers on new version tags (vX.Y.Z format)
 #    - Creates fern/pages-vX.Y.Z/ directory on docs-website branch
 #    - Updates fern/docs.yml with new version entry
@@ -77,59 +75,9 @@ jobs:
           gh_token: ${{ github.token }}
 
   #############################################################################
-  # LINT JOBS - Run on PRs when docs/** files change
-  #############################################################################
-
-  fern-check:
-    name: Fern Configuration Check
-    needs: changed-files
-    if: |
-      github.ref_type != 'tag' &&
-      needs.changed-files.outputs.docs == 'true' &&
-      (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install Fern CLI
-        run: npm install -g fern-api
-
-      - name: Validate Fern configuration
-        run: fern check
-
-  fern-broken-links:
-    name: Fern Broken Links Check
-    needs: changed-files
-    if: |
-      github.ref_type != 'tag' &&
-      needs.changed-files.outputs.docs == 'true' &&
-      (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Install Fern CLI
-        run: npm install -g fern-api
-
-      - name: Check for broken links
-        run: fern docs broken-links
-
-  #############################################################################
-  # SYNC & PUBLISH/PREVIEW - Syncs docs content to docs-website structure
+  # TRUSTED SYNC & PUBLISH/PREVIEW - Syncs docs content to docs-website structure
   # On main: commits, pushes, and publishes to Fern
-  # On PRs: generates a preview URL and comments on the PR
+  # On gated PR branches: generates a preview URL and comments on the PR
   #############################################################################
 
   preview-or-publish-docs:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -31,6 +31,7 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
+      docs: ${{ steps.changes.outputs.docs }}
       operator: ${{ steps.changes.outputs.operator }}
       snapshot: ${{ steps.changes.outputs.snapshot }}
       rust: ${{ steps.changes.outputs.rust }}
@@ -46,7 +47,7 @@ jobs:
 
   pre-merge-status-check:
     runs-on: ubuntu-latest
-    needs: [changed-files, pre-commit, operator, snapshot, rust-tests, rust-clippy]
+    needs: [changed-files, pre-commit, fern-check, fern-broken-links, operator, snapshot, rust-tests, rust-clippy]
     if: always()
     steps:
       - name: "Check all dependent jobs"
@@ -62,6 +63,41 @@ jobs:
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       timeout-minutes: 3
+
+  # Safe Fern docs checks run in pre-merge with read-only permissions.
+  fern-check:
+    name: Fern Configuration Check
+    needs: changed-files
+    if: needs.changed-files.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+    - name: Install Fern CLI
+      run: npm install -g fern-api
+    - name: Validate Fern configuration
+      run: fern check
+
+  fern-broken-links:
+    name: Fern Broken Links Check
+    needs: changed-files
+    if: needs.changed-files.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+    - name: Install Fern CLI
+      run: npm install -g fern-api
+    - name: Check for broken links
+      run: fern docs broken-links
 
   operator:
     needs: changed-files

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -21,8 +21,12 @@ on:
       - main
       - release/*.*.*
       - "pull-request/[0-9]+"
-    # Skip docs only changes
+    # Docs deployment is handled by fern-docs.yml. Docs-only changes are
+    # covered by pre-merge Fern checks, so do not wake this secrets-backed
+    # GitLab mirror/Test Lab pipeline for docs metadata/config.
     paths-ignore:
+      - 'docs/**'
+      - 'fern/**'
       - '**.md'
       - '**.rst'
 


### PR DESCRIPTION
Summary:
- Move Fern-specific validation into Pre Merge so docs-scoped pull_request events catch Fern config/navigation and Fern-rendered link failures before /ok-to-test.
- Keep Fern preview, publish, and version release in fern-docs.yml on trusted push/tag/workflow_dispatch paths.
- Ignore docs/** and fern/** in NVIDIA Test Lab Validation because docs deployment is handled by fern-docs.yml and docs-only changes should not wake the secrets-backed GitLab/Test Lab path.

Value:
- This is not a replacement for spelling, formatting, copyright, or generic Markdown link checks; those already run in existing pre-merge/PR workflows.
- The new value is Fern-specific coverage for docs metadata/config such as docs/index.yml and fern/**, where mistakes can break docs navigation or Fern deployment even when ordinary Markdown/RST checks pass.

Validation:
- git diff --check
- Ruby YAML parse for changed workflows
- yq parse for changed workflows
- pre-commit hooks during commits

Note: actionlint was not installed locally.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->