### PR TITLE
docs: correct TRT-LLM FPM availability and KV-transfer success metric side

### DIFF
--- a/docs/backends/trtllm/trtllm-observability.md
+++ b/docs/backends/trtllm/trtllm-observability.md
@@ -156,7 +156,7 @@ Metric name constants are defined in `lib/runtime/src/metrics/prometheus_names.r
 
 These metrics are only recorded in disaggregated (prefill + decode) deployments when a KV cache transfer actually occurs. They are sourced from TensorRT-LLM's `RequestPerfMetrics.timing_metrics`.
 
-- `trtllm_kv_transfer_success_total` (Counter) — Total number of successful KV cache transfers (recorded on prefill side)
+- `trtllm_kv_transfer_success_total` (Counter) — Total number of successful KV cache transfers (recorded on the decode worker, when it observes non-zero KV-transfer timing in `RequestPerfMetrics.timing_metrics`). Grows in lock-step with the `_count` of the sibling `trtllm_kv_transfer_latency_seconds` / `trtllm_kv_transfer_bytes` / `trtllm_kv_transfer_speed_gb_s` histograms for the same transfer events.
   - Labels: `model_name`, `disaggregation_mode`, `engine_type`
 - `trtllm_kv_transfer_latency_seconds` (Histogram) — KV cache transfer latency per request in seconds
   - Labels: `model_name`, `disaggregation_mode`, `engine_type`

--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -124,7 +124,11 @@ See [Planner Guide](planner-guide.md) for the full workflow.
 
 Load-based scaling has the following known limitations. Throughput-based scaling is not affected by any of these.
 
-**Requires ForwardPassMetrics (FPM).** Load-based scaling uses per-engine per-iteration metrics delivered via the Dynamo event plane (ForwardPassMetrics). FPM is currently only available for vllm and is automatically enabled when the engine uses `InstrumentedScheduler` and `DYN_FORWARDPASS_METRIC_PORT` is set. The KV Router is **not** required for load-based scaling.
+**Requires ForwardPassMetrics (FPM).** Load-based scaling uses per-engine per-iteration metrics delivered via the Dynamo event plane (ForwardPassMetrics). The KV Router is **not** required for load-based scaling. FPM availability by backend:
+
+- **vLLM** — supported. Automatically enabled when the engine uses `InstrumentedScheduler` and `DYN_FORWARDPASS_METRIC_PORT` is set.
+- **TensorRT-LLM** — supported for non-attention-DP workers (`attention_dp_size == 1`); gated off when `attention_dp_size > 1` pending per-rank FPM emission.
+- **SGLang** — pipeline wired in Dynamo, but the upstream SGLang FPM module is not included in the current 1.2.0 SGLang runtime image. See the [SGLang FPM section](../../backends/sglang/sglang-observability.md#forward-pass-metrics-fpm) for the runtime-image prerequisite.
 
 ### General
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -313,7 +313,7 @@ backend explicitly in these cases:
 | MoE models (DeepSeek-R1, Qwen3-MoE) | `sglang` (full MoE support) |
 | Using `searchStrategy: thorough` | Any except `auto` (required) |
 | TensorRT-LLM compilation caching | `trtllm` (add a compilation cache PVC) |
-| Need load-based planner scaling (FPM) | `vllm` (only backend with ForwardPassMetrics) |
+| Need load-based planner scaling (FPM) | `vllm` (any config) or `trtllm` (non-attention-DP only). SGLang FPM is wired in Dynamo but the upstream module is not in the 1.2.0 runtime image. |
 
 > [!WARNING]
 > TensorRT-LLM does not support Python 3.11. If your environment uses


### PR DESCRIPTION
## Overview

Three docs were inconsistent with the 1.2.0 TRT-LLM implementation:

1. **`docs/backends/trtllm/trtllm-observability.md:159`** said `trtllm_kv_transfer_success_total` is recorded on the prefill side. The 1.2.0 implementation records it on the decode worker, in lock-step with the sibling KV-transfer latency/bytes/speed histogram counts. Verified against `components/src/dynamo/trtllm/request_handlers/handler_base.py` and `components/src/dynamo/trtllm/metrics.py`.

2. **`docs/components/planner/README.md:127`** said FPM is "currently only available for vllm". TRT-LLM has supported FPM for non-attention-DP workers since `FpmDirectPublisher` landed (PRs #8356 and #8892); SGLang has the Dynamo-side pipeline wired but the upstream SGLang FPM module is not in the 1.2.0 runtime image. Replaced with a per-backend support matrix.

3. **`docs/kubernetes/model-deployment-guide.md:316`** carried the same vLLM-only claim in the "Recommended Backend" table. Updated to match the planner README matrix.

## Changes

- `docs/backends/trtllm/trtllm-observability.md` — correct counter side
- `docs/components/planner/README.md` — per-backend FPM support matrix
- `docs/kubernetes/model-deployment-guide.md` — update FPM row

No code or example changes. Pure documentation correctness fix.

## Test plan

- [x] Documentation renders cleanly (markdown only, no link/anchor changes)
- [x] Cross-link from `planner/README.md` to `sglang-observability.md#forward-pass-metrics-fpm` resolves
- [x] No bug-tracker URLs leak into user-facing docs

Fixes NVBug 6204453 / DYN-3091.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified TensorRT-LLM Prometheus metric documentation regarding KV cache transfer tracking.
  * Expanded ForwardPassMetrics backend support details for vLLM, TensorRT-LLM, and SGLang in planner configuration.
  * Updated backend selection guidance for load-based scaling scenarios with improved clarity on supported configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->