### PR TITLE
feat(router): add Python topology + transfer policy reading

### DIFF
--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -12,8 +12,6 @@ so they work without GPU, CUDA, or any backend installed.
 """
 
 import importlib.util
-import threading
-import time
 from pathlib import Path
 
 import pytest
@@ -65,6 +63,26 @@ def _enable_topology(
         monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", str(preferred_weight))
     else:
         monkeypatch.delenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raising=False)
+
+
+def _mock_topology_clock(monkeypatch, on_sleep=None):
+    """Replace topology's clock so polling tests do not use wall time."""
+    now = 0.0
+    sleep_calls = []
+
+    def monotonic():
+        return now
+
+    def sleep(seconds):
+        nonlocal now
+        sleep_calls.append(seconds)
+        if on_sleep is not None:
+            on_sleep(len(sleep_calls))
+        now += seconds
+
+    monkeypatch.setattr(topology.time, "monotonic", monotonic)
+    monkeypatch.setattr(topology.time, "sleep", sleep)
+    return sleep_calls
 
 
 class TestReadTopologyConfig:
@@ -146,6 +164,7 @@ class TestReadTopologyConfig:
             read_topology_config()
         assert exc_info.value.code == 1
 
+    @pytest.mark.timeout(5)
     def test_hard_exit_after_timeout_transfer_domain_file_missing(
         self, monkeypatch, tmp_path
     ):
@@ -155,11 +174,14 @@ class TestReadTopologyConfig:
         (topology_dir / "rack").write_text("rack-22")
 
         _enable_topology(monkeypatch, topology_dir)
+        sleep_calls = _mock_topology_clock(monkeypatch)
 
         with pytest.raises(SystemExit) as exc_info:
             read_topology_config(poll_interval=0.05, poll_timeout=0.15)
         assert exc_info.value.code == 1
+        assert sleep_calls == pytest.approx([0.05, 0.05, 0.05])
 
+    @pytest.mark.timeout(5)
     def test_retry_succeeds_when_transfer_domain_file_appears(
         self, monkeypatch, tmp_path
     ):
@@ -170,19 +192,18 @@ class TestReadTopologyConfig:
 
         _enable_topology(monkeypatch, topology_dir)
 
-        def write_after_delay():
-            time.sleep(0.1)
+        def publish_transfer_domain_on_retry(_sleep_count):
             (topology_dir / "zone").write_text("us-west-2a")
 
-        writer = threading.Thread(target=write_after_delay)
-        writer.start()
-
+        sleep_calls = _mock_topology_clock(
+            monkeypatch, on_sleep=publish_transfer_domain_on_retry
+        )
         config = read_topology_config(poll_interval=0.05, poll_timeout=2.0)
-        writer.join()
         assert config.topology_domains == {
             "rack": "rack-22",
             "zone": "us-west-2a",
         }
+        assert sleep_calls == [0.05]
 
     def test_reads_preferred_transfer_policy_env_vars(self, monkeypatch, tmp_path):
         """Reads preferred KV transfer policy and weight from env vars."""

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -4,7 +4,8 @@
 """Unit tests for topology domain utilities.
 
 Tests the read_topology_config() function that reads topology files from a
-Downward API volume and KV transfer policy from env vars at worker startup.
+deployment-provided directory and KV transfer policy from env vars at worker
+startup.
 
 These tests import topology.py directly (bypassing the dynamo package hierarchy)
 so they work without GPU, CUDA, or any backend installed.

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+pytestmark = (pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge)
 
 # ---------------------------------------------------------------------------
 # Module loading: import topology without triggering the full dynamo package

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = (pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge)
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 # ---------------------------------------------------------------------------
 # Module loading: import topology without triggering the full dynamo package

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -1,0 +1,396 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for topology domain utilities.
+
+Tests the read_topology_config() function that reads topology files from a
+Downward API volume and KV transfer policy from env vars at worker startup.
+
+These tests import topology.py directly (bypassing the dynamo package hierarchy)
+so they work without GPU, CUDA, or any backend installed.
+"""
+
+import importlib.util
+import math
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+# ---------------------------------------------------------------------------
+# Module loading: import topology without triggering the full dynamo package
+# (which requires dynamo.llm, CUDA, etc.)
+# ---------------------------------------------------------------------------
+_TOPOLOGY_PY = Path(__file__).resolve().parents[2] / "utils" / "topology.py"
+
+
+def _load_topology_module():
+    """Load topology.py as a standalone module."""
+    spec = importlib.util.spec_from_file_location("topology", _TOPOLOGY_PY)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+topology = _load_topology_module()
+read_topology_config = topology.read_topology_config
+apply_topology_config = topology.apply_topology_config
+
+
+class FakeRuntimeConfig:
+    def __init__(self):
+        self.topology_domains = {}
+        self.kv_transfer_domain = None
+        self.kv_transfer_enforcement = None
+        self.kv_transfer_preferred_weight = None
+        self.taints = set()
+
+
+def _enable_topology(monkeypatch, topology_dir: Path, transfer_domain: str = "zone"):
+    monkeypatch.setenv("DYN_TOPOLOGY_ENABLED", "true")
+    monkeypatch.setenv("DYN_TOPOLOGY_MOUNT_PATH", str(topology_dir))
+    monkeypatch.setenv("DYN_KV_TRANSFER_DOMAIN", transfer_domain)
+    monkeypatch.delenv("DYN_KV_TRANSFER_ENFORCEMENT", raising=False)
+    monkeypatch.delenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raising=False)
+
+
+class TestReadTopologyConfig:
+    """Tests for read_topology_config()."""
+
+    def test_returns_empty_when_not_enabled(self, monkeypatch):
+        """When DYN_TOPOLOGY_ENABLED is not set, returns empty config."""
+        monkeypatch.delenv("DYN_TOPOLOGY_ENABLED", raising=False)
+        config = read_topology_config()
+        assert not config.enabled
+        assert config.topology_domains == {}
+        assert config.kv_transfer_domain is None
+        assert config.kv_transfer_enforcement is None
+        assert config.kv_transfer_preferred_weight is None
+
+    def test_returns_empty_when_enabled_false(self, monkeypatch):
+        """When DYN_TOPOLOGY_ENABLED=false, returns empty config."""
+        monkeypatch.setenv("DYN_TOPOLOGY_ENABLED", "false")
+        config = read_topology_config()
+        assert not config.enabled
+
+    def test_returns_empty_when_enabled_empty_string(self, monkeypatch):
+        """When DYN_TOPOLOGY_ENABLED='', returns empty config."""
+        monkeypatch.setenv("DYN_TOPOLOGY_ENABLED", "")
+        config = read_topology_config()
+        assert not config.enabled
+
+    def test_reads_all_non_hidden_topology_files(self, monkeypatch, tmp_path):
+        """Reads every visible, non-empty file under the topology mount."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+        (topology_dir / "rack").write_text("rack-22")
+        (topology_dir / "empty").write_text("")
+        (topology_dir / ".hidden").write_text("ignored")
+        (topology_dir / "..data").mkdir()
+        (topology_dir / "nested").mkdir()
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        config = read_topology_config()
+
+        assert config.enabled
+        assert config.topology_domains == {
+            "rack": "rack-22",
+            "zone": "us-east-1a",
+        }
+        assert config.kv_transfer_domain == "zone"
+        assert config.kv_transfer_enforcement == "required"
+        assert config.kv_transfer_preferred_weight is None
+
+    def test_strips_whitespace_from_file_values(self, monkeypatch, tmp_path):
+        """Strips whitespace/newlines from topology file values."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("  us-east-1a\n")
+        (topology_dir / "rack").write_text("\t rack-22  \n")
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        config = read_topology_config()
+        assert config.topology_domains == {
+            "rack": "rack-22",
+            "zone": "us-east-1a",
+        }
+
+    def test_domain_keys_preserve_file_names(self, monkeypatch, tmp_path):
+        """Domain keys match the visible topology file names exactly."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "ZONE").write_text("us-east-1a")
+        (topology_dir / "Rack").write_text("rack-22")
+
+        _enable_topology(monkeypatch, topology_dir, transfer_domain="ZONE")
+
+        config = read_topology_config()
+        assert config.topology_domains == {
+            "Rack": "rack-22",
+            "ZONE": "us-east-1a",
+        }
+        assert config.kv_transfer_domain == "ZONE"
+
+    def test_hard_exit_when_transfer_domain_env_not_set(self, monkeypatch, tmp_path):
+        """Exits when enabled but DYN_KV_TRANSFER_DOMAIN is not set."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        monkeypatch.setenv("DYN_TOPOLOGY_ENABLED", "true")
+        monkeypatch.setenv("DYN_TOPOLOGY_MOUNT_PATH", str(topology_dir))
+        monkeypatch.delenv("DYN_KV_TRANSFER_DOMAIN", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            read_topology_config()
+        assert exc_info.value.code == 1
+
+    def test_hard_exit_after_timeout_transfer_domain_file_missing(
+        self, monkeypatch, tmp_path
+    ):
+        """Exits when the transfer-domain file never appears within timeout."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "rack").write_text("rack-22")
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        with pytest.raises(SystemExit) as exc_info:
+            read_topology_config(poll_interval=0.05, poll_timeout=0.15)
+        assert exc_info.value.code == 1
+
+    def test_hard_exit_after_timeout_transfer_domain_file_empty(
+        self, monkeypatch, tmp_path
+    ):
+        """Exits when the transfer-domain file exists but stays empty."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("")
+        (topology_dir / "rack").write_text("rack-22")
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        with pytest.raises(SystemExit) as exc_info:
+            read_topology_config(poll_interval=0.05, poll_timeout=0.15)
+        assert exc_info.value.code == 1
+
+    def test_retry_succeeds_when_transfer_domain_file_appears(
+        self, monkeypatch, tmp_path
+    ):
+        """Transfer-domain file appears after a delay; retry loop picks it up."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "rack").write_text("rack-22")
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        def write_after_delay():
+            time.sleep(0.1)
+            (topology_dir / "zone").write_text("us-west-2a")
+
+        writer = threading.Thread(target=write_after_delay)
+        writer.start()
+
+        config = read_topology_config(poll_interval=0.05, poll_timeout=2.0)
+        writer.join()
+        assert config.topology_domains == {
+            "rack": "rack-22",
+            "zone": "us-west-2a",
+        }
+
+    def test_retry_succeeds_when_empty_transfer_domain_file_gets_content(
+        self, monkeypatch, tmp_path
+    ):
+        """Empty transfer-domain file gets content after a delay."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        zone_file = topology_dir / "zone"
+        zone_file.write_text("")
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        def write_after_delay():
+            time.sleep(0.1)
+            zone_file.write_text("eu-central-1a")
+
+        writer = threading.Thread(target=write_after_delay)
+        writer.start()
+
+        config = read_topology_config(poll_interval=0.05, poll_timeout=2.0)
+        writer.join()
+        assert config.topology_domains == {"zone": "eu-central-1a"}
+
+    def test_reads_required_transfer_policy_env_vars(self, monkeypatch, tmp_path):
+        """Reads required KV transfer policy from env vars."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "required")
+
+        config = read_topology_config()
+        assert config.kv_transfer_domain == "zone"
+        assert config.kv_transfer_enforcement == "required"
+        assert config.kv_transfer_preferred_weight is None
+
+    def test_reads_preferred_transfer_policy_env_vars(self, monkeypatch, tmp_path):
+        """Reads preferred KV transfer policy and weight from env vars."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.85")
+
+        config = read_topology_config()
+        assert config.kv_transfer_domain == "zone"
+        assert config.kv_transfer_enforcement == "preferred"
+        assert config.kv_transfer_preferred_weight == 0.85
+
+    def test_required_is_default_enforcement_when_domain_set(
+        self, monkeypatch, tmp_path
+    ):
+        """Missing enforcement defaults to required when a transfer domain is set."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+
+        config = read_topology_config()
+        assert config.kv_transfer_enforcement == "required"
+
+    def test_reads_transfer_policy_env_vars_without_validation(
+        self, monkeypatch, tmp_path
+    ):
+        """Reader passes env values through; binding owns enum normalization."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "Preferred")
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.5")
+
+        config = read_topology_config()
+        assert config.kv_transfer_domain == "zone"
+        assert config.kv_transfer_enforcement == "Preferred"
+        assert config.kv_transfer_preferred_weight == 0.5
+
+    def test_reader_defers_missing_preferred_weight_validation(
+        self, monkeypatch, tmp_path
+    ):
+        """Reader publishes env values; runtime config validates policy shape."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
+        monkeypatch.delenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raising=False)
+
+        config = read_topology_config()
+        assert config.kv_transfer_enforcement == "preferred"
+        assert config.kv_transfer_preferred_weight is None
+
+    def test_reader_defers_invalid_transfer_enforcement_validation(
+        self, monkeypatch, tmp_path
+    ):
+        """Invalid enforcement is left for the ModelRuntimeConfig binding."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "fallback")
+
+        config = read_topology_config()
+        assert config.kv_transfer_enforcement == "fallback"
+
+    @pytest.mark.parametrize("raw_weight", ["1.1", "-0.1", "nan", "inf"])
+    def test_reader_defers_preferred_weight_range_validation(
+        self, monkeypatch, tmp_path, raw_weight
+    ):
+        """Reader only parses weight as float; binding validates finite range."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raw_weight)
+
+        config = read_topology_config()
+        if raw_weight == "nan":
+            assert math.isnan(config.kv_transfer_preferred_weight)
+        elif raw_weight == "inf":
+            assert math.isinf(config.kv_transfer_preferred_weight)
+        else:
+            assert config.kv_transfer_preferred_weight == float(raw_weight)
+
+    def test_non_float_preferred_weight_raises_value_error(self, monkeypatch, tmp_path):
+        """Python still parses string env vars before calling the float setter."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "heavy")
+
+        with pytest.raises(ValueError, match="could not convert string to float"):
+            read_topology_config()
+
+    def test_reader_defers_weight_enforcement_pair_validation(
+        self, monkeypatch, tmp_path
+    ):
+        """Required+weight is left for ModelRuntimeConfig validation."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "required")
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.85")
+
+        config = read_topology_config()
+        assert config.kv_transfer_enforcement == "required"
+        assert config.kv_transfer_preferred_weight == 0.85
+
+    def test_apply_topology_config_reads_env_and_leaves_existing_taints(
+        self, monkeypatch, tmp_path
+    ):
+        """Python publishes topology domains; Rust derives topology taints."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+        (topology_dir / "rack").write_text("rack-22")
+
+        _enable_topology(monkeypatch, topology_dir)
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.85")
+
+        runtime_config = FakeRuntimeConfig()
+        runtime_config.taints = {"user.taint/example"}
+
+        returned = apply_topology_config(runtime_config)
+
+        expected_topology_domains = {
+            "rack": "rack-22",
+            "zone": "us-east-1a",
+        }
+        assert returned.topology_domains == expected_topology_domains
+        assert runtime_config.topology_domains == expected_topology_domains
+        assert runtime_config.kv_transfer_domain == "zone"
+        assert runtime_config.kv_transfer_enforcement == "preferred"
+        assert runtime_config.kv_transfer_preferred_weight == 0.85
+        assert runtime_config.taints == {"user.taint/example"}

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -50,13 +50,16 @@ def _enable_topology(
     monkeypatch,
     topology_dir: Path,
     transfer_domain: str = "zone",
-    enforcement: str = "required",
+    enforcement: str | None = "required",
     preferred_weight: float | None = None,
 ):
     monkeypatch.setenv("DYN_TOPOLOGY_ENABLED", "true")
     monkeypatch.setenv("DYN_TOPOLOGY_MOUNT_PATH", str(topology_dir))
     monkeypatch.setenv("DYN_KV_TRANSFER_DOMAIN", transfer_domain)
-    monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", enforcement)
+    if enforcement is not None:
+        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", enforcement)
+    else:
+        monkeypatch.delenv("DYN_KV_TRANSFER_ENFORCEMENT", raising=False)
     if preferred_weight is not None:
         monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", str(preferred_weight))
     else:
@@ -150,6 +153,17 @@ class TestReadTopologyConfig:
             "ZONE": "us-east-1a",
         }
         assert config.kv_transfer_domain == "ZONE"
+
+    def test_defaults_transfer_enforcement_to_required(self, monkeypatch, tmp_path):
+        """Defaults enforcement to required when only transfer domain is set."""
+        topology_dir = tmp_path / "topology"
+        topology_dir.mkdir()
+        (topology_dir / "zone").write_text("us-east-1a")
+
+        _enable_topology(monkeypatch, topology_dir, enforcement=None)
+
+        config = read_topology_config()
+        assert config.kv_transfer_enforcement == "required"
 
     def test_hard_exit_when_transfer_domain_env_not_set(self, monkeypatch, tmp_path):
         """Exits when enabled but DYN_KV_TRANSFER_DOMAIN is not set."""

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -16,8 +16,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
-
 # ---------------------------------------------------------------------------
 # Module loading: import topology without triggering the full dynamo package
 # (which requires dynamo.llm, CUDA, etc.)
@@ -85,6 +83,9 @@ def _mock_topology_clock(monkeypatch, on_sleep=None):
     return sleep_calls
 
 
+@pytest.mark.unit
+@pytest.mark.gpu_0
+@pytest.mark.pre_merge
 class TestReadTopologyConfig:
     """Tests for read_topology_config()."""
 

--- a/components/src/dynamo/common/utils/tests/test_topology.py
+++ b/components/src/dynamo/common/utils/tests/test_topology.py
@@ -11,7 +11,6 @@ so they work without GPU, CUDA, or any backend installed.
 """
 
 import importlib.util
-import math
 import threading
 import time
 from pathlib import Path
@@ -50,12 +49,21 @@ class FakeRuntimeConfig:
         self.taints = set()
 
 
-def _enable_topology(monkeypatch, topology_dir: Path, transfer_domain: str = "zone"):
+def _enable_topology(
+    monkeypatch,
+    topology_dir: Path,
+    transfer_domain: str = "zone",
+    enforcement: str = "required",
+    preferred_weight: float | None = None,
+):
     monkeypatch.setenv("DYN_TOPOLOGY_ENABLED", "true")
     monkeypatch.setenv("DYN_TOPOLOGY_MOUNT_PATH", str(topology_dir))
     monkeypatch.setenv("DYN_KV_TRANSFER_DOMAIN", transfer_domain)
-    monkeypatch.delenv("DYN_KV_TRANSFER_ENFORCEMENT", raising=False)
-    monkeypatch.delenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raising=False)
+    monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", enforcement)
+    if preferred_weight is not None:
+        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", str(preferred_weight))
+    else:
+        monkeypatch.delenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raising=False)
 
 
 class TestReadTopologyConfig:
@@ -107,21 +115,6 @@ class TestReadTopologyConfig:
         assert config.kv_transfer_enforcement == "required"
         assert config.kv_transfer_preferred_weight is None
 
-    def test_strips_whitespace_from_file_values(self, monkeypatch, tmp_path):
-        """Strips whitespace/newlines from topology file values."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("  us-east-1a\n")
-        (topology_dir / "rack").write_text("\t rack-22  \n")
-
-        _enable_topology(monkeypatch, topology_dir)
-
-        config = read_topology_config()
-        assert config.topology_domains == {
-            "rack": "rack-22",
-            "zone": "us-east-1a",
-        }
-
     def test_domain_keys_preserve_file_names(self, monkeypatch, tmp_path):
         """Domain keys match the visible topology file names exactly."""
         topology_dir = tmp_path / "topology"
@@ -166,21 +159,6 @@ class TestReadTopologyConfig:
             read_topology_config(poll_interval=0.05, poll_timeout=0.15)
         assert exc_info.value.code == 1
 
-    def test_hard_exit_after_timeout_transfer_domain_file_empty(
-        self, monkeypatch, tmp_path
-    ):
-        """Exits when the transfer-domain file exists but stays empty."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("")
-        (topology_dir / "rack").write_text("rack-22")
-
-        _enable_topology(monkeypatch, topology_dir)
-
-        with pytest.raises(SystemExit) as exc_info:
-            read_topology_config(poll_interval=0.05, poll_timeout=0.15)
-        assert exc_info.value.code == 1
-
     def test_retry_succeeds_when_transfer_domain_file_appears(
         self, monkeypatch, tmp_path
     ):
@@ -205,49 +183,15 @@ class TestReadTopologyConfig:
             "zone": "us-west-2a",
         }
 
-    def test_retry_succeeds_when_empty_transfer_domain_file_gets_content(
-        self, monkeypatch, tmp_path
-    ):
-        """Empty transfer-domain file gets content after a delay."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        zone_file = topology_dir / "zone"
-        zone_file.write_text("")
-
-        _enable_topology(monkeypatch, topology_dir)
-
-        def write_after_delay():
-            time.sleep(0.1)
-            zone_file.write_text("eu-central-1a")
-
-        writer = threading.Thread(target=write_after_delay)
-        writer.start()
-
-        config = read_topology_config(poll_interval=0.05, poll_timeout=2.0)
-        writer.join()
-        assert config.topology_domains == {"zone": "eu-central-1a"}
-
-    def test_reads_required_transfer_policy_env_vars(self, monkeypatch, tmp_path):
-        """Reads required KV transfer policy from env vars."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "required")
-
-        config = read_topology_config()
-        assert config.kv_transfer_domain == "zone"
-        assert config.kv_transfer_enforcement == "required"
-        assert config.kv_transfer_preferred_weight is None
-
     def test_reads_preferred_transfer_policy_env_vars(self, monkeypatch, tmp_path):
         """Reads preferred KV transfer policy and weight from env vars."""
         topology_dir = tmp_path / "topology"
         topology_dir.mkdir()
         (topology_dir / "zone").write_text("us-east-1a")
 
-        _enable_topology(monkeypatch, topology_dir)
+        _enable_topology(
+            monkeypatch, topology_dir, enforcement="preferred", preferred_weight=0.85
+        )
         monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
         monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.85")
 
@@ -255,87 +199,6 @@ class TestReadTopologyConfig:
         assert config.kv_transfer_domain == "zone"
         assert config.kv_transfer_enforcement == "preferred"
         assert config.kv_transfer_preferred_weight == 0.85
-
-    def test_required_is_default_enforcement_when_domain_set(
-        self, monkeypatch, tmp_path
-    ):
-        """Missing enforcement defaults to required when a transfer domain is set."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-
-        config = read_topology_config()
-        assert config.kv_transfer_enforcement == "required"
-
-    def test_reads_transfer_policy_env_vars_without_validation(
-        self, monkeypatch, tmp_path
-    ):
-        """Reader passes env values through; binding owns enum normalization."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "Preferred")
-        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.5")
-
-        config = read_topology_config()
-        assert config.kv_transfer_domain == "zone"
-        assert config.kv_transfer_enforcement == "Preferred"
-        assert config.kv_transfer_preferred_weight == 0.5
-
-    def test_reader_defers_missing_preferred_weight_validation(
-        self, monkeypatch, tmp_path
-    ):
-        """Reader publishes env values; runtime config validates policy shape."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
-        monkeypatch.delenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raising=False)
-
-        config = read_topology_config()
-        assert config.kv_transfer_enforcement == "preferred"
-        assert config.kv_transfer_preferred_weight is None
-
-    def test_reader_defers_invalid_transfer_enforcement_validation(
-        self, monkeypatch, tmp_path
-    ):
-        """Invalid enforcement is left for the ModelRuntimeConfig binding."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "fallback")
-
-        config = read_topology_config()
-        assert config.kv_transfer_enforcement == "fallback"
-
-    @pytest.mark.parametrize("raw_weight", ["1.1", "-0.1", "nan", "inf"])
-    def test_reader_defers_preferred_weight_range_validation(
-        self, monkeypatch, tmp_path, raw_weight
-    ):
-        """Reader only parses weight as float; binding validates finite range."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
-        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", raw_weight)
-
-        config = read_topology_config()
-        if raw_weight == "nan":
-            assert math.isnan(config.kv_transfer_preferred_weight)
-        elif raw_weight == "inf":
-            assert math.isinf(config.kv_transfer_preferred_weight)
-        else:
-            assert config.kv_transfer_preferred_weight == float(raw_weight)
 
     def test_non_float_preferred_weight_raises_value_error(self, monkeypatch, tmp_path):
         """Python still parses string env vars before calling the float setter."""
@@ -343,54 +206,8 @@ class TestReadTopologyConfig:
         topology_dir.mkdir()
         (topology_dir / "zone").write_text("us-east-1a")
 
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
+        _enable_topology(monkeypatch, topology_dir, enforcement="preferred")
         monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "heavy")
 
         with pytest.raises(ValueError, match="could not convert string to float"):
             read_topology_config()
-
-    def test_reader_defers_weight_enforcement_pair_validation(
-        self, monkeypatch, tmp_path
-    ):
-        """Required+weight is left for ModelRuntimeConfig validation."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "required")
-        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.85")
-
-        config = read_topology_config()
-        assert config.kv_transfer_enforcement == "required"
-        assert config.kv_transfer_preferred_weight == 0.85
-
-    def test_apply_topology_config_reads_env_and_leaves_existing_taints(
-        self, monkeypatch, tmp_path
-    ):
-        """Python publishes topology domains; Rust derives topology taints."""
-        topology_dir = tmp_path / "topology"
-        topology_dir.mkdir()
-        (topology_dir / "zone").write_text("us-east-1a")
-        (topology_dir / "rack").write_text("rack-22")
-
-        _enable_topology(monkeypatch, topology_dir)
-        monkeypatch.setenv("DYN_KV_TRANSFER_ENFORCEMENT", "preferred")
-        monkeypatch.setenv("DYN_KV_TRANSFER_PREFERRED_WEIGHT", "0.85")
-
-        runtime_config = FakeRuntimeConfig()
-        runtime_config.taints = {"user.taint/example"}
-
-        returned = apply_topology_config(runtime_config)
-
-        expected_topology_domains = {
-            "rack": "rack-22",
-            "zone": "us-east-1a",
-        }
-        assert returned.topology_domains == expected_topology_domains
-        assert runtime_config.topology_domains == expected_topology_domains
-        assert runtime_config.kv_transfer_domain == "zone"
-        assert runtime_config.kv_transfer_enforcement == "preferred"
-        assert runtime_config.kv_transfer_preferred_weight == 0.85
-        assert runtime_config.taints == {"user.taint/example"}

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -35,6 +35,7 @@ _KV_TRANSFER_DOMAIN_VAR = "DYN_KV_TRANSFER_DOMAIN"
 _KV_TRANSFER_ENFORCEMENT_VAR = "DYN_KV_TRANSFER_ENFORCEMENT"
 _KV_TRANSFER_PREFERRED_WEIGHT_VAR = "DYN_KV_TRANSFER_PREFERRED_WEIGHT"
 _DEFAULT_MOUNT_PATH = "/etc/dynamo/topology"
+_DEFAULT_KV_TRANSFER_ENFORCEMENT = "required"
 _POLL_INTERVAL_SECS = 1.0
 _POLL_TIMEOUT_SECS = 30.0
 
@@ -92,7 +93,9 @@ def _read_kv_transfer_policy() -> tuple[str, str | None, float | None]:
     kv_transfer_domain = (
         kv_transfer_domain.strip() if kv_transfer_domain is not None else None
     )
-    kv_transfer_enforcement = os.environ.get(_KV_TRANSFER_ENFORCEMENT_VAR, "required")
+    kv_transfer_enforcement = os.environ.get(
+        _KV_TRANSFER_ENFORCEMENT_VAR, _DEFAULT_KV_TRANSFER_ENFORCEMENT
+    )
     raw_preferred_weight = os.environ.get(_KV_TRANSFER_PREFERRED_WEIGHT_VAR, None)
 
     if not kv_transfer_domain:

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -89,10 +89,13 @@ def _read_topology_domains(mount_path: Path) -> dict[str, str]:
 
 def _read_kv_transfer_policy() -> tuple[str, str | None, float | None]:
     kv_transfer_domain = os.environ.get(_KV_TRANSFER_DOMAIN_VAR, None)
+    kv_transfer_domain = (
+        kv_transfer_domain.strip() if kv_transfer_domain is not None else None
+    )
     kv_transfer_enforcement = os.environ.get(_KV_TRANSFER_ENFORCEMENT_VAR, None)
     raw_preferred_weight = os.environ.get(_KV_TRANSFER_PREFERRED_WEIGHT_VAR, None)
 
-    if kv_transfer_domain is None:
+    if not kv_transfer_domain:
         logger.error(
             "DYN_TOPOLOGY_ENABLED=true but %s is not set. The deployment "
             "environment must set the KV transfer domain when topology is "

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -92,7 +92,7 @@ def _read_kv_transfer_policy() -> tuple[str, str | None, float | None]:
     kv_transfer_domain = (
         kv_transfer_domain.strip() if kv_transfer_domain is not None else None
     )
-    kv_transfer_enforcement = os.environ.get(_KV_TRANSFER_ENFORCEMENT_VAR, None)
+    kv_transfer_enforcement = os.environ.get(_KV_TRANSFER_ENFORCEMENT_VAR, "required")
     raw_preferred_weight = os.environ.get(_KV_TRANSFER_PREFERRED_WEIGHT_VAR, None)
 
     if not kv_transfer_domain:

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -3,21 +3,22 @@
 
 """Topology domain utilities for topology-aware KV transfer routing.
 
-Workers read their topology placement (e.g. zone, rack) from a file
-projected by the Kubernetes Downward API volume, and read KV transfer
-policy from environment variables. The Rust runtime derives canonical
-topology taints from the published topology domains.
+Workers read their topology placement (e.g. zone, rack) from files provided
+by the deployment environment, and read KV transfer policy from environment
+variables. Each visible, non-empty file name is treated as a topology domain
+and its contents as this worker's value for that domain. The Rust runtime
+derives canonical topology taints from the published topology domains.
 
-Environment variables (set by the operator):
+Environment variables:
     DYN_TOPOLOGY_ENABLED: Set to "true" to enable topology reading.
-    DYN_TOPOLOGY_MOUNT_PATH: Directory where the Downward API volume is
-        mounted (default: /etc/dynamo/topology).
+    DYN_TOPOLOGY_MOUNT_PATH: Directory containing topology domain files
+        (default: /etc/dynamo/topology).
     DYN_KV_TRANSFER_DOMAIN: Which topology domain the router should enforce
         for KV transfer constraints (e.g. "zone"). The file at
         {mount_path}/{domain} must contain the transfer-domain topology value.
     DYN_KV_TRANSFER_ENFORCEMENT: KV transfer enforcement mode, either
         "required" or "preferred" (default: "required" when a domain is set).
-    DYN_KV_TRANSFER_PREFERRED_WEIGHT: Required preferred-taint weight when
+    DYN_KV_TRANSFER_PREFERRED_WEIGHT: Preferred-taint weight used when
         enforcement is "preferred".
 """
 
@@ -85,6 +86,7 @@ def _read_topology_domains(mount_path: Path) -> dict[str, str]:
 
     return topology_domains
 
+
 def _read_kv_transfer_policy() -> tuple[str, str | None, float | None]:
     kv_transfer_domain = os.environ.get(_KV_TRANSFER_DOMAIN_VAR, None)
     kv_transfer_enforcement = os.environ.get(_KV_TRANSFER_ENFORCEMENT_VAR, None)
@@ -92,8 +94,9 @@ def _read_kv_transfer_policy() -> tuple[str, str | None, float | None]:
 
     if kv_transfer_domain is None:
         logger.error(
-            "DYN_TOPOLOGY_ENABLED=true but %s is not set. The operator must "
-            "set the KV transfer domain when topology is enabled. Exiting.",
+            "DYN_TOPOLOGY_ENABLED=true but %s is not set. The deployment "
+            "environment must set the KV transfer domain when topology is "
+            "enabled. Exiting.",
             _KV_TRANSFER_DOMAIN_VAR,
         )
         sys.exit(1)
@@ -106,9 +109,10 @@ def read_topology_config(
     poll_interval: float = _POLL_INTERVAL_SECS,
     poll_timeout: float = _POLL_TIMEOUT_SECS,
 ) -> TopologyConfig:
-    """Read topology config from Downward API volume and env vars.
+    """Read topology config from a file-backed source and env vars.
 
-    The operator injects env vars for topology location and transfer policy:
+    The deployment environment injects env vars for topology location and
+    transfer policy:
       - DYN_TOPOLOGY_ENABLED=true
       - DYN_TOPOLOGY_MOUNT_PATH=/etc/dynamo/topology
       - DYN_KV_TRANSFER_DOMAIN=zone
@@ -116,7 +120,7 @@ def read_topology_config(
       - DYN_KV_TRANSFER_PREFERRED_WEIGHT=0.85
 
     Topology values are read by listing non-hidden files under the mount path.
-    Since the Downward API volume reflects live label updates, this function
+    The topology source may populate files asynchronously, so this function
     polls until the transfer-domain file has content, sleeping between retries.
 
     Args:
@@ -145,6 +149,7 @@ def read_topology_config(
     transfer_domain_file = topology_mount_path / kv_transfer_domain
 
     # Poll until the transfer-domain file has content or timeout expires.
+    # This supports topology sources that populate files asynchronously.
     deadline = time.monotonic() + poll_timeout
     topology_domains = _read_topology_domains(topology_mount_path)
     while kv_transfer_domain not in topology_domains and time.monotonic() < deadline:
@@ -161,8 +166,8 @@ def read_topology_config(
     if kv_transfer_domain not in topology_domains:
         logger.error(
             "DYN_TOPOLOGY_ENABLED=true but topology file %s was not populated "
-            "within %.0fs. This indicates the pod label was never projected "
-            "via the Downward API. Exiting.",
+            "within %.0fs. This indicates the configured topology source did "
+            "not publish the selected transfer domain. Exiting.",
             transfer_domain_file,
             poll_timeout,
         )

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -34,7 +34,6 @@ _KV_TRANSFER_DOMAIN_VAR = "DYN_KV_TRANSFER_DOMAIN"
 _KV_TRANSFER_ENFORCEMENT_VAR = "DYN_KV_TRANSFER_ENFORCEMENT"
 _KV_TRANSFER_PREFERRED_WEIGHT_VAR = "DYN_KV_TRANSFER_PREFERRED_WEIGHT"
 _DEFAULT_MOUNT_PATH = "/etc/dynamo/topology"
-_DEFAULT_KV_TRANSFER_ENFORCEMENT = "required"
 _POLL_INTERVAL_SECS = 1.0
 _POLL_TIMEOUT_SECS = 30.0
 
@@ -86,15 +85,10 @@ def _read_topology_domains(mount_path: Path) -> dict[str, str]:
 
     return topology_domains
 
-
-def _optional_env(var_name: str) -> str | None:
-    return os.environ.get(var_name, "").strip() or None
-
-
-def _read_kv_transfer_policy() -> tuple[str, str, float | None]:
-    kv_transfer_domain = _optional_env(_KV_TRANSFER_DOMAIN_VAR)
-    kv_transfer_enforcement = _optional_env(_KV_TRANSFER_ENFORCEMENT_VAR)
-    raw_preferred_weight = os.environ.get(_KV_TRANSFER_PREFERRED_WEIGHT_VAR, "").strip()
+def _read_kv_transfer_policy() -> tuple[str, str | None, float | None]:
+    kv_transfer_domain = os.environ.get(_KV_TRANSFER_DOMAIN_VAR, None)
+    kv_transfer_enforcement = os.environ.get(_KV_TRANSFER_ENFORCEMENT_VAR, None)
+    raw_preferred_weight = os.environ.get(_KV_TRANSFER_PREFERRED_WEIGHT_VAR, None)
 
     if kv_transfer_domain is None:
         logger.error(
@@ -104,9 +98,6 @@ def _read_kv_transfer_policy() -> tuple[str, str, float | None]:
         )
         sys.exit(1)
 
-    kv_transfer_enforcement = (
-        kv_transfer_enforcement or _DEFAULT_KV_TRANSFER_ENFORCEMENT
-    )
     preferred_weight = float(raw_preferred_weight) if raw_preferred_weight else None
     return kv_transfer_domain, kv_transfer_enforcement, preferred_weight
 

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -140,9 +140,11 @@ def read_topology_config(
     if enabled != "true":
         return TopologyConfig()
 
-    kv_transfer_domain, kv_transfer_enforcement, kv_transfer_preferred_weight = (
-        _read_kv_transfer_policy()
-    )
+    (
+        kv_transfer_domain,
+        kv_transfer_enforcement,
+        kv_transfer_preferred_weight,
+    ) = _read_kv_transfer_policy()
 
     mount_path = os.environ.get(_TOPOLOGY_MOUNT_PATH_VAR, _DEFAULT_MOUNT_PATH)
     topology_mount_path = Path(mount_path)

--- a/components/src/dynamo/common/utils/topology.py
+++ b/components/src/dynamo/common/utils/topology.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Topology domain utilities for topology-aware KV transfer routing.
+
+Workers read their topology placement (e.g. zone, rack) from a file
+projected by the Kubernetes Downward API volume, and read KV transfer
+policy from environment variables. The Rust runtime derives canonical
+topology taints from the published topology domains.
+
+Environment variables (set by the operator):
+    DYN_TOPOLOGY_ENABLED: Set to "true" to enable topology reading.
+    DYN_TOPOLOGY_MOUNT_PATH: Directory where the Downward API volume is
+        mounted (default: /etc/dynamo/topology).
+    DYN_KV_TRANSFER_DOMAIN: Which topology domain the router should enforce
+        for KV transfer constraints (e.g. "zone"). The file at
+        {mount_path}/{domain} must contain the transfer-domain topology value.
+    DYN_KV_TRANSFER_ENFORCEMENT: KV transfer enforcement mode, either
+        "required" or "preferred" (default: "required" when a domain is set).
+    DYN_KV_TRANSFER_PREFERRED_WEIGHT: Required preferred-taint weight when
+        enforcement is "preferred".
+"""
+
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_TOPOLOGY_ENABLED_VAR = "DYN_TOPOLOGY_ENABLED"
+_TOPOLOGY_MOUNT_PATH_VAR = "DYN_TOPOLOGY_MOUNT_PATH"
+_KV_TRANSFER_DOMAIN_VAR = "DYN_KV_TRANSFER_DOMAIN"
+_KV_TRANSFER_ENFORCEMENT_VAR = "DYN_KV_TRANSFER_ENFORCEMENT"
+_KV_TRANSFER_PREFERRED_WEIGHT_VAR = "DYN_KV_TRANSFER_PREFERRED_WEIGHT"
+_DEFAULT_MOUNT_PATH = "/etc/dynamo/topology"
+_DEFAULT_KV_TRANSFER_ENFORCEMENT = "required"
+_POLL_INTERVAL_SECS = 1.0
+_POLL_TIMEOUT_SECS = 30.0
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TopologyConfig:
+    """Topology and KV transfer policy configuration read at worker startup."""
+
+    topology_domains: dict[str, str] = field(default_factory=dict)
+    kv_transfer_domain: str | None = None
+    kv_transfer_enforcement: str | None = None
+    kv_transfer_preferred_weight: float | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.topology_domains)
+
+
+def _read_topology_domains(mount_path: Path) -> dict[str, str]:
+    """Read all non-hidden, non-empty topology files from the mount path."""
+    try:
+        topology_files = sorted(mount_path.iterdir(), key=lambda path: path.name)
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        logger.warning("Unable to list topology mount path %s: %s", mount_path, exc)
+        return {}
+
+    topology_domains: dict[str, str] = {}
+    for topology_file in topology_files:
+        file_name = topology_file.name
+        if file_name.startswith("."):
+            continue
+
+        try:
+            if not topology_file.is_file():
+                continue
+            value = topology_file.read_text().strip()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.warning("Unable to read topology file %s: %s", topology_file, exc)
+            continue
+
+        if value:
+            topology_domains[file_name] = value
+
+    return topology_domains
+
+
+def _optional_env(var_name: str) -> str | None:
+    return os.environ.get(var_name, "").strip() or None
+
+
+def _read_kv_transfer_policy() -> tuple[str, str, float | None]:
+    kv_transfer_domain = _optional_env(_KV_TRANSFER_DOMAIN_VAR)
+    kv_transfer_enforcement = _optional_env(_KV_TRANSFER_ENFORCEMENT_VAR)
+    raw_preferred_weight = os.environ.get(_KV_TRANSFER_PREFERRED_WEIGHT_VAR, "").strip()
+
+    if kv_transfer_domain is None:
+        logger.error(
+            "DYN_TOPOLOGY_ENABLED=true but %s is not set. The operator must "
+            "set the KV transfer domain when topology is enabled. Exiting.",
+            _KV_TRANSFER_DOMAIN_VAR,
+        )
+        sys.exit(1)
+
+    kv_transfer_enforcement = (
+        kv_transfer_enforcement or _DEFAULT_KV_TRANSFER_ENFORCEMENT
+    )
+    preferred_weight = float(raw_preferred_weight) if raw_preferred_weight else None
+    return kv_transfer_domain, kv_transfer_enforcement, preferred_weight
+
+
+def read_topology_config(
+    poll_interval: float = _POLL_INTERVAL_SECS,
+    poll_timeout: float = _POLL_TIMEOUT_SECS,
+) -> TopologyConfig:
+    """Read topology config from Downward API volume and env vars.
+
+    The operator injects env vars for topology location and transfer policy:
+      - DYN_TOPOLOGY_ENABLED=true
+      - DYN_TOPOLOGY_MOUNT_PATH=/etc/dynamo/topology
+      - DYN_KV_TRANSFER_DOMAIN=zone
+      - DYN_KV_TRANSFER_ENFORCEMENT=required
+      - DYN_KV_TRANSFER_PREFERRED_WEIGHT=0.85
+
+    Topology values are read by listing non-hidden files under the mount path.
+    Since the Downward API volume reflects live label updates, this function
+    polls until the transfer-domain file has content, sleeping between retries.
+
+    Args:
+        poll_interval: Seconds between retries (default: 1.0).
+        poll_timeout: Maximum seconds to wait (default: 30.0).
+
+    Returns:
+        TopologyConfig with topology domains and transfer policy.
+        Empty config if topology is not enabled.
+
+    Raises:
+        SystemExit: If DYN_TOPOLOGY_ENABLED=true but DYN_KV_TRANSFER_DOMAIN is
+            not set, the transfer-domain topology file is still missing or
+            empty after the timeout.
+    """
+    enabled = os.environ.get(_TOPOLOGY_ENABLED_VAR, "").strip().lower()
+    if enabled != "true":
+        return TopologyConfig()
+
+    kv_transfer_domain, kv_transfer_enforcement, kv_transfer_preferred_weight = (
+        _read_kv_transfer_policy()
+    )
+
+    mount_path = os.environ.get(_TOPOLOGY_MOUNT_PATH_VAR, _DEFAULT_MOUNT_PATH)
+    topology_mount_path = Path(mount_path)
+    transfer_domain_file = topology_mount_path / kv_transfer_domain
+
+    # Poll until the transfer-domain file has content or timeout expires.
+    deadline = time.monotonic() + poll_timeout
+    topology_domains = _read_topology_domains(topology_mount_path)
+    while kv_transfer_domain not in topology_domains and time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        logger.info(
+            "Waiting for topology domain %s in %s (%.0fs remaining)...",
+            kv_transfer_domain,
+            topology_mount_path,
+            remaining,
+        )
+        time.sleep(min(poll_interval, max(remaining, 0)))
+        topology_domains = _read_topology_domains(topology_mount_path)
+
+    if kv_transfer_domain not in topology_domains:
+        logger.error(
+            "DYN_TOPOLOGY_ENABLED=true but topology file %s was not populated "
+            "within %.0fs. This indicates the pod label was never projected "
+            "via the Downward API. Exiting.",
+            transfer_domain_file,
+            poll_timeout,
+        )
+        sys.exit(1)
+
+    config = TopologyConfig(
+        topology_domains=topology_domains,
+        kv_transfer_domain=kv_transfer_domain,
+        kv_transfer_enforcement=kv_transfer_enforcement,
+        kv_transfer_preferred_weight=kv_transfer_preferred_weight,
+    )
+    logger.info("Topology config: %s (from %s)", config, topology_mount_path)
+    return config
+
+
+def apply_topology_config(runtime_config) -> TopologyConfig:
+    """Apply topology config to a ModelRuntimeConfig-like object."""
+    topology_config = read_topology_config()
+    if not topology_config.enabled:
+        return topology_config
+
+    runtime_config.topology_domains = topology_config.topology_domains
+    runtime_config.kv_transfer_domain = topology_config.kv_transfer_domain
+    runtime_config.kv_transfer_enforcement = topology_config.kv_transfer_enforcement
+    runtime_config.kv_transfer_preferred_weight = (
+        topology_config.kv_transfer_preferred_weight
+    )
+    return topology_config

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -14,6 +14,7 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 from dynamo._core import Endpoint
 from dynamo.common.utils.output_modalities import get_output_modalities
+from dynamo.common.utils.topology import apply_topology_config
 from dynamo.llm import (
     MediaDecoder,
     MediaFetcher,
@@ -294,6 +295,9 @@ async def _get_runtime_config(
                 "Failed to attach SGLang worker group metadata to registration: %s",
                 e,
             )
+
+    # Set topology and KV transfer policy for topology-aware routing
+    apply_topology_config(runtime_config)
 
     # Set bootstrap endpoint for disaggregated serving (prefill workers)
     bootstrap_host, bootstrap_port = _get_bootstrap_info_for_config(engine)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -43,6 +43,7 @@ from dynamo.common.utils.prometheus import (
     register_engine_metrics_callback,
 )
 from dynamo.common.utils.runtime import parse_endpoint
+from dynamo.common.utils.topology import apply_topology_config
 from dynamo.llm import (
     KvEventPublisher,
     MediaDecoder,
@@ -317,9 +318,9 @@ async def init_llm_worker(
                     f"Using existing event_buffer_max_size={existing} from kv_cache_config"
                 )
             else:
-                current_kv_config[
-                    "event_buffer_max_size"
-                ] = DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
+                current_kv_config["event_buffer_max_size"] = (
+                    DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
+                )
 
         # Only pytorch backend is supported for now to publish events and metrics.
         if "backend" not in arg_map:
@@ -508,6 +509,9 @@ async def init_llm_worker(
         # Need to name ADP as `data_parallel_size` for parity with other frameworks
         attention_dp_size = engine.get_attention_dp_size()
         runtime_config.data_parallel_size = attention_dp_size
+
+        # Set topology and KV transfer policy for topology-aware routing
+        apply_topology_config(runtime_config)
 
         logging.info(f"Set runtime config max_num_seqs: {runtime_config.max_num_seqs}")
         logging.info(

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -318,9 +318,9 @@ async def init_llm_worker(
                     f"Using existing event_buffer_max_size={existing} from kv_cache_config"
                 )
             else:
-                current_kv_config["event_buffer_max_size"] = (
-                    DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
-                )
+                current_kv_config[
+                    "event_buffer_max_size"
+                ] = DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
 
         # Only pytorch backend is supported for now to publish events and metrics.
         if "backend" not in arg_map:

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -27,6 +27,7 @@ from dynamo.common.utils.prometheus import (
     register_engine_metrics_callback,
 )
 from dynamo.common.utils.runtime import create_runtime
+from dynamo.common.utils.topology import apply_topology_config
 from dynamo.llm import (
     KvEventPublisher,
     MediaDecoder,
@@ -667,6 +668,9 @@ async def register_vllm_model(
     dp_range = get_dp_range_for_worker(vllm_config)
     runtime_config.data_parallel_start_rank = dp_range[0]
     runtime_config.data_parallel_size = dp_range[1]
+
+    # Set topology and KV transfer policy for topology-aware routing
+    apply_topology_config(runtime_config)
 
     # Configure media decoder for frontend image decoding when enabled
     # This enables frontend to decode images and transfer via NIXL RDMA

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -274,12 +274,13 @@ impl ModelRuntimeConfig {
 
     #[setter]
     fn set_topology_domains(&mut self, topology_domains: &Bound<'_, PyDict>) -> PyResult<()> {
-        self.inner.topology_domains.clear();
+        let mut new_topology_domains = HashMap::new();
         for (key, value) in topology_domains.iter() {
             let key_str: String = key.extract()?;
             let value_str: String = value.extract()?;
-            self.inner.topology_domains.insert(key_str, value_str);
+            new_topology_domains.insert(key_str, value_str);
         }
+        self.inner.topology_domains = new_topology_domains;
         Ok(())
     }
 

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -313,7 +313,7 @@ impl ModelRuntimeConfig {
             return Ok(());
         };
 
-        let kv_transfer_enforcement = kv_transfer_enforcement.trim().to_ascii_lowercase();
+        let kv_transfer_enforcement = kv_transfer_enforcement;
         self.inner.kv_transfer_enforcement = match kv_transfer_enforcement.as_str() {
             "" => None,
             "required" => Some(RsKvTransferEnforcement::Required),
@@ -337,14 +337,6 @@ impl ModelRuntimeConfig {
         &mut self,
         kv_transfer_preferred_weight: Option<f32>,
     ) -> PyResult<()> {
-        if let Some(value) = kv_transfer_preferred_weight
-            && (!value.is_finite() || !(0.0..=1.0).contains(&value))
-        {
-            return Err(PyValueError::new_err(
-                "kv_transfer_preferred_weight must be finite and between 0.0 and 1.0",
-            ));
-        }
-
         self.inner.kv_transfer_preferred_weight = kv_transfer_preferred_weight;
         Ok(())
     }

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -4,7 +4,9 @@
 use std::collections::{HashMap, HashSet};
 
 use super::*;
-use dynamo_kv_router::protocols::RoutingConstraints as RsRoutingConstraints;
+use dynamo_kv_router::protocols::{
+    KvTransferEnforcement as RsKvTransferEnforcement, RoutingConstraints as RsRoutingConstraints,
+};
 use llm_rs::local_model::runtime_config::DisaggregatedEndpoint as RsDisaggregatedEndpoint;
 use llm_rs::local_model::runtime_config::ModelRuntimeConfig as RsModelRuntimeConfig;
 use pyo3::exceptions::PyValueError;
@@ -259,5 +261,91 @@ impl ModelRuntimeConfig {
     #[getter]
     fn taints(&self) -> HashSet<String> {
         self.inner.taints.clone()
+    }
+
+    #[getter]
+    fn topology_domains(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        for (key, value) in &self.inner.topology_domains {
+            dict.set_item(key, value)?;
+        }
+        Ok(dict.into())
+    }
+
+    #[setter]
+    fn set_topology_domains(&mut self, topology_domains: &Bound<'_, PyDict>) -> PyResult<()> {
+        self.inner.topology_domains.clear();
+        for (key, value) in topology_domains.iter() {
+            let key_str: String = key.extract()?;
+            let value_str: String = value.extract()?;
+            self.inner.topology_domains.insert(key_str, value_str);
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn kv_transfer_domain(&self) -> Option<String> {
+        self.inner.kv_transfer_domain.clone()
+    }
+
+    #[setter]
+    fn set_kv_transfer_domain(&mut self, kv_transfer_domain: Option<String>) {
+        self.inner.kv_transfer_domain = kv_transfer_domain;
+    }
+
+    #[getter]
+    fn kv_transfer_enforcement(&self) -> Option<String> {
+        self.inner
+            .kv_transfer_enforcement
+            .map(|enforcement| match enforcement {
+                RsKvTransferEnforcement::Required => "required".to_string(),
+                RsKvTransferEnforcement::Preferred => "preferred".to_string(),
+            })
+    }
+
+    #[setter]
+    fn set_kv_transfer_enforcement(
+        &mut self,
+        kv_transfer_enforcement: Option<String>,
+    ) -> PyResult<()> {
+        let Some(kv_transfer_enforcement) = kv_transfer_enforcement else {
+            self.inner.kv_transfer_enforcement = None;
+            return Ok(());
+        };
+
+        let kv_transfer_enforcement = kv_transfer_enforcement.trim().to_ascii_lowercase();
+        self.inner.kv_transfer_enforcement = match kv_transfer_enforcement.as_str() {
+            "" => None,
+            "required" => Some(RsKvTransferEnforcement::Required),
+            "preferred" => Some(RsKvTransferEnforcement::Preferred),
+            value => {
+                return Err(PyValueError::new_err(format!(
+                    "kv_transfer_enforcement must be 'required' or 'preferred', got {value:?}"
+                )));
+            }
+        };
+        Ok(())
+    }
+
+    #[getter]
+    fn kv_transfer_preferred_weight(&self) -> Option<f32> {
+        self.inner.kv_transfer_preferred_weight
+    }
+
+    #[setter]
+    fn set_kv_transfer_preferred_weight(
+        &mut self,
+        kv_transfer_preferred_weight: Option<f32>,
+    ) -> PyResult<()> {
+        if let Some(value) = kv_transfer_preferred_weight
+            && (!value.is_finite() || !(0.0..=1.0).contains(&value))
+        {
+            return Err(PyValueError::new_err(
+                "kv_transfer_preferred_weight must be finite and between 0.0 and 1.0",
+            ));
+        }
+
+        self.inner.kv_transfer_preferred_weight = kv_transfer_preferred_weight;
+        Ok(())
     }
 }

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -313,7 +313,6 @@ impl ModelRuntimeConfig {
             return Ok(());
         };
 
-        let kv_transfer_enforcement = kv_transfer_enforcement;
         self.inner.kv_transfer_enforcement = match kv_transfer_enforcement.as_str() {
             "" => None,
             "required" => Some(RsKvTransferEnforcement::Required),

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -651,6 +651,10 @@ class ModelRuntimeConfig:
     taints: Set[str]
     stable_routing_id: str | None
     runtime_data: dict[str, Any]
+    topology_domains: dict[str, str]
+    kv_transfer_domain: str | None
+    kv_transfer_enforcement: str | None
+    kv_transfer_preferred_weight: float | None
     tensor_model_config: Any | None
     bootstrap_host: str | None
     bootstrap_port: int | None

--- a/lib/bindings/python/tests/test_model_runtime_config_topology.py
+++ b/lib/bindings/python/tests/test_model_runtime_config_topology.py
@@ -5,14 +5,11 @@ import pytest
 
 from dynamo.llm import ModelRuntimeConfig
 
-pytestmark = [
-    pytest.mark.unit,
-    pytest.mark.none,
-    pytest.mark.gpu_0,
-    pytest.mark.pre_merge,
-]
 
-
+@pytest.mark.unit
+@pytest.mark.none
+@pytest.mark.gpu_0
+@pytest.mark.pre_merge
 def test_model_runtime_config_topology_fields_round_trip():
     runtime_config = ModelRuntimeConfig()
 
@@ -35,6 +32,10 @@ def test_model_runtime_config_topology_fields_round_trip():
     assert runtime_config.kv_transfer_preferred_weight is None
 
 
+@pytest.mark.unit
+@pytest.mark.none
+@pytest.mark.gpu_0
+@pytest.mark.pre_merge
 def test_model_runtime_config_rejects_invalid_topology_policy_values():
     runtime_config = ModelRuntimeConfig()
 

--- a/lib/bindings/python/tests/test_model_runtime_config_topology.py
+++ b/lib/bindings/python/tests/test_model_runtime_config_topology.py
@@ -19,7 +19,7 @@ def test_model_runtime_config_topology_fields_round_trip():
     runtime_config.taints = {"user.taint/example"}
     runtime_config.topology_domains = {"zone": "us-east-1a"}
     runtime_config.kv_transfer_domain = "zone"
-    runtime_config.kv_transfer_enforcement = "Preferred"
+    runtime_config.kv_transfer_enforcement = "preferred"
     runtime_config.kv_transfer_preferred_weight = 0.85
 
     assert runtime_config.taints == {"user.taint/example"}
@@ -40,7 +40,3 @@ def test_model_runtime_config_rejects_invalid_topology_policy_values():
 
     with pytest.raises(ValueError, match="kv_transfer_enforcement"):
         runtime_config.kv_transfer_enforcement = "fallback"
-
-    for invalid_weight in (1.1, -0.1, float("nan"), float("inf")):
-        with pytest.raises(ValueError, match="kv_transfer_preferred_weight"):
-            runtime_config.kv_transfer_preferred_weight = invalid_weight

--- a/lib/bindings/python/tests/test_model_runtime_config_topology.py
+++ b/lib/bindings/python/tests/test_model_runtime_config_topology.py
@@ -5,12 +5,12 @@ import pytest
 
 from dynamo.llm import ModelRuntimeConfig
 
-pytestmark = [
+pytestmark = (
     pytest.mark.unit,
     pytest.mark.none,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
-]
+)
 
 
 def test_model_runtime_config_topology_fields_round_trip():

--- a/lib/bindings/python/tests/test_model_runtime_config_topology.py
+++ b/lib/bindings/python/tests/test_model_runtime_config_topology.py
@@ -5,12 +5,12 @@ import pytest
 
 from dynamo.llm import ModelRuntimeConfig
 
-pytestmark = (
+pytestmark = [
     pytest.mark.unit,
     pytest.mark.none,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
-)
+]
 
 
 def test_model_runtime_config_topology_fields_round_trip():

--- a/lib/bindings/python/tests/test_model_runtime_config_topology.py
+++ b/lib/bindings/python/tests/test_model_runtime_config_topology.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.llm import ModelRuntimeConfig
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_model_runtime_config_topology_fields_round_trip():
+    runtime_config = ModelRuntimeConfig()
+
+    runtime_config.taints = {"user.taint/example"}
+    runtime_config.topology_domains = {"zone": "us-east-1a"}
+    runtime_config.kv_transfer_domain = "zone"
+    runtime_config.kv_transfer_enforcement = "Preferred"
+    runtime_config.kv_transfer_preferred_weight = 0.85
+
+    assert runtime_config.taints == {"user.taint/example"}
+    assert runtime_config.topology_domains == {"zone": "us-east-1a"}
+    assert runtime_config.kv_transfer_domain == "zone"
+    assert runtime_config.kv_transfer_enforcement == "preferred"
+    assert runtime_config.kv_transfer_preferred_weight == pytest.approx(0.85)
+
+    runtime_config.kv_transfer_enforcement = None
+    runtime_config.kv_transfer_preferred_weight = None
+
+    assert runtime_config.kv_transfer_enforcement is None
+    assert runtime_config.kv_transfer_preferred_weight is None
+
+
+def test_model_runtime_config_rejects_invalid_topology_policy_values():
+    runtime_config = ModelRuntimeConfig()
+
+    with pytest.raises(ValueError, match="kv_transfer_enforcement"):
+        runtime_config.kv_transfer_enforcement = "fallback"
+
+    for invalid_weight in (1.1, -0.1, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="kv_transfer_preferred_weight"):
+            runtime_config.kv_transfer_preferred_weight = invalid_weight

--- a/lib/bindings/python/tests/test_model_runtime_config_topology.py
+++ b/lib/bindings/python/tests/test_model_runtime_config_topology.py
@@ -41,3 +41,17 @@ def test_model_runtime_config_rejects_invalid_topology_policy_values():
 
     with pytest.raises(ValueError, match="kv_transfer_enforcement"):
         runtime_config.kv_transfer_enforcement = "fallback"
+
+
+@pytest.mark.unit
+@pytest.mark.none
+@pytest.mark.gpu_0
+@pytest.mark.pre_merge
+def test_model_runtime_config_topology_domains_setter_is_atomic():
+    runtime_config = ModelRuntimeConfig()
+    runtime_config.topology_domains = {"zone": "us-east-1a"}
+
+    with pytest.raises(TypeError):
+        runtime_config.topology_domains = {"rack": "rack-22", 1: "us-west-2a"}
+
+    assert runtime_config.topology_domains == {"zone": "us-east-1a"}


### PR DESCRIPTION
## Summary

- Add Python topology env/file reader for worker startup and DGD KV transfer policy fields
- Keep Python validation scoped to transfer-domain setup: the domain env must identify the file, and the selected Downward API file must become available; enum/weight policy validation is deferred to the `ModelRuntimeConfig` binding/runtime config
- Wire topology config into vLLM, SGLang, and TRT-LLM runtime config publication
- Expose topology/KV transfer fields through the Python `ModelRuntimeConfig` binding
- Preserve user/backend taints in Python; Rust derives canonical topology taints

## Linear

- DYN-2986: https://linear.app/nvidia/issue/DYN-2986/tar-pr2-python-topology-env-reading-worker-topology-taints
- DEP: https://github.com/ai-dynamo/dynamo/issues/9118

## Validation

- `cargo fmt --check`
- `cargo fmt --check` (lib/bindings/python)
- `ruff format --check components/src/dynamo/common/utils/topology.py components/src/dynamo/common/utils/tests/test_topology.py lib/bindings/python/tests/test_model_runtime_config_topology.py`
- `python -m py_compile components/src/dynamo/common/utils/topology.py components/src/dynamo/common/utils/tests/test_topology.py lib/bindings/python/tests/test_model_runtime_config_topology.py`
- `cargo check -p dynamo-llm`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --lib`
- Direct import smoke test for topology reader pass-through behavior and apply logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added topology-aware KV transfer routing configuration support, enabling systems to read and apply transfer domain preferences from environment variables and filesystem mounts during model registration.

* **Tests**
  * Added comprehensive test coverage for topology configuration reading, validation, and KV transfer policy handling across multiple components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->