### PR TITLE
docs(sglang): note SGLang FPM is unavailable in the 1.2.0 runtime image

### DIFF
--- a/docs/backends/sglang/sglang-observability.md
+++ b/docs/backends/sglang/sglang-observability.md
@@ -113,6 +113,8 @@ For the complete and authoritative list of all SGLang metrics, see the [official
 
 ## Forward Pass Metrics (FPM)
 
+> **Availability in the 1.2.0 SGLang runtime.** The published `sglang-runtime:1.2.0` image does not yet include the upstream `sglang.srt.observability.forward_pass_metrics` module or the corresponding `ServerArgs` fields (`enable_forward_pass_metrics`, `forward_pass_metrics_worker_id`, `forward_pass_metrics_ipc_name`). Setting `DYN_FORWARDPASS_METRIC_PORT` starts the Dynamo-side relay successfully and the worker continues to serve requests, but no SGLang-side FPM payloads are emitted to the NATS event plane. **The pipeline and schema below describe the intended architecture and will become functional once the upstream SGLang FPM module is included in a future SGLang runtime image.** For load-based Planner scaling on 1.2.0, use a vLLM or TensorRT-LLM (non-attention-DP) backend; see the [Planner FPM support matrix](../../components/planner/README.md#load-based-scaling).
+
 Forward Pass Metrics provide **per-iteration scheduler telemetry** pushed over ZMQ, giving the [Planner](../../components/planner/README.md) real-time visibility into batch composition, queue depth, and GPU forward pass duration. Unlike Prometheus metrics (which are scraped asynchronously and reflect only the latest gauge value), FPM emits a structured message after every scheduler iteration with the exact batch state.
 
 ### Pipeline

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -469,5 +469,5 @@ For the full list of metrics, configuration options, and architecture details, s
 - [Distributed Runtime Architecture](../design-docs/distributed-runtime.md)
 - [Dynamo Architecture Overview](../design-docs/architecture.md)
 - [Backend Guide](../development/backend-guide.md)
-- [Forward Pass Metrics (SGLang)](../backends/sglang/sglang-observability.md#forward-pass-metrics-fpm) - Per-iteration scheduler telemetry via ZMQ/NATS for planner-driven scaling
+- [Forward Pass Metrics (SGLang)](../backends/sglang/sglang-observability.md#forward-pass-metrics-fpm) — Per-iteration scheduler telemetry via ZMQ/NATS for planner-driven scaling (intended architecture; not available in the 1.2.0 SGLang runtime image)
 - [Forward Pass Metrics RFC](../proposals/vllm-rfc-forward-pass-metrics.md) - Design rationale for per-iteration metrics


### PR DESCRIPTION
## Overview

`docs/backends/sglang/sglang-observability.md` describes the SGLang ForwardPassMetrics (FPM) pipeline as if it's functional in 1.2.0, but the upstream module is missing from the runtime image and no payloads are emitted.

Verified against the 1.2.0 runtime image (`nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.2.0-post.1-rc.3-cuda12`):

\`\`\`
sglang_version            = 0.5.11
matching_modules          = []
fpm_module_error          = ModuleNotFoundError: No module named 'sglang.srt.observability.forward_pass_metrics'
server_arg_enable_forward_pass_metrics = False
server_arg_forward_pass_metrics_worker_id = False
server_arg_forward_pass_metrics_ipc_name = False
\`\`\`

The Dynamo-side relay (`components/src/dynamo/sglang/publisher.py`, `args.py`) starts cleanly with `DYN_FORWARDPASS_METRIC_PORT` set and the worker serves requests, but no FPM payloads reach the NATS subscriber. The bundled contract test `components/src/dynamo/sglang/tests/test_fpm_contract.py` already gates on this with `pytest.importorskip("sglang.srt.observability.forward_pass_metrics", reason="SGLang FPM module not available (requires sglang FPM branch)")`.

## Changes

- `docs/backends/sglang/sglang-observability.md` — adds a runtime-availability note at the top of the FPM section directing 1.2.0 users to vLLM or TRT-LLM (non-attention-DP) for load-based Planner scaling. Keeps the existing architecture / schema content intact as future-state documentation.
- `docs/observability/metrics.md` — annotates the SGLang FPM cross-link with the same availability caveat.

No code, example, or schema changes.

## Test plan

- [x] Both files render cleanly; new admonition uses the existing `> **...**` blockquote pattern used elsewhere in the docs tree
- [x] Cross-link to `planner/README.md#load-based-scaling` resolves
- [x] No bug-tracker IDs in the rendered docs

Fixes NVBug 6204779 / DYN-3094.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Forward Pass Metrics availability in SGLang runtime 1.2.0, noting the feature is not currently functional in this version.
  * Added guidance recommending alternative backends (vLLM or TensorRT-LLM) for load-based Planner scaling as a workaround.
  * Updated documentation to reflect intended future functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->