### PR TITLE
fix(vllm): allow prefill sleep after NIXL KV transfer

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -276,6 +276,16 @@ def update_engine_config_with_dynamo(
                 f"be injected. To use forward pass metrics, either remove "
                 f"--scheduler-cls or subclass InstrumentedScheduler."
             )
+    else:
+        existing_cls = getattr(engine_config, "scheduler_cls", None)
+        if existing_cls is None and _uses_nixl_connector(engine_config):
+            defaults[
+                "scheduler_cls"
+            ] = "dynamo.vllm.scheduler_patches.PatchedAsyncScheduler"
+            logger.info(
+                "NixlConnector detected: scheduler_cls set to PatchedAsyncScheduler "
+                "for disaggregated sleep support"
+            )
 
     if dynamo_config.benchmark_mode is not None:
         if dynamo_config.multimodal_worker or dynamo_config.multimodal_decode_worker:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -251,6 +251,7 @@ class VllmEngineQuiesceController:
         else:
             await self._engine_client.wake_up(tags)
         await self._engine_client.resume_generation()
+        self._is_quiesced = False
         return True
 
     def mark_resumed(self) -> None:
@@ -600,6 +601,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     # __new__ still have a sane value; __init__ overrides this from
     # hf_config.use_unified_vision_chunk on real instances.
     _use_unified_vision_chunk: bool = False
+    _endpoint_needs_registration: bool = False
+    _scheduler_needs_resume: bool = False
 
     def __init__(
         self,
@@ -652,6 +655,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self._quiesce_controller = VllmEngineQuiesceController(self.engine_client)
         self._quiesce_lock = asyncio.Lock()
         self._mm_kwargs_receiver: MmKwargsNixlReceiver | None = None
+        # Track partial sleep/wake transitions so failure paths can reconcile
+        # scheduler/discovery state on retry.
+        self._endpoint_needs_registration = False
+        self._scheduler_needs_resume = False
 
         # Some models (Kimi-K2.5) declare their image modality as
         # "vision_chunk" rather than "image". vLLM's openai entrypoint
@@ -761,19 +768,30 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
             try:
                 # Step 1: Unregister endpoint instance before memory transitions.
-                if self.generate_endpoint is not None:
+                if (
+                    self.generate_endpoint is not None
+                    and not self._endpoint_needs_registration
+                ):
                     await self.generate_endpoint.unregister_endpoint_instance()
+                    self._endpoint_needs_registration = True
                     logger.info(
                         "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
                     )
 
                 # Step 2: Abort in-flight requests and wait for them to drain so the
                 # GPU is fully quiesced before unmapping memory.
-                if not await self._quiesce_controller.quiesce(level):
+                try:
+                    transitioned = await self._quiesce_controller.quiesce(level)
+                except Exception:
+                    self._scheduler_needs_resume = True
+                    raise
+
+                if not transitioned:
                     return {
                         "status": "ok",
                         "message": "Engine already sleeping",
                     }
+                self._scheduler_needs_resume = False
 
                 return {
                     "status": "ok",
@@ -781,6 +799,32 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")
+                # If the engine did not fully enter sleep mode, undo any
+                # partial scheduler/discovery transition.  Keep the repair
+                # flags set if rollback fails so a later wake_up call can
+                # retry the reconciliation.
+                if not self._quiesce_controller.is_quiesced:
+                    try:
+                        if self._scheduler_needs_resume:
+                            await self.engine_client.resume_generation()
+                            self._scheduler_needs_resume = False
+                            logger.info(
+                                "[Sleep] Resumed scheduler after failed sleep"
+                            )
+                        if (
+                            self.generate_endpoint is not None
+                            and self._endpoint_needs_registration
+                        ):
+                            await self.generate_endpoint.register_endpoint_instance()
+                            self._endpoint_needs_registration = False
+                            logger.info(
+                                "[Sleep] Re-registered endpoint after failed sleep - worker restored to routing pool"
+                            )
+                    except Exception as rollback_error:
+                        logger.error(
+                            "Failed to restore scheduler/discovery after sleep failure: %s",
+                            rollback_error,
+                        )
                 return {"status": "error", "message": str(e)}
 
     async def scale_elastic_ep(self, body: dict) -> dict:
@@ -896,18 +940,31 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         body = body or {}
         tags = body.get("tags")
         async with self._quiesce_lock:
-            if not self._quiesce_controller.is_quiesced:
+            if (
+                not self._quiesce_controller.is_quiesced
+                and not self._endpoint_needs_registration
+                and not self._scheduler_needs_resume
+            ):
                 return {"status": "ok", "message": "Engine already awake"}
 
             try:
                 # Step 1: Wake engine first - must be ready before accepting requests
-                await self._quiesce_controller.resume(tags)
-                if self.generate_endpoint is not None:
+                if self._quiesce_controller.is_quiesced:
+                    await self._quiesce_controller.resume(tags)
+                    self._scheduler_needs_resume = False
+                elif self._scheduler_needs_resume:
+                    await self.engine_client.resume_generation()
+                    self._scheduler_needs_resume = False
+                    logger.info("[Wake] Resumed scheduler after failed sleep attempt")
+                if (
+                    self.generate_endpoint is not None
+                    and self._endpoint_needs_registration
+                ):
                     await self.generate_endpoint.register_endpoint_instance()
+                    self._endpoint_needs_registration = False
                     logger.info(
                         "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
                     )
-                self._quiesce_controller.mark_resumed()
 
                 return {
                     "status": "ok",

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -109,6 +109,12 @@ from dynamo.common.forward_pass_metrics import (
 )
 from dynamo.runtime.logging import configure_dynamo_logging
 
+# Import for side effect: applies the reset_prefix_cache patch needed for
+# disaggregated sleep support (NixlConnector delay-free blocks). This keeps
+# benchmark/FPM workers patched even though they use InstrumentedScheduler
+# instead of PatchedAsyncScheduler.
+from dynamo.vllm import scheduler_patches  # noqa: F401
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.v1.kv_cache_interface import KVCacheConfig

--- a/components/src/dynamo/vllm/scheduler_patches.py
+++ b/components/src/dynamo/vllm/scheduler_patches.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Temporary vLLM scheduler patches for NIXL disaggregated sleep.
+
+The upstream fix is being tracked in vllm-project/vllm#41180. Until it lands in
+the runtime images Dynamo uses, this module makes ``/engine/sleep`` robust after
+prefill-side NIXL KV transfer by:
+
+* freeing requests whose blocks are still pinned by connector delayed-free state
+  before ``Scheduler.reset_prefix_cache(reset_running_requests=True)`` delegates
+  to upstream vLLM; and
+* ignoring late ``finished_sending`` / ``finished_recving`` notifications for
+  request ids that were already freed during that reset.
+
+``dynamo.vllm.args`` selects :class:`PatchedAsyncScheduler` only for NIXL configs
+with no user-specified scheduler class. vLLM resolves that class in the
+EngineCore subprocess, so the monkey patches below are installed in the process
+that owns the scheduler.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.request import RequestStatus
+
+logger = logging.getLogger(__name__)
+
+# Scheduler attributes used by the patch.
+_DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR = "_dynamo_original_reset_prefix_cache"
+_IGNORE_LATE_KV_XFER_ATTR = "_dynamo_ignored_kv_xfer_req_ids"
+
+
+def _get_ignore_set(scheduler: Scheduler) -> set[str]:
+    s = getattr(scheduler, _IGNORE_LATE_KV_XFER_ATTR, None)
+    if s is None:
+        s = set()
+        setattr(scheduler, _IGNORE_LATE_KV_XFER_ATTR, s)
+    return s
+
+
+def _remember_for_late_kv_xfer_drop(scheduler: Scheduler, req_id: str) -> None:
+    """Record that a request was force-freed during cache reset."""
+
+    _get_ignore_set(scheduler).add(req_id)
+
+
+def _take_ignored_req_id(scheduler: Scheduler, req_id: str) -> bool:
+    """Return True if a late connector notification should be dropped."""
+
+    ignore = _get_ignore_set(scheduler)
+    if req_id not in ignore:
+        return False
+    ignore.discard(req_id)
+    return True
+
+
+def _reset_prefix_cache_with_delay_free(
+    self: Scheduler,
+    reset_running_requests: bool = False,
+    reset_connector: bool = False,
+) -> bool:
+    if reset_running_requests:
+        freed_finished = 0
+        freed_waiting_recv = 0
+        waiting_recv_requests = []
+        for req_id in list(self.requests.keys()):
+            request = self.requests[req_id]
+            if request.is_finished():
+                # Prefill finished-but-delayed (NixlConnector
+                # delay_free_blocks=True).
+                self._free_blocks(request)
+                _remember_for_late_kv_xfer_drop(self, req_id)
+                freed_finished += 1
+            elif request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                # Decode-side: blocks allocated at schedule time, normally
+                # freed only when the remote send signals completion.
+                # Caller is about to wipe KV memory anyway.
+                request.status = RequestStatus.FINISHED_ABORTED
+                waiting_recv_requests.append(request)
+                self._free_blocks(request)
+                _remember_for_late_kv_xfer_drop(self, req_id)
+                freed_waiting_recv += 1
+        if waiting_recv_requests:
+            self.waiting.remove_requests(waiting_recv_requests)
+            self.skipped_waiting.remove_requests(waiting_recv_requests)
+        if freed_finished or freed_waiting_recv:
+            logger.info(
+                "reset_prefix_cache: force-freed %d finished-but-delayed "
+                "and %d WAITING_FOR_REMOTE_KVS requests before cache "
+                "reset (ignore-set size=%d).",
+                freed_finished,
+                freed_waiting_recv,
+                len(_get_ignore_set(self)),
+            )
+        self.finished_recving_kv_req_ids.clear()
+        self.failed_recving_kv_req_ids.clear()
+
+    original = getattr(Scheduler, _DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR)
+    return original(self, reset_running_requests, reset_connector)
+
+
+def _update_from_kv_xfer_finished_safe(self: Scheduler, kv_connector_output) -> None:
+    """Drop stale connector completions before applying upstream's state update.
+
+    Upstream asserts every completion still has a live ``self.requests`` entry.
+    That is not true after sleep/reset force-frees NIXL-delayed blocks.
+    """
+    if self.connector is not None:
+        self.connector.update_connector_output(kv_connector_output)
+
+    for req_id in kv_connector_output.finished_recving or ():
+        if _take_ignored_req_id(self, req_id) or req_id not in self.requests:
+            logger.debug("Dropping stale finished_recving for request %s", req_id)
+            continue
+        req = self.requests[req_id]
+        if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+            self.finished_recving_kv_req_ids.add(req_id)
+        else:
+            assert RequestStatus.is_finished(req.status)
+            self._free_blocks(self.requests[req_id])
+
+    for req_id in kv_connector_output.finished_sending or ():
+        if _take_ignored_req_id(self, req_id) or req_id not in self.requests:
+            logger.debug("Dropping stale finished_sending for request %s", req_id)
+            continue
+        self._free_blocks(self.requests[req_id])
+
+
+def _install_scheduler_patches() -> None:
+    """Install the monkey patches, preserving the true upstream methods."""
+
+    original_reset = getattr(Scheduler, _DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR, None)
+    if original_reset is None:
+        original_reset = Scheduler.reset_prefix_cache
+
+    setattr(Scheduler, _DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR, original_reset)
+
+    Scheduler.reset_prefix_cache = _reset_prefix_cache_with_delay_free
+    Scheduler._update_from_kv_xfer_finished = _update_from_kv_xfer_finished_safe
+
+
+_install_scheduler_patches()
+
+
+class PatchedAsyncScheduler(AsyncScheduler):
+    """Import target used as ``--scheduler-cls`` for NIXL workers."""

--- a/components/src/dynamo/vllm/tests/test_vllm_scheduler_patches.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_scheduler_patches.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the temporary NIXL scheduler patches."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.fixture
+def scheduler(monkeypatch):
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    import dynamo.vllm.scheduler_patches as sp
+
+    monkeypatch.setattr(
+        Scheduler,
+        sp._DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR,
+        lambda *args, **kwargs: True,
+    )
+
+    s = MagicMock(spec=Scheduler)
+    s.reset_prefix_cache = sp._reset_prefix_cache_with_delay_free.__get__(s, Scheduler)
+    s._update_from_kv_xfer_finished = sp._update_from_kv_xfer_finished_safe.__get__(
+        s, Scheduler
+    )
+    s.finished_recving_kv_req_ids = set()
+    s.failed_recving_kv_req_ids = set()
+    s.connector = None
+    s.requests = {}
+    s.waiting = MagicMock()
+    s.skipped_waiting = MagicMock()
+    s._free_blocks = MagicMock()
+    return s
+
+
+def _req(req_id: str, *, finished: bool = False, status=None):
+    request = SimpleNamespace(request_id=req_id, status=status)
+    request.is_finished = lambda: finished
+    return request
+
+
+def test_reset_frees_finished_delay_free_request(scheduler):
+    """Finished NIXL-prefill requests may still pin KV blocks."""
+
+    import dynamo.vllm.scheduler_patches as sp
+
+    delayed = _req("delayed", finished=True)
+    active = _req("active")
+    scheduler.requests = {"delayed": delayed, "active": active}
+
+    assert scheduler.reset_prefix_cache(reset_running_requests=True) is True
+
+    scheduler._free_blocks.assert_called_once_with(delayed)
+    assert getattr(scheduler, sp._IGNORE_LATE_KV_XFER_ATTR) == {"delayed"}
+
+
+def test_reset_frees_waiting_for_remote_kvs_request(scheduler):
+    """Decode-side WAITING_FOR_REMOTE_KVS requests must not block sleep."""
+
+    from vllm.v1.request import RequestStatus
+
+    waiting = _req("recv", status=RequestStatus.WAITING_FOR_REMOTE_KVS)
+    scheduler.requests = {"recv": waiting}
+
+    assert scheduler.reset_prefix_cache(reset_running_requests=True) is True
+
+    scheduler._free_blocks.assert_called_once_with(waiting)
+    scheduler.waiting.remove_requests.assert_called_once_with([waiting])
+    scheduler.skipped_waiting.remove_requests.assert_called_once_with([waiting])
+    assert waiting.status == RequestStatus.FINISHED_ABORTED
+
+
+def test_late_finished_signals_for_force_freed_requests_are_dropped(scheduler):
+    """Late NIXL completion events for force-freed req_ids are harmless."""
+
+    import dynamo.vllm.scheduler_patches as sp
+
+    setattr(scheduler, sp._IGNORE_LATE_KV_XFER_ATTR, {"stale-send", "stale-recv"})
+
+    scheduler._update_from_kv_xfer_finished(
+        SimpleNamespace(
+            finished_recving={"stale-recv"},
+            finished_sending={"stale-send"},
+        )
+    )
+
+    scheduler._free_blocks.assert_not_called()
+    assert getattr(scheduler, sp._IGNORE_LATE_KV_XFER_ATTR) == set()
+
+
+def test_unknown_finished_signal_is_dropped(scheduler):
+    """Do not assert if vLLM reports a completion for a vanished request."""
+
+    scheduler._update_from_kv_xfer_finished(
+        SimpleNamespace(finished_recving=set(), finished_sending={"unknown"})
+    )
+
+    scheduler._free_blocks.assert_not_called()
+
+
+def test_live_finished_signal_keeps_upstream_behavior(scheduler):
+    """Live requests still use the normal _free_blocks path."""
+
+    live = _req("live", finished=True)
+    scheduler.requests = {"live": live}
+
+    scheduler._update_from_kv_xfer_finished(
+        SimpleNamespace(finished_recving=set(), finished_sending={"live"})
+    )
+
+    scheduler._free_blocks.assert_called_once_with(live)
+
+
+def test_patch_installs_importable_scheduler_cls():
+    """Importing the scheduler class installs both monkey patches."""
+
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    import dynamo.vllm.scheduler_patches as sp
+
+    assert Scheduler.reset_prefix_cache is sp._reset_prefix_cache_with_delay_free
+    assert (
+        Scheduler._update_from_kv_xfer_finished is sp._update_from_kv_xfer_finished_safe
+    )
+    assert issubclass(sp.PatchedAsyncScheduler, Scheduler)
+
+
+def test_reimport_preserves_original_reset_method():
+    """Reloading should not wrap the wrapper as the upstream original."""
+
+    import importlib
+
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    import dynamo.vllm.scheduler_patches as sp
+
+    original_reset = getattr(Scheduler, sp._DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR)
+
+    importlib.reload(sp)
+
+    assert Scheduler.reset_prefix_cache is sp._reset_prefix_cache_with_delay_free
+    assert (
+        getattr(Scheduler, sp._DYNAMO_ORIGINAL_RESET_PREFIX_CACHE_ATTR)
+        is original_reset
+    )

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -12,6 +12,7 @@ from dynamo.vllm.handlers import BaseWorkerHandler, VllmEngineQuiesceController
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
@@ -36,6 +37,8 @@ def _make_handler() -> _TestWorkerHandler:
     )
     handler._quiesce_controller = VllmEngineQuiesceController(handler.engine_client)
     handler._quiesce_lock = asyncio.Lock()
+    handler._endpoint_needs_registration = False
+    handler._scheduler_needs_resume = False
     return handler
 
 
@@ -71,7 +74,7 @@ async def test_sleep_and_wake_are_idempotent():
 
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
-    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    assert handler.generate_endpoint.register_endpoint_instance.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -95,6 +98,7 @@ async def test_quiesce_without_level_uses_vllm_default_sleep():
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
     await handler._quiesce_controller.quiesce(1)
+    handler._endpoint_needs_registration = True
 
     result = await handler.wake_up({"tags": ["weights"]})
 
@@ -116,12 +120,87 @@ async def test_sleep_returns_error_for_unregister_failure():
     assert result["status"] == "error"
     handler.engine_client.pause_generation.assert_not_awaited()
     handler.engine_client.sleep.assert_not_awaited()
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sleep_rolls_back_discovery_when_quiesce_fails():
+    handler = _make_handler()
+    handler.engine_client.sleep = AsyncMock(side_effect=RuntimeError("sleep failed"))
+
+    result = await handler.sleep({"level": 1})
+
+    assert result["status"] == "error"
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+    handler.engine_client.pause_generation.assert_awaited_once()
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    handler.engine_client.resume_generation.assert_awaited_once()
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is False
+    assert handler._scheduler_needs_resume is False
+
+
+@pytest.mark.asyncio
+async def test_sleep_keeps_registration_repair_pending_when_rollback_fails():
+    handler = _make_handler()
+    handler.engine_client.sleep = AsyncMock(side_effect=RuntimeError("sleep failed"))
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=RuntimeError("discovery write timeout")
+    )
+
+    result = await handler.sleep({"level": 1})
+
+    assert result["status"] == "error"
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+    handler.engine_client.pause_generation.assert_awaited_once()
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    handler.engine_client.resume_generation.assert_awaited_once()
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is True
+    assert handler._scheduler_needs_resume is False
+
+
+@pytest.mark.asyncio
+async def test_sleep_resumes_scheduler_when_quiesce_fails_without_endpoint():
+    handler = _make_handler()
+    handler.generate_endpoint = None
+    handler.engine_client.sleep = AsyncMock(side_effect=RuntimeError("sleep failed"))
+
+    result = await handler.sleep({"level": 1})
+
+    assert result["status"] == "error"
+    handler.engine_client.pause_generation.assert_awaited_once()
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    handler.engine_client.resume_generation.assert_awaited_once()
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is False
+    assert handler._scheduler_needs_resume is False
+
+
+@pytest.mark.asyncio
+async def test_wake_up_repairs_pending_resume_and_registration():
+    handler = _make_handler()
+    handler._scheduler_needs_resume = True
+    handler._endpoint_needs_registration = True
+
+    result = await handler.wake_up({})
+
+    assert result["status"] == "ok"
+    handler.engine_client.wake_up.assert_not_awaited()
+    handler.engine_client.resume_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is False
+    assert handler._scheduler_needs_resume is False
 
 
 @pytest.mark.asyncio
 async def test_wake_up_returns_error_for_register_failure():
     handler = _make_handler()
     await handler._quiesce_controller.quiesce(1)
+    handler._endpoint_needs_registration = True
     handler.generate_endpoint.register_endpoint_instance = AsyncMock(
         side_effect=RuntimeError("discovery write timeout")
     )
@@ -131,4 +210,26 @@ async def test_wake_up_returns_error_for_register_failure():
     assert result["status"] == "error"
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
-    assert handler._quiesce_controller.is_quiesced is True
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is True
+    assert handler._scheduler_needs_resume is False
+
+
+@pytest.mark.asyncio
+async def test_wake_up_retries_registration_without_rewaking_engine():
+    handler = _make_handler()
+    await handler.sleep({"level": 1})
+    handler.generate_endpoint.register_endpoint_instance = AsyncMock(
+        side_effect=[RuntimeError("discovery write timeout"), None]
+    )
+
+    first_result = await handler.wake_up({})
+    second_result = await handler.wake_up({})
+
+    assert first_result["status"] == "error"
+    assert second_result["status"] == "ok"
+    handler.engine_client.wake_up.assert_awaited_once_with()
+    handler.engine_client.resume_generation.assert_awaited_once()
+    assert handler.generate_endpoint.register_endpoint_instance.await_count == 2
+    assert handler._quiesce_controller.is_quiesced is False
+    assert handler._endpoint_needs_registration is False

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -861,6 +861,24 @@ class TestRunnerPreservation:
         assert not hasattr(engine_cfg, "runner")
 
 
+def test_nixl_connector_uses_patched_scheduler_by_default():
+    dynamo_cfg = _make_dynamo_config()
+    engine_cfg = _make_engine_config_with_runner(
+        kv_transfer_config=SimpleNamespace(
+            kv_connector="NixlConnector",
+            kv_connector_extra_config=None,
+        ),
+        scheduler_cls=None,
+    )
+
+    update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+    assert (
+        engine_cfg.scheduler_cls
+        == "dynamo.vllm.scheduler_patches.PatchedAsyncScheduler"
+    )
+
+
 class TestEmbeddingWorkerFlag:
     """Parsing + validation for --embedding-worker."""
 


### PR DESCRIPTION
## Summary

Fixes prefill `/engine/sleep` in disaggregated vLLM deployments after NIXL KV transfer has occurred, and prevents Dynamo discovery from being left unregistered if sleep fails part-way through.

This covers the reported GMS + `--enable-sleep-mode` prefill failure where vLLM's `pause_scheduler` path raises:

> Failed to reset KV cache even when all the running requests are preempted and moved to the waiting queue. This is likely due to the presence of running requests waiting for remote KV transfer, which is not supported yet.

Upstream vLLM has an open fix attempt for the scheduler/NIXL side: https://github.com/vllm-project/vllm/pull/41180. This PR keeps a minimal Dynamo-side monkey patch until that fix is available in the runtime images.

## Changes

- Add a temporary Dynamo vLLM scheduler patch module for NIXL V1 disagg sleep:
  - select `PatchedAsyncScheduler` only for NIXL configs with no user-specified scheduler class;
  - force-free finished requests whose KV blocks are still delayed by NIXL transfer state before prefix-cache reset;
  - abort/free `WAITING_FOR_REMOTE_KVS` requests before reset;
  - clear stale recv failure/success KV-transfer bookkeeping before reset;
  - tolerate late KV-transfer completion notifications for requests already removed during sleep.
- Keep benchmark/FPM workers patched by importing the patch from `InstrumentedScheduler`.
- Harden sleep/wake discovery handling:
  - if sleep unregisters discovery and then scheduler quiesce fails, attempt to resume generation and re-register discovery;
  - make wake defensively reconcile endpoint registration even when the engine reports it is already awake.
- Add unit coverage for scheduler patch behavior, scheduler selection, and sleep/wake rollback/re-registration behavior.

## Validation

Local:

- `python -m py_compile` for touched vLLM files/tests
- `git diff --check origin/main...HEAD`
- `components/src/dynamo/vllm/tests/test_vllm_scheduler_patches.py`: 7 passed
- `components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py`: 11 passed
- `components/src/dynamo/vllm/tests/test_vllm_unit.py::test_nixl_connector_uses_patched_scheduler_by_default`: 1 passed

Nscale cluster validation:

- Built/pushed patched runtime overlay image:
  `nvcr.io/nvidian/dynamo-dev/schwinns:dynamo-vllm-prefill-sleep-nixl-8f76fd04b40d-20260521T230913Z`
  digest `sha256:96eaea414dff2152fa90befb3a3d1b55c756838be7fb909b548bd1a972ed664c`
- Deployed in fresh namespace `pfslp-nixl-main-test` using copied `hf-token-secret`, `ngc-secret`, and `acr-token-secret`.
- Model: `Qwen/Qwen3-0.6B`
- Workers: 1 prefill + 1 decode, GMS enabled, `--enable-sleep-mode`, NIXL `kv_both`, B200.
- Verified:
  - fresh prefill sleep/wake succeeds;
  - inference succeeds and triggers NIXL KV transfer;
  - prefill sleep after inference succeeds;
  - wake succeeds;
  - subsequent inference succeeds (no `no instances found` routing damage);
  - decode sleep/wake still succeeds;
  - repeated post-inference prefill sleep/wake + inference succeeds.
- Prefill logs showed the intended cleanup path:
  `reset_prefix_cache: force-freed 1 finished-but-delayed and 0 WAITING_FOR_REMOTE_KVS requests before cache reset`.
- Cleaned up DGD, Helm release, and fresh namespace after validation.
