### PR TITLE
fix(parsers): enable EOF recovery for non-streaming tool-call parse aggregator

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -4,7 +4,7 @@
 use futures::{Stream, StreamExt};
 use std::collections::{BTreeMap, HashMap};
 
-use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate;
+use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate_finalize;
 
 use super::{NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse};
 use crate::protocols::{
@@ -72,7 +72,7 @@ struct DeltaChoice {
     tool_call_chunks: BTreeMap<u32, dynamo_protocols::types::ChatCompletionMessageToolCallChunk>,
     // Optional tool calls for the chat choice, populated *after* fold either
     // by finalizing `tool_call_chunks` above, or by
-    // `try_tool_call_parse_aggregate` running against `text` for producers
+    // `try_tool_call_parse_aggregate_finalize` running against `text` for producers
     // that put tool calls in content rather than as structured chunks.
     tool_calls: Option<Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>>,
 
@@ -355,8 +355,8 @@ impl DeltaAggregator {
                 .filter_map(finalize_merged_tool_chunk)
                 .collect();
             // choice.tool_calls is always None at this point: or_insert
-            // initializes it to None, try_tool_call_parse_aggregate runs
-            // strictly after this loop. Unconditional assign is the only
+            // initializes it to None, try_tool_call_parse_aggregate_finalize
+            // runs strictly after this loop. Unconditional assign is the only
             // reachable path; no merge-with-existing needed.
             if !finalized.is_empty() {
                 choice.tool_calls = Some(finalized);
@@ -375,7 +375,9 @@ impl DeltaAggregator {
                 }
 
                 let (tool_calls, content) =
-                    match try_tool_call_parse_aggregate(&choice.text, Some(parser), None).await {
+                    match try_tool_call_parse_aggregate_finalize(&choice.text, Some(parser), None)
+                        .await
+                    {
                         Ok(result) => result,
                         Err(error) => {
                             tracing::debug!(


### PR DESCRIPTION
## Summary

The non-streaming chat completion path (`DeltaAggregator::apply`) called the non-recovery aggregator variant, so when a model running the qwen3_coder / nemotron_nano XML parser hit `max_tokens` (or otherwise truncated) before emitting `</function>` / `</tool_call>`, the parser fell through to the normal-text branch and the raw `<tool_call>...<function=...>...<parameter=...>...` XML leaked into the response `content`. Observed against nemotron_nano in production — `finish_reason=length`, `tool_calls=[]`, raw XML in `content`.

`try_tool_call_parse_aggregate_finalize` was added in #8888 specifically for this case (EOF recovery: missing outer end-token, truncated JSON args), and the docstring on it explicitly says *"Use this from stream-end / non-streaming aggregator paths only"*. The streaming-jail finalize path in `jail.rs` was wired up in that PR; the non-streaming `DeltaAggregator::apply` callsite was missed.

Tracing the leak on current main:

1. Truncated text reaches `aggregator.rs:378` → `try_tool_call_parse_aggregate` (non-recovery).
2. XML parser's `extract_tool_calls` finds `<tool_call>` but not `</tool_call>` → falls into the recovery branch at `xml/parser.rs:204-225`.
3. That branch is gated on `config.allow_eof_recovery`, which the non-recovery entry point leaves at `false`.
4. Falls through to `normal_parts.push(&text[abs_start..])` → raw XML is emitted as `content`.

This is the one-line wiring fix.

## Changes

- `lib/llm/src/protocols/openai/chat_completions/aggregator.rs`: swap `try_tool_call_parse_aggregate` → `try_tool_call_parse_aggregate_finalize` (import + callsite + two comment touch-ups).

## Test plan

- [ ] CI lint / build / unit tests
- [ ] Regression test against `DeltaAggregator::apply` exercising truncated nemotron_nano XML — left out of this PR pending guidance on the preferred fixture vs. inline-test placement (cc @keivenchang since #8888 is the design anchor for this surface)
- [ ] Manual repro against an aggregated nemotron_nano deployment with `request-1` from the existing customer repro on a build containing this fix

## Related

- Wires up the helper added in #8888 to the path it was designed for.
- DIS-1842 (the original silent-drop tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the tool-call parsing mechanism in chat completions to better handle structured data transformation during the streaming process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->