### PR TITLE
fix(snapshot): fail checkpoint jobs on helper container errors

### DIFF
--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -209,7 +209,7 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 	}
 
 	jobStatus := job.Annotations[snapshotprotocol.CheckpointStatusAnnotation]
-	if jobStatus == snapshotprotocol.CheckpointStatusCompleted || jobStatus == snapshotprotocol.CheckpointStatusFailed {
+	if jobStatus == snapshotprotocol.CheckpointStatusFailed {
 		return
 	}
 
@@ -248,6 +248,10 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 				opLog.Error(err, "Failed to signal running checkpoint container", "container", status.Name)
 			}
 		}
+		return
+	}
+
+	if jobStatus == snapshotprotocol.CheckpointStatusCompleted {
 		return
 	}
 

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -212,6 +212,24 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 
+	if failed := failedRegularContainer(pod); failed != nil {
+		term := failed.State.Terminated
+		message := fmt.Sprintf("Checkpoint container %q terminated with exit code %d", failed.Name, term.ExitCode)
+		if term.Reason != "" {
+			message = fmt.Sprintf("%s: %s", message, term.Reason)
+		}
+		opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container", failed.Name)
+		opLog.Info("Checkpoint pod container failed", "exit_code", term.ExitCode, "reason", term.Reason)
+		emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", message)
+		if err := annotateJob(ctx, w.clientset, opLog, job, map[string]string{
+			snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusFailed,
+		}); err != nil {
+			opLog.Error(err, "Failed to mark checkpoint job failed")
+		}
+		w.killRunningCheckpointContainers(ctx, pod, fmt.Sprintf("checkpoint container %s failed", failed.Name))
+		return
+	}
+
 	// Checkpoint contract: exactly one target container per job.
 	targets, err := snapshotprotocol.TargetContainersFromAnnotations(pod.Annotations, 1, 1)
 	if err != nil {
@@ -375,6 +393,34 @@ func restoreContainerResolveAttemptContext(ctx context.Context, deadlineAt time.
 		attemptDeadline = deadlineAt
 	}
 	return context.WithDeadline(ctx, attemptDeadline)
+}
+
+func failedRegularContainer(pod *corev1.Pod) *corev1.ContainerStatus {
+	for i := range pod.Status.ContainerStatuses {
+		term := pod.Status.ContainerStatuses[i].State.Terminated
+		if term != nil && term.ExitCode != 0 {
+			return &pod.Status.ContainerStatuses[i]
+		}
+	}
+	return nil
+}
+
+func (w *NodeController) killRunningCheckpointContainers(ctx context.Context, pod *corev1.Pod, reason string) {
+	log := w.log.WithValues("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.State.Running == nil || status.ContainerID == "" {
+			continue
+		}
+		containerID := snapshotruntime.StripCRIScheme(status.ContainerID)
+		pid, _, err := w.runtime.ResolveContainer(ctx, containerID)
+		if err != nil {
+			log.Error(err, "Failed to resolve running checkpoint container", "container", status.Name)
+			continue
+		}
+		if err := snapshotruntime.SendSignalToPID(log, pid, syscall.SIGKILL, reason); err != nil {
+			log.Error(err, "Failed to signal running checkpoint container", "container", status.Name)
+		}
+	}
 }
 
 func (w *NodeController) startRestoreForContainer(

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/executor"
 	snapshotruntime "github.com/ai-dynamo/dynamo/deploy/snapshot/internal/runtime"
@@ -52,10 +53,9 @@ type checkpointLocations struct {
 }
 
 const (
-	restoreContainerResolveInterval       = 50 * time.Millisecond
-	restoreContainerResolveAttemptTimeout = 1 * time.Second
-	restoreContainerResolveTimeout        = 30 * time.Second
-	checkpointContainerResolveTimeout     = 2 * time.Second
+	containerResolveAttemptTimeout  = 1 * time.Second
+	restoreContainerResolveInterval = 50 * time.Millisecond
+	restoreContainerResolveTimeout  = 30 * time.Second
 )
 
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
@@ -213,8 +213,12 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 
-	if failed := failedRegularContainer(pod); failed != nil {
+	for i := range pod.Status.ContainerStatuses {
+		failed := &pod.Status.ContainerStatuses[i]
 		term := failed.State.Terminated
+		if term == nil || term.ExitCode == 0 {
+			continue
+		}
 		message := fmt.Sprintf("Checkpoint container %q terminated with exit code %d", failed.Name, term.ExitCode)
 		if term.Reason != "" {
 			message = fmt.Sprintf("%s: %s", message, term.Reason)
@@ -227,7 +231,23 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		}); err != nil {
 			opLog.Error(err, "Failed to mark checkpoint job failed")
 		}
-		w.killRunningCheckpointContainers(ctx, pod, fmt.Sprintf("checkpoint container %s failed", failed.Name))
+		reason := fmt.Sprintf("checkpoint container %s failed", failed.Name)
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Running == nil || status.ContainerID == "" {
+				continue
+			}
+			containerID := snapshotruntime.StripCRIScheme(status.ContainerID)
+			resolveCtx, cancel := context.WithTimeout(ctx, containerResolveAttemptTimeout)
+			pid, _, err := w.runtime.ResolveContainer(resolveCtx, containerID)
+			cancel()
+			if err != nil {
+				opLog.Error(err, "Failed to resolve running checkpoint container", "container", status.Name)
+				continue
+			}
+			if err := snapshotruntime.SendSignalToPID(opLog, pid, syscall.SIGKILL, reason); err != nil {
+				opLog.Error(err, "Failed to signal running checkpoint container", "container", status.Name)
+			}
+		}
 		return
 	}
 
@@ -389,62 +409,11 @@ func (w *NodeController) pollForContainerID(
 }
 
 func restoreContainerResolveAttemptContext(ctx context.Context, deadlineAt time.Time) (context.Context, context.CancelFunc) {
-	attemptDeadline := time.Now().Add(restoreContainerResolveAttemptTimeout)
+	attemptDeadline := time.Now().Add(containerResolveAttemptTimeout)
 	if deadlineAt.Before(attemptDeadline) {
 		attemptDeadline = deadlineAt
 	}
 	return context.WithDeadline(ctx, attemptDeadline)
-}
-
-func failedRegularContainer(pod *corev1.Pod) *corev1.ContainerStatus {
-	for i := range pod.Status.ContainerStatuses {
-		term := pod.Status.ContainerStatuses[i].State.Terminated
-		if term != nil && term.ExitCode != 0 {
-			return &pod.Status.ContainerStatuses[i]
-		}
-	}
-	return nil
-}
-
-func (w *NodeController) killRunningCheckpointContainers(ctx context.Context, pod *corev1.Pod, reason string) {
-	log := w.log.WithValues("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
-	for _, status := range pod.Status.ContainerStatuses {
-		if status.State.Running == nil || status.ContainerID == "" {
-			continue
-		}
-		containerID := snapshotruntime.StripCRIScheme(status.ContainerID)
-		resolveCtx, cancel := context.WithTimeout(ctx, checkpointContainerResolveTimeout)
-		pid, _, err := w.runtime.ResolveContainer(resolveCtx, containerID)
-		cancel()
-		if err != nil {
-			log.Error(err, "Failed to resolve running checkpoint container", "container", status.Name)
-			continue
-		}
-		if err := snapshotruntime.SendSignalToPID(log, pid, syscall.SIGKILL, reason); err != nil {
-			log.Error(err, "Failed to signal running checkpoint container", "container", status.Name)
-		}
-	}
-}
-
-func (w *NodeController) setCheckpointStatus(ctx context.Context, log logr.Logger, job *batchv1.Job, value string) (bool, error) {
-	if value == snapshotprotocol.CheckpointStatusCompleted {
-		current, err := w.clientset.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, fmt.Errorf("failed to get current checkpoint job %s/%s: %w", job.Namespace, job.Name, err)
-		}
-		if current.Annotations[snapshotprotocol.CheckpointStatusAnnotation] == snapshotprotocol.CheckpointStatusFailed {
-			log.Info("Skipping checkpoint completion because checkpoint job is already failed",
-				"job", fmt.Sprintf("%s/%s", job.Namespace, job.Name),
-			)
-			return false, nil
-		}
-	}
-	if err := annotateJob(ctx, w.clientset, log, job, map[string]string{
-		snapshotprotocol.CheckpointStatusAnnotation: value,
-	}); err != nil {
-		return false, err
-	}
-	return true, nil
 }
 
 func (w *NodeController) startRestoreForContainer(
@@ -550,11 +519,47 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	go w.renewCheckpointLease(leaseCtx, log, job, stopLease)
 
 	setCheckpointStatus := func(value string) (bool, error) {
-		updated, err := w.setCheckpointStatus(ctx, log, job, value)
+		if value != snapshotprotocol.CheckpointStatusCompleted {
+			if err := annotateJob(ctx, w.clientset, log, job, map[string]string{
+				snapshotprotocol.CheckpointStatusAnnotation: value,
+			}); err != nil {
+				releasePodOnExit = false
+				releaseLeaseOnExit = false
+				return false, fmt.Errorf("failed to persist terminal checkpoint status %q: %w", value, err)
+			}
+			return true, nil
+		}
+
+		updated := false
+		jobClient := w.clientset.BatchV1().Jobs(job.Namespace)
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current, err := jobClient.Get(ctx, job.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get current checkpoint job %s/%s: %w", job.Namespace, job.Name, err)
+			}
+			if current.Annotations[snapshotprotocol.CheckpointStatusAnnotation] == snapshotprotocol.CheckpointStatusFailed {
+				updated = false
+				return nil
+			}
+			if current.Annotations == nil {
+				current.Annotations = map[string]string{}
+			}
+			current.Annotations[snapshotprotocol.CheckpointStatusAnnotation] = value
+			if _, err := jobClient.Update(ctx, current, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+			updated = true
+			return nil
+		})
 		if err != nil {
 			releasePodOnExit = false
 			releaseLeaseOnExit = false
 			return false, fmt.Errorf("failed to persist terminal checkpoint status %q: %w", value, err)
+		}
+		if !updated {
+			log.Info("Skipping checkpoint completion because checkpoint job is already failed",
+				"job", fmt.Sprintf("%s/%s", job.Namespace, job.Name),
+			)
 		}
 		return updated, nil
 	}

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -55,6 +55,7 @@ const (
 	restoreContainerResolveInterval       = 50 * time.Millisecond
 	restoreContainerResolveAttemptTimeout = 1 * time.Second
 	restoreContainerResolveTimeout        = 30 * time.Second
+	checkpointContainerResolveTimeout     = 2 * time.Second
 )
 
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
@@ -412,7 +413,9 @@ func (w *NodeController) killRunningCheckpointContainers(ctx context.Context, po
 			continue
 		}
 		containerID := snapshotruntime.StripCRIScheme(status.ContainerID)
-		pid, _, err := w.runtime.ResolveContainer(ctx, containerID)
+		resolveCtx, cancel := context.WithTimeout(ctx, checkpointContainerResolveTimeout)
+		pid, _, err := w.runtime.ResolveContainer(resolveCtx, containerID)
+		cancel()
 		if err != nil {
 			log.Error(err, "Failed to resolve running checkpoint container", "container", status.Name)
 			continue
@@ -421,6 +424,27 @@ func (w *NodeController) killRunningCheckpointContainers(ctx context.Context, po
 			log.Error(err, "Failed to signal running checkpoint container", "container", status.Name)
 		}
 	}
+}
+
+func (w *NodeController) setCheckpointStatus(ctx context.Context, log logr.Logger, job *batchv1.Job, value string) (bool, error) {
+	if value == snapshotprotocol.CheckpointStatusCompleted {
+		current, err := w.clientset.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get current checkpoint job %s/%s: %w", job.Namespace, job.Name, err)
+		}
+		if current.Annotations[snapshotprotocol.CheckpointStatusAnnotation] == snapshotprotocol.CheckpointStatusFailed {
+			log.Info("Skipping checkpoint completion because checkpoint job is already failed",
+				"job", fmt.Sprintf("%s/%s", job.Namespace, job.Name),
+			)
+			return false, nil
+		}
+	}
+	if err := annotateJob(ctx, w.clientset, log, job, map[string]string{
+		snapshotprotocol.CheckpointStatusAnnotation: value,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (w *NodeController) startRestoreForContainer(
@@ -525,15 +549,14 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 
 	go w.renewCheckpointLease(leaseCtx, log, job, stopLease)
 
-	setCheckpointStatus := func(value string) error {
-		if err := annotateJob(ctx, w.clientset, log, job, map[string]string{
-			snapshotprotocol.CheckpointStatusAnnotation: value,
-		}); err != nil {
+	setCheckpointStatus := func(value string) (bool, error) {
+		updated, err := w.setCheckpointStatus(ctx, log, job, value)
+		if err != nil {
 			releasePodOnExit = false
 			releaseLeaseOnExit = false
-			return fmt.Errorf("failed to persist terminal checkpoint status %q: %w", value, err)
+			return false, fmt.Errorf("failed to persist terminal checkpoint status %q: %w", value, err)
 		}
-		return nil
+		return updated, nil
 	}
 
 	// Resolve the target container ID from pod status.
@@ -546,7 +569,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	}
 	if containerID == "" {
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", fmt.Sprintf("Could not resolve container %q ID", containerName))
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
@@ -557,7 +580,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	if err != nil {
 		log.Error(err, "Failed to resolve container")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", fmt.Sprintf("Container resolve failed: %v", err))
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
@@ -567,7 +590,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	if err != nil {
 		log.Error(err, "Checkpoint pod is missing storage metadata")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
@@ -575,7 +598,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	if err := w.validatePodMountContainerPID(ctx, containerID, containerPID); err != nil {
 		log.Error(err, "Checkpoint container changed before storage access")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
@@ -603,7 +626,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "checkpoint failed"); signalErr != nil {
 			log.Error(signalErr, "Failed to signal checkpoint failure to runtime process")
 		}
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
@@ -621,7 +644,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "checkpoint verification failed"); signalErr != nil {
 			log.Error(signalErr, "Failed to signal checkpoint verification failure to runtime process")
 		}
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
@@ -630,20 +653,23 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	// snapshot-control volume; containerPID is a PID inside the container's
 	// mount namespace, which is all the /host/proc/<pid>/root write path
 	// requires. The Succeeded event is emitted only after the sentinel has
-	// been written so a sentinel-write failure doesn't produce conflicting
-	// Succeeded+Failed events for the same operation.
+	// been written and the terminal status has been persisted so failures don't
+	// produce conflicting Succeeded+Failed events for the same operation.
 	if err := snapshotruntime.WriteControlSentinel(containerPID, snapshotprotocol.SnapshotCompleteFile); err != nil {
 		log.Error(err, "Failed to write snapshot-complete sentinel")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-		if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+		if _, statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
 			return statusErr
 		}
 		return nil
 	}
-	emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointSucceeded", fmt.Sprintf("Checkpoint completed: %s", checkpointID))
 
-	if err := setCheckpointStatus(snapshotprotocol.CheckpointStatusCompleted); err != nil {
+	updated, err := setCheckpointStatus(snapshotprotocol.CheckpointStatusCompleted)
+	if err != nil {
 		return err
+	}
+	if updated {
+		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeNormal, "CheckpointSucceeded", fmt.Sprintf("Checkpoint completed: %s", checkpointID))
 	}
 	return nil
 }

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -524,35 +524,6 @@ func TestReconcileCheckpointPodFailsWhenAnyRegularContainerFails(t *testing.T) {
 	}
 }
 
-func TestSetCheckpointStatusDoesNotCompleteFailedJob(t *testing.T) {
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "checkpoint-job",
-			Namespace: "default",
-			Annotations: map[string]string{
-				snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusFailed,
-			},
-		},
-	}
-	w := makeTestController(t, job)
-
-	updated, err := w.setCheckpointStatus(context.Background(), w.log, job, snapshotprotocol.CheckpointStatusCompleted)
-	if err != nil {
-		t.Fatalf("setCheckpointStatus() error = %v", err)
-	}
-	if updated {
-		t.Fatal("setCheckpointStatus() updated failed job to completed")
-	}
-
-	got, err := w.clientset.BatchV1().Jobs("default").Get(context.Background(), "checkpoint-job", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to get checkpoint job: %v", err)
-	}
-	if status := got.Annotations[snapshotprotocol.CheckpointStatusAnnotation]; status != snapshotprotocol.CheckpointStatusFailed {
-		t.Fatalf("checkpoint status annotation = %q, want %q", status, snapshotprotocol.CheckpointStatusFailed)
-	}
-}
-
 func TestReconcileRestorePod(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -524,6 +524,35 @@ func TestReconcileCheckpointPodFailsWhenAnyRegularContainerFails(t *testing.T) {
 	}
 }
 
+func TestSetCheckpointStatusDoesNotCompleteFailedJob(t *testing.T) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "checkpoint-job",
+			Namespace: "default",
+			Annotations: map[string]string{
+				snapshotprotocol.CheckpointStatusAnnotation: snapshotprotocol.CheckpointStatusFailed,
+			},
+		},
+	}
+	w := makeTestController(t, job)
+
+	updated, err := w.setCheckpointStatus(context.Background(), w.log, job, snapshotprotocol.CheckpointStatusCompleted)
+	if err != nil {
+		t.Fatalf("setCheckpointStatus() error = %v", err)
+	}
+	if updated {
+		t.Fatal("setCheckpointStatus() updated failed job to completed")
+	}
+
+	got, err := w.clientset.BatchV1().Jobs("default").Get(context.Background(), "checkpoint-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get checkpoint job: %v", err)
+	}
+	if status := got.Annotations[snapshotprotocol.CheckpointStatusAnnotation]; status != snapshotprotocol.CheckpointStatusFailed {
+		t.Fatalf("checkpoint status annotation = %q, want %q", status, snapshotprotocol.CheckpointStatusFailed)
+	}
+}
+
 func TestReconcileRestorePod(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -30,12 +30,14 @@ const testContainerID = "test-container"
 // fakeRuntime is a minimal Runtime implementation for controller reconciliation
 // tests.
 type fakeRuntime struct {
-	containerIDByPod string
+	containerIDByPod     string
+	resolvedContainerIDs []string
 }
 
 var _ snapshotruntime.Runtime = (*fakeRuntime)(nil)
 
 func (r *fakeRuntime) ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error) {
+	r.resolvedContainerIDs = append(r.resolvedContainerIDs, id)
 	return 0, nil, errors.New("not implemented")
 }
 func (r *fakeRuntime) ResolveContainerIDByPod(ctx context.Context, pod, ns, ctr string) (string, error) {
@@ -452,6 +454,73 @@ func TestReconcileCheckpointPod(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		})
+	}
+}
+
+func TestReconcileCheckpointPodFailsWhenAnyRegularContainerFails(t *testing.T) {
+	labels := map[string]string{
+		snapshotprotocol.CheckpointSourceLabel: "true",
+		snapshotprotocol.CheckpointIDLabel:     "abc123",
+		"batch.kubernetes.io/job-name":         "checkpoint-job",
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "checkpoint-job",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+	}
+	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "helper"})
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name:        "main",
+			Ready:       true,
+			State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			ContainerID: "containerd://main-id",
+		},
+		{
+			Name: "helper",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+			},
+			ContainerID: "containerd://helper-id",
+		},
+	}
+
+	w := makeTestController(t, job)
+	rt := &fakeRuntime{}
+	w.runtime = rt
+	w.reconcileCheckpointPod(context.Background(), pod)
+
+	updated, err := w.clientset.BatchV1().Jobs("default").Get(context.Background(), "checkpoint-job", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get checkpoint job: %v", err)
+	}
+	if got := updated.Annotations[snapshotprotocol.CheckpointStatusAnnotation]; got != snapshotprotocol.CheckpointStatusFailed {
+		t.Fatalf("checkpoint status annotation = %q, want %q", got, snapshotprotocol.CheckpointStatusFailed)
+	}
+
+	var sawFailureEvent bool
+	for _, action := range w.clientset.(*fake.Clientset).Actions() {
+		create, ok := action.(clientgotesting.CreateAction)
+		if !ok || create.GetResource().Resource != "events" {
+			continue
+		}
+		event, ok := create.GetObject().(*corev1.Event)
+		if ok && event.Reason == "CheckpointFailed" && strings.Contains(event.Message, `container "helper"`) {
+			sawFailureEvent = true
+			break
+		}
+	}
+	if !sawFailureEvent {
+		t.Fatalf("expected CheckpointFailed event for failed regular container; actions=%#v", w.clientset.(*fake.Clientset).Actions())
+	}
+	if len(w.inFlight) != 0 {
+		t.Fatalf("failed checkpoint pod should not start snapshot worker, got inFlight=%v", w.inFlight)
+	}
+	if len(rt.resolvedContainerIDs) != 1 || rt.resolvedContainerIDs[0] != "main-id" {
+		t.Fatalf("expected to resolve remaining running container before failing job, got %v", rt.resolvedContainerIDs)
 	}
 }
 

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -458,69 +458,76 @@ func TestReconcileCheckpointPod(t *testing.T) {
 }
 
 func TestReconcileCheckpointPodFailsWhenAnyRegularContainerFails(t *testing.T) {
-	labels := map[string]string{
-		snapshotprotocol.CheckpointSourceLabel: "true",
-		snapshotprotocol.CheckpointIDLabel:     "abc123",
-		"batch.kubernetes.io/job-name":         "checkpoint-job",
-	}
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "checkpoint-job",
-			Namespace:   "default",
-			Annotations: map[string]string{},
-		},
-	}
-	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
-	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "helper"})
-	pod.Status.ContainerStatuses = []corev1.ContainerStatus{
-		{
-			Name:        "main",
-			Ready:       true,
-			State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
-			ContainerID: "containerd://main-id",
-		},
-		{
-			Name: "helper",
-			State: corev1.ContainerState{
-				Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
-			},
-			ContainerID: "containerd://helper-id",
-		},
-	}
+	for _, jobStatus := range []string{"", snapshotprotocol.CheckpointStatusCompleted} {
+		t.Run("job status "+jobStatus, func(t *testing.T) {
+			labels := map[string]string{
+				snapshotprotocol.CheckpointSourceLabel: "true",
+				snapshotprotocol.CheckpointIDLabel:     "abc123",
+				"batch.kubernetes.io/job-name":         "checkpoint-job",
+			}
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "checkpoint-job",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			}
+			if jobStatus != "" {
+				job.Annotations[snapshotprotocol.CheckpointStatusAnnotation] = jobStatus
+			}
+			pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
+			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: "helper"})
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+				{
+					Name:        "main",
+					Ready:       true,
+					State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					ContainerID: "containerd://main-id",
+				},
+				{
+					Name: "helper",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+					},
+					ContainerID: "containerd://helper-id",
+				},
+			}
 
-	w := makeTestController(t, job)
-	rt := &fakeRuntime{}
-	w.runtime = rt
-	w.reconcileCheckpointPod(context.Background(), pod)
+			w := makeTestController(t, job)
+			rt := &fakeRuntime{}
+			w.runtime = rt
+			w.reconcileCheckpointPod(context.Background(), pod)
 
-	updated, err := w.clientset.BatchV1().Jobs("default").Get(context.Background(), "checkpoint-job", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("failed to get checkpoint job: %v", err)
-	}
-	if got := updated.Annotations[snapshotprotocol.CheckpointStatusAnnotation]; got != snapshotprotocol.CheckpointStatusFailed {
-		t.Fatalf("checkpoint status annotation = %q, want %q", got, snapshotprotocol.CheckpointStatusFailed)
-	}
+			updated, err := w.clientset.BatchV1().Jobs("default").Get(context.Background(), "checkpoint-job", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get checkpoint job: %v", err)
+			}
+			if got := updated.Annotations[snapshotprotocol.CheckpointStatusAnnotation]; got != snapshotprotocol.CheckpointStatusFailed {
+				t.Fatalf("checkpoint status annotation = %q, want %q", got, snapshotprotocol.CheckpointStatusFailed)
+			}
 
-	var sawFailureEvent bool
-	for _, action := range w.clientset.(*fake.Clientset).Actions() {
-		create, ok := action.(clientgotesting.CreateAction)
-		if !ok || create.GetResource().Resource != "events" {
-			continue
-		}
-		event, ok := create.GetObject().(*corev1.Event)
-		if ok && event.Reason == "CheckpointFailed" && strings.Contains(event.Message, `container "helper"`) {
-			sawFailureEvent = true
-			break
-		}
-	}
-	if !sawFailureEvent {
-		t.Fatalf("expected CheckpointFailed event for failed regular container; actions=%#v", w.clientset.(*fake.Clientset).Actions())
-	}
-	if len(w.inFlight) != 0 {
-		t.Fatalf("failed checkpoint pod should not start snapshot worker, got inFlight=%v", w.inFlight)
-	}
-	if len(rt.resolvedContainerIDs) != 1 || rt.resolvedContainerIDs[0] != "main-id" {
-		t.Fatalf("expected to resolve remaining running container before failing job, got %v", rt.resolvedContainerIDs)
+			var sawFailureEvent bool
+			for _, action := range w.clientset.(*fake.Clientset).Actions() {
+				create, ok := action.(clientgotesting.CreateAction)
+				if !ok || create.GetResource().Resource != "events" {
+					continue
+				}
+				event, ok := create.GetObject().(*corev1.Event)
+				if ok && event.Reason == "CheckpointFailed" && strings.Contains(event.Message, `container "helper"`) {
+					sawFailureEvent = true
+					break
+				}
+			}
+			if !sawFailureEvent {
+				t.Fatalf("expected CheckpointFailed event for failed regular container; actions=%#v", w.clientset.(*fake.Clientset).Actions())
+			}
+			if len(w.inFlight) != 0 {
+				t.Fatalf("failed checkpoint pod should not start snapshot worker, got inFlight=%v", w.inFlight)
+			}
+			if len(rt.resolvedContainerIDs) != 1 || rt.resolvedContainerIDs[0] != "main-id" {
+				t.Fatalf("expected to resolve remaining running container before failing job, got %v", rt.resolvedContainerIDs)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Overview:

Make snapshot checkpoint Jobs fail promptly when any regular checkpoint pod container exits non-zero. This prevents multi-container checkpoint Jobs from hanging when a workload/helper container fails while another helper keeps running.

#### Details:

- Detect non-zero regular container termination in the snapshot node controller before starting checkpoint work.
- Mark the checkpoint Job with the snapshot failed annotation and emit a `CheckpointFailed` event.
- SIGKILL remaining running regular containers so kubelet can move the pod/job to a failed terminal state instead of waiting for `activeDeadlineSeconds`.
- Bound cleanup-time runtime resolution with a per-container timeout.
- Keep checkpoint status terminal-aware so a later completion path does not overwrite an already-failed Job.
- Add controller tests for helper-container failure and failed-status completion suppression.

Tests:

- `cd deploy/snapshot && go test ./...`

#### Where should the reviewer start?

- `deploy/snapshot/internal/controller/controller.go`
- `deploy/snapshot/internal/controller/controller_test.go`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GMS + Snapshot checkpoint Job testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved checkpoint pod failure detection and handling with earlier logging when containers terminate with non-zero exit codes
  * Checkpoint jobs are now properly marked as failed with `CheckpointFailed` events emitted
  * Running checkpoint containers are now properly cleaned up on the node when failures occur
  * Enhanced checkpoint workflow error handling and status persistence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->