### PR TITLE
fix(ci): raise sglang completions_only KV cap; add CI guideline for validating test fixes

### DIFF
--- a/.ai/ci-guidelines.md
+++ b/.ai/ci-guidelines.md
@@ -12,7 +12,9 @@ has already merged.
 When the PR exists to fix a failing or quarantined test:
 
 1. **Promote** the test's scheduling marker to `pytest.mark.pre_merge`,
-   replacing the original.
+   replacing the original. If the test is quarantined via
+   `@pytest.mark.skip(...)` / `@pytest.mark.skipif(...)`, remove (or narrow)
+   the skip in the same commit — otherwise the promotion is a no-op.
 2. **Annotate** with a `TODO` next to the marker:
    ```python
    # TODO: revert to pytest.mark.post_merge after pre_merge validation
@@ -20,8 +22,9 @@ When the PR exists to fix a failing or quarantined test:
    pytest.mark.pre_merge,
    ```
 3. **Verify** the promoted test passed in the PR's CI.
-4. **Revert** the marker back in a follow-up commit on the same PR before
-   merging. Both commits ship in one PR — splitting them loses the signal.
+4. **Revert** the marker back (and reinstate any quarantine skip that
+   should stay) in a follow-up commit on the same PR before merging. Both
+   commits ship in one PR — splitting them loses the signal.
 
 Skip this for unrelated refactors that incidentally touch a non-pre-merge
 test (formatting, imports, type hints).
@@ -29,5 +32,16 @@ test (formatting, imports, type hints).
 ### Reviewer checklist
 
 - Non-`pre_merge` test touched → temporary promotion present with `TODO`.
-- Final commit reverts the marker back.
-- The promoted run is green on the SHA being merged.
+- A revert commit on this same PR restores the original marker (and any
+  quarantine skip) before merge.
+- The promoted run was green on the commit immediately before the revert
+  (by construction, the SHA being merged no longer carries the promotion).
+- Withhold final approval until the revert commit lands — or re-approve
+  explicitly after it does. Squash-merging an already-approved PR with the
+  promotion still active reintroduces exactly the gap this flow closes.
+
+### Future hardening
+
+A lint check that fails when `pytest.mark.pre_merge` appears next to a
+`# TODO: revert to` comment would make step 4 enforceable rather than
+process-dependent. Out of scope for this doc; track as a follow-up.

--- a/.ai/ci-guidelines.md
+++ b/.ai/ci-guidelines.md
@@ -1,0 +1,33 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# CI Guidelines
+
+## Validating test fixes in the same PR
+
+Pre-merge CI only runs tests marked `pre_merge`. A fix to a `post_merge`,
+`nightly`, `weekly`, or `release` test is otherwise unverified until the PR
+has already merged.
+
+When the PR exists to fix a failing or quarantined test:
+
+1. **Promote** the test's scheduling marker to `pytest.mark.pre_merge`,
+   replacing the original.
+2. **Annotate** with a `TODO` next to the marker:
+   ```python
+   # TODO: revert to pytest.mark.post_merge after pre_merge validation
+   # on this PR (see .ai/ci-guidelines.md).
+   pytest.mark.pre_merge,
+   ```
+3. **Verify** the promoted test passed in the PR's CI.
+4. **Revert** the marker back in a follow-up commit on the same PR before
+   merging. Both commits ship in one PR — splitting them loses the signal.
+
+Skip this for unrelated refactors that incidentally touch a non-pre-merge
+test (formatting, imports, type hints).
+
+### Reviewer checklist
+
+- Non-`pre_merge` test touched → temporary promotion present with `TODO`.
+- Final commit reverts the marker back.
+- The promoted run is green on the SHA being merged.

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -628,9 +628,7 @@ sglang_configs = {
             # max_total_tokens (bisected ~1040 for these payloads). Matches
             # the "aggregated" config above.
             pytest.mark.timeout(341),  # profiled 57s on RTX 6000 Ada
-            # TODO: revert to pytest.mark.post_merge after pre_merge validation
-            # on this PR (see .ai/ci-guidelines.md).
-            pytest.mark.pre_merge,
+            pytest.mark.post_merge,
         ],
         model="deepseek-ai/deepseek-llm-7b-base",
         script_args=[

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -619,13 +619,18 @@ sglang_configs = {
         marks=[
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(
-                14.7
-            ),  # actual peak at recommended token count
+                15.7
+            ),  # ~14.7 weights + ~1 GiB for 2048-token KV cache on deepseek-llm-7b
             pytest.mark.requested_sglang_kv_tokens(
-                64
-            ),  # KV cache cap (2x safety over min=32)
+                2048
+            ),  # >= prompt(~16) + max_tokens(1000) + scheduler reserve;
+            # SGLang 0.5.11 silently hangs when prompt+max_tokens nears
+            # max_total_tokens (bisected ~1040 for these payloads). Matches
+            # the "aggregated" config above.
             pytest.mark.timeout(341),  # profiled 57s on RTX 6000 Ada
-            pytest.mark.post_merge,
+            # TODO: revert to pytest.mark.post_merge after pre_merge validation
+            # on this PR (see .ai/ci-guidelines.md).
+            pytest.mark.pre_merge,
         ],
         model="deepseek-ai/deepseek-llm-7b-base",
         script_args=[


### PR DESCRIPTION
Closes: OPS-5105

## Summary

- Fixes the recurring post-merge failure of `tests/serve/test_sglang.py::test_sglang_deployment[completions_only-2]` on `sglang-runtime / Test cuda12.9, amd64` (and cuda13.0). The `/v1/completions` POST times out at 60s because SGLang 0.5.11 silently hangs when `prompt + max_tokens` nears `max_total_tokens`, and the config caps `requested_sglang_kv_tokens` at 64 against a payload that asks for `max_tokens=1000`.
- Raises the cap to 2048 (matching the sibling `aggregated` config, whose comments document the bisected hang threshold of ~1040) and bumps `profiled_vram_gib` from 14.7 → 15.7 to cover the extra ~1 GiB of KV cache on the 7B model.
- Adds `.ai/ci-guidelines.md` codifying the temp-promote-then-revert flow so future test fixes are actually exercised by the PR's CI before merge.

## Temporary `pre_merge` promotion (must be reverted before merge)

Per the new guideline added in this PR, the `completions_only` config is temporarily marked `pytest.mark.pre_merge` (instead of `post_merge`) so this PR's CI runs the fix. The marker carries an inline `TODO` and must be reverted to `post_merge` in a follow-up commit on this same PR before it merges.

## Test plan

- [ ] Pre-merge CI runs `test_sglang_deployment[completions_only-2]` against `deepseek-ai/deepseek-llm-7b-base` and it passes on both cuda12.9 and cuda13.0 amd64.
- [ ] Confirm `profiled_vram_gib(15.7)` fits the runner's VRAM budget (RTX 6000 Ada / L4 tier).
- [ ] Final commit on this PR reverts the marker back to `pytest.mark.post_merge`.
- [ ] Reviewer skims `.ai/ci-guidelines.md` for the temp-promote flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CI guidelines documentation for handling test fixes in pull requests, including procedures for temporarily adjusting test scheduling markers during development and validation, with reviewer checklists to ensure compliance.

* **Tests**
  * Updated test configuration parameters to reflect adjusted resource requirements and modified scheduling settings for improved test execution and resource allocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->