### PR TITLE
fix: set sglang prefill cuda graph batch size (#9852)

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -26,7 +26,7 @@ try:
         BaseConfigModifier,
         apply_dgd_overrides,
     )
-    from dynamo.profiler.utils.defaults import SearchStrategy
+    from dynamo.profiler.utils.defaults import EngineType, SearchStrategy
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
         OverridesSpec,
@@ -65,6 +65,116 @@ def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
     )
     assert decode_service["resources"]["limits"]["gpu"] == "8"
     assert decode_service.get("multinode") is None
+
+
+def test_build_dgd_config_sglang_prefill_mrr_one_sets_cuda_graph_bs() -> None:
+    """SGLang prefill with one running request must capture bs=1 explicitly."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="Qwen/Qwen3-30B-A3B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-post.1",
+        prefill_cli_args=[
+            "--tensor-parallel-size",
+            "2",
+            "--data-parallel-size",
+            "2",
+            "--max-running-requests",
+            "1",
+            "--max-prefill-tokens",
+            "5500",
+            "--enable-dp-attention",
+        ],
+        prefill_replicas=2,
+        prefill_gpus=4,
+        decode_cli_args=[
+            "--max-running-requests",
+            "512",
+            "--cuda-graph-bs",
+            "1",
+        ],
+        decode_replicas=2,
+        decode_gpus=8,
+        num_gpus_per_node=8,
+    )
+
+    prefill_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "prefill"
+    )
+    prefill_args = prefill_service["extraPodSpec"]["mainContainer"]["args"]
+
+    assert prefill_args.count("--cuda-graph-bs") == 1
+    assert prefill_args[prefill_args.index("--cuda-graph-bs") + 1] == "1"
+
+
+def test_build_dgd_config_sglang_prefill_keeps_existing_cuda_graph_bs() -> None:
+    """Do not duplicate an explicit CUDA graph batch-size setting."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    dgd_config = modifier.build_dgd_config(
+        mode="disagg",
+        model_name="Qwen/Qwen3-30B-A3B",
+        image="nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-post.1",
+        prefill_cli_args=[
+            "--max-running-requests",
+            "1",
+            "--cuda-graph-bs=1",
+        ],
+        prefill_replicas=2,
+        prefill_gpus=4,
+        decode_cli_args=["--max-running-requests", "512"],
+        decode_replicas=2,
+        decode_gpus=8,
+        num_gpus_per_node=8,
+    )
+
+    prefill_service = next(
+        service
+        for service in dgd_config["spec"]["services"].values()
+        if service.get("subComponentType") == "prefill"
+    )
+    prefill_args = prefill_service["extraPodSpec"]["mainContainer"]["args"]
+
+    cuda_graph_bs_args = [
+        arg
+        for arg in prefill_args
+        if arg == "--cuda-graph-bs" or arg.startswith("--cuda-graph-bs=")
+    ]
+    assert cuda_graph_bs_args == ["--cuda-graph-bs=1"]
+
+
+def test_sglang_set_prefill_config_uses_effective_mrr_override() -> None:
+    """Later MRR overrides must drive CUDA graph batch-size safety."""
+    modifier = CONFIG_MODIFIERS["sglang"]
+    config = modifier.convert_config(
+        modifier.load_default_config(mode="disagg"),
+        target=EngineType.PREFILL,
+    )
+    service = next(
+        service
+        for service in config["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    service["extraPodSpec"]["mainContainer"]["args"] = [
+        "--max-running-requests=512",
+    ]
+
+    result = modifier.set_prefill_config(
+        config,
+        max_batch_size=1,
+        max_num_tokens=5500,
+    )
+    worker = next(
+        service
+        for service in result["spec"]["services"].values()
+        if service.get("subComponentType") == "decode"
+    )
+    args = worker["extraPodSpec"]["mainContainer"]["args"]
+
+    assert args[args.index("--max-running-requests") + 1] == "1"
+    assert args.count("--cuda-graph-bs") == 1
+    assert args[args.index("--cuda-graph-bs") + 1] == "1"
 
 
 def test_build_dgd_config_multinode_when_tp_exceeds_node() -> None:

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -46,6 +46,36 @@ DEFAULT_SGLANG_AGG_CONFIG_PATH = resolve_deploy_path(
 )
 
 
+def _arg_value(args: list[str], key: str) -> str | None:
+    for idx in range(len(args) - 1, -1, -1):
+        arg = args[idx]
+        if arg.startswith(f"{key}="):
+            return arg.split("=", 1)[1]
+        if arg == key:
+            return args[idx + 1] if idx + 1 < len(args) else None
+    return None
+
+
+def _has_arg(args: list[str], key: str) -> bool:
+    return any(arg == key or arg.startswith(f"{key}=") for arg in args)
+
+
+def _ensure_safe_prefill_cuda_graph_bs(args: list[str]) -> list[str]:
+    args = list(args)
+    if _has_arg(args, "--cuda-graph-bs") or _has_arg(args, "--disable-cuda-graph"):
+        return args
+
+    max_running_requests = _arg_value(args, "--max-running-requests")
+    try:
+        max_running_requests_int = int(max_running_requests or "")
+    except ValueError:
+        return args
+
+    if max_running_requests_int == 1:
+        args = append_argument(args, ["--cuda-graph-bs", "1"])
+    return args
+
+
 class SGLangConfigModifier(BaseConfigModifier):
     BACKEND = "sglang"
 
@@ -63,6 +93,30 @@ class SGLangConfigModifier(BaseConfigModifier):
     def update_image(cls, config, image: str) -> dict:
         """Update container image for all DGD services (frontend, planner, workers)."""
         return update_image(config, image)
+
+    @classmethod
+    def _apply_disagg_workers(
+        cls,
+        cfg: Config,
+        prefill_cli_args: list[str],
+        prefill_replicas: int,
+        prefill_gpus: int,
+        decode_cli_args: list[str],
+        decode_replicas: int,
+        decode_gpus: int,
+        num_gpus_per_node: int | None = None,
+    ) -> None:
+        prefill_cli_args = _ensure_safe_prefill_cuda_graph_bs(prefill_cli_args)
+        super()._apply_disagg_workers(
+            cfg,
+            prefill_cli_args=prefill_cli_args,
+            prefill_replicas=prefill_replicas,
+            prefill_gpus=prefill_gpus,
+            decode_cli_args=decode_cli_args,
+            decode_replicas=decode_replicas,
+            decode_gpus=decode_gpus,
+            num_gpus_per_node=num_gpus_per_node,
+        )
 
     @classmethod
     def convert_config(
@@ -366,6 +420,7 @@ class SGLangConfigModifier(BaseConfigModifier):
 
         # Set max concurrency to control effective batch size
         args = set_argument_value(args, "--max-running-requests", str(max_batch_size))
+        args = _ensure_safe_prefill_cuda_graph_bs(args)
 
         # Cap total tokens processed in a batch to avoid chunked prefill
         args = set_argument_value(args, "--chunked-prefill-size", str(max_num_tokens))


### PR DESCRIPTION
## Summary

- Cherry-pick #9852 to `release/1.2.0`
- Fix DYN-3079 by setting `--cuda-graph-bs 1` for SGLang prefill when `--max-running-requests 1` is selected
- Includes the review fix for effective-last CLI arg handling and regression coverage

## Testing

- `.venv/bin/python -m pytest components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py -v`
  - `20 passed in 2.88s`

Main PR: #9852
Merge commit: f897b2544530ef3f8b59f0b16e16ebcb85d7e126
Cherry-pick commit: ea98c9e77ed

Fixes DYN-3079.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->