### PR TITLE
fix(sglang): restore NetworkAddress compat shim for dsv4 base image

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -16,7 +16,9 @@ fallback and any associated polyfills.
 """
 
 import inspect
+import ipaddress
 import logging
+import socket
 from functools import lru_cache
 from typing import Any
 
@@ -103,6 +105,94 @@ def filter_supported_async_generate_kwargs(
     return {key: value for key, value in kwargs.items() if key in supported_kwarg_names}
 
 
+# ---------------------------------------------------------------------------
+# Network utilities: NetworkAddress, get_local_ip_auto, get_zmq_socket
+#
+# Canonical: sglang.srt.utils.network (0.5.10 release + 0.5.11+).
+#
+# Fallback covers the SGLang dsv4 base snapshot (sglang.__version__ ==
+# 0.5.10rc0, sglang/__init__.py from commit 6d0858d2a8) shipped as
+# lmsysorg/sglang:deepseek-v4-blackwell, where `sglang.srt.utils` is a
+# package whose __init__ is just `from sglang.srt.utils.common import *`:
+# get_local_ip_auto / get_zmq_socket reach us via the wildcard re-export
+# from common, but NetworkAddress does not exist yet anywhere in that tree
+# so we polyfill it.
+#
+# Remove when min supported SGLang base ships sglang.srt.utils.network.
+# ---------------------------------------------------------------------------
+try:
+    from sglang.srt.utils.network import (  # noqa: F401
+        NetworkAddress,
+        get_local_ip_auto,
+        get_zmq_socket,
+    )
+except ImportError:
+    from sglang.srt.utils import (  # type: ignore[no-redef]  # noqa: F401
+        get_local_ip_auto,
+        get_zmq_socket,
+    )
+
+    logger.info(
+        "sglang.srt.utils.network not found; using compatibility shim for "
+        "NetworkAddress (dsv4 sglang 0.5.10rc0 snapshot)"
+    )
+
+    class NetworkAddress:  # type: ignore[no-redef]
+        """Minimal polyfill for sglang.srt.utils.network.NetworkAddress."""
+
+        def __init__(self, host: str, port: int) -> None:
+            self.host = host
+            self.port = port
+
+        @property
+        def is_ipv6(self) -> bool:
+            try:
+                ipaddress.IPv6Address(self.host)
+                return True
+            except ValueError:
+                return False
+
+        @classmethod
+        def parse(cls, addr: str) -> "NetworkAddress":
+            """Parse 'host:port', '[IPv6]:port', or bare host."""
+            addr = addr.strip()
+            if addr.startswith("["):
+                end = addr.find("]")
+                host = addr[1:end] if end != -1 else addr.strip("[]")
+                rest = addr[end + 1 :] if end != -1 else ""
+                if rest.startswith(":") and rest[1:].isdigit():
+                    return cls(host, int(rest[1:]))
+                return cls(host, 0)
+            if addr.count(":") == 1:
+                host_part, port_part = addr.rsplit(":", 1)
+                if port_part.isdigit():
+                    return cls(host_part, int(port_part))
+            return cls(addr, 0)
+
+        def resolved(self) -> "NetworkAddress":
+            """DNS-resolve the host, preserving port."""
+            try:
+                infos = socket.getaddrinfo(
+                    self.host, None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+                )
+                resolved_ip = infos[0][4][0]
+                return NetworkAddress(resolved_ip, self.port)
+            except socket.gaierror:
+                return self
+
+        def to_host_port_str(self) -> str:
+            """Return '[IPv6]:port' or 'host:port'."""
+            if self.is_ipv6:
+                return f"[{self.host}]:{self.port}"
+            return f"{self.host}:{self.port}"
+
+        def to_tcp(self) -> str:
+            """Return 'tcp://[IPv6]:port' or 'tcp://host:port'."""
+            if self.is_ipv6:
+                return f"tcp://[{self.host}]:{self.port}"
+            return f"tcp://{self.host}:{self.port}"
+
+
 def get_scheduler_info(engine: Any) -> dict:
     """Return the scheduler-info dict for rank-0 of an ``sgl.Engine``.
 
@@ -146,8 +236,11 @@ def enable_disjoint_streaming_output(server_args: Any) -> None:
 
 
 __all__ = [
+    "NetworkAddress",
     "enable_disjoint_streaming_output",
     "ensure_sglang_top_level_exports",
     "filter_supported_async_generate_kwargs",
+    "get_local_ip_auto",
     "get_scheduler_info",
+    "get_zmq_socket",
 ]

--- a/components/src/dynamo/sglang/_disagg.py
+++ b/components/src/dynamo/sglang/_disagg.py
@@ -37,7 +37,7 @@ SGLANG_WORKER_GROUP_ID_KEY = "sglang_worker_group_id"
 def _network_address_cls():
     # Deferred to function body so pre-commit test collection can import
     # `_disagg` without the SGLang network helper available.
-    from sglang.srt.utils.network import NetworkAddress
+    from dynamo.sglang._compat import NetworkAddress
 
     return NetworkAddress
 
@@ -54,7 +54,7 @@ def compute_bootstrap_address(
     """
     # Deferred to function body so pre-commit test collection can import
     # `_disagg` without sglang installed.
-    from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
+    from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto
 
     try:
         inner_tm = engine.tokenizer_manager

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -22,7 +22,6 @@ import sglang as sgl
 import zmq
 import zmq.asyncio
 from sglang.srt.disaggregation.kv_events import ZmqEventPublisher
-from sglang.srt.utils.network import get_local_ip_auto, get_zmq_socket
 
 from dynamo._core import Context
 from dynamo.common.backend import telemetry
@@ -43,7 +42,7 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.llm import ModelInput
-from dynamo.sglang._compat import get_scheduler_info
+from dynamo.sglang._compat import get_local_ip_auto, get_scheduler_info, get_zmq_socket
 from dynamo.sglang._disagg import (
     SGLANG_WORKER_GROUP_ID_KEY,
     compute_bootstrap_address,

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -13,7 +13,6 @@ import sglang as sgl
 import zmq
 import zmq.asyncio
 from sglang.srt.disaggregation.kv_events import ZmqEventPublisher
-from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto, get_zmq_socket
 
 if TYPE_CHECKING:
     from prometheus_client import CollectorRegistry
@@ -24,6 +23,7 @@ from dynamo.common.utils.prometheus import (
 )
 from dynamo.llm import KvEventPublisher, WorkerMetricsPublisher
 from dynamo.runtime import Endpoint
+from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto, get_zmq_socket
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import Config
 

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -24,7 +24,6 @@ from typing import (
 )
 
 import sglang as sgl
-from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
@@ -41,6 +40,7 @@ from dynamo.llm import (
 )
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
+from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 


### PR DESCRIPTION
## Summary

- PR #9230 ("bump to 0.5.11 and prune 0.5.9 fallbacks in `_compat`") pruned the `NetworkAddress` / `get_local_ip_auto` / `get_zmq_socket` compatibility shim under the assumption that the supported N−1 base would canonically expose `sglang.srt.utils.network`. The dsv4 SGLang base shipped in [`lmsysorg/sglang:deepseek-v4-blackwell@sha256:940f7652…`](https://hub.docker.com/layers/lmsysorg/sglang/deepseek-v4-blackwell/images/sha256-940f7652dd16b04e82ecc57c4dcb6a3ae7d7283bc38db1ce3c4aa6ae3685c4aa) — which both `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-*` and downstream rebuilds use — is `sglang 0.5.10rc0` at commit `6d0858d2a`, a transitional snapshot where `sglang.srt.utils` is a package whose `__init__.py` is just `from sglang.srt.utils.common import *`. In that tree `get_local_ip_auto`/`get_zmq_socket` reach us via the wildcard, but `sglang.srt.utils.network` doesn't exist and `NetworkAddress` is nowhere in the tree.
- The 1.2.0-rc wheels built after #9230 therefore fail at import time with `ModuleNotFoundError: No module named 'sglang.srt.utils.network'` (first hit is `dynamo/sglang/publisher.py:16`). The 1.2.0-deepseek-v4-cuda12-dev.3 NGC image is unaffected because it was built from `v1.2.0-deepseek-v4-dev.3`, which still had the shim — its log line `INFO _compat.py:128: sglang.srt.utils.network not found (sglang 0.5.9); using compatibility shim for NetworkAddress` is the fallback firing.
- This PR restores the shim in `_compat.py` (canonical import, fallback to `sglang.srt.utils.common` re-exports, minimal `NetworkAddress` polyfill matching what #9230 removed) and reroutes the five direct callers (`publisher.py`, `llm_engine.py`, `_disagg.py` × 2, `request_handlers/handler_base.py`) through `dynamo.sglang._compat`. Comment in `_compat.py` documents exactly which base snapshot the fallback covers and when it can be removed, per the existing policy in `components/src/dynamo/sglang/CLAUDE.md`.

## Test plan

- [x] Verified end-to-end against `lmsysorg/sglang:deepseek-v4-blackwell@sha256:940f7652…` + dynamo 1.2.0 wheels patched with this branch:
  - `python3 -c "from dynamo.sglang.main import main"` → success; shim log line `_compat.py:135: sglang.srt.utils.network not found; using compatibility shim for NetworkAddress (dsv4 sglang 0.5.10rc0 snapshot)` fires.
  - `python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file --mem-fraction-static 0.3 --context-length 4096 --max-running-requests 16 --disable-cuda-graph` reaches `register._register_model_with_runtime_config: Successfully registered LLM with runtime config` and `/v1/models` returns `Qwen/Qwen3-0.6B`.
  - `curl /v1/chat/completions` with `model: Qwen/Qwen3-0.6B` returns a chat completion.
- [ ] Pre-merge CI on canonical `lmsysorg/sglang:v0.5.10.post1-runtime` / `v0.5.11+` (try-branch covers the canonical path — those have `sglang.srt.utils.network`, so the canonical import in `_compat.py` is exercised exactly as today).
- [ ] Existing `tests/sglang/test_sglang_publisher.py` monkeypatches `publisher_mod.get_local_ip_auto` and `disagg_mod._network_address_cls` by module attribute — preserved by re-exporting from `_compat` (verified locally that both attributes still resolve).

Closes the import-time regression on the dsv4 base; unblocks 1.2.0-rc wheels in custom dsv4 rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated network utility dependencies through an internal compatibility layer to enhance system resilience and improve support for varying versions of external dependencies across system components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->