### PR TITLE
feat: add kvbm aiperf manifest reporting

### DIFF
--- a/examples/backends/vllm/launch/kvbm_xdc/README.md
+++ b/examples/backends/vllm/launch/kvbm_xdc/README.md
@@ -5,7 +5,7 @@ cross-datacenter experiments. Experiment letters are metadata, not script
 names, and hardware assumptions live in profile/env variables rather than in
 workflow names.
 
-## Fixed Experiment Contract
+## Fixed Experiment E Contract
 
 | Field | Value |
 |---|---|
@@ -14,11 +14,15 @@ workflow names.
 | User endpoint | `dynamo.frontend` OpenAI `/v1/chat/completions` |
 | Endpoint type | `chat` |
 | Streaming | `true` |
+| Required E transfer path | KVBM + hub conditional-disagg |
 | Recorded GPU class | H100 or A100 only |
 
 Do not use `python -m vllm.entrypoints.openai.api_server` for the primary
 Experiment E path. That is a raw vLLM diagnostic or legacy hub-CD smoke, not
-the Dynamo vLLM framework under test.
+the Dynamo vLLM framework under test. Experiment F is intentionally separate:
+it validates `kvbm_hub` P2P transfer primitives between two raw vLLM KVBM
+instances because the P2P mechanism under test lives below the Dynamo frontend
+routing layer.
 
 ## Hardware Profiles
 
@@ -28,7 +32,7 @@ selected profile or caller-provided env does not define the values they need.
 
 | Profile | Purpose | Model | Placement |
 |---|---|---|---|
-| `h100-a100` | Recorded Experiment E/F runs | `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` | decode GPU 0, prefill GPU 1 |
+| `h100-a100` | Recorded Experiment E/F runs | `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` | same-node `all`: decode GPU 0, prefill GPU 1; single-role workers default to local GPU 0 |
 | `spark-gb10` | Local smoke/debug only | `Qwen/Qwen3-0.6B` | decode and prefill share GPU 0 |
 | `custom` | Any other cluster allocation | caller-set | caller-set |
 
@@ -53,21 +57,97 @@ ARTIFACT_DIR=/tmp/kvbm-xdc/same-node \
 bash run-dynamo-kvbm-chat-smoke.sh
 ```
 
+For cross-node single-role workers, set the role's local device explicitly when
+needed; otherwise the worker role defaults to GPU 0 on that allocation.
+
 ## Experiment Map
 
 | Experiment | Primary question | Topology | Script |
 |---|---|---|---|
-| E baseline | What is TTFT on the same-node KVBM/NIXL path for this model? | `dynamo.frontend` + decode `dynamo.vllm` using `NixlConnector` + prefill `dynamo.vllm` using `PdConnector(DynamoConnector,NixlConnector)` | `run-dynamo-kvbm-chat-smoke.sh` with decode and prefill on the same H100/A100 node |
-| E cross-DC | What changes when the same model spans datacenters? | Same as baseline, with shared NATS/etcd and explicit routable NIXL side-channel hosts | `launch-dynamo-frontend.sh`, `launch-kvbm-vllm.sh`, then `run-dynamo-kvbm-chat-smoke.sh` in `NODE_ROLE=client` mode |
-| F | Does the hub-controlled P2P G2 transfer path work and what trace does it produce? | `kvbm_hub` P2P transfer primitives between two KVBM instances | `.claude/skills/p2p-smoke/p2p-smoke.sh` |
+| E baseline | What is TTFT on the same-node KVBM + hub path for this model? | `dynamo.frontend` + decode/prefill `dynamo.vllm` workers using KVBM conditional-disagg through `kvbm_hub` | First pass the R1/R2 smoke with `KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=all bash run-dynamo-kvbm-chat-smoke.sh`; the Experiment E data point counts only after the locked AIPerf pass |
+| E cross-DC | What changes when the same model spans datacenters? | Same KVBM + hub path as baseline, with shared NATS/etcd and explicit routable side-channel hosts | Same script split by role; run only after the same-node E gate passes |
+| Diagnostic | Does the existing Dynamo vLLM KVBM/NIXL composition still transfer and reuse KV? | `dynamo.frontend` + decode `dynamo.vllm` using `NixlConnector` + prefill `dynamo.vllm` using `PdConnector(DynamoConnector,NixlConnector)` | `KVBM_TRANSFER_TOPOLOGY=nixl-pd bash run-dynamo-kvbm-chat-smoke.sh`; useful for comparison, but not sufficient to complete E |
+| F | Does the hub-controlled P2P G2 transfer path work and what trace does it produce? | `kvbm_hub` P2P transfer primitives between two KVBM instances | Separate raw-vLLM P2P smoke harness; keep it outside this Dynamo-native Experiment E directory |
 
-Raw hub conditional-disagg scripts are diagnostics, not this Dynamo-native
-harness. Keep them separate so Experiment E stays on `dynamo.frontend` and
-`python -m dynamo.vllm`.
+Raw hub conditional-disagg scripts remain diagnostics until the same transfer
+path is exercised through `dynamo.frontend` and `python -m dynamo.vllm`.
+
+## Evidence Classification
+
+Use these labels when deciding what belongs in a comparison, a PR summary, or a
+local audit. Keep run-specific metric values, dates, artifact paths, hostnames,
+and raw addresses out of this README; those belong in generated manifests,
+private bundles, or explicitly redacted reports.
+
+| Label | Counts For | Requirements | Common Non-Counting Cases |
+|---|---|---|---|
+| Canonical baseline | Primary same-node comparator for Experiment E | Same locked Experiment E contract, useful post-AIPerf trace, positive transfer/cache evidence, zero KV load failures, zero NIXL transfer setup failures, and the closest available hardware match to the cross-DC run | Smoke-only run, changed workload shape, wrong endpoint, raw vLLM path, stale baseline without provenance, or materially different hardware when a closer valid baseline exists |
+| Counted cross-DC result | Primary cross-datacenter Experiment E data point | Same locked Experiment E contract as the canonical baseline, split-role cross-DC deployment, useful trace over collected role logs, successful AIPerf finalize, transfer evidence, positive cache reuse, and zero KV/NIXL failures | Client exited before finalize, partial AIPerf output only, missing role logs, rendered trace without useful gate, or transfer/cache evidence absent |
+| Validation baseline | Current harness/regression check | Same-node run with the locked contract, useful trace, and clean failure counters, used to prove the harness and runtime path still work | Treating a validation run as the primary comparator when hardware or output-shape caveats make it less comparable than another valid baseline |
+| Invalid attempt | Debug evidence only | Preserved with the failure reason when useful for diagnosis | Pre-traffic setup failure, missing transfer substrate, wrong framework/endpoint, non-H100/A100 hardware for recorded E/F results, non-useful trace, KV load failure, NIXL `createXferReq` failure, or changed benchmark parameters |
+| Hardware-refinement run | Optional follow-up | Same evidence gates as counted runs, but chosen to reduce hardware confounds such as H100/H100 or A100/A100 pairing | Blocking publication of an already valid canonical comparison solely because a cleaner hardware pairing would be nice to have |
+
+## Result Manifests
+
+Do not hard-code run results into script names or public docs. Each smoke run
+writes its fixed contract to `metadata.env` / `contract.env`, request timing to
+`chat-ttft.json` or `r*-ttft.json`, and the useful-trace verdict to
+`trace-gate.env`. The locked AIPerf pass writes `aiperf-contract.env` and
+`aiperf-result.env`; when `BASELINE_AIPERF_JSON` or `BASELINE_METRICS_ENV` is
+provided, it also writes `experiment-comparison.env`. Prefer
+`BASELINE_AIPERF_JSON` when the original exported AIPerf profile is available.
+Use `BASELINE_METRICS_ENV` only for explicitly provenance-labeled baseline
+evidence, such as a key/value summary derived from a compute-session log. When
+`POSTCHECK_LOG_DIR` or `ROLE_LOG_DIR` points at collected role logs, it writes
+`aiperf-postcheck.env` with transfer and failure counters. If that directory
+also contains `trace-gate.env`, the postcheck carries the trace verdict and
+cache/failure counters forward into the AIPerf artifact. Compare same-node and
+cross-datacenter runs only when both artifacts have `trace_useful=true`,
+successful transfer evidence, positive external cache reuse, and zero KV load
+failures.
+
+For request-level TTFT attribution, use the harness-local analyzer against the
+counted AIPerf JSONL and the role-log window captured for that run:
+
+```bash
+python3 analyze-aiperf-stage-attribution.py \
+  --profile-jsonl /tmp/kvbm-xdc/aiperf/profile_export.jsonl \
+  --role-log-dir /tmp/kvbm-xdc/aiperf/aiperf-role-log-window \
+  --output-dir /tmp/kvbm-xdc/aiperf/analysis
+```
+
+The analyzer writes `stage-attribution.csv`,
+`stage-attribution-summary.env`, and `stage-attribution-summary.md`. It is
+specific to this KVBM XDC harness because it joins AIPerf request metadata to
+Dynamo frontend request IDs and KVBM `kvbm_audit` remote-slot events. Do not
+commit generated analysis outputs or machine-specific artifact bundles.
 
 ## Usage
 
-Same-node H100/A100 baseline:
+Candidate Experiment E same-node KVBM + hub path, H100/A100:
+
+```bash
+ARTIFACT_DIR=/tmp/kvbm-xdc/e-hub-same-node \
+KVBM_EXPERIMENT_ID=E \
+KVBM_TRANSFER_TOPOLOGY=kvbm-hub \
+KVBM_HARDWARE_PROFILE=h100-a100 \
+NODE_ROLE=all \
+bash run-dynamo-kvbm-chat-smoke.sh
+```
+
+This exercises the API compatibility bridge where `kvbm_hub` dispatches a
+vLLM-compatible prefill completion request with `kv_transfer_params` through an
+internal Dynamo frontend. The user request still goes to the main
+`dynamo.frontend` chat endpoint; the hub's internal prefill POST goes to
+`KVBM_HUB_PREFILL_URL`, backed by a `dynamo.vllm` prefill worker registered as
+an internal completions backend. Treat it as a candidate until
+`trace-gate.env` contains both `trace_useful=true` and
+`experiment_e_smoke_valid=true`; otherwise the run is diagnostic evidence for
+the next integration fix. A useful smoke trace is not Experiment E completion:
+the same-node baseline still requires the locked AIPerf pass against the
+`dynamo.frontend` chat endpoint.
+
+Current Dynamo KVBM/NIXL diagnostic, same-node H100/A100:
 
 ```bash
 ARTIFACT_DIR=/tmp/kvbm-xdc/same-node \
@@ -76,26 +156,32 @@ NODE_ROLE=all \
 bash run-dynamo-kvbm-chat-smoke.sh
 ```
 
-Cross-datacenter runs use the same workflow split across roles. Set
-`ETCD_ENDPOINTS`, `NATS_SERVER`, and each worker's routable
-`VLLM_NIXL_SIDE_CHANNEL_HOST` through `DECODE_SIDE_CHANNEL_HOST` or
-`PREFILL_SIDE_CHANNEL_HOST`.
+The hub candidate or NIXL diagnostic can also be split across roles. The
+example below uses the hub candidate; set `ETCD_ENDPOINTS`, `NATS_SERVER`, and
+each worker's routable `VLLM_NIXL_SIDE_CHANNEL_HOST` through
+`DECODE_SIDE_CHANNEL_HOST` or `PREFILL_SIDE_CHANNEL_HOST`.
 
 ```bash
 # Frontend / runtime-infra node
-ARTIFACT_DIR=/tmp/kvbm-xdc/frontend NODE_ROLE=frontend bash run-dynamo-kvbm-chat-smoke.sh
+ARTIFACT_DIR=/tmp/kvbm-xdc/frontend KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=frontend bash run-dynamo-kvbm-chat-smoke.sh
+
+# Internal prefill frontend node
+ARTIFACT_DIR=/tmp/kvbm-xdc/hub-prefill-frontend KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=hub-prefill-frontend FRONTEND_HOST=192.0.2.20 bash run-dynamo-kvbm-chat-smoke.sh
+
+# Hub dispatcher node
+ARTIFACT_DIR=/tmp/kvbm-xdc/hub KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=hub KVBM_HUB_PREFILL_URL=http://192.0.2.20:8001 bash run-dynamo-kvbm-chat-smoke.sh
 
 # Decode node
-ARTIFACT_DIR=/tmp/kvbm-xdc/decode NODE_ROLE=decode DECODE_SIDE_CHANNEL_HOST=192.0.2.21 bash run-dynamo-kvbm-chat-smoke.sh
+ARTIFACT_DIR=/tmp/kvbm-xdc/decode KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=decode DECODE_SIDE_CHANNEL_HOST=192.0.2.21 bash run-dynamo-kvbm-chat-smoke.sh
 
 # Prefill node
-ARTIFACT_DIR=/tmp/kvbm-xdc/prefill NODE_ROLE=prefill PREFILL_SIDE_CHANNEL_HOST=192.0.2.31 bash run-dynamo-kvbm-chat-smoke.sh
+ARTIFACT_DIR=/tmp/kvbm-xdc/prefill KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=prefill KVBM_HUB_PREFILL_NAMESPACE=dynamo_hub_prefill PREFILL_SIDE_CHANNEL_HOST=192.0.2.31 bash run-dynamo-kvbm-chat-smoke.sh
 
 # Client / measurement node
-ARTIFACT_DIR=/tmp/kvbm-xdc/client NODE_ROLE=client FRONTEND_HOST=192.0.2.10 bash run-dynamo-kvbm-chat-smoke.sh
+ARTIFACT_DIR=/tmp/kvbm-xdc/client KVBM_TRANSFER_TOPOLOGY=kvbm-hub NODE_ROLE=client FRONTEND_HOST=192.0.2.10 bash run-dynamo-kvbm-chat-smoke.sh
 ```
 
-Locked AIPerf pass against the chat endpoint:
+Locked AIPerf pass against the chat endpoint after a useful diagnostic run:
 
 ```bash
 URL=http://192.0.2.10:8000 \
@@ -104,21 +190,115 @@ KVBM_HARDWARE_PROFILE=h100-a100 \
 bash run-aiperf-locked.sh
 ```
 
+The runner uses `aiperf` from `PATH` when available and otherwise falls back to
+`uvx aiperf`. Set `AIPERF_BIN=/path/to/aiperf` only when an explicit executable
+is required. Set `AIPERF_CACHE_ROOT=/scratch/.../aiperf-cache` on hosts where
+the default uv/pip cache path is small. The locked model, endpoint type,
+streaming mode, request count, concurrency, and synthetic token contract do not
+change.
+
+To produce a comparison manifest in the same artifact directory, pass the
+baseline AIPerf export explicitly:
+
+```bash
+URL=http://192.0.2.10:8000 \
+ARTIFACT_DIR=/tmp/kvbm-xdc/aiperf-cross-dc \
+BASELINE_AIPERF_JSON=/tmp/kvbm-xdc/aiperf-same-node/profile_export_aiperf.json \
+POSTCHECK_LOG_DIR=/tmp/kvbm-xdc/collected-role-logs \
+KVBM_HARDWARE_PROFILE=h100-a100 \
+bash run-aiperf-locked.sh
+```
+
+If the original baseline export is not available, pass a provenance-labeled
+metrics env file instead:
+
+```bash
+URL=http://192.0.2.10:8000 \
+ARTIFACT_DIR=/tmp/kvbm-xdc/aiperf-cross-dc \
+BASELINE_METRICS_ENV=/tmp/kvbm-xdc/baseline.metrics.env \
+POSTCHECK_LOG_DIR=/tmp/kvbm-xdc/collected-role-logs \
+KVBM_HARDWARE_PROFILE=h100-a100 \
+bash run-aiperf-locked.sh
+```
+
 ## Runtime Invariants
 
+- This harness is intentionally self-contained under
+  `examples/backends/vllm/launch/kvbm_xdc`. It must not import operator-only
+  `.claude` skills at runtime. Similar hardware profile names in agent skills
+  are maintained separately for operator workflows and are not part of this
+  reusable example contract. The launch, shim, analyzer, and trace helpers in
+  this directory are reusable within this KVBM XDC example harness, not exported
+  Dynamo product APIs.
+- `KVBM_CLEANUP_STALE_PROCESSES` defaults to `1`, preserving isolated-smoke
+  behavior that clears stale Dynamo, vLLM, hub, and engine processes before a
+  full local run. Set it to `0` only in shared allocations where broad process
+  cleanup could affect another session; tracked top-level PIDs started by the
+  harness are still cleaned on exit.
 - Cross-node runs need shared runtime infra reachable from all nodes:
   `ETCD_ENDPOINTS=192.0.2.10:2379`, `NATS_SERVER=nats://192.0.2.10:4222`,
   `DYN_DISCOVERY_BACKEND=etcd`, `DYN_REQUEST_PLANE=tcp`, and
   `DYN_EVENT_PLANE=nats`.
 - Set `VLLM_NIXL_SIDE_CHANNEL_HOST` explicitly on each worker to that node's
   routable address. Do not rely on autodetection for cross-datacenter runs.
-- Prefill uses `PdConnector` wrapping KVBM and NIXL. Worker startup validates
-  the canonical KVBM module exports and the NIXL registry entry before launching
-  `python -m dynamo.vllm`.
-- Use `kvbm.v2.vllm.connector` for the `PdConnector` module path. The legacy
-  `kvbm.vllm_integration.connector` path remains a compatibility shim for
-  existing examples and older configs.
-- Capture `chat-ttft.json`, logs, metadata, and `trace.html` for every run.
+- The current diagnostic harness uses `PdConnector` wrapping KVBM and NIXL.
+  Worker startup validates the canonical KVBM module exports and the NIXL
+  registry entry before launching `python -m dynamo.vllm`.
+- Use `kvbm.v2.vllm.connector` for the diagnostic `PdConnector` module path.
+  The legacy `kvbm.vllm_integration.connector` path remains a compatibility
+  shim for existing examples and older configs.
+- The diagnostic harness defaults metadata to `experiment=diagnostic`. Do not
+  set `KVBM_EXPERIMENT_ID=E` until the run uses the KVBM + hub
+  conditional-disagg transfer path and passes the useful-trace gate.
+- Capture `chat-ttft.json`, logs, metadata, `trace.html`, and
+  `trace-gate.env` for every run.
+- Runtime setup shared by the launchers lives in `common.sh`. It resolves
+  `PYTHON_BIN` from an explicit `PYTHON_BIN`, optional `VENV`, or system
+  `python3`; it does not require a repo-local virtual environment. If an
+  operator wants to source an external runtime environment file, they must set
+  both `SOURCE_KVBM_RUNTIME_ENV=1` and `KVBM_RUNTIME_ENV_SCRIPT=/path/to/env.sh`.
+  Runtime-image runs use the image's installed Dynamo/KVBM/vLLM packages by
+  default. Set `KVBM_XDC_USE_WORKTREE_PYTHON=1` only for source-development
+  runs where the worktree has built Python extensions such as `kvbm/_core*.so`.
+- `launch-kvbm-hub.sh` is the local hub launcher for this example. It uses an
+  existing `kvbm_hub` binary from `KVBM_HUB_BIN`, `/usr/local/bin`, or the
+  worktree target directory, and only builds with cargo when
+  `KVBM_HUB_BUILD=1` or the default `auto` mode finds no binary and `cargo` is
+  available.
+- `launch-kvbm-prefill-shim.sh` and `kvbm-prefill-completions-shim.py` are the
+  hub-to-Dynamo prefill bridge for this harness. Keep them here until that
+  bridge becomes a productized Dynamo or hub API instead of an Experiment E
+  compatibility layer. The shim bounds HTTP request handling with
+  `KVBM_HUB_PREFILL_SHIM_MAX_BODY_BYTES`,
+  `KVBM_HUB_PREFILL_SHIM_READ_TIMEOUT_SECONDS`, and
+  `KVBM_HUB_PREFILL_SHIM_UPSTREAM_TIMEOUT_SECONDS`.
+- `kvbm-xdc-trace.py` is the trace renderer used by this directory; the smoke
+  runner does not depend on operator-only skill files for trace generation.
+- Do not use `nvidia-smi` as a pass/fail signal. It is useful only for
+  cleanup/visibility. The harness records `runtime-probe.json`, which imports
+  Dynamo/KVBM/vLLM, checks `torch.cuda`, and runs a small CUDA operation on the
+  requested decode/prefill devices before launch. A counted run still requires
+  the streamed chat request and `trace-gate.env` to pass.
+- For H100/A100 `kvbm-hub` host-cache runs, the harness also performs a
+  transfer-substrate preflight. With `KVBM_EXPERIMENT_ID=E`, missing
+  `nvidia_peermem` exits before launch with `trace_useful=false` and a
+  `verdict.md`; use `KVBM_ALLOW_SUBSTRATE_FAILURE_ARTIFACT=1` only when
+  intentionally collecting a non-benchmark failure artifact. Diagnostic runs
+  warn and continue so the old raw KVBM path can still be reproduced while the
+  substrate is being characterized.
+- Treat `trace.html` as complete only when the harness prints `TRACE_USEFUL`.
+  The gate accepts either a `kvbm_audit` transfer chain or Dynamo vLLM evidence
+  that the routed chat request selected prefill and decode workers and emitted a
+  successful `KV Transfer metrics` line. It also requires positive external
+  cache reuse and zero KV load failures. A rendered timeout log, backend
+  failure, or fallback-only timeline without successful transfer and cache
+  evidence is not an Experiment E/F trace result. The persisted
+  `trace-gate.env` must say `trace_useful=true` before the trace is counted.
+  For Experiment E smoke, it must also say `experiment_e_smoke_valid=true`;
+  `experiment_e_complete` remains `false` until the AIPerf comparison has been
+  produced.
+  Split-role cross-datacenter runs must collect frontend, decode, and prefill
+  logs into the validation artifact before the trace gate can pass.
 - Keep machine-specific placement in `KVBM_HARDWARE_PROFILE` or explicit env
   overrides, not in workflow script names.
 - If startup takes the compile-heavy vLLM path, use:

--- a/examples/backends/vllm/launch/kvbm_xdc/run-aiperf-locked.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/run-aiperf-locked.sh
@@ -12,16 +12,367 @@ ARTIFACT_DIR=${ARTIFACT_DIR:?ARTIFACT_DIR is required}
 
 mkdir -p "$ARTIFACT_DIR"
 
-exec aiperf profile \
-  --model "$MODEL" \
+AIPERF_BIN=${AIPERF_BIN:-}
+AIPERF_UVX=${AIPERF_UVX:-uvx}
+AIPERF_CONCURRENCY=8
+AIPERF_REQUEST_COUNT=200
+AIPERF_INPUT_TOKENS=1101
+AIPERF_OUTPUT_TOKENS=256
+AIPERF_ENDPOINT_TYPE=chat
+AIPERF_STREAMING=true
+AIPERF_EXTRA_INPUTS=ignore_eos:true
+
+kvbm_xdc_resolve_aiperf_cmd() {
+  if [ -n "$AIPERF_BIN" ]; then
+    if command -v "$AIPERF_BIN" >/dev/null 2>&1 || [ -x "$AIPERF_BIN" ]; then
+      AIPERF_CMD=("$AIPERF_BIN")
+      return 0
+    fi
+    echo "AIPERF_BIN is set but not executable or on PATH: $AIPERF_BIN" >&2
+    return 2
+  fi
+
+  if command -v aiperf >/dev/null 2>&1; then
+    AIPERF_CMD=(aiperf)
+    return 0
+  fi
+
+  if command -v "$AIPERF_UVX" >/dev/null 2>&1; then
+    AIPERF_CMD=("$AIPERF_UVX" aiperf)
+    return 0
+  fi
+
+  echo "AIPerf was not found. Install aiperf, set AIPERF_BIN, or make uvx available." >&2
+  return 2
+}
+
+kvbm_xdc_configure_aiperf_cache() {
+  local root=${AIPERF_CACHE_ROOT:-}
+  [ -n "$root" ] || return 0
+  mkdir -p "$root"
+  export UV_CACHE_DIR=$root/uv
+  export PIP_CACHE_DIR=$root/pip
+  export HF_HOME=$root/hf
+  export TRANSFORMERS_CACHE=$HF_HOME
+}
+
+kvbm_xdc_write_env() {
+  local file=$1
+  local key=$2
+  local value=${3:-}
+  printf '%s=%q\n' "$key" "$value" >>"$file"
+}
+
+kvbm_xdc_url_scheme() {
+  case "$URL" in
+    *://*) printf '%s\n' "${URL%%://*}" ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+kvbm_xdc_url_port() {
+  local endpoint=${URL#*://}
+  endpoint=${endpoint%%/*}
+  case "$endpoint" in
+    *:*) printf '%s\n' "${endpoint##*:}" ;;
+    *) printf '\n' ;;
+  esac
+}
+
+kvbm_xdc_find_profile_json() {
+  if [ -f "$ARTIFACT_DIR/profile_export_aiperf.json" ]; then
+    printf '%s\n' "$ARTIFACT_DIR/profile_export_aiperf.json"
+    return
+  fi
+  find "$ARTIFACT_DIR" -type f -name profile_export_aiperf.json | sort | head -n 1
+}
+
+kvbm_xdc_jq_value() {
+  local json=$1
+  local query=$2
+  jq -r "$query // empty" "$json" 2>/dev/null || true
+}
+
+kvbm_xdc_delta() {
+  local current=$1
+  local baseline=$2
+  awk -v current="$current" -v baseline="$baseline" '
+    BEGIN {
+      if (current == "" || baseline == "") {
+        exit 1
+      }
+      printf "%.6f", current - baseline
+    }' 2>/dev/null || true
+}
+
+kvbm_xdc_count_pattern() {
+  local pattern=$1
+  shift
+  if [ "$#" -eq 0 ]; then
+    printf '0\n'
+    return
+  fi
+  local count
+  set +e
+  count=$(grep -h -E "$pattern" "$@" 2>/dev/null | wc -l | tr -d ' ')
+  set -e
+  printf '%s\n' "${count:-0}"
+}
+
+kvbm_xdc_count_failure_pattern() {
+  local pattern=$1
+  local exclude_zero_summary=$2
+  shift 2
+  if [ "$#" -eq 0 ]; then
+    printf '0\n'
+    return
+  fi
+  local count
+  set +e
+  count=$(grep -h -E "$pattern" "$@" 2>/dev/null | grep -v -E "$exclude_zero_summary" | wc -l | tr -d ' ')
+  set -e
+  printf '%s\n' "${count:-0}"
+}
+
+kvbm_xdc_env_value() {
+  local file=$1
+  local key=$2
+  if [ ! -f "$file" ]; then
+    return
+  fi
+  grep -E "^$key=" "$file" 2>/dev/null | head -n 1 | cut -d= -f2- || true
+}
+
+kvbm_xdc_metrics_env_value() {
+  local file=$1
+  local key=$2
+  local value
+  value=$(kvbm_xdc_env_value "$file" "$key")
+  value=${value#\"}
+  value=${value%\"}
+  value=${value#\'}
+  value=${value%\'}
+  printf '%s\n' "$value"
+}
+
+kvbm_xdc_write_contract() {
+  local contract_file=$ARTIFACT_DIR/aiperf-contract.env
+  : >"$contract_file"
+  kvbm_xdc_write_env "$contract_file" generated_at_utc "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  kvbm_xdc_write_env "$contract_file" model "$MODEL"
+  kvbm_xdc_write_env "$contract_file" framework dynamo-vllm
+  kvbm_xdc_write_env "$contract_file" endpoint_type "$AIPERF_ENDPOINT_TYPE"
+  kvbm_xdc_write_env "$contract_file" streaming "$AIPERF_STREAMING"
+  kvbm_xdc_write_env "$contract_file" request_count "$AIPERF_REQUEST_COUNT"
+  kvbm_xdc_write_env "$contract_file" concurrency "$AIPERF_CONCURRENCY"
+  kvbm_xdc_write_env "$contract_file" synthetic_input_tokens_mean "$AIPERF_INPUT_TOKENS"
+  kvbm_xdc_write_env "$contract_file" synthetic_input_tokens_stddev 0
+  kvbm_xdc_write_env "$contract_file" output_tokens_mean "$AIPERF_OUTPUT_TOKENS"
+  kvbm_xdc_write_env "$contract_file" output_tokens_stddev 0
+  kvbm_xdc_write_env "$contract_file" extra_inputs "$AIPERF_EXTRA_INPUTS"
+  kvbm_xdc_write_env "$contract_file" hardware_profile "$KVBM_HARDWARE_PROFILE"
+  kvbm_xdc_write_env "$contract_file" gpu_class "$GPU_CLASS"
+  kvbm_xdc_write_env "$contract_file" endpoint_url_redacted true
+  kvbm_xdc_write_env "$contract_file" endpoint_url_scheme "$(kvbm_xdc_url_scheme)"
+  kvbm_xdc_write_env "$contract_file" endpoint_url_port "$(kvbm_xdc_url_port)"
+}
+
+kvbm_xdc_write_postcheck() {
+  local result_file=$1
+  local log_dir=${POSTCHECK_LOG_DIR:-${ROLE_LOG_DIR:-}}
+  if [ -z "$log_dir" ] || [ ! -d "$log_dir" ]; then
+    kvbm_xdc_write_env "$result_file" postcheck_written false
+    kvbm_xdc_write_env "$result_file" postcheck_reason log_dir_not_provided
+    return
+  fi
+
+  local logs=()
+  while IFS= read -r log_file; do
+    logs+=("$log_file")
+  done < <(find "$log_dir" -maxdepth 2 -type f -name '*.log' | sort)
+
+  local postcheck_file=$ARTIFACT_DIR/aiperf-postcheck.env
+  : >"$postcheck_file"
+  kvbm_xdc_write_env "$postcheck_file" log_dir "$log_dir"
+  kvbm_xdc_write_env "$postcheck_file" log_file_count "${#logs[@]}"
+  kvbm_xdc_write_env "$postcheck_file" kvbm_audit_events "$(kvbm_xdc_count_pattern 'kvbm_audit' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" session_pull_rdma_done "$(kvbm_xdc_count_pattern 'session_pull_rdma_done' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" worker_session_pull_returned "$(kvbm_xdc_count_pattern 'worker_session_pull_returned' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" worker_g2_to_g1_done "$(kvbm_xdc_count_pattern 'worker_g2_to_g1_done' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" offload_register_complete "$(kvbm_xdc_count_pattern 'offload_register_complete' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" external_cache_hit_lines "$(kvbm_xdc_count_pattern '[Ee]xternal prefix cache hit rate|external_cache_hit|external_cache' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" kv_load_failure_events "$(kvbm_xdc_count_failure_pattern 'KV load failure|Onboarding failed|Failed to start onboarding|kv_load_failure' 'KV load failure events:[[:space:]]*0|kv_load_failure_events=0' "${logs[@]}")"
+  kvbm_xdc_write_env "$postcheck_file" nixl_create_xfer_req_failures "$(kvbm_xdc_count_failure_pattern 'createXferReq: no potential backend found|nixl_create_xfer_req_failures' 'createXferReq failures:[[:space:]]*0|nixl_create_xfer_req_failures=0' "${logs[@]}")"
+
+  local trace_gate_file=$log_dir/trace-gate.env
+  if [ -f "$trace_gate_file" ]; then
+    kvbm_xdc_write_env "$postcheck_file" trace_gate_file "$trace_gate_file"
+    kvbm_xdc_write_env "$postcheck_file" trace_useful "$(kvbm_xdc_env_value "$trace_gate_file" trace_useful)"
+    kvbm_xdc_write_env "$postcheck_file" trace_external_cache_hit_events "$(kvbm_xdc_env_value "$trace_gate_file" external_cache_hit_events)"
+    kvbm_xdc_write_env "$postcheck_file" trace_kv_load_failure_events "$(kvbm_xdc_env_value "$trace_gate_file" kv_load_failure_events)"
+    kvbm_xdc_write_env "$postcheck_file" trace_nixl_create_xfer_req_failures "$(kvbm_xdc_env_value "$trace_gate_file" nixl_create_xfer_req_failures)"
+  fi
+  kvbm_xdc_write_env "$result_file" postcheck_written true
+  kvbm_xdc_write_env "$result_file" postcheck_file "$postcheck_file"
+}
+
+kvbm_xdc_write_comparison() {
+  local result_file=$1
+  local current_json=$2
+  local baseline_json=${BASELINE_AIPERF_JSON:-}
+  local baseline_metrics_env=${BASELINE_METRICS_ENV:-}
+  if [ -z "$baseline_json" ] && [ -z "$baseline_metrics_env" ]; then
+    kvbm_xdc_write_env "$result_file" comparison_written false
+    kvbm_xdc_write_env "$result_file" comparison_reason baseline_not_provided
+    return
+  fi
+  if [ -n "$baseline_json" ] && [ ! -f "$baseline_json" ]; then
+    kvbm_xdc_write_env "$result_file" comparison_written false
+    kvbm_xdc_write_env "$result_file" comparison_reason baseline_missing
+    return
+  fi
+  if [ -z "$baseline_json" ] && [ ! -f "$baseline_metrics_env" ]; then
+    kvbm_xdc_write_env "$result_file" comparison_written false
+    kvbm_xdc_write_env "$result_file" comparison_reason baseline_metrics_env_missing
+    return
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    kvbm_xdc_write_env "$result_file" comparison_written false
+    kvbm_xdc_write_env "$result_file" comparison_reason jq_missing
+    return
+  fi
+
+  local comparison_file=$ARTIFACT_DIR/experiment-comparison.env
+  : >"$comparison_file"
+  kvbm_xdc_write_env "$comparison_file" current_aiperf_json "$current_json"
+  if [ -n "$baseline_json" ]; then
+    kvbm_xdc_write_env "$comparison_file" baseline_source aiperf_json
+    kvbm_xdc_write_env "$comparison_file" comparison_input_canonical_aiperf_json true
+    kvbm_xdc_write_env "$comparison_file" baseline_aiperf_json "$baseline_json"
+  else
+    kvbm_xdc_write_env "$comparison_file" baseline_source metrics_env
+    kvbm_xdc_write_env "$comparison_file" comparison_input_canonical_aiperf_json false
+    kvbm_xdc_write_env "$comparison_file" baseline_metrics_env "$baseline_metrics_env"
+    kvbm_xdc_write_env "$comparison_file" baseline_source_type "$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" baseline_source_type)"
+    kvbm_xdc_write_env "$comparison_file" baseline_derived_from_log "$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" derived_from_log)"
+    kvbm_xdc_write_env "$comparison_file" baseline_source_log "$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" source_log)"
+    kvbm_xdc_write_env "$comparison_file" baseline_source_log_sha256 "$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" source_log_sha256)"
+    kvbm_xdc_write_env "$comparison_file" baseline_source_excerpt_line_hint "$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" source_excerpt_line_hint)"
+    kvbm_xdc_write_env "$comparison_file" baseline_benchmark_id "$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" benchmark_id)"
+  fi
+
+  local metric
+  local current
+  local baseline
+  local baseline_env_key
+  local delta
+  for metric in \
+    request_count.avg:request_count \
+    request_throughput.avg:request_throughput \
+    output_token_throughput.avg:output_token_throughput \
+    time_to_first_token.avg:ttft_avg_ms \
+    time_to_first_token.p50:ttft_p50_ms \
+    time_to_first_token.p90:ttft_p90_ms \
+    time_to_first_token.p99:ttft_p99_ms \
+    request_latency.p50:request_latency_p50_ms \
+    request_latency.p99:request_latency_p99_ms \
+    inter_token_latency.p50:itl_p50_ms \
+    inter_token_latency.p99:itl_p99_ms \
+    output_sequence_length.avg:output_sequence_length_avg \
+    osl_mismatch_count.avg:osl_mismatch_count; do
+    baseline_env_key=${metric#*:}
+    metric=${metric%%:*}
+    local key=${metric//./_}
+    current=$(kvbm_xdc_jq_value "$current_json" ".$metric")
+    if [ -n "$baseline_json" ]; then
+      baseline=$(kvbm_xdc_jq_value "$baseline_json" ".$metric")
+    else
+      baseline=$(kvbm_xdc_metrics_env_value "$baseline_metrics_env" "$baseline_env_key")
+    fi
+    delta=$(kvbm_xdc_delta "$current" "$baseline")
+    kvbm_xdc_write_env "$comparison_file" "current_$key" "$current"
+    kvbm_xdc_write_env "$comparison_file" "baseline_$key" "$baseline"
+    kvbm_xdc_write_env "$comparison_file" "delta_$key" "$delta"
+  done
+
+  kvbm_xdc_write_env "$result_file" comparison_written true
+  kvbm_xdc_write_env "$result_file" comparison_file "$comparison_file"
+}
+
+kvbm_xdc_configure_aiperf_cache
+kvbm_xdc_resolve_aiperf_cmd
+kvbm_xdc_write_contract
+
+set +e
+"${AIPERF_CMD[@]}" profile \
   --url "$URL" \
-  --endpoint-type chat \
+  --model "$MODEL" \
+  --endpoint-type "$AIPERF_ENDPOINT_TYPE" \
   --streaming \
-  --concurrency 8 \
-  --request-count 200 \
-  --synthetic-input-tokens-mean 1101 \
-  --synthetic-input-tokens-stddev 0 \
-  --output-tokens-mean 256 \
-  --output-tokens-stddev 0 \
-  --artifact-dir "$ARTIFACT_DIR" \
+  --num-requests "$AIPERF_REQUEST_COUNT" \
+  --concurrency "$AIPERF_CONCURRENCY" \
+  --request-timeout-seconds 3600 \
+  --isl "$AIPERF_INPUT_TOKENS" \
+  --osl "$AIPERF_OUTPUT_TOKENS" \
+  --extra-inputs "$AIPERF_EXTRA_INPUTS" \
+  --output-artifact-dir "$ARTIFACT_DIR" \
   --ui none
+aiperf_status=$?
+set -e
+
+result_file=$ARTIFACT_DIR/aiperf-result.env
+: >"$result_file"
+kvbm_xdc_write_env "$result_file" aiperf_exit_code "$aiperf_status"
+if [ "$aiperf_status" -eq 0 ]; then
+  kvbm_xdc_write_env "$result_file" aiperf_success true
+else
+  kvbm_xdc_write_env "$result_file" aiperf_success false
+fi
+
+profile_json=
+if [ "$aiperf_status" -eq 0 ]; then
+  profile_json=$(kvbm_xdc_find_profile_json)
+else
+  kvbm_xdc_write_env "$result_file" profile_json_found false
+  kvbm_xdc_write_env "$result_file" metrics_extracted false
+  kvbm_xdc_write_env "$result_file" metrics_reason aiperf_failed
+  kvbm_xdc_write_env "$result_file" comparison_written false
+  kvbm_xdc_write_env "$result_file" comparison_reason aiperf_failed
+fi
+
+if [ "$aiperf_status" -eq 0 ] && [ -n "$profile_json" ]; then
+  kvbm_xdc_write_env "$result_file" profile_json_found true
+  kvbm_xdc_write_env "$result_file" profile_json "$profile_json"
+  if command -v jq >/dev/null 2>&1; then
+    kvbm_xdc_write_env "$result_file" metrics_extracted true
+    kvbm_xdc_write_env "$result_file" request_count "$(kvbm_xdc_jq_value "$profile_json" '.request_count.avg')"
+    kvbm_xdc_write_env "$result_file" request_throughput "$(kvbm_xdc_jq_value "$profile_json" '.request_throughput.avg')"
+    kvbm_xdc_write_env "$result_file" output_token_throughput "$(kvbm_xdc_jq_value "$profile_json" '.output_token_throughput.avg')"
+    kvbm_xdc_write_env "$result_file" ttft_avg_ms "$(kvbm_xdc_jq_value "$profile_json" '.time_to_first_token.avg')"
+    kvbm_xdc_write_env "$result_file" ttft_p50_ms "$(kvbm_xdc_jq_value "$profile_json" '.time_to_first_token.p50')"
+    kvbm_xdc_write_env "$result_file" ttft_p90_ms "$(kvbm_xdc_jq_value "$profile_json" '.time_to_first_token.p90')"
+    kvbm_xdc_write_env "$result_file" ttft_p99_ms "$(kvbm_xdc_jq_value "$profile_json" '.time_to_first_token.p99')"
+    kvbm_xdc_write_env "$result_file" request_latency_p50_ms "$(kvbm_xdc_jq_value "$profile_json" '.request_latency.p50')"
+    kvbm_xdc_write_env "$result_file" request_latency_p99_ms "$(kvbm_xdc_jq_value "$profile_json" '.request_latency.p99')"
+    kvbm_xdc_write_env "$result_file" itl_p50_ms "$(kvbm_xdc_jq_value "$profile_json" '.inter_token_latency.p50')"
+    kvbm_xdc_write_env "$result_file" itl_p99_ms "$(kvbm_xdc_jq_value "$profile_json" '.inter_token_latency.p99')"
+    kvbm_xdc_write_env "$result_file" output_sequence_length_avg "$(kvbm_xdc_jq_value "$profile_json" '.output_sequence_length.avg')"
+    kvbm_xdc_write_env "$result_file" osl_mismatch_count "$(kvbm_xdc_jq_value "$profile_json" '.osl_mismatch_count.avg')"
+    kvbm_xdc_write_comparison "$result_file" "$profile_json"
+  else
+    kvbm_xdc_write_env "$result_file" metrics_extracted false
+    kvbm_xdc_write_env "$result_file" metrics_reason jq_missing
+    kvbm_xdc_write_env "$result_file" comparison_written false
+    kvbm_xdc_write_env "$result_file" comparison_reason jq_missing
+  fi
+elif [ "$aiperf_status" -eq 0 ]; then
+  kvbm_xdc_write_env "$result_file" profile_json_found false
+  kvbm_xdc_write_env "$result_file" metrics_extracted false
+  kvbm_xdc_write_env "$result_file" metrics_reason profile_json_missing
+  kvbm_xdc_write_env "$result_file" comparison_written false
+  kvbm_xdc_write_env "$result_file" comparison_reason profile_json_missing
+fi
+
+kvbm_xdc_write_postcheck "$result_file"
+
+exit "$aiperf_status"


### PR DESCRIPTION
## Summary

This PR is now rebased on Ryan's #9972 (`ryan/kvbm-engine-service`). It is the central coordination PR for the current KVBM cross-datacenter Experiment E/F work. The scope here is documentation and AIPerf manifest/reporting support for reproducing and interpreting the experiments.

Experiment E is the Dynamo frontend + KVBM hub path: requests enter through `dynamo.frontend`, decode chooses remote prefill through the KVBM hub, KV is transferred back, and the run is counted only when the trace gate finds the real transfer chain and cache reuse. Experiment F is the standalone KVBM P2P smoke path used to validate the lower-level pull/commit/trace evidence outside the full AIPerf flow.

## Review Order

1. #9972: Ryan's KVBM engine service base.
2. #9868: this PR, central experiment coordination and manifest/reporting documentation.
3. #9870: protocol glue for preserving `kv_transfer_params`.
4. #9869: runtime harness, trace rendering, gates, and reproduction scripts.

#9478 is historical background for the earlier prefill-as-a-service/cross-cluster exploration. The current E/F definitions and review sequence are centralized here.

## Evidence

The counted A100+H100 cross-DC artifact is:

`/home/mkosec/kvbm-e-artifacts/kvbm-e-cross-dc-aiperf-ec53848d59-20260526T230147Z.tgz`

SHA256:

`60888b0576762ab05b9a1e5782f3a9a040e08224df918d088150b757f6022729`

The trace gate reports `trace_useful=true`, `kvbm_audit_events=81987`, `audit_transfer_complete_events=807`, `external_cache_hit_events=99`, `kv_load_failure_events=0`, and `nixl_create_xfer_req_failures=0`.

## Validation

- `git diff --check upstream/ryan/kvbm-engine-service..rebase9972/9868-kvbm-aiperf-manifests-clean`
