### PR TITLE
fix: exclude Istio sidecar injection from agentgateway-proxy pod for gaie

### DIFF
--- a/deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+++ b/deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
@@ -46,6 +46,31 @@ helm upgrade -i --namespace "$AGW_NAMESPACE" --version "$AGW_VERSION" agentgatew
   --set inferenceExtension.enabled=true \
   --wait
 
+# Create an AgentgatewayParameters resource that excludes Istio sidecar injection
+# from the agentgateway-proxy pods. When the deployment namespace has
+# istio-injection=enabled, the Istio sidecar intercepts the ext_proc gRPC
+# connection from agentgateway-proxy to EPP (port 9002), causing all inference
+# requests to return HTTP 500. Setting sidecar.istio.io/inject: "false" on the
+# pod template prevents sidecar injection so that ext_proc traffic reaches EPP
+# directly. This annotation is a no-op on clusters where Istio is not installed.
+#
+# AgentgatewayParameters must live in the same namespace as the Gateway because
+# Gateway API's infrastructure.parametersRef is a LocalParametersReference
+# (no namespace field).
+kubectl apply --server-side -n "$NAMESPACE" -f - <<'EOF'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayParameters
+metadata:
+  name: inference-gateway-params
+spec:
+  deployment:
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+EOF
+
 kubectl apply -n "$NAMESPACE" -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -53,6 +78,11 @@ metadata:
   name: inference-gateway
 spec:
   gatewayClassName: agentgateway
+  infrastructure:
+    parametersRef:
+      group: agentgateway.dev
+      kind: AgentgatewayParameters
+      name: inference-gateway-params
   listeners:
     - name: http
       port: 80

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -326,6 +326,117 @@ spec:
 
 If you are **not** using the Dynamo operator's Helm chart, you must create this `DestinationRule` manually for each EPP service. Without it, Istio's default mTLS policy will conflict with the EPP's gRPC TLS endpoint.
 
+**Inference-gateway Istio sidecar exclusion**
+
+When namespace-level Istio sidecar injection is enabled (`istio-injection=enabled`), the agentgateway-proxy pod also receives an Istio sidecar. This sidecar intercepts the ext_proc gRPC connection from agentgateway-proxy to EPP (port 9002) and routes it through `PassthroughCluster`, which breaks the connection and causes all inference requests to return HTTP 500 with an empty body.
+
+The fix is to tell agentgateway to stamp `sidecar.istio.io/inject: "false"` on the proxy pod template so the Istio webhook skips that pod. EPP and worker pods still receive sidecars normally.
+
+You have two options depending on how you set up the gateway:
+
+***Option A: Per-gateway `AgentgatewayParameters` (recommended)***
+
+This is what `install_gaie_crd_agentgateway.sh` does automatically. It only affects the `inference-gateway` proxy pods and leaves any other agentgateway-managed gateways untouched.
+
+1. Create an `AgentgatewayParameters` resource in **the same namespace as the `inference-gateway` Gateway** (e.g. `dynamo-cloud`). It must be co-located with the `Gateway` because the Gateway API `spec.infrastructure.parametersRef` is a `LocalParametersReference` — it has no `namespace` field.
+
+   ```yaml
+   apiVersion: agentgateway.dev/v1alpha1
+   kind: AgentgatewayParameters
+   metadata:
+     name: inference-gateway-params
+     namespace: dynamo-cloud   # same as the Gateway
+   spec:
+     deployment:
+       spec:
+         template:
+           metadata:
+             annotations:
+               sidecar.istio.io/inject: "false"
+   ```
+
+   Apply it with server-side apply (recommended by agentgateway):
+
+   ```bash
+   kubectl apply --server-side -n dynamo-cloud -f agentgateway-params.yaml
+   ```
+
+2. Wire the existing `Gateway` to use it. If the Gateway already exists, patch it in place:
+
+   ```bash
+   kubectl patch gateway inference-gateway -n dynamo-cloud --type='merge' -p '{
+     "spec": {
+       "infrastructure": {
+         "parametersRef": {
+           "group": "agentgateway.dev",
+           "kind":  "AgentgatewayParameters",
+           "name":  "inference-gateway-params"
+         }
+       }
+     }
+   }'
+   ```
+
+   Or include the `infrastructure` block directly in your `Gateway` manifest:
+
+   ```yaml
+   apiVersion: gateway.networking.k8s.io/v1
+   kind: Gateway
+   metadata:
+     name: inference-gateway
+     namespace: dynamo-cloud
+   spec:
+     gatewayClassName: agentgateway
+     infrastructure:
+       parametersRef:
+         group: agentgateway.dev
+         kind: AgentgatewayParameters
+         name: inference-gateway-params
+     listeners:
+       - name: http
+         port: 80
+         protocol: HTTP
+   ```
+
+3. agentgateway will roll the proxy pod. Verify the new pod no longer has an `istio-proxy` container:
+
+   ```bash
+   kubectl get pod -l gateway.networking.k8s.io/gateway-name=inference-gateway \
+     -n dynamo-cloud \
+     -o jsonpath='{.items[0].spec.containers[*].name}{"\n"}'
+   # Expect: agentgateway   (NOT "agentgateway istio-proxy")
+   ```
+
+***Option B: Patch the default `AgentgatewayParameters` CR (cluster-wide)***
+
+The agentgateway controller creates a default `AgentgatewayParameters` resource named `agentgateway` in `agentgateway-system`. Any `Gateway` that does not set `spec.infrastructure.parametersRef` inherits this default. Patching it affects **all** agentgateway-managed proxies in the cluster.
+
+```bash
+kubectl patch agentgatewayparameters agentgateway -n agentgateway-system \
+  --type='merge' -p '{
+  "spec": {
+    "deployment": {
+      "spec": {
+        "template": {
+          "metadata": {
+            "annotations": {
+              "sidecar.istio.io/inject": "false"
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Use Option A instead if you have multiple agentgateway-managed gateways in the cluster and only want the `inference-gateway` proxy to skip injection.
+
+The annotation is a no-op on clusters where Istio is not installed, so it is safe to set unconditionally.
+
+> [!NOTE]
+> With both the `DestinationRule` (for EPP) and the `AgentgatewayParameters` sidecar exclusion (for agentgateway-proxy) in place, end-to-end GAIE inference works correctly under Istio namespace-level injection.
+
 ### 6. Verify Installation ###
 
 Check that all resources are properly deployed:


### PR DESCRIPTION
When namespace-level Istio injection (istio-injection=enabled) is active, the agentgateway-proxy pod receives an Istio sidecar that intercepts the ext_proc gRPC connection to EPP (port 9002) through PassthroughCluster, returning HTTP 500 for all inference requests.

install_gaie_crd_agentgateway.sh now creates an AgentgatewayParameters resource (agentgateway.dev/v1alpha1) in the inference-gateway's namespace with sidecar.istio.io/inject: "false" set in
spec.deployment.spec.template.metadata.annotations, and creates the inference-gateway Gateway with spec.infrastructure.parametersRef pointing at it. Gateway API's parametersRef is a LocalParametersReference (no namespace field), so AgentgatewayParameters lives in the Gateway's namespace.

This prevents the Istio sidecar from being injected into agentgateway-proxy pods while remaining a no-op on clusters without Istio. It complements the DestinationRule auto-generation added for EPP in PR #8270: both pieces are required for end-to-end GAIE inference under namespace-level Istio sidecar injection.

Update docs/kubernetes/inference-gateway.md with the same two-option manual remediation guide (per-gateway AgentgatewayParameters vs patch of the default cluster-wide CR) that was added for kgateway in DYN-3077.

Fixes: DYN-3077

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Istio sidecar interference with ext_proc gRPC communication in inference gateway deployments, preventing HTTP 500 errors.

* **Documentation**
  * Added comprehensive guide for configuring Istio sidecar exclusion with two supported configuration approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->