### PR TITLE
docs(release/1.2.0): pin observability links to release branch to unbreak lychee

### DIFF
--- a/docs/development/runtime-guide.md
+++ b/docs/development/runtime-guide.md
@@ -31,7 +31,7 @@ cargo test
 
 The simplest way to deploy the pre-requisite services is using
 [docker-compose](https://docs.docker.com/compose/install/linux/),
-defined in [deploy/docker-compose.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/docker-compose.yml).
+defined in [deploy/docker-compose.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/docker-compose.yml).
 
 ```
 # At the root of the repository:

--- a/docs/kubernetes/cloud-providers/eks/efa.md
+++ b/docs/kubernetes/cloud-providers/eks/efa.md
@@ -1,11 +1,8 @@
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 title: EFA (RDMA over AWS Fabric) on EKS
 ---
-
-<!--
-SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
--->
 
 # EFA (RDMA over AWS Fabric) on EKS
 

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -96,14 +96,14 @@ The dcgm-exporter service in the Docker Compose network is configured to use por
 ### Configuration Files
 
 The following configuration files are located in the `deploy/observability/` directory:
-- [docker-compose.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/docker-compose.yml): Defines NATS and etcd services
-- [docker-observability.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/docker-observability.yml): Defines Prometheus, Grafana, Tempo, and exporters
-- [prometheus.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/prometheus.yml): Contains Prometheus scraping configuration
-- [grafana-datasources.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/grafana-datasources.yml): Contains Grafana datasource configuration
-- [otel-collector.yaml](https://github.com/ai-dynamo/dynamo/blob/main/deploy/observability/otel-collector.yaml): OpenTelemetry Collector configuration (routes traces to Tempo, logs to Loki)
-- [loki.yaml](https://github.com/ai-dynamo/dynamo/blob/main/deploy/observability/loki.yaml): Loki log aggregation configuration
-- [loki-datasource.yml](https://github.com/ai-dynamo/dynamo/blob/main/deploy/observability/loki-datasource.yml): Grafana Loki datasource with trace ID linking to Tempo
-- [grafana_dashboards/dashboard-providers.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/grafana_dashboards/dashboard-providers.yml): Contains Grafana dashboard provider configuration
-- [grafana_dashboards/dynamo.json](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/grafana_dashboards/dynamo.json): A general Dynamo Dashboard for both SW and HW metrics
-- [grafana_dashboards/dcgm-metrics.json](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/grafana_dashboards/dcgm-metrics.json): Contains Grafana dashboard configuration for DCGM GPU metrics
-- [grafana_dashboards/kvbm.json](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/grafana_dashboards/kvbm.json): Contains Grafana dashboard configuration for KVBM metrics
+- [docker-compose.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/docker-compose.yml): Defines NATS and etcd services
+- [docker-observability.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/docker-observability.yml): Defines Prometheus, Grafana, Tempo, and exporters
+- [prometheus.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/prometheus.yml): Contains Prometheus scraping configuration
+- [grafana-datasources.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/grafana-datasources.yml): Contains Grafana datasource configuration
+- [otel-collector.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.2.0/deploy/observability/otel-collector.yaml): OpenTelemetry Collector configuration (routes traces to Tempo, logs to Loki)
+- [loki.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.2.0/deploy/observability/loki.yaml): Loki log aggregation configuration
+- [loki-datasource.yml](https://github.com/ai-dynamo/dynamo/blob/release/1.2.0/deploy/observability/loki-datasource.yml): Grafana Loki datasource with trace ID linking to Tempo
+- [grafana_dashboards/dashboard-providers.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/grafana_dashboards/dashboard-providers.yml): Contains Grafana dashboard provider configuration
+- [grafana_dashboards/dynamo.json](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/grafana_dashboards/dynamo.json): A general Dynamo Dashboard for both SW and HW metrics
+- [grafana_dashboards/dcgm-metrics.json](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/grafana_dashboards/dcgm-metrics.json): Contains Grafana dashboard configuration for DCGM GPU metrics
+- [grafana_dashboards/kvbm.json](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/grafana_dashboards/kvbm.json): Contains Grafana dashboard configuration for KVBM metrics

--- a/docs/observability/prometheus-grafana.md
+++ b/docs/observability/prometheus-grafana.md
@@ -80,7 +80,7 @@ Other interfaces:
 
 ### Prometheus
 
-The Prometheus configuration is specified in [prometheus.yml](https://github.com/ai-dynamo/dynamo/tree/main/deploy/observability/prometheus.yml). This file is set up to collect metrics from the metrics aggregation service endpoint.
+The Prometheus configuration is specified in [prometheus.yml](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0/deploy/observability/prometheus.yml). This file is set up to collect metrics from the metrics aggregation service endpoint.
 
 Please be aware that you might need to modify the target settings to align with your specific host configuration and network environment.
 


### PR DESCRIPTION
Closes OPS-6586

## Summary
Every PR targeting `release/1.2.0` has been failing the **Docs link check / lychee** job, and the docs CI on this branch had a second latent failure waiting behind it.

### 1. lychee (`Docs link check`) — fixed in commit 1
- Docs on this branch reference `github.com/ai-dynamo/dynamo/tree/main/deploy/...` URLs for files that have been removed/restructured on `main` as part of an observability refactor (e.g. `deploy/docker-compose.yml`, `deploy/docker-observability.yml`, and the whole `deploy/observability/grafana_dashboards/` dir). Lychee fetches the URLs live, gets 404s, and exits 2. Example failure: https://github.com/ai-dynamo/dynamo/actions/runs/26244622313/job/77239631302
- Fix: pin the 13 affected links to the `release/1.2.0` branch, where the referenced files still exist.

Touched:
- `docs/development/runtime-guide.md` (1 link)
- `docs/observability/README.md` (11 links)
- `docs/observability/prometheus-grafana.md` (1 link)

Other `tree/main/` references in the release docs are technically also stale-pointer risks, but they currently resolve and lychee passes them, so they're left out of scope here.

### 2. Fern Broken Links Check / Preview or publish docs — fixed in commit 2
The `Fern Docs` workflow is path-filtered to `docs/**`. Previous release-branch PRs were Go-only, so this workflow had **never run** against the `release/1.2.0` content. The first commit on this PR touched docs, triggered the workflow, and surfaced a pre-existing MDX parse error: ``Unexpected character `\!` (U+0021) before name`` — see https://github.com/ai-dynamo/dynamo/actions/runs/26261605981/job/77296067110.

Root cause: `docs/kubernetes/cloud-providers/eks/efa.md` is the only file in `docs/` with an HTML comment block (`<\!-- ... -->`) for its SPDX header. Fern's MDX-flavored parser rejects HTML comments outside code fences. Every other docs file in the repo puts SPDX lines as `#` comments inside the YAML frontmatter — this one is the outlier.

Fix: move the SPDX lines into the frontmatter to match repo convention. This also resolves the downstream `Preview or publish docs` failure, which fails on the same parse error.

## Test plan
- [ ] `Docs link check / lychee` passes
- [ ] `Fern Broken Links Check` passes
- [ ] `Preview or publish docs` passes
- [ ] Spot-check the rendered links resolve to files on the `release/1.2.0` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
