### PR TITLE
fix(global-router): Allow passing target ttft and itl

### DIFF
--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -242,19 +242,21 @@ In disaggregated mode, prefill and decode retry are independent. A prefill failu
 
 ### Passing SLA Targets
 
-Clients can pass TTFT and ITL targets via `extra_args` in the request:
+Clients can pass TTFT and ITL targets via `nvext.router` in the request:
 
 ```json
 {
     "messages": [...],
-    "extra_args": {
-        "ttft_target": 100,
-        "itl_target": 20
+    "nvext": {
+        "router": {
+            "ttft_target": 100,
+            "itl_target": 20
+        }
     }
 }
 ```
 
-If not provided, the middle of the configured range is used as default. For disagg mode, `ttft_target` drives prefill pool selection and `itl_target` drives decode pool selection. For agg mode, both `ttft_target` and `itl_target` drive pool selection.
+The preprocessor forwards `nvext.router` to the backend as the typed `router` field on `PreprocessedRequest`. If not provided, the middle of the configured range is used as default. For disagg mode, `ttft_target` drives prefill pool selection and `itl_target` drives decode pool selection. For agg mode, both `ttft_target` and `itl_target` drive pool selection.
 
 ## Request Flow
 

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -222,9 +222,13 @@ class GlobalRouterHandler:
         token_ids = request.get("token_ids", [])
         isl = len(token_ids)
 
-        # Extract TTFT target from extra_args if provided, fallback to CLI default
-        extra_args = request.get("extra_args") or {}
-        ttft_target_ms = extra_args.get("ttft_target") or self.default_ttft_target_ms
+        # Extract TTFT target from nvext.router (forwarded by the preprocessor
+        # as the `router` field on PreprocessedRequest), fallback to CLI default.
+        # Use `is None` to preserve explicit 0 (routes to the fastest bucket).
+        router_params = request.get("router") or {}
+        ttft_target_ms = router_params.get("ttft_target")
+        if ttft_target_ms is None:
+            ttft_target_ms = self.default_ttft_target_ms
 
         # Extract priority from routing hints (set by nvext.agent_hints.priority)
         routing = request.get("routing") or {}
@@ -278,9 +282,10 @@ class GlobalRouterHandler:
         # TODO: predict OSL based on ISL
         context_length = len(token_ids)
 
-        # Extract ITL target from extra_args if provided, fallback to CLI default
-        extra_args = request.get("extra_args") or {}
-        itl_target_ms = extra_args.get("itl_target") or self.default_itl_target_ms
+        router_params = request.get("router") or {}
+        itl_target_ms = router_params.get("itl_target")
+        if itl_target_ms is None:
+            itl_target_ms = self.default_itl_target_ms
 
         # Extract priority from routing hints (set by nvext.agent_hints.priority)
         routing = request.get("routing") or {}
@@ -330,13 +335,14 @@ class GlobalRouterHandler:
         assert self.config.agg_pool_selection_strategy is not None
         assert self.config.agg_pool_dynamo_namespaces is not None
 
-        # Extract SLA targets from extra_args, fallback to CLI defaults.
+        # Extract SLA targets from nvext.router (forwarded by the preprocessor
+        # as the `router` field on PreprocessedRequest), fallback to CLI defaults.
         # Use `is None` checks to preserve explicit 0 values.
-        extra_args = request.get("extra_args") or {}
-        ttft_target_ms = extra_args.get("ttft_target")
+        router_params = request.get("router") or {}
+        ttft_target_ms = router_params.get("ttft_target")
         if ttft_target_ms is None:
             ttft_target_ms = self.default_ttft_target_ms
-        itl_target_ms = extra_args.get("itl_target")
+        itl_target_ms = router_params.get("itl_target")
         if itl_target_ms is None:
             itl_target_ms = self.default_itl_target_ms
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -465,6 +465,12 @@ impl OpenAIPreprocessor {
             .with_label_values(&[STAGE_PREPROCESS])
             .observe(preprocess_start.elapsed().as_secs_f64());
 
+        if let Some(nvext) = request.nvext()
+            && let Some(router_params) = &nvext.router
+        {
+            builder.router(Some(router_params.clone()));
+        }
+
         Ok((builder.build()?, annotations, prompt_injected_reasoning))
     }
 

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -10,12 +10,28 @@ use dynamo_kv_router::{
     protocols::{BlockExtraInfo, RoutingConstraints, WorkerId},
 };
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::timing::RequestTracker;
 use super::{OutputOptions, SamplingOptions, StopConditions};
 use crate::agents::context::AgentContext;
 use crate::preprocessor::media::RdmaMediaDataDescriptor;
 use crate::protocols::TokenIdType;
+
+/// Router-specific parameters carried via `nvext.router`.
+///
+/// Consumed by router implementations such as the global router for
+/// hierarchical pool selection. Unknown to engines/backends.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub struct RouterParams {
+    /// Target time-to-first-token in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttft_target: Option<f64>,
+
+    /// Target inter-token latency in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub itl_target: Option<f64>,
+}
 
 /// Routing hints for directing requests to specific workers.
 /// These fields are extracted from nvext and used by the router to determine
@@ -223,6 +239,13 @@ pub struct PreprocessedRequest {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_args: Option<serde_json::Value>,
+
+    /// Router-specific parameters forwarded from `nvext.router`.
+    /// Consumed by router implementations (e.g. the global router) and ignored
+    /// by engines/backends.
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router: Option<RouterParams>,
 
     /// Optional agent identity metadata forwarded from nvext.
     #[builder(default)]

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -412,7 +412,14 @@ pub struct NvExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(value_type = RoutingConstraintsSchema)]
     pub routing_constraints: Option<RoutingConstraints>,
+
+    /// Parameters forwarded to global router .
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router: Option<RouterParams>,
 }
+
+pub use crate::protocols::common::preprocessor::RouterParams;
 
 /// Hints from the agent/caller about request characteristics.
 #[derive(ToSchema, Serialize, Deserialize, Builder, Debug, Clone, Default, PartialEq)]


### PR DESCRIPTION
The original PR https://github.com/ai-dynamo/dynamo/pull/5697 documented an `extra_args` field in the request that could have two global router config fields.

That never worked because we reject unknown HTTP request fields. It was also too generic a name (`extra_args` for what?).

This PR puts moves it to `nvext`, which we allow on the request, in a `router` sub-field. The schema of that is checked at de-serialize time.

Fixes QA bug DYN-2783.

Assisted-By: Claude Opus 4.7

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SLA routing targets documentation to reflect new request parameter mechanism and backend forwarding behavior.

* **New Features**
  * SLA timing targets (TTFT/ITL) now forwarded to the routing backend via request parameters, enabling optimized pool selection for both disaggregated and aggregated modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->