### PR TITLE
fix(metrics): bound unknown-model label cardinality

### DIFF
--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -5,7 +5,7 @@ mod model;
 pub use model::Model;
 
 mod model_manager;
-pub use model_manager::{ModelManager, ModelManagerError};
+pub use model_manager::{ModelManager, ModelManagerError, UNKNOWN_METRIC_MODEL};
 
 mod worker_set;
 pub use worker_set::WorkerSet;

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -69,6 +69,13 @@ pub enum ModelManagerError {
     ModelAlreadyExists(String),
 }
 
+/// Sentinel label value used in frontend Prometheus metrics for requests
+/// that target an unregistered model. Bounds label cardinality so arbitrary
+/// client-supplied model strings cannot create unbounded Prometheus series.
+/// The `_model` suffix makes accidental collision with a real model name
+/// implausible while keeping the value readable in Grafana dropdowns.
+pub const UNKNOWN_METRIC_MODEL: &str = "unknown_model";
+
 /// Central manager for model engines, routing, and configuration.
 ///
 /// Models are stored hierarchically: ModelManager → Model → WorkerSet.
@@ -184,6 +191,29 @@ impl ModelManager {
     /// Check if any model (decode or prefill) is registered.
     pub fn has_model_any(&self, model: &str) -> bool {
         self.has_decode_model(model) || self.has_prefill_model(model)
+    }
+
+    /// Check if any engine (chat, completions, embeddings, images, etc.) is
+    /// registered under this exact model name. Case-sensitive. Distinct from
+    /// [`has_model_any`](Self::has_model_any), which checks specifically for a
+    /// decode or prefill engine.
+    pub fn has_registered_model(&self, model: &str) -> bool {
+        self.models.contains_key(model)
+    }
+
+    /// Resolve the model name to use in frontend Prometheus metrics.
+    ///
+    /// Returns the user-supplied name if a model is registered under it
+    /// (preserving original casing), otherwise returns the bounded sentinel
+    /// [`UNKNOWN_METRIC_MODEL`]. Callers should use this resolved name
+    /// for every metric child created before engine lookup so unknown-model
+    /// requests do not pollute Prometheus label cardinality.
+    pub fn metric_model_for<'a>(&self, model: &'a str) -> &'a str {
+        if self.has_registered_model(model) {
+            model
+        } else {
+            UNKNOWN_METRIC_MODEL
+        }
     }
 
     pub fn model_display_names(&self) -> HashSet<String> {
@@ -1136,6 +1166,35 @@ mod tests {
 
         mm.add_worker_set("llama", "ns1", make_worker_set("ns1", "abc"));
         assert!(mm.has_model_any("llama")); // has prefill
+    }
+
+    #[test]
+    fn test_metric_model_for_resolves_to_sentinel_for_unknown() {
+        let mm = ModelManager::new();
+        mm.add_worker_set(
+            "Llama-3.1-8B-Instruct",
+            "ns1",
+            make_worker_set("ns1", "abc"),
+        );
+
+        // Registered models preserve their original casing.
+        assert_eq!(
+            mm.metric_model_for("Llama-3.1-8B-Instruct"),
+            "Llama-3.1-8B-Instruct"
+        );
+
+        // Case mismatches and unregistered strings collapse to the sentinel so
+        // arbitrary client-supplied values cannot create unbounded Prometheus
+        // series.
+        assert_eq!(
+            mm.metric_model_for("llama-3.1-8b-instruct"),
+            UNKNOWN_METRIC_MODEL
+        );
+        assert_eq!(
+            mm.metric_model_for("nonexistent-model-1"),
+            UNKNOWN_METRIC_MODEL
+        );
+        assert_eq!(mm.metric_model_for(""), UNKNOWN_METRIC_MODEL);
     }
 
     #[test]

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -46,7 +46,7 @@ use crate::protocols::openai::chat_completions::{
     aggregator::ChatCompletionAggregator,
 };
 use crate::protocols::unified::UnifiedRequest;
-use crate::request_template::RequestTemplate;
+use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
@@ -149,8 +149,9 @@ async fn handler_anthropic_messages(
     // Create request context
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.stream;
+    let resolved_model = resolve_request_model(&request.model, template.as_ref());
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(&request.model).to_string(),
+        model: state.manager().metric_model_for(resolved_model).to_string(),
         endpoint: Endpoint::AnthropicMessages.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -150,7 +150,7 @@ async fn handler_anthropic_messages(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.stream;
     let cancellation_labels = CancellationLabels {
-        model: request.model.clone(),
+        model: state.manager().metric_model_for(&request.model).to_string(),
         endpoint: Endpoint::AnthropicMessages.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -211,7 +211,8 @@ async fn anthropic_messages(
     }
 
     let model = request.model.clone();
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let metric_model = state.manager().metric_model_for(&model).to_string();
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     tracing::trace!("Received Anthropic messages request: {:?}", &*request);
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -514,17 +514,18 @@ async fn completions_single(
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     let model = request.inner.model.clone();
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     // Create inflight_guard early to ensure all errors are counted
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        &model,
+        &metric_model,
         Endpoint::Completions,
         streaming,
         &request_id,
     );
 
     // Create http_queue_guard early - tracks time waiting to be processed
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     // todo - error handling should be more robust
     let (engine, parsing_options) = state
@@ -536,7 +537,9 @@ async fn completions_single(
             err_response
         })?;
 
-    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
 
     // prepare to process any annotations
     let annotations = request.annotations();
@@ -663,17 +666,18 @@ async fn completions_batch(
     let request_id = request.id().to_string();
     let streaming = request.inner.stream.unwrap_or(false);
     let model = request.inner.model.clone();
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     // Create inflight_guard early to ensure all errors are counted
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        &model,
+        &metric_model,
         Endpoint::Completions,
         streaming,
         &request_id,
     );
 
     // Create http_queue_guard early - tracks time waiting to be processed
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     let (engine, parsing_options) = state
         .manager()
@@ -684,7 +688,9 @@ async fn completions_batch(
             err_response
         })?;
 
-    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
 
     // prepare to process any annotations
     let annotations = request.annotations();
@@ -855,17 +861,18 @@ async fn embeddings(
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     let model = &request.inner.model;
+    let metric_model = state.manager().metric_model_for(model).to_string();
 
     // Create inflight_guard early to ensure all errors are counted
     let mut inflight = state.metrics_clone().create_inflight_guard(
-        model,
+        &metric_model,
         Endpoint::Embeddings,
         streaming,
         &request_id,
     );
 
     // Create http_queue_guard early - tracks time waiting to be processed
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     // todo - error handling should be more robust
     let engine = state.manager().get_embeddings_engine(model).map_err(|e| {
@@ -874,7 +881,9 @@ async fn embeddings(
         err_response
     })?;
 
-    let mut response_collector = state.metrics_clone().create_response_collector(model);
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
     let model_name = model.to_string();
 
     // issue the generate call on the engine
@@ -1275,12 +1284,13 @@ async fn chat_completions(
     // todo - when optional, if none, apply a default
     // todo - determine the proper error code for when a request model is not present
     let model = request.inner.model.clone();
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     tracing::trace!("Received chat completions request: {:?}", request.content());
 
     // Create inflight_guard early to ensure all errors (including validation) are counted
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        &model,
+        &metric_model,
         Endpoint::ChatCompletions,
         streaming,
         &request_id,
@@ -1314,7 +1324,7 @@ async fn chat_completions(
     }
 
     // Create HTTP queue guard after template resolution so labels are correct
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
@@ -1327,7 +1337,9 @@ async fn chat_completions(
             err_response
         })?;
 
-    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
 
     let annotations = request.annotations();
 
@@ -1658,11 +1670,12 @@ async fn responses(
 
     let model = request.inner.model.clone().unwrap_or_default();
     let streaming = request.inner.stream.unwrap_or(false);
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     // Create http_queue_guard early - tracks time waiting to be processed
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        &model,
+        &metric_model,
         Endpoint::Responses,
         streaming,
         request.id(),
@@ -1751,7 +1764,9 @@ async fn responses(
             err_response
         })?;
 
-    let mut response_collector = state.metrics_clone().create_response_collector(&model);
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
 
     tracing::trace!("Issuing generate call for responses");
 
@@ -2209,8 +2224,10 @@ async fn images(
         })
         .unwrap_or_else(|| "diffusion".to_string());
 
+    let metric_model = state.manager().metric_model_for(&model).to_string();
+
     // Create http_queue_guard early - tracks time waiting to be processed
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     // Get the image generation engine
     let engine = state
@@ -2325,9 +2342,10 @@ async fn videos(
 
     // Get the model name from the request (video generation model)
     let model = request.model.clone();
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     // Create http_queue_guard early - tracks time waiting to be processed
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     // Get the video generation engine
     let engine = state
@@ -2439,8 +2457,9 @@ async fn video_stream(
     let request_id = get_or_create_request_id(&headers);
     let request = Context::with_id(request, request_id);
     let model = request.model.clone();
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     let engine = state
         .manager()
@@ -2614,8 +2633,9 @@ async fn audio_speech(
             .next()
             .unwrap_or_default()
     });
+    let metric_model = state.manager().metric_model_for(&model).to_string();
 
-    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&model);
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     let engine = state
         .manager()

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -58,7 +58,7 @@ use crate::protocols::openai::{
     videos::{NvCreateVideoRequest, NvVideosResponse},
 };
 use crate::protocols::unified::UnifiedRequest;
-use crate::request_template::RequestTemplate;
+use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
@@ -945,11 +945,9 @@ async fn handler_chat_completions(
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
+    let resolved_model = resolve_request_model(&request.inner.model, template.as_ref());
     let cancellation_labels = CancellationLabels {
-        model: state
-            .manager()
-            .metric_model_for(&request.inner.model)
-            .to_string(),
+        model: state.manager().metric_model_for(resolved_model).to_string(),
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -1614,9 +1612,10 @@ async fn handler_responses(
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
-    let raw_model = request.inner.model.clone().unwrap_or_default();
+    let raw_model = request.inner.model.as_deref().unwrap_or("");
+    let resolved_model = resolve_request_model(raw_model, template.as_ref());
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(&raw_model).to_string(),
+        model: state.manager().metric_model_for(resolved_model).to_string(),
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -436,7 +436,10 @@ async fn handler_completions(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let cancellation_labels = CancellationLabels {
-        model: request.inner.model.clone(),
+        model: state
+            .manager()
+            .metric_model_for(&request.inner.model)
+            .to_string(),
         endpoint: Endpoint::Completions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -943,7 +946,10 @@ async fn handler_chat_completions(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let cancellation_labels = CancellationLabels {
-        model: request.inner.model.clone(),
+        model: state
+            .manager()
+            .metric_model_for(&request.inner.model)
+            .to_string(),
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -1608,8 +1614,9 @@ async fn handler_responses(
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
+    let raw_model = request.inner.model.clone().unwrap_or_default();
     let cancellation_labels = CancellationLabels {
-        model: request.inner.model.clone().unwrap_or_default(),
+        model: state.manager().metric_model_for(&raw_model).to_string(),
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };

--- a/lib/llm/src/request_template.rs
+++ b/lib/llm/src/request_template.rs
@@ -20,3 +20,58 @@ impl RequestTemplate {
         Ok(template)
     }
 }
+
+/// Resolve a request's `model` field against an optional [`RequestTemplate`].
+///
+/// Returns `raw` when it is non-empty; otherwise falls back to
+/// `template.model`. If `raw` is empty and no template is configured, returns
+/// the (empty) `raw` so the caller's downstream logic still observes the
+/// missing-model condition.
+///
+/// HTTP handler wrappers use this to compute the effective model for
+/// cancellation metric labels, keeping the wrapper and the inner handler's
+/// own template merge consistent.
+pub fn resolve_request_model<'a>(raw: &'a str, template: Option<&'a RequestTemplate>) -> &'a str {
+    if raw.is_empty() {
+        template.map(|t| t.model.as_str()).unwrap_or(raw)
+    } else {
+        raw
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn template(model: &str) -> RequestTemplate {
+        RequestTemplate {
+            model: model.to_string(),
+            temperature: 0.0,
+            max_completion_tokens: 0,
+        }
+    }
+
+    #[test]
+    fn non_empty_raw_wins() {
+        let t = template("template-default");
+        // Non-empty raw is returned regardless of whether a template is set.
+        assert_eq!(
+            resolve_request_model("user-supplied", Some(&t)),
+            "user-supplied"
+        );
+        assert_eq!(
+            resolve_request_model("user-supplied", None),
+            "user-supplied"
+        );
+    }
+
+    #[test]
+    fn empty_raw_falls_back() {
+        let t = template("template-default");
+        // With a template, empty raw resolves to the template's model.
+        assert_eq!(resolve_request_model("", Some(&t)), "template-default");
+        // Without a template, empty raw stays empty so callers can detect
+        // the missing-model condition downstream.
+        assert_eq!(resolve_request_model("", None), "");
+    }
+}

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -4,6 +4,7 @@
 use anyhow::Error;
 use async_stream::stream;
 use dynamo_llm::{
+    discovery::UNKNOWN_METRIC_MODEL,
     http::service::{metrics::Endpoint, service_v2::HttpService},
     model_card::ModelDeploymentCard,
     preprocessor::LLMMetricAnnotation,
@@ -312,6 +313,119 @@ async fn test_metrics_with_mock_model() {
         assert!(metrics_body.contains("status=\"success\""));
 
         // Clean up
+        cancel_token.cancel();
+        task.await.unwrap().unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_unknown_model_uses_sentinel_label() {
+    // Regression test: unknown-model requests must collapse to the bounded
+    // sentinel `UNKNOWN_METRIC_MODEL` instead of letting arbitrary
+    // client-supplied strings create unbounded Prometheus series. Both the
+    // pre-lookup InflightGuard and HttpQueueGuard must use the sentinel from
+    // the start, since their Drop impls cannot retroactively relabel children.
+    temp_env::async_with_vars([(METRICS_PREFIX_ENV, None::<&str>)], async {
+        let (listener, port) = bind_random_port().await;
+        let service = HttpService::builder()
+            .port(port)
+            .enable_chat_endpoints(true)
+            .build()
+            .unwrap();
+
+        let state = service.state_clone();
+        let manager = state.manager();
+
+        let token = CancellationToken::new();
+        let cancel_token = token.clone();
+        let task =
+            tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+
+        // Register exactly one valid model so the manager can distinguish
+        // known vs unknown lookups.
+        let card = ModelDeploymentCard::with_name_only("mockmodel");
+        let mock_engine = Arc::new(MockModelEngine {});
+        manager
+            .add_chat_completions_model("mockmodel", card.mdcsum(), mock_engine)
+            .unwrap();
+
+        wait_for_metrics_ready(port).await;
+
+        let client = reqwest::Client::new();
+        let message = dynamo_protocols::types::ChatCompletionRequestMessage::User(
+            dynamo_protocols::types::ChatCompletionRequestUserMessage {
+                content: dynamo_protocols::types::ChatCompletionRequestUserMessageContent::Text(
+                    "hi".to_string(),
+                ),
+                name: None,
+            },
+        );
+
+        // Two distinct unknown-model strings exercise the cardinality concern:
+        // without the sentinel each would create its own Prometheus child.
+        let bogus_models = ["nonexistent-model-1", "Foo"];
+        for bogus in bogus_models {
+            let request = dynamo_protocols::types::CreateChatCompletionRequestArgs::default()
+                .model(bogus)
+                .messages(vec![message.clone()])
+                .max_tokens(8u32)
+                .stream(false)
+                .build()
+                .expect("Failed to build request");
+
+            let resp = client
+                .post(format!("http://localhost:{}/v1/chat/completions", port))
+                .json(&request)
+                .send()
+                .await
+                .unwrap();
+            // Unknown model must fail. The exact status is not what we're
+            // testing; only that the guard's drop path ran.
+            assert!(
+                !resp.status().is_success(),
+                "expected unknown-model request for {bogus} to fail"
+            );
+        }
+
+        // Give Drop impls time to emit the request counter / duration samples.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let metrics_body = client
+            .get(format!("http://localhost:{}/metrics", port))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        // Scan only `dynamo_frontend_*` series lines so we don't false-positive
+        // on HELP/TYPE descriptors or unrelated metric namespaces:
+        //   * at least one such series must carry the sentinel label
+        //   * none of them may carry a raw user-supplied bogus name
+        let sentinel_needle = format!("model=\"{UNKNOWN_METRIC_MODEL}\"");
+        let mut sentinel_seen = false;
+        for line in metrics_body.lines() {
+            if !line.starts_with("dynamo_frontend_") {
+                continue;
+            }
+            if line.contains(&sentinel_needle) {
+                sentinel_seen = true;
+            }
+            for bogus in bogus_models {
+                let needle = format!("model=\"{bogus}\"");
+                assert!(
+                    !line.contains(&needle),
+                    "unknown-model label leaked into Prometheus series: {line}"
+                );
+            }
+        }
+        assert!(
+            sentinel_seen,
+            "expected at least one dynamo_frontend_* series under {sentinel_needle}, got:\n{metrics_body}"
+        );
+
         cancel_token.cancel();
         task.await.unwrap().unwrap();
     })


### PR DESCRIPTION
## Summary

The HTTP frontend emits `dynamo_frontend_*` Prometheus metrics with a user-supplied `model` label before confirming the model is registered. A client sending requests with arbitrary model names causes Prometheus to retain one time series per distinct value, visible in Grafana as invalid entries like `nonexistent-model-1`, `nonexistent-model-2`, etc.

This PR resolves the metric model up-front via a new `ModelManager::metric_model_for` helper. Registered models keep their original casing (preserving PR #9775 behavior). Unregistered names, case mismatches, and empty strings all collapse to a bounded sentinel `UNKNOWN_METRIC_MODEL = "unknown_model"`.

## Behavior change

Only Prometheus output changes. Clients see identical HTTP responses.

**Before** (each invalid client name produces its own series):
```
dynamo_frontend_requests_total{model="nonexistent-model-1", endpoint="chat_completions", ...} 1
dynamo_frontend_requests_total{model="Foo",                  endpoint="chat_completions", ...} 1
dynamo_frontend_inflight_requests{model="nonexistent-model-1"} 0
dynamo_frontend_queued_requests{model="Foo"} 0
```

**After** (all unknown-model requests share one bounded child):
```
dynamo_frontend_requests_total{model="unknown_model", endpoint="chat_completions", ...} 2
dynamo_frontend_inflight_requests{model="unknown_model"} 0
dynamo_frontend_queued_requests{model="unknown_model"} 0
```

## Affected metrics

All `dynamo_frontend_*` series created before engine lookup:
- `requests_total`, `requests_started_total`
- `inflight_requests`, `active_requests`
- `queued_requests`
- `request_duration_seconds`

## What does not change

- HTTP responses (still `404 "Model not found: <raw-name>"` echoing the actual requested model).
- Engine routing and lookup behavior.
- Registered-model metrics (still labeled with the user-supplied casing per #9775).
- Post-lookup metrics (`inc_rejection`, `inc_cancellation`, `inc_migration_*`, runtime config gauges).
- gRPC service handlers (engine lookup already precedes guard construction; verified).
- Success path latency or behavior beyond one `DashMap::contains_key` per request.

## Implementation

Nine HTTP handlers compute the resolved label once, immediately after capturing the user-supplied model:
```rust
let model = request.inner.model.clone();
let metric_model = state.manager().metric_model_for(&model).to_string();
```
`metric_model` is passed to every guard constructor that runs before engine lookup. `model` (raw) stays in `manager().get_*_engine(&model)` so the not-found error message echoes the actual requested name.

Per-handler scope:
- **Fully pre-lookup** (chat_completions, completions_single, completions_batch, embeddings, responses): `inflight_guard`, `http_queue_guard`, and `response_collector` all use `metric_model`.
- **Partially pre-lookup** (images, videos, video_stream, audio_speech, anthropic_messages): only `http_queue_guard` is constructed before engine lookup, so only it uses `metric_model`; `inflight` and `collector` use the raw `model` (which equals `metric_model` by construction once the engine lookup succeeds).

## Notes for reviewers

1. **Cancellation labels assumption.** The four `handler_*` wrappers construct `CancellationLabels` from the raw user model string. `inc_cancellation` only fires on mid-stream client disconnect, and the connection monitor is disarmed synchronously on the 404 error path, so this is unreachable today. Future refactors that delay monitor disarming would need to revisit those sites.

2. **Concurrent registration race.** If a model is registered between `metric_model_for(...)` and the engine lookup, the metric label may be `unknown_model` while the request succeeds. Self-correcting on the next request; not worth defending in code.

3. **`has_*_model` method family.** We now have `has_decode_model`, `has_prefill_model`, `has_model_any`, and `has_registered_model`. Worth a follow-up to consolidate into a single method with a kind parameter; out of scope here.

## Test plan

- [x] Unit test (`test_metric_model_for_resolves_to_sentinel_for_unknown`): registered casing preserved; case mismatch, unregistered, and empty inputs all return the sentinel.
- [x] Integration test (`test_unknown_model_uses_sentinel_label`): spins up the HTTP service with one registered mock model, sends chat completion requests to two distinct unknown names (`"nonexistent-model-1"` and `"Foo"`), scrapes `/metrics`, asserts `model="unknown_model"` is present on at least one `dynamo_frontend_*` line and neither raw name appears on any `dynamo_frontend_*` line.
- [x] `cargo fmt --check`, `cargo clippy --lib --tests`, full `dynamo-llm` test suite pass locally.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prometheus metrics now use a sentinel value for requests with unregistered models, preventing unbounded cardinality in metric labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->