### PR TITLE
feat(operator): add topology label controller for node label copy

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/topology-label-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/topology-label-rbac.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Grants the operator read-only node access for topology label copy.
+# Nodes are cluster-scoped resources that cannot be granted via a namespace-scoped Role,
+# so this is always provided as a dedicated ClusterRole.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-topology-label
+  labels:
+    {{- include "dynamo-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-topology-label
+  labels:
+    {{- include "dynamo-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-topology-label
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dynamo-operator.fullname" . }}-controller-manager
+    namespace: {{ .Release.Namespace }}

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -712,6 +712,16 @@ func registerControllers(
 		}
 	}
 
+	if err = (&controller.TopologyLabelReconciler{
+		Client:        mgr.GetClient(),
+		NodeReader:    mgr.GetAPIReader(),
+		Config:        operatorCfg,
+		RuntimeConfig: runtimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("topology-label"),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create TopologyLabel controller: %w", err)
+	}
+
 	setupLog.Info("Controllers registered successfully")
 	return nil
 }

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -24,6 +24,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create
@@ -40,6 +46,7 @@ rules:
   - deletecollection
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apps

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -91,6 +91,12 @@ const (
 	EnvTopologyEnabled   = "DYN_TOPOLOGY_ENABLED"
 	EnvTopologyMountPath = "DYN_TOPOLOGY_MOUNT_PATH"
 
+	// KubeAnnotationTopologyLabelKey is set on worker pods when
+	// spec.experimental.kvTransferPolicy.labelKey is configured. The topology
+	// label controller watches for pods with this annotation and copies the
+	// corresponding node label onto the pod after scheduling.
+	KubeAnnotationTopologyLabelKey = "nvidia.com/topology-label-key"
+
 	DynamoDeploymentConfigEnvVar      = "DYN_DEPLOYMENT_CONFIG"
 	DynamoNamespaceEnvVar             = "DYN_NAMESPACE"
 	DynamoNamespacePrefixEnvVar       = "DYN_NAMESPACE_PREFIX"

--- a/deploy/operator/internal/controller/topology_label_controller.go
+++ b/deploy/operator/internal/controller/topology_label_controller.go
@@ -1,0 +1,183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+)
+
+const topologyLabelMissingReason = "TopologyLabelMissing"
+
+// TopologyLabelReconciler watches worker pods that have the
+// nvidia.com/topology-label-key annotation. When a pod is scheduled
+// (spec.nodeName is set) but the target label is missing, the controller
+// reads the label from the node and patches it onto the pod. The Downward
+// API volume then picks up the label value.
+type TopologyLabelReconciler struct {
+	client.Client
+	NodeReader    client.Reader
+	Config        *configv1alpha1.OperatorConfiguration
+	RuntimeConfig *commonController.RuntimeConfig
+	Recorder      record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get
+
+func (r *TopologyLabelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var pod corev1.Pod
+	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	labelKey, ok := topologyLabelCopyTarget(&pod)
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+
+	var node corev1.Node
+	if err := r.NodeReader.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, &node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("get node %s: %w", pod.Spec.NodeName, err)
+	}
+
+	labelValue, exists := node.Labels[labelKey]
+	if !exists {
+		logger.Info("Node missing topology label, skipping",
+			"node", pod.Spec.NodeName, "labelKey", labelKey, "pod", req.NamespacedName)
+		if r.Recorder != nil {
+			r.Recorder.Eventf(&pod, corev1.EventTypeWarning, topologyLabelMissingReason,
+				"Node %q does not have required topology label %q; topology metadata will remain unavailable",
+				pod.Spec.NodeName, labelKey)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	patch := client.MergeFrom(pod.DeepCopy())
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	pod.Labels[labelKey] = labelValue
+	if err := r.Patch(ctx, &pod, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch pod label: %w", err)
+	}
+
+	logger.Info("Copied node topology label to pod",
+		"pod", req.NamespacedName, "node", pod.Spec.NodeName,
+		"label", labelKey, "value", labelValue)
+	return ctrl.Result{}, nil
+}
+
+func (r *TopologyLabelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithEventFilter(predicate.And(
+			commonController.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig),
+			topologyLabelPredicate(),
+		)).
+		Complete(r)
+}
+
+// topologyLabelPredicate filters to annotated, scheduled pods that still need
+// the target topology label copied from the node.
+func topologyLabelPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return needsTopologyLabelCopy(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return topologyLabelCopyBecameNeeded(e.ObjectOld, e.ObjectNew)
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func topologyLabelCopyBecameNeeded(oldObj, newObj client.Object) bool {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok || oldPod == nil {
+		return false
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok || newPod == nil {
+		return false
+	}
+
+	if !needsTopologyLabelCopy(newPod) {
+		return false
+	}
+
+	oldLabelKey := oldPod.GetAnnotations()[consts.KubeAnnotationTopologyLabelKey]
+	newLabelKey := newPod.GetAnnotations()[consts.KubeAnnotationTopologyLabelKey]
+
+	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
+		return true
+	}
+	if oldLabelKey != newLabelKey {
+		return true
+	}
+	if oldLabelKey == "" {
+		return false
+	}
+
+	_, oldHadLabel := oldPod.GetLabels()[oldLabelKey]
+	_, newHasLabel := newPod.GetLabels()[oldLabelKey]
+	return oldHadLabel && !newHasLabel
+}
+
+func needsTopologyLabelCopy(obj client.Object) bool {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod == nil {
+		return false
+	}
+	_, ok = topologyLabelCopyTarget(pod)
+	return ok
+}
+
+func topologyLabelCopyTarget(pod *corev1.Pod) (string, bool) {
+	if pod == nil || !isDynamoComponentPod(pod) {
+		return "", false
+	}
+
+	labelKey := pod.GetAnnotations()[consts.KubeAnnotationTopologyLabelKey]
+	if labelKey == "" {
+		return "", false
+	}
+
+	if _, exists := pod.GetLabels()[labelKey]; exists {
+		return "", false
+	}
+
+	if pod.Spec.NodeName == "" {
+		return "", false
+	}
+
+	return labelKey, true
+}
+
+func isDynamoComponentPod(pod *corev1.Pod) bool {
+	labels := pod.GetLabels()
+	return labels[consts.KubeLabelDynamoGraphDeploymentName] != "" &&
+		labels[consts.KubeLabelDynamoComponent] != ""
+}

--- a/deploy/operator/internal/controller/topology_label_controller_test.go
+++ b/deploy/operator/internal/controller/topology_label_controller_test.go
@@ -1,0 +1,331 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+)
+
+func dynamoComponentPodLabels(labels map[string]string) map[string]string {
+	result := map[string]string{
+		consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+		consts.KubeLabelDynamoComponent:           "worker",
+	}
+	for k, v := range labels {
+		result[k] = v
+	}
+	return result
+}
+
+func TestTopologyLabelReconciler_CopiesToPod(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				consts.KubeAnnotationTopologyLabelKey: "topology.kubernetes.io/zone",
+			},
+			Labels: dynamoComponentPodLabels(nil),
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+
+	cl := fake.NewClientBuilder().WithObjects(pod).Build()
+	nodeReader := fake.NewClientBuilder().WithObjects(node).Build()
+	r := &TopologyLabelReconciler{Client: cl, NodeReader: nodeReader}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "worker-abc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var patched corev1.Pod
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &patched))
+	assert.Equal(t, "us-east-1a", patched.Labels["topology.kubernetes.io/zone"])
+}
+
+func TestTopologyLabelReconciler_SkipsIfLabelExists(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"topology.kubernetes.io/zone": "us-east-1b"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				consts.KubeAnnotationTopologyLabelKey: "topology.kubernetes.io/zone",
+			},
+			Labels: dynamoComponentPodLabels(map[string]string{
+				"topology.kubernetes.io/zone": "us-east-1a",
+			}),
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+
+	cl := fake.NewClientBuilder().WithObjects(node, pod).Build()
+	r := &TopologyLabelReconciler{Client: cl, NodeReader: cl}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "worker-abc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var unchanged corev1.Pod
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &unchanged))
+	assert.Equal(t, "us-east-1a", unchanged.Labels["topology.kubernetes.io/zone"])
+}
+
+func TestTopologyLabelReconciler_SkipsUnscheduledPod(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				consts.KubeAnnotationTopologyLabelKey: "topology.kubernetes.io/zone",
+			},
+			Labels: dynamoComponentPodLabels(nil),
+		},
+		Spec: corev1.PodSpec{}, // No NodeName yet
+	}
+
+	cl := fake.NewClientBuilder().WithObjects(pod).Build()
+	r := &TopologyLabelReconciler{Client: cl, NodeReader: cl}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "worker-abc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var unchanged corev1.Pod
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &unchanged))
+	assert.NotContains(t, unchanged.Labels, "topology.kubernetes.io/zone")
+}
+
+func TestTopologyLabelReconciler_SkipsIfNodeMissingLabel(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{}, // Missing the topology label
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				consts.KubeAnnotationTopologyLabelKey: "topology.kubernetes.io/zone",
+			},
+			Labels: dynamoComponentPodLabels(nil),
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+
+	cl := fake.NewClientBuilder().WithObjects(node, pod).Build()
+	recorder := record.NewFakeRecorder(1)
+	r := &TopologyLabelReconciler{Client: cl, NodeReader: cl, Recorder: recorder}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "worker-abc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	// Pod should NOT have the label
+	var patched corev1.Pod
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &patched))
+	assert.NotContains(t, patched.Labels, "topology.kubernetes.io/zone")
+
+	select {
+	case event := <-recorder.Events:
+		assert.True(t, strings.Contains(event, corev1.EventTypeWarning), event)
+		assert.True(t, strings.Contains(event, topologyLabelMissingReason), event)
+		assert.True(t, strings.Contains(event, "node-1"), event)
+		assert.True(t, strings.Contains(event, "topology.kubernetes.io/zone"), event)
+	case <-time.After(time.Second):
+		t.Fatal("expected topology missing warning event")
+	}
+}
+
+func TestTopologyLabelReconciler_SkipsPodWithoutAnnotation(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-abc",
+			Namespace: "default",
+			// No topology-label-key annotation
+			Labels: dynamoComponentPodLabels(nil),
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+
+	cl := fake.NewClientBuilder().WithObjects(node, pod).Build()
+	r := &TopologyLabelReconciler{Client: cl, NodeReader: cl}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "worker-abc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var unchanged corev1.Pod
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &unchanged))
+	assert.NotContains(t, unchanged.Labels, "topology.kubernetes.io/zone")
+}
+
+func TestTopologyLabelReconciler_SkipsNonDynamoComponentPod(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				consts.KubeAnnotationTopologyLabelKey: "topology.kubernetes.io/zone",
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+	}
+
+	cl := fake.NewClientBuilder().WithObjects(node, pod).Build()
+	r := &TopologyLabelReconciler{Client: cl, NodeReader: cl}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "worker-abc", Namespace: "default"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	var unchanged corev1.Pod
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: "worker-abc", Namespace: "default"}, &unchanged))
+	assert.NotContains(t, unchanged.Labels, "topology.kubernetes.io/zone")
+}
+
+func TestTopologyLabelPredicate(t *testing.T) {
+	const labelKey = "topology.kubernetes.io/zone"
+	const otherLabelKey = "topology.kubernetes.io/rack"
+
+	pod := func(nodeName string, annotations map[string]string, labels map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "worker-abc",
+				Namespace:   "default",
+				Annotations: annotations,
+				Labels:      dynamoComponentPodLabels(labels),
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+	}
+
+	predicate := topologyLabelPredicate()
+	needsLabelCopy := pod("node-1", map[string]string{
+		consts.KubeAnnotationTopologyLabelKey: labelKey,
+	}, nil)
+
+	assert.True(t, predicate.Create(event.CreateEvent{Object: needsLabelCopy}))
+	assert.True(t, predicate.Update(event.UpdateEvent{
+		ObjectOld: pod("", map[string]string{consts.KubeAnnotationTopologyLabelKey: labelKey}, nil),
+		ObjectNew: needsLabelCopy,
+	}))
+	assert.True(t, predicate.Update(event.UpdateEvent{
+		ObjectOld: pod("node-1", nil, nil),
+		ObjectNew: needsLabelCopy,
+	}))
+	assert.True(t, predicate.Update(event.UpdateEvent{
+		ObjectOld: pod("node-1", map[string]string{consts.KubeAnnotationTopologyLabelKey: otherLabelKey}, nil),
+		ObjectNew: needsLabelCopy,
+	}))
+	assert.True(t, predicate.Update(event.UpdateEvent{
+		ObjectOld: pod("node-1", map[string]string{consts.KubeAnnotationTopologyLabelKey: labelKey}, map[string]string{
+			labelKey: "us-east-1a",
+		}),
+		ObjectNew: needsLabelCopy,
+	}))
+	assert.False(t, predicate.Create(event.CreateEvent{
+		Object: pod("", map[string]string{consts.KubeAnnotationTopologyLabelKey: labelKey}, nil),
+	}))
+	assert.False(t, predicate.Create(event.CreateEvent{
+		Object: pod("node-1", nil, nil),
+	}))
+	assert.False(t, predicate.Create(event.CreateEvent{
+		Object: pod("node-1", map[string]string{consts.KubeAnnotationTopologyLabelKey: labelKey}, map[string]string{
+			labelKey: "us-east-1a",
+		}),
+	}))
+	assert.False(t, predicate.Update(event.UpdateEvent{
+		ObjectOld: needsLabelCopy,
+		ObjectNew: needsLabelCopy,
+	}))
+	assert.False(t, predicate.Update(event.UpdateEvent{
+		ObjectOld: needsLabelCopy,
+		ObjectNew: pod("node-1", map[string]string{consts.KubeAnnotationTopologyLabelKey: labelKey}, map[string]string{
+			labelKey: "us-east-1a",
+		}),
+	}))
+	nonDynamoLabelCases := map[string]map[string]string{
+		"missing ownership labels": nil,
+		"missing DGD label": {
+			consts.KubeLabelDynamoComponent: "worker",
+		},
+		"missing component label": {
+			consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+		},
+	}
+	for name, labels := range nonDynamoLabelCases {
+		t.Run(name, func(t *testing.T) {
+			assert.False(t, predicate.Create(event.CreateEvent{
+				Object: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "non-dynamo",
+						Namespace: "default",
+						Annotations: map[string]string{
+							consts.KubeAnnotationTopologyLabelKey: labelKey,
+						},
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{NodeName: "node-1"},
+				},
+			}))
+		})
+	}
+	assert.False(t, predicate.Delete(event.DeleteEvent{Object: needsLabelCopy}))
+	assert.False(t, predicate.Generic(event.GenericEvent{Object: needsLabelCopy}))
+}

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -358,6 +358,7 @@ func generateSingleDCD(
 	if err := applyDGDComponentAlphaCompatibilityToDCD(parentDGD, componentName, deployment); err != nil {
 		return nil, err
 	}
+	delete(deployment.Annotations, commonconsts.KubeAnnotationTopologyLabelKey)
 
 	labels := make(map[string]string)
 	maps.Copy(labels, GetPodTemplateLabels(component))
@@ -378,6 +379,14 @@ func generateSingleDCD(
 	}
 
 	applyDGDTemplateDefaults(&deployment.Spec.DynamoComponentDeploymentSharedSpec, parentDGD)
+
+	// Topology label controller marker: set on the DCD so it propagates to pods.
+	if shouldApplyKvTransferPolicyToWorkerComponent(component, parentDGD) {
+		if deployment.Annotations == nil {
+			deployment.Annotations = make(map[string]string)
+		}
+		deployment.Annotations[commonconsts.KubeAnnotationTopologyLabelKey] = parentDGD.Spec.Experimental.KvTransferPolicy.LabelKey
+	}
 
 	// Apply restart annotation if this component should be restarted.
 	if restartState.ShouldAnnotateComponent(componentName) {
@@ -1775,6 +1784,7 @@ func shouldApplyKvTransferPolicyToWorkerComponent(
 		dynamoDeployment != nil &&
 		dynamoDeployment.Spec.Experimental != nil &&
 		dynamoDeployment.Spec.Experimental.KvTransferPolicy != nil &&
+		dynamoDeployment.Spec.Experimental.KvTransferPolicy.LabelKey != "" &&
 		IsWorkerComponent(string(component.ComponentType))
 }
 
@@ -2014,6 +2024,10 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 	annotations, err := generateAnnotations(p.component, p.dynamoDeployment, p.componentName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate annotations: %w", err)
+	}
+	delete(annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+	if p.r.Role != RoleGMS && shouldApplyKvTransferPolicyToWorkerComponent(p.component, p.dynamoDeployment) {
+		annotations[commonconsts.KubeAnnotationTopologyLabelKey] = p.dynamoDeployment.Spec.Experimental.KvTransferPolicy.LabelKey
 	}
 	if p.r.Role != RoleGMS {
 		if err := checkpoint.ApplyRestorePodMetadataWithStorageConfig(labels, annotations, p.checkpointInfo, p.operatorConfig.Checkpoint.Storage); err != nil {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -893,6 +893,210 @@ func TestGenerateDynamoComponentsDeployments_PropagatesPreservedAlphaServiceAnno
 	assert.Equal(t, "nginx", ptr.Deref(ingressSpec.IngressControllerClassName, ""))
 }
 
+func TestGenerateDynamoComponentsDeployments_AddsTopologyLabelAnnotationToWorkers(t *testing.T) {
+	labelKey := "topology.kubernetes.io/zone"
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "worker", ComponentType: v1beta1.ComponentTypeWorker},
+				{ComponentName: "frontend", ComponentType: v1beta1.ComponentTypeFrontend},
+			},
+			Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
+				KvTransferPolicy: &v1beta1.KvTransferPolicy{
+					LabelKey:    labelKey,
+					Domain:      "zone",
+					Enforcement: v1beta1.KvTransferEnforcementRequired,
+				},
+			},
+		},
+	}
+
+	dcds, err := GenerateDynamoComponentsDeployments(dgd, nil, nil, RollingUpdateContext{})
+	require.NoError(t, err)
+
+	worker := dcds["worker"]
+	require.NotNil(t, worker)
+	assert.Equal(t, labelKey, worker.Annotations[commonconsts.KubeAnnotationTopologyLabelKey])
+	assert.Equal(t, labelKey, GetDCDKubeAnnotations(worker)[commonconsts.KubeAnnotationTopologyLabelKey])
+
+	frontend := dcds["frontend"]
+	require.NotNil(t, frontend)
+	assert.NotContains(t, frontend.Annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+	assert.NotContains(t, GetDCDKubeAnnotations(frontend), commonconsts.KubeAnnotationTopologyLabelKey)
+}
+
+func TestTopologyLabelMetadataFromConvertedAlphaDGD(t *testing.T) {
+	labelKey := "topology.kubernetes.io/zone"
+	alpha := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Annotations: map[string]string{
+				commonconsts.KubeAnnotationTopologyLabelKey: "wrong-from-dgd-spec",
+			},
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoGraphDeploymentName: "wrong-from-dgd-spec",
+				commonconsts.KubeLabelDynamoComponent:           "wrong-from-dgd-spec",
+			},
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": {
+					ComponentType:    commonconsts.ComponentTypeWorker,
+					SubComponentType: commonconsts.ComponentTypePrefill,
+					Annotations: map[string]string{
+						commonconsts.KubeAnnotationTopologyLabelKey: "wrong-from-alpha-service",
+					},
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoGraphDeploymentName: "wrong-from-alpha-service",
+						commonconsts.KubeLabelDynamoComponent:           "wrong-from-alpha-service",
+					},
+					ExtraPodMetadata: &v1alpha1.ExtraPodMetadata{
+						Annotations: map[string]string{
+							commonconsts.KubeAnnotationTopologyLabelKey: "wrong-from-extra-metadata",
+						},
+						Labels: map[string]string{
+							commonconsts.KubeLabelDynamoGraphDeploymentName: "wrong-from-extra-metadata",
+							commonconsts.KubeLabelDynamoComponent:           "wrong-from-extra-metadata",
+						},
+					},
+				},
+				"frontend": {
+					ComponentType: commonconsts.ComponentTypeFrontend,
+				},
+			},
+			Experimental: &v1alpha1.DynamoGraphDeploymentExperimentalSpec{
+				KvTransferPolicy: &v1alpha1.KvTransferPolicy{
+					LabelKey:    labelKey,
+					Domain:      v1alpha1.TopologyDomain("zone"),
+					Enforcement: v1alpha1.KvTransferEnforcementRequired,
+				},
+			},
+		},
+	}
+	beta := &v1beta1.DynamoGraphDeployment{}
+	require.NoError(t, alpha.ConvertTo(beta))
+
+	dcds, err := GenerateDynamoComponentsDeployments(beta, nil, nil, RollingUpdateContext{})
+	require.NoError(t, err)
+	prefillDCD := dcds["prefill"]
+	require.NotNil(t, prefillDCD)
+	assert.Equal(t, labelKey, prefillDCD.Annotations[commonconsts.KubeAnnotationTopologyLabelKey])
+	assert.Equal(t, labelKey, GetDCDKubeAnnotations(prefillDCD)[commonconsts.KubeAnnotationTopologyLabelKey])
+
+	prefillDCDLabels := GetDCDKubeLabels(prefillDCD)
+	assert.Equal(t, "test-dgd", prefillDCDLabels[commonconsts.KubeLabelDynamoGraphDeploymentName])
+	assert.Equal(t, "prefill", prefillDCDLabels[commonconsts.KubeLabelDynamoComponent])
+	frontendDCD := dcds["frontend"]
+	require.NotNil(t, frontendDCD)
+	assert.NotContains(t, frontendDCD.Annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+	assert.NotContains(t, GetDCDKubeAnnotations(frontendDCD), commonconsts.KubeAnnotationTopologyLabelKey)
+
+	pcs, err := GenerateGrovePodCliqueSet(
+		context.Background(),
+		beta,
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	cliques := make(map[string]*grovev1alpha1.PodCliqueTemplateSpec)
+	for _, clique := range pcs.Spec.Template.Cliques {
+		cliques[clique.Name] = clique
+	}
+	require.Contains(t, cliques, "prefill")
+	assert.Equal(t, labelKey, cliques["prefill"].Annotations[commonconsts.KubeAnnotationTopologyLabelKey])
+	assert.Equal(t, "test-dgd", cliques["prefill"].Labels[commonconsts.KubeLabelDynamoGraphDeploymentName])
+	assert.Equal(t, "prefill", cliques["prefill"].Labels[commonconsts.KubeLabelDynamoComponent])
+	assert.NotContains(t, cliques["frontend"].Annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+}
+
+func TestGenerateDynamoComponentsDeployments_SkipsTopologyLabelAnnotationWithoutLabelKey(t *testing.T) {
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "worker", ComponentType: v1beta1.ComponentTypeWorker},
+			},
+			Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
+				KvTransferPolicy: &v1beta1.KvTransferPolicy{
+					Domain:      "zone",
+					Enforcement: v1beta1.KvTransferEnforcementRequired,
+				},
+			},
+		},
+	}
+
+	dcds, err := GenerateDynamoComponentsDeployments(dgd, nil, nil, RollingUpdateContext{})
+	require.NoError(t, err)
+
+	worker := dcds["worker"]
+	require.NotNil(t, worker)
+	assert.NotContains(t, worker.Annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+	assert.NotContains(t, GetDCDKubeAnnotations(worker), commonconsts.KubeAnnotationTopologyLabelKey)
+}
+
+func TestGenerateGrovePodCliqueSet_AddsTopologyLabelAnnotationToWorkerCliques(t *testing.T) {
+	labelKey := "topology.kubernetes.io/zone"
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "worker", ComponentType: v1beta1.ComponentTypeWorker},
+				{ComponentName: "frontend", ComponentType: v1beta1.ComponentTypeFrontend},
+			},
+			Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
+				KvTransferPolicy: &v1beta1.KvTransferPolicy{
+					LabelKey:    labelKey,
+					Domain:      "zone",
+					Enforcement: v1beta1.KvTransferEnforcementRequired,
+				},
+			},
+		},
+	}
+
+	got, err := GenerateGrovePodCliqueSet(
+		context.Background(),
+		dgd,
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	cliques := make(map[string]*grovev1alpha1.PodCliqueTemplateSpec)
+	for _, clique := range got.Spec.Template.Cliques {
+		cliques[clique.Name] = clique
+	}
+
+	require.Contains(t, cliques, "worker")
+	require.Contains(t, cliques, "frontend")
+	assert.Equal(t, labelKey, cliques["worker"].Annotations[commonconsts.KubeAnnotationTopologyLabelKey])
+	assert.NotContains(t, cliques["frontend"].Annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+}
+
 func TestGenerateLabelsAndAnnotations_UsePreservedAlphaDGDServiceMetadata(t *testing.T) {
 	alpha := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -9420,6 +9624,36 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 		require.NoError(t, err)
 
 		envMap := envVarsToMap(podSpec.Containers[0].Env)
+		assert.NotContains(t, envMap, commonconsts.EnvTopologyEnabled)
+		assert.False(t, hasTopologyLabelVolume(podSpec.Volumes))
+		assert.False(t, hasTopologyLabelVolumeMount(podSpec.Containers[0].VolumeMounts))
+	})
+
+	t.Run("worker with empty label key has no topology", func(t *testing.T) {
+		dgd := &v1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+			Spec: v1beta1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+					{ComponentName: "worker", ComponentType: v1beta1.ComponentTypeWorker},
+				},
+				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
+					KvTransferPolicy: &v1beta1.KvTransferPolicy{
+						Domain:      "zone",
+						Enforcement: v1beta1.KvTransferEnforcementRequired,
+					},
+				},
+			},
+		}
+		component := dgd.Spec.Components[0].DeepCopy()
+		podSpec, err := GeneratePodSpecForComponent(
+			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+		)
+		require.NoError(t, err)
+
+		envMap := envVarsToMap(podSpec.Containers[0].Env)
+		assert.NotContains(t, envMap, commonconsts.EnvKvTransferDomain)
 		assert.NotContains(t, envMap, commonconsts.EnvTopologyEnabled)
 		assert.False(t, hasTopologyLabelVolume(podSpec.Volumes))
 		assert.False(t, hasTopologyLabelVolumeMount(podSpec.Containers[0].VolumeMounts))

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -47,6 +47,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const testTopologyLabelKey = "topology.kubernetes.io/zone"
+
 func TestGenerateDynamoComponentsDeployments(t *testing.T) {
 	type args struct {
 		parentDynamoGraphDeployment *v1alpha1.DynamoGraphDeployment
@@ -894,7 +896,7 @@ func TestGenerateDynamoComponentsDeployments_PropagatesPreservedAlphaServiceAnno
 }
 
 func TestGenerateDynamoComponentsDeployments_AddsTopologyLabelAnnotationToWorkers(t *testing.T) {
-	labelKey := "topology.kubernetes.io/zone"
+	labelKey := testTopologyLabelKey
 	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
@@ -931,7 +933,7 @@ func TestGenerateDynamoComponentsDeployments_AddsTopologyLabelAnnotationToWorker
 }
 
 func TestTopologyLabelMetadataFromConvertedAlphaDGD(t *testing.T) {
-	labelKey := "topology.kubernetes.io/zone"
+	labelKey := testTopologyLabelKey
 	alpha := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
@@ -1051,7 +1053,7 @@ func TestGenerateDynamoComponentsDeployments_SkipsTopologyLabelAnnotationWithout
 }
 
 func TestGenerateGrovePodCliqueSet_AddsTopologyLabelAnnotationToWorkerCliques(t *testing.T) {
-	labelKey := "topology.kubernetes.io/zone"
+	labelKey := testTopologyLabelKey
 	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
@@ -9224,7 +9226,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 				},
 				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
 					KvTransferPolicy: &v1beta1.KvTransferPolicy{
-						LabelKey:    "topology.kubernetes.io/zone",
+						LabelKey:    testTopologyLabelKey,
 						Domain:      "zone",
 						Enforcement: v1beta1.KvTransferEnforcementRequired,
 					},
@@ -9311,7 +9313,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 				},
 				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
 					KvTransferPolicy: &v1beta1.KvTransferPolicy{
-						LabelKey:    "topology.kubernetes.io/zone",
+						LabelKey:    testTopologyLabelKey,
 						Domain:      "zone",
 						Enforcement: v1beta1.KvTransferEnforcementRequired,
 					},
@@ -9345,7 +9347,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 				},
 				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
 					KvTransferPolicy: &v1beta1.KvTransferPolicy{
-						LabelKey:    "topology.kubernetes.io/zone",
+						LabelKey:    testTopologyLabelKey,
 						Domain:      "zone",
 						Enforcement: v1beta1.KvTransferEnforcementRequired,
 					},
@@ -9431,7 +9433,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 				},
 				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
 					KvTransferPolicy: &v1beta1.KvTransferPolicy{
-						LabelKey: "topology.kubernetes.io/zone",
+						LabelKey: testTopologyLabelKey,
 						Domain:   "zone",
 						// Enforcement omitted (zero value)
 					},
@@ -9505,7 +9507,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 				},
 				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
 					KvTransferPolicy: &v1beta1.KvTransferPolicy{
-						LabelKey:    "topology.kubernetes.io/zone",
+						LabelKey:    testTopologyLabelKey,
 						Domain:      "zone",
 						Enforcement: v1beta1.KvTransferEnforcementRequired,
 					},
@@ -9533,7 +9535,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 				require.NotNil(t, v.DownwardAPI)
 				require.Len(t, v.DownwardAPI.Items, 1)
 				assert.Equal(t, "zone", v.DownwardAPI.Items[0].Path)
-				assert.Equal(t, "metadata.labels['topology.kubernetes.io/zone']", v.DownwardAPI.Items[0].FieldRef.FieldPath)
+				assert.Equal(t, "metadata.labels['"+testTopologyLabelKey+"']", v.DownwardAPI.Items[0].FieldRef.FieldPath)
 			}
 		}
 		assert.Equal(t, 1, topologyVolumes, "topology-labels volume should be operator-owned")
@@ -9562,7 +9564,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 				},
 				Experimental: &v1beta1.DynamoGraphDeploymentExperimentalSpec{
 					KvTransferPolicy: &v1beta1.KvTransferPolicy{
-						LabelKey:    "topology.kubernetes.io/zone",
+						LabelKey:    testTopologyLabelKey,
 						Domain:      "zone",
 						Enforcement: v1beta1.KvTransferEnforcementRequired,
 					},

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -142,6 +142,14 @@ func GetDCDKubeAnnotations(dcd *v1beta1.DynamoComponentDeployment) map[string]st
 	maps.Copy(annotations, GetPodTemplateAnnotations(&dcd.Spec.DynamoComponentDeploymentSharedSpec))
 	AddBaseModelAnnotation(annotations, dcd.Spec.ModelRef)
 	delete(annotations, commonconsts.KubeAnnotationDynamoOperatorOriginVersion)
+	delete(annotations, commonconsts.KubeAnnotationTopologyLabelKey)
+
+	// Propagate topology label key from DCD metadata to pods so the topology
+	// label controller can discover which node label to copy.
+	if v := dcd.Annotations[commonconsts.KubeAnnotationTopologyLabelKey]; v != "" {
+		annotations[commonconsts.KubeAnnotationTopologyLabelKey] = v
+	}
+
 	return annotations
 }
 


### PR DESCRIPTION
## Summary
- Add `TopologyLabelReconciler` to watch annotated, scheduled pods and copy the configured topology label from their node.
- Mark worker DCDs with `nvidia.com/topology-label-key` from `spec.experimental.kvTransferPolicy.labelKey` and propagate it onto pod annotations.
- Register the controller and generate the minimal pod patch / node get RBAC needed for the copy path.
- Add dedicated Helm `topology-label-rbac.yaml` node-read ClusterRole/Binding so platform installs work in both cluster-wide and namespace-restricted modes.
- Tighten pod update predicates to enqueue only when topology label copy becomes newly actionable: scheduling, annotation add/change, or copied label removal.

## Validation
- `make manifests SHELL=/bin/sh .SHELLFLAGS=-ec`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest-release-0.19 use 1.29.0 --bin-dir "$(pwd)/bin" -p path)" go test ./internal/controller ./internal/dynamo ./cmd`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest-release-0.19 use 1.29.0 --bin-dir "$(pwd)/bin" -p path)" go test $(go list ./... | grep -v /e2e | grep -v /test | grep -v /cmd)`
- `go vet ./...`
- `helm template dyn ./deploy/helm/charts/platform/components/operator --set discoveryBackend=kubernetes --show-only templates/topology-label-rbac.yaml`
- `helm template dyn ./deploy/helm/charts/platform/components/operator --set discoveryBackend=kubernetes --set namespaceRestriction.enabled=true --show-only templates/topology-label-rbac.yaml`
- `helm template dyn ./deploy/helm/charts/platform/components/operator --set discoveryBackend=kubernetes --show-only templates/manager-rbac.yaml`
- `helm template dyn ./deploy/helm/charts/platform/components/operator --set discoveryBackend=kubernetes --set namespaceRestriction.enabled=true --show-only templates/manager-rbac.yaml`

## Links
- Linear: https://linear.app/nvidia/issue/DYN-3070/tar-pr4c-topology-label-controller-for-nodepod-label-copy
- DEP: https://github.com/ai-dynamo/dynamo/issues/9118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added topology label controller that automatically copies node topology labels to worker pods when topology label configuration is enabled.

* **Tests**
  * Added comprehensive test suite validating topology label copying behavior and edge cases.

* **Chores**
  * Updated RBAC permissions to grant operator read access to cluster nodes and pod patching capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->