### PR TITLE
fix: exclude Istio sidecar injection from kgateway-proxy pod for gaie

### DIFF
--- a/deploy/inference-gateway/scripts/install_gaie_crd_kgateway.sh
+++ b/deploy/inference-gateway/scripts/install_gaie_crd_kgateway.sh
@@ -42,7 +42,43 @@ helm upgrade -i --namespace kgateway-system --version $KGTW_VERSION kgateway \
   oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
   --set inferenceExtension.enabled=true
 
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/refs/tags/${IGW_LATEST_RELEASE}/config/manifests/gateway/agentgateway/gateway.yaml -n "$NAMESPACE"
+# Create a GatewayParameters resource that excludes Istio sidecar injection from the
+# kgateway-proxy pods. When the deployment namespace has istio-injection=enabled, the
+# Istio sidecar intercepts the ext_proc gRPC connection from kgateway-proxy to EPP
+# (port 9002), causing all inference requests to return HTTP 500. Setting
+# sidecar.istio.io/inject: "false" prevents sidecar injection on the proxy pod so
+# that ext_proc traffic reaches EPP directly. This annotation is a no-op on clusters
+# where Istio is not installed.
+#
+# GatewayParameters must live in the same namespace as the Gateway because
+# Gateway API's infrastructure.parametersRef is a LocalParametersReference
+# (no namespace field).
+kubectl apply -n "$NAMESPACE" -f - <<'EOF'
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: inference-gateway-params
+spec:
+  kube:
+    podTemplate:
+      extraAnnotations:
+        sidecar.istio.io/inject: "false"
+EOF
 
-kubectl patch gateway inference-gateway -n "$NAMESPACE" --type='json' \
-  -p='[{"op": "replace", "path": "/spec/gatewayClassName", "value": "kgateway"}]'
+kubectl apply -n "$NAMESPACE" -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: inference-gateway
+spec:
+  gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: inference-gateway-params
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+EOF

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -43,7 +43,6 @@ cd deploy/inference-gateway
 export NAMESPACE=my-model # You can put the inference gateway into another namespace and then adjust your http-route.yaml
 ./scripts/install_gaie_crd_kgateway.sh
 ```
-**Note**: The manifest at `config/manifests/gateway/agentgateway/gateway.yaml` uses `gatewayClassName: agentgateway`, but kGateway's helm chart creates a GatewayClass named `kgateway`. The patch command in the script fixes this mismatch.
 
 #### f. Verify the Gateway is running
 

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -321,6 +321,43 @@ spec:
 
 If you are **not** using the Dynamo operator's Helm chart, you must create this `DestinationRule` manually for each EPP service. Without it, Istio's default mTLS policy will conflict with the EPP's gRPC TLS endpoint.
 
+**Inference-gateway Istio sidecar exclusion**
+
+When namespace-level Istio sidecar injection is enabled (`istio-injection=enabled`), the kgateway-proxy pod also receives an Istio sidecar. This sidecar intercepts the ext_proc gRPC connection from kgateway-proxy to EPP (port 9002) and routes it through `PassthroughCluster`, which breaks the connection and causes all inference requests to return HTTP 500 with an empty body.
+
+The `install_gaie_crd_kgateway.sh` script handles this automatically by creating a kgateway `GatewayParameters` resource in the same namespace as the `inference-gateway` Gateway. The resource sets `sidecar.istio.io/inject: "false"` on the kgateway-proxy pod template:
+
+```yaml
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: inference-gateway-params
+  # Must be in the same namespace as the inference-gateway Gateway
+  # because Gateway API's infrastructure.parametersRef is a
+  # LocalParametersReference (no namespace field).
+spec:
+  kube:
+    podTemplate:
+      extraAnnotations:
+        sidecar.istio.io/inject: "false"
+```
+
+The `inference-gateway` Gateway references this `GatewayParameters` via `spec.infrastructure.parametersRef`, so kgateway applies the annotation to every kgateway-proxy pod it creates for this gateway. The annotation is a no-op on clusters where Istio is not installed.
+
+If you set up the inference-gateway manually (without the install script), apply the `GatewayParameters` above to the Gateway's namespace and reference it from your Gateway:
+
+```yaml
+spec:
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: inference-gateway-params
+```
+
+> [!NOTE]
+> With both the `DestinationRule` (for EPP) and the `GatewayParameters` sidecar exclusion (for kgateway-proxy) in place, end-to-end GAIE inference works correctly under Istio namespace-level injection.
+
 ### 6. Verify Installation ###
 
 Check that all resources are properly deployed:

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -325,35 +325,109 @@ If you are **not** using the Dynamo operator's Helm chart, you must create this 
 
 When namespace-level Istio sidecar injection is enabled (`istio-injection=enabled`), the kgateway-proxy pod also receives an Istio sidecar. This sidecar intercepts the ext_proc gRPC connection from kgateway-proxy to EPP (port 9002) and routes it through `PassthroughCluster`, which breaks the connection and causes all inference requests to return HTTP 500 with an empty body.
 
-The `install_gaie_crd_kgateway.sh` script handles this automatically by creating a kgateway `GatewayParameters` resource in the same namespace as the `inference-gateway` Gateway. The resource sets `sidecar.istio.io/inject: "false"` on the kgateway-proxy pod template:
+The fix is to tell kgateway to stamp `sidecar.istio.io/inject: "false"` on the kgateway-proxy pod template so the Istio webhook skips that pod. EPP and worker pods still receive sidecars normally.
 
-```yaml
-apiVersion: gateway.kgateway.dev/v1alpha1
-kind: GatewayParameters
-metadata:
-  name: inference-gateway-params
-  # Must be in the same namespace as the inference-gateway Gateway
-  # because Gateway API's infrastructure.parametersRef is a
-  # LocalParametersReference (no namespace field).
-spec:
-  kube:
-    podTemplate:
-      extraAnnotations:
-        sidecar.istio.io/inject: "false"
+You have two options to apply the annotation depending on how you installed kgateway:
+
+***Option A: Per-gateway `GatewayParameters` (recommended)***
+
+This is what `install_gaie_crd_kgateway.sh` does automatically. It only affects the `inference-gateway` proxy pods and leaves any other kgateway-managed gateways untouched.
+
+1. Create a `GatewayParameters` resource in **the same namespace as the `inference-gateway` Gateway** (e.g. `dynamo-cloud`). The `GatewayParameters` must be co-located with the `Gateway` because the Gateway API `spec.infrastructure.parametersRef` is a `LocalParametersReference` — it has no `namespace` field.
+
+   ```yaml
+   apiVersion: gateway.kgateway.dev/v1alpha1
+   kind: GatewayParameters
+   metadata:
+     name: inference-gateway-params
+     namespace: dynamo-cloud   # same as the Gateway
+   spec:
+     kube:
+       podTemplate:
+         extraAnnotations:
+           sidecar.istio.io/inject: "false"
+   ```
+
+2. Wire the existing `Gateway` to use it. If the Gateway already exists, patch it in place:
+
+   ```bash
+   kubectl patch gateway inference-gateway -n dynamo-cloud --type='merge' -p '{
+     "spec": {
+       "infrastructure": {
+         "parametersRef": {
+           "group": "gateway.kgateway.dev",
+           "kind":  "GatewayParameters",
+           "name":  "inference-gateway-params"
+         }
+       }
+     }
+   }'
+   ```
+
+   Or include the `infrastructure` block directly in your `Gateway` manifest:
+
+   ```yaml
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: Gateway
+   metadata:
+     name: inference-gateway
+     namespace: dynamo-cloud
+   spec:
+     gatewayClassName: kgateway
+     infrastructure:
+       parametersRef:
+         group: gateway.kgateway.dev
+         kind: GatewayParameters
+         name: inference-gateway-params
+     listeners:
+       - name: http
+         port: 80
+         protocol: HTTP
+   ```
+
+3. kgateway will roll the proxy pod. Verify the new pod no longer has an `istio-proxy` container:
+
+   ```bash
+   kubectl get pod -l gateway.networking.k8s.io/gateway-name=inference-gateway \
+     -n dynamo-cloud \
+     -o jsonpath='{.items[0].spec.containers[*].name}{"\n"}'
+   # Expect: kgateway-proxy   (NOT "kgateway-proxy istio-proxy")
+   ```
+
+***Option B: Patch the default `GatewayParameters` CR (cluster-wide)***
+
+If you want every kgateway-managed proxy in the cluster (not just `inference-gateway`) to skip the Istio sidecar, edit the default `GatewayParameters` resource that the kgateway controller creates in `kgateway-system` at install time. Any `Gateway` that does not set `spec.infrastructure.parametersRef` falls back to this default.
+
+> [!WARNING]
+> The kgateway v2.1.1 Helm chart does not yet expose proxy `podTemplate.extraAnnotations` as a Helm value (tracked upstream in [kgateway-dev/kgateway#10696](https://github.com/kgateway-dev/kgateway/issues/10696)), so this annotation cannot be set via `helm install --set` for v2.1.1 today. Editing the default `GatewayParameters` directly is the only cluster-wide path that works on v2.1.1. The kgateway documentation cautions that manual edits to the default `GatewayParameters` may be overwritten on Helm upgrade — re-apply the patch after upgrading kgateway, or switch to Option A for a per-gateway fix that survives upgrades.
+
+Patch the default resource in place:
+
+```bash
+kubectl patch gatewayparameters kgateway -n kgateway-system --type='merge' -p '{
+  "spec": {
+    "kube": {
+      "podTemplate": {
+        "extraAnnotations": {
+          "sidecar.istio.io/inject": "false"
+        }
+      }
+    }
+  }
+}'
 ```
 
-The `inference-gateway` Gateway references this `GatewayParameters` via `spec.infrastructure.parametersRef`, so kgateway applies the annotation to every kgateway-proxy pod it creates for this gateway. The annotation is a no-op on clusters where Istio is not installed.
+After patching, restart any existing kgateway-proxy pods (or recreate the `Gateway`) so they are re-provisioned with the new annotation:
 
-If you set up the inference-gateway manually (without the install script), apply the `GatewayParameters` above to the Gateway's namespace and reference it from your Gateway:
-
-```yaml
-spec:
-  infrastructure:
-    parametersRef:
-      group: gateway.kgateway.dev
-      kind: GatewayParameters
-      name: inference-gateway-params
+```bash
+kubectl rollout restart deployment \
+  -l gateway.networking.k8s.io/gateway-name=inference-gateway \
+  -n dynamo-cloud
 ```
+
+This affects **all** kgateway-managed proxies in the cluster. Choose Option A unless you have only one `Gateway` in the cluster, or you genuinely want every kgateway proxy excluded from the mesh.
+
+The annotation is a no-op on clusters where Istio is not installed, so it is safe to set unconditionally.
 
 > [!NOTE]
 > With both the `DestinationRule` (for EPP) and the `GatewayParameters` sidecar exclusion (for kgateway-proxy) in place, end-to-end GAIE inference works correctly under Istio namespace-level injection.


### PR DESCRIPTION
When namespace-level Istio injection (istio-injection=enabled) is active, the kgateway-proxy pod receives an Istio sidecar that intercepts the ext_proc gRPC connection to EPP (port 9002) through PassthroughCluster, returning HTTP 500 for all inference requests.

install_gaie_crd_kgateway.sh now creates a kgateway GatewayParameters resource in the inference-gateway's namespace with sidecar.istio.io/inject: "false" set in spec.kube.podTemplate.extraAnnotations, and creates the inference-gateway Gateway inline (in place of the upstream agentgateway gateway.yaml + patch) with spec.infrastructure.parametersRef pointing at the new GatewayParameters. Gateway API's parametersRef is a LocalParametersReference (no namespace field), so the GatewayParameters lives in the Gateway's namespace.

This prevents the Istio sidecar from being injected into kgateway-proxy pods while remaining a no-op on clusters without Istio. It complements the DestinationRule auto-generation added for EPP in PR #8270: both pieces are required for end-to-end GAIE inference under namespace-level Istio sidecar injection.

Update docs/kubernetes/inference-gateway.md to explain the sidecar exclusion mechanism and provide manual setup instructions.

Fixes: [DYN-3077](https://linear.app/nvidia/issue/DYN-3077/dynamorelease120eppvllmagg-kgateway-istio-sidecar-injection-causes)

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->