### PR TITLE
feat(sglang): gate chat-shaped Prometheus collectors on embedding worker (DIS-2107)

### DIFF
--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -67,6 +67,9 @@ async def init_llm_diffusion(
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
     )
+    # ``setup_sgl_metrics`` only returns ``None`` for embedding workers,
+    # which take a different init path entirely. Narrow for mypy.
+    assert publisher is not None, "setup_sgl_metrics returned None on chat path"
 
     if server_args.node_rank >= 1:
         await handle_non_leader_node(engine, publisher, metrics_task)

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -93,6 +93,9 @@ async def init_decode(
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
     )
+    # ``setup_sgl_metrics`` only returns ``None`` for embedding workers,
+    # which take a different init path entirely. Narrow for mypy.
+    assert publisher is not None, "setup_sgl_metrics returned None on chat path"
 
     publisher.component_gauges.set_model_load_time(load_time)
     logging.debug(f"SGLang model load time: {load_time:.2f}s")
@@ -238,6 +241,9 @@ async def init_prefill(
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
     )
+    # ``setup_sgl_metrics`` only returns ``None`` for embedding workers,
+    # which take a different init path entirely. Narrow for mypy.
+    assert publisher is not None, "setup_sgl_metrics returned None on chat path"
 
     publisher.component_gauges.set_model_load_time(load_time)
 

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -477,7 +477,7 @@ async def setup_sgl_metrics(
     so callers can keep the same ``await setup_sgl_metrics(...)`` shape
     and ``metrics_task.cancel()`` cleanup. Embedding-shaped metrics are
     registered separately by ``init_embedding.py`` via
-    ``init_embedding_metrics`` (see DIS-2094 part 1).
+    ``init_embedding_metrics``.
 
     Args:
         engine: The SGLang engine instance.
@@ -496,9 +496,13 @@ async def setup_sgl_metrics(
             "wiring (no KV cache, no prefill/decode, no scheduler metrics). "
             "Embedding-shaped metrics are registered separately."
         )
+
         # Hold a never-completing task so callers can ``cancel()`` + ``await``
         # it uniformly in their finally blocks, matching the chat-worker shape.
-        task = asyncio.create_task(asyncio.Event().wait())
+        async def _idle() -> None:
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(_idle())
         return None, task, metrics_labels
 
     # Register SGLang multiprocess metrics only when --enable-metrics was passed.

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -460,8 +460,24 @@ async def setup_sgl_metrics(
     config: Config,
     generate_endpoint: Endpoint,
     kv_worker_id: Optional[int] = None,
-) -> tuple[DynamoSglangPublisher, asyncio.Task, list[tuple[str, str]]]:
+) -> tuple[Optional[DynamoSglangPublisher], asyncio.Task, list[tuple[str, str]]]:
     """Create publisher, initialize metrics, and start the metrics publishing loop.
+
+    For chat/decode workers (the default), this registers SGLang's
+    multiprocess ``sglang:*`` metrics, the Dynamo ``LLMBackendMetrics``
+    chat-shaped gauges (KV total_blocks, gpu_cache_usage, model_load_time),
+    and starts a ``DynamoSglangPublisher`` that pulls scheduler metrics
+    over ZMQ and (optionally) forwards KV events / FPM stats.
+
+    For **embedding workers** (``config.dynamo_args.embedding_worker``),
+    the chat-shaped pipeline is **skipped entirely**: pooling engines
+    have no KV cache, no prefill/decode phase, and no scheduler metrics
+    worth collecting, so every metric in that pipeline would emit zeros
+    forever. The function returns ``(None, <noop task>, metrics_labels)``
+    so callers can keep the same ``await setup_sgl_metrics(...)`` shape
+    and ``metrics_task.cancel()`` cleanup. Embedding-shaped metrics are
+    registered separately by ``init_embedding.py`` via
+    ``init_embedding_metrics`` (see DIS-2094 part 1).
 
     Args:
         engine: The SGLang engine instance.
@@ -470,8 +486,21 @@ async def setup_sgl_metrics(
         kv_worker_id: Optional worker identity for KV event attribution.
 
     Returns:
-        Tuple of (publisher instance, running asyncio task, metrics labels).
+        Tuple of (publisher instance or None, asyncio task, metrics labels).
     """
+    metrics_labels = [("model", engine.server_args.served_model_name)]
+
+    if getattr(config.dynamo_args, "embedding_worker", False):
+        logging.info(
+            "Embedding worker: skipping chat-shaped Prometheus + KV-event "
+            "wiring (no KV cache, no prefill/decode, no scheduler metrics). "
+            "Embedding-shaped metrics are registered separately."
+        )
+        # Hold a never-completing task so callers can ``cancel()`` + ``await``
+        # it uniformly in their finally blocks, matching the chat-worker shape.
+        task = asyncio.create_task(asyncio.Event().wait())
+        return None, task, metrics_labels
+
     # Register SGLang multiprocess metrics only when --enable-metrics was passed.
     # SGLang only calls set_prometheus_multiproc_dir() when enable_metrics=True,
     # so MultiProcessCollector will crash without it.
@@ -498,7 +527,6 @@ async def setup_sgl_metrics(
         component_name=config.dynamo_args.component,
     )
 
-    metrics_labels = [("model", engine.server_args.served_model_name)]
     publisher = DynamoSglangPublisher(
         engine,
         config,

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -15,6 +15,7 @@ from dynamo.sglang.publisher import (
     get_local_dp_rank_range,
     handle_non_leader_node,
     set_forward_pass_metrics_worker_id,
+    setup_sgl_metrics,
 )
 
 pytestmark = [
@@ -476,3 +477,155 @@ def test_init_kv_event_publish_allows_zero_worker_id_override(monkeypatch):
 
     assert calls[0]["worker_id"] == 0
     publisher.cleanup()
+
+
+# ---- DIS-2107: per-worker metric gating ----
+
+
+@pytest.mark.asyncio
+async def test_setup_sgl_metrics_skips_chat_pipeline_for_embedding_worker(monkeypatch):
+    """``setup_sgl_metrics`` short-circuits for embedding workers.
+
+    Chat-shaped collectors (``sglang:*`` multiproc metrics, the Dynamo
+    ``LLMBackendMetrics`` gauges, ``DynamoSglangPublisher`` itself with
+    its KV-events / FPM relay wiring) emit zeros forever on a pooling
+    engine. Verify they are not constructed when
+    ``config.dynamo_args.embedding_worker`` is True, while preserving
+    the ``(publisher, task, metrics_labels)`` return shape so the
+    embedding init path can keep its uniform cleanup.
+    """
+    calls: dict[str, int] = {}
+
+    def _track(name):
+        def _wrapped(*_a, **_kw):
+            calls[name] = calls.get(name, 0) + 1
+            raise AssertionError(
+                f"setup_sgl_metrics should not call {name} on the embedding-worker path"
+            )
+
+        return _wrapped
+
+    monkeypatch.setattr(publisher_mod, "setup_prometheus_registry", _track("setup_prometheus_registry"))
+    monkeypatch.setattr(
+        publisher_mod, "register_engine_metrics_callback", _track("register_engine_metrics_callback")
+    )
+    monkeypatch.setattr(publisher_mod, "LLMBackendMetrics", _track("LLMBackendMetrics"))
+    monkeypatch.setattr(publisher_mod, "DynamoSglangPublisher", _track("DynamoSglangPublisher"))
+
+    engine = SimpleNamespace(
+        server_args=SimpleNamespace(
+            served_model_name="Qwen/Qwen3-Embedding-4B",
+            enable_metrics=True,  # would normally enable chat-shaped sglang:* metrics
+            node_rank=0,
+        )
+    )
+    config = SimpleNamespace(
+        dynamo_args=SimpleNamespace(embedding_worker=True),
+        server_args=engine.server_args,
+    )
+    generate_endpoint = SimpleNamespace()
+
+    publisher, task, metrics_labels = await setup_sgl_metrics(
+        engine, config, generate_endpoint
+    )
+
+    try:
+        assert publisher is None
+        assert metrics_labels == [("model", "Qwen/Qwen3-Embedding-4B")]
+        assert isinstance(task, asyncio.Task)
+        # Task is intentionally a never-completing waiter so callers can
+        # ``cancel()`` + ``await`` uniformly in their finally blocks.
+        assert not task.done()
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # Hard assertion: NONE of the chat-shaped constructors fired.
+    assert calls == {}
+
+
+@pytest.mark.asyncio
+async def test_setup_sgl_metrics_returns_publisher_for_chat_worker(monkeypatch):
+    """The chat-worker path still constructs the publisher.
+
+    Sibling to the embedding-worker test above: gives confidence the
+    gating doesn't accidentally short-circuit the default code path.
+    """
+    constructed: dict[str, int] = {}
+
+    def _count(name):
+        def _wrapped(*_a, **_kw):
+            constructed[name] = constructed.get(name, 0) + 1
+            return SimpleNamespace()
+
+        return _wrapped
+
+    monkeypatch.setattr(publisher_mod, "setup_prometheus_registry", _count("setup_prometheus_registry"))
+    monkeypatch.setattr(
+        publisher_mod, "register_engine_metrics_callback", _count("register_engine_metrics_callback")
+    )
+    monkeypatch.setattr(publisher_mod, "LLMBackendMetrics", _count("LLMBackendMetrics"))
+
+    # Replace the publisher constructor with one that returns a stub whose
+    # methods exist but no-op, so we can keep the test free of real ZMQ / NATS.
+    class _StubPublisher:
+        def __init__(self, *_a, **_kw):
+            constructed["DynamoSglangPublisher"] = constructed.get("DynamoSglangPublisher", 0) + 1
+            self.metrics_publisher = SimpleNamespace(
+                create_endpoint=lambda _ep: _async_noop()
+            )
+
+        def init_engine_metrics_publish(self):
+            pass
+
+        def init_kv_event_publish(self):
+            pass
+
+        def init_fpm_relay(self):
+            pass
+
+        async def run(self):
+            await asyncio.Event().wait()
+
+    async def _async_noop():
+        return None
+
+    monkeypatch.setattr(publisher_mod, "DynamoSglangPublisher", _StubPublisher)
+
+    engine = SimpleNamespace(
+        server_args=SimpleNamespace(
+            served_model_name="Qwen/Qwen3-0.6B",
+            enable_metrics=False,  # skip setup_prometheus_registry but still run chat path
+            node_rank=0,
+        )
+    )
+    config = SimpleNamespace(
+        dynamo_args=SimpleNamespace(
+            embedding_worker=False,
+            component="sglang-decode",
+        ),
+        server_args=engine.server_args,
+    )
+    generate_endpoint = SimpleNamespace()
+
+    publisher, task, _labels = await setup_sgl_metrics(
+        engine, config, generate_endpoint
+    )
+
+    try:
+        assert publisher is not None
+        # All three chat-shaped constructors fired.
+        assert constructed.get("register_engine_metrics_callback", 0) == 1
+        assert constructed.get("LLMBackendMetrics", 0) == 1
+        assert constructed.get("DynamoSglangPublisher", 0) == 1
+        # setup_prometheus_registry was gated off by enable_metrics=False.
+        assert "setup_prometheus_registry" not in constructed
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -479,7 +479,7 @@ def test_init_kv_event_publish_allows_zero_worker_id_override(monkeypatch):
     publisher.cleanup()
 
 
-# ---- DIS-2107: per-worker metric gating ----
+# ---- per-worker metric gating (embedding vs chat) ----
 
 
 @pytest.mark.asyncio
@@ -505,12 +505,18 @@ async def test_setup_sgl_metrics_skips_chat_pipeline_for_embedding_worker(monkey
 
         return _wrapped
 
-    monkeypatch.setattr(publisher_mod, "setup_prometheus_registry", _track("setup_prometheus_registry"))
     monkeypatch.setattr(
-        publisher_mod, "register_engine_metrics_callback", _track("register_engine_metrics_callback")
+        publisher_mod, "setup_prometheus_registry", _track("setup_prometheus_registry")
+    )
+    monkeypatch.setattr(
+        publisher_mod,
+        "register_engine_metrics_callback",
+        _track("register_engine_metrics_callback"),
     )
     monkeypatch.setattr(publisher_mod, "LLMBackendMetrics", _track("LLMBackendMetrics"))
-    monkeypatch.setattr(publisher_mod, "DynamoSglangPublisher", _track("DynamoSglangPublisher"))
+    monkeypatch.setattr(
+        publisher_mod, "DynamoSglangPublisher", _track("DynamoSglangPublisher")
+    )
 
     engine = SimpleNamespace(
         server_args=SimpleNamespace(
@@ -563,9 +569,13 @@ async def test_setup_sgl_metrics_returns_publisher_for_chat_worker(monkeypatch):
 
         return _wrapped
 
-    monkeypatch.setattr(publisher_mod, "setup_prometheus_registry", _count("setup_prometheus_registry"))
     monkeypatch.setattr(
-        publisher_mod, "register_engine_metrics_callback", _count("register_engine_metrics_callback")
+        publisher_mod, "setup_prometheus_registry", _count("setup_prometheus_registry")
+    )
+    monkeypatch.setattr(
+        publisher_mod,
+        "register_engine_metrics_callback",
+        _count("register_engine_metrics_callback"),
     )
     monkeypatch.setattr(publisher_mod, "LLMBackendMetrics", _count("LLMBackendMetrics"))
 
@@ -573,7 +583,9 @@ async def test_setup_sgl_metrics_returns_publisher_for_chat_worker(monkeypatch):
     # methods exist but no-op, so we can keep the test free of real ZMQ / NATS.
     class _StubPublisher:
         def __init__(self, *_a, **_kw):
-            constructed["DynamoSglangPublisher"] = constructed.get("DynamoSglangPublisher", 0) + 1
+            constructed["DynamoSglangPublisher"] = (
+                constructed.get("DynamoSglangPublisher", 0) + 1
+            )
             self.metrics_publisher = SimpleNamespace(
                 create_endpoint=lambda _ep: _async_noop()
             )


### PR DESCRIPTION
#### Overview:

Closes the SGLang half of [DIS-2107](https://linear.app/nvidia/issue/DIS-2107). Operators monitoring an embedding fleet today see chat-shaped collectors emit zeros forever: KV gauges, prefill/decode counters, SGLang's `sglang:*` multiproc metrics, and the Dynamo `LLMBackendMetrics` series all live on every worker regardless of whether the engine even has a KV cache. This PR makes the SGLang publisher skip all of that wiring for embedding workers.

#### Details:

`setup_sgl_metrics(engine, config, generate_endpoint)` now short-circuits when `config.dynamo_args.embedding_worker` is True:

- **Not constructed**: `setup_prometheus_registry()` (SGLang `sglang:*` multiproc metrics), `LLMBackendMetrics()` (total_blocks, gpu_cache_usage, model_load_time), `DynamoSglangPublisher()` (ZMQ scheduler pull + KV-event publisher + FPM relay).
- **Still returned**: the function preserves its `(publisher_or_None, asyncio.Task, metrics_labels)` shape so `init_embedding.py` can keep the same `await metrics_task` + `metrics_task.cancel()` cleanup as the chat-worker path. The task is a never-completing waiter for uniformity.
- **Still set up by `init_embedding.py`**: the embedding-shaped collectors (`dynamo_embedding_batch_size`, `dynamo_embedding_input_tokens` — see #9753).

The result: on an embedding worker's `/metrics`, you see only the metrics that actually move on a pooling engine, not the always-zero chat noise.

#### Tests:

Two new cases in `components/src/dynamo/sglang/tests/test_sglang_publisher.py`:

- **`test_setup_sgl_metrics_skips_chat_pipeline_for_embedding_worker`** — patches each chat-shaped constructor with a function that raises if invoked. With `config.dynamo_args.embedding_worker=True`, none of them must fire. Verifies the return tuple too: `publisher is None`, `task` is a cancellable `asyncio.Task`, `metrics_labels` still carries `("model", served_name)`.
- **`test_setup_sgl_metrics_returns_publisher_for_chat_worker`** — sibling check that the chat-worker path is unchanged: `register_engine_metrics_callback`, `LLMBackendMetrics`, and `DynamoSglangPublisher` all fire exactly once. Confirms the gating doesn't accidentally short-circuit the default code path.

#### Why not vLLM in this PR?

vLLM's embedding-worker shape (DIS-2092 / PR #9713) hasn't merged yet, and the vLLM-side embedding observation PR (DIS-2094 part 3) is still pending. Once both land, the same gating will mirror to `components/src/dynamo/vllm/publisher.py` in a follow-up PR.

#### Where should the reviewer start?

1. `components/src/dynamo/sglang/publisher.py` — the early-exit in `setup_sgl_metrics()`. The shape of the return tuple is preserved by design.
2. `components/src/dynamo/sglang/tests/test_sglang_publisher.py` — the two new tests at the bottom of the file.

Linear: https://linear.app/nvidia/issue/DIS-2107

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding workers in metrics initialization, with proper resource cleanup handling.

* **Tests**
  * Added test coverage for metrics setup behavior with embedding and non-embedding worker configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->