### PR TITLE
fix(docs): update Network Operator link

### DIFF
--- a/docs/kubernetes/cloud-providers/aks/rdma-infiniband.md
+++ b/docs/kubernetes/cloud-providers/aks/rdma-infiniband.md
@@ -44,7 +44,7 @@ The RDMA setup involves five components installed in this order:
 
 ## Step 1: Install the NVIDIA Network Operator
 
-The [NVIDIA Network Operator](https://docs.nvidia.com/networking/display/cokan10/network+operator) automates deployment of networking components including Mellanox OFED drivers for InfiniBand support.
+The [NVIDIA Network Operator](https://docs.nvidia.com/networking/display/kubernetes2610/deployment-guide-kubernetes.html) automates deployment of networking components including Mellanox OFED drivers for InfiniBand support.
 
 Create the namespace and label it for privileged workloads:
 
@@ -418,6 +418,5 @@ kubectl rollout restart daemonset/nvidia-driver-daemonset -n gpu-operator
 - [Azure AKS RDMA InfiniBand — GitHub](https://github.com/Azure/aks-rdma-infiniband)
 - [Set up InfiniBand on Azure HPC VMs — Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband)
 - [Enable InfiniBand VM extension — Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/enable-infiniband)
-- [NVIDIA Network Operator Documentation](https://docs.nvidia.com/networking/display/cokan10/network+operator)
+- [NVIDIA Network Operator Documentation](https://docs.nvidia.com/networking/display/kubernetes2610/deployment-guide-kubernetes.html)
 - [Disaggregated Communication Guide](../../disagg-communication-guide.md) — transport options, UCX configuration, performance expectations
-


### PR DESCRIPTION
#### Overview:

Updates the AKS RDMA / InfiniBand guide to point at the current NVIDIA Network Operator deployment guide instead of the older `cokan10` docs URL that lychee is currently failing to reach.

#### Details:

- Replaces two NVIDIA Network Operator documentation links with the versioned v26.1.0 deployment guide URL.
- Keeps the link aligned with the guide's existing `helm install ... --version v26.1.0` command.

#### Where should the reviewer start?

- `docs/kubernetes/cloud-providers/aks/rdma-infiniband.md`

#### Validation:

- `docker run --rm -v /home/connorc/dynamo-docs-network-operator-link:/workspace:ro -w /workspace lycheeverse/lychee:0.23.0 --no-progress --max-retries 4 --retry-wait-time 3 --timeout 30 --root-dir /workspace --exclude-path '.*ATTRIBUTIONS.*' --exclude-path './lib/llm/tests/data/.*' --accept '200..=299, 403, 429' --exclude-all-private --exclude 0.0.0.0 --verbose --host-concurrency 10 --host-request-interval 1s --host-stats docs/kubernetes/cloud-providers/aks/rdma-infiniband.md`
- `git diff --check`

#### Related Issues:

- Relates to #9856
