### PR TITLE
fix(frontend): pass tools to ToolParser ctor in vllm chat processor

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -119,7 +119,7 @@ def _prepare_request(
     has_tools = bool(request_for_sampling.tools)
     if tool_parser_class and (has_tools or enable_auto_tool_choice):
         if request_for_sampling.tool_choice != "none":
-            tool_parser = tool_parser_class(tokenizer)
+            tool_parser = tool_parser_class(tokenizer, request_for_sampling.tools)
             request_for_sampling = tool_parser.adjust_request(request_for_sampling)
 
     # Strip tools from the template when tool_choice=none so the model doesn't

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -7,11 +7,13 @@ Tests for the tool-stripping behaviour of _prepare_request when
 tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
 from _routed_engine_fakes import FakeRoutedEngine as _FakeRoutedEngine
 from transformers import AutoTokenizer
+from vllm.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
 
 from dynamo.frontend.prepost import _prepare_request
 
@@ -336,3 +338,74 @@ class TestRoutedEnginePath:
                 "object": "chat.completion.chunk",
             }
         ]
+
+
+OBJECT_TYPED_TOOL_REQUEST = {
+    "model": MODEL,
+    "messages": [{"role": "user", "content": "set my profile"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "set_profile",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "profile": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "age": {"type": "integer"},
+                            },
+                        }
+                    },
+                    "required": ["profile"],
+                },
+            },
+        }
+    ],
+    "tool_choice": "auto",
+}
+
+
+# ---------------------------------------------------------------------------
+# _prepare_request: schema-aware tool-parser end-to-end regression
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaAwareToolParser:
+    """Schema-aware parsers (e.g. qwen3_coder) need ``tools`` at construction
+    to coerce object/array-typed parameter values from raw text into JSON;
+    without them, the value comes through as a string-in-a-string inside the
+    final ``arguments`` JSON.
+    """
+
+    def test_qwen3_coder_coerces_object_typed_arg(self, tokenizer):
+        """qwen3_coder must coerce object-typed parameter values into nested
+        objects, not leave them as JSON-encoded strings inside ``arguments``.
+        """
+        model_output = (
+            "<tool_call><function=set_profile>\n"
+            "<parameter=profile>\n"
+            '{"name": "Alice", "age": 30}\n'
+            "</parameter>\n"
+            "</function></tool_call>"
+        )
+
+        request_for_sampling, parser, _, _, _ = _prepare_request(
+            OBJECT_TYPED_TOOL_REQUEST,
+            tokenizer=tokenizer,
+            tool_parser_class=Qwen3CoderToolParser,
+        )
+        assert parser is not None, "Expected _prepare_request to construct the parser"
+
+        result = parser.extract_tool_calls(model_output, request_for_sampling)
+
+        assert result.tools_called, f"Expected tools_called=True; got {result!r}"
+        assert len(result.tool_calls) == 1
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert isinstance(args["profile"], dict), (
+            f"Schema-aware parser should coerce object-typed arg to dict; "
+            f"got {type(args['profile']).__name__}: {args['profile']!r}"
+        )
+        assert args["profile"] == {"name": "Alice", "age": 30}

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -221,6 +221,7 @@ STUB_MODULES = [
     "vllm.tool_parsers",
     "vllm.tool_parsers.hermes_tool_parser",
     "vllm.tool_parsers.mistral_tool_parser",
+    "vllm.tool_parsers.qwen3coder_tool_parser",
     "vllm.utils",
     "vllm.utils.async_utils",
     "vllm.utils.hashing",


### PR DESCRIPTION
## Summary

`--dyn-chat-processor vllm` constructs vLLM tool-call parsers without passing `request.tools`. Schema-aware parsers (e.g. `qwen3_coder`) need the tools list at construction time to coerce `object`/`array`-typed parameter values from raw text into JSON. Without it, those values end up as strings inside the final `arguments` JSON, breaking any tool whose schema declares an object-typed parameter.

## Root cause

`components/src/dynamo/frontend/prepost.py:122` (pre-fix):

```python
tool_parser = tool_parser_class(tokenizer)
```

`qwen3_coder` (and similar schema-aware parsers) accepts an optional `tools` argument in its ctor:

```python
# vllm/tool_parsers/qwen3coder_tool_parser.py
def __init__(self, tokenizer, tools=None):
    self.tools = tools
```

Without it, `self.tools = None`, so `find_tool_properties(self.tools, function_name)` returns `{}` and `_convert_param_value` short-circuits at:

```python
if param_name not in param_config:
    return param_value  # raw string, no json.loads coercion
```

The object-coercion branch in `qwen3coder_tool_parser.py` that calls `json.loads` on `object`/`array`-typed values is never reached. The parser then dumps the dict to a JSON string via `json.dumps(param_dict)`, producing a string-in-a-string for any object-typed parameter.

vLLM's own OpenAI server passes `tools` to the parser ctor (`vllm/entrypoints/openai/chat_completion/serving.py`):

```python
tool_parser = self.tool_parser(tokenizer, request.tools)
```

This PR mirrors that behavior so the Dynamo chat processor matches vLLM's reference server.

## Reproducer

Run a Dynamo frontend with `--dyn-chat-processor vllm --tool-call-parser qwen3_coder` and send a chat completion with a tool whose schema declares an object-typed parameter:

```bash
curl -sS -X POST -H "Content-Type: application/json" "${ENDPOINT}/v1/chat/completions" \
  -d '{
    "model": "...",
    "messages": [{"role": "user", "content": "Set the user profile to name=Alice, age=30."}],
    "tools": [{
      "type": "function",
      "function": {
        "name": "set_profile",
        "parameters": {
          "type": "object",
          "properties": {
            "profile": {
              "type": "object",
              "properties": {
                "name": {"type": "string"},
                "age": {"type": "integer"}
              }
            }
          },
          "required": ["profile"]
        }
      }
    }],
    "tool_choice": "auto",
    "temperature": 0.0
  }' | jq '.choices[0].message.tool_calls[0].function.arguments'
```

**Before:** `"{\"profile\": \"{\\\"name\\\": \\\"Alice\\\", \\\"age\\\": 30}\"}"` (object value is a string-in-a-string)

**After:** `"{\"profile\": {\"name\": \"Alice\", \"age\": 30}}"` (object value is a proper nested object)

## Fix

Pass `request_for_sampling.tools` to the parser ctor so the parser can use the schema for type-aware coercion.

## Impact

- No effect when `tools` is `None` (parser still receives `None`; behavior unchanged).
- Brings the chat-processor path in line with vLLM's reference server, which has always passed `tools` to the parser ctor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool parser initialization to properly receive tool information during request processing, enhancing tool handling capabilities in requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->