### PR TITLE
feat: vLLM worker rejection on engine queue depth

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -258,21 +258,29 @@ def update_engine_config_with_dynamo(
         f"(use_kv_events={dynamo_config.use_kv_events})"
     )
 
-    if envs.is_set("DYN_FORWARDPASS_METRIC_PORT"):
+    queue_rejection_enabled = envs.DYN_VLLM_REJECT_QUEUE_THRESHOLD > 0
+    fpm_enabled = envs.is_set("DYN_FORWARDPASS_METRIC_PORT")
+    if fpm_enabled or queue_rejection_enabled:
         existing_cls = getattr(engine_config, "scheduler_cls", None)
         if existing_cls is None:
             defaults[
                 "scheduler_cls"
             ] = "dynamo.vllm.instrumented_scheduler.InstrumentedScheduler"
+            reason = (
+                "forward pass metrics" if fpm_enabled else "vLLM queue-depth rejection"
+            )
             logger.info(
-                "Forward pass metrics enabled: scheduler_cls set to InstrumentedScheduler "
-                f"(port={envs.DYN_FORWARDPASS_METRIC_PORT})"
+                "%s enabled: scheduler_cls set to InstrumentedScheduler " "(port=%d)",
+                reason,
+                envs.DYN_FORWARDPASS_METRIC_PORT,
             )
         else:
             logger.warning(
-                f"DYN_FORWARDPASS_METRIC_PORT is set but scheduler_cls "
-                f"is already '{existing_cls}'. InstrumentedScheduler will NOT "
-                f"be injected. To use forward pass metrics, either remove "
+                f"InstrumentedScheduler was requested by "
+                f"{'DYN_FORWARDPASS_METRIC_PORT' if fpm_enabled else 'DYN_VLLM_REJECT_QUEUE_THRESHOLD'} "
+                f"but scheduler_cls is already '{existing_cls}'. "
+                f"InstrumentedScheduler will NOT be injected. To use forward pass "
+                f"metrics or vLLM queue-depth rejection, either remove "
                 f"--scheduler-cls or subclass InstrumentedScheduler."
             )
 

--- a/components/src/dynamo/vllm/envs.py
+++ b/components/src/dynamo/vllm/envs.py
@@ -20,6 +20,7 @@ REGISTERED_PORT_MAX = 49151
 
 if TYPE_CHECKING:
     DYN_FORWARDPASS_METRIC_PORT: int = 20380
+    DYN_VLLM_REJECT_QUEUE_THRESHOLD: int = 0
 
 
 def _resolve_port(env_var: str, default_port: int) -> int:
@@ -56,10 +57,33 @@ def _resolve_port(env_var: str, default_port: int) -> int:
     return port
 
 
+def _resolve_nonneg_int(env_var: str, default: int) -> int:
+    """Parse a non-negative integer env var. Raises ValueError on bad input."""
+    raw = os.getenv(env_var)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{env_var} must be a non-negative integer, got {raw!r}."
+        ) from exc
+    if value < 0:
+        raise ValueError(f"{env_var} must be >= 0, got {value}.")
+    return value
+
+
 # Environment variables configuration
 environment_variables: dict[str, Callable[[], Any]] = {
     "DYN_FORWARDPASS_METRIC_PORT": lambda: _resolve_port(
         "DYN_FORWARDPASS_METRIC_PORT", 20380
+    ),
+    # Worker-local admission guard for AWS Ads incident repro: when the
+    # latest vLLM scheduler waiting-queue depth has already reached this
+    # value, reject new arrivals before submitting them to the engine.
+    # 0 (default) disables the guard.
+    "DYN_VLLM_REJECT_QUEUE_THRESHOLD": lambda: _resolve_nonneg_int(
+        "DYN_VLLM_REJECT_QUEUE_THRESHOLD", 0
     ),
 }
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncIterator, Dict, Final, Generic, Optional, TypeVar
 
 import torch
+import zmq
 from vllm.config import ModelConfig, VllmConfig
 from vllm.inputs import EmbedsPrompt, TextPrompt, TokensPrompt
 from vllm.lora.request import LoRARequest
@@ -22,6 +23,7 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
+from dynamo.common.forward_pass_metrics import decode as decode_forward_pass_metrics
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
@@ -50,6 +52,7 @@ from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import Client
 from dynamo.runtime.logging import configure_dynamo_logging
 
+from . import envs
 from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
@@ -470,6 +473,77 @@ RequestT = TypeVar("RequestT")
 ResponseT = TypeVar("ResponseT")
 
 
+class _VllmSchedulerQueueDepthMonitor:
+    """Tracks vLLM scheduler waiting-queue depth from InstrumentedScheduler FPM."""
+
+    def __init__(self, base_port: int, dp_start: int, dp_size: int) -> None:
+        self._lock = threading.Lock()
+        self._queued_by_dp_rank = {
+            rank: 0 for rank in range(dp_start, dp_start + dp_size)
+        }
+        self._stop = threading.Event()
+        self._ctx = zmq.Context.instance()
+        self._poller = zmq.Poller()
+        self._sockets: list[zmq.Socket] = []
+
+        for dp_rank in self._queued_by_dp_rank:
+            sock = self._ctx.socket(zmq.SUB)
+            sock.setsockopt(zmq.SUBSCRIBE, b"")
+            sock.connect(f"tcp://127.0.0.1:{base_port + dp_rank}")
+            self._poller.register(sock, zmq.POLLIN)
+            self._sockets.append(sock)
+
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="vllm-scheduler-queue-depth-monitor",
+        )
+        self._thread.start()
+
+    def queued_depth(self) -> int:
+        with self._lock:
+            return sum(self._queued_by_dp_rank.values())
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        for sock in self._sockets:
+            try:
+                self._poller.unregister(sock)
+            except Exception:
+                pass
+            sock.close(linger=0)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                events = dict(self._poller.poll(timeout=100))
+            except zmq.ZMQError:
+                continue
+
+            for sock in self._sockets:
+                if sock not in events:
+                    continue
+                try:
+                    parts = sock.recv_multipart(flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    continue
+                except zmq.ZMQError:
+                    continue
+                if not parts:
+                    continue
+
+                metrics = decode_forward_pass_metrics(parts[-1])
+                if metrics is None:
+                    continue
+
+                queued = metrics.queued_requests
+                queued_depth = queued.num_prefill_requests + queued.num_decode_requests
+                with self._lock:
+                    if metrics.dp_rank in self._queued_by_dp_rank:
+                        self._queued_by_dp_rank[metrics.dp_rank] = queued_depth
+
+
 class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     """
     Request handler for the generate and clear_kv_blocks endpoints.
@@ -536,6 +610,91 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
         # Store shutdown event for graceful shutdown monitoring
         self.shutdown_event = shutdown_event
+
+        # Worker-side admission guard for AWS Ads repro. Queue depth comes from
+        # InstrumentedScheduler's self.waiting snapshot, not the duration from
+        # vLLM submission to first token.
+        self._reject_queue_threshold = int(
+            getattr(envs, "DYN_VLLM_REJECT_QUEUE_THRESHOLD", 0)
+        )
+        self._load_shed_rejections = 0
+        self._queue_depth_monitor: _VllmSchedulerQueueDepthMonitor | None = None
+        if self._reject_queue_threshold > 0:
+            dp_start, dp_size = self.dp_range
+            self._queue_depth_monitor = _VllmSchedulerQueueDepthMonitor(
+                envs.DYN_FORWARDPASS_METRIC_PORT,
+                dp_start,
+                dp_size,
+            )
+            logger.info(
+                "Worker-local load shedding enabled: rejecting new requests when "
+                "vLLM scheduler queued requests >= %d "
+                "(DYN_VLLM_REJECT_QUEUE_THRESHOLD)",
+                self._reject_queue_threshold,
+            )
+
+    def _vllm_scheduler_queue_depth(self) -> int:
+        if self._queue_depth_monitor is None:
+            return 0
+        return self._queue_depth_monitor.queued_depth()
+
+    def _should_load_shed(self) -> bool:
+        """Return True if vLLM's scheduler waiting queue is over threshold."""
+        return (
+            self._reject_queue_threshold > 0
+            and self._vllm_scheduler_queue_depth() >= self._reject_queue_threshold
+        )
+
+    def _load_shed_message(self, request_id: str) -> str:
+        return (
+            f"load_shed: worker rejected request_id={request_id} "
+            f"vllm_queued={self._vllm_scheduler_queue_depth()} "
+            f"threshold={self._reject_queue_threshold}"
+        )
+
+    def _load_shed_token_chunk(
+        self, request_id: str, *, include_disaggregated_params: bool = False
+    ) -> dict[str, Any]:
+        chunk: dict[str, Any] = {
+            "token_ids": [],
+            "finish_reason": f"error: {self._load_shed_message(request_id)}",
+        }
+        if include_disaggregated_params:
+            chunk["disaggregated_params"] = None
+        return chunk
+
+    def _load_shed_openai_chunk(self, request: dict[str, Any], request_id: str):
+        openai_request_id = request.get("id") or request.get("request_id", request_id)
+        message = self._load_shed_message(request_id)
+        return {
+            "id": openai_request_id,
+            "created": int(time.time()),
+            "object": "chat.completion.chunk",
+            "model": request.get("model", "unknown"),
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": message},
+                    "finish_reason": "stop",
+                }
+            ],
+            "error": message,
+        }
+
+    def _record_load_shed(self, request_id: str, role: str) -> None:
+        """Log a load-shed rejection with a stable, grep-able tag."""
+        self._load_shed_rejections += 1
+        # Stable tag "load_shed: rejected" makes this trivially grep-able
+        # in repro logs and easy to count over a window.
+        logger.warning(
+            "load_shed: rejected %s request_id=%s vllm_queued=%d threshold=%d "
+            "total_rejected=%d",
+            role,
+            request_id,
+            self._vllm_scheduler_queue_depth(),
+            self._reject_queue_threshold,
+            self._load_shed_rejections,
+        )
 
     def init_embedding_loader(
         self, config: Config, encode_worker_client: Optional[Client] = None
@@ -1224,6 +1383,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def cleanup(self):
         """Clean up resources including temporary directories."""
+        queue_depth_monitor = getattr(self, "_queue_depth_monitor", None)
+        if queue_depth_monitor is not None:
+            queue_depth_monitor.close()
+            self._queue_depth_monitor = None
         for temp_dir in self.temp_dirs:
             try:
                 temp_dir.cleanup()
@@ -1786,6 +1949,17 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # Use context ID for request tracking and correlation
         request_id = context.id()
         logger.debug(f"Decode Request ID: {request_id}")
+
+        # Worker-local admission guard. Check before any heavy work so a hot
+        # decode worker drops the arrival immediately rather than queueing it.
+        if self._should_load_shed():
+            self._record_load_shed(request_id, role="decode")
+            if self.use_vllm_tokenizer:
+                yield self._load_shed_openai_chunk(request, request_id)
+            else:
+                yield self._load_shed_token_chunk(request_id)
+            return
+
         first_token = True
         with time_and_log_code_section(
             f"[DECODE] request: {request_id} generate"
@@ -2102,6 +2276,15 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         # Use context ID for request tracking and correlation with decode phase
         request_id = context.id()
         logger.debug(f"Prefill Request ID: {request_id}")
+
+        # Worker-local admission guard. Prefill error chunks must carry
+        # disaggregated_params=None (see _generate_token_mode error path).
+        if self._should_load_shed():
+            self._record_load_shed(request_id, role="prefill")
+            yield self._load_shed_token_chunk(
+                request_id, include_disaggregated_params=True
+            )
+            return
 
         # Token-in-token-out mode: internal protocol format
         with time_and_log_code_section(f"[PREFILL] request: {request_id} generate"):

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -484,6 +484,129 @@ def _make_prefill_handler(model: str = "test-model") -> mod.PrefillWorkerHandler
     return handler
 
 
+def _enable_worker_load_shed(handler, *, vllm_queued: int = 1, threshold: int = 1):
+    monitor = MagicMock()
+    monitor.queued_depth.return_value = vllm_queued
+    handler._queue_depth_monitor = monitor
+    handler._reject_queue_threshold = threshold
+    handler._load_shed_rejections = 0
+
+
+@pytest.mark.asyncio(loop_scope="function")
+class TestWorkerLocalLoadShedding:
+    async def test_decode_generate_rejects_token_mode_when_threshold_reached(self):
+        handler = _make_decode_handler()
+        handler.use_vllm_tokenizer = False
+        _enable_worker_load_shed(handler)
+        context = MagicMock()
+        context.id.return_value = "req-decode-shed"
+
+        chunks = [chunk async for chunk in handler.generate({}, context)]
+
+        assert chunks == [
+            {
+                "token_ids": [],
+                "finish_reason": (
+                    "error: load_shed: worker rejected "
+                    "request_id=req-decode-shed vllm_queued=1 threshold=1"
+                ),
+            }
+        ]
+        assert handler._load_shed_rejections == 1
+        assert handler._vllm_scheduler_queue_depth() == 1
+
+    async def test_generate_tokens_does_not_track_time_to_first_token_as_queue(self):
+        handler = _make_decode_handler()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+        handler._queue_depth_monitor = MagicMock()
+        handler._queue_depth_monitor.queued_depth.return_value = 3
+
+        first = MagicMock()
+        first.token_ids = [10]
+        first.finish_reason = "stop"
+        first.stop_reason = None
+        first.logprobs = None
+
+        response = _make_engine_response(request_id="req-queue", finished=True)
+        response.outputs = [first]
+
+        async def fake_generate(*args, **kwargs):
+            assert handler._vllm_scheduler_queue_depth() == 3
+            yield response
+            assert handler._vllm_scheduler_queue_depth() == 3
+
+        handler.engine_client.generate = fake_generate
+
+        chunks = [
+            chunk
+            async for chunk in handler.generate_tokens(
+                mod.TokensPrompt(prompt_token_ids=[1, 2, 3]),
+                MagicMock(),
+                "req-queue",
+            )
+        ]
+
+        assert chunks[0]["token_ids"] == [10]
+        assert chunks[0]["finish_reason"] == "stop"
+        assert handler._vllm_scheduler_queue_depth() == 3
+
+    async def test_decode_generate_rejects_openai_mode_with_openai_shape(self):
+        handler = _make_decode_handler()
+        handler.use_vllm_tokenizer = True
+        _enable_worker_load_shed(handler)
+        context = MagicMock()
+        context.id.return_value = "ctx-decode-shed"
+        request = {"id": "chatcmpl-load-shed", "model": "test-model"}
+
+        chunks = [chunk async for chunk in handler.generate(request, context)]
+
+        assert len(chunks) == 1
+        chunk = chunks[0]
+        assert chunk["id"] == "chatcmpl-load-shed"
+        assert chunk["model"] == "test-model"
+        assert chunk["object"] == "chat.completion.chunk"
+        assert chunk["choices"] == [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": (
+                        "load_shed: worker rejected request_id=ctx-decode-shed "
+                        "vllm_queued=1 threshold=1"
+                    ),
+                },
+                "finish_reason": "stop",
+            }
+        ]
+        assert (
+            chunk["error"] == "load_shed: worker rejected request_id=ctx-decode-shed "
+            "vllm_queued=1 threshold=1"
+        )
+        assert handler._load_shed_rejections == 1
+
+    async def test_prefill_generate_rejects_with_disagg_params_none(self):
+        handler = _make_prefill_handler()
+        _enable_worker_load_shed(handler)
+        context = MagicMock()
+        context.id.return_value = "req-prefill-shed"
+
+        chunks = [chunk async for chunk in handler.generate({}, context)]
+
+        assert chunks == [
+            {
+                "token_ids": [],
+                "finish_reason": (
+                    "error: load_shed: worker rejected "
+                    "request_id=req-prefill-shed vllm_queued=1 threshold=1"
+                ),
+                "disaggregated_params": None,
+            }
+        ]
+        assert handler._load_shed_rejections == 1
+        assert handler._vllm_scheduler_queue_depth() == 1
+
+
 class TestBuildEmbeddingParams:
     """Tests for PrefillWorkerHandler._build_embedding_params."""
 

--- a/tests/fault_tolerance/rejection/test_vllm.py
+++ b/tests/fault_tolerance/rejection/test_vllm.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for vLLM worker-side queue-depth rejection."""
+
+import concurrent.futures
+import logging
+import os
+import shutil
+import time
+from typing import Any
+
+import pytest
+import requests
+
+from tests.fault_tolerance.cancellation.utils import (
+    CancellableRequest,
+    DynamoFrontendProcess,
+)
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.payloads import check_health_generate, check_models_api
+from tests.utils.port_utils import allocate_port, deallocate_port
+
+logger = logging.getLogger(__name__)
+
+VLLM_MAX_NUM_SEQS = 4
+QUEUE_REJECT_THRESHOLD = 4
+
+pytestmark = [
+    pytest.mark.fault_tolerance,
+    pytest.mark.vllm,
+    pytest.mark.e2e,
+    pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
+    pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
+]
+
+
+class DynamoVllmQueueRejectionWorkerProcess(ManagedProcess):
+    """Process manager for a vLLM worker with queue-depth rejection enabled."""
+
+    def __init__(self, request, frontend_port: int):
+        self.system_port = allocate_port(9100)
+        self.fpm_port = allocate_port(20380)
+        self.frontend_port = frontend_port
+
+        command = [
+            "python3",
+            "-m",
+            "dynamo.vllm",
+            "--model",
+            FAULT_TOLERANCE_MODEL_NAME,
+            "--enforce-eager",
+            "--use-vllm-tokenizer",
+            "--gpu-memory-utilization",
+            "0.45",
+            "--max-model-len",
+            "2048",
+            "--max-num-seqs",
+            str(VLLM_MAX_NUM_SEQS),
+        ]
+
+        env = os.environ.copy()
+        env["DYN_REQUEST_PLANE"] = request.getfixturevalue("request_plane")
+        env["DYN_LOG"] = "debug"
+        env["DYN_HEALTH_CHECK_ENABLED"] = "false"
+        env["DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS"] = '["generate"]'
+        env["DYN_SYSTEM_PORT"] = str(self.system_port)
+        env["DYN_HTTP_PORT"] = str(frontend_port)
+        env["DYN_FORWARDPASS_METRIC_PORT"] = str(self.fpm_port)
+        env["DYN_VLLM_REJECT_QUEUE_THRESHOLD"] = str(QUEUE_REJECT_THRESHOLD)
+
+        log_dir = f"{request.node.name}_vllm_queue_rejection_worker"
+        try:
+            shutil.rmtree(log_dir)
+        except FileNotFoundError:
+            pass
+
+        super().__init__(
+            command=command,
+            env=env,
+            health_check_urls=[
+                (f"http://localhost:{self.system_port}/health", self.is_ready),
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api),
+                (f"http://localhost:{frontend_port}/health", check_health_generate),
+            ],
+            timeout=300,
+            display_output=True,
+            terminate_all_matching_process_names=False,
+            stragglers=["VLLM::EngineCore"],
+            straggler_commands=["-m dynamo.vllm"],
+            log_dir=log_dir,
+            display_name="vllm_queue_rejection_worker",
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            deallocate_port(self.system_port)
+            deallocate_port(self.fpm_port)
+        except Exception as e:
+            logger.warning("Failed to release vLLM queue rejection worker ports: %s", e)
+        return super().__exit__(exc_type, exc_val, exc_tb)
+
+    def is_ready(self, response) -> bool:
+        try:
+            data = response.json()
+            if data.get("status") == "ready":
+                logger.info("vLLM queue rejection worker is ready")
+                return True
+            logger.warning("Worker status is not ready: %s", data.get("status"))
+        except ValueError:
+            logger.warning("Worker health response is not valid JSON")
+        return False
+
+
+def _chat_payload(prompt: str, max_tokens: int, stream: bool = False) -> dict[str, Any]:
+    return {
+        "model": FAULT_TOLERANCE_MODEL_NAME,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "ignore_eos": True,
+        "stream": stream,
+    }
+
+
+def _post_chat(frontend_port: int, prompt: str, max_tokens: int) -> requests.Response:
+    return requests.post(
+        f"http://localhost:{frontend_port}/v1/chat/completions",
+        headers={"Content-Type": "application/json"},
+        json=_chat_payload(prompt, max_tokens=max_tokens),
+        timeout=180,
+    )
+
+
+def _start_streaming_chat(
+    frontend_port: int, prompt: str, max_tokens: int
+) -> CancellableRequest:
+    request = CancellableRequest()
+    request.post(
+        f"http://localhost:{frontend_port}/v1/chat/completions",
+        headers={"Content-Type": "application/json"},
+        json=_chat_payload(prompt, max_tokens=max_tokens, stream=True),
+        stream=True,
+        timeout=180,
+    )
+    return request
+
+
+def _wait_for_cancellable_response(
+    request: CancellableRequest, timeout: float = 30.0
+) -> requests.Response:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if request.exception:
+            raise request.exception
+        if request.response is not None:
+            return request.response
+        time.sleep(0.05)
+    pytest.fail("Timed out waiting for streaming request response headers")
+
+
+def _response_contains_load_shed(response: requests.Response) -> bool:
+    text = response.text
+    return "load_shed" in text or "vllm_queued" in text
+
+
+def _assert_successful_response(response: requests.Response) -> None:
+    assert response.status_code == 200, response.text
+    assert not _response_contains_load_shed(response), response.text
+    body = response.json()
+    assert body["choices"], body
+
+
+def _wait_for_vllm_queued_depth(
+    fpm_port: int,
+    target_depth: int,
+    timeout: float = 90.0,
+) -> int:
+    """Wait until InstrumentedScheduler reports target vLLM waiting depth."""
+    import zmq
+
+    from dynamo.common.forward_pass_metrics import decode as decode_forward_pass_metrics
+
+    ctx = zmq.Context.instance()
+    sock = ctx.socket(zmq.SUB)
+    sock.setsockopt(zmq.SUBSCRIBE, b"")
+    sock.connect(f"tcp://127.0.0.1:{fpm_port}")
+    poller = zmq.Poller()
+    poller.register(sock, zmq.POLLIN)
+
+    deadline = time.monotonic() + timeout
+    last_depth = 0
+    try:
+        while time.monotonic() < deadline:
+            remaining_ms = max(1, int((deadline - time.monotonic()) * 1000))
+            events = dict(poller.poll(timeout=min(500, remaining_ms)))
+            if sock not in events:
+                continue
+
+            parts = sock.recv_multipart()
+            metrics = decode_forward_pass_metrics(parts[-1])
+            if metrics is None:
+                continue
+
+            queued = metrics.queued_requests
+            last_depth = queued.num_prefill_requests + queued.num_decode_requests
+            logger.info(
+                "Observed vLLM queued depth=%d (prefill=%d decode=%d)",
+                last_depth,
+                queued.num_prefill_requests,
+                queued.num_decode_requests,
+            )
+            if last_depth >= target_depth:
+                return last_depth
+    finally:
+        try:
+            poller.unregister(sock)
+        except Exception:
+            pass
+        sock.close(linger=0)
+
+    pytest.fail(
+        f"Timed out waiting for vLLM queued depth >= {target_depth}; "
+        f"last_depth={last_depth}"
+    )
+
+
+def _start_streaming_holders(
+    frontend_port: int,
+    count: int,
+    prompt_prefix: str,
+    max_tokens: int = 512,
+) -> list[CancellableRequest]:
+    return [
+        _start_streaming_chat(
+            frontend_port,
+            f"{prompt_prefix} {idx}: count upward until stopped.",
+            max_tokens,
+        )
+        for idx in range(count)
+    ]
+
+
+def _wait_for_streaming_responses(
+    holders: list[CancellableRequest],
+    count: int,
+) -> None:
+    for holder in holders[:count]:
+        response = _wait_for_cancellable_response(holder)
+        assert response.status_code == 200, response.text
+
+
+def _post_overflow_requests(
+    frontend_port: int,
+    count: int = 2,
+) -> list[requests.Response]:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=count) as executor:
+        futures = [
+            executor.submit(
+                _post_chat,
+                frontend_port,
+                f"Overflow request {idx}",
+                8,
+            )
+            for idx in range(count)
+        ]
+        return [future.result(timeout=60) for future in futures]
+
+
+@pytest.mark.timeout(240)
+@pytest.mark.post_merge
+@pytest.mark.gpu_1
+def test_vllm_worker_does_not_reject_when_running_capacity_is_full(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+):
+    """Do not reject when vLLM only has running work, not queued work.
+
+    vLLM is configured to run four requests concurrently and reject only when
+    the scheduler waiting queue reaches four requests. Four streaming requests
+    fill running capacity but do not make queued depth reach the threshold, so
+    two additional requests should be accepted by the worker instead of being
+    load-shed before engine submit.
+    """
+    with DynamoFrontendProcess(request) as frontend:
+        with DynamoVllmQueueRejectionWorkerProcess(
+            request, frontend.frontend_port
+        ) as worker:
+            logger.info("Worker PID: %s", worker.get_pid())
+
+            holders: list[CancellableRequest] = []
+            try:
+                holders = _start_streaming_holders(
+                    frontend.frontend_port,
+                    VLLM_MAX_NUM_SEQS,
+                    "Running capacity fill request",
+                )
+                _wait_for_streaming_responses(holders, VLLM_MAX_NUM_SEQS)
+
+                overflow_responses = _post_overflow_requests(frontend.frontend_port)
+
+                assert len(overflow_responses) == 2
+                for response in overflow_responses:
+                    _assert_successful_response(response)
+            finally:
+                for holder in holders:
+                    holder.cancel()
+
+
+@pytest.mark.timeout(240)
+@pytest.mark.post_merge
+@pytest.mark.gpu_1
+def test_vllm_worker_rejects_when_scheduler_queue_depth_exceeds_threshold(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+):
+    """Reject overflow requests when vLLM waiting queue reaches threshold.
+
+    vLLM is configured to run four requests concurrently. With the rejection
+    threshold set to four queued requests, the test holds eight streaming
+    requests open, waits until vLLM reports four requests in its scheduler
+    waiting queue (four running + four waiting), then sends two overflow
+    requests that should be rejected by the worker before engine submit.
+    """
+    with DynamoFrontendProcess(request) as frontend:
+        with DynamoVllmQueueRejectionWorkerProcess(
+            request, frontend.frontend_port
+        ) as worker:
+            logger.info("Worker PID: %s", worker.get_pid())
+
+            holders: list[CancellableRequest] = []
+            try:
+                holders = _start_streaming_holders(
+                    frontend.frontend_port,
+                    VLLM_MAX_NUM_SEQS + QUEUE_REJECT_THRESHOLD,
+                    "Queue fill request",
+                )
+                _wait_for_streaming_responses(holders, VLLM_MAX_NUM_SEQS)
+
+                observed_depth = _wait_for_vllm_queued_depth(
+                    worker.fpm_port,
+                    QUEUE_REJECT_THRESHOLD,
+                )
+                assert observed_depth >= QUEUE_REJECT_THRESHOLD
+
+                # Give the worker-local subscriber a moment to consume the same
+                # scheduler snapshot seen by the test subscriber.
+                time.sleep(0.25)
+
+                overflow_responses = _post_overflow_requests(frontend.frontend_port)
+                rejected = [
+                    response
+                    for response in overflow_responses
+                    if _response_contains_load_shed(response)
+                ]
+                assert len(rejected) == 2, [
+                    (response.status_code, response.text[:500])
+                    for response in overflow_responses
+                ]
+            finally:
+                for holder in holders:
+                    holder.cancel()


### PR DESCRIPTION
#### Overview:

Adds vLLM worker-level request rejection based on the actual vLLM scheduler queue depth.

#### Details:

- Adds a vLLM queue-depth tracker that updates from vLLM forward-pass metrics.
- Rejects new requests at the worker when the observed vLLM scheduler queue depth exceeds the configured threshold.
- Keeps “running” requests separate from “queued at the engine” requests, so saturated execution slots alone do not trigger rejection.
- Adds unit coverage for queue-depth tracking, metric updates, and rejection behavior.
- Adds vLLM E2E rejection coverage under tests/fault_tolerance/rejection/test_vllm.py.
- Adds coverage for both expected behaviors:
  - no rejection when vLLM concurrency is full but scheduler queue depth is still below threshold
  - rejection when the scheduler queue is already at threshold and additional requests arrive
- Documents that the worker uses the latest queue depth reported by vLLM metrics, rather than a direct local in-flight request counter.

#### Where should the reviewer start?

Start with:

- components/src/dynamo/vllm/handlers.py for the worker rejection logic and queue-depth tracking.
- components/src/dynamo/vllm/args.py for the new rejection configuration.
- components/src/dynamo/vllm/tests/test_vllm_worker_handler.py for unit coverage.
- tests/fault_tolerance/rejection/test_vllm.py for the E2E behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes DIS-2117
