### PR TITLE
fix(llm): disable eagle hash mode for prefill router

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -780,6 +780,9 @@ impl ModelWatcher {
                         // Create prefill-specific config with track_active_blocks disabled
                         let mut prefill_config = router_config.kv_router_config.clone();
                         prefill_config.router_track_active_blocks = false;
+                        // Prefill KV events are emitted by prefill workers; do not inherit
+                        // decode-only speculative hash mode.
+                        let prefill_enable_eagle = false;
 
                         PrefillRouter::new(
                             rx,
@@ -791,7 +794,7 @@ impl ModelWatcher {
                             router_config.enforce_disagg,
                             model_name.clone(),
                             namespace.clone(),
-                            card.runtime_config.enable_eagle,
+                            prefill_enable_eagle,
                         )
                     })
             } else {


### PR DESCRIPTION
Force the disaggregated prefill router to use prefill-side KV hash semantics instead of inheriting decode-only EAGLE settings. This prevents prefill KV events from being indexed under one hash mode and queried under another.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated prefill router configuration handling for improved consistency during model initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->