### PR TITLE
fix(gms): use DP-adjusted device for vLLM GMS connect

### DIFF
--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -81,6 +81,44 @@ if os.environ.get("MX_ENABLED", "0") == "1":
 from vllm.v1.worker.gpu_worker import Worker  # noqa: E402
 
 
+def _get_dp_adjusted_local_rank(local_rank: int, parallel_config) -> int:
+    """Return the CUDA device index vLLM will use for this worker.
+
+    vLLM adjusts ``self.local_rank`` inside ``Worker.init_device()`` for
+    intra-node data parallelism so that every local DP engine lands on a
+    different GPU:
+
+        DP_LOCAL_RANK * TP_PP_WORLD_SIZE + TP_LOCAL_RANK
+
+    GMS intentionally connects before ``super().init_device()`` because the
+    initial vLLM ``MemorySnapshot`` needs GMS-aware committed-byte accounting.
+    That means GMS cannot observe vLLM's in-place local-rank adjustment yet, so
+    duplicate the upstream calculation here and use it only for the early GMS
+    socket/device selection.
+
+    TODO: add an upstream vLLM hook/API that exposes the resolved CUDA device
+    before the initial MemorySnapshot, then replace this duplicated vLLM logic.
+    """
+    adjusted_local_rank = local_rank
+    if (
+        parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
+        and parallel_config.data_parallel_backend != "ray"
+        and parallel_config.nnodes_within_dp == 1
+    ):
+        # Use local DP rank if available, otherwise use global DP rank.
+        dp_local_rank = parallel_config.data_parallel_rank_local
+        if dp_local_rank is None:
+            dp_local_rank = parallel_config.data_parallel_index
+
+        tp_pp_world_size = (
+            parallel_config.pipeline_parallel_size
+            * parallel_config.tensor_parallel_size
+        )
+        adjusted_local_rank += dp_local_rank * tp_pp_world_size
+
+    return adjusted_local_rank
+
+
 class GMSWorker(Worker):
     """vLLM Worker subclass with GMS integration."""
 
@@ -92,8 +130,9 @@ class GMSWorker(Worker):
         """
         from vllm.platforms import current_platform
 
-        # Set CUDA device first (vLLM provides self.local_rank)
-        device = self.local_rank
+        # Set CUDA device first. Do not mutate self.local_rank here; the parent
+        # Worker will apply the same DP adjustment during super().init_device().
+        device = _get_dp_adjusted_local_rank(self.local_rank, self.parallel_config)
         current_platform.set_device(torch.device(f"cuda:{device}"))
 
         # Establish weights GMS connection (so MemorySnapshot can query committed bytes).


### PR DESCRIPTION
#### Overview:

vLLM adjusts the CUDA device for intra-node data parallel workers inside `Worker.init_device()`. The GMS vLLM worker needs to connect to GMS before calling `super().init_device()` so vLLM's initial `MemorySnapshot` uses GMS-aware memory accounting. With DP=2, the early GMS connection was still using the unadjusted `local_rank`, so both DP workers could select the same GMS/CUDA device and rank 0 could hang before distributed init.

This PR mirrors vLLM's DP-adjusted local-rank calculation before the early GMS connection, while leaving vLLM to perform its normal `self.local_rank` mutation later in `super().init_device()`.

#### Details:

- Add a small helper to compute the CUDA device vLLM will assign for local DP workers.
- Use that helper for the pre-`super().init_device()` GMS socket/device selection.
- Add a TODO noting that this duplicated vLLM logic should be replaced with an upstream vLLM hook/API that exposes the resolved CUDA device before the initial `MemorySnapshot`.

Validation:
- `python3 -m py_compile lib/gpu_memory_service/integrations/vllm/worker.py`
- Build-on-demand vLLM runtime succeeded: https://github.com/ai-dynamo/dynamo/actions/runs/26243585561
- Deployed `Qwen/Qwen3-30B-A3B` with `--load-format gms --data-parallel-size 2 --data-parallel-size-local 2` on nscale-dev DRA B200 node `s2877`; DGD became Ready and served a `/v1/chat/completions` request.

#### Where should the reviewer start?

`lib/gpu_memory_service/integrations/vllm/worker.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CUDA device mapping in data-parallel distributed training configurations to ensure proper device assignment during GPU memory service initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->