### PR TITLE
fix:  Preventing Silent Data Poisoning and Vector Integrity Loss from Malicious Boolean Inputs

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2904,7 +2904,7 @@ class EmbeddingWorkerHandler:
         prompts: list[Any] = _classify_embedding_input(input_field)
 
         dimensions = request.get("dimensions")
-        if dimensions is not None and not isinstance(dimensions, int):
+        if dimensions is not None and (not isinstance(dimensions, int) or isinstance(dimensions, bool)):
             raise TypeError(
                 f"Invalid 'dimensions' type {type(dimensions).__name__}; "
                 "expected int"

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2767,6 +2767,14 @@ class EmbeddingWorkerHandler:
         config: Config,
         shutdown_event: Optional[asyncio.Event] = None,
     ) -> None:
+        """Initialize the standalone handler for embedding requests.
+
+        Args:
+            runtime: The dynamo runtime instance.
+            engine: The vLLM AsyncLLM engine client.
+            config: The backend configuration.
+            shutdown_event: Optional event to signal engine shutdown.
+        """
         self.runtime = runtime
         self.engine_client = engine
         self.config = config
@@ -2787,12 +2795,17 @@ class EmbeddingWorkerHandler:
         return None
 
     async def _monitor_abort(self, context: Context, request_id: str) -> None:
-        """Background task: abort the encode if context is cancelled or
-        shutdown_event fires. Raises EngineShutdown on shutdown so the
-        ``_abort_monitor`` context manager can propagate it.
+        """Background task: abort the encode if context is cancelled.
 
-        Mirrors ``BaseWorkerHandler._monitor_abort`` but trimmed for the
-        embedding path (no ``is_prefill``, no ``abort_guard``).
+        On cancellation or shutdown, it signals the engine to abort the
+        request. Mirrors ``BaseWorkerHandler._monitor_abort``.
+
+        Args:
+            context: The request context containing cancellation signals.
+            request_id: The unique ID of the request to abort.
+
+        Raises:
+            EngineShutdown: If the engine was shut down during processing.
         """
         shutdown_task: Optional[asyncio.Task] = None
         try:
@@ -2854,9 +2867,11 @@ class EmbeddingWorkerHandler:
 
     @asynccontextmanager
     async def _abort_monitor(self, context: Context, request_id: str):
-        """Create + tear down an abort monitor task around one encode call.
+        """Context manager to monitor request cancellation.
 
-        On exit, re-raises EngineShutdown if the monitor caught a shutdown.
+        Args:
+            context: The request context.
+            request_id: The unique ID of the request.
         """
         task = asyncio.create_task(self._monitor_abort(context, request_id))
         try:

--- a/components/src/dynamo/vllm/tests/test_vllm_embedding_validation.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_embedding_validation.py
@@ -1,81 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for boolean validation of the dimensions parameter in vLLM embeddings."""
+"""Minimal unit tests for boolean validation of the dimensions parameter."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from dynamo.vllm.handlers import EmbeddingWorkerHandler
 
-pytestmark = [
-    pytest.mark.unit,
-    pytest.mark.vllm,
-    pytest.mark.core,
-    pytest.mark.gpu_0,
-    pytest.mark.pre_merge,
-]
+pytestmark = [pytest.mark.unit, pytest.mark.vllm, pytest.mark.pre_merge]
 
 
 @pytest.mark.asyncio
 async def test_embedding_handler_rejects_boolean_dimensions():
-    """Verify that the embedding handler rejects boolean values for dimensions."""
-    # Mock dependencies
-    config = MagicMock()
-    config.served_model_name = "test-model"
-    engine_client = MagicMock()
-    runtime = MagicMock()
+    """Verify that dimensions=True is rejected."""
+    handler = EmbeddingWorkerHandler(MagicMock(), MagicMock(), MagicMock())
+    request = {"input": "test", "dimensions": True}
 
-    handler = EmbeddingWorkerHandler(runtime, engine_client, config)
-
-    context = MagicMock()
-    context.id.return_value = "req-123"
-
-    # dimensions=True should be rejected
-    request = {"model": "test-model", "input": "hello", "dimensions": True}
-
-    with pytest.raises(TypeError, match="Invalid 'dimensions' type bool; expected int"):
-        # We need to trigger the validation inside generate()
-        gen = handler.generate(request, context)
-        await gen.__anext__()
-
-
-@pytest.mark.asyncio
-async def test_embedding_handler_accepts_integer_dimensions():
-    """Verify that the embedding handler accepts integer values for dimensions."""
-    # Mock dependencies
-    config = MagicMock()
-    config.served_model_name = "test-model"
-    engine_client = MagicMock()
-    runtime = MagicMock()
-
-    # Mock engine_client.encode to return a minimal iterator
-    mock_output = MagicMock()
-    mock_output.outputs.data = [0.1, 0.2, 0.3]
-
-    async def mock_encode(*args, **kwargs):
-        yield mock_output
-
-    engine_client.encode = mock_encode
-
-    handler = EmbeddingWorkerHandler(runtime, engine_client, config)
-
-    context = MagicMock()
-    context.id.return_value = "req-123"
-    # async_killed_or_stopped needs to return an awaitable for the abort monitor
-    context.async_killed_or_stopped.return_value = AsyncMock()()
-
-    # dimensions=2 should be accepted
-    request = {"model": "test-model", "input": "hello", "dimensions": 2}
-
-    # This should not raise TypeError during validation
-    gen = handler.generate(request, context)
-    try:
-        await gen.__anext__()
-    except StopAsyncIteration:
-        pass
-    except Exception as e:
-        # We expect it might fail later if mocks aren't perfect,
-        # but it shouldn't be a TypeError from our validation.
-        assert not isinstance(e, TypeError) or "dimensions" not in str(e)
+    with pytest.raises(TypeError, match="Invalid 'dimensions' type bool"):
+        async for _ in handler.generate(request, MagicMock()):
+            pass

--- a/components/src/dynamo/vllm/tests/test_vllm_embedding_validation.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_embedding_validation.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from dynamo.vllm.handlers import EmbeddingWorkerHandler
+
+@pytest.mark.asyncio
+async def test_embedding_handler_rejects_boolean_dimensions():
+    # Mock dependencies
+    config = MagicMock()
+    config.served_model_name = "test-model"
+    engine_client = MagicMock()
+    
+    handler = EmbeddingWorkerHandler(config, engine_client)
+    
+    context = MagicMock()
+    context.id.return_value = "req-123"
+    
+    # dimensions=True should be rejected
+    request = {
+        "model": "test-model",
+        "input": "hello",
+        "dimensions": True
+    }
+    
+    with pytest.raises(TypeError, match="Invalid 'dimensions' type bool; expected int"):
+        # We need to trigger the validation inside generate()
+        # Using a minimal mock context and request
+        gen = handler.generate(request, context)
+        await gen.__anext__()
+
+@pytest.mark.asyncio
+async def test_embedding_handler_accepts_integer_dimensions():
+    # Mock dependencies
+    config = MagicMock()
+    config.served_model_name = "test-model"
+    engine_client = MagicMock()
+    
+    # Mock engine_client.encode to return a minimal iterator
+    mock_output = MagicMock()
+    mock_output.outputs.data = [0.1, 0.2, 0.3]
+    
+    async def mock_encode(*args, **kwargs):
+        yield mock_output
+        
+    engine_client.encode = mock_encode
+    
+    handler = EmbeddingWorkerHandler(config, engine_client)
+    
+    context = MagicMock()
+    context.id.return_value = "req-123"
+    
+    # dimensions=2 should be accepted
+    request = {
+        "model": "test-model",
+        "input": "hello",
+        "dimensions": 2
+    }
+    
+    # This should not raise TypeError during validation
+    gen = handler.generate(request, context)
+    try:
+        await gen.__anext__()
+    except StopAsyncIteration:
+        pass
+    except Exception as e:
+        # We expect it might fail later if mocks aren't perfect, 
+        # but it shouldn't be a TypeError from our validation.
+        assert not isinstance(e, TypeError) or "dimensions" not in str(e)

--- a/components/src/dynamo/vllm/tests/test_vllm_embedding_validation.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_embedding_validation.py
@@ -1,60 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for boolean validation of the dimensions parameter in vLLM embeddings."""
+
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+
 from dynamo.vllm.handlers import EmbeddingWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
 
 @pytest.mark.asyncio
 async def test_embedding_handler_rejects_boolean_dimensions():
+    """Verify that the embedding handler rejects boolean values for dimensions."""
     # Mock dependencies
     config = MagicMock()
     config.served_model_name = "test-model"
     engine_client = MagicMock()
-    
-    handler = EmbeddingWorkerHandler(config, engine_client)
-    
+    runtime = MagicMock()
+
+    handler = EmbeddingWorkerHandler(runtime, engine_client, config)
+
     context = MagicMock()
     context.id.return_value = "req-123"
-    
+
     # dimensions=True should be rejected
-    request = {
-        "model": "test-model",
-        "input": "hello",
-        "dimensions": True
-    }
-    
+    request = {"model": "test-model", "input": "hello", "dimensions": True}
+
     with pytest.raises(TypeError, match="Invalid 'dimensions' type bool; expected int"):
         # We need to trigger the validation inside generate()
-        # Using a minimal mock context and request
         gen = handler.generate(request, context)
         await gen.__anext__()
 
+
 @pytest.mark.asyncio
 async def test_embedding_handler_accepts_integer_dimensions():
+    """Verify that the embedding handler accepts integer values for dimensions."""
     # Mock dependencies
     config = MagicMock()
     config.served_model_name = "test-model"
     engine_client = MagicMock()
-    
+    runtime = MagicMock()
+
     # Mock engine_client.encode to return a minimal iterator
     mock_output = MagicMock()
     mock_output.outputs.data = [0.1, 0.2, 0.3]
-    
+
     async def mock_encode(*args, **kwargs):
         yield mock_output
-        
+
     engine_client.encode = mock_encode
-    
-    handler = EmbeddingWorkerHandler(config, engine_client)
-    
+
+    handler = EmbeddingWorkerHandler(runtime, engine_client, config)
+
     context = MagicMock()
     context.id.return_value = "req-123"
-    
+    # async_killed_or_stopped needs to return an awaitable for the abort monitor
+    context.async_killed_or_stopped.return_value = AsyncMock()()
+
     # dimensions=2 should be accepted
-    request = {
-        "model": "test-model",
-        "input": "hello",
-        "dimensions": 2
-    }
-    
+    request = {"model": "test-model", "input": "hello", "dimensions": 2}
+
     # This should not raise TypeError during validation
     gen = handler.generate(request, context)
     try:
@@ -62,6 +76,6 @@ async def test_embedding_handler_accepts_integer_dimensions():
     except StopAsyncIteration:
         pass
     except Exception as e:
-        # We expect it might fail later if mocks aren't perfect, 
+        # We expect it might fail later if mocks aren't perfect,
         # but it shouldn't be a TypeError from our validation.
         assert not isinstance(e, TypeError) or "dimensions" not in str(e)


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

Issue Trigger Scene : 
A malicious actor deliberately crafts an API request or a misconfigured client incorrectly passes a boolean value (e.g.,
     "dimensions": true) to the /v1/embeddings endpoint. This unexpected input field is designed to exploit weak type-validation logic in the  embedding truncation flow.

The service fails to detect the semantic error and proceeds with the request, resulting in a silent "Data Poisoning" event. The API  returns 200 OK, but the payload contains a corrupted 1-dimensional embedding vector. This allows invalid data to propagate into downstream vector  databases or RAG systems undetected.

Expected Behavior:  The system should strictly validate that dimensions is a positive integer. If a boolean or any other non-integer type is  provided, it should raise a TypeError and return a 400 Bad Request.

Root Cause: 
In Python, bool is a subclass of int. The existing check isinstance(dimensions, int) returns True for boolean values. Furthermore,  Python's slicing logic treats embedding[:True] as embedding[:1], leading to the unintended truncation of the vector. From a security perspective, this lack of input sanitization allows untrusted/malicious input to bypass logic checks, potentially leading to downstream data corruption.




#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of the dimensions parameter to correctly reject boolean values, which are now properly distinguished from valid integer inputs.

* **Tests**
  * Added test coverage for embedding dimension validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->