### PR TITLE
fix(parsers): MiniMax M2.7 stream parity for leaked and truncated tool calls

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1057,16 +1057,17 @@ impl JailedStream {
                         // stripping Harmony envelopes when no reasoning parser is configured.
                         // In zero-call Harmony marker cases, emit the stripped normal_text rather
                         // than accumulated_content, which still contains raw protocol markers.
-                        let content = if normal_text.as_deref() == Some("") {
-                            ""
-                        } else if is_finalize
+                        let content = if is_finalize
                             && self.tool_call_parser.as_deref() == Some("minimax_m2")
+                            && normal_text.as_deref() == Some("")
                         {
                             // MiniMax's reference parser is strict: missing paired fences means
                             // zero recovered calls. The raw `<minimax:tool_call>` envelope is
                             // still protocol markup, so keep only pre-call prose at stream end.
                             self.prefix_before_first_tool_call_marker(accumulated_content)
                                 .unwrap_or("")
+                        } else if normal_text.as_deref() == Some("") {
+                            ""
                         } else if is_harmony_parser(self.tool_call_parser.as_deref())
                             && contains_harmony_protocol(accumulated_content)
                         {

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -849,6 +849,21 @@ impl JailedStream {
         sequence_match || tool_call_match
     }
 
+    fn prefix_before_first_tool_call_marker<'a>(&self, content: &'a str) -> Option<&'a str> {
+        let mut first_marker: Option<usize> = None;
+
+        for marker in &self.jail_start_sequences {
+            if marker.is_empty() {
+                continue;
+            }
+            if let Some(pos) = content.find(marker) {
+                first_marker = Some(first_marker.map_or(pos, |current| current.min(pos)));
+            }
+        }
+
+        first_marker.map(|pos| &content[..pos])
+    }
+
     /// Check if accumulated content should end jail
     async fn should_end_jail(&self, accumulated_content: &str) -> (bool, usize) {
         match &self.jail_mode {
@@ -1044,6 +1059,14 @@ impl JailedStream {
                         // than accumulated_content, which still contains raw protocol markers.
                         let content = if normal_text.as_deref() == Some("") {
                             ""
+                        } else if is_finalize
+                            && self.tool_call_parser.as_deref() == Some("minimax_m2")
+                        {
+                            // MiniMax's reference parser is strict: missing paired fences means
+                            // zero recovered calls. The raw `<minimax:tool_call>` envelope is
+                            // still protocol markup, so keep only pre-call prose at stream end.
+                            self.prefix_before_first_tool_call_marker(accumulated_content)
+                                .unwrap_or("")
                         } else if is_harmony_parser(self.tool_call_parser.as_deref())
                             && contains_harmony_protocol(accumulated_content)
                         {

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1059,7 +1059,9 @@ impl JailedStream {
                         // than accumulated_content, which still contains raw protocol markers.
                         let content = if is_finalize
                             && self.tool_call_parser.as_deref() == Some("minimax_m2")
-                            && normal_text.as_deref() == Some("")
+                            && self
+                                .prefix_before_first_tool_call_marker(accumulated_content)
+                                .is_some()
                         {
                             // MiniMax's reference parser is strict: missing paired fences means
                             // zero recovered calls. The raw `<minimax:tool_call>` envelope is

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3609,7 +3609,10 @@ fahrenheit
                 !content.contains("<minimax:tool_call>") && !content.contains("<invoke"),
                 "{label}: MiniMax protocol markup leaked into content: {content:?}"
             );
-            assert_eq!(content, expected_content, "{label}: unexpected residual content");
+            assert_eq!(
+                content, expected_content,
+                "{label}: unexpected residual content"
+            );
         }
     }
 

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3541,6 +3541,65 @@ fahrenheit
         }
     }
 
+    /// MiniMax uses a strict reference parser: incomplete paired XML fences do
+    /// not recover a call. At stream end, the jail must still avoid surfacing
+    /// the raw `<minimax:tool_call>` protocol block as assistant content.
+    #[tokio::test]
+    async fn test_minimax_m2_stream_finalize_zero_call_truncation_drops_markup() {
+        let cases = [
+            (
+                "complete body without outer close",
+                "<minimax:tool_call>\n\
+                 <invoke name=\"get_weather\">\n\
+                 <parameter name=\"location\">NYC</parameter>\n\
+                 </invoke>",
+            ),
+            (
+                "mid-call body truncation",
+                "<minimax:tool_call>\n\
+                 <invoke name=\"get_weather\">\n\
+                 <parameter name=\"location\">NY",
+            ),
+        ];
+
+        for (label, partial_tool_call) in cases {
+            let input_chunks = vec![
+                test_utils::create_mock_response_chunk(partial_tool_call.to_string(), 0),
+                test_utils::create_final_response_chunk(0),
+            ];
+
+            let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+                Some("minimax_m2".to_string()),
+                None,
+                None,
+                stream::iter(input_chunks),
+            )
+            .collect()
+            .await;
+
+            let tool_call_count: usize = results
+                .iter()
+                .map(|r| {
+                    r.data.as_ref().map_or(0, |d| {
+                        d.inner
+                            .choices
+                            .iter()
+                            .map(|c| c.delta.tool_calls.as_ref().map_or(0, |tc| tc.len()))
+                            .sum::<usize>()
+                    })
+                })
+                .sum();
+            assert_eq!(tool_call_count, 0, "{label}: strict MiniMax must not recover a call");
+
+            let content = test_utils::reconstruct_content(&results);
+            assert!(
+                !content.contains("<minimax:tool_call>") && !content.contains("<invoke"),
+                "{label}: MiniMax protocol markup leaked into content: {content:?}"
+            );
+            assert_eq!(content, "", "{label}: no pre-call prose should remain");
+        }
+    }
+
     /// tool_choice=required with the alternate `arguments` key (SGLang's
     /// JsonArrayParser and some vLLM paths emit this variant).  The
     /// base_json_parser accepts either `parameters` or `arguments`.

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3553,16 +3553,26 @@ fahrenheit
                  <invoke name=\"get_weather\">\n\
                  <parameter name=\"location\">NYC</parameter>\n\
                  </invoke>",
+                "",
             ),
             (
                 "mid-call body truncation",
                 "<minimax:tool_call>\n\
                  <invoke name=\"get_weather\">\n\
                  <parameter name=\"location\">NY",
+                "",
+            ),
+            (
+                "pre-marker prose before truncated call",
+                "I will check that. <minimax:tool_call>\n\
+                 <invoke name=\"get_weather\">\n\
+                 <parameter name=\"location\">NYC</parameter>\n\
+                 </invoke>",
+                "I will check that. ",
             ),
         ];
 
-        for (label, partial_tool_call) in cases {
+        for (label, partial_tool_call, expected_content) in cases {
             let input_chunks = vec![
                 test_utils::create_mock_response_chunk(partial_tool_call.to_string(), 0),
                 test_utils::create_final_response_chunk(0),
@@ -3599,7 +3609,7 @@ fahrenheit
                 !content.contains("<minimax:tool_call>") && !content.contains("<invoke"),
                 "{label}: MiniMax protocol markup leaked into content: {content:?}"
             );
-            assert_eq!(content, "", "{label}: no pre-call prose should remain");
+            assert_eq!(content, expected_content, "{label}: unexpected residual content");
         }
     }
 

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3589,7 +3589,10 @@ fahrenheit
                     })
                 })
                 .sum();
-            assert_eq!(tool_call_count, 0, "{label}: strict MiniMax must not recover a call");
+            assert_eq!(
+                tool_call_count, 0,
+                "{label}: strict MiniMax must not recover a call"
+            );
 
             let content = test_utils::reconstruct_content(&results);
             assert!(

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3546,6 +3546,9 @@ fahrenheit
     /// the raw `<minimax:tool_call>` protocol block as assistant content.
     #[tokio::test]
     async fn test_minimax_m2_stream_finalize_zero_call_truncation_drops_markup() {
+        // These are jail/finalize regression checks for existing parser parity cases:
+        // the first and prefix-preservation rows cover PARSER.stream.4.a, and
+        // the mid-call body truncation row covers PARSER.stream.4.b.
         let cases = [
             (
                 "complete body without outer close",

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -177,7 +177,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   = {{ panel.stats.slots }} grid slots ({{ panel.stats.na }} n/a, {{ panel.stats.missing }} missing).
   <strong>{{ panel.stats.real }}</strong> real cases:
   <span style="color:#0a7d2c">{{ panel.stats.parity }} full parity</span> ·
-  <span style="color:#555">{{ panel.stats.documented }} documented divergences</span>
+  <span style="color:#0a7d2c">{{ panel.stats.documented }} documented divergences</span>
   (have <code>reason:</code>) ·
   <span style="color:#c63">{{ panel.stats.research }} research-needed</span>
   (no <code>reason:</code> yet) ·

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -22,7 +22,7 @@ td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
 td.cell { text-align: center; min-width: 24px; }
 td.cell.ok         { color: #0a7d2c; }
-td.cell.documented { color: #555; }
+td.cell.documented { color: #0a7d2c; }
 td.cell.research   { color: #c63;    font-weight: bold; }
 td.cell.leak       { color: #555;    font-weight: bold; }
 td.cell.err        { color: #b00;    font-weight: bold; }
@@ -146,7 +146,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <strong>Legend:</strong>
   <span style="color:#0a7d2c">=</span> full parity
   (Dynamo, vLLM, and SGLang produce the same results) ·
-  <span style="color:#555">V/S</span> divergence
+  <span style="color:#0a7d2c">V/S</span> divergence
   (V = vLLM, S = SGLang; intentional, has <code>reason:</code>) ·
   <span style="color:#c63">?</span> more research needed
   (e.g. V?, S? — diverges with no <code>reason:</code> yet) ·

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.2.yaml
@@ -8,6 +8,7 @@ cases:
   PARSER.stream.2:
     description: Multiple tool calls split across multiple content chunks
     ref: derived from PARSER.batch.2.a
+    spec_ref: https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md#model-output-format
     chunks:
     - delta_text: '<minimax:'
     - delta_text: tool_ca
@@ -79,6 +80,9 @@ cases:
           <parameter name="timezone">EST</parameter>
           </invoke>
           </minimax:tool_call>
+        reason: |-
+          SGLang leaks the complete MiniMax tool-call block into normal_text;
+          Dynamo parses it as structured tool output per the M2.7 spec.
       vllm:
         calls: []
         normal_text: |-
@@ -90,3 +94,6 @@ cases:
           <parameter name="timezone">EST</parameter>
           </invoke>
           </minimax:tool_call>
+        reason: |-
+          vLLM leaks the complete MiniMax tool-call block into normal_text;
+          Dynamo parses it as structured tool output per the M2.7 spec.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.3.yaml
@@ -8,6 +8,7 @@ cases:
   PARSER.stream.3:
     description: Complete single tool call with a grammar token split across chunk boundaries
     ref: derived from PARSER.batch.1
+    spec_ref: https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md#model-output-format
     chunks:
     - delta_text: <m
     - delta_text: ini
@@ -55,6 +56,9 @@ cases:
           <parameter name="location">NYC</parameter>
           </invoke>
           </minimax:tool_call>
+        reason: |-
+          SGLang leaks the complete MiniMax tool-call block into normal_text;
+          Dynamo parses it as structured tool output per the M2.7 spec.
       vllm:
         calls: []
         normal_text: |-
@@ -63,3 +67,6 @@ cases:
           <parameter name="location">NYC</parameter>
           </invoke>
           </minimax:tool_call>
+        reason: |-
+          vLLM leaks the complete MiniMax tool-call block into normal_text;
+          Dynamo parses it as structured tool output per the M2.7 spec.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.stream.4.yaml
@@ -8,6 +8,7 @@ cases:
   PARSER.stream.4.a:
     description: Truncated stream terminates after a complete in-flight tool-call body
     ref: derived from PARSER.batch.5.a
+    spec_ref: https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md#parsing-tool-calls
     chunks:
     - delta_text: |-
         <minimax:tool_call>
@@ -25,27 +26,38 @@ cases:
             type: string
     expected:
       dynamo:
+        reason: |-
+          Strict per MiniMax-M2.7's published parser regexes: the outer
+          <minimax:tool_call>...</minimax:tool_call> block must be paired, so
+          a stream that ends before </minimax:tool_call> recovers no call.
+          Dynamo drops the buffered protocol block from normal_text so
+          tool-call markup does not leak to user-facing content.
         calls: []
-        normal_text: |-
-          <minimax:tool_call>
-          <invoke name="get_weather">
-          <parameter name="location">NYC</parameter>
-          </invoke>
+        normal_text: ''
       sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
+        reason: |-
+          SGLang's streaming parser recovers a MiniMax call from a body that
+          lacks the required closing </minimax:tool_call>; that contradicts
+          the strict MiniMax-M2.7 reference parser.
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
+        reason: |-
+          vLLM's streaming parser recovers a MiniMax call from a body that
+          lacks the required closing </minimax:tool_call>; that contradicts
+          the strict MiniMax-M2.7 reference parser.
   PARSER.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from PARSER.batch.5.c
+    spec_ref: https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md#parsing-tool-calls
     chunks:
     - delta_text: |-
         <minimax:tool_call>
@@ -63,17 +75,22 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &d_4_b
+        reason: |-
+          Strict per MiniMax-M2.7's published parser regexes: the outer
+          <minimax:tool_call>, inner <invoke>, and <parameter> blocks must all
+          be paired. This stream ends mid-parameter, so Dynamo recovers no call
+          and drops the buffered protocol block from normal_text.
         calls: []
-        normal_text: |-
-          <minimax:tool_call>
-          <invoke name="get_weather">
-          <parameter name="location">NY
+        normal_text: ''
       sglang:
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
-      vllm:
-        calls: []
-        normal_text: ''
+        reason: |-
+          SGLang's streaming parser emits an empty-argument MiniMax call from
+          a stream that ends before </parameter>, </invoke>, and
+          </minimax:tool_call>; that contradicts the strict MiniMax-M2.7
+          reference parser.
+      vllm: *d_4_b


### PR DESCRIPTION
#### Overview:

This PR updates MiniMax `PARSER.stream.*` parity expectations and fixes Dynamo’s stream-finalization behavior for truncated MiniMax tool-call markup.

For `PARSER.stream.2` and `PARSER.stream.3`, both vLLM and SGLang leak complete MiniMax tool-call XML into `normal_text`. Dynamo treats the completed `<minimax:tool_call>...</minimax:tool_call>` block as structured tool output and strips the protocol markup from user-visible text.

Example vLLM output for `PARSER.stream.3`:

```yaml
normal_text='<minimax:tool_call>
<invoke name="get_weather">
<parameter name="location">NYC</parameter>
</invoke>
<invoke name="get_time">
<parameter name="timezone">EST</parameter>
</invoke>
</minimax:tool_call>'
calls=[]
```

For `PARSER.stream.4.a` and `PARSER.stream.4.b`, we comply with the alignment rubric from PR #9583 by following the upstream MiniMax spec. The MiniMax M2.7 tool-calling guide defines tool calls as paired `<minimax:tool_call>...</minimax:tool_call>` XML and its parser only matches complete paired blocks:

Spec reference:
https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md

For `PARSER.stream.4.b`, Dynamo now aligns with vLLM under the parity alignment rule: both drop the incomplete in-flight call and keep protocol markup out of user-visible text. SGLang still emits an empty-argument call from an incomplete block, so that divergence is documented.

#### Details:

- Add documented MiniMax stream parity reasons for `PARSER.stream.2`, `.3`, `.4.a`, and `.4.b`.
- Fix MiniMax stream finalization so incomplete `<minimax:tool_call>` markup is not leaked into `normal_text` for `.4.a`, and `.4.b`.
- Add a regression test for MiniMax stream finalization with incomplete tool-call markup.

#### Where should the reviewer start?

- `lib/llm/src/protocols/openai/chat_completions/jail.rs`
- `lib/llm/tests/test_jail.rs`
- `tests/parity/parser/fixtures/minimax_m2/PARSER.stream.*.yaml`


#### Related Issues:
- PR #9583 for alignment rubric


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of incomplete or truncated tool-call markers by preserving leading text instead of discarding it, enhancing robustness for edge cases.

* **Tests**
  * Added regression tests for handling malformed tool-call XML and backend parsing consistency across different scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->