### PR TITLE
fix(operator): Normalize GMS ResourceClaimTemplate names

### DIFF
--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -306,7 +306,7 @@ func getDeviceClassName(gmsSpec *v1beta1.GPUMemoryServiceSpec) string {
 
 // gmsRCTName returns a deterministic ResourceClaimTemplate name for a given rank.
 func gmsRCTName(serviceName string, rank int32) string {
-	return fmt.Sprintf("%s-gpu-rank-%d", serviceName, rank)
+	return fmt.Sprintf("%s-gpu-rank-%d", NormalizeKubeResourceName(serviceName), rank)
 }
 
 // gmsResourceClaimTemplateConfigs builds one PCS-level ResourceClaimTemplateConfig

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -371,6 +372,8 @@ func TestGroveMultinodeDeployer_GMS(t *testing.T) {
 func TestGmsRCTName(t *testing.T) {
 	assert.Equal(t, "my-svc-gpu-rank-0", gmsRCTName("my-svc", 0))
 	assert.Equal(t, "llama-gpu-rank-2", gmsRCTName("llama", 2))
+	assert.Equal(t, "vllmworker-gpu-rank-0", gmsRCTName("VllmWorker", 0))
+	assert.Empty(t, validation.IsDNS1123Subdomain(gmsRCTName("VllmWorker", 0)))
 }
 
 func TestGmsResourceClaimTemplateConfigs_SingleNode(t *testing.T) {
@@ -381,11 +384,12 @@ func TestGmsResourceClaimTemplateConfigs_SingleNode(t *testing.T) {
 		{Name: "svc", Role: RoleMain, Rank: 0, Replicas: 2},
 	}
 
-	configs, err := gmsResourceClaimTemplateConfigs("svc", gmsSpec, resources, roles)
+	configs, err := gmsResourceClaimTemplateConfigs("VllmWorker", gmsSpec, resources, roles)
 	require.NoError(t, err)
 
 	require.Len(t, configs, 1)
-	assert.Equal(t, "svc-gpu-rank-0", configs[0].Name)
+	assert.Equal(t, "vllmworker-gpu-rank-0", configs[0].Name)
+	assert.Empty(t, validation.IsDNS1123Subdomain(configs[0].Name))
 
 	req := configs[0].TemplateSpec.Spec.Devices.Requests[0]
 	require.NotNil(t, req.Exactly)
@@ -421,10 +425,11 @@ func TestGmsResourceSharingEntries_SingleNode(t *testing.T) {
 		{Name: "svc", Role: RoleMain, Rank: 0, Replicas: 2},
 	}
 
-	refs := gmsResourceSharingEntries("svc", roles)
+	refs := gmsResourceSharingEntries("VllmWorker", roles)
 
 	require.Len(t, refs, 1)
-	assert.Equal(t, "svc-gpu-rank-0", refs[0].Name)
+	assert.Equal(t, "vllmworker-gpu-rank-0", refs[0].Name)
+	assert.Empty(t, validation.IsDNS1123Subdomain(refs[0].Name))
 	assert.Equal(t, grovev1alpha1.ResourceSharingScopePerReplica, refs[0].Scope)
 	require.NotNil(t, refs[0].Filter)
 	assert.Equal(t, []string{"svc-gms-0", "svc"}, refs[0].Filter.ChildCliqueNames)


### PR DESCRIPTION
## Summary

Normalize inter-pod GMS ResourceClaimTemplate names with the existing Kubernetes resource-name helper.

Dynamo logical component/service names can be CamelCase, for example `VllmWorker`, but Grove uses the generated GMS ResourceClaimTemplate/resourceSharing name when creating PCSG-level `ResourceClaim` objects. Kubernetes validates `ResourceClaim.metadata.name` as a lowercase DNS-1123 subdomain, so the previous `VllmWorker-gpu-rank-0` name caused Grove reconciliation to fail.

This change routes the GMS RCT name through `NormalizeKubeResourceName`, so the template and matching resourceSharing reference are both generated as `vllmworker-gpu-rank-0`.

## Validation

- Added coverage for CamelCase service names in `gmsRCTName`
- Added DNS-1123 validation for generated GMS ResourceClaimTemplate names
- Added DNS-1123 validation for generated GMS resourceSharing names
- Ran `go test ./internal/dynamo -run 'TestGms' -count=1`
- Ran `go test ./internal/dynamo -count=1`

Closes DYN-3083

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource claim template naming to follow DNS-1123 subdomain validation standards. Service identifiers are now properly normalized before template name generation, improving Kubernetes compliance. This ensures resource names are valid and consistent across cluster deployments, with added validation checks confirming naming standards are met.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->