### PR TITLE
fix(llm): disable eagle hash mode for prefill router (cherry-pick)

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -771,6 +771,9 @@ impl ModelWatcher {
                     // Create prefill-specific config with track_active_blocks disabled
                     let mut prefill_config = router_config.kv_router_config.clone();
                     prefill_config.router_track_active_blocks = false;
+                    // Prefill KV events are emitted by prefill workers; do not inherit
+                    // decode-only speculative hash mode.
+                    let prefill_enable_eagle = false;
 
                     PrefillRouter::new(
                         rx,
@@ -782,7 +785,7 @@ impl ModelWatcher {
                         router_config.enforce_disagg,
                         model_name.clone(),
                         namespace.clone(),
-                        card.runtime_config.enable_eagle,
+                        prefill_enable_eagle,
                     )
                 });
 


### PR DESCRIPTION
Cherry-pick of #9857 onto release/1.2.0.

Source PR: https://github.com/ai-dynamo/dynamo/pull/9857
Source squash commit on main: fca7c62f276737adaeacebd54f5c537c2c989492
Backport commit: 0e4421491bb

Force the disaggregated prefill router to use prefill-side KV hash semantics instead of inheriting decode-only EAGLE settings. This prevents prefill KV events from being indexed under one hash mode and queried under another.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->