### PR TITLE
fix: preserve kv transfer params for prefill

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2631,9 +2631,14 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         )
         if sampling_params.extra_args is None:
             sampling_params.extra_args = {}
+        caller_kv_transfer_params = sampling_params.extra_args.get("kv_transfer_params")
+        if caller_kv_transfer_params is None:
+            request_extra_args = request.get("extra_args")
+            if isinstance(request_extra_args, dict):
+                caller_kv_transfer_params = request_extra_args.get("kv_transfer_params")
         sampling_params.extra_args[
             "kv_transfer_params"
-        ] = kv_protocol.prefill_request_kv_transfer_params()
+        ] = kv_protocol.prefill_request_kv_transfer_params(caller_kv_transfer_params)
         # Override for prefill: only generate 1 token
         sampling_params.max_tokens = 1
         sampling_params.min_tokens = 1
@@ -2681,7 +2686,10 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 os._exit(1)
 
             async for res in gen:
-                logger.debug(f"kv transfer params: {res.kv_transfer_params}")
+                logger.debug(
+                    "prefill response has kv_transfer_params=%s",
+                    res.kv_transfer_params is not None,
+                )
 
                 token_ids = res.outputs[0].token_ids if res.outputs else []
 

--- a/components/src/dynamo/vllm/kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/kv_connector_protocols.py
@@ -26,8 +26,15 @@ class KvConnectorProtocol(ABC):
         self._vllm_config = vllm_config
 
     @abstractmethod
-    def prefill_request_kv_transfer_params(self) -> Dict[str, Any]:
-        """``kv_transfer_params`` for the prefill request to vLLM."""
+    def prefill_request_kv_transfer_params(
+        self, caller_kv_transfer_params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """``kv_transfer_params`` for the prefill request to vLLM.
+
+        ``caller_kv_transfer_params`` is the request-supplied value, when
+        present. Most protocols synthesize their own prefill-side payload and
+        ignore it; KVBM hub conditional-disagg preserves the hub payload.
+        """
 
     @abstractmethod
     def decode_request_kv_transfer_params(
@@ -41,7 +48,9 @@ class KvConnectorProtocol(ABC):
 class NixlConnectorProtocol(KvConnectorProtocol):
     """Pull-based: decode-side params come straight off the engine response."""
 
-    def prefill_request_kv_transfer_params(self) -> Dict[str, Any]:
+    def prefill_request_kv_transfer_params(
+        self, caller_kv_transfer_params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         return {
             "do_remote_decode": True,
             "do_remote_prefill": False,
@@ -84,7 +93,9 @@ class MooncakeConnectorProtocol(KvConnectorProtocol):
         self._get_bootstrap_addr = get_mooncake_bootstrap_addr
         self._transfer_id: str = str(uuid.uuid4())
 
-    def prefill_request_kv_transfer_params(self) -> Dict[str, Any]:
+    def prefill_request_kv_transfer_params(
+        self, caller_kv_transfer_params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         return {
             "do_remote_decode": True,
             "do_remote_prefill": False,
@@ -105,8 +116,46 @@ class MooncakeConnectorProtocol(KvConnectorProtocol):
         }
 
 
+class DynamoConnectorProtocol(KvConnectorProtocol):
+    """KVBM hub conditional-disagg preserves dispatcher transfer params.
+
+    The hub posts a tokenized prefill request whose ``kv_transfer_params`` is a
+    ``kvbm_protocols::disagg::TransferParams`` JSON object. The KVBM
+    ``DynamoConnector`` reads that object directly from the vLLM request, so
+    the Dynamo prefill handler must not replace it with NIXL-style fields.
+    """
+
+    def prefill_request_kv_transfer_params(
+        self, caller_kv_transfer_params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if caller_kv_transfer_params is None:
+            raise ValueError(
+                "DynamoConnector PD prefill requires caller-provided "
+                "kv_transfer_params with top-level remote_prefill"
+            )
+        if not isinstance(caller_kv_transfer_params, dict):
+            raise ValueError(
+                "DynamoConnector PD prefill requires kv_transfer_params to be a dict"
+            )
+        remote_prefill = caller_kv_transfer_params.get("remote_prefill")
+        if not isinstance(remote_prefill, dict):
+            raise ValueError(
+                "DynamoConnector PD prefill requires kv_transfer_params.remote_prefill"
+            )
+        return caller_kv_transfer_params
+
+    def decode_request_kv_transfer_params(
+        self, prefill_response: Any
+    ) -> Optional[Dict[str, Any]]:
+        # KVBM hub conditional-disagg owns the transfer/session lifecycle. The
+        # Dynamo frontend must not synthesize a NIXL decode handoff for this
+        # path.
+        return None
+
+
 # Keyed by ``KVTransferConfig.kv_connector``. One entry per connector.
 KV_CONNECTOR_PROTOCOLS: Dict[str, Type[KvConnectorProtocol]] = {
+    "DynamoConnector": DynamoConnectorProtocol,
     "NixlConnector": NixlConnectorProtocol,
     # KVBM's PdConnector wraps DynamoConnector with NixlConnector. The Dynamo
     # frontend/decode handoff still uses the NIXL child connector's pull-based

--- a/components/src/dynamo/vllm/tests/test_vllm_kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_kv_connector_protocols.py
@@ -21,6 +21,7 @@ import pytest
 
 from dynamo.vllm.kv_connector_protocols import (
     KV_CONNECTOR_PROTOCOLS,
+    DynamoConnectorProtocol,
     KvConnectorProtocol,
     MooncakeConnectorProtocol,
     NixlConnectorProtocol,
@@ -70,7 +71,7 @@ def _install_fake_mooncake(monkeypatch, host: str, port: int) -> None:
 @pytest.fixture
 def fake_mooncake(monkeypatch):
     """Default fake bootstrap helper returning a fixed (host, port)."""
-    _install_fake_mooncake(monkeypatch, "10.0.0.5", 8998)
+    _install_fake_mooncake(monkeypatch, "192.0.2.5", 8998)
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +147,7 @@ def test_mooncake_distinct_instances_get_distinct_transfer_ids(fake_mooncake):
 def test_mooncake_decode_uses_vllm_bootstrap_helper_and_prefixes_http(monkeypatch):
     """Decode bootstrap addr comes from vLLM's helper; ``http://`` is
     non-optional because the decode side does ``addr + "/query"``."""
-    _install_fake_mooncake(monkeypatch, "192.168.0.110", 8998)
+    _install_fake_mooncake(monkeypatch, "192.0.2.110", 8998)
     cfg = _config("MooncakeConnector", engine_id="eng-prefill-0")
     proto = MooncakeConnectorProtocol(cfg)
     params = proto.decode_request_kv_transfer_params(
@@ -156,7 +157,7 @@ def test_mooncake_decode_uses_vllm_bootstrap_helper_and_prefixes_http(monkeypatc
         "do_remote_decode": False,
         "do_remote_prefill": True,
         "transfer_id": params["transfer_id"],
-        "remote_bootstrap_addr": "http://192.168.0.110:8998",
+        "remote_bootstrap_addr": "http://192.0.2.110:8998",
         "remote_engine_id": "eng-prefill-0",
     }
 
@@ -210,6 +211,47 @@ def test_mooncake_decode_does_not_reimport_per_call(fake_mooncake):
 
 
 # ---------------------------------------------------------------------------
+# DynamoConnectorProtocol
+# ---------------------------------------------------------------------------
+
+
+def test_dynamo_connector_preserves_hub_remote_prefill_payload():
+    """KVBM hub dispatch already emits the protocol payload KVBM needs."""
+    proto = DynamoConnectorProtocol(_config("DynamoConnector"))
+    payload = {
+        "remote_prefill": {
+            "protocol_version": 1,
+            "session_id": "54b12bb2-7b73-43cb-b70d-4db3796f174a",
+            "initiator_instance_id": "1339456a-a960-420c-9860-e64702fa692f",
+            "sequence_hashes": ["10", "11"],
+            "num_computed_tokens": 32,
+        }
+    }
+    assert proto.prefill_request_kv_transfer_params(payload) is payload
+
+
+def test_dynamo_connector_returns_no_decode_handoff():
+    proto = DynamoConnectorProtocol(_config("DynamoConnector"))
+    response = SimpleNamespace(kv_transfer_params={"remote_prefill": {}})
+    assert proto.decode_request_kv_transfer_params(response) is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"remote_prefill": None},
+        {"remote_prefill": "not-a-dict"},
+    ],
+)
+def test_dynamo_connector_requires_hub_remote_prefill_payload(payload):
+    proto = DynamoConnectorProtocol(_config("DynamoConnector"))
+    with pytest.raises(ValueError, match="DynamoConnector PD prefill"):
+        proto.prefill_request_kv_transfer_params(payload)
+
+
+# ---------------------------------------------------------------------------
 # Factory + registry
 # ---------------------------------------------------------------------------
 
@@ -227,6 +269,11 @@ def test_make_kv_connector_protocol_dispatches_pdconnector_as_nixl():
 def test_make_kv_connector_protocol_dispatches_mooncake(fake_mooncake):
     proto = make_kv_connector_protocol(_config("MooncakeConnector"))
     assert isinstance(proto, MooncakeConnectorProtocol)
+
+
+def test_make_kv_connector_protocol_dispatches_dynamo_connector():
+    proto = make_kv_connector_protocol(_config("DynamoConnector"))
+    assert isinstance(proto, DynamoConnectorProtocol)
 
 
 def test_make_kv_connector_protocol_falls_back_to_nixl_for_missing_config():
@@ -256,6 +303,7 @@ def test_registry_keys_match_vllm_connector_names():
     """Wire-format guard: KV_CONNECTOR_PROTOCOLS keys must match the strings
     vLLM uses in ``KVTransferConfig.kv_connector``."""
     assert set(KV_CONNECTOR_PROTOCOLS) == {
+        "DynamoConnector",
         "NixlConnector",
         "PdConnector",
         "MooncakeConnector",


### PR DESCRIPTION
## Summary

This PR is rebased in the current stack on top of #9868, which is now based on Ryan's #9972. Its scope is the small protocol glue needed for KVBM hub prefill requests: preserve `kv_transfer_params` through the Dynamo vLLM connector protocol instead of dropping them during request handling.

This is intentionally narrow. It does not carry the runtime harness, trace scripts, AIPerf analysis, or P2P behavior changes.

## Review Order

1. #9972: Ryan's KVBM engine service base.
2. #9868: experiment coordination and manifests.
3. #9870: this protocol glue PR.
4. #9869: runtime harness and reproduction scripts.

## Validation

- `PYTHONPATH=components/src python3 -B -m pytest -c /dev/null components/src/dynamo/vllm/tests/test_vllm_kv_connector_protocols.py -q`
- Result: `24 passed, 1 skipped`
- `git diff --check rebase9972/9868-kvbm-aiperf-manifests-clean..rebase9972/9870-kvbm-vllm-kv-transfer-params`
