### PR TITLE
fix(ci): decouple GPU auto slots from VRAM profiles

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Only run tests with @pytest.mark.profiled_vram_gib(N) that fit in N GiB. "
         "Without -n: runs tests sequentially. "
         "With -n N: runs N tests concurrently as subprocesses with VRAM-aware scheduling. "
-        "With -n auto: calculates max concurrent slots from GPU VRAM / max_vram_gib.",
+        "With -n auto: uses a bounded process cap with VRAM-aware launch gates.",
     )
     parser.addoption(
         "--dry-run",
@@ -144,7 +144,7 @@ logging.basicConfig(
 # ---------------------------------------------------------------------------
 # GPU-serial and GPU-parallel: VRAM-aware test scheduling
 #
-# Activated only when both --max-vram-gib and -n auto are passed:
+# Activated only when both --max-vram-gib and -n are passed:
 #   pytest --max-vram-gib=48 -n auto -m "gpu_1 and sglang" tests/serve/
 # ---------------------------------------------------------------------------
 

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -15,12 +15,14 @@ Usage (always via pytest):
 
 Flags:
     --max-vram-gib=N   Only run tests with profiled_vram_gib <= N
-    -n N / -n auto     Run N tests concurrently (auto = GPU budget / smallest test)
+    -n N / -n auto     Run N tests concurrently (auto = bounded process cap)
     -s                 Stream subprocess output live with [wN] prefixes
     -v / -vv           Passed through to subprocesses for verbose test names
 
-A 10-second cooldown between launches avoids the vLLM profiling race
-(bug #10643). Tests that fail due to profiling race are retried up to 3 times.
+VRAM safety is enforced separately at launch time using profiled test memory and
+live GPU usage. A short per-GPU cooldown between vLLM launches avoids the vLLM
+profiling race (bug #10643). Tests that fail due to profiling race are retried
+up to 3 times.
 """
 
 from __future__ import annotations
@@ -898,7 +900,7 @@ def main() -> int:
         "-n",
         type=str,
         default="auto",
-        help="Number of concurrent slots. 'auto' = gpu_usable / max_vram_gib.",
+        help="Number of concurrent slots. 'auto' = bounded process cap with VRAM-aware launch gates.",
     )
 
     raw = sys.argv[1:]

--- a/tests/utils/test_vram_utils.py
+++ b/tests/utils/test_vram_utils.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.utils.vram_utils import (
+    DEFAULT_GPU_PARALLEL_PROCESS_CAP,
+    auto_worker_count,
+    print_gpu_plan,
+)
+
+
+def _gpu(total_gib: int = 22) -> dict:
+    return {"index": 0, "name": "Test GPU", "total_mib": total_gib * 1024}
+
+
+def test_auto_worker_count_uses_bounded_process_cap_for_mixed_profiles():
+    assert (
+        auto_worker_count([_gpu()], 24, test_profiled_gibs=[0, 3.7, 14.2])
+        == DEFAULT_GPU_PARALLEL_PROCESS_CAP
+    )
+
+
+def test_auto_worker_count_respects_explicit_process_cap():
+    assert (
+        auto_worker_count(
+            [_gpu()],
+            24,
+            test_profiled_gibs=[0, 3.7, 14.2],
+            max_process_slots=12,
+        )
+        == 12
+    )
+
+
+def test_auto_worker_count_is_bounded_across_multiple_gpus():
+    gpus = [_gpu(), {"index": 1, "name": "Test GPU 2", "total_mib": 22 * 1024}]
+
+    assert auto_worker_count(gpus, 24, test_profiled_gibs=[0, 3.7]) == 16
+
+
+def test_auto_worker_count_falls_back_without_usable_vram_metadata():
+    assert auto_worker_count([], 24) == 1
+    assert auto_worker_count([_gpu()], 0) == 1
+
+
+def test_print_gpu_plan_describes_process_cap_and_vram_gates(capsys):
+    print_gpu_plan([_gpu()], 24, [("zero", 0), ("gpu", 3.7)])
+
+    out = capsys.readouterr().out
+    assert "-n auto  : up to 16 process slots" in out
+    assert "VRAM gates still apply per GPU" in out
+    assert "Smallest nonzero profiled test: 3.7 GiB" in out

--- a/tests/utils/vram_utils.py
+++ b/tests/utils/vram_utils.py
@@ -5,7 +5,7 @@
 
 Functions:
     detect_gpus()                  Enumerate GPUs via pynvml
-    auto_worker_count(gpus, limit) Calculate slot count for -n auto
+    auto_worker_count(gpus, limit) Calculate process slot count for -n auto
     write_test_meta(items)         Serialize profiled/requested vram + timeout
     load_test_meta()               Read the serialized test metadata
     print_gpu_plan(gpus, limit, would_run)  Dry-run GPU plan summary
@@ -32,6 +32,8 @@ _logger = logging.getLogger(__name__)
 # When 2+ tests run concurrently, reserve 15% of GPU VRAM for CUDA context
 # overhead across processes.  A single test gets the full GPU (0% margin).
 VRAM_MULTI_PROC_MARGIN = 0.15
+
+DEFAULT_GPU_PARALLEL_PROCESS_CAP = 16
 
 _TEST_META_FILENAME = "pytest_gpu_parallel_test_meta.json"
 
@@ -69,23 +71,17 @@ def auto_worker_count(
     gpus: list[dict],
     vram_limit: float,
     test_profiled_gibs: list[float] | None = None,
+    max_process_slots: int = DEFAULT_GPU_PARALLEL_PROCESS_CAP,
 ) -> int:
-    """Calculate slot count for -n auto.
+    """Calculate process slot count for -n auto.
 
-    Uses the smallest profiled test size (if provided) to maximize parallelism.
-    Falls back to vram_limit when no test sizes are available.
+    The scheduler separately gates each launch by reserved profiled VRAM and
+    live GPU memory. Keep auto as a bounded process cap so zero/low-VRAM tests
+    do not throttle GPU-heavy workloads by consuming a VRAM-derived slot count.
     """
     if not gpus or vram_limit <= 0:
         return len(gpus) or 1
-    min_gpu_gib = min(g["total_mib"] for g in gpus) / 1024.0
-    budget_gib = min_gpu_gib * (1.0 - VRAM_MULTI_PROC_MARGIN)
-    divisor = vram_limit
-    if test_profiled_gibs:
-        nonzero = [g for g in test_profiled_gibs if g > 0]
-        if nonzero:
-            divisor = min(nonzero)
-    workers_per_gpu = max(1, int(budget_gib / divisor)) if divisor > 0 else 1
-    return len(gpus) * workers_per_gpu
+    return max(1, int(max_process_slots))
 
 
 def write_test_meta(items, dest_dir: str | None = None) -> None:
@@ -149,8 +145,8 @@ def print_gpu_plan(
     min_gpu_gib = min(g["total_mib"] for g in gpus) / 1024.0
     budget_gib = min_gpu_gib * (1.0 - VRAM_MULTI_PROC_MARGIN)
     profiled_gibs = [gib for _, gib in would_run if gib is not None and gib > 0]
-    min_test_gib = min(profiled_gibs) if profiled_gibs else vram_limit
-    auto_slots = max(1, int(budget_gib / min_test_gib)) if min_test_gib > 0 else 1
+    min_test_gib = min(profiled_gibs) if profiled_gibs else None
+    auto_slots = auto_worker_count(gpus, vram_limit, profiled_gibs)
 
     print(f"\n{'=' * 60}")
     print("GPU-Parallel Plan")
@@ -162,12 +158,14 @@ def print_gpu_plan(
     print("\n  Run options:")
     print("    (no -n)  : sequential, 1 test at a time")
     print(
-        f"    -n auto  : up to {auto_slots} slots per GPU "
-        f"({budget_gib:.0f} / {min_test_gib:.0f} GiB smallest test)"
+        f"    -n auto  : up to {auto_slots} process slots; "
+        "VRAM gates still apply per GPU"
     )
     print(f"    -n N     : N concurrent slots across {len(gpus)} GPU(s)")
+    if min_test_gib is not None:
+        print(f"\n  Smallest nonzero profiled test: {min_test_gib:.1f} GiB")
     print("\n  Usage:")
     print(
-        f"    pytest --max-vram-gib={vram_limit:.0f} -n {auto_slots} "
+        f"    pytest --max-vram-gib={vram_limit:.0f} -n auto "
         f'-m "gpu_1 and vllm" tests/serve/'
     )


### PR DESCRIPTION
#### Overview:

Updates the GPU-parallel scheduler so `-n auto` uses a bounded process cap instead of deriving the process slot count from the smallest profiled VRAM test.

#### Details:

- Adds a default GPU-parallel process cap of 16 slots for `-n auto`.
- Keeps the existing profiled VRAM reservation and live GPU memory launch gates in place.
- Updates scheduler help and dry-run output to distinguish process slots from VRAM gating.
- Adds focused unit coverage for the new auto-slot behavior.

#### Why:

The previous auto-slot calculation could become inefficient when zero- or very low-VRAM tests were present, because those tests influenced the scheduler's process slot count even though GPU safety is already enforced separately by the launch gate.

#### Validation:

- `DYN_TEST_OUTPUT_PATH=/tmp/dynamo_tests_connorc pytest tests/utils/test_vram_utils.py -q`
- `python -m py_compile tests/utils/vram_utils.py tests/utils/pytest_parallel_gpu.py tests/conftest.py tests/utils/test_vram_utils.py`
- `git diff --check`

#### Related Issues:

- Relates to GPU-parallel CI scheduler follow-up after #9634
