### PR TITLE
docs(parsers): clarify tool call and reasoning parser layer

### DIFF
--- a/docs/reasoning/README.md
+++ b/docs/reasoning/README.md
@@ -7,18 +7,35 @@ subtitle: Separate reasoning content from assistant output for chain-of-thought 
 
 Some models emit reasoning or thinking content separately from their final
 response. Dynamo can split that output into `reasoning_content` and normal
-assistant content by configuring a reasoning parser. As with tool calling,
-there are two ways to do this to ensure wide coverage and day0 model support.
+assistant content by configuring a reasoning parser.
+
+There are two ways to parse reasoning in Dynamo, depending on whether the
+parser lives in Dynamo's own registry or in an upstream engine frontend
+(`vllm serve`, `sglang serve`, or `trtllm-serve`).
 
 ## Choose a parsing path
 
 | Path | When to use | Page |
 |------|-------------|------|
-| **Dynamo** | Dynamo ships a Rust parser for the model's reasoning format. Lowest latency, the default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
+| **Dynamo** | Dynamo ships a framework-agnostic Rust parser for the model's reasoning format. Default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Use the framework's parser implementation (vLLM or SGLang today; TRTLLM in progress) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.
+
+## Why Dynamo implements tool-call and reasoning parsers
+
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and
+reasoning parsing happens in the engine's frontend server, with subtle
+behavioral differences across each. Since Dynamo orchestrates efficient
+routing and tokenization, it connects directly to each engine and circumvents
+each engine's frontend server to avoid redundant work.
+
+Dynamo therefore implements tool-call parsing and reasoning parsing in its
+frontend as a framework-agnostic Rust layer. This gives Dynamo one tested
+OpenAI-compatible contract across vLLM, SGLang, TRTLLM, and other workers,
+while keeping the serving hot path highly concurrent and scalable, avoiding
+Python GIL bottlenecks.
 
 ## See Also
 

--- a/docs/reasoning/README.md
+++ b/docs/reasoning/README.md
@@ -27,9 +27,9 @@ registry does not list a parser for your model.
 
 In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and
 reasoning parsing happens in the engine's frontend server, with subtle
-behavioral differences across each. Since Dynamo orchestrates efficient
-routing and tokenization, it connects directly to each engine and circumvents
-each engine's frontend server to avoid redundant work.
+behavioral differences across each. For performance purposes, Dynamo orchestrates
+routing and tokenization, passing tokens directly to each LLM engine and circumventing
+each engine's frontend OpenAI API server to avoid duplicate work per request.
 
 Dynamo therefore implements tool-call parsing and reasoning parsing in its
 frontend as a framework-agnostic Rust layer. This gives Dynamo one tested

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -11,17 +11,32 @@ syntax out of raw model output and surfacing it as OpenAI-compatible
 and `tools` request parameters on the chat completions API.
 
 There are two ways to parse tool calls in Dynamo, depending on whether the
-parser lives in Dynamo's own registry or in the upstream engine (vLLM, SGLang).
+parser lives in Dynamo's own registry or in an upstream engine frontend
+(`vllm serve`, `sglang serve`, or `trtllm-serve`).
 
 ## Choose a parsing path
 
 | Path | When to use | Page |
 |------|-------------|------|
-| **Dynamo** | Dynamo ships a Rust parser for the model's tool-call format. Lowest latency, the default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
+| **Dynamo** | Dynamo ships a framework-agnostic Rust parser for the model's tool-call format. Default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Use the framework's frontend implementation (vLLM or SGLang today; TRTLLM in progress) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.
+
+## Why Dynamo implements tool-call parsers
+
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing belongs
+to the engine's frontend server. Dynamo provides its own OpenAI-compatible
+frontend and connects to engines below that layer, so the default path cannot
+rely on those engine frontends.
+
+Dynamo therefore implements tool-call parsing in its frontend as a
+framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible
+contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the hot
+path highly concurrent and scalable and avoiding Python GIL overhead. Use
+engine fallback only when Dynamo does not yet ship a parser for the model, or
+when exact framework parity is required.
 
 ## Troubleshooting
 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -19,7 +19,7 @@ parser lives in Dynamo's own registry or in an upstream engine frontend
 | Path | When to use | Page |
 |------|-------------|------|
 | **Dynamo** | Dynamo ships a framework-agnostic Rust parser for the model's tool-call format. Default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Use the framework's frontend implementation (vLLM or SGLang today; TRTLLM in progress) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
+| **Engine Fallback** | Use the framework's parser implementation (vLLM or SGLang today; TRTLLM in progress) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -29,7 +29,7 @@ registry does not list a parser for your model.
 In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and reasoning parsing happens
 in the engine's frontend server, with subtle behavioral differences across each.```
 
-Dynamo implements tool-call parsing and reasoning parsing in its frontend as a
+Dynamo therefore implements tool-call parsing and reasoning parsing in its frontend as a
 framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible
 contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the serving 
 hot path highly concurrent and scalable, avoiding Python GIL bottlenecks. 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -28,14 +28,15 @@ registry does not list a parser for your model.
 
 In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and
 reasoning parsing happens in the engine's frontend server, with subtle
-behavioral differences across each. Since Dynamo orchestrates efficient
-routing and tokenization, it connects directly to each engine and circumvents
-each engine's frontend server to avoid redundant work.
+behavioral differences across each. For performance purposes, Dynamo orchestrates
+routing and tokenization, passing tokens directly to each LLM engine and circumventing
+each engine's frontend OpenAI API server to avoid duplicate work per request.
 
-Dynamo therefore implements tool-call parsing and reasoning parsing in its frontend as a
-framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible
-contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the serving
-hot path highly concurrent and scalable, avoiding Python GIL bottlenecks.
+Dynamo therefore implements tool-call parsing and reasoning parsing in its
+frontend as a framework-agnostic Rust layer. This gives Dynamo one tested
+OpenAI-compatible contract across vLLM, SGLang, TRTLLM, and other workers,
+while keeping the serving hot path highly concurrent and scalable, avoiding
+Python GIL bottlenecks.
 
 ## Troubleshooting
 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -26,16 +26,16 @@ registry does not list a parser for your model.
 
 ## Why Dynamo implements tool-call and reasoning parsers
 
-In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and 
-reasoning parsing happens in the engine's frontend server, with subtle 
-behavioral differences across each. Since Dynamo orchestrates efficient 
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and
+reasoning parsing happens in the engine's frontend server, with subtle
+behavioral differences across each. Since Dynamo orchestrates efficient
 routing and tokenization, it connects directly to each engine and circumvents
 each engine's frontend server to avoid redundant work.
 
 Dynamo therefore implements tool-call parsing and reasoning parsing in its frontend as a
 framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible
-contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the serving 
-hot path highly concurrent and scalable, avoiding Python GIL bottlenecks. 
+contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the serving
+hot path highly concurrent and scalable, avoiding Python GIL bottlenecks.
 
 ## Troubleshooting
 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -26,8 +26,11 @@ registry does not list a parser for your model.
 
 ## Why Dynamo implements tool-call parsers
 
-In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and reasoning parsing happens
-in the engine's frontend server, with subtle behavioral differences across each.```
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and 
+reasoning parsing happens in the engine's frontend server, with subtle 
+behavioral differences across each. Since Dynamo orchestrates efficient 
+routing and tokenization, it connects directly to each engine and circumvents
+each engine's frontend server to avoid redundant work.
 
 Dynamo therefore implements tool-call parsing and reasoning parsing in its frontend as a
 framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -24,7 +24,7 @@ parser lives in Dynamo's own registry or in an upstream engine frontend
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.
 
-## Why Dynamo implements tool-call parsers
+## Why Dynamo implements tool-call and reasoning parsers
 
 In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and 
 reasoning parsing happens in the engine's frontend server, with subtle 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -26,10 +26,8 @@ registry does not list a parser for your model.
 
 ## Why Dynamo implements tool-call parsers
 
-In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing belongs
-to the engine's frontend server. Dynamo provides its own OpenAI-compatible
-frontend and connects to engines below that layer, so the default path cannot
-rely on those engine frontends.
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and reasoning parsing happens
+in the engine's frontend server, with subtle behavioral differences across each.```
 
 Dynamo implements tool-call parsing and reasoning parsing in its frontend as a
 framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -31,12 +31,10 @@ to the engine's frontend server. Dynamo provides its own OpenAI-compatible
 frontend and connects to engines below that layer, so the default path cannot
 rely on those engine frontends.
 
-Dynamo therefore implements tool-call parsing in its frontend as a
+Dynamo implements tool-call parsing and reasoning parsing in its frontend as a
 framework-agnostic Rust layer. This gives Dynamo one tested OpenAI-compatible
-contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the hot
-path highly concurrent and scalable and avoiding Python GIL overhead. Use
-engine fallback only when Dynamo does not yet ship a parser for the model, or
-when exact framework parity is required.
+contract across vLLM, SGLang, TRTLLM, and other workers, while keeping the serving 
+hot path highly concurrent and scalable, avoiding Python GIL bottlenecks. 
 
 ## Troubleshooting
 


### PR DESCRIPTION
Clarifies why Dynamo implements tool-call and reasoning parsers in its own framework-agnostic Rust frontend layer instead of relying on engine serve frontends.

Updates the top-level tool-calling and reasoning docs, including vLLM, SGLang, and TRTLLM wording.

Validation: `pre-commit run trailing-whitespace --files docs/tool-calling/README.md docs/reasoning/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced reasoning parsing documentation with clarified parsing approaches and expanded explanation of implementation strategy.
  * Improved tool-calling parsing documentation with updated descriptions and comprehensive coverage of parsing options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->