### PR TITLE
fix(operator): scope docker secret indexing in restricted mode

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -476,7 +476,7 @@ func main() {
 		"istio", runtimeConfig.IstioAvailable,
 	)
 
-	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader())
+	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader(), restrictedNamespace)
 	// refresh whenever a secret is created/deleted/updated
 	// Set up informer
 	var factory informers.SharedInformerFactory

--- a/deploy/operator/internal/secrets/docker.go
+++ b/deploy/operator/internal/secrets/docker.go
@@ -14,22 +14,25 @@ import (
 
 type DockerSecretIndexer struct {
 	// maps for a namespace, a docker registry server to a list of secret names
-	secrets map[string]map[string][]string
-	client  client.Reader
-	mu      sync.RWMutex
+	secrets   map[string]map[string][]string
+	client    client.Reader
+	namespace string
+	mu        sync.RWMutex
 }
 
-func NewDockerSecretIndexer(client client.Reader) *DockerSecretIndexer {
+// NewDockerSecretIndexer builds an indexer scoped to namespace. An empty namespace indexes all namespaces.
+func NewDockerSecretIndexer(reader client.Reader, namespace string) *DockerSecretIndexer {
 	return &DockerSecretIndexer{
-		secrets: make(map[string]map[string][]string),
-		client:  client,
+		secrets:   make(map[string]map[string][]string),
+		client:    reader,
+		namespace: namespace,
 	}
 }
 
 func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	// scan for all secrets in the namespace
 	secrets := &corev1.SecretList{}
-	if err := i.client.List(ctx, secrets); err != nil {
+	if err := i.client.List(ctx, secrets, i.listOptions()...); err != nil {
 		return fmt.Errorf("unable to list secrets: %w", err)
 	}
 	slices.SortFunc(secrets.Items, func(a, b corev1.Secret) int {
@@ -81,6 +84,13 @@ func (i *DockerSecretIndexer) RefreshIndex(ctx context.Context) error {
 	defer i.mu.Unlock()
 	i.secrets = tmpSecrets
 	return nil
+}
+
+func (i *DockerSecretIndexer) listOptions() []client.ListOption {
+	if i.namespace == "" {
+		return nil
+	}
+	return []client.ListOption{client.InNamespace(i.namespace)}
 }
 
 func (i *DockerSecretIndexer) GetSecrets(namespace, registry string) ([]string, error) {

--- a/deploy/operator/internal/secrets/docker_test.go
+++ b/deploy/operator/internal/secrets/docker_test.go
@@ -53,7 +53,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		WithObjects(&mockSecrets[0], &mockSecrets[1], &mockSecrets[2]).
 		Build()
 
-	i := NewDockerSecretIndexer(fakeClient)
+	i := NewDockerSecretIndexer(fakeClient, "")
 	if err := i.RefreshIndex(context.Background()); err != nil {
 		t.Errorf("DockerSecretIndexer.RefreshIndex() error = %v, wantErr %v", err, nil)
 	}
@@ -124,7 +124,7 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 		WithObjects(&mockSecrets[0], &mockSecrets[1]).
 		Build()
 
-	i := NewDockerSecretIndexer(fakeClient)
+	i := NewDockerSecretIndexer(fakeClient, "")
 	if err := i.RefreshIndex(context.Background()); err != nil {
 		t.Fatalf("DockerSecretIndexer.RefreshIndex() error = %v", err)
 	}
@@ -144,5 +144,56 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 	}
 	if got, want := secrets, []string{"secret-a", "secret-b"}; !slices.Equal(got, want) {
 		t.Fatalf("DockerSecretIndexer.GetSecrets() after caller mutation = %v, want %v", got, want)
+	}
+}
+
+func TestDockerSecretIndexer_RefreshIndexRespectsNamespaceScope(t *testing.T) {
+	mockSecrets := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "target-secret",
+				Namespace: "target",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"target-registry.io/team":{}}}`),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "malformed-secret",
+				Namespace: "other",
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`not-json`),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&mockSecrets[0], &mockSecrets[1]).
+		Build()
+
+	i := NewDockerSecretIndexer(fakeClient, "target")
+	if err := i.RefreshIndex(context.Background()); err != nil {
+		t.Fatalf("DockerSecretIndexer.RefreshIndex() error = %v", err)
+	}
+
+	secrets, err := i.GetSecrets("target", "target-registry.io")
+	if err != nil {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
+	}
+	if got, want := secrets, []string{"target-secret"}; !slices.Equal(got, want) {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() = %v, want %v", got, want)
+	}
+
+	secrets, err = i.GetSecrets("other", "target-registry.io")
+	if err != nil {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() error = %v", err)
+	}
+	if len(secrets) != 0 {
+		t.Fatalf("DockerSecretIndexer.GetSecrets() = %v, want no out-of-scope secrets", secrets)
 	}
 }

--- a/deploy/operator/internal/secrets/docker_test.go
+++ b/deploy/operator/internal/secrets/docker_test.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -54,7 +53,7 @@ func TestDockerSecretIndexer_RefreshIndex(t *testing.T) {
 		Build()
 
 	i := NewDockerSecretIndexer(fakeClient, "")
-	if err := i.RefreshIndex(context.Background()); err != nil {
+	if err := i.RefreshIndex(t.Context()); err != nil {
 		t.Errorf("DockerSecretIndexer.RefreshIndex() error = %v, wantErr %v", err, nil)
 	}
 
@@ -125,7 +124,7 @@ func TestDockerSecretIndexer_DeterministicSecrets(t *testing.T) {
 		Build()
 
 	i := NewDockerSecretIndexer(fakeClient, "")
-	if err := i.RefreshIndex(context.Background()); err != nil {
+	if err := i.RefreshIndex(t.Context()); err != nil {
 		t.Fatalf("DockerSecretIndexer.RefreshIndex() error = %v", err)
 	}
 
@@ -177,7 +176,7 @@ func TestDockerSecretIndexer_RefreshIndexRespectsNamespaceScope(t *testing.T) {
 		Build()
 
 	i := NewDockerSecretIndexer(fakeClient, "target")
-	if err := i.RefreshIndex(context.Background()); err != nil {
+	if err := i.RefreshIndex(t.Context()); err != nil {
 		t.Fatalf("DockerSecretIndexer.RefreshIndex() error = %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Fix Docker secret indexing when the operator runs in restricted namespace mode.

The indexer now takes the restricted namespace as part of its own configuration and applies `client.InNamespace(...)` internally when listing secrets through `mgr.GetAPIReader()`.

## Why

`mgr.GetAPIReader()` bypasses `mgrOpts.Cache.DefaultNamespaces`, so restricted namespace mode could list docker config secrets from every namespace. That meant an unrelated malformed docker config secret outside the operator scope could fail the initial index refresh and prevent startup.

## Changes

- Pass the configured restricted namespace into `DockerSecretIndexer`.
- Encapsulate namespace scoping inside the indexer instead of exposing raw list options from `main.go`.
- Keep unrestricted mode behavior unchanged by listing all namespaces when no namespace is configured.
- Add regression coverage for a malformed docker config secret outside the restricted namespace.

## Validation

- `go test ./internal/secrets ./internal/controller_common -count=1`
- `go test ./cmd/... ./internal/controller -run TestDoesNotExist -count=0`
- `git diff --check`



<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional namespace scoping for Docker secret indexing, enabling operators to restrict secret access to specific namespaces for improved isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->