### PR TITLE
fix(snapshot): fail checkpoint jobs on helper container errors

### DIFF
--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -212,6 +212,24 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 
+	if failed := failedRegularContainer(pod); failed != nil {
+		term := failed.State.Terminated
+		message := fmt.Sprintf("Checkpoint container %q terminated with exit code %d", failed.Name, term.ExitCode)
+		if term.Reason != "" {
+			message = fmt.Sprintf("%s: %s", message, term.Reason)
+		}
+		opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container", failed.Name)
+		opLog.Info("Checkpoint pod container failed", "exit_code", term.ExitCode, "reason", term.Reason)
+		emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", message)
+		if err := annotateJob(ctx, w.clientset, opLog, job, map[string]string{
+			snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusFailed,
+		}); err != nil {
+			opLog.Error(err, "Failed to mark checkpoint job failed")
+		}
+		w.killRunningCheckpointContainers(ctx, pod, fmt.Sprintf("checkpoint container %s failed", failed.Name))
+		return
+	}
+
 	// Checkpoint contract: exactly one target container per job.
 	targets, err := snapshotprotocol.TargetContainersFromAnnotations(pod.Annotations, 1, 1)
 	if err != nil {
@@ -375,6 +393,34 @@ func restoreContainerResolveAttemptContext(ctx context.Context, deadlineAt time.
 		attemptDeadline = deadlineAt
 	}
 	return context.WithDeadline(ctx, attemptDeadline)
+}
+
+func failedRegularContainer(pod *corev1.Pod) *corev1.ContainerStatus {
+	for i := range pod.Status.ContainerStatuses {
+		term := pod.Status.ContainerStatuses[i].State.Terminated
+		if term != nil && term.ExitCode != 0 {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	return nil
+}
+
+func (w *NodeController) killRunningCheckpointContainers(ctx context.Context, pod *corev1.Pod, reason string) {
+	log := w.log.WithValues("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Running == nil || status.ContainerID == "" {
+			continue
+		}
+		containerID := snapshotruntime.StripCRIScheme(status.ContainerID)
+		pid, _, err := w.runtime.ResolveContainer(ctx, containerID)
+		if err != nil {
+			log.Error(err, "Failed to resolve running checkpoint container", "container", status.Name)
+			continue
+		}
+		if err := snapshotruntime.SendSignalToPID(log, pid, syscall.SIGKILL, reason); err != nil {
+			log.Error(err, "Failed to signal running checkpoint container", "container", status.Name)
+		}
+	}
 }
 
 func (w *NodeController) startRestoreForContainer(

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -30,12 +30,14 @@ const testContainerID = "test-container"
 // fakeRuntime is a minimal Runtime implementation for controller reconciliation
 // tests.
 type fakeRuntime struct {
-	containerIDByPod string
+	containerIDByPod     string
+	resolvedContainerIDs []string
 }
 
 var _ snapshotruntime.Runtime = (*fakeRuntime)(nil)
 
 func (r *fakeRuntime) ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error) {
+	r.resolvedContainerIDs = append(r.resolvedContainerIDs, id)
 	return 0, nil, errors.New("not implemented")
 }
 func (r *fakeRuntime) ResolveContainerIDByPod(ctx context.Context, pod, ns, ctr string) (string, error) {
@@ -452,6 +454,73 @@ func TestReconcileCheckpointPod(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		})
+	}
+}
+
+func TestReconcileCheckpointPodFailsWhenAnyRegularContainerFails(t *testing.T) {
+	labels := map[string]string{
+		snapshotprotocol.CheckpointSourceLabel: "true",
+		snapshotprotocol.CheckpointIDLabel:     "abc123",
+		"batch.kubernetes.io/job-name":         "checkpoint-job",
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "checkpoint-job",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+	}
+	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "helper"})
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name:        "main",
+			Ready:       true,
+			State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			ContainerID: "containerd://main-id",
+		},
+		{
+			Name: "helper",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+			},
+			ContainerID: "containerd://helper-id",
+		},
+	}
+
+	w := makeTestController(t, job)
+	rt := &fakeRuntime{}
+	w.runtime = rt
+	w.reconcileCheckpointPod(context.Background(), pod)
+
+	updated, err := w.clientset.BatchV1().Jobs("default").Get(context.Background(), "checkpoint-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get checkpoint job: %v", err)
+	}
+	if got := updated.Annotations[snapshotprotocol.CheckpointStatusAnnotation]; got != snapshotprotocol.CheckpointStatusFailed {
+		t.Fatalf("checkpoint status annotation = %q, want %q", got, snapshotprotocol.CheckpointStatusFailed)
+	}
+
+	var sawFailureEvent bool
+	for _, action := range w.clientset.(*fake.Clientset).Actions() {
+		create, ok := action.(clientgotesting.CreateAction)
+		if !ok || create.GetResource().Resource != "events" {
+			continue
+		}
+		event, ok := create.GetObject().(*corev1.Event)
+		if ok && event.Reason == "CheckpointFailed" && strings.Contains(event.Message, `container "helper"`) {
+			sawFailureEvent = true
+			break
+		}
+	}
+	if !sawFailureEvent {
+		t.Fatalf("expected CheckpointFailed event for failed regular container; actions=%#v", w.clientset.(*fake.Clientset).Actions())
+	}
+	if len(w.inFlight) != 0 {
+		t.Fatalf("failed checkpoint pod should not start snapshot worker, got inFlight=%v", w.inFlight)
+	}
+	if len(rt.resolvedContainerIDs) != 1 || rt.resolvedContainerIDs[0] != "main-id" {
+		t.Fatalf("expected to resolve remaining running container before failing job, got %v", rt.resolvedContainerIDs)
 	}
 }
 


### PR DESCRIPTION
#### Overview:

Make snapshot checkpoint Jobs fail promptly when any regular checkpoint pod container exits non-zero. This prevents multi-container checkpoint Jobs from hanging when a workload/helper container fails while another helper keeps running.

#### Details:

- Detect non-zero regular container termination in the snapshot node controller before starting checkpoint work.
- Mark the checkpoint Job with the snapshot failed annotation and emit a `CheckpointFailed` event.
- SIGKILL remaining running regular containers so kubelet can move the pod/job to a failed terminal state instead of waiting for `activeDeadlineSeconds`.
- Add a controller test for a failed helper container with the target container still running.

Tests:

- `cd deploy/snapshot && go test ./...`

#### Where should the reviewer start?

- `deploy/snapshot/internal/controller/controller.go`
- `deploy/snapshot/internal/controller/controller_test.go`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GMS + Snapshot checkpoint Job testing.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced checkpoint failure handling: the system now detects when containers fail during checkpoint operations, emits failure notifications, and properly cleans up affected checkpoint processes to prevent resource leaks.

* **Tests**
  * Added test coverage for container failure detection during checkpoint operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->