### PR TITLE
test: add reasoning parity fixtures (part 1)

### DIFF
--- a/docs/kubernetes/cloud-providers/aks/rdma-infiniband.md
+++ b/docs/kubernetes/cloud-providers/aks/rdma-infiniband.md
@@ -44,7 +44,7 @@ The RDMA setup involves five components installed in this order:
 
 ## Step 1: Install the NVIDIA Network Operator
 
-The [NVIDIA Network Operator](https://docs.nvidia.com/networking/display/cokan10/network+operator) automates deployment of networking components including Mellanox OFED drivers for InfiniBand support.
+The [NVIDIA Network Operator](https://docs.nvidia.com/networking/display/kubernetes25100/index.html) automates deployment of networking components including Mellanox OFED drivers for InfiniBand support.
 
 Create the namespace and label it for privileged workloads:
 
@@ -418,6 +418,5 @@ kubectl rollout restart daemonset/nvidia-driver-daemonset -n gpu-operator
 - [Azure AKS RDMA InfiniBand — GitHub](https://github.com/Azure/aks-rdma-infiniband)
 - [Set up InfiniBand on Azure HPC VMs — Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband)
 - [Enable InfiniBand VM extension — Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/enable-infiniband)
-- [NVIDIA Network Operator Documentation](https://docs.nvidia.com/networking/display/cokan10/network+operator)
+- [NVIDIA Network Operator Documentation](https://docs.nvidia.com/networking/display/kubernetes25100/index.html)
 - [Disaggregated Communication Guide](../../disagg-communication-guide.md) — transport options, UCX configuration, performance expectations
-

--- a/lib/parsers/REASONING_CASES.md
+++ b/lib/parsers/REASONING_CASES.md
@@ -25,30 +25,92 @@ and (where applicable) format tags. `N/A` is called out explicitly.
 
 ## Quick reference
 
+### Reasoning parser family groups
+
+Several "model parsers" share the same reasoning grammar. Group them
+first, otherwise we copy the same delimiter cases into many model
+rows and miss the contract that is actually being tested.
+
+| Group | Dynamo parser families / aliases | Grammar / contract | Notes |
+|---|---|---|---|
+| Explicit `<think>` block | `qwen3`, `deepseek_v4`, `nemotron_deci`, `glm45`, `basic` | Reasoning is inside `<think>...</think>`. Text outside the markers is normal text. | Most reusable cases are `REASONING.batch.{1,2,3,4,5,6}` and `REASONING.stream.{1,2,3,4}`. |
+| Force-reasoning `<think>` block | `deepseek_r1`, `deepseek_v3`, `deepseek_v3_1`, `deepseek_v3_2`, `step3`, `nemotron_nano`, `nemotron3`, `nemotron_v3` | Same delimiter, but generation may start already inside reasoning. Marker-free text can be reasoning until an end marker or stop condition. | Reuses the explicit `<think>` cases, but the plain-text/no-start behavior is different. |
+| Kimi K2.5 force-reasoning block | `kimi_k25` | `<think>` reasoning with a tool-section marker that can end an open reasoning span. | Keep separate from generic force-reasoning because tool-section boundaries are part of the reasoning contract. |
+| Kimi delimiter block | `kimi` | `◁think▷...◁/think▷` | Same block semantics as `<think>`, different marker spelling and more Unicode boundary risk. |
+| Mistral bracket block | `mistral` | `[THINK]...[/THINK]` | Same paired-marker cases with bracket tokens. |
+| Gemma channel block | `gemma4` | `<|channel>thought...<channel|>` | Needs prefix-disambiguation coverage: `thought` vs similar prefixes and partial channel markers. |
+| Granite phrase block | `granite` | `Here is my thought process:` followed by `Here is my response:` | Phrase-prefix buffering matters because partial phrases look like ordinary text until enough bytes arrive. |
+| Harmony channel block | `gpt_oss` | Harmony channels, especially `analysis`, `final`, `commentary`, and tool-call envelopes. | Some upstream tests are token/tag-level rather than plain text; convert what is portable and mark token-ID-only cases separately. |
+| Append-think content wrapper | `minimax_append_think` | Does not expose reasoning in the same way; vLLM prepends/preserves `<think>` as output content. | Treat as its own contract instead of forcing it into the normal "separate reasoning text" model. |
+
 ### Reasoning, batch mode
 
-The numbering mirrors `PARSER.batch.{N}` so that "PARSER.batch.X tests
-the same shape on the tool-call side that REASONING.batch.X tests on
-the reasoning side." Some numbers are N/A on the reasoning side (no
-analog of "empty args" for a reasoning block) and are tagged
-explicitly as `N/A` rather than silently absent.
+The numbering is organized by behavior, not by the order cases were
+added. Keep no-op / empty input first, simple reasoning extraction
+second, and batch tool call boundary cases third.
 
-- **`REASONING.batch.1`** Single reasoning block, happy path — `<think>...</think>` (or analog) present, no tool call. Parser populates `reasoning_text`, leaves `tool_calls` empty.
-- **`REASONING.batch.2`** Paired reasoning + downstream tool call — model emits `<think>...</think>` followed by tool-call tokens. Reasoning parser must extract the think content **and leave the tool-call markers intact in `normal_text`** for the downstream tool-call parser to consume. Watch for the "unclosed think-tag swallows tool call" bug.
-- **`REASONING.batch.3`** Reasoning + normal text (no tool call) — `<think>...</think>` interleaved with user-visible narration. Reasoning content goes to `reasoning_text`; narration goes to `normal_text`.
-- **`REASONING.batch.4`** Malformed reasoning content — dangling end marker (close without open), open without close (truncation), or invalid syntax inside the reasoning block. Behavior is impl-defined: graceful fallback to `normal_text`, partial extraction, or explicit error are all valid.
-- **`REASONING.batch.5`** Missing end-marker recovery — analog of `PARSER.batch.5` for reasoning. Engine hit `max_tokens` mid-think; pin behavior (recover the partial reasoning, surface as truncated, or treat all as `normal_text`).
-- **`REASONING.batch.6`** Empty reasoning content — `<think></think>` (or analog with zero bytes between markers). Must still register as a reasoning span, not be silently dropped.
-- **`REASONING.batch.7`** Complex reasoning content — large blocks, multi-paragraph, special characters, Unicode, newlines. Verify content makes it through without truncation or escape bugs.
-- **`REASONING.batch.8`** Empty/null content variants — empty input, whitespace-only input, null in upstream chunk. Parser must not crash and must produce coherent output.
-- **`REASONING.batch.9`** Multiple reasoning spans in one response — e.g., two `<think>...</think>` blocks back-to-back. Behavior is impl-defined: concatenate, surface only the first, or surface as a list.
+- **`REASONING.batch.1.a`** Empty input — empty model text. Parser must not crash and must produce coherent empty output.
+- **`REASONING.batch.1.b`** Plain text, no reasoning markers — non-empty model text with no reasoning wrapper. Parser must not invent `reasoning_text`.
+- **`REASONING.batch.1.c`** Whitespace-only input — whitespace with no reasoning wrapper. Parser must preserve or normalize according to the family contract.
+- **`REASONING.batch.1.d`** Null / missing upstream content — upstream content is absent rather than an empty string. Parser dispatch must not crash.
+- **`REASONING.batch.2.a`** Basic complete reasoning span — `<think>...</think>` (or analog) present, no downstream tool call. `normal_text` may be empty or may contain the family-specific final-answer section.
+- **`REASONING.batch.2.b`** Normal text before reasoning — user-visible text appears before the reasoning span.
+- **`REASONING.batch.2.c`** Reasoning followed by normal text — reasoning content goes to `reasoning_text`; final answer text goes to `normal_text`.
+- **`REASONING.batch.2.d`** Normal text around reasoning — user-visible text appears on both sides of the reasoning span.
+- **`REASONING.batch.2.e`** Empty reasoning content — `<think></think>` (or analog with zero bytes between markers). Must still register as a reasoning span if the family exposes empty spans.
+- **`REASONING.batch.2.f`** Complex reasoning content — large blocks, multi-paragraph, special characters, Unicode, newlines, and marker-looking strings inside the reasoning body.
+- **`REASONING.batch.3.a`** Closed reasoning followed by downstream tool-call text — reasoning parser must extract the think content **and leave the tool-call markers intact in `normal_text`** for the downstream tool-call parser to consume.
+- **`REASONING.batch.3.b`** Open reasoning interrupted by downstream tool-call text — tool-call markers can terminate or escape an open reasoning span for families that define that boundary.
+- **`REASONING.batch.4`** Malformed reasoning marker syntax — dangling close marker, invalid channel marker, or marker that does not belong to the family grammar.
+- **`REASONING.batch.5`** Missing end-marker recovery — engine hit `max_tokens` mid-think; pin behavior: recover partial reasoning, surface as truncated, or treat all as `normal_text`.
+- **`REASONING.batch.6.a`** Multiple reasoning spans, adjacent or separated by normal text — e.g., two `<think>...</think>` blocks in one response. Behavior is impl-defined: concatenate, surface only the first, or document a divergence.
+- **`REASONING.batch.6.b`** Multiple reasoning spans with malformed later span — first span is valid, later span is incomplete or malformed.
 
 ### Reasoning, stream mode
 
-- **`REASONING.stream.1`** Single reasoning block across N chunks — incremental assembly of `<think>...</think>` content over multiple chunks of any sizing.
-- **`REASONING.stream.2`** Start-marker chunk-boundary split — opening `<think>` (or analog) straddles a chunk boundary; partial-token matching must keep buffering instead of flushing as plain text.
-- **`REASONING.stream.3`** End-marker chunk-boundary split — closing `</think>` straddles a chunk boundary; same buffering contract.
-- **`REASONING.stream.4`** Diverged accumulated text — accumulated text never matches the start marker; parser must give up cleanly and treat all input as `normal_text`.
+Stream buckets follow the same shape as batch: no-op / empty stream
+first, ordinary reasoning extraction second, then boundary cases.
+
+- **`REASONING.stream.1.a`** Empty stream chunk — no emitted content. Parser must not crash, buffer forever, or invent reasoning text.
+- **`REASONING.stream.1.b`** Plain text stream, no reasoning markers — chunks contain user-visible text only. Explicit-marker parsers should pass it through as `normal_text`; force-reasoning parsers may keep it in `reasoning_text`.
+- **`REASONING.stream.2.a`** Single reasoning block across N chunks — incremental assembly of `<think>...</think>` content over multiple chunks of any sizing.
+- **`REASONING.stream.2.b`** Multiple reasoning spans across chunks — same contract as `REASONING.batch.6.*`, but state must reset between spans.
+- **`REASONING.stream.3.a`** Start-marker chunk-boundary split — opening `<think>` (or analog) straddles a chunk boundary; partial-token matching must keep buffering instead of flushing as plain text.
+- **`REASONING.stream.3.b`** End-marker chunk-boundary split — closing `</think>` straddles a chunk boundary; same buffering contract as `REASONING.stream.3.a`.
+- **`REASONING.stream.3.c`** Partial marker prefix later diverges into normal text — accumulated text starts like a marker but later proves it is not one.
+
+### Upstream test inventory
+
+There are reasoning tests in both vLLM and SGLang. Reuse the cases,
+not the Python harnesses: translate the input / expected output into
+language-neutral YAML fixtures, then preserve the upstream URL in the
+fixture `ref` field.
+
+| Source | What exists upstream | Reusable Dynamo categories |
+|---|---|---|
+| [vLLM `tests/reasoning/`](https://github.com/vllm-project/vllm/tree/main/tests/reasoning) | Per-family parser tests for Qwen3, DeepSeek R1/V3, Gemma 4, GPT-OSS, Granite, Kimi K2, MiniMax M2, Mistral, Nemotron V3, and shared base thinking parsers. | Strong source for `REASONING.batch.{1,2,4,5,6}` and `REASONING.stream.{1,2,3,4}`. |
+| [vLLM chat reasoning + tool tests](https://github.com/vllm-project/vllm/blob/main/tests/entrypoints/openai/chat_completion/test_chat_with_tool_reasoning.py) | End-to-end streaming and batch chat tests where reasoning and tool calls appear in the same response. | Directly maps to `REASONING.batch.3.*` and streaming tool-boundary cases. |
+| [SGLang unit reasoning parser tests](https://github.com/sgl-project/sglang/blob/main/test/registered/unit/parser/test_reasoning_parser.py) | Broad detector coverage: base reasoning, Qwen3, forced Qwen3, Kimi, Kimi K2, GLM45, Hunyuan, Nemotron3, Gemma4, GPT-OSS, MiniMax append-think, buffer-loss regressions, tool-call interaction, and continue-final-message behavior. | Strong source for delimiter grouping, partial marker splits, tool-interrupt cases, and no-stream behavior. |
+| [SGLang reasoning kit](https://github.com/sgl-project/sglang/blob/main/python/sglang/test/kits/reasoning_kit.py) and [registered reasoning tests](https://github.com/sgl-project/sglang/tree/main/test/registered/reasoning) | API-level reasoning-content behavior, streaming response checks, and model-facing integration tests. | Useful for expected OpenAI response shape, less reusable as pure parser fixtures. |
+
+### Reusable upstream case shapes
+
+| Upstream shape | Seen in | Dynamo bucket |
+|---|---|---|
+| Plain text, empty input, whitespace, or missing content with no reasoning markers | vLLM shared parser tests; SGLang buffer-loss and no-reasoning regressions | `REASONING.batch.1.*` |
+| Basic complete reasoning span | vLLM Qwen3, DeepSeek, Mistral, Gemma, Granite; SGLang base/Qwen/Kimi/Gemma detectors | `REASONING.batch.2.a` |
+| Reasoning block followed or preceded by normal answer text | vLLM Qwen3/Kimi/Mistral/Granite; SGLang base detector | `REASONING.batch.2.{b,c,d}` |
+| Reasoning followed by tool-call markers, with the tool marker preserved for the downstream parser | vLLM chat reasoning+tool tests; vLLM Qwen3/Kimi K2; SGLang Kimi K2/GLM45/Hunyuan/GPT-OSS tool-call tests | `REASONING.batch.3.a` |
+| Open reasoning span interrupted by a tool-section marker | vLLM Qwen3/Kimi K2; SGLang Kimi K2/GLM45/Hunyuan | `REASONING.batch.3.b` |
+| No end marker / truncated reasoning | vLLM Qwen3, DeepSeek, Mistral; SGLang forced-reasoning detectors | `REASONING.batch.5` |
+| Empty reasoning span | vLLM Kimi K2/MiniMax; SGLang base and tool-call interaction tests | `REASONING.batch.2.e` |
+| Special characters, code blocks, nested marker-looking text | vLLM MiniMax/Kimi/Mistral; SGLang parser-advanced tests | `REASONING.batch.2.f` |
+| Multiple reasoning spans or repeated start/end patterns | vLLM shared base tests; SGLang integration scenarios | `REASONING.batch.6.*` |
+| Empty stream chunk and marker-free stream | vLLM shared parser tests; SGLang no-reasoning and buffer-loss regressions | `REASONING.stream.1.*` |
+| Single reasoning block across stream chunks | vLLM Qwen3/Kimi/Gemma/Granite; SGLang base streaming tests | `REASONING.stream.2.a` |
+| Start/end marker split across stream chunks | vLLM Qwen3/Kimi/Gemma/Granite; SGLang buffer-loss and partial-marker tests | `REASONING.stream.3.{a,b}` |
+| Partial marker prefix later diverges into normal text | vLLM Granite/Gemma prefix tests; SGLang buffer-loss regressions | `REASONING.stream.3.c` |
+| Token-ID-dependent buffering before text | vLLM Kimi K2 and GPT-OSS token/tag tests | Portable only when fixtures include `delta_token_ids`; otherwise mark as unavailable rather than inventing IDs. |
 
 ### Format-conditional tags (cross-stage)
 
@@ -56,15 +118,17 @@ The `PARSER.fmt|xml|harmony.*` tags from `PARSER_CASES.md` also apply
 to reasoning parsers when they consume the corresponding format. For
 example, the GPT-OSS reasoning parser exercises Harmony's
 `<|channel|>analysis<|message|>...<|end|>` envelope, so its tests
-carry both `REASONING.batch.1` and `PARSER.harmony.1`.
+carry both `REASONING.batch.2.a` and `PARSER.harmony.1`.
 
 ### Categories that are N/A for reasoning parsers
 
-- `PARSER.batch.2` — "multiple tool calls" maps to `REASONING.batch.9`
+- `PARSER.batch.2` — "multiple tool calls" maps to `REASONING.batch.6.*`
   (multiple reasoning spans), not directly. The tool-call-shaped tag
   doesn't apply.
 - `PARSER.batch.8` — interleaved tool-call markers and normal text;
-  reasoning's analog is `REASONING.batch.3` (reasoning + normal text).
+  reasoning's analog is `REASONING.batch.2.{b,c,d}` (reasoning +
+  normal text) or `REASONING.batch.3.*` (reasoning + downstream tool
+  call).
 - `FRONTEND.tool_choice` — request-time gating, see
   `FRONTEND_CASES.md`.
 - `PIPELINE.finish_reason` — pipeline-boundary contract, see
@@ -72,66 +136,94 @@ carry both `REASONING.batch.1` and `PARSER.harmony.1`.
 
 ---
 
-## `REASONING.batch.1` — Reasoning content only
+## `REASONING.batch.1.*` — No reasoning content
+
+No reasoning wrapper is present. This includes plain text, empty input,
+whitespace-only input, and null / missing upstream content.
+
+- Applies to every reasoning parser.
+- Parser must not invent `reasoning_text`.
+- This bucket is first because no-op behavior is the baseline for
+  routing and fallback.
+
+## `REASONING.batch.2.*` — Simple reasoning extraction
 
 `<think>...</think>` (or analog: `<seed:think>`, harmony's
-`<|channel|>analysis`) present, no tool call.
+`<|channel|>analysis`) is present and the content is not part of a
+tool call.
 
 - Applies to every reasoning parser.
 - Parser populates `reasoning_text` with the content between the
-  markers; `tool_calls` empty; `normal_text` either empty or carries
-  any text outside the reasoning block (see `REASONING.batch.3`).
+  markers.
+- `normal_text` carries only user-visible text outside the reasoning
+  block.
+- Empty and complex content stay in this family because they are still
+  ordinary extraction cases.
 
-## `REASONING.batch.2` — Paired reasoning + downstream tool call
+## `REASONING.batch.3.*` — Reasoning + downstream tool call
 
-Model emits reasoning content followed by tool-call tokens:
-`<think>...</think><|tool_call_begin|>...`. Both must be extracted —
-`reasoning_text` populated AND the tool-call markers preserved in
-`normal_text` so the downstream tool-call parser can consume them.
+Model emits reasoning content and then tool-call tokens:
+`<think>...</think><|tool_call_begin|>...`. The reasoning parser must
+extract the reasoning content and preserve the tool-call-shaped text in
+`normal_text` so the downstream tool-call parser can consume it.
 
 - Applies to every (reasoning, tool-call) parser pair.
 - Failure mode: greedy reasoning parser eats the tool-call content
   that follows. Pin the boundary explicitly.
 
-## `REASONING.batch.3` — Reasoning + normal text
+## `REASONING.batch.4` — Malformed marker syntax
 
-`<think>...</think>` followed (or preceded) by user-visible narration,
-no tool call. Reasoning content → `reasoning_text`; narration →
-`normal_text`.
+Dangling close marker, invalid channel marker, or family-specific
+syntax that does not form a valid reasoning span.
 
-- Applies to every reasoning parser.
+## `REASONING.batch.5` — Missing end-marker recovery
+
+Open reasoning marker without the matching close marker. This is the
+reasoning analog of model output truncated by `max_tokens`.
+
+## `REASONING.batch.6.*` — Multiple reasoning spans
+
+Two or more reasoning spans appear in one model response. The contract
+is family-specific: concatenate, surface only the first span, or
+document a divergence.
 
 ---
 
-## `REASONING.stream.1` — Single reasoning block across N chunks
+## `REASONING.stream.1.*` — No reasoning stream content
+
+No complete reasoning wrapper is present. This includes plain text,
+empty chunks, and marker-looking prefixes that ultimately do not match
+the family grammar.
+
+- Explicit-marker parsers should not invent reasoning content.
+- Force-reasoning parsers may keep marker-free text in `reasoning_text`
+  until an end marker or tool boundary appears.
+- Empty chunks should be stable no-ops.
+
+## `REASONING.stream.2.*` — Streaming reasoning extraction
 
 One complete reasoning block delivered across multiple SSE chunks of
 any sizing. Parser incrementally reconstructs `reasoning_text`.
 
 - Applies to every reasoning parser. Dominant production path.
 
-## `REASONING.stream.2` — Start-marker chunk-boundary split
+## `REASONING.stream.3.*` — Split reasoning markers
 
 The opening reasoning marker (`<think>`, `<|channel|>analysis`, etc.)
 straddles a chunk boundary. Partial-token matching must return "keep
 buffering" rather than flushing the partial bytes as `normal_text` and
 completing the match when the next chunk lands.
 
-- Applies to every reasoning parser.
-
-## `REASONING.stream.3` — End-marker chunk-boundary split
-
 The closing reasoning marker (`</think>`, `<|end|>`, etc.) straddles a
-chunk boundary. Same buffering contract as `REASONING.stream.2`.
+chunk boundary. Same buffering contract as the start marker.
 
 - Applies to every reasoning parser.
 
-## `REASONING.stream.4` — Diverged accumulated text
+## `REASONING.stream.4.*` — Downstream parser boundary
 
-The accumulated text never matches the start marker (the model emitted
-plain text from the start, no reasoning block). Parser must give up
-cleanly and treat the entire stream as `normal_text` rather than
-buffering forever.
+A downstream tool-call section marker appears while the reasoning
+parser is still processing reasoning. The reasoning parser must stop at
+the right boundary and preserve the downstream parser's input.
 
 - Applies to every reasoning parser.
 
@@ -143,7 +235,7 @@ Same convention as `PARSER_CASES.md`: include the originating
 reference inline in the `#[test]` comment.
 
 ```rust
-#[test] // REASONING.batch.2 (PR #1234)
+#[test] // REASONING.batch.3.b (PR #1234)
 fn test_unclosed_think_tag_no_longer_swallows_tool_call() { ... }
 ```
 
@@ -153,15 +245,16 @@ fn test_unclosed_think_tag_no_longer_swallows_tool_call() { ... }
 
 Minimum viable set:
 
-1. `REASONING.batch.{1, 3}` — baseline reasoning extraction +
-   reasoning-with-narration split.
-2. `REASONING.batch.2` — boundary contract with downstream tool-call
+1. `REASONING.batch.1.*` — no reasoning content: plain text, empty
+   input, whitespace, and null / missing upstream content.
+2. `REASONING.batch.2.*` — baseline reasoning extraction, narration
+   split, empty reasoning span, and complex reasoning body.
+3. `REASONING.batch.3.*` — boundary contract with downstream tool-call
    parser. Non-negotiable for any reasoning parser used alongside
    tool calling.
-3. `REASONING.batch.{4, 5}` — malformed input + missing-end-marker
+4. `REASONING.batch.{4, 5}` — malformed input + missing-end-marker
    recovery. Pin behavior; silent drop is the failure mode.
-4. `REASONING.batch.{6, 7, 8}` — empty / complex / null content.
-5. `REASONING.batch.9` — multiple reasoning spans. Document the
+5. `REASONING.batch.6.*` — multiple reasoning spans. Document the
    contract.
 6. `REASONING.stream.{1, 2, 3, 4}` — streaming. Essentially
    non-negotiable for any parser behind a streaming frontend.

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -345,7 +345,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.c
     fn test_detect_and_parse_reasoning_reasoning() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -354,7 +354,7 @@ mod tests {
         assert_eq!(result.normal_text, "and more text.");
         assert_eq!(result.reasoning_text, "with reasoning");
     }
-    #[test] // REASONING.batch.3 — no reasoning content
+    #[test] // REASONING.batch.1.b — no reasoning content
     fn test_detect_and_parse_reasoning_reasoning_no_reasoning() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -362,7 +362,7 @@ mod tests {
         assert_eq!(result.normal_text, "This is a test without reasoning.");
         assert_eq!(result.reasoning_text, "");
     }
-    #[test] // REASONING.batch.4, REASONING.batch.1
+    #[test] // REASONING.batch.5
     fn test_detect_and_parse_reasoning_reasoning_truncated_reasoning() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -371,7 +371,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with truncated reasoning");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.3.a
     fn test_parse_reasoning_streaming_incremental() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -380,7 +380,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c
     fn test_parse_reasoning_streaming_incremental_complete() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -392,7 +392,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with reasoning");
     }
 
-    #[test] // REASONING.batch.4, REASONING.batch.5, REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.batch.5, REASONING.stream.3.b
     fn test_parse_reasoning_streaming_incremental_no_end_token() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "with reasoning");
     }
 
-    #[test] // REASONING.batch.2, REASONING.batch.1 — multi-block
+    #[test] // REASONING.batch.6.a — multi-block
     fn test_detect_and_parse_reasoning_multiple_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "first reasoningsecond reasoning");
     }
 
-    #[test] // REASONING.batch.2, REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.batch.6.a, REASONING.stream.2.b
     fn test_streaming_multiple_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, false);
@@ -429,7 +429,7 @@ mod tests {
         assert_eq!(result2.normal_text, "  end"); // " " prefix + " end" suffix
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.a, helper
     fn test_partial_token_matching_opening_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -448,7 +448,7 @@ mod tests {
         assert_eq!(result2.reasoning_text, "reasoning content");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.b, helper
     fn test_partial_token_matching_closing_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, false);
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(result2.reasoning_text, "reasoning content");
     }
 
-    #[test] // REASONING.stream.3
+    #[test] // REASONING.stream.3.a, REASONING.stream.3.b
     fn test_buffer_state_persistence_across_calls() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, false);
@@ -491,7 +491,7 @@ mod tests {
         assert_eq!(result4.reasoning_text, "part1 part2 part3");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c
     fn test_streaming_with_stream_reasoning_enabled() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -512,7 +512,7 @@ mod tests {
         assert_eq!(result3.reasoning_text, "more");
     }
 
-    #[test] // REASONING.batch.1 — nested
+    #[test] // REASONING.batch.2.f — nested marker-looking content
     fn test_nested_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -527,7 +527,7 @@ mod tests {
         assert_eq!(result.normal_text, "reasoning</think> normal");
     }
 
-    #[test] // REASONING.batch.4, REASONING.batch.5
+    #[test] // REASONING.batch.5
     fn test_malformed_missing_closing_tag() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -557,7 +557,7 @@ mod tests {
         assert_eq!(result.normal_text, "normal");
     }
 
-    #[test] // REASONING.batch.6, REASONING.batch.1
+    #[test] // REASONING.batch.2.e
     fn test_empty_reasoning_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.1, PARSER.fmt.2
+    #[test] // REASONING.batch.2.e, PARSER.fmt.2
     fn test_whitespace_only_reasoning_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -575,7 +575,7 @@ mod tests {
         assert_eq!(result.reasoning_text, ""); // Should be empty after trim
     }
 
-    #[test] // REASONING.batch.1 — force-mode
+    #[test] // REASONING.batch.2.a — force-mode
     fn test_force_reasoning_mode() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
@@ -584,7 +584,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "no think tags here");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.b, REASONING.batch.2.c, REASONING.stream.1.b
     fn test_streaming_reset_state_after_complete_block() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -624,7 +624,7 @@ mod tests {
         assert_eq!(r3.normal_text, " final");
     }
 
-    #[test] // REASONING.batch.2, REASONING.batch.3
+    #[test] // REASONING.batch.3.a
     fn test_post_reasoning_angle_bracket_not_buffered() {
         // After reasoning ends, a standalone `<` should pass through immediately
         // as normal text. It must NOT be buffered as a potential prefix of <think>
@@ -650,7 +650,7 @@ mod tests {
         assert_eq!(r3.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.2
+    #[test] // REASONING.batch.3.a
     fn test_post_reasoning_tool_call_xml_preserved() {
         // Simulates the MiniMax tool call scenario: reasoning followed by XML tool call.
         // The `<` in `<invoke` must not be consumed by the reasoning parser.
@@ -679,7 +679,7 @@ mod tests {
         assert_eq!(r6.normal_text, "invoke name=\"get_weather\">");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.3
+    #[test] // REASONING.stream.2.b, REASONING.batch.6.a, REASONING.batch.2.c
     fn test_interleaved_streaming_across_chunks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(r6.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.2, REASONING.batch.1
+    #[test] // REASONING.batch.6.a
     fn test_three_reasoning_blocks_non_streaming() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -721,7 +721,7 @@ mod tests {
         assert_eq!(result.normal_text, "one  two  three");
     }
 
-    #[test] // REASONING.stream.3
+    #[test] // REASONING.stream.2.b
     fn test_streaming_transition_chunk() {
         // </think> and <think> arrive in the same chunk.
         // With loop-based processing, the second block's opening content is emitted
@@ -745,7 +745,7 @@ mod tests {
         assert_eq!(r3.normal_text, " end");
     }
 
-    #[test] // REASONING.batch.1, REASONING.batch.3
+    #[test] // REASONING.batch.2.c — force-mode
     fn test_interleaved_with_force_reasoning() {
         // deepseek_r1 mode: force_reasoning=true, first tokens are reasoning without <think>
         let mut parser =
@@ -768,7 +768,7 @@ mod tests {
         assert_eq!(r3.normal_text, " done");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.3
+    #[test] // REASONING.stream.3.a, REASONING.stream.2.b, REASONING.batch.6.a
     fn test_interleaved_partial_think_tag_between_blocks() {
         // After first reasoning block, partial <think> tag arrives across chunks
         let mut parser =
@@ -789,7 +789,7 @@ mod tests {
         assert_eq!(r3.normal_text, " end");
     }
 
-    #[test] // REASONING.batch.3, helper
+    #[test] // REASONING.batch.3.a, helper
     fn test_lone_angle_bracket_between_reasoning_blocks() {
         // A lone `<` between reasoning blocks should pass through (not buffer)
         let mut parser =
@@ -814,7 +814,7 @@ mod tests {
         assert_eq!(r4.normal_text, " done");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c — force-mode
     fn test_force_reasoning_stream_false_buffers_until_end_token() {
         // force_reasoning=true, stream_reasoning=false: content is buffered until </think>
         // arrives, then returned as a single chunk. This is the expected behavior.
@@ -836,7 +836,7 @@ mod tests {
         assert_eq!(r3.normal_text, " answer");
     }
 
-    #[test] // REASONING.batch.2, REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.batch.6.a, REASONING.stream.2.b
     fn test_multiple_full_blocks_in_single_streaming_chunk() {
         // Two complete <think>...</think> blocks arrive in one chunk.
         // The loop exhausts all transitions in a single call — both blocks are fully
@@ -857,7 +857,7 @@ mod tests {
         assert_eq!(r2.normal_text, "");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.b, helper
     fn test_partial_end_token_stream_reasoning_true() {
         // Partial </think> split across chunks with stream_reasoning=true.
         // The partial-end-token buffer check only fires when the parser is ALREADY in
@@ -882,7 +882,7 @@ mod tests {
         assert_eq!(r3.normal_text, " normal");
     }
 
-    #[test] // REASONING.batch.3, REASONING.batch.8
+    #[test] // REASONING.batch.1.a, REASONING.stream.1.a
     fn test_empty_string_input_various_states() {
         // Empty string input should always return empty results without changing state
         let mut parser =
@@ -910,7 +910,7 @@ mod tests {
         assert_eq!(r3.normal_text, "");
     }
 
-    #[test] // REASONING.batch.2, REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.batch.6.a, REASONING.stream.2.b
     fn test_force_reasoning_stream_false_multiple_blocks() {
         // force_reasoning=true (deepseek_r1 mode), stream_reasoning=false.
         // First block uses forced-reasoning (no explicit <think>); subsequent blocks
@@ -931,7 +931,7 @@ mod tests {
         assert_eq!(r2.normal_text, " normal2");
     }
 
-    #[test] // REASONING.stream.3 — GLM-5 burst pattern
+    #[test] // REASONING.batch.3.a, REASONING.batch.6.a — GLM-5 burst pattern
     fn test_glm5_pattern_a_burst_single_chunk() {
         // GLM-5 Pattern A: the entire completion arrives in one SSE event.
         // Format: <think>T1</think><tool_call>A</tool_call><think>T2</think><tool_call>B</tool_call>
@@ -958,7 +958,7 @@ mod tests {
         assert_eq!(r2.normal_text, "");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.2, REASONING.batch.3
+    #[test] // REASONING.batch.3.a, REASONING.batch.6.a
     fn test_tool_call_xml_between_reasoning_blocks_streaming() {
         // GLM-5 Pattern A chunk-by-chunk: verifies that tool call XML between reasoning
         // blocks lands in normal_text, not reasoning_text, across separate SSE events.
@@ -992,7 +992,7 @@ mod tests {
     // Ported from PR #6448 (ryanolson) with additional fakeout tests.
     // =========================================================================
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.a, helper
     fn test_mid_string_partial_opening_tag_batched() {
         // Backend batches tokens: "Hello world <th" arrives as one chunk
         let mut parser =
@@ -1009,7 +1009,7 @@ mod tests {
         assert_eq!(r2.normal_text, " answer");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.a, helper
     fn test_batched_tag_boundary_split() {
         // Aggressive batching: <think> tag split with normal text prefix
         let mut parser =
@@ -1024,7 +1024,7 @@ mod tests {
         assert_eq!(r2.normal_text, "42");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.b, helper
     fn test_mid_string_partial_closing_tag_stream_reasoning_false() {
         // With stream_reasoning=false, content stays buffered until </think>.
         // Partial </think> split mid-string while in reasoning mode.
@@ -1041,7 +1041,7 @@ mod tests {
         assert_eq!(r2.normal_text, " normal text");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.b, helper
     fn test_mid_string_partial_closing_tag_stream_reasoning_true() {
         // With stream_reasoning=true, reasoning content is emitted incrementally.
         // The partial "</th" at the end must NOT be emitted as reasoning text.
@@ -1059,7 +1059,7 @@ mod tests {
         assert_eq!(r2.normal_text, " normal text");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.3
+    #[test] // REASONING.stream.3.a, REASONING.stream.2.b, REASONING.batch.6.a
     fn test_batched_interleaved_with_mid_string_partial() {
         // First block complete in chunk 1, second block's <think> split at boundary
         let mut parser =
@@ -1136,7 +1136,7 @@ mod tests {
             .with_tool_start_token(crate::reasoning::KIMI_K2_TOOL_SECTION_BEGIN)
     }
 
-    #[rstest] // REASONING.stream.3 — Kimi K2 split
+    #[rstest] // REASONING.batch.3.b — Kimi K2 split
     #[case(
         "thinking text <|tool_calls_section_begin|><|tool_call_begin|>functions.foo:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
         "thinking text",
@@ -1159,7 +1159,7 @@ mod tests {
         assert_eq!(r.normal_text, expected_normal);
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.batch.3.b
     fn test_force_exit_streaming_single_chunk() {
         let mut parser = kimi_k2_parser();
         let r = parser.parse_reasoning_streaming_incremental(
@@ -1173,7 +1173,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.batch.3.b, helper
     fn test_force_exit_streaming_split_across_chunks() {
         let mut parser = kimi_k2_parser();
 
@@ -1191,7 +1191,7 @@ mod tests {
         assert_eq!(r3.normal_text, "<|tool_calls_section_begin|>rest");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.c, helper
     fn test_force_exit_partial_marker_resolves_as_non_marker() {
         // First chunk ends with "<|tool_ca" (prefix of marker) — must be buffered.
         // Second chunk "xxx" makes the combined "<|tool_caxxx" which is NOT a marker.
@@ -1207,7 +1207,7 @@ mod tests {
         assert_eq!(r2.normal_text, "");
     }
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.f
     fn test_no_tool_start_token_behaves_as_before() {
         // Without the tool_start_token setter, BasicReasoningParser is byte-identical
         // to the pre-patch behavior — the marker is just reasoning content.

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -274,7 +274,7 @@ impl ReasoningParser for Gemma4ReasoningParser {
 mod tests {
     use super::*;
 
-    #[test] // REASONING.batch.1 — non-streaming basic case
+    #[test] // REASONING.batch.2.c — non-streaming basic case
     fn detect_basic_thinking() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning(
@@ -285,7 +285,7 @@ mod tests {
         assert_eq!(r.normal_text, "The answer is 42.");
     }
 
-    #[test] // REASONING.batch.3 — no reasoning markers, pass through
+    #[test] // REASONING.batch.1.b — no reasoning markers, pass through
     fn detect_no_markers_passes_through() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning("just a plain answer", &[]);
@@ -302,7 +302,7 @@ mod tests {
         assert_eq!(r.normal_text, "intro ");
     }
 
-    #[test] // REASONING.batch.3 — text before AND after the reasoning span preserved
+    #[test] // REASONING.batch.2.d — text before AND after the reasoning span preserved
     fn detect_text_before_and_after() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning(
@@ -313,7 +313,7 @@ mod tests {
         assert_eq!(r.normal_text, "Hello.  Goodbye.");
     }
 
-    #[test] // REASONING.batch.5, REASONING.batch.3 — dangling end marker, missing start (upstream INVALID_SIMPLE)
+    #[test] // REASONING.batch.4 — dangling end marker, missing start (upstream INVALID_SIMPLE)
     fn detect_dangling_end_marker_extracts_prefix_as_reasoning() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning("some thinking<channel|>final answer", &[]);
@@ -321,7 +321,7 @@ mod tests {
         assert_eq!(r.normal_text, "final answer");
     }
 
-    #[test] // REASONING.batch.5, REASONING.batch.3 — dangling end + thought prefix on the head (upstream INVALID_COMPLETE)
+    #[test] // REASONING.batch.4 — dangling end + thought prefix on the head (upstream INVALID_COMPLETE)
     fn detect_dangling_end_marker_strips_thought_prefix() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning("thought\nrumination<channel|>final answer", &[]);
@@ -340,7 +340,7 @@ mod tests {
         assert_eq!(r.normal_text, "answer");
     }
 
-    #[test] // REASONING.stream.3 — streaming arrival, single chunk
+    #[test] // REASONING.stream.2.a — streaming arrival, single chunk
     fn streaming_single_chunk() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.parse_reasoning_streaming_incremental(
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(r.normal_text, "final");
     }
 
-    #[test] // REASONING.stream.3 — streaming with `thought\n` split across deltas
+    #[test] // REASONING.stream.3.a — streaming with `thought\n` split across deltas
     fn streaming_thought_prefix_split_across_deltas() {
         let mut p = Gemma4ReasoningParser::new();
         let chunks = [
@@ -373,7 +373,7 @@ mod tests {
         assert_eq!(normal, "the answer.");
     }
 
-    #[test] // REASONING.stream.3 — start marker split across deltas
+    #[test] // REASONING.stream.3.a — start marker split across deltas
     fn streaming_start_marker_split() {
         let mut p = Gemma4ReasoningParser::new();
         let chunks = [
@@ -395,7 +395,7 @@ mod tests {
         assert_eq!(normal, "intro outro");
     }
 
-    #[test] // REASONING.stream.3 — end marker split across deltas
+    #[test] // REASONING.stream.3.b — end marker split across deltas
     fn streaming_end_marker_split() {
         let mut p = Gemma4ReasoningParser::new();
         let chunks = [
@@ -416,7 +416,7 @@ mod tests {
         assert_eq!(normal, "answer");
     }
 
-    #[test] // REASONING.stream.3 — diverged accumulated text (no `thought\n` prefix at all)
+    #[test] // REASONING.stream.3.c — diverged accumulated text (no `thought\n` prefix at all)
     fn streaming_no_thought_prefix_streaming() {
         let mut p = Gemma4ReasoningParser::new();
         let chunks = [
@@ -436,7 +436,7 @@ mod tests {
         assert_eq!(normal, "answer");
     }
 
-    #[test] // REASONING.batch.3 — streaming with no markers at all
+    #[test] // REASONING.stream.1.b — streaming with no markers at all
     fn streaming_no_markers() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.parse_reasoning_streaming_incremental("plain text only", &[]);
@@ -444,7 +444,7 @@ mod tests {
         assert_eq!(r.normal_text, "plain text only");
     }
 
-    #[test] // REASONING.batch.2 — multiple reasoning spans back-to-back
+    #[test] // REASONING.batch.6.a — multiple reasoning spans back-to-back
     fn streaming_multiple_reasoning_spans() {
         let mut p = Gemma4ReasoningParser::new();
         let input =
@@ -457,7 +457,7 @@ mod tests {
         assert!(r.normal_text.contains("answer2"));
     }
 
-    #[test] // REASONING.batch.2 — paired reasoning + tool call. The reasoning parser
+    #[test] // REASONING.batch.3.a — paired reasoning + tool call. The reasoning parser
     // must extract the channel content as `reasoning_text` and leave the
     // following `<|tool_call>...<tool_call|>` markers intact in
     // `normal_text` for the tool-call parser to consume downstream.
@@ -477,16 +477,12 @@ mod tests {
 
     // ----- Explicit N/A coverage notes (per lib/parsers/PARSER_CASES.md) -----
     //
-    // REASONING.batch.1, REASONING.batch.4, REASONING.batch.6, REASONING.batch.7  — Tool-call-only categories. N/A for
-    //          a reasoning parser.
+    // REASONING.batch.1.a/c/d — empty, whitespace-only, and null/missing
+    //          input variants are not Gemma-specific.
     // FRONTEND.tool_choice, PIPELINE.finish_reason — `tool_choice` and `finish_reason`: tool-call concerns,
     //          N/A for reasoning. (Universal cross-parser gap regardless;
     //          see notes in `tool_calling/gemma4/parser.rs`.)
-    // REASONING.batch.8 — Empty / null content: empty input is covered implicitly
-    //          via the no-markers passthrough cases (`detect_no_markers_*`,
-    //          `streaming_no_markers`).
-    // REASONING.batch.9 — Duplicate calls: tool-call concept; N/A. Multi-span
-    //          reasoning is the analog and is covered by
+    // REASONING.batch.6.* — Multi-span reasoning is covered by
     //          `streaming_multiple_reasoning_spans`.
     // PARSER.xml.1 / PARSER.xml.2 — XML-family only. N/A.
     // PARSER.harmony.1 / PARSER.harmony.2 — Harmony only. N/A.

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -365,7 +365,7 @@ impl ReasoningParser for GptOssReasoningParser {
 mod tests {
     use super::*;
 
-    #[test] // REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.batch.2.c, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis<|message|>The user asks a simple factual question: capital of Brazil. The answer is Brasília. No additional explanation needed.<|end|><|start|>assistant<|channel|>final<|message|>The capital of Brazil is Brasília.";
@@ -377,7 +377,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let chunks = vec![
@@ -401,7 +401,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_chunked() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let enc = get_harmony_encoding()
@@ -430,7 +430,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.batch.3.a, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_variable_length_chunks() {
         let text = "<|channel|>analysis<|message|>User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>{}";
         let enc = get_harmony_encoding()

--- a/lib/parsers/src/reasoning/granite_parser.rs
+++ b/lib/parsers/src/reasoning/granite_parser.rs
@@ -202,7 +202,7 @@ mod tests {
         assert_eq!(result.normal_text, " Final answer.");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.a, helper
     fn test_streaming_partial_tokens() {
         let mut parser = GraniteReasoningParser::new();
 
@@ -218,7 +218,7 @@ mod tests {
         assert_eq!(result2.normal_text, "");
     }
 
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.b, helper
     fn test_streaming_partial_end_tokens() {
         let mut parser = GraniteReasoningParser::new();
 
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(result2.normal_text, " Done!");
     }
 
-    #[test] // REASONING.batch.3, helper
+    #[test] // REASONING.batch.1.b, helper
     fn test_no_reasoning_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "This is just normal text without any special tokens.";
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.4, REASONING.batch.5, helper
+    #[test] // REASONING.batch.5, helper
     fn test_only_start_token_no_end() {
         let mut parser = GraniteReasoningParser::new();
 
@@ -266,7 +266,7 @@ mod tests {
         assert_eq!(result2.normal_text, "");
     }
 
-    #[test] // REASONING.batch.6, REASONING.batch.1
+    #[test] // REASONING.batch.2.e
     fn test_empty_reasoning_block() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:Here's my response: Direct answer.";
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(result.normal_text, " Direct answer.");
     }
 
-    #[test] // REASONING.batch.1, PARSER.fmt.2
+    #[test] // REASONING.batch.2.f, PARSER.fmt.2
     fn test_reasoning_with_whitespace() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:   \n  Indented reasoning  \n  Here's my response:   Final result  ";
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.f
     fn test_nested_or_repeated_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: I think Here's my thought process: is confusing. Here's my response: Done.";
@@ -310,7 +310,7 @@ mod tests {
         assert_eq!(result.normal_text, " Done.");
     }
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.c
     fn test_detect_and_parse_reasoning_basic() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: I need to analyze this problem. Here's my response: The solution is clear.";
@@ -320,7 +320,7 @@ mod tests {
         assert_eq!(result.normal_text, "The solution is clear.");
     }
 
-    #[test] // REASONING.batch.1, PARSER.fmt.3
+    #[test] // REASONING.batch.2.c, PARSER.fmt.3
     fn test_detect_and_parse_reasoning_alternative_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here is my thought process: Different reasoning approach. Here is my response: Final conclusion.";
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(result.normal_text, "Final conclusion.");
     }
 
-    #[test] // REASONING.batch.3
+    #[test] // REASONING.batch.1.b
     fn test_detect_and_parse_reasoning_no_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "This is just normal text without special markers.";
@@ -340,7 +340,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.4, REASONING.batch.5, REASONING.batch.1
+    #[test] // REASONING.batch.5
     fn test_detect_and_parse_reasoning_only_start_token() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: This reasoning has no end marker.";
@@ -350,7 +350,7 @@ mod tests {
         assert_eq!(result.normal_text, "");
     }
 
-    #[test] // REASONING.batch.6, REASONING.batch.1
+    #[test] // REASONING.batch.2.e
     fn test_detect_and_parse_reasoning_empty_sections() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:Here's my response:";
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(result.normal_text, "");
     }
 
-    #[test] // REASONING.batch.1, PARSER.fmt.2
+    #[test] // REASONING.batch.2.f, PARSER.fmt.2
     fn test_detect_and_parse_reasoning_whitespace_handling() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process:   \n\tSpaced reasoning\n   Here's my response:  \n  Spaced response\n";
@@ -370,7 +370,7 @@ mod tests {
         assert_eq!(result.normal_text, "Spaced response");
     }
 
-    #[test] // REASONING.batch.1, PARSER.fmt.3
+    #[test] // REASONING.batch.2.f, PARSER.fmt.3
     fn test_detect_and_parse_reasoning_multiple_end_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: Thinking about Here's my response: in the middle. Here's my response: Real end.";
@@ -394,7 +394,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.1, PARSER.fmt.3
+    #[test] // REASONING.batch.2.c, PARSER.fmt.3
     fn test_detect_and_parse_reasoning_mixed_tokens() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: First reasoning. Here is my response: Mixed token response.";
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(result.normal_text, "Mixed token response.");
     }
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.f
     fn test_detect_and_parse_reasoning_long_content() {
         let mut parser = GraniteReasoningParser::new();
         let text = "Here's my thought process: This is a very long reasoning section that spans multiple sentences. I need to consider various factors. The analysis requires careful thought. Here's my response: After all that thinking, here is the comprehensive answer with multiple parts and detailed explanation.";

--- a/lib/parsers/src/reasoning/minimax_append_think_parser.rs
+++ b/lib/parsers/src/reasoning/minimax_append_think_parser.rs
@@ -69,7 +69,7 @@ impl ReasoningParser for MiniMaxAppendThinkParser {
 mod tests {
     use super::*;
 
-    #[test] // REASONING.batch.1 — minimax inline-reasoning
+    #[test] // REASONING.batch.2.a — minimax inline-reasoning
     fn test_detect_and_parse_prepends_think_all_as_normal_text() {
         let mut parser = MiniMaxAppendThinkParser::new();
         let result = parser.detect_and_parse_reasoning("reasoning content here", &[]);
@@ -78,7 +78,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.1 — minimax inline-reasoning
+    #[test] // REASONING.batch.2.c — minimax inline-reasoning
     fn test_detect_and_parse_with_end_token_is_still_normal_text() {
         let mut parser = MiniMaxAppendThinkParser::new();
         let result =
@@ -92,7 +92,7 @@ mod tests {
         assert_eq!(result.reasoning_text, "");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c
     fn test_streaming_first_chunk_gets_prefix_rest_pass_through() {
         let mut parser = MiniMaxAppendThinkParser::new();
 
@@ -110,7 +110,7 @@ mod tests {
         assert_eq!(r3.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.3 — minimax leaves tool-call shape inline
+    #[test] // REASONING.batch.3.a — minimax leaves tool-call shape inline
     fn test_streaming_bare_json_tool_call_is_normal_text() {
         // Regression: under SGLang guided decoding the model emits a bare
         // JSON array with no `</think>`. The parser must not capture it as
@@ -128,7 +128,7 @@ mod tests {
         assert_eq!(r.reasoning_text, "");
     }
 
-    #[test] // REASONING.batch.2, REASONING.batch.3 — minimax inline-reasoning
+    #[test] // REASONING.batch.3.a — minimax inline-reasoning
     fn test_streaming_tool_call_after_reasoning_is_all_normal_text() {
         let mut parser = MiniMaxAppendThinkParser::new();
 

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -312,7 +312,7 @@ mod tests {
         }
     }
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.c
     fn test_deepseek_v4_detect_and_parse() {
         for parser_name in ["deepseek_v4", "deepseek-v4", "deepseekv4"] {
             let mut parser = ReasoningParserType::get_reasoning_parser_from_name(parser_name);
@@ -322,7 +322,7 @@ mod tests {
         }
     }
 
-    #[test] // REASONING.batch.3, REASONING.batch.1
+    #[test] // REASONING.batch.1.b
     fn test_deepseek_v4_no_forced_reasoning_without_tags() {
         let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
         let result = parser.detect_and_parse_reasoning("answer only", &[]);
@@ -330,7 +330,7 @@ mod tests {
         assert_eq!(result.normal_text, "answer only");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c
     fn test_deepseek_v4_streaming() {
         let mut parser = ReasoningParserType::get_reasoning_parser_from_name("deepseek_v4");
 
@@ -348,7 +348,7 @@ mod tests {
         assert_eq!(normal, "answer");
     }
 
-    #[test] // REASONING.batch.1
+    #[test] // REASONING.batch.2.a, REASONING.batch.2.c, REASONING.batch.2.e
     fn test_kimi_k25_detect_and_parse() {
         // (description, input, expected_reasoning, expected_normal)
         let cases = [
@@ -389,7 +389,7 @@ mod tests {
         }
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.3.a, REASONING.stream.3.b, REASONING.batch.2.c
     fn test_kimi_k25_streaming_force_reasoning() {
         // Streaming: force_reasoning means tokens before <think> are treated as reasoning
         let mut parser = ReasoningParserType::KimiK25.get_reasoning_parser();
@@ -410,7 +410,7 @@ mod tests {
         assert_eq!(r3.normal_text, "Hello!");
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, REASONING.batch.2.e
     fn test_kimi_k25_streaming() {
         // (description, tokens, expected_reasoning, expected_content)
         let cases: Vec<(&str, &[&str], &str, &str)> = vec![
@@ -483,7 +483,7 @@ mod tests {
     // Simulates the OpenAI path where the preprocessor detects prompt-injected
     // reasoning and calls set_in_reasoning(true). The parser should correctly
     // transition from reasoning to content when </think> arrives.
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c — force-mode
     fn test_nemotron_streaming_with_set_in_reasoning() {
         let mut parser = ReasoningParserType::DeepseekR1.get_reasoning_parser();
         parser.set_in_reasoning(true); // OpenAI path calls this
@@ -506,7 +506,7 @@ mod tests {
     // set_in_reasoning is never called. The parser still starts in reasoning
     // mode (force_reasoning=true) but stripped_think_start=false. The </think>
     // boundary must still be detected correctly.
-    #[test] // REASONING.stream.3, REASONING.batch.1
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c — force-mode
     fn test_nemotron_streaming_force_reasoning_without_set_in_reasoning() {
         // DeepseekR1 has force_reasoning=true but we do NOT call set_in_reasoning
         let mut parser = ReasoningParserType::DeepseekR1.get_reasoning_parser();
@@ -529,7 +529,7 @@ mod tests {
     // is false, the parser's prefix-check could buffer '<' and interfere with
     // </think> detection. This test verifies the boundary is detected even when
     // </think> arrives as individual characters.
-    #[test] // REASONING.stream.3, helper
+    #[test] // REASONING.stream.3.b, helper
     fn test_nemotron_streaming_split_end_think_tokens() {
         let mut parser = ReasoningParserType::DeepseekR1.get_reasoning_parser();
         parser.set_in_reasoning(true);

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,8 +1,9 @@
 # Cross-impl parity test suite
 
 Shared test infrastructure for diffing parser / preprocess / postprocess
-behavior across Dynamo, vLLM, and SGLang. Today only the parser stage
-is populated (`parser/`); other stages slot in as siblings as they land.
+behavior across Dynamo, vLLM, and SGLang. Tool call parser parity lives
+in `parser/`; reasoning parser parity lives in `reasoning/`. Other stages
+slot in as siblings as they land.
 
 > **Triaging a tool-call issue from a user?** Before stepping into the
 > parity harness, point them at
@@ -21,11 +22,11 @@ tests/parity/
 ├── README.md                       (this file)
 ├── conftest.py                     ← session-scoped fixtures (server boots, etc.)
 ├── common.py                       ← ParseResult, canonical-JSON diff, decode_arguments
-├── generate_parity_table.py        ← common table CLI: parser
+├── generate_parity_table.py        ← common table CLI: parser / reasoning
 ├── parity_table.html.j2            ← shared HTML template
-└── parser/
+├── parser/
     ├── fixtures/                   ← static YAML, generated from Dynamo as oracle
-    │   └── <family>/PARSER.batch.yaml         (and per-top-level-case files like PARSER.batch.8.yaml; see Fixture file schema)
+│   └── <family>/PARSER.batch.yaml         (and per-case files like PARSER.batch.4.yaml; see Fixture file schema)
     ├── capture_parser_outputs.py     ← drift-check (default) or merge any impl's output into `expected.{dynamo,vllm,sglang}`
     ├── table.py                    ← parser table adapter
     │
@@ -37,7 +38,31 @@ tests/parity/
     ├── server.py                   ← M3 subprocess boot helper
     ├── client.py                   ← M3 HTTP client (vllm + sglang)
     └── test_parity_e2e.py          ← M3 harness (server-stack parity over HTTP)
+└── reasoning/
+    ├── fixtures/                   ← static YAML contracts for REASONING.batch.* and REASONING.stream.*
+    ├── table.py                    ← reasoning table adapter
+    ├── dynamo.py                   ← Dynamo Rust reasoning parser via PyO3 binding
+    ├── vllm.py                     ← vLLM reasoning parser wrapper
+    ├── sglang.py                   ← SGLang reasoning parser wrapper
+    └── test_parity_reasoning.py    ← M2 harness for reasoning parser parity
 ```
+
+## Reasoning parity status
+
+The initial reasoning harness uses the same contract shape as `parser/`:
+each `REASONING.*.yaml` fixture records `expected.dynamo`,
+`expected.vllm`, and `expected.sglang`. A peer block can anchor to Dynamo,
+document a divergence, mark an expected error, or say the peer parser is
+unavailable.
+
+Generate the reasoning table from repo root:
+
+```bash
+python3 tests/parity/generate_parity_table.py reasoning --html > tests/parity/reasoning/PARITY.html
+```
+
+`PARITY.html` is for local review, like the parser table. The YAML fixtures
+remain the source of truth.
 
 ## Three methods (M1, M2, M3) — what each one really means
 
@@ -258,8 +283,9 @@ or by us standing up a Dynamo-side stub) would let the harness surface
 - `PARSER.batch.4` (malformed JSON) and `PARSER.batch.5` (missing
   end-token) — recovery is impl-defined per `PARSER_CASES.md`;
   divergences are documented rather than asserted-against.
-- `PARSER.batch.8` (interleaved normal text) — vLLM and SGLang both
-  drop the trailing text after the wrapper across XML-style families.
+- `PARSER.batch.1.{b,c,d}` / `PARSER.batch.2.e` (simple normal-text
+  placement) — vLLM and SGLang often drop trailing text after the
+  wrapper across XML-style families.
 - `harmony/sglang` — 8 of 10 cases divergent because SGLang's
   `GptOssDetector` requires the strict
   `<|start|>assistant<|channel|>commentary` envelope where Dynamo
@@ -290,10 +316,10 @@ to run (otherwise they skip cleanly).
 ... -k "kimi_k2"
 
 # One sub-case across every family + every impl
-... -k "PARSER.batch.8.b"
+... -k "PARSER.batch.1.c"
 
 # Exactly one (family, sub-case, impl)
-... "tests/parity/parser/test_parity_parser.py::test_parity[kimi_k2/PARSER.batch.8.b#vllm]"
+... "tests/parity/parser/test_parity_parser.py::test_parity[kimi_k2/PARSER.batch.1.c#vllm]"
 ```
 
 **From the host** (outside the container), wrap the command in
@@ -316,7 +342,7 @@ in the family's YAML fixture (concrete `calls` + `normal_text`, or
 `{error: <substring>}`, or `{unavailable: <reason>}`). Cells that
 match Dynamo are stored as anchor refs `*d_<case>` to the dynamo
 block. Goal: drive the non-`=` count toward zero by fixing whichever
-side is wrong. Worked example: `kimi_k2 / PARSER.batch.8.b → V`
+side is wrong. Worked example: `kimi_k2 / PARSER.batch.1.c → V`
 (vLLM drops trailing text after the wrapper).
 
 ### 1. Pick a cell
@@ -326,13 +352,14 @@ output.
 
 ### 2. Look up the side-by-side diff in the YAML
 
-Open `tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml` and
-find the `PARSER.batch.8.b:` block. The `expected:` block carries all
+Open `tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml`
+(legacy filename for the text-placement cases) and find the
+`PARSER.batch.1.c:` block. The `expected:` block carries all
 three engines' actual recorded output, so the diff is right there —
 **no harness run needed to read it.**
 
 ```yaml
-PARSER.batch.8.b:
+PARSER.batch.1.c:
   description: Narration after tool call only
   ref: originated from https://github.com/vllm-project/vllm/.../test_kimi_k2_tool_parser.py#L435
   model_text: |-
@@ -360,7 +387,7 @@ upstream vLLM/SGLang test the shape was derived from (useful context).
 
 ```bash
 PYTHONPATH=lib/bindings/python/src python3 -m pytest \
-  "tests/parity/parser/test_parity_parser.py::test_parity[kimi_k2/PARSER.batch.8.b#vllm]" \
+  "tests/parity/parser/test_parity_parser.py::test_parity[kimi_k2/PARSER.batch.1.c#vllm]" \
   -v --tb=short
 ```
 
@@ -471,7 +498,7 @@ but didn't re-capture peer outputs), the test fails with a diff
 pointing at the YAML edit needed:
 
 ```text
-FAILED tests/parity/parser/test_parity_parser.py::test_parity[kimi_k2/PARSER.batch.8.b#vllm]
+FAILED tests/parity/parser/test_parity_parser.py::test_parity[kimi_k2/PARSER.batch.1.c#vllm]
        expected: {'calls': [...], 'normal_text': ''}
        got:      {'calls': [...], 'normal_text': 'Let me know if you need more.'}
 ```
@@ -486,11 +513,11 @@ verbatim:
 
 ```yaml
 expected:
-  dynamo: &d_8_b
+  dynamo: &d_1_c
     calls: [...]
     normal_text: '...'
-  vllm: *d_8_b        # ← was a concrete `vllm:` block; now ref to dynamo
-  sglang: *d_8_b      # (same, if SGLang also now matches)
+  vllm: *d_1_c        # ← was a concrete `vllm:` block; now ref to dynamo
+  sglang: *d_1_c      # (same, if SGLang also now matches)
 ```
 
 Add a `spec_ref:` field directly to the case in its fixture YAML so
@@ -498,7 +525,7 @@ the paper trail survives — point at whatever made V/S right (spec
 section, model card, GH issue, upstream PR, or the team-decision doc):
 
 ```yaml
-PARSER.batch.8.b:
+PARSER.batch.1.c:
   description: Narration after tool call only
   ref: originated from https://github.com/vllm-project/vllm/.../test_kimi_k2_tool_parser.py#L435
   spec_ref: https://platform.moonshot.ai/docs/tool-call-spec#L42  # or GH issue / PR url
@@ -562,7 +589,7 @@ blocks when diverging):
 family: kimi_k2
 mode: batch
 cases:
-  PARSER.batch.1:
+  PARSER.batch.1.a:
     description: Single tool call (happy path)
     model_text: |-
       <|tool_calls_section_begin|>...
@@ -577,13 +604,13 @@ cases:
         normal_text: ''
       vllm: *d_1           # vLLM matches Dynamo
       sglang: *d_1         # SGLang matches Dynamo
-  PARSER.batch.8.a:        # sub-case keys also valid
+  PARSER.batch.1.b:        # sub-case keys also valid
     description: Narration before tool call only
     ref: originated from https://github.com/vllm-project/vllm/blob/<sha>/tests/tool_parsers/test_<family>_tool_parser.py#L<line>
     model_text: |-
       ...
     expected:
-      dynamo: &d_8_a
+      dynamo: &d_1_b
         calls: [...]
         normal_text: 'I will check the weather.'
       vllm:                # vLLM diverges — concrete output recorded
@@ -638,9 +665,9 @@ comment.
 
 Case keys are the full IDs from
 [`lib/parsers/PARSER_CASES.md`](../../lib/parsers/PARSER_CASES.md)
-(`PARSER.batch.1` … `PARSER.batch.10`, plus sub-cases like
-`PARSER.batch.8.a`). They match the pytest
-parametrize IDs directly, so a single `grep PARSER.batch.8.a` finds the
+(`PARSER.batch.1.a` … `PARSER.batch.31.b`, including sub-cases like
+`PARSER.batch.1.b`). They match the pytest
+parametrize IDs directly, so a single `grep PARSER.batch.1.b` finds the
 case across docs, fixtures, and Rust source comments.
 
 `model_text` uses YAML's literal block scalar (`|-`) so multi-line

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_r1
+model_label: DeepSeek R1 / Nemotron
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text stays in force-reasoning mode
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm: *d_0
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.2.a:
+    description: Force-reasoning parser with explicit think tags
+    ref: dynamo
+    model_text: <think>thinking</think>answer
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: <think>choose tool</think><tool_call>{}
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <think>choose tool<tool_call>{}
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.2.c:
+    description: Reasoning followed by normal answer text
+    ref: dynamo
+    model_text: <think>compute</think>answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute
+        normal_text: answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.2.d:
+    description: Normal text around reasoning is not applicable in force-reasoning mode
+    reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
+  REASONING.batch.4:
+    description: Dangling end marker exits force-reasoning mode
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: normal
+        normal_text: answer
+      vllm: *d_4
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: <think>partial
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial
+        normal_text: ''
+      vllm: *d_5
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: <think></think>answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <think>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}</think>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated by Dynamo
+    ref: dynamo
+    model_text: <think>first</think> middle <think>second</think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_r1
+model_label: DeepSeek R1 / Nemotron
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.stream.2.a:
+    description: Single reasoning block across chunks
+    ref: dynamo
+    chunks:
+    - <think>thin
+    - king</think>
+    - answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - <think>first</think>
+    - ' middle '
+    - <think>second</think> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <th
+    - ink>thinking</think>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - <think>thinking</th
+    - ink>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later resolves as force-reasoning text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+      vllm: *d_s6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+  REASONING.stream.1.b:
+    description: Plain text stays in force-reasoning mode until an end marker
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm: *d_s4
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+model_label: DeepSeek V3.x
+mode: batch
+chat_template_kwargs:
+  thinking: true
+cases:
+  REASONING.batch.1.b:
+    description: Plain text stays in force-reasoning mode
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm: *d_0
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.2.a:
+    description: DeepSeek V3.x thinking output with explicit think tags
+    ref: dynamo
+    model_text: <think>thinking</think>answer
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: <think>choose tool</think><tool_call>{}
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <think>choose tool<tool_call>{}
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.2.c:
+    description: Reasoning followed by normal answer text
+    ref: dynamo
+    model_text: <think>compute</think>answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute
+        normal_text: answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.2.d:
+    description: Normal text around reasoning is not applicable in force-reasoning mode
+    reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
+  REASONING.batch.4:
+    description: Thinking-mode completion exits on a dangling end marker
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: normal
+        normal_text: answer
+      vllm: *d_4
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: <think>partial
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial
+        normal_text: ''
+      vllm: *d_5
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: <think></think>answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <think>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}</think>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated by Dynamo
+    ref: dynamo
+    model_text: <think>first</think> middle <think>second</think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+model_label: DeepSeek V3.x
+mode: stream
+chat_template_kwargs:
+  thinking: true
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.stream.2.a:
+    description: Single reasoning block across chunks
+    ref: dynamo
+    chunks:
+    - <think>thin
+    - king</think>
+    - answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - <think>first</think>
+    - ' middle '
+    - <think>second</think> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <th
+    - ink>thinking</think>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - <think>thinking</th
+    - ink>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later resolves as force-reasoning text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+      vllm: *d_s6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+  REASONING.stream.1.b:
+    description: Plain text stays in force-reasoning mode until an end marker
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm: *d_s4
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+model_label: DeepSeek V4
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without reasoning markers
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        reasoning_text: plain answer
+        normal_text: ''
+        reason: vLLM DeepSeek V4 batch parser treats marker-free text as reasoning when thinking is enabled.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.2.a:
+    description: Single reasoning block
+    ref: dynamo
+    model_text: <think>thinking</think>
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: ''
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: <think>choose tool</think><tool_call>{}
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <think>choose tool<tool_call>{}
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.2.c:
+    description: Reasoning followed by normal answer text
+    ref: dynamo
+    model_text: <think>thinking</think>answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.2.d:
+    description: Normal text around reasoning
+    ref: dynamo
+    model_text: before <think>thinking</think> after
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: before  after
+      vllm:
+        reasoning_text: thinking
+        normal_text: ' after'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.4:
+    description: Dangling end marker without an opening think tag
+    dynamo_leak: true
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: ''
+        normal_text: normal</think>answer
+      vllm:
+        reasoning_text: normal
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: <think>partial reasoning
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm: *d_5
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: <think></think>answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <think>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}</think>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated by Dynamo
+    ref: dynamo
+    model_text: <think>first</think> middle <think>second</think> done
+    expected:
+      dynamo: &d_9
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+model_label: DeepSeek V4
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.stream.2.a:
+    description: Single reasoning block across chunks
+    ref: dynamo
+    chunks:
+    - <think>thin
+    - king</think>answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - <think>first</think>
+    - ' middle '
+    - <think>second</think> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <th
+    - ink>thinking</think>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - <think>thinking</th
+    - ink>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later becomes normal text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: plain <thesis answer
+      vllm:
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+        reason: vLLM DeepSeek V4 streaming parser treats marker-free stream text as reasoning in this shape.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+  REASONING.stream.1.b:
+    description: Plain text never enters reasoning mode in Dynamo
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        reasoning_text: plain answer
+        normal_text: ''
+        reason: vLLM streaming parser treats plain text before a reasoning end marker as reasoning.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+model_label: Gemma 4
+mode: batch
+cases:
+  REASONING.batch.2.a:
+    description: Gemma thought channel with role label stripped
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      step one
+      step two<channel|>The answer is 42.
+    expected:
+      dynamo: &d_1
+        reasoning_text: |-
+          step one
+          step two
+        normal_text: The answer is 42.
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.3.a:
+    description: Gemma reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      choose tool<channel|><|tool_call>call<tool_call|>
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <|tool_call>call<tool_call|>
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.3.b:
+    description: Open Gemma thought channel interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      choose tool<tool_call>{}
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.2.c:
+    description: Gemma reasoning followed by normal answer text
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      compute<channel|>answer
+    expected:
+      dynamo: &d_10
+        reasoning_text: compute
+        normal_text: answer
+      vllm: *d_10
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.2.d:
+    description: Gemma normal text around reasoning
+    ref: dynamo
+    model_text: |-
+      Hello. <|channel>thought
+      rumination<channel|> Goodbye.
+    expected:
+      dynamo: &d_11
+        reasoning_text: rumination
+        normal_text: Hello.  Goodbye.
+      vllm:
+        reasoning_text: rumination
+        normal_text: ' Goodbye.'
+        reason: vLLM drops text before the Gemma reasoning channel.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.1.b:
+    description: No reasoning markers pass through as normal text
+    ref: dynamo
+    model_text: just a plain answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: ''
+        normal_text: just a plain answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.4:
+    description: Dangling Gemma channel end marker extracts text before the marker as reasoning
+    ref: dynamo
+    model_text: normal<channel|>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: normal
+        normal_text: answer
+      vllm: *d_4
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.5:
+    description: Open thought channel without close treats suffix as reasoning
+    ref: dynamo
+    model_text: |-
+      intro <|channel>thought
+      partial
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial
+        normal_text: 'intro '
+      vllm:
+        reasoning_text: partial
+        normal_text: ''
+        reason: vLLM drops text before an open Gemma reasoning channel.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.2.e:
+    description: Empty Gemma reasoning channel
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      <channel|>answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.2.f:
+    description: Complex Gemma reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}<channel|>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.batch.6.a:
+    description: Gemma batch parser stops after the first reasoning channel
+    ref: dynamo
+    model_text: |-
+      <|channel>thought
+      first<channel|> middle <|channel>thought
+      second<channel|> done
+    expected:
+      dynamo: &d_9
+        reasoning_text: first
+        normal_text: " middle <|channel>thought\nsecond<channel|> done"
+      vllm: *d_9
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+model_label: Gemma 4
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.stream.2.a:
+    description: Gemma thought channel across chunks
+    ref: dynamo
+    chunks:
+    - |
+      <|channel>thought
+      step one
+    - |-
+      step two<channel|>
+    - The answer is 42.
+    expected:
+      dynamo: &d_s1
+        reasoning_text: |-
+          step one
+          step two
+        normal_text: The answer is 42.
+      vllm:
+        reasoning_text: |-
+          <|channel>thought
+          step one
+          step two
+        normal_text: The answer is 42.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.stream.2.b:
+    description: Multiple Gemma thought channels across chunks
+    ref: dynamo
+    chunks:
+    - |-
+      <|channel>thought
+      first<channel|>
+    - ' middle '
+    - |-
+      <|channel>thought
+      second<channel|> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: " middle <|channel>thought\nsecond<channel|> done"
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <|chan
+    - |-
+      nel>thought
+      thinking<channel|>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: ''
+        normal_text: |-
+          <|channel>thought
+          thinking<channel|>answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - |-
+      <|channel>thought
+      thinking<chan
+    - nel|>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: |-
+          <|channel>thought
+          thinking<channel|>answer
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.stream.3.c:
+    description: Partial channel marker prefix later becomes normal text
+    ref: dynamo
+    chunks:
+    - plain <|chan
+    - ce answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: plain <|chance answer
+      vllm: *d_s6
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+  REASONING.stream.1.b:
+    description: Plain text never enters reasoning mode
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm: *d_s4
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gpt_oss
+model_label: gpt-oss
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without Harmony channel markers
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.2.a:
+    description: Harmony analysis channel followed by final channel
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|>thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.3.a:
+    description: Harmony analysis followed by commentary tool-call channel
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|>choose tool<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: '{"city":"SF"}'
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.2.c:
+    description: Harmony analysis followed by normal final answer text
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|>compute<|end|><|start|>assistant<|channel|>final<|message|>answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute
+        normal_text: answer
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.4:
+    description: Final channel without prior analysis channel
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <|channel|>final<|message|>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: answer
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.5:
+    description: Analysis channel without a final or commentary channel
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|>partial reasoning<|end|>
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.2.e:
+    description: Empty analysis channel followed by final text
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|><|end|><|start|>assistant<|channel|>final<|message|>answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.2.f:
+    description: Complex Harmony analysis content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <|channel|>analysis<|message|>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}<|end|><|start|>assistant<|channel|>final<|message|>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.6.a:
+    description: Multiple Harmony analysis spans
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done
+    expected:
+      dynamo: &d_9
+        reasoning_text: first
+        normal_text: second
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.2.d:
+    description: Normal text before a Harmony analysis channel is not a portable parser-level fixture
+    reason: Harmony reasoning content is channel-framed; prefix text before the first channel is outside this parser-level fixture contract.
+  REASONING.batch.3.b:
+    description: Tool-call boundary inside an open Harmony analysis channel
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <|channel|>analysis<|message|>choose tool<tool_call>{}
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gpt_oss
+model_label: gpt-oss
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.2.a:
+    description: Harmony analysis block across chunks
+    ref: dynamo
+    chunks:
+    - <|channel|>
+    - analysis<|message|>thinking
+    - <|end|><|start|>assistant<|channel|>final<|message|>
+    - answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.2.b:
+    description: Multiple Harmony analysis spans across chunks
+    dynamo_leak: true
+    ref: dynamo
+    chunks:
+    - <|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>final<|message|>one
+    - <|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>two
+    expected:
+      dynamo:
+        reasoning_text: first
+        normal_text: one<|channel|>analysis<|message|>secondtwo
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.3.a:
+    description: Harmony start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <|chan
+    - nel|>analysis<|message|>thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.3.b:
+    description: Harmony end marker split across chunks
+    dynamo_leak: true
+    ref: dynamo
+    chunks:
+    - <|channel|>analysis<|message|>thinking<|e
+    - nd|><|start|>assistant<|channel|>final<|message|>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.3.c:
+    description: Partial Harmony channel marker prefix later becomes non-channel text
+    ref: dynamo
+    chunks:
+    - plain <|chan
+    - ce answer
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.1.b:
+    description: Plain text without Harmony channel markers
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'

--- a/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: granite
+model_label: Granite
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without Granite reasoning markers
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm: *d_0
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.2.a:
+    description: Granite thought-process marker
+    ref: dynamo
+    model_text: "Here is my thought process: thinking Here is my response: answer"
+    expected:
+      dynamo: &d_1
+        reasoning_text: 'thinking '
+        normal_text: answer
+      vllm:
+        reasoning_text: ' thinking '
+        normal_text: ' answer'
+        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.3.a:
+    description: Granite reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: "Here is my thought process: choose tool Here is my response: <tool_call>{}"
+    expected:
+      dynamo: &d_2
+        reasoning_text: 'choose tool '
+        normal_text: <tool_call>{}
+      vllm:
+        reasoning_text: ' choose tool '
+        normal_text: ' <tool_call>{}'
+        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.2.c:
+    description: Granite reasoning followed by normal answer text
+    ref: dynamo
+    model_text: "Here is my thought process: compute Here is my response: answer"
+    expected:
+      dynamo: &d_3
+        reasoning_text: 'compute '
+        normal_text: answer
+      vllm:
+        reasoning_text: ' compute '
+        normal_text: ' answer'
+        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.4:
+    description: Dangling Granite response marker without a thought marker
+    ref: dynamo
+    model_text: "normal Here is my response: answer"
+    expected:
+      dynamo: &d_4
+        reasoning_text: ''
+        normal_text: "normal Here is my response: answer"
+      vllm: *d_4
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.5:
+    description: Start marker without response marker keeps suffix as reasoning
+    ref: dynamo
+    model_text: "Here is my thought process: partial reasoning"
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: "Here is my thought process: partial reasoning"
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.2.e:
+    description: Empty Granite thought-process span
+    ref: dynamo
+    model_text: "Here is my thought process: Here is my response: answer"
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm:
+        reasoning_text: ''
+        normal_text: ' answer'
+        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.2.f:
+    description: Complex Granite reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      Here is my thought process: Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]} Here is my response: Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: "Line 1\nUnicode: café\nJSON-ish: {\"x\": [1, true]} "
+        normal_text: Done.
+      vllm:
+        reasoning_text: " Line 1\nUnicode: café\nJSON-ish: {\"x\": [1, true]} "
+        normal_text: ' Done.'
+        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.6.a:
+    description: Granite batch parser stops after the first thought-process span
+    ref: dynamo
+    model_text: "Here is my thought process: first Here is my response: middle Here is my thought process: second Here is my response: done"
+    expected:
+      dynamo:
+        reasoning_text: 'first '
+        normal_text: "middle Here is my thought process: second Here is my response: done"
+      vllm:
+        reasoning_text: ' first '
+        normal_text: " middle Here is my thought process: second Here is my response: done"
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.2.d:
+    description: Normal text before and after Granite thought-process markers
+    ref: dynamo
+    model_text: "before Here is my thought process: thinking Here is my response: after"
+    expected:
+      dynamo:
+        reasoning_text: 'before  thinking '
+        normal_text: after
+      vllm:
+        reasoning_text: ' thinking '
+        normal_text: ' after'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.batch.3.b:
+    description: Tool-call boundary inside an open Granite thought-process span
+    dynamo_leak: true
+    ref: dynamo
+    model_text: "Here is my thought process: choose tool <tool_call>{}"
+    expected:
+      dynamo:
+        reasoning_text: 'choose tool <tool_call>{}'
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: "Here is my thought process: choose tool <tool_call>{}"
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'

--- a/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: granite
+model_label: Granite
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.stream.2.a:
+    description: Granite thought-process marker across chunks
+    ref: dynamo
+    chunks:
+    - "Here is my thought process: thin"
+    - "king Here is my response:"
+    - " answer"
+    expected:
+      dynamo: &d_s1
+        reasoning_text: ' thinking '
+        normal_text: ' answer'
+      vllm:
+        reasoning_text: "Here is my thought process: thin"
+        normal_text: ' answer'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.stream.2.b:
+    description: Multiple thought-process spans across chunks
+    ref: dynamo
+    chunks:
+    - 'Here is my thought process: first Here is my response:'
+    - ' middle '
+    - 'Here is my thought process: second Here is my response: done'
+    expected:
+      dynamo: &d_s5
+        reasoning_text: ' first '
+        normal_text: ' middle Here is my thought process: second Here is my response: done'
+      vllm:
+        reasoning_text: ''
+        normal_text: ' middle Here is my thought process: second Here is my response: done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - "Here is my"
+    - " thought process: thinking Here is my response: answer"
+    expected:
+      dynamo: &d_s2
+        reasoning_text: ' thinking '
+        normal_text: ' answer'
+      vllm:
+        reasoning_text: 'g '
+        normal_text: ' answer'
+        reason: vLLM Granite streaming parser loses the prefix of the split start-marker span.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    dynamo_leak: true
+    ref: dynamo
+    chunks:
+    - "Here is my thought process: thinking Here is my res"
+    - "ponse: answer"
+    expected:
+      dynamo: &d_s3
+        reasoning_text: " thinking Here is my response: answer"
+        normal_text: ''
+      vllm:
+        reasoning_text: "Here is my thought process: thinking "
+        normal_text: ' answer'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.stream.3.c:
+    description: Partial phrase prefix later becomes normal text
+    ref: dynamo
+    chunks:
+    - plain Here is my thou
+    - ghtful answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: plain Here is my thoughtful answer
+      vllm: *d_s6
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+  REASONING.stream.1.b:
+    description: Plain text never enters reasoning mode
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm: *d_s4
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'granite'

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi
+model_label: Kimi reasoning
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without Kimi reasoning delimiters
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.2.a:
+    description: Single reasoning block with Kimi delimiters
+    ref: dynamo
+    model_text: ◁think▷thinking◁/think▷answer
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: ◁think▷choose tool◁/think▷<tool_call>{}
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.2.c:
+    description: Reasoning followed by normal answer text
+    ref: dynamo
+    model_text: ◁think▷compute◁/think▷answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.4:
+    description: Dangling end marker without an opening think tag
+    dynamo_leak: true
+    ref: dynamo
+    model_text: normal◁/think▷answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: ''
+        normal_text: normal◁/think▷answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: ◁think▷partial reasoning
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: ◁think▷◁/think▷answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      ◁think▷Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}◁/think▷Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated
+    ref: dynamo
+    model_text: ◁think▷first◁/think▷ middle ◁think▷second◁/think▷ done
+    expected:
+      dynamo: &d_9
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.2.d:
+    description: Normal text before and after a Kimi reasoning span
+    ref: dynamo
+    model_text: before ◁think▷thinking◁/think▷ after
+    expected:
+      dynamo: &d_10
+        reasoning_text: thinking
+        normal_text: before  after
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.batch.3.b:
+    description: Tool-call boundary inside an open Kimi reasoning span
+    dynamo_leak: true
+    ref: dynamo
+    model_text: ◁think▷choose tool<tool_call>{}
+    expected:
+      dynamo: &d_11
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi
+model_label: Kimi reasoning
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - ◁think▷first◁/think▷
+    - ' middle '
+    - ◁think▷second◁/think▷ done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.stream.2.a:
+    description: Single reasoning block across chunks
+    ref: dynamo
+    chunks:
+    - ◁think▷thin
+    - king◁/think▷
+    - answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - ◁thi
+    - nk▷thinking◁/think▷answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - ◁think▷thinking◁/thi
+    - nk▷answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later becomes normal text
+    ref: dynamo
+    chunks:
+    - plain ◁th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: plain ◁thesis answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+  REASONING.stream.1.b:
+    description: Plain text without reasoning markers
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
+      sglang:
+        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k25
+model_label: Kimi K2.5
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text stays in force-reasoning mode
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo:
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.2.a:
+    description: Force-reasoning parser with explicit think tags
+    ref: dynamo
+    model_text: <think>thinking</think>answer
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.3.b:
+    description: Tool-call section marker force-exits an open reasoning block
+    ref: dynamo
+    model_text: thinking <|tool_calls_section_begin|>tool text
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: <|tool_calls_section_begin|>tool text
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.2.c:
+    description: Force-reasoning parser treats plain output as reasoning
+    ref: dynamo
+    model_text: thinking without explicit tags
+    expected:
+      dynamo:
+        reasoning_text: thinking without explicit tags
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.4:
+    description: Dangling end marker exits force-reasoning mode
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo:
+        reasoning_text: normal
+        normal_text: answer
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: partial reasoning
+    expected:
+      dynamo:
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: <think></think>answer
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: answer
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <think>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}</think>Done.
+    expected:
+      dynamo:
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated
+    ref: dynamo
+    model_text: <think>first</think> middle <think>second</think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.batch.2.d:
+    description: Normal text around reasoning is not applicable in force-reasoning mode
+    reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
+  REASONING.batch.3.a:
+    description: Closed reasoning span followed by Kimi tool-call section marker
+    ref: dynamo
+    model_text: <think>choose tool</think><|tool_calls_section_begin|>tool text
+    expected:
+      dynamo:
+        reasoning_text: choose tool
+        normal_text: <|tool_calls_section_begin|>tool text
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k25
+model_label: Kimi K2.5
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.stream.2.a:
+    description: Force-reasoning stream exits on closing think tag
+    ref: dynamo
+    chunks:
+    - thinking
+    - </think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - <think>first</think>
+    - ' middle '
+    - <think>second</think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.stream.3.a:
+    description: Opening think marker split across chunks
+    ref: dynamo
+    chunks:
+    - <thi
+    - nk>thinking</think>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - <think>thinking</th
+    - ink>answer
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later resolves as force-reasoning text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo:
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
+  REASONING.stream.1.b:
+    description: Plain text stays in force-reasoning mode until an end marker
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo:
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm:
+        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_append_think
+model_label: MiniMax append-think
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text receives the synthetic think opener
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: ''
+        normal_text: <think>plain answer
+      vllm: *d_0
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.2.a:
+    description: MiniMax appends a synthetic think opener and leaves content inline
+    ref: dynamo
+    model_text: reasoning content
+    expected:
+      dynamo: &d_1
+        reasoning_text: ''
+        normal_text: <think>reasoning content
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.3.a:
+    description: Reasoning-shaped text followed by downstream MiniMax tool-call text
+    ref: dynamo
+    model_text: reasoning</think><minimax:tool_call><invoke name="get_weather">
+    expected:
+      dynamo: &d_2
+        reasoning_text: ''
+        normal_text: <think>reasoning</think><minimax:tool_call><invoke name="get_weather">
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.2.c:
+    description: Reasoning-shaped text followed by normal answer text
+    ref: dynamo
+    model_text: reasoning</think>answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: ''
+        normal_text: <think>reasoning</think>answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.4:
+    description: Dangling end marker is left inline
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: ''
+        normal_text: <think>normal</think>answer
+      vllm: *d_4
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.5:
+    description: Missing end marker is left inline
+    ref: dynamo
+    model_text: partial reasoning
+    expected:
+      dynamo: &d_5
+        reasoning_text: ''
+        normal_text: <think>partial reasoning
+      vllm: *d_5
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.2.e:
+    description: Empty input still emits the synthetic think opener
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: <think>
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.2.f:
+    description: Complex content remains inline after the synthetic opener
+    ref: dynamo
+    model_text: |-
+      Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}
+    expected:
+      dynamo: &d_7
+        reasoning_text: ''
+        normal_text: |-
+          <think>Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.1.a:
+    description: Empty input variant
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: <think>
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.6.a:
+    description: Multiple think-looking spans remain inline
+    ref: dynamo
+    model_text: first</think> middle <think>second</think> done
+    expected:
+      dynamo: &d_9
+        reasoning_text: ''
+        normal_text: <think>first</think> middle <think>second</think> done
+      vllm: *d_9
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.2.d:
+    description: Normal text around think-looking markup remains inline after the synthetic opener
+    ref: dynamo
+    model_text: before <think>thinking</think> after
+    expected:
+      dynamo: &d_10
+        reasoning_text: ''
+        normal_text: <think>before <think>thinking</think> after
+      vllm: *d_10
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.batch.3.b:
+    description: Tool-call marker remains inline after the synthetic think opener
+    ref: dynamo
+    model_text: <think>choose tool<tool_call>{}
+    expected:
+      dynamo: &d_11
+        reasoning_text: ''
+        normal_text: <think><think>choose tool<tool_call>{}
+      vllm: *d_11
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_append_think
+model_label: MiniMax append-think
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk still receives the synthetic think opener
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: <think>
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.stream.2.a:
+    description: First streamed chunk gets the synthetic think opener
+    ref: dynamo
+    chunks:
+    - 'reasoning '
+    - content
+    - </think>answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: ''
+        normal_text: <think>reasoning content</think>answer
+      vllm: *d_s1
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.stream.2.b:
+    description: Multiple append-think-looking spans remain normal text
+    ref: dynamo
+    chunks:
+    - first</think>
+    - ' middle '
+    - second</think> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: ''
+        normal_text: <think>first</think> middle second</think> done
+      vllm: *d_s5
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.stream.3.a:
+    description: Single chunk without a model-emitted think opener
+    ref: dynamo
+    chunks:
+    - reasoning content
+    expected:
+      dynamo: &d_s2
+        reasoning_text: ''
+        normal_text: <think>reasoning content
+      vllm: *d_s2
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.stream.3.b:
+    description: End marker split across chunks is still normal text
+    ref: dynamo
+    chunks:
+    - reasoning</th
+    - ink>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: ''
+        normal_text: <think>reasoning</think>answer
+      vllm: *d_s3
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.stream.3.c:
+    description: Partial marker-looking prefix remains normal text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: <think>plain <thesis answer
+      vllm: *d_s6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+  REASONING.stream.1.b:
+    description: Plain text is passed through after the synthetic opener
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: <think>plain answer
+      vllm: *d_s4
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+model_label: Mistral / Magistral
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text stays in force-reasoning mode in Dynamo
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: plain answer
+        reason: vLLM Mistral parser only enters reasoning after the explicit start token.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.2.a:
+    description: Mistral THINK block
+    ref: dynamo
+    model_text: '[THINK]thinking[/THINK]answer'
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.3.a:
+    description: Mistral reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: '[THINK]choose tool[/THINK]<tool_call>{}'
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: '[THINK]choose tool<tool_call>{}'
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.2.c:
+    description: Mistral reasoning followed by normal answer text
+    ref: dynamo
+    model_text: '[THINK]compute[/THINK]answer'
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute
+        normal_text: answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.2.d:
+    description: Normal text around reasoning is not applicable in force-reasoning mode
+    reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
+  REASONING.batch.4:
+    description: Dangling Mistral end marker without an opening marker
+    ref: dynamo
+    model_text: normal[/THINK]answer
+    expected:
+      dynamo:
+        reasoning_text: normal
+        normal_text: answer
+      vllm:
+        reasoning_text: ''
+        normal_text: normalanswer
+        reason: vLLM Mistral parser treats a dangling end marker as normal text and strips the marker.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.5:
+    description: Force-reasoning parser treats unterminated text as reasoning
+    ref: dynamo
+    model_text: thinking without an end marker
+    expected:
+      dynamo: &d_5
+        reasoning_text: thinking without an end marker
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: thinking without an end marker
+        reason: vLLM Mistral parser only enters reasoning after the explicit start token.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.2.e:
+    description: Empty Mistral reasoning block
+    ref: dynamo
+    model_text: '[THINK][/THINK]answer'
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.2.f:
+    description: Complex Mistral reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      [THINK]Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}[/THINK]Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.batch.6.a:
+    description: Multiple Mistral reasoning spans are concatenated by Dynamo
+    ref: dynamo
+    model_text: '[THINK]first[/THINK] middle [THINK]second[/THINK] done'
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle [THINK]second[/THINK] done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+model_label: Mistral / Magistral
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.stream.2.a:
+    description: Mistral THINK block across chunks
+    ref: dynamo
+    chunks:
+    - '[THINK]thin'
+    - 'king[/THINK]answer'
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: '[THINK]thinking'
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.stream.2.b:
+    description: Multiple Mistral THINK spans across chunks
+    ref: dynamo
+    chunks:
+    - '[THINK]first[/THINK]'
+    - ' middle '
+    - '[THINK]second[/THINK] done'
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle [THINK]second[/THINK] done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - '[TH'
+    - 'INK]thinking[/THINK]answer'
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: ''
+        normal_text: '[THINK]thinking[/THINK]answer'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - '[THINK]thinking[/TH'
+    - 'INK]answer'
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: '[THINK]thinking[/THINK]answer'
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later resolves as force-reasoning text
+    ref: dynamo
+    chunks:
+    - plain [TH
+    - ESIS answer
+    expected:
+      dynamo:
+        reasoning_text: plain [THESIS answer
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: plain [THESIS answer
+        reason: vLLM Mistral streaming parser only enters reasoning after an explicit start marker.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+  REASONING.stream.1.b:
+    description: Plain text stays in force-reasoning mode until an end marker
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo:
+        reasoning_text: plain answer
+        normal_text: ''
+      vllm:
+        reasoning_text: ''
+        normal_text: plain answer
+        reason: vLLM Mistral streaming parser only enters reasoning after an explicit start marker.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+model_label: Nemotron Deci / GLM 4.5
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without reasoning markers
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        reasoning_text: plain answer
+        normal_text: ''
+        reason: vLLM GLM/Nemotron batch parser treats marker-free text as reasoning.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.2.a:
+    description: Single think-tag reasoning block
+    ref: dynamo
+    model_text: <think>thinking</think>answer
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *d_1
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: <think>choose tool</think><tool_call>{}
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <think>choose tool<tool_call>{}
+    expected:
+      dynamo:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.2.c:
+    description: Reasoning followed by normal answer text
+    ref: dynamo
+    model_text: <think>compute</think>answer
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute
+        normal_text: answer
+      vllm: *d_3
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.2.d:
+    description: Normal text around reasoning
+    ref: dynamo
+    model_text: before <think>thinking</think> after
+    expected:
+      dynamo:
+        reasoning_text: thinking
+        normal_text: before  after
+      vllm:
+        reasoning_text: thinking
+        normal_text: ' after'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.4:
+    description: Dangling end marker without an opening think tag
+    dynamo_leak: true
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: normal</think>answer
+      vllm:
+        reasoning_text: normal
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: <think>partial
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial
+        normal_text: ''
+      vllm: *d_5
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: <think></think>answer
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: answer
+      vllm: *d_6
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <think>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}</think>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated by Dynamo
+    ref: dynamo
+    model_text: <think>first</think> middle <think>second</think> done
+    expected:
+      dynamo:
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+model_label: Nemotron Deci / GLM 4.5
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.stream.2.a:
+    description: Single reasoning block across chunks
+    ref: dynamo
+    chunks:
+    - <think>thin
+    - king</think>
+    - answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - <think>first</think>
+    - ' middle '
+    - <think>second</think> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <th
+    - ink>thinking</think>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - <think>thinking</th
+    - ink>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later becomes normal text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: plain <thesis answer
+      vllm:
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+        reason: vLLM GLM/Nemotron streaming parser treats marker-free text as reasoning.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+  REASONING.stream.1.b:
+    description: Plain text without reasoning markers
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        reasoning_text: plain answer
+        normal_text: ''
+        reason: vLLM GLM/Nemotron streaming parser treats marker-free text as reasoning.
+      sglang:
+        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3
+model_label: Qwen 3.x
+mode: batch
+cases:
+  REASONING.batch.1.b:
+    description: Plain text without reasoning markers
+    ref: dynamo
+    model_text: plain answer
+    expected:
+      dynamo: &d_0
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        reasoning_text: plain answer
+        normal_text: ''
+        reason: vLLM Qwen batch parser treats marker-free text as reasoning.
+      sglang: *d_0
+  REASONING.batch.2.a:
+    description: Single reasoning block
+    ref: dynamo
+    model_text: <think>thinking</think>
+    expected:
+      dynamo: &d_1
+        reasoning_text: thinking
+        normal_text: ''
+      vllm: *d_1
+      sglang: *d_1
+  REASONING.batch.3.a:
+    description: Reasoning followed by downstream tool-call text
+    ref: dynamo
+    model_text: |-
+      <think>choose the weather tool</think><tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call>
+    expected:
+      dynamo: &d_2
+        reasoning_text: choose the weather tool
+        normal_text: <tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call>
+      vllm: *d_2
+      sglang: *d_2
+  REASONING.batch.3.b:
+    description: Open reasoning interrupted by downstream tool-call text
+    dynamo_leak: true
+    ref: dynamo
+    model_text: <think>choose tool<tool_call>{}
+    expected:
+      dynamo: &d_10
+        reasoning_text: choose tool<tool_call>{}
+        normal_text: ''
+      vllm:
+        reasoning_text: choose tool
+        normal_text: <tool_call>{}
+      sglang: *d_10
+  REASONING.batch.2.c:
+    description: Reasoning followed by normal answer text
+    ref: dynamo
+    model_text: <think>compute it</think>The answer is 42.
+    expected:
+      dynamo: &d_3
+        reasoning_text: compute it
+        normal_text: The answer is 42.
+      vllm: *d_3
+      sglang: *d_3
+  REASONING.batch.2.d:
+    description: Normal text around reasoning
+    ref: dynamo
+    model_text: before <think>thinking</think> after
+    expected:
+      dynamo: &d_11
+        reasoning_text: thinking
+        normal_text: before  after
+      vllm:
+        reasoning_text: thinking
+        normal_text: ' after'
+      sglang:
+        reasoning_text: before thinking
+        normal_text: ' after'
+  REASONING.batch.4:
+    description: Dangling end marker without an opening think tag
+    dynamo_leak: true
+    ref: dynamo
+    model_text: normal</think>answer
+    expected:
+      dynamo: &d_4
+        reasoning_text: ''
+        normal_text: normal</think>answer
+      vllm:
+        reasoning_text: normal
+        normal_text: answer
+      sglang: *d_4
+  REASONING.batch.5:
+    description: Missing end marker keeps the remaining text as reasoning
+    ref: dynamo
+    model_text: <think>partial reasoning
+    expected:
+      dynamo: &d_5
+        reasoning_text: partial reasoning
+        normal_text: ''
+      vllm: *d_5
+      sglang: *d_5
+  REASONING.batch.2.e:
+    description: Empty reasoning block
+    ref: dynamo
+    model_text: <think></think>Direct answer.
+    expected:
+      dynamo: &d_6
+        reasoning_text: ''
+        normal_text: Direct answer.
+      vllm: *d_6
+      sglang: *d_6
+  REASONING.batch.2.f:
+    description: Complex reasoning content with Unicode and newlines
+    ref: dynamo
+    model_text: |-
+      <think>Line 1
+      Unicode: café
+      JSON-ish: {"x": [1, true]}</think>Done.
+    expected:
+      dynamo: &d_7
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
+      vllm: *d_7
+      sglang: *d_7
+  REASONING.batch.1.a:
+    description: Empty input
+    ref: dynamo
+    model_text: ''
+    expected:
+      dynamo: &d_8
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_8
+      sglang: *d_8
+  REASONING.batch.6.a:
+    description: Multiple reasoning spans are concatenated
+    ref: dynamo
+    model_text: <think>first</think> middle <think>second</think> done
+    expected:
+      dynamo: &d_9
+        reasoning_text: firstsecond
+        normal_text: middle  done
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3
+model_label: Qwen 3.x
+mode: stream
+cases:
+  REASONING.stream.1.a:
+    description: Empty stream chunk
+    ref: dynamo
+    chunks:
+    - ''
+    expected:
+      dynamo: &d_s0
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_s0
+      sglang: *d_s0
+  REASONING.stream.2.a:
+    description: Single reasoning block across chunks
+    ref: dynamo
+    chunks:
+    - <think>thin
+    - king</think>
+    - answer
+    expected:
+      dynamo: &d_s1
+        reasoning_text: thinking
+        normal_text: answer
+      vllm: *d_s1
+      sglang: *d_s1
+  REASONING.stream.2.b:
+    description: Multiple reasoning spans across chunks
+    ref: dynamo
+    chunks:
+    - <think>first</think>
+    - ' middle '
+    - <think>second</think> done
+    expected:
+      dynamo: &d_s5
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+      sglang:
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+  REASONING.stream.3.a:
+    description: Start marker split across chunks
+    ref: dynamo
+    chunks:
+    - <th
+    - ink>thinking</think>answer
+    expected:
+      dynamo: &d_s2
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: <think>thinking
+        normal_text: answer
+      sglang: *d_s2
+  REASONING.stream.3.b:
+    description: End marker split across chunks
+    ref: dynamo
+    chunks:
+    - <think>thinking</th
+    - ink>answer
+    expected:
+      dynamo: &d_s3
+        reasoning_text: thinking
+        normal_text: answer
+      vllm:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+      sglang:
+        reasoning_text: thinking</think>answer
+        normal_text: ''
+  REASONING.stream.3.c:
+    description: Partial start-marker prefix later becomes normal text
+    ref: dynamo
+    chunks:
+    - plain <th
+    - esis answer
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: plain <thesis answer
+      vllm:
+        reasoning_text: plain <thesis answer
+        normal_text: ''
+        reason: vLLM Qwen streaming parser treats marker-free stream text as reasoning in this shape.
+      sglang: *d_s6
+  REASONING.stream.1.b:
+    description: Plain text never enters reasoning mode
+    ref: dynamo
+    chunks:
+    - plain
+    - ' answer'
+    expected:
+      dynamo: &d_s4
+        reasoning_text: ''
+        normal_text: plain answer
+      vllm:
+        reasoning_text: plain answer
+        normal_text: ''
+        reason: vLLM Qwen streaming parser treats text before a reasoning end marker as reasoning; serving may bypass it when thinking is disabled.
+      sglang: *d_s4


### PR DESCRIPTION
#### Overview:

This PR is part 1 of the reasoning parity work: it adds the YAML/Markdown fixture contracts and Rust test annotations generated by #9781.

#### Details:

- **How is this fixed?** Add `REASONING_CASES.md` plus YAML batch/stream fixtures for supported reasoning parser families.
- Add Rust test annotations showing which `REASONING.batch.*` / `REASONING.stream.*` category each existing reasoning parser test covers.
- Update the parity README with the reasoning fixture/table flow.
- Keep the code/test/table generator harness in #9781; this PR is the contract and annotation base.
- Keep tool-calling parser fixtures untouched.

#### Verification:

`cargo fmt --check` passed; `python3 -m pytest tests/parity/parser/test_generate_parity_table.py tests/parity/reasoning/test_parity_reasoning.py` passed in the devcontainer; `python3 -m pytest lib/bindings/python/tests/test_parsers.py` passed.

#### Where should the reviewer start?

`lib/parsers/REASONING_CASES.md`, then `tests/parity/reasoning/fixtures`, then `lib/parsers/src/reasoning`

#### Related Issues:

Part 2 / generator harness: #9781; DIS-2063

/coderabbit profile chill