### PR TITLE
feat: add kvbm hub runtime harness

### DIFF
--- a/.claude/skills/disagg-trace/SKILL.md
+++ b/.claude/skills/disagg-trace/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: disagg-trace
-description: Render a self-contained trace.html visualizing the kvbm_audit timeline from a disagg experiment dir. Three lanes (Decode | Hub | Prefill), one row per audit event, sidebar filters by request_id.
+description: Render a self-contained trace.html visualizing the kvbm_audit timeline from a disagg or P2P experiment dir. Three lanes, one row per audit event, sidebar filters by request_id.
 ---
 
 # Skill: KVBM Disagg Trace Viewer
 
-Renders an HTML timeline from a `disagg-bringup` / `disagg-smoke` experiment dir. Reads `hub.log`, `prefill.log`, `decode.log` from the directory and emits `trace.html` in the same dir.
+Renders an HTML timeline from a `disagg-bringup`, `disagg-smoke`, or
+`p2p-smoke` experiment dir and emits `trace.html` in the same dir.
 
 ## Skill assets
 
 | File | Purpose |
 |---|---|
 | `cd-trace.py` | Parses `kvbm_audit` events from the three logs, builds a 3-lane timeline, emits self-contained HTML. |
+| `p2p-trace.py` | Same renderer shape for P2P logs: `instance_a.log`, `hub.log`, and `instance_b.log`. |
 
 ## Usage
 
 ```bash
-SKILL=/home/ryan/repos/dynamo/.claude/skills/disagg-trace
+SKILL=/path/to/dynamo/.claude/skills/disagg-trace
 python3 "$SKILL/cd-trace.py" /tmp/kvbm-experiments/<ts>-<label>/
+python3 "$SKILL/p2p-trace.py" /tmp/kvbm-experiments/<ts>-p2p-smoke/
 ```
 
 Open the resulting `trace.html` in a browser. Click any `request_id` in the sidebar to filter the timeline to that request.

--- a/.claude/skills/p2p-smoke/RESTART_PROMPT.md
+++ b/.claude/skills/p2p-smoke/RESTART_PROMPT.md
@@ -14,11 +14,19 @@ The P2P smoke starts:
 The request flow is:
 
 1. Send streaming chat request R1 to instance A to warm G2.
-2. Scrape A's audit log for `offload_register_complete` block hashes.
+2. Poll the hub indexer for A's published `hash_u128` block values.
 3. Use hub control-plane calls for `open_session`, `pull_from_session`, and
    `close_session`.
-4. Send streaming chat request R2 to instance B and assert a G2 hit.
-5. Render the trace artifact from the experiment directory.
+4. Assert the hub index lists instance B as an owner for the pulled block.
+5. Send streaming chat request R2 to instance B through the chat streaming
+   endpoint.
+6. Render the trace artifact from the experiment directory.
+7. Write `trace-gate.env` and only print PASS when the trace is non-empty and
+   useful.
+
+Runtime Python is resolved in this order: explicit `PYTHON_BIN`, optional
+`KVBM_VENV`, runtime image `/opt/dynamo/venv`, then `python3` on `PATH`. Do not
+assume a worktree-local sandbox or virtualenv exists.
 
 ## Hardware Profiles
 
@@ -53,8 +61,15 @@ P2P_B_CUDA_VISIBLE_DEVICES=1
 ## Do Not Regress
 
 - Keep endpoint type `chat` and streaming enabled for experiment runs.
-- Keep trace generation as part of the run.
+- Keep trace generation and `trace-gate.env` as part of the run. A rendered
+  but empty trace is not a useful trace.
 - Keep profile defaults in `hardware-profiles.sh`, not inline in
   `p2p-smoke.sh` or `launch-instance.sh`.
+- Keep broad stale-process cleanup enabled by default. Set
+  `P2P_CLEANUP_STALE_PROCESSES=0` only in shared sessions where machine-level
+  process or socket cleanup could affect another allocation.
+- Keep `P2P_ENFORCE_EAGER=1` for functional smoke runs unless the task is
+  specifically to debug vLLM compiled startup.
+- Treat `nvidia-smi` as cleanup telemetry only, not as a validation gate.
 - If TTFT is more than 1 second slower than the same-node NIXL baseline,
   preserve the run artifacts and inspect logs before rerunning.

--- a/.claude/skills/p2p-smoke/SKILL.md
+++ b/.claude/skills/p2p-smoke/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: p2p-smoke
-description: Hub-mediated P2P G2 block transfer smoke. Two same-model vLLMs + hub. R1 warms A's G2, hub /control/transfer/{open,pull,close} primitives copy blocks A→B via velo, R2 verifies B's G2 cache hit. Catches regressions in the leader transfer surface and the cross-instance pull plumbing.
+description: Hub-mediated P2P G2 block transfer smoke. Two same-model vLLMs + hub. R1 warms A's G2, hub /control/transfer/{open,pull,close} primitives copy blocks A→B via velo, the indexer verifies B owns pulled blocks, and R2 exercises B through chat streaming. Catches regressions in the leader transfer surface and the cross-instance pull plumbing.
 user-invocable: true
 disable-model-invocation: true
 ---
@@ -30,16 +30,22 @@ A future iteration may collapse these into one hub orchestration endpoint (`/v1/
 
 ## What it asserts
 
-- **R1 fired G1→G2 offload on A.** Greps A's audit log for `event="offload_register_complete"` with `dst=…G2`. This is the new audit event in `kvbm-engine/src/offload/pipeline.rs` (emitted on every batch register into the destination tier).
-- **The hashes from A's audit are findable on A.** `open_session(find_mode=sync)` returns a `committed` list — must be non-empty for the same hashes A just registered.
+- **R1 fired G1→G2 offload on A.** The harness polls the hub indexer for A's
+  published `hash_u128` values after the streaming chat warmup.
+- **The hashes from A's index entries are findable on A.** `open_session(find_mode=sync)` returns a `committed` list — must be non-empty for the same hashes A just registered.
 - **B pulled the blocks.** `pull_from_session` returns a `pulled` list matching what was committed.
-- **B's G2 now serves them.** R2 issues the same prompt to B; vLLM's `Cache Hit Rates` line surfaces a non-zero prefix cache match. The same `offload_register_complete` event should appear in B's audit log with B's hashes matching A's.
+- **B's G2 now owns them.** The hub index lists B as an owner for the pulled
+  block, and R2 issues the same prompt to B through the chat streaming endpoint.
+- **The run leaves a useful trace.** `trace.html` must render from audit events,
+  and `trace-gate.env` must report `trace_useful=true` before the smoke prints
+  PASS.
 
 ## Prerequisites
 
-- A current Dynamo/KVBM environment with `kvbm` importable. In a dev
-  container use `/opt/dynamo/venv`; in a local sandbox use
-  `/dynamo:kvbm:sandbox-venv` + `/dynamo:kvbm:maturin-dev`.
+- A current Dynamo/KVBM runtime with `kvbm` importable. In the runtime image,
+  `/opt/dynamo/venv` is used automatically. For local manual work, set
+  `PYTHON_BIN` or `KVBM_VENV`; the smoke does not assume a worktree-local
+  sandbox exists.
 - `target/debug/kvbm_hub` built: `cargo build --bin kvbm_hub`. The hub
   launcher rebuilds it incrementally unless `KVBM_HUB_SKIP_BUILD=1`.
 - Hardware profile selected via `P2P_HARDWARE_PROFILE`. The default
@@ -64,14 +70,19 @@ Outputs an experiment directory under `$KVBM_EXPERIMENTS_DIR/<ts>-p2p-smoke/` co
 | `instance_a.log` | A's vLLM + kvbm_audit stream |
 | `instance_b.log` | B's vLLM + kvbm_audit stream |
 | `trace.html` | three-lane visualization (A | Hub | B) via `p2p-trace.py` |
+| `trace-gate.env` | machine-readable trace gate and pin/pull counts |
+| `p2p-trace.log` | renderer stdout/stderr |
 
-The script prints a validation report at the end and the trace.html path.
+The script prints a validation report at the end only after the trace gate
+passes.
 
 ## Env vars
 
 | Var | Default | What |
 |---|---|---|
 | `KVBM_REPO` | inferred from script location | Repo root for sibling skill scripts + hub binary |
+| `PYTHON_BIN` | resolved | Explicit Python for vLLM and harness helpers |
+| `KVBM_VENV` | unset | Optional Python environment used before `/opt/dynamo/venv`, and for NIXL lib discovery |
 | `P2P_HARDWARE_PROFILE` | `h100-a100` | Hardware sizing profile: `h100-a100`, `spark-gb10`, or `custom` |
 | `P2P_MODEL` | profile-specific | `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` for `h100-a100`; `Qwen/Qwen3-0.6B` for `spark-gb10` unless overridden |
 | `P2P_GMU` | profile-specific | vLLM `--gpu-memory-utilization` for each instance |
@@ -79,7 +90,9 @@ The script prints a validation report at the end and the trace.html path.
 | `P2P_A_CUDA_VISIBLE_DEVICES` | profile-specific | GPU for instance A |
 | `P2P_B_CUDA_VISIBLE_DEVICES` | profile-specific | GPU for instance B |
 | `P2P_MAX_MODEL_LEN` | profile-specific | vLLM `--max-model-len` |
+| `P2P_ENFORCE_EAGER` | `1` | Functional smoke guard that passes vLLM `--enforce-eager`; set `0` only when explicitly debugging compiled startup, not for transfer-path validation |
 | `P2P_BLOCKS` | `16` | Number of full G2 blocks the prompt should fill (advisory — prompt is hand-tuned) |
+| `P2P_CLEANUP_STALE_PROCESSES` | `1` | Clears stale vLLM, hub, EngineCore, GPU compute PIDs, and velo sockets before the smoke. Set `0` only in shared sessions where broad cleanup could affect another allocation; smoke-owned PIDs are still cleaned on failure. |
 | `KVBM_BLOCK_LAYOUT` | `operational` | Threaded through `kv_connector_extra_config.default.block_layout`; both instances use the same value (P2P feature compat is enforced by the hub) |
 | `KVBM_EXPERIMENT_LABEL` | `p2p-smoke` | Suffix on the experiment directory name |
 
@@ -112,9 +125,10 @@ Profile defaults:
 | File | Purpose |
 |---|---|
 | `p2p-smoke.sh` | Orchestrator. Tears down, brings up hub + 2 vLLMs, drives the 3-call chain, runs R2, prints report. |
-| `launch-instance.sh` | Parameterized single-instance launcher. `P2P_PORT` + `P2P_ROLE` chosen by the orchestrator. |
+| `launch-instance.sh` | Parameterized single-instance launcher. `P2P_PORT` and GPU placement are chosen by the orchestrator. |
 | `SKILL.md` | This file. |
 | `../disagg-trace/p2p-trace.py` | HTML render of the kvbm_audit timeline across the three logs. Lanes are `Instance A | Hub | Instance B`. |
+| `../disagg-bringup/hardware-profiles.sh` | Shared model, GPU, cache, and max-length defaults. |
 
 ## See also
 

--- a/.claude/skills/p2p-smoke/launch-instance.sh
+++ b/.claude/skills/p2p-smoke/launch-instance.sh
@@ -18,13 +18,17 @@
 #   P2P_PORT=8000 bash launch-instance.sh   # FOREGROUND; background from caller
 #
 # Env vars (with defaults):
-#   KVBM_VENV          (default: <repo>/.sandbox)
+#   PYTHON_BIN         (optional explicit Python; otherwise resolved from
+#                       KVBM_VENV, runtime image, or PATH)
+#   KVBM_VENV          (optional Python environment for runtime + NIXL lib search)
 #   P2P_PORT           — vLLM listen port (e.g. 8000, 8002); required
 #   KVBM_HUB_URL       (default: http://127.0.0.1:1337) — discovery base
 #   KVBM_KVBMCTL_BIN   (default: <repo>/target/debug/kvbmctl — built by start-hub.sh)
 #   P2P_HARDWARE_PROFILE (default: h100-a100; also spark-gb10, custom) — sizing
 #   P2P_GMU / P2P_CACHE_GB / P2P_MAX_MODEL_LEN / P2P_MODEL — from the profile
 #   P2P_CUDA_VISIBLE_DEVICES (default: 0)
+#   P2P_ENFORCE_EAGER  (default: 1) — keep the functional smoke off the vLLM
+#                       compile path; set 0 only when debugging compiled startup
 #   KVBM_CONNECTOR_MODULE_PATH (default: kvbm.v2.vllm.connector)
 set -eu
 
@@ -35,7 +39,30 @@ kvbm_apply_p2p_profile
 # Reusable hub helpers (kvbm_hub_render_vllm).
 . "$REPO/.claude/skills/kvbm-hub-bringup/hub-lib.sh"
 
-KVBM_VENV=${KVBM_VENV:-$REPO/.sandbox}
+resolve_python() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    [ -x "$PYTHON_BIN" ] || { echo "PYTHON_BIN is set but not executable: $PYTHON_BIN" >&2; return 2; }
+  elif [ -n "${KVBM_VENV:-}" ] && [ -x "$KVBM_VENV/bin/python3" ]; then
+    PYTHON_BIN="$KVBM_VENV/bin/python3"
+  elif [ -n "${KVBM_VENV:-}" ] && [ -x "$KVBM_VENV/bin/python" ]; then
+    PYTHON_BIN="$KVBM_VENV/bin/python"
+  elif [ -x /opt/dynamo/venv/bin/python3 ]; then
+    KVBM_VENV=/opt/dynamo/venv
+    PYTHON_BIN=/opt/dynamo/venv/bin/python3
+  elif [ -x /opt/dynamo/venv/bin/python ]; then
+    KVBM_VENV=/opt/dynamo/venv
+    PYTHON_BIN=/opt/dynamo/venv/bin/python
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python3)
+  else
+    echo "No usable Python found; set PYTHON_BIN or KVBM_VENV" >&2
+    return 2
+  fi
+  export PYTHON_BIN
+  [ -z "${KVBM_VENV:-}" ] || export KVBM_VENV
+}
+resolve_python
+
 KVBM_CONNECTOR_MODULE_PATH=${KVBM_CONNECTOR_MODULE_PATH:-kvbm.v2.vllm.connector}
 KVBMCTL=${KVBM_KVBMCTL_BIN:-$REPO/target/debug/kvbmctl}
 PORT=${P2P_PORT:?"P2P_PORT required"}
@@ -43,6 +70,12 @@ HUB_URL=${KVBM_HUB_URL:-http://127.0.0.1:1337}
 GMU=${P2P_GMU:-0.70}
 CACHE_GB=${P2P_CACHE_GB:-2}
 MAX_MODEL_LEN=${P2P_MAX_MODEL_LEN:-2048}
+P2P_ENFORCE_EAGER=${P2P_ENFORCE_EAGER:-1}
+case "$P2P_ENFORCE_EAGER" in
+  1|true|yes|on) ENFORCE_EAGER_ARGS=(--enforce-eager) ;;
+  0|false|no|off) ENFORCE_EAGER_ARGS=() ;;
+  *) echo "P2P_ENFORCE_EAGER must be boolean, got $P2P_ENFORCE_EAGER" >&2; exit 2 ;;
+esac
 
 # Render the vLLM connector args from the live hub. The hub is the source of
 # truth for block_size / max_model_len / block_layout / leader.hub; free fields
@@ -65,9 +98,51 @@ KV_RENDERED=$(kvbm_hub_render_vllm "$KVBMCTL" "$HUB_URL" p2p,indexer \
     --kvbm 'worker.nixl.backends.POSIX={}') \
   || { echo "kvbmctl render failed (is the hub up at $HUB_URL with --features p2p?)" >&2; exit 1; }
 
-# kvbmctl shell-quotes the (space-free) JSON; eval re-parses the quotes so the
-# blob stays a single argv element. Output is trusted (we built the renderer).
-eval "KV_ARGS=( $KV_RENDERED )"
+# kvbmctl shell-quotes the JSON so the rendered fragment is pasteable. Parse it
+# with shlex instead of eval, then require the exact vLLM flags this smoke needs.
+KV_ARGS=()
+while IFS= read -r -d '' arg; do
+    KV_ARGS+=("$arg")
+done < <("$PYTHON_BIN" - "$KV_RENDERED" <<'PY'
+import json
+import shlex
+import sys
+
+rendered = sys.argv[1]
+try:
+    args = shlex.split(rendered)
+except ValueError as exc:
+    raise SystemExit(f"invalid kvbmctl render output: {exc}")
+
+expected_flags = ["--block-size", "--max-model-len", "--kv-transfer-config"]
+if len(args) != len(expected_flags) * 2:
+    raise SystemExit(f"unexpected kvbmctl render arg count: {len(args)}")
+
+for idx, flag in enumerate(expected_flags):
+    actual = args[idx * 2]
+    if actual != flag:
+        raise SystemExit(
+            f"unexpected kvbmctl render flag at position {idx * 2}: {actual}"
+        )
+
+for idx in (1, 3):
+    try:
+        value = int(args[idx])
+    except ValueError as exc:
+        raise SystemExit(f"{args[idx - 1]} must be an integer") from exc
+    if value <= 0:
+        raise SystemExit(f"{args[idx - 1]} must be positive")
+
+try:
+    json.loads(args[5])
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"--kv-transfer-config must be valid JSON: {exc}") from exc
+
+for arg in args:
+    sys.stdout.buffer.write(arg.encode("utf-8"))
+    sys.stdout.buffer.write(b"\0")
+PY
+)
 
 export CUDA_VISIBLE_DEVICES="${P2P_CUDA_VISIBLE_DEVICES:-0}"
 export DYN_KVBM_CPU_CACHE_GB="$CACHE_GB"
@@ -78,7 +153,7 @@ export KVBM_SKIP_VLLM_VERSION_CHECK=${KVBM_SKIP_VLLM_VERSION_CHECK:-1}
 # libs on LD_LIBRARY_PATH so `import kvbm` resolves `libnixl.so` (inherited by
 # vLLM's EngineCore subprocess, unlike figment KVBM_* vars).
 NIXL_LIBS=${KVBM_NIXL_LIBS:-}
-if [ -z "$NIXL_LIBS" ]; then
+if [ -z "$NIXL_LIBS" ] && [ -n "${KVBM_VENV:-}" ] && [ -d "$KVBM_VENV" ]; then
     for cand in "$KVBM_VENV"/lib/python*/site-packages/.nixl_cu12.mesonpy.libs \
                 "$KVBM_VENV"/lib/python*/site-packages/.nixl_cu13.mesonpy.libs; do
         [ -d "$cand" ] && NIXL_LIBS="$cand" && break
@@ -91,7 +166,8 @@ fi
 
 # --block-size / --max-model-len / --kv-transfer-config come from kvbmctl
 # (${KV_ARGS[@]}); do not also pass --max-model-len here — vLLM rejects dupes.
-exec "$KVBM_VENV/bin/python3" -m vllm.entrypoints.openai.api_server \
+echo "[p2p-smoke] P2P_ENFORCE_EAGER=$P2P_ENFORCE_EAGER" >&2
+exec "$PYTHON_BIN" -m vllm.entrypoints.openai.api_server \
   --model "$P2P_MODEL" \
   --served-model-name "$P2P_MODEL" \
   --max-num-seqs 8 \
@@ -99,4 +175,5 @@ exec "$KVBM_VENV/bin/python3" -m vllm.entrypoints.openai.api_server \
   --enable-chunked-prefill \
   --no-enable-prefix-caching \
   --port "$PORT" \
+  "${ENFORCE_EAGER_ARGS[@]}" \
   "${KV_ARGS[@]}"

--- a/.claude/skills/p2p-smoke/p2p-smoke.sh
+++ b/.claude/skills/p2p-smoke/p2p-smoke.sh
@@ -11,30 +11,67 @@
 #            block-copy peer.
 #
 # Flow:
-#   R1 → instance_a            (warms G2 on A; audit emits the ISL block hashes)
-#   scrape audit log on A      (extract sequence_hashes_hex)
+#   R1 → instance_a            (warms G2 on A; indexer publishes G2 hashes)
+#   query hub index            (discover A's offloaded hash_u128 values)
 #   kvbmctl p2p pin   on A     (open_session over those hashes → session+endpoint)
 #   kvbmctl p2p pull  A→B      (B registers A as a peer, then pulls into B's G2)
 #   kvbmctl p2p unpin on A     (close_session)
-#   R2 → instance_b            (same prompt; expect G2 cache hit in B's audit)
+#   verify hub index           (B is now an owner for the pulled blocks)
+#   R2 → instance_b            (same prompt, chat streaming)
 #
 # Usage:  bash p2p-smoke.sh [logs_dir]
 # Env:
 #   KVBM_REPO            (default: worktree root inferred from script location)
 #   P2P_HARDWARE_PROFILE (default: h100-a100; use spark-gb10 on a single GB10)
+#   KVBM_VENV            (optional Python environment; no default local sandbox)
+#   PYTHON_BIN           (optional explicit Python; otherwise resolved from
+#                         KVBM_VENV, runtime image, or PATH)
+#   P2P_CLEANUP_STALE_PROCESSES
+#                         (default: 1; set 0 in shared sessions to skip broad
+#                         stale-process and socket cleanup)
 set -eu
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 DYNAMO=${KVBM_REPO:-$(cd "$SCRIPT_DIR/../../.." && pwd)}
 export KVBM_REPO=$DYNAMO
-export KVBM_VENV=${KVBM_VENV:-$DYNAMO/.sandbox}
 SKILL_BRINGUP=$DYNAMO/.claude/skills/disagg-bringup
 HUB_BRINGUP=$DYNAMO/.claude/skills/kvbm-hub-bringup
 SKILL_TRACE=$DYNAMO/.claude/skills/disagg-trace
 KVBMCTL=${KVBM_KVBMCTL_BIN:-$DYNAMO/target/debug/kvbmctl}
 LABEL=${KVBM_EXPERIMENT_LABEL:-p2p-smoke}
+P2P_CLEANUP_STALE_PROCESSES=${P2P_CLEANUP_STALE_PROCESSES:-1}
 . "$SKILL_BRINGUP/hardware-profiles.sh"
 kvbm_apply_p2p_profile
+
+case "$P2P_CLEANUP_STALE_PROCESSES" in
+  1|true|yes|on) P2P_CLEANUP_STALE_PROCESSES=1 ;;
+  0|false|no|off) P2P_CLEANUP_STALE_PROCESSES=0 ;;
+  *) echo "P2P_CLEANUP_STALE_PROCESSES must be boolean, got $P2P_CLEANUP_STALE_PROCESSES" >&2; exit 2 ;;
+esac
+
+resolve_python() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    [ -x "$PYTHON_BIN" ] || { echo "PYTHON_BIN is set but not executable: $PYTHON_BIN" >&2; return 2; }
+  elif [ -n "${KVBM_VENV:-}" ] && [ -x "$KVBM_VENV/bin/python3" ]; then
+    PYTHON_BIN="$KVBM_VENV/bin/python3"
+  elif [ -n "${KVBM_VENV:-}" ] && [ -x "$KVBM_VENV/bin/python" ]; then
+    PYTHON_BIN="$KVBM_VENV/bin/python"
+  elif [ -x /opt/dynamo/venv/bin/python3 ]; then
+    KVBM_VENV=/opt/dynamo/venv
+    PYTHON_BIN=/opt/dynamo/venv/bin/python3
+  elif [ -x /opt/dynamo/venv/bin/python ]; then
+    KVBM_VENV=/opt/dynamo/venv
+    PYTHON_BIN=/opt/dynamo/venv/bin/python
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python3)
+  else
+    echo "No usable Python found; set PYTHON_BIN or KVBM_VENV" >&2
+    return 2
+  fi
+  export PYTHON_BIN
+  [ -z "${KVBM_VENV:-}" ] || export KVBM_VENV
+}
+resolve_python
 
 HUB_DISC=${KVBM_HUB_DISCOVERY_PORT:-1337}
 HUB_CTRL=${KVBM_HUB_CONTROL_PORT:-8337}
@@ -45,25 +82,86 @@ export KVBMCTL_HUB="$HUB1337"
 ROOT=${1:-$(bash "$SKILL_BRINGUP/new-experiment.sh" "$LABEL")}
 echo "EXP=$ROOT"
 echo "$ROOT" > /tmp/p2p-trace-current-exp
+TRACE_GATE="$ROOT/trace-gate.env"
 
 strip_ansi() { sed 's/\x1b\[[0-9;]*m//g'; }
+
+cleanup_started_processes() {
+  set +e
+  local pid
+  for pid in "${INSTANCE_A_PID:-}" "${INSTANCE_B_PID:-}" "${HUB_PID:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  done
+  sleep 1
+  for pid in "${INSTANCE_A_PID:-}" "${INSTANCE_B_PID:-}" "${HUB_PID:-}"; do
+    [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true
+  done
+  set -e
+}
+
+cleanup_stale_processes() {
+  if [ "$P2P_CLEANUP_STALE_PROCESSES" != "1" ]; then
+    echo "[p2p-smoke] skip broad stale-process cleanup; smoke-owned PIDs are still cleaned on failure"
+    return 0
+  fi
+
+  pkill -f "vllm.entrypoints.openai" 2>/dev/null || true
+  pkill -9 -f kvbm_hub 2>/dev/null || true
+  pkill -9 -f "EngineCore" 2>/dev/null || true
+  sleep 3
+  PIDS=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | tr -d ' ' | grep -v '^$' || true)
+  [ -n "$PIDS" ] && echo "$PIDS" | xargs -r kill -9 2>/dev/null || true
+  rm -f /tmp/velo-kvbm-*.sock 2>/dev/null || true
+  sleep 1
+}
+
 fail() {
   echo "FAIL: $1" >&2
   [ -n "${2:-}" ] && [ -f "$2" ] && { echo "--- tail $2 ---" >&2; tail -n 30 "$2" | strip_ansi >&2; }
-  pkill -f "vllm.entrypoints.openai" 2>/dev/null || true
-  pkill -9 -f kvbm_hub 2>/dev/null || true
+  cleanup_started_processes
+  cleanup_stale_processes
   exit 1
 }
 
+write_trace_gate() {
+  local useful=$1 reason=$2 rendered=${3:-false} events=${4:-0} bytes=${5:-0}
+  {
+    echo "trace_useful=$useful"
+    echo "trace_rendered=$rendered"
+    echo "reason=$reason"
+    echo "trace_audit_events=$events"
+    echo "trace_html_bytes=$bytes"
+    echo "p2p_pull_committed=${COMMITTED:-}"
+    echo "p2p_pull_pulled=${PULLED:-}"
+    echo "p2p_hash_count=${HASH_COUNT:-}"
+  } > "$TRACE_GATE"
+}
+
+render_trace() {
+  local trace_py="$SKILL_TRACE/p2p-trace.py"
+  local trace_log="$ROOT/p2p-trace.log"
+  local trace_file="$ROOT/trace.html"
+  local trace_output events bytes
+  [ -f "$trace_py" ] || { write_trace_gate false trace_renderer_missing false 0 0; fail "p2p trace renderer missing: $trace_py"; }
+  if ! trace_output=$("$PYTHON_BIN" "$trace_py" "$ROOT" 2>"$trace_log"); then
+    write_trace_gate false trace_render_failed false 0 0
+    fail "p2p trace render failed" "$trace_log"
+  fi
+  printf '%s\n' "$trace_output" >> "$trace_log"
+  [ -s "$trace_file" ] || { write_trace_gate false trace_html_missing_or_empty false 0 0; fail "p2p trace.html missing or empty" "$trace_log"; }
+  events=$(printf '%s\n' "$trace_output" | sed -n 's/^\([0-9][0-9]*\) audit events.*/\1/p' | tail -n 1)
+  events=${events:-0}
+  bytes=$(wc -c < "$trace_file" | tr -d ' ')
+  if [ "$events" -le 0 ]; then
+    write_trace_gate false p2p_trace_has_no_audit_events true "$events" "$bytes"
+    fail "p2p trace rendered but contained no audit events" "$trace_log"
+  fi
+  write_trace_gate true p2p_pin_pull_index_owner_validation_and_trace_rendered true "$events" "$bytes"
+  echo "TRACE_DONE trace=$trace_file events=$events bytes=$bytes gate=$TRACE_GATE"
+}
+
 # --- 0. teardown stale ----------------------------------------------------
-pkill -f "vllm.entrypoints.openai" 2>/dev/null || true
-pkill -9 -f kvbm_hub 2>/dev/null || true
-pkill -9 -f "EngineCore" 2>/dev/null || true
-sleep 3
-PIDS=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | tr -d ' ' | grep -v '^$' || true)
-[ -n "$PIDS" ] && echo "$PIDS" | xargs -r kill -9 2>/dev/null || true
-rm -f /tmp/velo-kvbm-*.sock 2>/dev/null || true
-sleep 1
+cleanup_stale_processes
 
 # --- 1. hub (--features p2p,indexer) --------------------------------------
 # p2p is under test; indexer is the harness hash-discovery mechanism (the
@@ -105,7 +203,7 @@ wait_for_models() {
 # the hub self-registers its own id here too, so discovery must exclude it.
 list_instances() {
   curl -sS "$HUB8337/v1/instances" \
-    | python3 -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(p["instance_id"] for p in d["instances"]))'
+    | "$PYTHON_BIN" -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(p["instance_id"] for p in d["instances"]))'
 }
 
 # The hub's own self-registered id(s), captured before any connector registers.
@@ -128,6 +226,7 @@ discover_new() {
 echo "launching instance A (port 8000)..."
 P2P_PORT=8000 P2P_CUDA_VISIBLE_DEVICES="$P2P_A_CUDA_VISIBLE_DEVICES" \
   bash "$SCRIPT_DIR/launch-instance.sh" > "$ROOT/instance_a.log" 2>&1 &
+INSTANCE_A_PID=$!
 disown
 wait_for_models 8000 "$P2P_STARTUP_TIMEOUT" || fail "instance A not ready in ${P2P_STARTUP_TIMEOUT}s" "$ROOT/instance_a.log"
 INSTANCE_A=$(discover_new "") || fail "instance A did not register with the hub" "$ROOT/instance_a.log"
@@ -136,20 +235,21 @@ echo "instance A up — INSTANCE_A=$INSTANCE_A"
 echo "launching instance B (port 8002)..."
 P2P_PORT=8002 P2P_CUDA_VISIBLE_DEVICES="$P2P_B_CUDA_VISIBLE_DEVICES" \
   bash "$SCRIPT_DIR/launch-instance.sh" > "$ROOT/instance_b.log" 2>&1 &
+INSTANCE_B_PID=$!
 disown
 wait_for_models 8002 "$P2P_STARTUP_TIMEOUT" || fail "instance B not ready in ${P2P_STARTUP_TIMEOUT}s" "$ROOT/instance_b.log"
 INSTANCE_B=$(discover_new "$INSTANCE_A") || fail "instance B did not register with the hub" "$ROOT/instance_b.log"
 echo "BOTH UP — INSTANCE_B=$INSTANCE_B"
 
 # --- 3. R1 → A (warm G2) --------------------------------------------------
-P1="$(python3 -c '
+P1="$("$PYTHON_BIN" -c '
 words = ["The","quick","brown","fox","jumps","over","the","lazy","dog","while","the","sun","sets","behind","the","ancient","mountains","casting","long","shadows","across","the","meadow","where","wildflowers","bloom","in","vibrant","colors","of","red","orange","yellow","and","purple","as","the","evening","breeze","carries","the","scent","of","pine","and","wet","earth","through","the","valley","below","where","a","stream","winds","its","way","between","moss","covered","stones"] * 4
 print(" ".join(words))
 ')"
 
 run_chat_stream() {
   local port="$1" label="$2" prompt="$3"
-  python3 - "$port" "$P2P_MODEL" "$ROOT/${label}-chat-stream.jsonl" "$prompt" <<'PY'
+  "$PYTHON_BIN" - "$port" "$P2P_MODEL" "$ROOT/${label}-chat-stream.jsonl" "$prompt" <<'PY'
 import json, sys, time, urllib.request
 port, model, stream_path, prompt = sys.argv[1:5]
 payload = {"model": model, "messages": [{"role": "user", "content": prompt}],
@@ -180,7 +280,7 @@ sleep 3  # let offload finish + audit flush
 # (ZMQ ingest is async) or time out.
 INDEXER="$HUB1337/v1/features/indexer"
 collect_hashes() {
-  python3 - "$INDEXER" "${P2P_MAX_MODEL_LEN:-1024}" <<'PY'
+  "$PYTHON_BIN" - "$INDEXER" "${P2P_MAX_MODEL_LEN:-1024}" <<'PY'
 import json, sys, urllib.request
 base, max_len = sys.argv[1], int(sys.argv[2])
 hashes = []
@@ -220,11 +320,11 @@ echo "=== kvbmctl p2p pin on A ==="
 PIN_RESP=$("$KVBMCTL" p2p pin --instance-id "$INSTANCE_A" --hashes "$DECIMAL_CSV") \
   || fail "kvbmctl p2p pin failed"
 echo "pin response: $(echo "$PIN_RESP" | head -c 400)"
-SESSION_ID=$(echo "$PIN_RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')
-COMMITTED=$(echo "$PIN_RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["committed_count"])')
-ENDPOINT=$(echo "$PIN_RESP" | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["endpoint"]))')
+SESSION_ID=$(echo "$PIN_RESP" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["session_id"])')
+COMMITTED=$(echo "$PIN_RESP" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["committed_count"])')
+ENDPOINT=$(echo "$PIN_RESP" | "$PYTHON_BIN" -c 'import json,sys; print(json.dumps(json.load(sys.stdin)["endpoint"]))')
 echo "session_id=$SESSION_ID committed=$COMMITTED"
-[ "$COMMITTED" -ge 1 ] || fail "pin committed 0 blocks (A's G2 lacks the hashes from its own audit?)"
+[ "$COMMITTED" -ge 1 ] || fail "pin committed 0 blocks (A's G2 lacks the published index hashes?)"
 
 # --- 6. pull A→B (kvbmctl p2p pull auto-registers the peer, then pulls) ----
 echo "=== kvbmctl p2p pull A→B ==="
@@ -232,7 +332,7 @@ PULL_RESP=$("$KVBMCTL" p2p pull --from "$INSTANCE_A" --to "$INSTANCE_B" \
   --session-id "$SESSION_ID" --endpoint "$ENDPOINT") \
   || { "$KVBMCTL" p2p unpin --instance-id "$INSTANCE_A" --session-id "$SESSION_ID" >/dev/null 2>&1 || true; fail "kvbmctl p2p pull failed"; }
 echo "pull response: $(echo "$PULL_RESP" | head -c 400)"
-PULLED=$(echo "$PULL_RESP" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("pulled", [])))')
+PULLED=$(echo "$PULL_RESP" | "$PYTHON_BIN" -c 'import json,sys; print(len(json.load(sys.stdin).get("pulled", [])))')
 echo "pulled $PULLED block(s) into B's G2"
 
 # --- 7. unpin on A (close_session) ----------------------------------------
@@ -249,11 +349,11 @@ echo "=== kvbmctl p2p unpin on A ==="
 # co-owner. This proves the transfer populated B's G2 with real blocks WITHOUT
 # relying on the Rust cache-hit log (which the EngineCore subprocess does not
 # surface in this environment).
-B_U128=$(python3 -c 'import uuid,sys; print(uuid.UUID(sys.argv[1]).int)' "$INSTANCE_B")
+B_U128=$("$PYTHON_BIN" -c 'import uuid,sys; print(uuid.UUID(sys.argv[1]).int)' "$INSTANCE_B")
 FIRST_HASH=$(echo "$DECIMAL_CSV" | cut -d, -f1)
 echo "=== verify B ($B_U128) owns pulled block $FIRST_HASH in the index ==="
 owners_of() {
-  python3 - "$INDEXER" "$1" <<'PY'
+  "$PYTHON_BIN" - "$INDEXER" "$1" <<'PY'
 import json, sys, urllib.request
 base, h = sys.argv[1], sys.argv[2]
 body = json.dumps({"hashes": [list(int(h).to_bytes(16, "big"))]}).encode()
@@ -283,5 +383,7 @@ echo "  -> B owns the pulled block in the index (transfer populated B's G2)"
 echo "=== R2: chat stream to instance B (8002) ==="
 run_chat_stream 8002 r2 "$P1" | head -c 200; echo
 
+render_trace
+
 echo
-echo "p2p-smoke PASS: pin/pull/unpin via kvbmctl moved $PULLED block(s) (of $COMMITTED committed, $HASH_COUNT requested) A→B; index confirms B now holds the pulled blocks"
+echo "p2p-smoke PASS: pin/pull/unpin via kvbmctl moved $PULLED block(s) (of $COMMITTED committed, $HASH_COUNT requested) A→B; index confirms B now holds the pulled blocks; trace gate at $TRACE_GATE"

--- a/examples/backends/vllm/launch/kvbm_xdc/analyze-aiperf-stage-attribution.py
+++ b/examples/backends/vllm/launch/kvbm_xdc/analyze-aiperf-stage-attribution.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Join AIPerf per-request records to KVBM hub role logs.
+
+This is intentionally local to the KVBM cross-datacenter harness. It depends on
+the Dynamo frontend request log shape and the KVBM `kvbm_audit` event names used
+by this example, so it is not a generic AIPerf parser.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean, median
+from typing import Iterable
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+RAW_TS_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+"
+    r"\w+\s+(?P<rest>.*)$"
+)
+FIELD_RE = re.compile(r"(?P<key>\w+)=(?:\"(?P<qv>(?:[^\"\\]|\\.)*)\"|(?P<bv>\S+))")
+X_REQUEST_RE = re.compile(r"\bx_request_id=\"?(?P<value>[^\"\s]+)\"?")
+REQUEST_RECEIVED_RE = re.compile(r"\brequest received request_id=(?P<value>[0-9a-f-]{36})\b")
+REQUEST_COMPLETED_RE = re.compile(
+    r"\brequest completed request_id=(?P<value>[0-9a-f-]{36})\b"
+)
+UUID_PREFIX_RE = re.compile(
+    r"^(?P<value>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12})(?:-|$)"
+)
+URL_RE = re.compile(r"\b(?:https?|nats)://[^\s\"'<>]+")
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b")
+IPV6_RE = re.compile(r"\b(?:[0-9a-fA-F]{1,4}:){2,}[0-9a-fA-F:]{1,}(?:%\w+)?(?::\d+)?\b")
+ABS_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])"
+    r"/(?:Users|home|tmp|private|workspace|mnt|scratch|var|opt)"
+    r"/[^\s\"'<>:,;)]*"
+)
+INTERNAL_HOST_RE = re.compile(
+    r"\b(?=[A-Za-z0-9.-]*[.-])(?=[A-Za-z0-9.-]*\d)"
+    r"[A-Za-z0-9.-]*(?:prod|cluster|login|compute|gpu|dgx|h100|a100)"
+    r"[A-Za-z0-9.-]*(?::\d+)?\b",
+    re.IGNORECASE,
+)
+
+STAGE_EVENTS = {
+    "commit_usaa1_state_built": "commit",
+    "worker_session_pull_call": "pull_call",
+    "worker_session_pull_returned": "pull_return",
+    "worker_g2_to_g1_done": "g2_to_g1",
+    "mark_onboarding_complete": "mark_complete",
+}
+FAILURE_PATTERNS = {
+    "kv_load_failure": re.compile(
+        r"KV load failure|Onboarding failed|Failed to start onboarding|kv_load_failure"
+    ),
+    "nixl_create_xfer_req_failure": re.compile(
+        r"createXferReq: no potential backend found|nixl_create_xfer_req_failures"
+    ),
+}
+ZERO_SUMMARY_PATTERNS = {
+    "kv_load_failure": re.compile(r"KV load failure events:\s*0|kv_load_failure_events=0"),
+    "nixl_create_xfer_req_failure": re.compile(
+        r"createXferReq failures:\s*0|nixl_create_xfer_req_failures=0"
+    ),
+}
+
+
+@dataclass
+class AiperfRecord:
+    line_no: int
+    session_num: str
+    x_request_id: str
+    request_start_ns: int
+    ttft_ms: float | None
+
+    @property
+    def start_ms(self) -> float:
+        return self.request_start_ns / 1_000_000
+
+    @property
+    def first_token_ms(self) -> float | None:
+        if self.ttft_ms is None:
+            return None
+        return self.start_ms + self.ttft_ms
+
+
+@dataclass
+class FrontendRecord:
+    request_id: str | None = None
+    recv_ms: float | None = None
+    select_ms: float | None = None
+    completed_ms: float | None = None
+    ttft_ms: float | None = None
+
+
+@dataclass
+class BackendRecord:
+    recv_ms: float | None = None
+    events: dict[str, float] = field(default_factory=dict)
+    remote_slots_len: int | None = None
+    expected_remote_hashes_len: int | None = None
+    worker_pull_filled: int | None = None
+    worker_g2_to_g1_blocks: int | None = None
+
+
+@dataclass
+class ParsedLogs:
+    frontend_by_x_request_id: dict[str, FrontendRecord] = field(default_factory=dict)
+    backend_by_request_id: dict[str, BackendRecord] = field(default_factory=dict)
+    failure_counts: dict[str, int] = field(
+        default_factory=lambda: {key: 0 for key in FAILURE_PATTERNS}
+    )
+
+
+CSV_COLUMNS = [
+    "order",
+    "session_num",
+    "x_request_id",
+    "backend_request_id",
+    "cohort",
+    "aiperf_start_utc",
+    "aiperf_first_token_utc",
+    "aiperf_ttft_ms",
+    "frontend_ttft_ms",
+    "remote_slots_len",
+    "expected_remote_hashes_len",
+    "worker_pull_filled",
+    "worker_g2_to_g1_blocks",
+    "frontend_recv_to_select_ms",
+    "frontend_recv_to_backend_recv_ms",
+    "backend_recv_to_commit_ms",
+    "commit_to_pull_call_ms",
+    "pull_call_to_pull_return_ms",
+    "pull_return_to_g2_to_g1_ms",
+    "g2_to_g1_to_mark_complete_ms",
+    "mark_complete_to_first_token_ms",
+    "frontend_recv_to_first_token_ms",
+    "commit_to_first_token_ms",
+]
+
+
+def scrub_text(value: str) -> str:
+    value = URL_RE.sub("<url>", value)
+    value = IPV4_RE.sub("<addr>", value)
+    value = IPV6_RE.sub("<addr>", value)
+    value = ABS_PATH_RE.sub("<path>", value)
+    value = INTERNAL_HOST_RE.sub("<host>", value)
+    return value
+
+
+def strip_ansi(line: str) -> str:
+    return ANSI_RE.sub("", line)
+
+
+def parse_fields(rest: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for match in FIELD_RE.finditer(rest):
+        value = match.group("qv") if match.group("qv") is not None else match.group("bv")
+        if value is None:
+            continue
+        if match.group("qv") is not None:
+            value = value.replace('\\"', '"').replace("\\\\", "\\")
+        else:
+            value = value.rstrip(",")
+        fields[match.group("key")] = value
+    return fields
+
+
+def parse_ts_ms(line: str) -> float | None:
+    match = RAW_TS_RE.match(line)
+    if not match:
+        return None
+    try:
+        ts = datetime.fromisoformat(match.group("ts").replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return ts.timestamp() * 1000
+
+
+def ns_to_utc(ns: int | None) -> str:
+    if ns is None:
+        return ""
+    dt = datetime.fromtimestamp(ns / 1_000_000_000, timezone.utc)
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def ms_to_utc(ms: float | None) -> str:
+    if ms is None:
+        return ""
+    dt = datetime.fromtimestamp(ms / 1000, timezone.utc)
+    return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def parse_int(value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def parse_float(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def format_float(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.3f}"
+
+
+def diff_ms(start_ms: float | None, end_ms: float | None) -> float | None:
+    if start_ms is None or end_ms is None:
+        return None
+    return end_ms - start_ms
+
+
+def request_prefix(request_id: str | None) -> str | None:
+    if not request_id:
+        return None
+    match = UUID_PREFIX_RE.match(request_id)
+    if not match:
+        return None
+    return match.group("value")
+
+
+def first_request_id(pattern: re.Pattern[str], line: str) -> str | None:
+    match = pattern.search(line)
+    if not match:
+        return None
+    return match.group("value")
+
+
+def line_x_request_id(line: str) -> str | None:
+    match = X_REQUEST_RE.search(line)
+    if not match:
+        return None
+    return match.group("value")
+
+
+def load_aiperf_records(profile_jsonl: Path) -> list[AiperfRecord]:
+    records: list[AiperfRecord] = []
+    with profile_jsonl.open(errors="replace") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{profile_jsonl}:{line_no}: invalid JSON: {exc}") from exc
+            metadata = data.get("metadata", {})
+            metrics = data.get("metrics", {})
+            x_request_id = metadata.get("x_request_id")
+            request_start_ns = parse_int(str(metadata.get("request_start_ns", "")))
+            ttft_metric = metrics.get("time_to_first_token", {})
+            ttft_ms = None
+            if isinstance(ttft_metric, dict):
+                ttft_ms = parse_float(str(ttft_metric.get("value", "")))
+            if not x_request_id or request_start_ns is None:
+                continue
+            records.append(
+                AiperfRecord(
+                    line_no=line_no,
+                    session_num=str(metadata.get("session_num", "")),
+                    x_request_id=str(x_request_id),
+                    request_start_ns=request_start_ns,
+                    ttft_ms=ttft_ms,
+                )
+            )
+    return sorted(records, key=lambda record: (record.request_start_ns, record.line_no))
+
+
+def iter_log_files(log_dir: Path) -> Iterable[Path]:
+    yield from sorted(path for path in log_dir.rglob("*.log") if path.is_file())
+
+
+def parse_role_logs(log_dir: Path) -> ParsedLogs:
+    parsed = ParsedLogs()
+    for log_file in iter_log_files(log_dir):
+        with log_file.open(errors="replace") as handle:
+            for raw_line in handle:
+                line = strip_ansi(raw_line.rstrip("\n"))
+                ts_ms = parse_ts_ms(line)
+                if ts_ms is None:
+                    continue
+                count_failures(parsed, line)
+                parse_frontend_line(parsed, line, ts_ms)
+                parse_backend_received_line(parsed, line, ts_ms)
+                parse_kvbm_audit_line(parsed, line, ts_ms)
+    return parsed
+
+
+def count_failures(parsed: ParsedLogs, line: str) -> None:
+    for name, pattern in FAILURE_PATTERNS.items():
+        if not pattern.search(line):
+            continue
+        if ZERO_SUMMARY_PATTERNS[name].search(line):
+            continue
+        parsed.failure_counts[name] += 1
+
+
+def parse_frontend_line(parsed: ParsedLogs, line: str, ts_ms: float) -> None:
+    x_request_id = line_x_request_id(line)
+    if not x_request_id:
+        return
+    record = parsed.frontend_by_x_request_id.setdefault(x_request_id, FrontendRecord())
+
+    request_id = first_request_id(REQUEST_RECEIVED_RE, line)
+    if request_id:
+        record.request_id = request_id
+        if record.recv_ms is None:
+            record.recv_ms = ts_ms
+
+    completed_id = first_request_id(REQUEST_COMPLETED_RE, line)
+    if completed_id:
+        record.request_id = record.request_id or completed_id
+        record.completed_ms = ts_ms
+        fields = parse_fields(line)
+        ttft_ms = parse_float(fields.get("ttft_ms"))
+        if ttft_ms is not None:
+            record.ttft_ms = ttft_ms
+
+    if "Selected worker:" in line and record.select_ms is None:
+        record.select_ms = ts_ms
+
+
+def parse_backend_received_line(parsed: ParsedLogs, line: str, ts_ms: float) -> None:
+    if "request received" not in line:
+        return
+    if "component=\"backend\"" not in line and "component=backend" not in line:
+        return
+    request_id = first_request_id(REQUEST_RECEIVED_RE, line)
+    if not request_id:
+        return
+    backend = parsed.backend_by_request_id.setdefault(request_id, BackendRecord())
+    if backend.recv_ms is None:
+        backend.recv_ms = ts_ms
+
+
+def parse_kvbm_audit_line(parsed: ParsedLogs, line: str, ts_ms: float) -> None:
+    if "kvbm_audit:" not in line:
+        return
+    rest = line.split("kvbm_audit:", 1)[1]
+    fields = parse_fields(rest)
+    event = fields.get("event")
+    key = STAGE_EVENTS.get(event or "")
+    request_id = fields.get("request_id")
+    base_request_id = request_prefix(request_id)
+    if not key or not base_request_id:
+        return
+
+    backend = parsed.backend_by_request_id.setdefault(base_request_id, BackendRecord())
+    backend.events.setdefault(key, ts_ms)
+    if event == "commit_usaa1_state_built":
+        backend.remote_slots_len = parse_int(fields.get("remote_slots_len"))
+        backend.expected_remote_hashes_len = parse_int(
+            fields.get("expected_remote_hashes_len")
+        )
+    elif event == "worker_session_pull_returned":
+        backend.worker_pull_filled = parse_int(fields.get("num_filled"))
+    elif event == "worker_g2_to_g1_done":
+        backend.worker_g2_to_g1_blocks = parse_int(fields.get("num_blocks"))
+
+
+def classify_cohort(remote_slots_len: int | None) -> str:
+    if remote_slots_len is None:
+        return "missing_remote_slots"
+    if remote_slots_len > 0:
+        return "remote_slots_nonzero"
+    return "remote_slots_empty"
+
+
+def build_rows(aiperf_records: list[AiperfRecord], logs: ParsedLogs) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for order, record in enumerate(aiperf_records, start=1):
+        frontend = logs.frontend_by_x_request_id.get(record.x_request_id, FrontendRecord())
+        backend_request_id = frontend.request_id or ""
+        backend = logs.backend_by_request_id.get(backend_request_id, BackendRecord())
+        first_token_ms = record.first_token_ms
+        commit_ms = backend.events.get("commit")
+        pull_call_ms = backend.events.get("pull_call")
+        pull_return_ms = backend.events.get("pull_return")
+        g2_to_g1_ms = backend.events.get("g2_to_g1")
+        mark_complete_ms = backend.events.get("mark_complete")
+
+        rows.append(
+            {
+                "order": str(order),
+                "session_num": record.session_num,
+                "x_request_id": record.x_request_id,
+                "backend_request_id": backend_request_id,
+                "cohort": classify_cohort(backend.remote_slots_len),
+                "aiperf_start_utc": ns_to_utc(record.request_start_ns),
+                "aiperf_first_token_utc": ms_to_utc(first_token_ms),
+                "aiperf_ttft_ms": format_float(record.ttft_ms),
+                "frontend_ttft_ms": format_float(frontend.ttft_ms),
+                "remote_slots_len": format_int(backend.remote_slots_len),
+                "expected_remote_hashes_len": format_int(
+                    backend.expected_remote_hashes_len
+                ),
+                "worker_pull_filled": format_int(backend.worker_pull_filled),
+                "worker_g2_to_g1_blocks": format_int(backend.worker_g2_to_g1_blocks),
+                "frontend_recv_to_select_ms": format_float(
+                    diff_ms(frontend.recv_ms, frontend.select_ms)
+                ),
+                "frontend_recv_to_backend_recv_ms": format_float(
+                    diff_ms(frontend.recv_ms, backend.recv_ms)
+                ),
+                "backend_recv_to_commit_ms": format_float(
+                    diff_ms(backend.recv_ms, commit_ms)
+                ),
+                "commit_to_pull_call_ms": format_float(diff_ms(commit_ms, pull_call_ms)),
+                "pull_call_to_pull_return_ms": format_float(
+                    diff_ms(pull_call_ms, pull_return_ms)
+                ),
+                "pull_return_to_g2_to_g1_ms": format_float(
+                    diff_ms(pull_return_ms, g2_to_g1_ms)
+                ),
+                "g2_to_g1_to_mark_complete_ms": format_float(
+                    diff_ms(g2_to_g1_ms, mark_complete_ms)
+                ),
+                "mark_complete_to_first_token_ms": format_float(
+                    diff_ms(mark_complete_ms, first_token_ms)
+                ),
+                "frontend_recv_to_first_token_ms": format_float(
+                    diff_ms(frontend.recv_ms, first_token_ms)
+                ),
+                "commit_to_first_token_ms": format_float(
+                    diff_ms(commit_ms, first_token_ms)
+                ),
+            }
+        )
+    return rows
+
+
+def format_int(value: int | None) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def row_float(row: dict[str, str], key: str) -> float | None:
+    value = row.get(key, "")
+    if value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+    sorted_values = sorted(values)
+    rank = (len(sorted_values) - 1) * pct
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    fraction = rank - lower
+    return sorted_values[lower] + (sorted_values[upper] - sorted_values[lower]) * fraction
+
+
+def summarize_values(rows: list[dict[str, str]], key: str) -> dict[str, float | int | None]:
+    values = [value for row in rows if (value := row_float(row, key)) is not None]
+    if not values:
+        return {"count": 0, "avg": None, "p50": None, "p90": None}
+    return {
+        "count": len(values),
+        "avg": mean(values),
+        "p50": median(values),
+        "p90": percentile(values, 0.90),
+    }
+
+
+def cohort_rows(rows: list[dict[str, str]], cohort: str) -> list[dict[str, str]]:
+    return [row for row in rows if row["cohort"] == cohort]
+
+
+def build_summary(
+    rows: list[dict[str, str]],
+    failure_counts: dict[str, int],
+    label: str | None,
+) -> tuple[str, str]:
+    cohorts = [
+        "remote_slots_nonzero",
+        "remote_slots_empty",
+        "missing_remote_slots",
+    ]
+    joined = sum(1 for row in rows if row["backend_request_id"])
+    env_lines = [
+        f"requests_total={len(rows)}",
+        f"joined_request_ids={joined}",
+    ]
+    markdown_lines = [
+        "# AIPerf/KVBM Stage Attribution",
+        "",
+    ]
+    if label:
+        markdown_lines.extend([f"Label: `{scrub_text(label)}`", ""])
+    markdown_lines.extend(
+        [
+            "This report joins per-request AIPerf JSONL records to Dynamo frontend "
+            "and KVBM audit role logs. Stage timings are observed correlations from "
+            "shared request IDs and timestamps; the remote pull interval can include "
+            "network, hub dispatch, remote worker scheduling, and transport setup.",
+            "",
+            f"- Requests in AIPerf JSONL: {len(rows)}",
+            f"- Requests joined to frontend/backend logs: {joined}",
+            f"- KV load failure evidence: {failure_counts['kv_load_failure']}",
+            f"- NIXL createXferReq failure evidence: {failure_counts['nixl_create_xfer_req_failure']}",
+            "",
+            "| Cohort | Requests | TTFT avg ms | TTFT p50 ms | TTFT p90 ms | Pull call->return avg ms | Pull call->return p50 ms | Pull call->return p90 ms | Mark complete->first token avg ms |",
+            "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+
+    for cohort in cohorts:
+        subset = cohort_rows(rows, cohort)
+        ttft = summarize_values(subset, "aiperf_ttft_ms")
+        pull = summarize_values(subset, "pull_call_to_pull_return_ms")
+        mark_to_token = summarize_values(subset, "mark_complete_to_first_token_ms")
+        env_prefix = cohort
+        env_lines.append(f"{env_prefix}_count={len(subset)}")
+        append_metric_env(env_lines, env_prefix, "ttft", ttft)
+        append_metric_env(env_lines, env_prefix, "pull_call_to_return", pull)
+        append_metric_env(env_lines, env_prefix, "mark_complete_to_first_token", mark_to_token)
+        markdown_lines.append(
+            "| "
+            + " | ".join(
+                [
+                    cohort,
+                    str(len(subset)),
+                    metric_cell(ttft["avg"]),
+                    metric_cell(ttft["p50"]),
+                    metric_cell(ttft["p90"]),
+                    metric_cell(pull["avg"]),
+                    metric_cell(pull["p50"]),
+                    metric_cell(pull["p90"]),
+                    metric_cell(mark_to_token["avg"]),
+                ]
+            )
+            + " |"
+        )
+
+    for name, count in failure_counts.items():
+        env_lines.append(f"{name}={count}")
+
+    markdown_lines.extend(
+        [
+            "",
+            "Use `remote_slots_nonzero` as the KVBM remote-pull cohort and "
+            "`remote_slots_empty` as the reuse/local cohort. Do not treat this "
+            "report alone as proof of WAN latency; it narrows the observed "
+            "slowdown to the KVBM pull path interval.",
+            "",
+        ]
+    )
+    return "\n".join(env_lines) + "\n", "\n".join(markdown_lines)
+
+
+def append_metric_env(
+    lines: list[str],
+    prefix: str,
+    metric_name: str,
+    summary: dict[str, float | int | None],
+) -> None:
+    for key in ("avg", "p50", "p90"):
+        value = summary[key]
+        lines.append(f"{prefix}_{metric_name}_{key}_ms={metric_cell(value)}")
+
+
+def metric_cell(value: float | int | None) -> str:
+    if value is None:
+        return ""
+    return f"{float(value):.3f}"
+
+
+def write_csv(rows: list[dict[str, str]], path: Path) -> None:
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Join AIPerf profile_export.jsonl records with KVBM XDC role logs."
+    )
+    parser.add_argument(
+        "--profile-jsonl",
+        required=True,
+        type=Path,
+        help="Path to AIPerf per-request profile_export.jsonl.",
+    )
+    parser.add_argument(
+        "--role-log-dir",
+        required=True,
+        type=Path,
+        help="Directory containing collected frontend/decode/prefill/hub .log files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for stage-attribution.csv, .env, and .md. Defaults to profile_jsonl parent / analysis.",
+    )
+    parser.add_argument(
+        "--label",
+        default="",
+        help="Optional report label. Hostnames, IPs, URLs, and absolute paths are scrubbed in markdown output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    profile_jsonl = args.profile_jsonl
+    role_log_dir = args.role_log_dir
+    output_dir = args.output_dir or profile_jsonl.parent / "analysis"
+
+    if not profile_jsonl.is_file():
+        raise SystemExit(f"profile JSONL not found: {profile_jsonl}")
+    if not role_log_dir.is_dir():
+        raise SystemExit(f"role log directory not found: {role_log_dir}")
+
+    aiperf_records = load_aiperf_records(profile_jsonl)
+    if not aiperf_records:
+        raise SystemExit(f"no per-request records found in {profile_jsonl}")
+
+    logs = parse_role_logs(role_log_dir)
+    rows = build_rows(aiperf_records, logs)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_csv(rows, output_dir / "stage-attribution.csv")
+    env_text, md_text = build_summary(rows, logs.failure_counts, args.label or None)
+    (output_dir / "stage-attribution-summary.env").write_text(env_text)
+    (output_dir / "stage-attribution-summary.md").write_text(md_text)
+
+    joined = sum(1 for row in rows if row["backend_request_id"])
+    print(
+        "Wrote stage attribution: "
+        f"requests={len(rows)} joined={joined} output_dir={output_dir}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/backends/vllm/launch/kvbm_xdc/common.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/common.sh
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Source-only helpers shared by the KVBM cross-datacenter launch scripts.
+
+kvbm_xdc_prepend_path() {
+  local var_name=$1
+  local entry=$2
+  [ -n "$entry" ] || return 0
+  [ -d "$entry" ] || return 0
+
+  local current=${!var_name-}
+  case ":$current:" in
+    *":$entry:"*) ;;
+    *) export "$var_name"="$entry${current:+:$current}" ;;
+  esac
+}
+
+kvbm_xdc_resolve_python() {
+  if [ -n "${PYTHON_BIN:-}" ]; then
+    if [ ! -x "$PYTHON_BIN" ]; then
+      echo "PYTHON_BIN is set but not executable: $PYTHON_BIN" >&2
+      return 2
+    fi
+    export PYTHON_BIN
+    return 0
+  fi
+
+  if [ -n "${VENV:-}" ] && [ -x "$VENV/bin/python" ]; then
+    PYTHON_BIN="$VENV/bin/python"
+  elif [ -x /opt/dynamo/venv/bin/python ]; then
+    VENV=/opt/dynamo/venv
+    PYTHON_BIN="$VENV/bin/python"
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python3)
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v python)
+  else
+    echo "No usable Python found; set PYTHON_BIN or VENV" >&2
+    return 2
+  fi
+
+  export VENV PYTHON_BIN
+}
+
+kvbm_xdc_configure_base_paths() {
+  if [ -n "${VENV:-}" ] && [ -d "$VENV/bin" ]; then
+    kvbm_xdc_prepend_path PATH "$VENV/bin"
+  fi
+  kvbm_xdc_prepend_path PATH /usr/local/cargo/bin
+  kvbm_xdc_prepend_path PATH /usr/local/cuda/bin
+  export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
+}
+
+kvbm_xdc_configure_python_paths() {
+  local worktree=${WORKTREE:-/workspace}
+  KVBM_XDC_USE_WORKTREE_PYTHON=${KVBM_XDC_USE_WORKTREE_PYTHON:-0}
+
+  case "$KVBM_XDC_USE_WORKTREE_PYTHON" in
+    0|false|off)
+      export KVBM_XDC_USE_WORKTREE_PYTHON
+      ;;
+    1|true|on)
+      local kvbm_core
+      kvbm_core=$(find "$worktree/lib/bindings/kvbm/python/kvbm" -maxdepth 1 -name '_core*.so' -print -quit 2>/dev/null || true)
+      if [ -z "$kvbm_core" ]; then
+        echo "KVBM_XDC_USE_WORKTREE_PYTHON=1 but $worktree/lib/bindings/kvbm/python/kvbm has no built _core*.so" >&2
+        return 2
+      fi
+
+      local path
+      for path in \
+        "$worktree/lib/bindings/python/src" \
+        "$worktree/lib/bindings/kvbm/python" \
+        "$worktree/components/src"; do
+        kvbm_xdc_prepend_path PYTHONPATH "$path"
+      done
+      export KVBM_XDC_USE_WORKTREE_PYTHON
+      ;;
+    *)
+      echo "KVBM_XDC_USE_WORKTREE_PYTHON must be 0 or 1, got $KVBM_XDC_USE_WORKTREE_PYTHON" >&2
+      return 2
+      ;;
+  esac
+
+  local path
+  if [ -n "${NIXL_PREFIX:-}" ]; then
+    for path in \
+      "$NIXL_PREFIX/lib64" \
+      "$NIXL_PREFIX/lib" \
+      "$NIXL_PREFIX/lib/x86_64-linux-gnu" \
+      "$NIXL_PREFIX/plugins"; do
+      kvbm_xdc_prepend_path LD_LIBRARY_PATH "$path"
+    done
+    if [ -z "${KVBM_XDC_PRESERVE_NIXL_ENV:-}" ] \
+      && [ -d "$NIXL_PREFIX/plugins" ]; then
+      export NIXL_PLUGIN_DIR="$NIXL_PREFIX/plugins"
+    fi
+    if [ -z "${KVBM_XDC_PRESERVE_NIXL_ENV:-}" ]; then
+      if [ -d "$NIXL_PREFIX/lib64" ]; then
+        export NIXL_LIB_DIR="$NIXL_PREFIX/lib64"
+      elif [ -d "$NIXL_PREFIX/lib" ]; then
+        export NIXL_LIB_DIR="$NIXL_PREFIX/lib"
+      fi
+    fi
+  fi
+
+  for path in \
+    "$worktree/.image-target/debug/deps" \
+    "$worktree/.image-target-kvbm/debug/deps" \
+    /usr/local/lib/python*/site-packages/.nixl_cu*.mesonpy.libs \
+    /usr/local/lib/python*/site-packages/nixl_cu*.libs; do
+    kvbm_xdc_prepend_path LD_LIBRARY_PATH "$path"
+    kvbm_xdc_prepend_path LD_LIBRARY_PATH "$path/plugins"
+    if [ -z "${NIXL_PREFIX:-}" ] \
+      && [ -z "${KVBM_XDC_PRESERVE_NIXL_ENV:-}" ] \
+      && [ -d "$path/plugins" ]; then
+      export NIXL_PLUGIN_DIR="$path/plugins"
+    fi
+    if [ -z "${NIXL_PREFIX:-}" ] \
+      && [ -z "${KVBM_XDC_PRESERVE_NIXL_ENV:-}" ]; then
+      case "$path" in
+        */.nixl_cu*.mesonpy.libs) export NIXL_LIB_DIR="$path" ;;
+      esac
+    fi
+  done
+}
+
+kvbm_xdc_configure_ucx_fallback() {
+  KVBM_FORCE_UCX_LOCAL_FALLBACK=${KVBM_FORCE_UCX_LOCAL_FALLBACK:-auto}
+
+  if [ "$KVBM_FORCE_UCX_LOCAL_FALLBACK" = "auto" ]; then
+    if [ "${NODE_ROLE:-}" = "all" ] \
+      && [ "${KVBM_TRANSFER_TOPOLOGY:-}" = "kvbm-hub" ] \
+      && [ ! -d /sys/module/nvidia_peermem ]; then
+      KVBM_FORCE_UCX_LOCAL_FALLBACK=1
+    else
+      KVBM_FORCE_UCX_LOCAL_FALLBACK=0
+    fi
+  fi
+  export KVBM_FORCE_UCX_LOCAL_FALLBACK
+
+  export UCX_RCACHE_MAX_UNRELEASED=${UCX_RCACHE_MAX_UNRELEASED:-1024}
+  if [ "$KVBM_FORCE_UCX_LOCAL_FALLBACK" = "1" ]; then
+    export UCX_TLS=${UCX_TLS:-tcp,sm,self,cuda_copy,cuda_ipc}
+    export UCX_NET_DEVICES=${UCX_NET_DEVICES:-^all}
+    export UCX_LOG_LEVEL=${UCX_LOG_LEVEL:-error}
+  fi
+}
+
+kvbm_xdc_source_optional_runtime_env() {
+  SOURCE_KVBM_RUNTIME_ENV=${SOURCE_KVBM_RUNTIME_ENV:-0}
+  [ "$SOURCE_KVBM_RUNTIME_ENV" = "1" ] || return 0
+
+  local worktree=${WORKTREE:-/workspace}
+  local env_script=${KVBM_RUNTIME_ENV_SCRIPT:-}
+  if [ -z "$env_script" ]; then
+    echo "SOURCE_KVBM_RUNTIME_ENV=1 requires KVBM_RUNTIME_ENV_SCRIPT" >&2
+    return 2
+  fi
+  if [ ! -f "$env_script" ]; then
+    echo "SOURCE_KVBM_RUNTIME_ENV=1 but runtime env script was not found: $env_script" >&2
+    return 2
+  fi
+
+  export KVBM_REPO=${KVBM_REPO:-$worktree}
+  if [ -n "${VENV:-}" ]; then
+    export KVBM_VENV=${KVBM_VENV:-$VENV}
+  fi
+
+  set +u
+  # shellcheck source=/dev/null
+  . "$env_script"
+  set -u
+}
+
+kvbm_xdc_prepare_runtime() {
+  kvbm_xdc_resolve_python
+  kvbm_xdc_configure_base_paths
+  kvbm_xdc_configure_ucx_fallback
+  kvbm_xdc_source_optional_runtime_env
+  kvbm_xdc_configure_python_paths
+}

--- a/examples/backends/vllm/launch/kvbm_xdc/hardware-profiles.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/hardware-profiles.sh
@@ -23,8 +23,10 @@ kvbm_xdc_apply_hardware_profile() {
       : "${MAX_MODEL_LEN:=2048}"
       : "${MAX_NUM_SEQS:=8}"
       : "${CPU_CACHE_GB:=16}"
-      : "${DECODE_CUDA_VISIBLE_DEVICES:=0}"
-      : "${PREFILL_CUDA_VISIBLE_DEVICES:=1}"
+      if [ "$scope" != "worker" ]; then
+        : "${DECODE_CUDA_VISIBLE_DEVICES:=0}"
+        : "${PREFILL_CUDA_VISIBLE_DEVICES:=1}"
+      fi
       : "${GPU_CLASS:=H100-or-A100}"
       ;;
     spark-gb10)

--- a/examples/backends/vllm/launch/kvbm_xdc/kvbm-prefill-completions-shim.py
+++ b/examples/backends/vllm/launch/kvbm_xdc/kvbm-prefill-completions-shim.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""HTTP shim from KVBM hub prefill dispatch to a Dynamo prefill endpoint.
+
+The current hub dispatcher posts tokenized prefill work to `/v1/completions`.
+For Experiment E we still want the prefill execution to go through
+`python -m dynamo.vllm`, whose prefill worker registers a Dynamo internal
+`ModelType.Prefill` endpoint rather than an OpenAI HTTP completions route.
+This shim preserves the hub's HTTP contract and forwards accepted requests to
+the configured Dynamo prefill endpoint as `PreprocessedRequest` dictionaries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+import traceback
+from typing import Any
+
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime.logging import configure_dynamo_logging
+
+configure_dynamo_logging()
+
+DEFAULT_MAX_BODY_BYTES = 1024 * 1024
+DEFAULT_READ_TIMEOUT_SECONDS = 10.0
+DEFAULT_UPSTREAM_TIMEOUT_SECONDS = 300.0
+
+
+class PublicHTTPError(Exception):
+    def __init__(self, status: int, error: str):
+        super().__init__(error)
+        self.status = status
+        self.error = error
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer") from exc
+    if value < 1:
+        raise RuntimeError(f"{name} must be positive")
+    return value
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be a number") from exc
+    if value <= 0:
+        raise RuntimeError(f"{name} must be positive")
+    return value
+
+
+def _json_response(status: int, payload: dict[str, Any]) -> bytes:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    reason = {
+        200: "OK",
+        400: "Bad Request",
+        404: "Not Found",
+        500: "Internal Server Error",
+    }.get(status, "OK")
+    headers = [
+        f"HTTP/1.1 {status} {reason}",
+        "content-type: application/json",
+        f"content-length: {len(body)}",
+        "connection: close",
+        "",
+        "",
+    ]
+    return "\r\n".join(headers).encode("ascii") + body
+
+
+def _decode_json_object(body: bytes) -> dict[str, Any]:
+    payload = json.loads(body.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("request body must be a JSON object")
+    return payload
+
+
+async def _read_http_request(
+    reader: asyncio.StreamReader,
+    max_body_bytes: int,
+    read_timeout_seconds: float,
+) -> tuple[str, str, bytes]:
+    try:
+        header_blob = await asyncio.wait_for(
+            reader.readuntil(b"\r\n\r\n"),
+            timeout=read_timeout_seconds,
+        )
+    except TimeoutError as exc:
+        raise PublicHTTPError(400, "request_timeout") from exc
+    except asyncio.LimitOverrunError as exc:
+        raise PublicHTTPError(400, "request_headers_too_large") from exc
+    except asyncio.IncompleteReadError as exc:
+        raise PublicHTTPError(400, "malformed_request") from exc
+
+    header_text = header_blob.decode("iso-8859-1")
+    lines = header_text.split("\r\n")
+    try:
+        method, path, _version = lines[0].split(" ", 2)
+    except ValueError as exc:
+        raise PublicHTTPError(400, "malformed_request") from exc
+
+    content_length = 0
+    for line in lines[1:]:
+        if not line:
+            continue
+        name, _, value = line.partition(":")
+        if name.lower() == "content-length":
+            try:
+                content_length = int(value.strip())
+            except ValueError as exc:
+                raise PublicHTTPError(400, "invalid_content_length") from exc
+            if content_length < 0:
+                raise PublicHTTPError(400, "invalid_content_length")
+            if content_length > max_body_bytes:
+                raise PublicHTTPError(400, "request_body_too_large")
+    if content_length:
+        try:
+            body = await asyncio.wait_for(
+                reader.readexactly(content_length),
+                timeout=read_timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise PublicHTTPError(400, "request_timeout") from exc
+        except asyncio.IncompleteReadError as exc:
+            raise PublicHTTPError(400, "incomplete_request_body") from exc
+    else:
+        body = b""
+    return method.upper(), path, body
+
+
+def _payload_to_preprocessed(payload: dict[str, Any], model: str) -> dict[str, Any]:
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, list) or not all(isinstance(t, int) for t in prompt):
+        raise ValueError("prompt must be a list of token ids")
+
+    extra_args = {}
+    if "kv_transfer_params" in payload:
+        extra_args["kv_transfer_params"] = payload["kv_transfer_params"]
+
+    max_tokens = payload.get("max_tokens", 1)
+    if not isinstance(max_tokens, int) or max_tokens < 1:
+        max_tokens = 1
+
+    return {
+        "model": payload.get("model") or model,
+        "token_ids": prompt,
+        "stop_conditions": {"max_tokens": max_tokens, "min_tokens": 1},
+        "sampling_options": {
+            "temperature": payload.get("temperature", 0),
+        },
+        "output_options": {},
+        "eos_token_ids": [],
+        "annotations": [],
+        "extra_args": extra_args or None,
+    }
+
+
+async def _collect_prefill(client: Any, request: dict[str, Any]) -> list[Any]:
+    items: list[Any] = []
+    stream = await client.generate(request)
+    async for item in stream:
+        if hasattr(item, "is_error") and item.is_error():
+            comments = item.comments() if hasattr(item, "comments") else []
+            raise RuntimeError("; ".join(comments) or "Dynamo prefill returned error")
+        data = item.data() if hasattr(item, "data") else item
+        if data is not None:
+            items.append(data)
+    return items
+
+
+async def _serve(runtime: DistributedRuntime) -> None:
+    model = os.environ["MODEL"]
+    endpoint_path = os.environ["KVBM_HUB_PREFILL_ENDPOINT"]
+    host = os.environ.get("KVBM_HUB_PREFILL_SHIM_HOST", "127.0.0.1")
+    port = int(os.environ.get("KVBM_HUB_PREFILL_SHIM_PORT", "8001"))
+    max_body_bytes = _env_int(
+        "KVBM_HUB_PREFILL_SHIM_MAX_BODY_BYTES",
+        DEFAULT_MAX_BODY_BYTES,
+    )
+    read_timeout_seconds = _env_float(
+        "KVBM_HUB_PREFILL_SHIM_READ_TIMEOUT_SECONDS",
+        DEFAULT_READ_TIMEOUT_SECONDS,
+    )
+    upstream_timeout_seconds = _env_float(
+        "KVBM_HUB_PREFILL_SHIM_UPSTREAM_TIMEOUT_SECONDS",
+        DEFAULT_UPSTREAM_TIMEOUT_SECONDS,
+    )
+
+    endpoint = runtime.endpoint(endpoint_path)
+    client = await endpoint.client()
+    await client.wait_for_instances()
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            method, path, body = await _read_http_request(
+                reader,
+                max_body_bytes,
+                read_timeout_seconds,
+            )
+            if method == "GET" and path == "/v1/models":
+                response = _json_response(
+                    200,
+                    {
+                        "object": "list",
+                        "data": [
+                            {
+                                "id": model,
+                                "object": "model",
+                                "created": int(time.time()),
+                                "owned_by": "nvidia",
+                            }
+                        ],
+                    },
+                )
+            elif method == "POST" and path == "/v1/completions":
+                payload = _decode_json_object(body)
+                preprocessed = _payload_to_preprocessed(payload, model)
+                outputs = await asyncio.wait_for(
+                    _collect_prefill(client, preprocessed),
+                    timeout=upstream_timeout_seconds,
+                )
+                response = _json_response(
+                    200,
+                    {
+                        "id": f"cmpl-prefill-{int(time.time() * 1000)}",
+                        "object": "text_completion",
+                        "model": model,
+                        "choices": [{"index": 0, "text": "", "finish_reason": "stop"}],
+                        "dynamo_prefill_output_count": len(outputs),
+                    },
+                )
+            else:
+                response = _json_response(404, {"error": "not found"})
+        except PublicHTTPError as exc:
+            response = _json_response(exc.status, {"error": exc.error})
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            print(f"[prefill-shim] invalid request: {exc}", flush=True)
+            response = _json_response(400, {"error": "invalid_request"})
+        except TimeoutError:
+            print("[prefill-shim] upstream request timed out", flush=True)
+            response = _json_response(500, {"error": "upstream_request_timeout"})
+        except Exception as exc:  # noqa: BLE001 - return failure to the hub.
+            traceback.print_exc()
+            print(
+                f"[prefill-shim] upstream request failed: {type(exc).__name__}",
+                flush=True,
+            )
+            response = _json_response(500, {"error": "upstream_request_failed"})
+
+        writer.write(response)
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, host, port)
+    addrs = ", ".join(str(sock.getsockname()) for sock in server.sockets or [])
+    print(
+        "[prefill-shim] serving /v1/completions for "
+        f"{endpoint_path} on {addrs} "
+        f"max_body_bytes={max_body_bytes} "
+        f"read_timeout_seconds={read_timeout_seconds} "
+        f"upstream_timeout_seconds={upstream_timeout_seconds}",
+        flush=True,
+    )
+    async with server:
+        await server.serve_forever()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime) -> None:
+    await _serve(runtime)
+
+
+if __name__ == "__main__":
+    asyncio.run(worker())

--- a/examples/backends/vllm/launch/kvbm_xdc/kvbm-xdc-trace.py
+++ b/examples/backends/vllm/launch/kvbm_xdc/kvbm-xdc-trace.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Render a two-column CD timeline as a self-contained HTML file.
+
+Reads kvbm_audit tracing events from hub.log, prefill.log, decode.log
+in an experiment directory and emits trace.html alongside them. If the
+current Dynamo/vLLM path does not emit kvbm_audit, falls back to a small
+set of operational breadcrumbs from the same logs: request receive/complete,
+endpoint registration, side-channel setup, cache stats, and KV transfer
+metrics. The HTML shows three lanes (Decode | Hub | Prefill) ordered by
+timestamp. Events that share a request_id are linked via a sidebar that
+filters to that request_id.
+
+Usage:
+    kvbm-xdc-trace.py <experiment-dir>
+    kvbm-xdc-trace.py /tmp/kvbm-xdc/<run-label>
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ANSI colour escape sequences emitted by `tracing_subscriber`'s
+# default formatter when stdout is a tty (or in our case piped to a
+# file but inheriting the terminal mode).
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# A kvbm_audit log line looks like (after ANSI stripping):
+#
+#   2026-04-30T08:46:09.231194Z  INFO kvbm_audit: event="gnmt_entry" role="prefill" request_id="cmpl-..." num_computed_tokens=0
+#
+# `tracing` adds nesting indicators (`get_num_new_matched_tokens:`)
+# between the level and the target, and a closing `[role=Decode]`
+# style suffix. We accept both shapes and key off the literal
+# `kvbm_audit:` token to identify audit lines.
+TS_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+"
+    r"\w+\s+"  # log level
+    r".*?kvbm_audit:\s*(?P<rest>.*)$"
+)
+FALLBACK_AUDIT_RE = re.compile(r".*?kvbm_audit:\s*(?P<rest>.*)$")
+
+# Field tokenizer: matches `key="quoted value"` or `key=bareword`.
+FIELD_RE = re.compile(r"(?P<key>\w+)=(?:\"(?P<qv>(?:[^\"\\]|\\.)*)\"|(?P<bv>\S+))")
+KV_TRANSFER_METRICS_RE = re.compile(
+    r"Num successful transfers=(?P<successful_transfers>\d+),\s*"
+    r"Avg xfer time \(ms\)=(?P<avg_xfer_ms>[\d.]+),\s*"
+    r"P90 xfer time \(ms\)=(?P<p90_xfer_ms>[\d.]+),\s*"
+    r"Avg post time \(ms\)=(?P<avg_post_ms>[\d.]+),\s*"
+    r"P90 post time \(ms\)=(?P<p90_post_ms>[\d.]+),\s*"
+    r"Avg MB per transfer=(?P<avg_mb_per_transfer>[\d.]+),\s*"
+    r"Throughput \(MB/s\)=(?P<throughput_mb_s>[\d.]+),\s*"
+    r"Avg number of descriptors=(?P<avg_descriptors>[\d.]+)"
+)
+CACHE_STATS_RE = re.compile(
+    r"Prefix cache hit rate:\s*(?P<prefix_cache_hit_rate_pct>[\d.]+)%,\s*"
+    r"External prefix cache hit rate:\s*(?P<external_prefix_cache_hit_rate_pct>[\d.]+)%"
+)
+RAW_TS_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s+" r"\w+\s+(?P<rest>.*)$"
+)
+GLOG_TS_RE = re.compile(
+    r"^(?P<level>[IWEF])(?P<mmdd>\d{4})\s+"
+    r"(?P<clock>\d{2}:\d{2}:\d{2}\.\d+)\s+\d+\s+(?P<rest>.*)$"
+)
+URL_RE = re.compile(r"\b(?:https?|nats)://[^\s\"'<>]+")
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b")
+IPV6_RE = re.compile(r"\b(?:[0-9a-fA-F]{1,4}:){2,}[0-9a-fA-F:]{1,}(?:%\w+)?(?::\d+)?\b")
+ABS_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])"
+    r"/(?:Users|home|tmp|private|workspace|mnt|scratch|var|opt)"
+    r"/[^\s\"'<>:,;)]*"
+)
+INTERNAL_HOST_RE = re.compile(
+    r"\b(?=[A-Za-z0-9.-]*[.-])(?=[A-Za-z0-9.-]*\d)"
+    r"[A-Za-z0-9.-]*(?:prod|cluster|login|compute|gpu|dgx|h100|a100)"
+    r"[A-Za-z0-9.-]*(?::\d+)?\b",
+    re.IGNORECASE,
+)
+
+
+def scrub_value(value: str) -> str:
+    value = URL_RE.sub("<url>", value)
+    value = IPV4_RE.sub("<addr>", value)
+    value = IPV6_RE.sub("<addr>", value)
+    value = ABS_PATH_RE.sub("<path>", value)
+    value = INTERNAL_HOST_RE.sub("<host>", value)
+    return value
+
+
+@dataclass
+class Event:
+    ts: str
+    source: str  # "decode" | "hub" | "prefill"
+    fields: dict = field(default_factory=dict)
+    line_no: int = 0
+    sort_ns: int | None = None
+
+    @property
+    def event(self) -> str:
+        return self.fields.get("event", "?")
+
+    @property
+    def request_id(self) -> str | None:
+        return self.fields.get("request_id")
+
+    @property
+    def role(self) -> str:
+        # role may be missing on hub events; fall back to source
+        return self.fields.get("role", self.source)
+
+
+def parse_log(path: Path, source: str) -> list[Event]:
+    if not path.exists():
+        return []
+    audit_events: list[Event] = []
+    fallback_events: list[Event] = []
+    for line_no, line in enumerate(
+        path.read_text(errors="replace").splitlines(), start=1
+    ):
+        line = ANSI_RE.sub("", line)
+        m = TS_RE.match(line)
+        if m:
+            ts = m.group("ts")
+            rest = m.group("rest")
+            fields = parse_fields(rest)
+            audit_events.append(
+                Event(
+                    ts=ts,
+                    source=source,
+                    fields=fields,
+                    line_no=line_no,
+                    sort_ns=audit_ts_ns(fields),
+                )
+            )
+            continue
+
+        m = FALLBACK_AUDIT_RE.match(line)
+        if m:
+            fields = parse_fields(m.group("rest"))
+            audit_events.append(
+                Event(
+                    ts="",
+                    source=source,
+                    fields=fields,
+                    line_no=line_no,
+                    sort_ns=audit_ts_ns(fields),
+                )
+            )
+            continue
+
+        fallback = parse_fallback_line(line, source)
+        if fallback is not None:
+            fallback.line_no = line_no
+            fallback_events.append(fallback)
+    return audit_events if audit_events else fallback_events
+
+
+def parse_fields(rest: str) -> dict:
+    fields = {}
+    for fm in FIELD_RE.finditer(rest):
+        v = fm.group("qv") if fm.group("qv") is not None else fm.group("bv")
+        # Unescape quoted strings (basic)
+        if fm.group("qv") is not None:
+            v = v.replace('\\"', '"').replace("\\\\", "\\")
+        else:
+            v = v.rstrip(",")
+        fields[fm.group("key")] = scrub_value(v)
+    return fields
+
+
+def parse_ts_ns(ts: str) -> int | None:
+    if not ts or "T" not in ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return int(dt.timestamp() * 1_000_000_000)
+    except ValueError:
+        return None
+
+
+def audit_ts_ns(fields: dict) -> int | None:
+    try:
+        return int(fields.get("audit_ts_ns", ""))
+    except ValueError:
+        return None
+
+
+SOURCE_TO_LANE = {"decode": 0, "hub": 1, "prefill": 2}
+
+
+def event_sort_key(event: Event) -> tuple[int, int, int]:
+    sort_ns = event.sort_ns
+    if sort_ns is None:
+        sort_ns = parse_ts_ns(event.ts)
+    if sort_ns is None:
+        sort_ns = event.line_no
+    return (sort_ns, SOURCE_TO_LANE.get(event.source, 1), event.line_no)
+
+
+def event_display_ts(event: Event) -> str:
+    if event.sort_ns is not None:
+        dt = datetime.fromtimestamp(event.sort_ns / 1_000_000_000, timezone.utc)
+        return dt.strftime("%H:%M:%S.%f")[:15]
+    if "T" in event.ts:
+        return event.ts.split("T", 1)[-1].rstrip("Z")[:15]
+    return f"line {event.line_no}"
+
+
+def parse_fallback_line(line: str, source: str) -> Event | None:
+    m = RAW_TS_RE.match(line)
+    if m:
+        ts = m.group("ts")
+        rest = m.group("rest")
+        level = None
+    else:
+        gm = GLOG_TS_RE.match(line)
+        if not gm:
+            return None
+        mmdd = gm.group("mmdd")
+        ts = (
+            f"{datetime.now(timezone.utc).year}-"
+            f"{mmdd[:2]}-{mmdd[2:]}T{gm.group('clock')}Z"
+        )
+        rest = gm.group("rest")
+        level = gm.group("level")
+    fields = parse_fields(rest)
+    role = fields.get("component", source)
+    event: str | None = None
+
+    if "request received" in rest:
+        event = "request_received"
+    elif "request completed" in rest:
+        event = "request_completed"
+    elif "KV Transfer metrics:" in rest:
+        event = "kv_transfer_metrics"
+        if metrics := KV_TRANSFER_METRICS_RE.search(rest):
+            fields.update(metrics.groupdict())
+    elif "External prefix cache hit rate:" in rest:
+        event = "cache_stats"
+        if stats := CACHE_STATS_RE.search(rest):
+            fields.update(stats.groupdict())
+    elif "Using existing VLLM_NIXL_SIDE_CHANNEL_HOST" in rest:
+        event = "side_channel_host"
+    elif "Registered endpoint" in rest and ".generate" in rest:
+        event = "generate_endpoint_registered"
+    elif "VllmWorker for" in rest and "has been initialized" in rest:
+        event = "worker_initialized"
+    elif "registerMem: registration failed" in rest:
+        event = "nixl_register_mem_failed"
+    elif "createXferReq: no potential backend found" in rest:
+        event = "nixl_create_xfer_req_no_backend"
+    elif "Recovered from KV load failure" in rest:
+        event = "kv_load_recovered_from_failure"
+    elif "No POSIX plugin found" in rest or "No UCX plugin found" in rest:
+        event = "nixl_plugin_missing"
+
+    if event is None:
+        return None
+
+    fields["event"] = event
+    fields.setdefault("role", role)
+    if level is not None:
+        fields["level"] = level
+    fields["message"] = scrub_value(rest)
+    return Event(ts=ts, source=source, fields=fields)
+
+
+def render_html(events: list[Event], out_path: Path, exp_label: str) -> None:
+    # Sort stably by timestamp.
+    events.sort(key=event_sort_key)
+
+    # Distinct request_ids for the sidebar.
+    request_ids = sorted({e.request_id for e in events if e.request_id})
+
+    rows_html: list[str] = []
+    for e in events:
+        rid = e.request_id or ""
+        role = e.role
+        # Lane: decode | hub | prefill
+        if role == "decode":
+            lane = 0
+        elif role == "prefill":
+            lane = 2
+        elif e.source == "hub":
+            lane = 1
+        else:
+            # role="both" (e.g. process_finished_onboarding events
+            # emitted by ConnectorLeader, agnostic of role) - drop
+            # them in the same lane as the source file.
+            lane = {"decode": 0, "hub": 1, "prefill": 2}.get(e.source, 1)
+
+        cells = ["", "", ""]
+        # Render fields excluding event/role/request_id (shown elsewhere).
+        body_fields = {
+            k: v
+            for k, v in e.fields.items()
+            if k not in {"event", "role", "request_id"}
+        }
+        body = f"<div class='ev'>{html.escape(e.event)}</div>" + "".join(
+            f"<div class='kv'><span class='k'>{html.escape(k)}</span>"
+            f"<span class='v'>{html.escape(scrub_value(v))}</span></div>"
+            for k, v in body_fields.items()
+        )
+        ts_short = event_display_ts(e)
+        cells[lane] = (
+            f"<div class='cell' data-rid='{html.escape(rid)}'>"
+            f"<div class='ts'>{html.escape(ts_short)}</div>"
+            f"{body}"
+            f"<div class='rid'>{html.escape(rid)}</div>"
+            f"</div>"
+        )
+        rid_attr = html.escape(rid) if rid else ""
+        rows_html.append(
+            f"<tr data-rid='{rid_attr}'>"
+            f"<td class='lane decode'>{cells[0]}</td>"
+            f"<td class='lane hub'>{cells[1]}</td>"
+            f"<td class='lane prefill'>{cells[2]}</td>"
+            f"</tr>"
+        )
+
+    sidebar = "".join(
+        f"<button class='rid-btn' data-rid='{html.escape(r)}'>{html.escape(r)}</button>"
+        for r in request_ids
+    )
+
+    page = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>kvbm-xdc-trace - {html.escape(exp_label)}</title>
+<style>
+  body {{ font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 12px;
+          margin: 0; background: #0d1117; color: #e6edf3; }}
+  header {{ padding: 8px 16px; background: #161b22; border-bottom: 1px solid #30363d;
+            display: flex; align-items: center; gap: 16px; }}
+  header h1 {{ font-size: 14px; margin: 0; }}
+  header .stats {{ color: #8b949e; }}
+  .layout {{ display: flex; height: calc(100vh - 41px); }}
+  aside {{ width: 280px; padding: 8px; overflow-y: auto; border-right: 1px solid #30363d;
+           background: #0d1117; }}
+  aside h2 {{ font-size: 11px; color: #8b949e; text-transform: uppercase;
+              margin: 8px 0 4px; }}
+  .rid-btn {{ display: block; width: 100%; text-align: left; background: transparent;
+              border: 1px solid #30363d; color: #e6edf3; padding: 4px 6px;
+              margin-bottom: 4px; cursor: pointer; border-radius: 4px;
+              font-family: inherit; font-size: 11px; word-break: break-all; }}
+  .rid-btn.active {{ background: #1f6feb; border-color: #1f6feb; }}
+  .rid-btn:hover {{ background: #21262d; }}
+  main {{ flex: 1; overflow-y: auto; padding: 0; }}
+  table {{ width: 100%; border-collapse: collapse; }}
+  th {{ position: sticky; top: 0; background: #161b22; padding: 6px 8px;
+        border-bottom: 1px solid #30363d; text-align: left; }}
+  th.decode {{ color: #58a6ff; }}
+  th.hub {{ color: #d2a8ff; }}
+  th.prefill {{ color: #f0883e; }}
+  td {{ vertical-align: top; padding: 0 8px; border-bottom: 1px solid #161b22;
+        width: 33.33%; }}
+  td.lane {{ height: 1px; }}
+  .cell {{ background: #161b22; padding: 4px 6px; margin: 4px 0; border-radius: 4px;
+           border-left: 3px solid #30363d; }}
+  td.decode .cell {{ border-left-color: #58a6ff; }}
+  td.hub .cell {{ border-left-color: #d2a8ff; }}
+  td.prefill .cell {{ border-left-color: #f0883e; }}
+  .ts {{ color: #8b949e; font-size: 10px; }}
+  .ev {{ font-weight: 600; color: #e6edf3; }}
+  .kv {{ font-size: 11px; color: #c9d1d9; }}
+  .kv .k {{ color: #7ee787; margin-right: 4px; }}
+  .kv .v {{ color: #d2a8ff; word-break: break-all; }}
+  .rid {{ color: #6e7681; font-size: 10px; margin-top: 4px; }}
+  tr.dimmed {{ opacity: 0.15; }}
+</style>
+</head>
+<body>
+  <header>
+    <h1>kvbm-xdc-trace - {html.escape(exp_label)}</h1>
+    <span class='stats'>{len(events)} trace events - {len(request_ids)} request_ids</span>
+  </header>
+  <div class='layout'>
+    <aside>
+      <h2>Filter by request_id</h2>
+      <button class='rid-btn active' data-rid=''>(all)</button>
+      {sidebar}
+    </aside>
+    <main>
+      <table>
+        <thead>
+          <tr>
+            <th class='decode'>decode</th>
+            <th class='hub'>hub</th>
+            <th class='prefill'>prefill</th>
+          </tr>
+        </thead>
+        <tbody>
+          {''.join(rows_html)}
+        </tbody>
+      </table>
+    </main>
+  </div>
+<script>
+  const buttons = document.querySelectorAll('.rid-btn');
+  buttons.forEach(b => b.addEventListener('click', () => {{
+    const target = b.dataset.rid;
+    buttons.forEach(x => x.classList.toggle('active', x === b));
+    document.querySelectorAll('tbody tr').forEach(tr => {{
+      const rid = tr.dataset.rid || '';
+      tr.classList.toggle('dimmed', !!target && rid !== target);
+    }});
+  }}));
+</script>
+</body>
+</html>
+"""
+    out_path.write_text(page)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    exp_dir = Path(sys.argv[1]).resolve()
+    if not exp_dir.is_dir():
+        print(f"not a directory: {exp_dir}", file=sys.stderr)
+        return 2
+
+    events: list[Event] = []
+    for source in ("decode", "hub", "prefill"):
+        events.extend(parse_log(exp_dir / f"{source}.log", source))
+
+    out = exp_dir / "trace.html"
+    render_html(events, out, exp_dir.name)
+    print(f"{len(events)} trace events -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/backends/vllm/launch/kvbm_xdc/launch-dynamo-frontend.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/launch-dynamo-frontend.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$SCRIPT_DIR/hardware-profiles.sh"
+. "$SCRIPT_DIR/common.sh"
 kvbm_xdc_apply_hardware_profile model-only
 
 WORKTREE=${WORKTREE:-/workspace}
@@ -12,26 +13,13 @@ ROUTER_MODE=${ROUTER_MODE:-kv}
 ROUTER_RESET_STATES=${ROUTER_RESET_STATES:-1}
 ENFORCE_DISAGG=${ENFORCE_DISAGG:-1}
 ROUTER_MIN_INITIAL_WORKERS=${ROUTER_MIN_INITIAL_WORKERS:-0}
-VENV=${VENV:-/opt/dynamo/venv}
+VENV=${VENV:-}
+SOURCE_KVBM_RUNTIME_ENV=${SOURCE_KVBM_RUNTIME_ENV:-0}
+PYTHON_BIN=${PYTHON_BIN:-}
 
 : "${MODEL:?MODEL must be set by KVBM_HARDWARE_PROFILE or env override}"
 
-export PATH="$VENV/bin:/usr/local/cargo/bin:/usr/local/cuda/bin:$PATH"
-export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
-for lib_dir in "$WORKTREE/.image-target/debug/deps" "$WORKTREE/.image-target-kvbm/debug/deps" /usr/local/lib/python*/site-packages/nixl_cu*.libs; do
-  if [[ -d "$lib_dir" ]]; then
-    export LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}"
-  fi
-done
-if [[ -d "$WORKTREE/lib/bindings/python/src" ]]; then
-  export PYTHONPATH="$WORKTREE/lib/bindings/python/src:${PYTHONPATH:-}"
-fi
-if [[ -d "$WORKTREE/lib/bindings/kvbm/python" ]]; then
-  export PYTHONPATH="$WORKTREE/lib/bindings/kvbm/python:${PYTHONPATH:-}"
-fi
-if [[ -d "$WORKTREE/components/src" ]]; then
-  export PYTHONPATH="$WORKTREE/components/src:${PYTHONPATH:-}"
-fi
+kvbm_xdc_prepare_runtime
 
 args=(
   --namespace "$NAMESPACE"
@@ -48,4 +36,4 @@ if [[ "$ENFORCE_DISAGG" == "1" ]]; then
 fi
 
 echo "[frontend] model=$MODEL namespace=$NAMESPACE http_port=$HTTP_PORT router=$ROUTER_MODE enforce_disagg=$ENFORCE_DISAGG"
-exec "$VENV/bin/python" -m dynamo.frontend "${args[@]}"
+exec "$PYTHON_BIN" -m dynamo.frontend "${args[@]}"

--- a/examples/backends/vllm/launch/kvbm_xdc/launch-kvbm-hub.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/launch-kvbm-hub.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$SCRIPT_DIR/hardware-profiles.sh"
+if [ -n "${KVBM_HUB_MODEL:-}" ] && [ -z "${MODEL:-}" ]; then
+  MODEL=$KVBM_HUB_MODEL
+  export MODEL
+fi
+kvbm_xdc_apply_hardware_profile model-only
+
+LOG=${1:?"usage: $0 <log_path>"}
+WORKTREE=${WORKTREE:-${KVBM_REPO:-/workspace}}
+
+if [ -n "${KVBM_HUB_MODEL:-}" ]; then
+  HUB_MODEL=$KVBM_HUB_MODEL
+else
+  : "${MODEL:?MODEL must be set by KVBM_HARDWARE_PROFILE or env override}"
+  HUB_MODEL=${SERVED_MODEL_NAME:-$MODEL}
+fi
+
+find_hub_bin() {
+  local candidate
+  for candidate in \
+    "${KVBM_HUB_BIN:-}" \
+    /usr/local/bin/kvbm_hub \
+    "$WORKTREE/target/release/kvbm_hub" \
+    "$WORKTREE/target/debug/kvbm_hub"; do
+    [ -n "$candidate" ] || continue
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+HUB_BIN=$(find_hub_bin || true)
+KVBM_HUB_BUILD=${KVBM_HUB_BUILD:-auto}
+if [ -z "$HUB_BIN" ] && { [ "$KVBM_HUB_BUILD" = "1" ] || [ "$KVBM_HUB_BUILD" = "auto" ]; }; then
+  if command -v cargo >/dev/null 2>&1; then
+    echo "[kvbm-xdc] building kvbm_hub in $WORKTREE" > "$LOG"
+    (
+      cd "$WORKTREE"
+      cargo build --bin kvbm_hub
+    ) >> "$LOG" 2>&1
+    HUB_BIN=$(find_hub_bin || true)
+  fi
+fi
+
+if [ -z "$HUB_BIN" ]; then
+  echo "kvbm_hub binary not found. Set KVBM_HUB_BIN or build with KVBM_HUB_BUILD=1." >&2
+  exit 2
+fi
+
+KVBM_HUB_FEATURES=${KVBM_HUB_FEATURES:-disagg}
+KVBM_HUB_DISCOVERY_PORT=${KVBM_HUB_DISCOVERY_PORT:-1337}
+KVBM_HUB_CONTROL_PORT=${KVBM_HUB_CONTROL_PORT:-8337}
+KVBM_HUB_VELO_PORT=${KVBM_HUB_VELO_PORT:-1338}
+KVBM_HUB_BLOCK_SIZE=${KVBM_HUB_BLOCK_SIZE:-16}
+KVBM_HUB_MAX_SEQ_LEN=${KVBM_HUB_MAX_SEQ_LEN:-${MAX_MODEL_LEN:-1024}}
+KVBM_HUB_LAYOUT=${KVBM_HUB_LAYOUT:-${KVBM_BLOCK_LAYOUT:-operational}}
+KVBM_HUB_G2_MEMORY_GIB=${KVBM_HUB_G2_MEMORY_GIB:-${CPU_CACHE_GB:-2}}
+KVBM_HUB_HEARTBEAT_SECS=${KVBM_HUB_HEARTBEAT_SECS:-10}
+KVBM_KV_INDEX_ADVERTISE_HOST=${KVBM_KV_INDEX_ADVERTISE_HOST:-127.0.0.1}
+KVBM_HUB_PREFILL_VLLM_URL=${KVBM_HUB_PREFILL_VLLM_URL:-${KVBM_HUB_PREFILL_URL:-}}
+KVBM_HUB_PREFILL_VLLM_MODEL=${KVBM_HUB_PREFILL_VLLM_MODEL:-$HUB_MODEL}
+KVBM_ONBOARD_MODE=${KVBM_ONBOARD_MODE:-inter}
+RUST_LOG=${RUST_LOG:-info,kvbm_hub=debug,kvbm_connector=debug}
+
+case "$KVBM_HUB_LAYOUT" in
+  operational|universal) ;;
+  *) echo "KVBM_HUB_LAYOUT must be operational or universal, got $KVBM_HUB_LAYOUT" >&2; exit 2 ;;
+esac
+case "$KVBM_ONBOARD_MODE" in
+  inter|intra) ;;
+  *) echo "KVBM_ONBOARD_MODE must be inter or intra, got $KVBM_ONBOARD_MODE" >&2; exit 2 ;;
+esac
+
+args=(
+  --discovery-port "$KVBM_HUB_DISCOVERY_PORT"
+  --control-port "$KVBM_HUB_CONTROL_PORT"
+  --velo-port "$KVBM_HUB_VELO_PORT"
+  --heartbeat-interval-secs "$KVBM_HUB_HEARTBEAT_SECS"
+  --block-size "$KVBM_HUB_BLOCK_SIZE"
+  --max-seq-len "$KVBM_HUB_MAX_SEQ_LEN"
+  --layout "$KVBM_HUB_LAYOUT"
+  --kv-index-advertise-host "$KVBM_KV_INDEX_ADVERTISE_HOST"
+  --features "$KVBM_HUB_FEATURES"
+)
+
+if [ -n "${KVBM_HUB_G2_BLOCKS:-}" ]; then
+  args+=(--g2-block "$KVBM_HUB_G2_BLOCKS")
+else
+  args+=(--g2-memory "$KVBM_HUB_G2_MEMORY_GIB")
+fi
+
+if [ -n "$KVBM_HUB_PREFILL_VLLM_URL" ]; then
+  args+=(
+    --prefill-vllm-url "$KVBM_HUB_PREFILL_VLLM_URL"
+    --prefill-vllm-model "$KVBM_HUB_PREFILL_VLLM_MODEL"
+  )
+fi
+
+KVBM_HUB_KVBM=${KVBM_HUB_KVBM:-"leader.tokio.worker_threads=2
+worker.tokio.worker_threads=2
+leader.control.metrics=true
+leader.control.dev=true
+leader.onboard.mode=$KVBM_ONBOARD_MODE
+worker.nixl.backends.UCX={}
+worker.nixl.backends.POSIX={}"}
+
+if [ -n "${KVBM_HUB_KVBM_CONFIG:-}" ]; then
+  args+=(--kvbm-config "$KVBM_HUB_KVBM_CONFIG")
+fi
+if [ -n "$KVBM_HUB_KVBM" ]; then
+  while IFS= read -r kv; do
+    [ -n "$kv" ] && args+=(--kvbm "$kv")
+  done <<< "$KVBM_HUB_KVBM"
+fi
+
+export RUST_LOG
+exec "$HUB_BIN" "${args[@]}" >> "$LOG" 2>&1

--- a/examples/backends/vllm/launch/kvbm_xdc/launch-kvbm-prefill-shim.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/launch-kvbm-prefill-shim.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$SCRIPT_DIR/hardware-profiles.sh"
+. "$SCRIPT_DIR/common.sh"
+kvbm_xdc_apply_hardware_profile model-only
+
+WORKTREE=${WORKTREE:-/workspace}
+VENV=${VENV:-}
+SOURCE_KVBM_RUNTIME_ENV=${SOURCE_KVBM_RUNTIME_ENV:-0}
+KVBM_HUB_PREFILL_ENDPOINT=${KVBM_HUB_PREFILL_ENDPOINT:?KVBM_HUB_PREFILL_ENDPOINT is required}
+KVBM_HUB_PREFILL_SHIM_HOST=${KVBM_HUB_PREFILL_SHIM_HOST:-127.0.0.1}
+KVBM_HUB_PREFILL_SHIM_PORT=${KVBM_HUB_PREFILL_SHIM_PORT:-8001}
+PYTHON_BIN=${PYTHON_BIN:-}
+
+: "${MODEL:?MODEL must be set by KVBM_HARDWARE_PROFILE or env override}"
+
+kvbm_xdc_prepare_runtime
+
+echo "[prefill-shim] model=$MODEL endpoint=$KVBM_HUB_PREFILL_ENDPOINT port=$KVBM_HUB_PREFILL_SHIM_PORT"
+exec "$PYTHON_BIN" "$SCRIPT_DIR/kvbm-prefill-completions-shim.py"

--- a/examples/backends/vllm/launch/kvbm_xdc/launch-kvbm-vllm.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/launch-kvbm-vllm.sh
@@ -3,25 +3,59 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$SCRIPT_DIR/hardware-profiles.sh"
+. "$SCRIPT_DIR/common.sh"
 kvbm_xdc_apply_hardware_profile worker
 
 ROLE=${ROLE:?ROLE must be prefill or decode}
 WORKTREE=${WORKTREE:-/workspace}
 NAMESPACE=${NAMESPACE:-dynamo}
 ENDPOINT_TYPES=${ENDPOINT_TYPES:-chat}
+ENDPOINT=${ENDPOINT:-}
 KV_EVENTS_PORT=${KV_EVENTS_PORT:-20081}
 ENFORCE_EAGER=${ENFORCE_EAGER:-0}
-ENABLE_PREFIX_CACHING=${ENABLE_PREFIX_CACHING:-1}
+KVBM_TRANSFER_TOPOLOGY=${KVBM_TRANSFER_TOPOLOGY:-nixl-pd}
+case "$KVBM_TRANSFER_TOPOLOGY" in
+  nixl-pd|kvbm-hub) ;;
+  *) echo "KVBM_TRANSFER_TOPOLOGY must be nixl-pd or kvbm-hub, got $KVBM_TRANSFER_TOPOLOGY" >&2; exit 2 ;;
+esac
+if [[ -z "${ENABLE_PREFIX_CACHING+x}" ]]; then
+  if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+    ENABLE_PREFIX_CACHING=0
+  else
+    ENABLE_PREFIX_CACHING=1
+  fi
+fi
 VLLM_RUNNER=${VLLM_RUNNER:-}
 VLLM_USE_AOT_COMPILE=${VLLM_USE_AOT_COMPILE:-}
 VLLM_USE_STANDALONE_COMPILE=${VLLM_USE_STANDALONE_COMPILE:-}
 VLLM_ENABLE_V1_MULTIPROCESSING=${VLLM_ENABLE_V1_MULTIPROCESSING:-}
+NUM_GPU_BLOCKS_OVERRIDE=${NUM_GPU_BLOCKS_OVERRIDE:-}
 KVBM_SKIP_VLLM_VERSION_CHECK=${KVBM_SKIP_VLLM_VERSION_CHECK:-1}
 KVBM_CONNECTOR_MODULE_PATH=${KVBM_CONNECTOR_MODULE_PATH:-kvbm.v2.vllm.connector}
 PREFILL_KV_CONNECTOR_WRAPPER=${PREFILL_KV_CONNECTOR_WRAPPER:-PdConnector}
 DECODE_KV_CONNECTOR=${DECODE_KV_CONNECTOR:-NixlConnector}
 VALIDATE_CONNECTORS=${VALIDATE_CONNECTORS:-1}
-VENV=${VENV:-/opt/dynamo/venv}
+VENV=${VENV:-}
+SOURCE_KVBM_RUNTIME_ENV=${SOURCE_KVBM_RUNTIME_ENV:-0}
+ENABLE_PERMUTE_LOCAL_KV=${ENABLE_PERMUTE_LOCAL_KV:-1}
+VLLM_KV_CACHE_LAYOUT=${VLLM_KV_CACHE_LAYOUT:-HND}
+RUST_LOG=${RUST_LOG:-info,kvbm_connector=debug,kvbm_audit=info}
+DYN_LOG=${DYN_LOG:-$RUST_LOG}
+KVBM_HUB_URL=${KVBM_HUB_URL:-http://127.0.0.1:1337}
+KVBM_BLOCK_LAYOUT=${KVBM_BLOCK_LAYOUT:-operational}
+KVBM_ONBOARD_MODE=${KVBM_ONBOARD_MODE:-inter}
+KVBM_WORKER_NIXL_BACKENDS=${KVBM_WORKER_NIXL_BACKENDS:-}
+KVBM_VALIDATE_CONFIG_ONLY=${KVBM_VALIDATE_CONFIG_ONLY:-0}
+PYTHON_BIN=${PYTHON_BIN:-}
+
+case "$KVBM_BLOCK_LAYOUT" in
+  operational|universal) ;;
+  *) echo "KVBM_BLOCK_LAYOUT must be operational or universal, got $KVBM_BLOCK_LAYOUT" >&2; exit 2 ;;
+esac
+case "$KVBM_ONBOARD_MODE" in
+  inter|intra) ;;
+  *) echo "KVBM_ONBOARD_MODE must be inter or intra, got $KVBM_ONBOARD_MODE" >&2; exit 2 ;;
+esac
 
 case "$ROLE" in
   prefill|decode) ;;
@@ -29,14 +63,16 @@ case "$ROLE" in
 esac
 
 : "${MODEL:?MODEL must be set by KVBM_HARDWARE_PROFILE or env override}"
+MODEL_PATH=${MODEL_PATH:-$MODEL}
+SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-$MODEL}
 : "${MAX_MODEL_LEN:?MAX_MODEL_LEN must be set by KVBM_HARDWARE_PROFILE or env override}"
 : "${MAX_NUM_SEQS:?MAX_NUM_SEQS must be set by KVBM_HARDWARE_PROFILE or env override}"
 : "${GPU_MEMORY_UTILIZATION:?GPU_MEMORY_UTILIZATION must be set by KVBM_HARDWARE_PROFILE or env override}"
 : "${CPU_CACHE_GB:?CPU_CACHE_GB must be set by KVBM_HARDWARE_PROFILE or env override}"
 
 case "$ROLE" in
-  prefill) CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-${PREFILL_CUDA_VISIBLE_DEVICES:-}} ;;
-  decode) CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-${DECODE_CUDA_VISIBLE_DEVICES:-}} ;;
+  prefill) CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-${PREFILL_CUDA_VISIBLE_DEVICES:-0}} ;;
+  decode) CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-${DECODE_CUDA_VISIBLE_DEVICES:-0}} ;;
 esac
 if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then
   echo "CUDA_VISIBLE_DEVICES is required for ROLE=$ROLE when the selected hardware profile does not define placement" >&2
@@ -46,22 +82,10 @@ export CUDA_VISIBLE_DEVICES
 export DYN_KVBM_CPU_CACHE_GB="$CPU_CACHE_GB"
 export VLLM_ATTENTION_BACKEND=${VLLM_ATTENTION_BACKEND:-FLASH_ATTN}
 export KVBM_SKIP_VLLM_VERSION_CHECK
-export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
-export PATH="$VENV/bin:/usr/local/cargo/bin:/usr/local/cuda/bin:$PATH"
-for lib_dir in "$WORKTREE/.image-target/debug/deps" "$WORKTREE/.image-target-kvbm/debug/deps" /usr/local/lib/python*/site-packages/nixl_cu*.libs; do
-  if [[ -d "$lib_dir" ]]; then
-    export LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}"
-  fi
-done
-if [[ -d "$WORKTREE/lib/bindings/python/src" ]]; then
-  export PYTHONPATH="$WORKTREE/lib/bindings/python/src:${PYTHONPATH:-}"
-fi
-if [[ -d "$WORKTREE/lib/bindings/kvbm/python" ]]; then
-  export PYTHONPATH="$WORKTREE/lib/bindings/kvbm/python:${PYTHONPATH:-}"
-fi
-if [[ -d "$WORKTREE/components/src" ]]; then
-  export PYTHONPATH="$WORKTREE/components/src:${PYTHONPATH:-}"
-fi
+export VLLM_KV_CACHE_LAYOUT
+export RUST_LOG
+export DYN_LOG
+kvbm_xdc_prepare_runtime
 
 if [[ -n "${SIDE_CHANNEL_HOST:-}" ]]; then
   export VLLM_NIXL_SIDE_CHANNEL_HOST="$SIDE_CHANNEL_HOST"
@@ -89,24 +113,29 @@ fi
 if [[ -n "$VLLM_RUNNER" ]]; then
   flags+=(--runner "$VLLM_RUNNER")
 fi
+if [[ -n "$NUM_GPU_BLOCKS_OVERRIDE" ]]; then
+  flags+=(--num-gpu-blocks-override "$NUM_GPU_BLOCKS_OVERRIDE")
+fi
 
 if [[ "$VALIDATE_CONNECTORS" == "1" ]]; then
-  "$VENV/bin/python" - "$ROLE" "$DECODE_KV_CONNECTOR" "$PREFILL_KV_CONNECTOR_WRAPPER" "$KVBM_CONNECTOR_MODULE_PATH" <<'PY'
+  "$PYTHON_BIN" - "$ROLE" "$DECODE_KV_CONNECTOR" "$PREFILL_KV_CONNECTOR_WRAPPER" "$KVBM_CONNECTOR_MODULE_PATH" "$KVBM_TRANSFER_TOPOLOGY" <<'PY'
 import importlib
 import sys
 
-role, decode_connector, prefill_wrapper, kvbm_module = sys.argv[1:5]
+role, decode_connector, prefill_wrapper, kvbm_module, topology = sys.argv[1:6]
 module = importlib.import_module(kvbm_module)
 getattr(module, "DynamoConnector")
-if role == "prefill":
+if topology == "nixl-pd" and role == "prefill":
     getattr(module, prefill_wrapper)
 
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 
 registry = set(getattr(KVConnectorFactory, "_registry", {}).keys())
-required = {decode_connector}
-if role == "prefill":
-    required.add("NixlConnector")
+required = set()
+if topology == "nixl-pd":
+    required.add(decode_connector)
+    if role == "prefill":
+        required.add("NixlConnector")
 missing = sorted(required - registry)
 if missing:
     raise SystemExit(
@@ -118,6 +147,7 @@ if missing:
 print(
     "connector preflight OK:"
     f" role={role}"
+    f" topology={topology}"
     f" decode_connector={decode_connector}"
     f" prefill_wrapper={prefill_wrapper}"
     f" kvbm_module={kvbm_module}"
@@ -125,19 +155,105 @@ print(
 PY
 fi
 
-DECODE_KV_TRANSFER_CONFIG='{"kv_connector":"'"$DECODE_KV_CONNECTOR"'","kv_role":"kv_both"}'
-PREFILL_KV_TRANSFER_CONFIG='{"kv_connector":"'"$PREFILL_KV_CONNECTOR_WRAPPER"'","kv_role":"kv_both","kv_connector_module_path":"'"$KVBM_CONNECTOR_MODULE_PATH"'","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"'"$KVBM_CONNECTOR_MODULE_PATH"'","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]}}'
+permute_local_kv_field=
+if [[ "$ENABLE_PERMUTE_LOCAL_KV" == "1" ]]; then
+  permute_local_kv_field=',"enable_permute_local_kv":true'
+fi
+
+worker_nixl_json=
+case "$KVBM_WORKER_NIXL_BACKENDS" in
+  ""|auto)
+    ;;
+  ucx-posix)
+    worker_nixl_json='"nixl":{"backends":{"UCX":{},"POSIX":{}}},'
+    ;;
+  *)
+    echo "KVBM_WORKER_NIXL_BACKENDS must be empty, auto, or ucx-posix, got $KVBM_WORKER_NIXL_BACKENDS" >&2
+    exit 2
+    ;;
+esac
+
+build_kvbm_hub_config() {
+  local role=$1
+  printf '{"kv_connector":"DynamoConnector","kv_role":"kv_both","kv_load_failure_policy":"recompute","kv_connector_module_path":"%s","kv_connector_extra_config":{"default":{"block_layout":"%s"},"leader":{"hub":{"url":"%s","features":["disagg"]},"disagg":{"role":"%s"},"cache":{"host":{"cache_size_gb":%s}},"tokio":{"worker_threads":2},"control":{"metrics":true},"onboard":{"mode":"%s"}},"worker":{%s"tokio":{"worker_threads":2}}}}' \
+    "$KVBM_CONNECTOR_MODULE_PATH" \
+    "$KVBM_BLOCK_LAYOUT" \
+    "$KVBM_HUB_URL" \
+    "$role" \
+    "$CPU_CACHE_GB" \
+    "$KVBM_ONBOARD_MODE" \
+    "$worker_nixl_json"
+}
+
+validate_kvbm_hub_config() {
+  local role=$1
+  local config_json=$2
+  "$PYTHON_BIN" - "$role" "$KVBM_HUB_URL" "$config_json" <<'PY'
+import json
+import sys
+
+role, expected_hub_url, raw = sys.argv[1:4]
+cfg = json.loads(raw)
+if cfg.get("kv_connector") != "DynamoConnector":
+    raise SystemExit("kvbm-hub config must use DynamoConnector")
+
+extra = cfg.get("kv_connector_extra_config")
+if not isinstance(extra, dict):
+    raise SystemExit("kvbm-hub config missing kv_connector_extra_config")
+
+leader = extra.get("leader")
+if not isinstance(leader, dict):
+    raise SystemExit("kvbm-hub config missing leader config")
+
+hub = leader.get("hub")
+if not isinstance(hub, dict):
+    raise SystemExit("kvbm-hub config missing leader.hub")
+if hub.get("url") != expected_hub_url:
+    raise SystemExit(f"kvbm-hub config leader.hub.url mismatch: {hub.get('url')!r}")
+if "disagg" not in hub.get("features", []):
+    raise SystemExit("kvbm-hub config leader.hub.features must include disagg")
+
+disagg = leader.get("disagg")
+if not isinstance(disagg, dict):
+    raise SystemExit("kvbm-hub config missing leader.disagg")
+if disagg.get("role") != role:
+    raise SystemExit(f"kvbm-hub config leader.disagg.role must be {role!r}")
+if "hub_url" in disagg:
+    raise SystemExit("kvbm-hub config must not use stale leader.disagg.hub_url")
+
+print(f"kvbm-hub config preflight OK: role={role} hub={expected_hub_url}")
+PY
+}
+
+if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+  DECODE_KV_TRANSFER_CONFIG=$(build_kvbm_hub_config decode)
+  PREFILL_KV_TRANSFER_CONFIG=$(build_kvbm_hub_config prefill)
+  validate_kvbm_hub_config decode "$DECODE_KV_TRANSFER_CONFIG"
+  validate_kvbm_hub_config prefill "$PREFILL_KV_TRANSFER_CONFIG"
+else
+  DECODE_KV_TRANSFER_CONFIG='{"kv_connector":"'"$DECODE_KV_CONNECTOR"'","kv_role":"kv_both"'"$permute_local_kv_field"'}'
+  PREFILL_KV_TRANSFER_CONFIG='{"kv_connector":"'"$PREFILL_KV_CONNECTOR_WRAPPER"'","kv_role":"kv_both","kv_connector_module_path":"'"$KVBM_CONNECTOR_MODULE_PATH"'","kv_connector_extra_config":{"connectors":[{"kv_connector":"DynamoConnector","kv_connector_module_path":"'"$KVBM_CONNECTOR_MODULE_PATH"'","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"'"$permute_local_kv_field"'}]}}'
+fi
 KV_EVENTS_CONFIG='{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:'"$KV_EVENTS_PORT"'","enable_kv_cache_events":true}'
+
+if [[ "$KVBM_VALIDATE_CONFIG_ONLY" == "1" ]]; then
+  echo "kvbm config validation complete: topology=$KVBM_TRANSFER_TOPOLOGY role=$ROLE"
+  exit 0
+fi
 
 args=(
   --namespace "$NAMESPACE"
-  --model "$MODEL" \
-  --served-model-name "$MODEL" \
+  --model "$MODEL_PATH" \
+  --served-model-name "$SERVED_MODEL_NAME" \
   --endpoint-types "$ENDPOINT_TYPES"
   --max-model-len "$MAX_MODEL_LEN" \
   --max-num-seqs "$MAX_NUM_SEQS" \
   --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
 )
+
+if [[ -n "$ENDPOINT" ]]; then
+  args+=(--endpoint "$ENDPOINT")
+fi
 
 if [[ "$ROLE" == "decode" ]]; then
   args+=(
@@ -152,4 +268,4 @@ else
   )
 fi
 
-exec "$VENV/bin/python" -m dynamo.vllm "${args[@]}" "${flags[@]}"
+exec "$PYTHON_BIN" -m dynamo.vllm "${args[@]}" "${flags[@]}"

--- a/examples/backends/vllm/launch/kvbm_xdc/run-dynamo-kvbm-chat-smoke.sh
+++ b/examples/backends/vllm/launch/kvbm_xdc/run-dynamo-kvbm-chat-smoke.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$SCRIPT_DIR/hardware-profiles.sh"
+. "$SCRIPT_DIR/common.sh"
 
 ARTIFACT_DIR=${ARTIFACT_DIR:?ARTIFACT_DIR is required}
 NODE_ROLE=${NODE_ROLE:-all}
 case "$NODE_ROLE" in
-  frontend|client) profile_scope=model-only ;;
+  frontend|hub|hub-prefill-frontend|client|trace) profile_scope=model-only ;;
   decode|prefill) profile_scope=worker ;;
   all) profile_scope=all ;;
   *) profile_scope=all ;;
@@ -19,7 +20,8 @@ NAMESPACE=${NAMESPACE:-dynamo}
 HTTP_PORT=${HTTP_PORT:-8000}
 FRONTEND_HOST=${FRONTEND_HOST:-127.0.0.1}
 READY_TIMEOUT=${READY_TIMEOUT:-900}
-VENV=${VENV:-/opt/dynamo/venv}
+TRANSFER_EVIDENCE_TIMEOUT=${TRANSFER_EVIDENCE_TIMEOUT:-30}
+VENV=${VENV:-}
 START_LOCAL_INFRA=${START_LOCAL_INFRA:-1}
 INFRA_HOST=${INFRA_HOST:-127.0.0.1}
 PREFETCH_MODEL=${PREFETCH_MODEL:-1}
@@ -31,8 +33,67 @@ ENFORCE_EAGER=${ENFORCE_EAGER:-1}
 VLLM_RUNNER=${VLLM_RUNNER:-generate}
 KVBM_CONNECTOR_MODULE_PATH=${KVBM_CONNECTOR_MODULE_PATH:-kvbm.v2.vllm.connector}
 PREFILL_KV_CONNECTOR_WRAPPER=${PREFILL_KV_CONNECTOR_WRAPPER:-PdConnector}
+SOURCE_KVBM_RUNTIME_ENV=${SOURCE_KVBM_RUNTIME_ENV:-0}
+ENABLE_PERMUTE_LOCAL_KV=${ENABLE_PERMUTE_LOCAL_KV:-1}
+VLLM_KV_CACHE_LAYOUT=${VLLM_KV_CACHE_LAYOUT:-HND}
+RUST_LOG=${RUST_LOG:-info,kvbm_connector=debug,kvbm_audit=info}
+DYN_LOG=${DYN_LOG:-$RUST_LOG}
+KVBM_PLAIN_AUDIT=${KVBM_PLAIN_AUDIT:-1}
+KVBM_EXPERIMENT_ID=${KVBM_EXPERIMENT_ID:-diagnostic}
+KVBM_TRANSFER_TOPOLOGY=${KVBM_TRANSFER_TOPOLOGY:-nixl-pd}
+KVBM_HUB_URL=${KVBM_HUB_URL:-http://127.0.0.1:1337}
+KVBM_HUB_PREFILL_NAMESPACE=${KVBM_HUB_PREFILL_NAMESPACE:-${NAMESPACE}_hub_prefill}
+KVBM_HUB_PREFILL_HTTP_PORT=${KVBM_HUB_PREFILL_HTTP_PORT:-8001}
+KVBM_HUB_PREFILL_HOST=${KVBM_HUB_PREFILL_HOST:-$FRONTEND_HOST}
+KVBM_BLOCK_LAYOUT=${KVBM_BLOCK_LAYOUT:-operational}
+KVBM_ONBOARD_MODE=${KVBM_ONBOARD_MODE:-inter}
+KVBM_WORKER_NIXL_BACKENDS=${KVBM_WORKER_NIXL_BACKENDS:-}
+KVBM_RECORD_NETWORK_ENDPOINTS=${KVBM_RECORD_NETWORK_ENDPOINTS:-0}
+KVBM_FORCE_UCX_LOCAL_FALLBACK=${KVBM_FORCE_UCX_LOCAL_FALLBACK:-auto}
+KVBM_TRANSFER_SUBSTRATE_PREFLIGHT=${KVBM_TRANSFER_SUBSTRATE_PREFLIGHT:-auto}
+KVBM_ALLOW_SUBSTRATE_FAILURE_ARTIFACT=${KVBM_ALLOW_SUBSTRATE_FAILURE_ARTIFACT:-0}
+KVBM_SERVE_ONLY=${KVBM_SERVE_ONLY:-0}
+KVBM_CLEANUP_STALE_PROCESSES=${KVBM_CLEANUP_STALE_PROCESSES:-1}
+PYTHON_BIN=${PYTHON_BIN:-}
 
 : "${MODEL:?MODEL must be set by KVBM_HARDWARE_PROFILE or env override}"
+MODEL_PATH=${MODEL_PATH:-$MODEL}
+SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-$MODEL}
+case "$KVBM_TRANSFER_TOPOLOGY" in
+  nixl-pd|kvbm-hub) ;;
+  *) echo "KVBM_TRANSFER_TOPOLOGY must be nixl-pd or kvbm-hub, got $KVBM_TRANSFER_TOPOLOGY" >&2; exit 2 ;;
+esac
+if [[ -z "${KVBM_HUB_PREFILL_URL+x}" ]]; then
+  if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+    KVBM_HUB_PREFILL_URL="http://$KVBM_HUB_PREFILL_HOST:$KVBM_HUB_PREFILL_HTTP_PORT"
+  else
+    KVBM_HUB_PREFILL_URL="http://$FRONTEND_HOST:$HTTP_PORT"
+  fi
+fi
+if [[ -z "${FRONTEND_ENFORCE_DISAGG+x}" ]]; then
+  if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+    FRONTEND_ENFORCE_DISAGG=0
+  else
+    FRONTEND_ENFORCE_DISAGG=1
+  fi
+fi
+case "$KVBM_BLOCK_LAYOUT" in
+  operational|universal) ;;
+  *) echo "KVBM_BLOCK_LAYOUT must be operational or universal, got $KVBM_BLOCK_LAYOUT" >&2; exit 2 ;;
+esac
+case "$KVBM_ONBOARD_MODE" in
+  inter|intra) ;;
+  *) echo "KVBM_ONBOARD_MODE must be inter or intra, got $KVBM_ONBOARD_MODE" >&2; exit 2 ;;
+esac
+case "$KVBM_TRANSFER_SUBSTRATE_PREFLIGHT" in
+  auto|strict|warn|0|false|off) ;;
+  *) echo "KVBM_TRANSFER_SUBSTRATE_PREFLIGHT must be auto, strict, warn, or 0, got $KVBM_TRANSFER_SUBSTRATE_PREFLIGHT" >&2; exit 2 ;;
+esac
+case "$KVBM_CLEANUP_STALE_PROCESSES" in
+  1|true|yes|on) KVBM_CLEANUP_STALE_PROCESSES=1 ;;
+  0|false|no|off) KVBM_CLEANUP_STALE_PROCESSES=0 ;;
+  *) echo "KVBM_CLEANUP_STALE_PROCESSES must be boolean, got $KVBM_CLEANUP_STALE_PROCESSES" >&2; exit 2 ;;
+esac
 case "$NODE_ROLE" in
   all)
     : "${GPU_MEMORY_UTILIZATION:?GPU_MEMORY_UTILIZATION must be set by KVBM_HARDWARE_PROFILE or env override}"
@@ -50,7 +111,7 @@ case "$NODE_ROLE" in
     : "${MAX_MODEL_LEN:?MAX_MODEL_LEN must be set by KVBM_HARDWARE_PROFILE or env override}"
     : "${MAX_NUM_SEQS:?MAX_NUM_SEQS must be set by KVBM_HARDWARE_PROFILE or env override}"
     : "${CPU_CACHE_GB:?CPU_CACHE_GB must be set by KVBM_HARDWARE_PROFILE or env override}"
-    DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES:-}}
+    DECODE_CUDA_VISIBLE_DEVICES=${DECODE_CUDA_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES:-0}}
     : "${DECODE_CUDA_VISIBLE_DEVICES:?DECODE_CUDA_VISIBLE_DEVICES or CUDA_VISIBLE_DEVICES is required for NODE_ROLE=decode}"
     ;;
   prefill)
@@ -59,7 +120,7 @@ case "$NODE_ROLE" in
     : "${MAX_MODEL_LEN:?MAX_MODEL_LEN must be set by KVBM_HARDWARE_PROFILE or env override}"
     : "${MAX_NUM_SEQS:?MAX_NUM_SEQS must be set by KVBM_HARDWARE_PROFILE or env override}"
     : "${CPU_CACHE_GB:?CPU_CACHE_GB must be set by KVBM_HARDWARE_PROFILE or env override}"
-    PREFILL_CUDA_VISIBLE_DEVICES=${PREFILL_CUDA_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES:-}}
+    PREFILL_CUDA_VISIBLE_DEVICES=${PREFILL_CUDA_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES:-0}}
     : "${PREFILL_CUDA_VISIBLE_DEVICES:?PREFILL_CUDA_VISIBLE_DEVICES or CUDA_VISIBLE_DEVICES is required for NODE_ROLE=prefill}"
     ;;
 esac
@@ -70,7 +131,9 @@ if [[ "$ISOLATE_HF_CACHE" == "1" ]]; then
   export HF_HUB_CACHE="$HF_HOME/hub"
   export TRANSFORMERS_CACHE="$HF_HOME/transformers"
 fi
+
 exec > >(tee "$ARTIFACT_DIR/${NODE_ROLE}.log") 2>&1
+kvbm_xdc_prepare_runtime
 
 cd "$WORKTREE"
 
@@ -83,14 +146,21 @@ export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
 
 cat >"$ARTIFACT_DIR/metadata.env" <<EOF
 timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-experiment=E
-topology=dynamo-native-kvbm-disagg
+experiment=$KVBM_EXPERIMENT_ID
+transfer_topology=$KVBM_TRANSFER_TOPOLOGY
+topology=$(if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then printf 'dynamo-native-kvbm-hub'; else printf 'dynamo-native-kvbm-nixl-diagnostic'; fi)
+experiment_e_transfer_path=kvbm-hub-conditional-disagg-required
+experiment_e_complete=false
+experiment_e_smoke_valid=false
 hardware_profile=$KVBM_HARDWARE_PROFILE
 gpu_class=$GPU_CLASS
 node_role=$NODE_ROLE
-hostname=$(hostname)
-worktree=$WORKTREE
-model=$MODEL
+node_label=${NODE_LABEL:-redacted}
+hostname_redacted=true
+worktree_redacted=true
+model=$SERVED_MODEL_NAME
+model_load_path=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$MODEL_PATH"; elif [[ "$MODEL_PATH" == "$MODEL" ]]; then printf 'same-as-model'; else printf 'redacted'; fi)
+model_load_path_redacted=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" || "$MODEL_PATH" == "$MODEL" ]]; then printf 'false'; else printf 'true'; fi)
 framework=dynamo.vllm
 frontend=dynamo.frontend
 raw_vllm=false
@@ -98,52 +168,247 @@ endpoint_type=chat
 streaming=true
 namespace=$NAMESPACE
 http_port=$HTTP_PORT
-frontend_host=$FRONTEND_HOST
+frontend_host=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$FRONTEND_HOST"; else printf 'redacted'; fi)
 discovery_backend=$DYN_DISCOVERY_BACKEND
 request_plane=$DYN_REQUEST_PLANE
 event_plane=$DYN_EVENT_PLANE
-etcd_endpoints=$ETCD_ENDPOINTS
-nats_server=$NATS_SERVER
+etcd_endpoints=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$ETCD_ENDPOINTS"; else printf 'redacted'; fi)
+nats_server=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$NATS_SERVER"; else printf 'redacted'; fi)
 max_model_len=${MAX_MODEL_LEN:-}
 max_num_seqs=${MAX_NUM_SEQS:-}
 cpu_cache_gb=${CPU_CACHE_GB:-}
 enforce_eager=$ENFORCE_EAGER
 vllm_runner=$VLLM_RUNNER
+num_gpu_blocks_override=${NUM_GPU_BLOCKS_OVERRIDE:-}
 kvbm_connector_module_path=$KVBM_CONNECTOR_MODULE_PATH
 prefill_kv_connector_wrapper=$PREFILL_KV_CONNECTOR_WRAPPER
+kvbm_hub_url=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$KVBM_HUB_URL"; else printf 'redacted'; fi)
+kvbm_hub_prefill_url=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$KVBM_HUB_PREFILL_URL"; else printf 'redacted'; fi)
+kvbm_hub_prefill_namespace=$KVBM_HUB_PREFILL_NAMESPACE
+kvbm_hub_prefill_http_port=$KVBM_HUB_PREFILL_HTTP_PORT
+kvbm_hub_prefill_dispatcher=dynamo-prefill-completions-shim
+kvbm_block_layout=$KVBM_BLOCK_LAYOUT
+kvbm_onboard_mode=$KVBM_ONBOARD_MODE
+kvbm_worker_nixl_backends=${KVBM_WORKER_NIXL_BACKENDS:-}
+kvbm_transfer_substrate_preflight=$KVBM_TRANSFER_SUBSTRATE_PREFLIGHT
+kvbm_allow_substrate_failure_artifact=$KVBM_ALLOW_SUBSTRATE_FAILURE_ARTIFACT
 decode_cuda_visible_devices=${DECODE_CUDA_VISIBLE_DEVICES:-}
 prefill_cuda_visible_devices=${PREFILL_CUDA_VISIBLE_DEVICES:-}
-decode_side_channel_host=${DECODE_SIDE_CHANNEL_HOST:-}
-prefill_side_channel_host=${PREFILL_SIDE_CHANNEL_HOST:-}
-trace_renderer=.claude/skills/disagg-trace/cd-trace.py
+decode_side_channel_host=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "${DECODE_SIDE_CHANNEL_HOST:-}"; else printf 'redacted'; fi)
+prefill_side_channel_host=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "${PREFILL_SIDE_CHANNEL_HOST:-}"; else printf 'redacted'; fi)
+network_endpoints_redacted=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf 'false'; else printf 'true'; fi)
+trace_renderer=examples/backends/vllm/launch/kvbm_xdc/kvbm-xdc-trace.py
+enable_permute_local_kv=$ENABLE_PERMUTE_LOCAL_KV
+vllm_kv_cache_layout=$VLLM_KV_CACHE_LAYOUT
+rust_log=$RUST_LOG
+dyn_log=$DYN_LOG
+kvbm_plain_audit=$KVBM_PLAIN_AUDIT
+ucx_rcache_max_unreleased=${UCX_RCACHE_MAX_UNRELEASED:-}
+ucx_tls=${UCX_TLS:-}
+ucx_net_devices=${UCX_NET_DEVICES:-}
+kvbm_force_ucx_local_fallback=$KVBM_FORCE_UCX_LOCAL_FALLBACK
+frontend_enforce_disagg=$FRONTEND_ENFORCE_DISAGG
+serve_only=$KVBM_SERVE_ONLY
 start_local_infra=$START_LOCAL_INFRA
-infra_host=$INFRA_HOST
+cleanup_stale_processes=$KVBM_CLEANUP_STALE_PROCESSES
+transfer_evidence_timeout=$TRANSFER_EVIDENCE_TIMEOUT
+infra_host=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "$INFRA_HOST"; else printf 'redacted'; fi)
 prefetch_model=$PREFETCH_MODEL
 isolate_hf_cache=$ISOLATE_HF_CACHE
-hf_home=${HF_HOME:-}
-hf_hub_cache=${HF_HUB_CACHE:-}
-transformers_cache=${TRANSFORMERS_CACHE:-}
+hf_home=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "${HF_HOME:-}"; else printf 'redacted'; fi)
+hf_hub_cache=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "${HF_HUB_CACHE:-}"; else printf 'redacted'; fi)
+transformers_cache=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf '%s' "${TRANSFORMERS_CACHE:-}"; else printf 'redacted'; fi)
+cache_paths_redacted=$(if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then printf 'false'; else printf 'true'; fi)
 EOF
+
+stop_tracked_pid() {
+  local name=$1
+  local pid=${2:-}
+  [[ -n "$pid" ]] || return 1
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "[smoke] stop $name pid=$pid"
+    kill "$pid" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
+force_kill_tracked_pid() {
+  local name=$1
+  local pid=${2:-}
+  [[ -n "$pid" ]] || return 0
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "[smoke] force stop $name pid=$pid"
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
 
 cleanup() {
   set +e
-  pkill -f "dynamo.frontend" 2>/dev/null
-  pkill -f "dynamo.vllm" 2>/dev/null
-  pkill -f "EngineCore" 2>/dev/null
-  if [[ -n "${ETCD_PID:-}" ]]; then kill "$ETCD_PID" 2>/dev/null; fi
-  if [[ -n "${NATS_PID:-}" ]]; then kill "$NATS_PID" 2>/dev/null; fi
+  if [[ "$KVBM_CLEANUP_STALE_PROCESSES" == "1" ]]; then
+    pkill -f "dynamo[.]frontend" 2>/dev/null
+    pkill -f "dynamo[.]vllm" 2>/dev/null
+    pkill -f "[k]vbm-prefill-completions-shim[.]py" 2>/dev/null
+    pkill -f "[E]ngineCore" 2>/dev/null
+    pkill -x "kvbm_hub" 2>/dev/null
+  fi
+  local tracked_pid_stopped=0
+  if stop_tracked_pid frontend "${FRONTEND_PID:-}"; then tracked_pid_stopped=1; fi
+  if stop_tracked_pid decode "${DECODE_PID:-}"; then tracked_pid_stopped=1; fi
+  if stop_tracked_pid prefill "${PREFILL_PID:-}"; then tracked_pid_stopped=1; fi
+  if stop_tracked_pid hub "${HUB_PID:-}"; then tracked_pid_stopped=1; fi
+  if stop_tracked_pid hub-prefill-frontend "${HUB_PREFILL_FRONTEND_PID:-}"; then tracked_pid_stopped=1; fi
+  if stop_tracked_pid etcd "${ETCD_PID:-}"; then tracked_pid_stopped=1; fi
+  if stop_tracked_pid nats "${NATS_PID:-}"; then tracked_pid_stopped=1; fi
+  if [[ "$tracked_pid_stopped" == "1" ]]; then
+    sleep 1
+  fi
+  force_kill_tracked_pid frontend "${FRONTEND_PID:-}"
+  force_kill_tracked_pid decode "${DECODE_PID:-}"
+  force_kill_tracked_pid prefill "${PREFILL_PID:-}"
+  force_kill_tracked_pid hub "${HUB_PID:-}"
+  force_kill_tracked_pid hub-prefill-frontend "${HUB_PREFILL_FRONTEND_PID:-}"
+  force_kill_tracked_pid etcd "${ETCD_PID:-}"
+  force_kill_tracked_pid nats "${NATS_PID:-}"
   set -e
+}
+
+write_failure_trace_gate() {
+  local raw_reason=${1:-smoke_failed}
+  local reason
+  reason=$(printf '%s' "$raw_reason" | tr -c 'A-Za-z0-9_.:-' '_')
+  reason=${reason%_}
+  reason=${reason:-smoke_failed}
+
+  [[ -f "$ARTIFACT_DIR/trace-gate.env" ]] && return 0
+
+  local trace_html_bytes=0
+  if [[ -f "$ARTIFACT_DIR/trace.html" ]]; then
+    trace_html_bytes=$(wc -c < "$ARTIFACT_DIR/trace.html" 2>/dev/null || echo 0)
+  fi
+
+  local runtime_probe_passed=false
+  if grep -q '"probe_passed": true' "$ARTIFACT_DIR/runtime-probe.json" 2>/dev/null; then
+    runtime_probe_passed=true
+  fi
+
+  {
+    echo "trace_useful=false"
+    echo "useful_trace_complete=false"
+    echo "reason=$reason"
+    echo "experiment=$KVBM_EXPERIMENT_ID"
+    echo "transfer_topology=$KVBM_TRANSFER_TOPOLOGY"
+    echo "experiment_e_complete=false"
+    echo "experiment_e_smoke_valid=false"
+    if [[ "$KVBM_EXPERIMENT_ID" == "E" && "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+      echo "experiment_e_aiperf_required=true"
+    else
+      echo "experiment_e_aiperf_required=false"
+    fi
+    echo "runtime_probe_passed=$runtime_probe_passed"
+    echo "trace_html_bytes=$trace_html_bytes"
+  } > "$ARTIFACT_DIR/trace-gate.env"
 }
 
 fail() {
   echo "SMOKE_FAIL: $*" >&2
-  for log in frontend decode prefill client; do
+  if declare -F render_trace >/dev/null 2>&1; then
+    render_trace || true
+  fi
+  write_failure_trace_gate "$*"
+  for log in frontend hub-prefill-frontend hub decode prefill client; do
     if [[ -f "$ARTIFACT_DIR/$log.log" ]]; then
       echo "--- tail $log.log ---" >&2
       tail -n 100 "$ARTIFACT_DIR/$log.log" | sed 's/\x1b\[[0-9;]*m//g' >&2
     fi
   done
   exit 1
+}
+
+write_substrate_preflight_failure() {
+  local reason=$1
+  local peermem_state=$2
+
+  {
+    echo "trace_useful=false"
+    echo "useful_trace_complete=false"
+    echo "reason=$reason"
+    echo "experiment=$KVBM_EXPERIMENT_ID"
+    echo "transfer_topology=$KVBM_TRANSFER_TOPOLOGY"
+    echo "experiment_e_complete=false"
+    echo "experiment_e_smoke_valid=false"
+    echo "experiment_e_aiperf_required=true"
+    echo "runtime_probe=not_run"
+    echo "nvidia_peermem=$peermem_state"
+  } > "$ARTIFACT_DIR/trace-gate.env"
+
+  {
+    echo "# Experiment E Same-Node Verdict"
+    echo
+    echo "status=not_benchmark_valid"
+    echo "reason=$reason"
+    echo "runtime_probe=not_run"
+    echo "experiment_e_complete=false"
+    echo "experiment_e_smoke_valid=false"
+    echo "trace_useful=false"
+    echo "nvidia_peermem=$peermem_state"
+    echo "model=$SERVED_MODEL_NAME"
+    echo "framework=dynamo.vllm"
+    echo "endpoint_type=chat"
+    echo "streaming=true"
+    echo
+    echo "This preflight fails before launch because the selected KVBM+hub host-cache path requires a working NIXL/UCX transfer substrate. Re-run on a verified H100/A100 substrate or set KVBM_ALLOW_SUBSTRATE_FAILURE_ARTIFACT=1 only when intentionally collecting a failure artifact."
+  } > "$ARTIFACT_DIR/verdict.md"
+}
+
+transfer_substrate_preflight() {
+  case "$KVBM_TRANSFER_SUBSTRATE_PREFLIGHT" in
+    0|false|off) return 0 ;;
+  esac
+  [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]] || return 0
+  case "$NODE_ROLE" in
+    all|decode|prefill) ;;
+    *) return 0 ;;
+  esac
+  [[ "${CPU_CACHE_GB:-0}" != "0" ]] || return 0
+  case "$GPU_CLASS" in
+    *H100*|*A100*) ;;
+    *) return 0 ;;
+  esac
+
+  local peermem_state=loaded
+  if [[ ! -d /sys/module/nvidia_peermem ]]; then
+    peermem_state=missing
+  fi
+
+  {
+    echo "nvidia_peermem=$peermem_state"
+    echo "gpu_class=$GPU_CLASS"
+    echo "transfer_topology=$KVBM_TRANSFER_TOPOLOGY"
+    echo "cpu_cache_gb=${CPU_CACHE_GB:-}"
+    echo "node_role=$NODE_ROLE"
+  } > "$ARTIFACT_DIR/substrate-preflight.env"
+
+  local strict_gate=0
+  if [[ "$KVBM_TRANSFER_SUBSTRATE_PREFLIGHT" == "strict" ]]; then
+    strict_gate=1
+  elif [[ "$KVBM_TRANSFER_SUBSTRATE_PREFLIGHT" == "auto" && "$KVBM_EXPERIMENT_ID" == "E" ]]; then
+    strict_gate=1
+  fi
+
+  if [[ "$peermem_state" == "missing" && "$strict_gate" == "1" && "$KVBM_ALLOW_SUBSTRATE_FAILURE_ARTIFACT" != "1" ]]; then
+    write_substrate_preflight_failure kvbm_transfer_substrate_preflight_failed "$peermem_state"
+    echo "SUBSTRATE_PREFLIGHT_FAIL: nvidia_peermem is missing for KVBM+hub host-cache H100/A100 run" >&2
+    echo "SUBSTRATE_PREFLIGHT_FAIL: artifact_dir=$ARTIFACT_DIR" >&2
+    exit 2
+  fi
+
+  if [[ "$peermem_state" == "missing" ]]; then
+    echo "[smoke] transfer substrate preflight warning: nvidia_peermem=missing; artifact is diagnostic unless transfer evidence later proves the path" >&2
+    return 0
+  fi
+
+  echo "[smoke] transfer substrate preflight: nvidia_peermem=$peermem_state"
 }
 
 start_local_infra() {
@@ -182,10 +447,16 @@ start_local_infra() {
 }
 
 prefetch_model() {
+  if [[ -d "$MODEL_PATH" ]]; then
+    echo "[smoke] use local model snapshot path for $SERVED_MODEL_NAME"
+    printf '%s\n' "$MODEL_PATH" > "$ARTIFACT_DIR/model-snapshot-path.txt"
+    return 0
+  fi
+
   [[ "$PREFETCH_MODEL" == "1" ]] || return 0
 
-  echo "[smoke] prefetch model cache for $MODEL"
-  "$VENV/bin/python" - "$MODEL" "$ARTIFACT_DIR/model-snapshot-path.txt" <<'PY'
+  echo "[smoke] prefetch model cache for $MODEL_PATH"
+  "$PYTHON_BIN" - "$MODEL_PATH" "$ARTIFACT_DIR/model-snapshot-path.txt" <<'PY'
 import os
 import sys
 
@@ -201,11 +472,116 @@ print("HF_HUB_CACHE=" + os.environ.get("HF_HUB_CACHE", ""))
 PY
 }
 
+runtime_probe() {
+  echo "[smoke] runtime probe: Python imports, torch CUDA, and device matmul"
+  "$PYTHON_BIN" - \
+    "$ARTIFACT_DIR/runtime-probe.json" \
+    "$NODE_ROLE" \
+    "${DECODE_CUDA_VISIBLE_DEVICES:-}" \
+    "${PREFILL_CUDA_VISIBLE_DEVICES:-}" <<'PY'
+import importlib
+import json
+import sys
+
+out_path, node_role, decode_devices, prefill_devices = sys.argv[1:5]
+imports = [
+    "dynamo._core",
+    "dynamo.vllm.handlers",
+    "kvbm",
+    "torch",
+    "vllm",
+]
+loaded = {}
+for name in imports:
+    module = importlib.import_module(name)
+    loaded[name] = getattr(module, "__file__", "built-in")
+
+import torch
+
+if not torch.cuda.is_available():
+    raise SystemExit("torch.cuda.is_available() is false")
+
+device_count = torch.cuda.device_count()
+requested = []
+for raw in (decode_devices, prefill_devices):
+    for part in raw.split(","):
+        part = part.strip()
+        if part.isdigit():
+            idx = int(part)
+            if idx not in requested:
+                requested.append(idx)
+
+if node_role == "all" and len(requested) < 2:
+    raise SystemExit(
+        f"NODE_ROLE=all requires distinct decode/prefill CUDA device ids; got {requested}"
+    )
+
+for idx in requested:
+    if idx >= device_count:
+        raise SystemExit(
+            f"requested CUDA device {idx} is outside torch device_count={device_count}"
+        )
+    torch.cuda.set_device(idx)
+    a = torch.ones((8, 8), device=f"cuda:{idx}")
+    b = a @ a
+    torch.cuda.synchronize(idx)
+    if float(b[0, 0].item()) != 8.0:
+        raise SystemExit(f"unexpected CUDA matmul result on device {idx}")
+
+result = {
+    "imports": loaded,
+    "torch_cuda_available": True,
+    "torch_cuda_device_count": device_count,
+    "requested_cuda_devices": requested,
+    "probe": "imports_cuda_matmul",
+    "probe_passed": True,
+}
+with open(out_path, "w", encoding="utf-8") as f:
+    json.dump(result, f, indent=2, sort_keys=True)
+print(json.dumps(result, indent=2, sort_keys=True))
+print("RUNTIME_PROBE_PASS")
+PY
+}
+
+start_kvbm_hub() {
+  [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]] || return 0
+
+  local logged_prefill_url=redacted
+  if [[ "$KVBM_RECORD_NETWORK_ENDPOINTS" == "1" ]]; then
+    logged_prefill_url=$KVBM_HUB_PREFILL_URL
+  fi
+  echo "[smoke] start kvbm_hub dispatcher prefill_url=$logged_prefill_url"
+  env KVBM_REPO="$WORKTREE" KVBM_HUB_MODEL="$SERVED_MODEL_NAME" \
+    KVBM_HUB_PREFILL_URL="$KVBM_HUB_PREFILL_URL" \
+    RUST_LOG="$RUST_LOG" \
+    KVBM_PLAIN_AUDIT="$KVBM_PLAIN_AUDIT" \
+    bash "$SCRIPT_DIR/launch-kvbm-hub.sh" "$ARTIFACT_DIR/hub.log" &
+  HUB_PID=$!
+  echo "[smoke] kvbm_hub pid=$HUB_PID"
+}
+
+start_hub_prefill_frontend() {
+  [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]] || return 0
+
+  echo "[smoke] start Dynamo prefill completions shim namespace=$KVBM_HUB_PREFILL_NAMESPACE port=$KVBM_HUB_PREFILL_HTTP_PORT"
+  env WORKTREE="$WORKTREE" VENV="$VENV" PYTHON_BIN="$PYTHON_BIN" \
+    MODEL="$SERVED_MODEL_NAME" \
+    NAMESPACE="$KVBM_HUB_PREFILL_NAMESPACE" \
+    KVBM_HUB_PREFILL_ENDPOINT="$KVBM_HUB_PREFILL_NAMESPACE.backend.generate" \
+    KVBM_HUB_PREFILL_SHIM_HOST="$KVBM_HUB_PREFILL_HOST" \
+    KVBM_HUB_PREFILL_SHIM_PORT="$KVBM_HUB_PREFILL_HTTP_PORT" \
+    SOURCE_KVBM_RUNTIME_ENV="$SOURCE_KVBM_RUNTIME_ENV" \
+    bash "$SCRIPT_DIR/launch-kvbm-prefill-shim.sh" \
+    >"$ARTIFACT_DIR/hub-prefill-frontend.log" 2>&1 &
+  HUB_PREFILL_FRONTEND_PID=$!
+  echo "[smoke] prefill completions shim pid=$HUB_PREFILL_FRONTEND_PID"
+}
+
 wait_for_frontend() {
   local deadline=$(( $(date +%s) + READY_TIMEOUT ))
   local status_logged=0
   until curl -fsS -m 5 "http://$FRONTEND_HOST:$HTTP_PORT/v1/models" >"$ARTIFACT_DIR/models.json" 2>"$ARTIFACT_DIR/models.err" \
-    && "$VENV/bin/python" - "$ARTIFACT_DIR/models.json" "$MODEL" <<'PY'
+    && "$PYTHON_BIN" - "$ARTIFACT_DIR/models.json" "$SERVED_MODEL_NAME" <<'PY'
 import json
 import sys
 
@@ -226,6 +602,9 @@ PY
     if [[ -n "${PREFILL_PID:-}" ]]; then
       kill -0 "$PREFILL_PID" 2>/dev/null || fail "prefill worker exited before frontend ready"
     fi
+    if [[ -n "${HUB_PID:-}" ]]; then
+      kill -0 "$HUB_PID" 2>/dev/null || fail "kvbm_hub exited before frontend ready"
+    fi
     if [[ "$status_logged" == "0" && -s "$ARTIFACT_DIR/models.json" ]]; then
       echo "[smoke] frontend answered, waiting for model registration"
       cat "$ARTIFACT_DIR/models.json"
@@ -239,76 +618,181 @@ PY
   echo
 }
 
+wait_for_frontend_chat_route() {
+  local deadline=$(( $(date +%s) + READY_TIMEOUT ))
+  local frontend_log="$ARTIFACT_DIR/frontend.log"
+  echo "[smoke] wait for frontend chat route"
+  while ! grep -aEq "Chat completions is ready|chat endpoints enabled" "$frontend_log" 2>/dev/null; do
+    [[ "$(date +%s)" -ge "$deadline" ]] && fail "frontend chat route not ready after ${READY_TIMEOUT}s"
+    if [[ -n "${FRONTEND_PID:-}" ]]; then
+      kill -0 "$FRONTEND_PID" 2>/dev/null || fail "frontend exited before chat route ready"
+    fi
+    if [[ -n "${DECODE_PID:-}" ]]; then
+      kill -0 "$DECODE_PID" 2>/dev/null || fail "decode worker exited before frontend chat route ready"
+    fi
+    if [[ -n "${PREFILL_PID:-}" ]]; then
+      kill -0 "$PREFILL_PID" 2>/dev/null || fail "prefill worker exited before frontend chat route ready"
+    fi
+    if [[ -n "${HUB_PID:-}" ]]; then
+      kill -0 "$HUB_PID" 2>/dev/null || fail "kvbm_hub exited before frontend chat route ready"
+    fi
+    sleep 1
+  done
+  echo "[smoke] frontend chat route ready"
+}
+
+wait_for_hub_prefill_frontend() {
+  [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]] || return 0
+
+  local deadline=$(( $(date +%s) + READY_TIMEOUT ))
+  local status_logged=0
+  until curl -fsS -m 5 "http://$KVBM_HUB_PREFILL_HOST:$KVBM_HUB_PREFILL_HTTP_PORT/v1/models" >"$ARTIFACT_DIR/hub-prefill-models.json" 2>"$ARTIFACT_DIR/hub-prefill-models.err" \
+    && "$PYTHON_BIN" - "$ARTIFACT_DIR/hub-prefill-models.json" "$SERVED_MODEL_NAME" <<'PY'
+import json
+import sys
+
+path, model = sys.argv[1:3]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+ids = [item.get("id") for item in data.get("data", []) if isinstance(item, dict)]
+raise SystemExit(0 if model in ids else 1)
+PY
+  do
+    [[ "$(date +%s)" -ge "$deadline" ]] && fail "internal prefill frontend not ready after ${READY_TIMEOUT}s"
+    if [[ -n "${HUB_PREFILL_FRONTEND_PID:-}" ]]; then
+      kill -0 "$HUB_PREFILL_FRONTEND_PID" 2>/dev/null || fail "internal prefill frontend exited before ready"
+    fi
+    if [[ -n "${PREFILL_PID:-}" ]]; then
+      kill -0 "$PREFILL_PID" 2>/dev/null || fail "prefill worker exited before internal frontend ready"
+    fi
+    if [[ "$status_logged" == "0" && -s "$ARTIFACT_DIR/hub-prefill-models.json" ]]; then
+      echo "[smoke] internal prefill frontend answered, waiting for model registration"
+      cat "$ARTIFACT_DIR/hub-prefill-models.json"
+      echo
+      status_logged=1
+    fi
+    sleep 5
+  done
+  echo "[smoke] internal prefill frontend model ready"
+  cat "$ARTIFACT_DIR/hub-prefill-models.json"
+  echo
+}
+
 run_client() {
-  echo "[smoke] streaming chat request"
-  "$VENV/bin/python" - "$FRONTEND_HOST" "$HTTP_PORT" "$MODEL" "$ARTIFACT_DIR/chat-stream.jsonl" \
+  echo "[smoke] streaming chat requests (R1 cold, R2 shared-prefix reuse)"
+  "$PYTHON_BIN" - "$FRONTEND_HOST" "$HTTP_PORT" "$SERVED_MODEL_NAME" "$ARTIFACT_DIR" \
     >"$ARTIFACT_DIR/chat-ttft.json" <<'PY'
 import json
 import sys
 import time
 import urllib.request
 
-host, port, model, out_path = sys.argv[1:5]
-payload = {
-    "model": model,
-    "messages": [
-        {
-            "role": "user",
-            "content": (
-                "Explain in four concise sentences why KV cache transfer "
-                "matters for disaggregated LLM serving."
-            ),
-        }
-    ],
-    "max_tokens": 96,
-    "temperature": 0,
-    "stream": True,
-}
+host, port, model, artifact_dir = sys.argv[1:5]
 url = f"http://{host}:{port}/v1/chat/completions"
-req = urllib.request.Request(
-    url,
-    data=json.dumps(payload).encode(),
-    headers={"content-type": "application/json"},
-    method="POST",
+prefix = (
+    "KV cache transfer matters for disaggregated LLM serving because prefill "
+    "and decode often run on different workers. A correct implementation must "
+    "move reusable prefix blocks without recomputing them, preserve request "
+    "ordering, and expose enough telemetry to prove that reuse happened. "
 )
-start = time.perf_counter()
-first_byte = None
-first_token = None
-chunks = 0
-content_chars = 0
-with urllib.request.urlopen(req, timeout=300) as resp, open(out_path, "w") as out:
-    for raw in resp:
-        now = time.perf_counter()
-        if first_byte is None:
-            first_byte = now
-        line = raw.decode("utf-8", errors="replace").strip()
-        if not line:
-            continue
-        out.write(line + "\n")
-        out.flush()
-        if not line.startswith("data: "):
-            continue
-        data = line[len("data: "):]
-        if data == "[DONE]":
-            break
-        chunks += 1
-        obj = json.loads(data)
-        delta = obj["choices"][0].get("delta", {})
-        text = delta.get("content") or ""
-        if text and first_token is None:
-            first_token = now
-        content_chars += len(text)
-end = time.perf_counter()
+prompts = [
+    (
+        "r1",
+        prefix
+        + "Explain this in four concise sentences for an inference engineer.",
+    ),
+    (
+        "r2",
+        prefix
+        + "Now compare the latency implications for a same-node baseline versus "
+        "a cross-datacenter deployment in four concise sentences.",
+    ),
+]
+
+def send(label, prompt):
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 96,
+        "temperature": 0,
+        "stream": True,
+    }
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    first_byte = None
+    first_token = None
+    chunks = 0
+    content_chars = 0
+    stream_path = f"{artifact_dir}/chat-{label}-stream.jsonl"
+    with urllib.request.urlopen(req, timeout=300) as resp, open(stream_path, "w") as out:
+        for raw in resp:
+            now = time.perf_counter()
+            if first_byte is None:
+                first_byte = now
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line:
+                continue
+            out.write(line + "\n")
+            out.flush()
+            if not line.startswith("data: "):
+                continue
+            data = line[len("data: "):]
+            if data == "[DONE]":
+                break
+            chunks += 1
+            obj = json.loads(data)
+            if "error" in obj:
+                print(
+                    "server returned streaming error: "
+                    + json.dumps(obj["error"], sort_keys=True),
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+            if "choices" not in obj:
+                print(
+                    "streaming chunk missing choices: "
+                    + json.dumps(obj, sort_keys=True),
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+            delta = obj["choices"][0].get("delta", {})
+            text = delta.get("content") or ""
+            if text and first_token is None:
+                first_token = now
+            content_chars += len(text)
+    end = time.perf_counter()
+    if first_token is None or chunks < 1 or content_chars < 1:
+        raise SystemExit(f"{label} did not produce streamed text")
+    return {
+        "label": label,
+        "ttfb_seconds": None if first_byte is None else first_byte - start,
+        "ttft_seconds": first_token - start,
+        "total_seconds": end - start,
+        "chunks": chunks,
+        "content_chars": content_chars,
+        "stream_path": stream_path,
+    }
+
+results = [send(label, prompt) for label, prompt in prompts]
+with open(f"{artifact_dir}/chat-metrics.env", "w", encoding="utf-8") as env:
+    env.write(f"successful_streamed_chat_requests={len(results)}\n")
+    for item in results:
+        env.write(f"{item['label']}_ttft_seconds={item['ttft_seconds']:.6f}\n")
+        env.write(f"{item['label']}_chunks={item['chunks']}\n")
+        env.write(f"{item['label']}_content_chars={item['content_chars']}\n")
+
 print(json.dumps({
     "model": model,
     "framework": "dynamo.vllm",
     "endpoint_type": "chat",
     "streaming": True,
-    "ttfb_seconds": None if first_byte is None else first_byte - start,
-    "ttft_seconds": None if first_token is None else first_token - start,
-    "total_seconds": end - start,
-    "chunks": chunks,
-    "content_chars": content_chars,
+    "request_count": len(results),
+    "requests": results,
 }, indent=2, sort_keys=True))
 PY
   cat "$ARTIFACT_DIR/chat-ttft.json"
@@ -320,16 +804,226 @@ render_trace() {
     cp "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/hub.log"
   fi
   touch "$ARTIFACT_DIR/hub.log"
-  "$VENV/bin/python" "$WORKTREE/.claude/skills/disagg-trace/cd-trace.py" "$ARTIFACT_DIR" \
+  "$PYTHON_BIN" "$SCRIPT_DIR/kvbm-xdc-trace.py" "$ARTIFACT_DIR" \
     | tee "$ARTIFACT_DIR/trace-render.log"
+}
+
+grep_count() {
+  local pattern=$1
+  shift
+  { grep -aE "$pattern" "$@" 2>/dev/null || true; } | wc -l | tr -d ' '
+}
+
+wait_for_trace_evidence() {
+  local deadline=$(( $(date +%s) + TRANSFER_EVIDENCE_TIMEOUT ))
+  echo "[smoke] wait for transfer evidence"
+  while true; do
+    local audit_events
+    local transfer_events
+    local dynamo_transfer_metrics
+    local external_cache_hit_events
+    local nixl_transfer_errors
+    audit_events=$(grep_count "kvbm_audit" \
+      "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+    transfer_events=$(grep_count "event=\"(session_pull_rdma_done|worker_session_pull_returned|worker_g2_to_g1_done|transfer_pull_registered|transfer_pull_completed)\"" \
+      "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+    dynamo_transfer_metrics=$(grep_count "KV Transfer metrics: Num successful transfers=[1-9][0-9]*" \
+      "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+    external_cache_hit_events=$(grep_count "External prefix cache hit rate:[[:space:]]*([1-9][0-9]*([.][0-9]+)?|0*[.][0-9]*[1-9][0-9]*)%" \
+      "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+    nixl_transfer_errors=$(grep_count "createXferReq: no potential backend found" \
+      "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+
+    if [[ "$nixl_transfer_errors" -gt 0 ]]; then
+      echo "[smoke] transfer failure evidence observed; validation will fail"
+      return 0
+    fi
+    if [[ "$audit_events" -ge 1 && "$transfer_events" -ge 1 && "$external_cache_hit_events" -ge 1 ]]; then
+      echo "[smoke] audit transfer and external cache-hit evidence observed"
+      return 0
+    fi
+    if [[ "$KVBM_EXPERIMENT_ID" != "E" || "$KVBM_TRANSFER_TOPOLOGY" != "kvbm-hub" ]] \
+      && [[ "$dynamo_transfer_metrics" -ge 1 && "$external_cache_hit_events" -ge 1 ]]; then
+      echo "[smoke] Dynamo transfer metrics and external cache-hit evidence observed"
+      return 0
+    fi
+    if [[ "$(date +%s)" -ge "$deadline" ]]; then
+      echo "[smoke] transfer evidence not observed within ${TRANSFER_EVIDENCE_TIMEOUT}s"
+      return 0
+    fi
+    sleep 1
+  done
+}
+
+validate_useful_trace() {
+  local audit_events
+  local transfer_events
+  local dynamo_transfer_metrics
+  local request_successes
+  local selected_prefill
+  local selected_decode
+  local nixl_transfer_errors
+  local external_cache_hit_events
+  local kv_load_failure_events
+  local client_request_successes
+  local remote_slots_empty_events
+  local remote_slots_nonzero_events
+  local missing_required_role_logs=0
+
+  if [[ "$KVBM_EXPERIMENT_ID" == "E" && "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+    for required_log in frontend hub hub-prefill-frontend decode prefill; do
+      if [[ ! -s "$ARTIFACT_DIR/$required_log.log" ]]; then
+        echo "  missing required Experiment E role log: $required_log.log"
+        missing_required_role_logs=$((missing_required_role_logs + 1))
+      fi
+    done
+  fi
+
+  audit_events=$(grep_count "kvbm_audit" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  transfer_events=$(grep_count "event=\"(session_pull_rdma_done|worker_session_pull_returned|worker_g2_to_g1_done|transfer_pull_registered|transfer_pull_completed)\"" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  dynamo_transfer_metrics=$(grep_count "KV Transfer metrics: Num successful transfers=[1-9][0-9]*" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  request_successes=$(grep_count "request completed .*endpoint.*chat_completions.*status.*success" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  selected_prefill=$(grep_count "Selected worker: worker_type=prefill" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log")
+  selected_decode=$(grep_count "Selected worker: worker_type=decode" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log")
+  nixl_transfer_errors=$(grep_count "createXferReq: no potential backend found" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  external_cache_hit_events=$(grep_count "External prefix cache hit rate:[[:space:]]*([1-9][0-9]*([.][0-9]+)?|0*[.][0-9]*[1-9][0-9]*)%" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  kv_load_failure_events=$(grep_count "Recovered from KV load failure|Onboarding failed|Failed to start onboarding" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  client_request_successes=$(awk -F= '/^successful_streamed_chat_requests=/ {print $2}' "$ARTIFACT_DIR/chat-metrics.env" 2>/dev/null | tail -1)
+  client_request_successes=${client_request_successes:-0}
+  remote_slots_empty_events=$(grep_count "event=\"remote_pipeline_complete_set\".*reason=\"remote_slots_empty\"" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+  remote_slots_nonzero_events=$(grep_count "event=\"commit_usaa1_state_built\".*remote_slots_len=[1-9][0-9]*" \
+    "$ARTIFACT_DIR/hub.log" "$ARTIFACT_DIR/frontend.log" "$ARTIFACT_DIR/decode.log" "$ARTIFACT_DIR/prefill.log")
+
+  echo
+  echo "-- useful trace gate --"
+  echo "  kvbm_audit events: $audit_events"
+  echo "  audit transfer-complete events: $transfer_events"
+  echo "  Dynamo transfer metric events: $dynamo_transfer_metrics"
+  echo "  successful streamed chat completions: $request_successes"
+  echo "  selected prefill workers: $selected_prefill"
+  echo "  selected decode workers: $selected_decode"
+  echo "  external cache-hit events: $external_cache_hit_events"
+  echo "  successful client streamed chat requests: $client_request_successes"
+  echo "  KV load failure events: $kv_load_failure_events"
+  echo "  NIXL createXferReq failures: $nixl_transfer_errors"
+  echo "  remote slots empty events: $remote_slots_empty_events"
+  echo "  remote slots nonzero events: $remote_slots_nonzero_events"
+  echo "  missing required Experiment E role logs: $missing_required_role_logs"
+
+  write_trace_gate() {
+    local useful=$1
+    local reason=$2
+    {
+      echo "trace_useful=$useful"
+      echo "useful_trace_complete=$useful"
+      echo "reason=$reason"
+      echo "experiment=$KVBM_EXPERIMENT_ID"
+      echo "transfer_topology=$KVBM_TRANSFER_TOPOLOGY"
+      echo "experiment_e_complete=false"
+      if [[ "$useful" == "true" && "$KVBM_EXPERIMENT_ID" == "E" && "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" && "$client_request_successes" -ge 2 ]]; then
+        echo "experiment_e_smoke_valid=true"
+      else
+        echo "experiment_e_smoke_valid=false"
+      fi
+      if [[ "$KVBM_EXPERIMENT_ID" == "E" && "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+        echo "experiment_e_aiperf_required=true"
+      else
+        echo "experiment_e_aiperf_required=false"
+      fi
+      echo "trace_html_bytes=$(wc -c < "$ARTIFACT_DIR/trace.html" 2>/dev/null || echo 0)"
+      echo "kvbm_audit_events=$audit_events"
+      echo "audit_transfer_complete_events=$transfer_events"
+      echo "dynamo_transfer_metric_events=$dynamo_transfer_metrics"
+      echo "successful_streamed_chat_completions=$request_successes"
+      echo "successful_client_streamed_chat_requests=$client_request_successes"
+      echo "selected_prefill_workers=$selected_prefill"
+      echo "selected_decode_workers=$selected_decode"
+      echo "external_cache_hit_events=$external_cache_hit_events"
+      echo "kv_load_failure_events=$kv_load_failure_events"
+      echo "nixl_create_xfer_req_failures=$nixl_transfer_errors"
+      echo "remote_slots_empty_events=$remote_slots_empty_events"
+      echo "remote_slots_nonzero_events=$remote_slots_nonzero_events"
+      echo "missing_required_experiment_e_role_logs=$missing_required_role_logs"
+    } > "$ARTIFACT_DIR/trace-gate.env"
+  }
+
+  if [[ "$missing_required_role_logs" -gt 0 ]]; then
+    write_trace_gate false missing_required_experiment_e_role_logs
+    echo "TRACE_NOT_USEFUL: Experiment E split-role validation is missing required role logs" >&2
+    return 2
+  fi
+  if [[ "$nixl_transfer_errors" -gt 0 ]]; then
+    write_trace_gate false nixl_transfer_backend_failure
+    echo "TRACE_NOT_USEFUL: NIXL transfer backend failure was captured" >&2
+    return 2
+  fi
+  if [[ "$kv_load_failure_events" -gt 0 ]]; then
+    write_trace_gate false kv_load_failure
+    echo "TRACE_NOT_USEFUL: KV load failure was captured" >&2
+    return 2
+  fi
+  if [[ "$external_cache_hit_events" -lt 1 ]]; then
+    write_trace_gate false no_external_cache_reuse
+    echo "TRACE_NOT_USEFUL: no positive external cache-hit evidence was captured" >&2
+    return 2
+  fi
+  if [[ "$client_request_successes" -lt 2 ]]; then
+    write_trace_gate false incomplete_r1_r2_chat_smoke
+    echo "TRACE_NOT_USEFUL: R1/R2 streamed chat smoke did not complete" >&2
+    return 2
+  fi
+  if [[ "$audit_events" -ge 1 && "$transfer_events" -ge 1 ]]; then
+    write_trace_gate true kvbm_audit_transfer_chain_and_cache_reuse
+    echo "TRACE_USEFUL: real KVBM transfer audit chain and external cache reuse captured"
+    return 0
+  fi
+  if [[ "$KVBM_EXPERIMENT_ID" == "E" && "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+    if [[ "$remote_slots_empty_events" -gt 0 ]]; then
+      write_trace_gate false remote_slots_empty
+      echo "TRACE_NOT_USEFUL: Experiment E did not create a remote destination slice" >&2
+    elif [[ "$remote_slots_nonzero_events" -gt 0 ]]; then
+      write_trace_gate false remote_slots_nonzero_without_destination_pull
+      echo "TRACE_NOT_USEFUL: Experiment E created remote slots but no destination pull/completion evidence" >&2
+    else
+      write_trace_gate false no_destination_transfer_evidence
+      echo "TRACE_NOT_USEFUL: Experiment E requires destination pull/completion transfer evidence" >&2
+    fi
+    return 2
+  fi
+  if [[ "$dynamo_transfer_metrics" -ge 1 && "$request_successes" -ge 1 && "$selected_prefill" -ge 1 && "$selected_decode" -ge 1 ]]; then
+    write_trace_gate true dynamo_vllm_transfer_metrics_and_cache_reuse
+    echo "TRACE_USEFUL: Dynamo vLLM routed chat completion captured successful KV transfer metrics and external cache reuse"
+    return 0
+  fi
+  if [[ "$audit_events" -lt 1 && "$dynamo_transfer_metrics" -lt 1 ]]; then
+    write_trace_gate false no_transfer_evidence
+    echo "TRACE_NOT_USEFUL: real KVBM transfer audit chain was not captured" >&2
+    return 2
+  fi
+  write_trace_gate false incomplete_routed_transfer_evidence
+  echo "TRACE_NOT_USEFUL: trace did not capture enough routed transfer evidence" >&2
+  return 2
 }
 
 common_env=(
   WORKTREE="$WORKTREE"
   VENV="$VENV"
+  PYTHON_BIN="$PYTHON_BIN"
   KVBM_HARDWARE_PROFILE="$KVBM_HARDWARE_PROFILE"
   GPU_CLASS="$GPU_CLASS"
   MODEL="$MODEL"
+  MODEL_PATH="$MODEL_PATH"
+  SERVED_MODEL_NAME="$SERVED_MODEL_NAME"
   NAMESPACE="$NAMESPACE"
   MAX_MODEL_LEN="${MAX_MODEL_LEN:-}"
   MAX_NUM_SEQS="${MAX_NUM_SEQS:-}"
@@ -339,18 +1033,53 @@ common_env=(
   VLLM_USE_AOT_COMPILE="${VLLM_USE_AOT_COMPILE:-0}"
   VLLM_USE_STANDALONE_COMPILE="${VLLM_USE_STANDALONE_COMPILE:-0}"
   VLLM_ENABLE_V1_MULTIPROCESSING="${VLLM_ENABLE_V1_MULTIPROCESSING:-0}"
+  NUM_GPU_BLOCKS_OVERRIDE="${NUM_GPU_BLOCKS_OVERRIDE:-}"
   KVBM_CONNECTOR_MODULE_PATH="$KVBM_CONNECTOR_MODULE_PATH"
   PREFILL_KV_CONNECTOR_WRAPPER="$PREFILL_KV_CONNECTOR_WRAPPER"
+  SOURCE_KVBM_RUNTIME_ENV="$SOURCE_KVBM_RUNTIME_ENV"
+  KVBM_RUNTIME_ENV_SCRIPT="${KVBM_RUNTIME_ENV_SCRIPT:-}"
+  KVBM_TRANSFER_TOPOLOGY="$KVBM_TRANSFER_TOPOLOGY"
+  KVBM_HUB_URL="$KVBM_HUB_URL"
+  KVBM_BLOCK_LAYOUT="$KVBM_BLOCK_LAYOUT"
+  KVBM_ONBOARD_MODE="$KVBM_ONBOARD_MODE"
+  KVBM_WORKER_NIXL_BACKENDS="$KVBM_WORKER_NIXL_BACKENDS"
+  ENABLE_PERMUTE_LOCAL_KV="$ENABLE_PERMUTE_LOCAL_KV"
+  VLLM_KV_CACHE_LAYOUT="$VLLM_KV_CACHE_LAYOUT"
+  RUST_LOG="$RUST_LOG"
+  DYN_LOG="$DYN_LOG"
+  KVBM_PLAIN_AUDIT="$KVBM_PLAIN_AUDIT"
   PYTHONUNBUFFERED=1
 )
 
 case "$NODE_ROLE" in
   frontend)
     start_local_infra
-    exec env "${common_env[@]}" HTTP_PORT="$HTTP_PORT" \
+    exec env "${common_env[@]}" HTTP_PORT="$HTTP_PORT" ENFORCE_DISAGG="$FRONTEND_ENFORCE_DISAGG" \
       bash "$SCRIPT_DIR/launch-dynamo-frontend.sh"
     ;;
+  hub-prefill-frontend)
+    start_local_infra
+    exec env WORKTREE="$WORKTREE" VENV="$VENV" PYTHON_BIN="$PYTHON_BIN" \
+      KVBM_HARDWARE_PROFILE="$KVBM_HARDWARE_PROFILE" \
+      MODEL="$SERVED_MODEL_NAME" \
+      NAMESPACE="$KVBM_HUB_PREFILL_NAMESPACE" \
+      KVBM_HUB_PREFILL_ENDPOINT="$KVBM_HUB_PREFILL_NAMESPACE.backend.generate" \
+      KVBM_HUB_PREFILL_SHIM_HOST="$KVBM_HUB_PREFILL_HOST" \
+      KVBM_HUB_PREFILL_SHIM_PORT="$KVBM_HUB_PREFILL_HTTP_PORT" \
+      SOURCE_KVBM_RUNTIME_ENV="$SOURCE_KVBM_RUNTIME_ENV" \
+      KVBM_RUNTIME_ENV_SCRIPT="${KVBM_RUNTIME_ENV_SCRIPT:-}" \
+      PYTHONUNBUFFERED=1 \
+      bash "$SCRIPT_DIR/launch-kvbm-prefill-shim.sh"
+    ;;
+  hub)
+    exec env KVBM_REPO="$WORKTREE" KVBM_HUB_MODEL="$SERVED_MODEL_NAME" \
+      KVBM_HUB_PREFILL_URL="$KVBM_HUB_PREFILL_URL" \
+      RUST_LOG="$RUST_LOG" \
+      KVBM_PLAIN_AUDIT="$KVBM_PLAIN_AUDIT" \
+      bash "$SCRIPT_DIR/launch-kvbm-hub.sh" "$ARTIFACT_DIR/hub.log"
+    ;;
   decode)
+    transfer_substrate_preflight
     prefetch_model
     exec env "${common_env[@]}" ROLE=decode CUDA_VISIBLE_DEVICES="${DECODE_CUDA_VISIBLE_DEVICES:-}" \
       GPU_MEMORY_UTILIZATION="$DECODE_GPU_MEMORY_UTILIZATION" \
@@ -358,31 +1087,57 @@ case "$NODE_ROLE" in
       bash "$SCRIPT_DIR/launch-kvbm-vllm.sh"
     ;;
   prefill)
+    transfer_substrate_preflight
     prefetch_model
-    exec env "${common_env[@]}" ROLE=prefill CUDA_VISIBLE_DEVICES="${PREFILL_CUDA_VISIBLE_DEVICES:-}" \
+    prefill_endpoint_env=()
+    if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+      prefill_endpoint_env=(
+        NAMESPACE="$KVBM_HUB_PREFILL_NAMESPACE"
+        ENDPOINT="$KVBM_HUB_PREFILL_NAMESPACE.backend.generate"
+        ENDPOINT_TYPES=completions
+      )
+    fi
+    exec env "${common_env[@]}" "${prefill_endpoint_env[@]}" ROLE=prefill CUDA_VISIBLE_DEVICES="${PREFILL_CUDA_VISIBLE_DEVICES:-}" \
       GPU_MEMORY_UTILIZATION="$PREFILL_GPU_MEMORY_UTILIZATION" KV_EVENTS_PORT="$PREFILL_KV_EVENTS_PORT" \
       SIDE_CHANNEL_HOST="${PREFILL_SIDE_CHANNEL_HOST:-}" SIDE_CHANNEL_PORT="$PREFILL_SIDE_CHANNEL_PORT" \
       bash "$SCRIPT_DIR/launch-kvbm-vllm.sh"
     ;;
   client)
     wait_for_frontend
-    run_client
+    run_client || fail "streaming chat request failed"
+    wait_for_trace_evidence
     render_trace
+    validate_useful_trace
     echo "SMOKE_DONE artifact_dir=$ARTIFACT_DIR trace=$ARTIFACT_DIR/trace.html"
+    ;;
+  trace)
+    wait_for_trace_evidence
+    render_trace
+    validate_useful_trace
+    echo "TRACE_DONE artifact_dir=$ARTIFACT_DIR trace=$ARTIFACT_DIR/trace.html"
     ;;
   all)
     trap cleanup EXIT
-    echo "[smoke] cleanup stale Dynamo processes"
+    if [[ "$KVBM_CLEANUP_STALE_PROCESSES" == "1" ]]; then
+      echo "[smoke] cleanup stale Dynamo processes"
+    else
+      echo "[smoke] skip broad stale-process cleanup; tracked top-level PIDs will still be cleaned on exit"
+    fi
     cleanup
     sleep 2
+    transfer_substrate_preflight
+    runtime_probe || fail "runtime_probe_failed"
     start_local_infra
     prefetch_model
 
     echo "[smoke] start frontend"
-    env "${common_env[@]}" HTTP_PORT="$HTTP_PORT" \
+    env "${common_env[@]}" HTTP_PORT="$HTTP_PORT" ENFORCE_DISAGG="$FRONTEND_ENFORCE_DISAGG" \
       bash "$SCRIPT_DIR/launch-dynamo-frontend.sh" >"$ARTIFACT_DIR/frontend.log" 2>&1 &
     FRONTEND_PID=$!
     echo "[smoke] frontend pid=$FRONTEND_PID"
+
+    start_hub_prefill_frontend
+    start_kvbm_hub
 
     echo "[smoke] start decode dynamo.vllm"
     env "${common_env[@]}" ROLE=decode CUDA_VISIBLE_DEVICES="$DECODE_CUDA_VISIBLE_DEVICES" \
@@ -393,7 +1148,15 @@ case "$NODE_ROLE" in
     echo "[smoke] decode pid=$DECODE_PID"
 
     echo "[smoke] start prefill dynamo.vllm"
-    env "${common_env[@]}" ROLE=prefill CUDA_VISIBLE_DEVICES="$PREFILL_CUDA_VISIBLE_DEVICES" \
+    prefill_endpoint_env=()
+    if [[ "$KVBM_TRANSFER_TOPOLOGY" == "kvbm-hub" ]]; then
+      prefill_endpoint_env=(
+        NAMESPACE="$KVBM_HUB_PREFILL_NAMESPACE"
+        ENDPOINT="$KVBM_HUB_PREFILL_NAMESPACE.backend.generate"
+        ENDPOINT_TYPES=completions
+      )
+    fi
+    env "${common_env[@]}" "${prefill_endpoint_env[@]}" ROLE=prefill CUDA_VISIBLE_DEVICES="$PREFILL_CUDA_VISIBLE_DEVICES" \
       GPU_MEMORY_UTILIZATION="$PREFILL_GPU_MEMORY_UTILIZATION" KV_EVENTS_PORT="$PREFILL_KV_EVENTS_PORT" \
       SIDE_CHANNEL_HOST="${PREFILL_SIDE_CHANNEL_HOST:-}" SIDE_CHANNEL_PORT="$PREFILL_SIDE_CHANNEL_PORT" \
       bash "$SCRIPT_DIR/launch-kvbm-vllm.sh" >"$ARTIFACT_DIR/prefill.log" 2>&1 &
@@ -401,12 +1164,20 @@ case "$NODE_ROLE" in
     echo "[smoke] prefill pid=$PREFILL_PID"
 
     wait_for_frontend
-    run_client
+    wait_for_frontend_chat_route
+    wait_for_hub_prefill_frontend
+    if [[ "$KVBM_SERVE_ONLY" == "1" ]]; then
+      echo "SERVE_READY artifact_dir=$ARTIFACT_DIR url=http://$FRONTEND_HOST:$HTTP_PORT"
+      wait
+    fi
+    run_client || fail "streaming chat request failed"
+    wait_for_trace_evidence
     render_trace
+    validate_useful_trace
     echo "SMOKE_DONE artifact_dir=$ARTIFACT_DIR trace=$ARTIFACT_DIR/trace.html"
     ;;
   *)
-    echo "NODE_ROLE must be all, frontend, decode, prefill, or client; got $NODE_ROLE" >&2
+    echo "NODE_ROLE must be all, frontend, hub-prefill-frontend, hub, decode, prefill, client, or trace; got $NODE_ROLE" >&2
     exit 2
     ;;
 esac

--- a/lib/kvbm-config/README.md
+++ b/lib/kvbm-config/README.md
@@ -213,7 +213,6 @@ Omit entire `[disagg]` section to run in aggregated (non-disagg) mode.
 | Config Path | Type | Default | Description |
 |---|---|---|---|
 | `disagg` | `Option<DisaggConfig>` | None | None = aggregated mode (no hub coordination) |
-| `disagg.hub_url` | `String` | `"http://127.0.0.1:1337"` | kvbm-hub control-plane URL |
 | `disagg.role` | `DisaggregationRole` | required | `prefill` or `decode` |
 
 Typical leader-only JSON (worker ignores `disagg`):
@@ -221,7 +220,8 @@ Typical leader-only JSON (worker ignores `disagg`):
 ```json
 {
   "leader": {
-    "disagg": { "hub_url": "http://127.0.0.1:1337", "role": "prefill" }
+    "hub": { "url": "http://127.0.0.1:1337", "features": ["disagg"] },
+    "disagg": { "role": "prefill" }
   }
 }
 ```


### PR DESCRIPTION
## Summary

This PR is rebased in the current stack on top of #9870, with #9868 based on Ryan's #9972. Its scope is the runtime harness needed to reproduce and inspect KVBM cross-datacenter Experiment E/F: launch scripts, trace rendering, trace gates, AIPerf postcheck wiring, stage attribution, and the prefill completions shim.

I preserved Ryan's #9972 P2P resolver semantics. The puller-side `VeloSessionFactory::attach` resolver change that was useful for standalone smoke convenience has been dropped from this PR. If we still need that behavior for standalone P2P smoke, it should be proposed separately instead of mixed into this harness stack.

## Review Order

1. #9972: Ryan's KVBM engine service base.
2. #9868: experiment coordination and manifests.
3. #9870: protocol glue for `kv_transfer_params`.
4. #9869: this runtime harness and reproduction PR.

## What This Adds

The harness writes a `trace.html`, `trace-gate.env`, AIPerf postcheck output, and stage-attribution summaries. A counted trace must show the KVBM audit transfer chain and cache reuse, and must not show KV load failures or NIXL transfer request failures.

The counted A100+H100 artifact showed the important split: 100 `remote_slots_nonzero` AIPerf requests paid the remote pull/onboard TTFT cost, and 100 `remote_slots_empty` requests were the fast cache-reuse/local cohort. The trace proves the mechanism; it does not isolate WAN latency from hub dispatch, remote prefill service time, local scheduling, and pull mechanics.

## Validation

- `git diff --check rebase9972/9870-kvbm-vllm-kv-transfer-params..rebase9972/9869-kvbm-hub-runtime-harness`
- `bash -n examples/backends/vllm/launch/kvbm_xdc/*.sh .claude/skills/p2p-smoke/*.sh`
- `python3 -B -m py_compile examples/backends/vllm/launch/kvbm_xdc/*.py`
- `PYTHONPATH=components/src python3 -B -m pytest -c /dev/null components/src/dynamo/vllm/tests/test_vllm_kv_connector_protocols.py -q`
- Result: `24 passed, 1 skipped`

I also attempted `cargo test -p kvbm-engine --test velo_session_peer_resolver`, but local macOS compilation failed inside the upstream `velo` crate before reaching this code path: `SockRef::set_tcp_user_timeout` was unavailable.
