### PR TITLE
fix(memory): add macOS NIXL link shim

### DIFF
--- a/lib/memory/bin/validate_numa_placement.rs
+++ b/lib/memory/bin/validate_numa_placement.rs
@@ -17,7 +17,13 @@
 //! cargo run -p dynamo-memory --bin validate_numa_placement -- --gpus 0,2  # specific GPUs
 //! ```
 
+#[cfg(target_os = "linux")]
 use std::process;
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("validate_numa_placement is only supported on Linux");
+}
 
 /// Query the NUMA node of each page in a memory region using `move_pages(2)`.
 ///
@@ -25,6 +31,7 @@ use std::process;
 /// with the current NUMA node of each page without moving anything.
 ///
 /// Returns a Vec of NUMA node IDs (one per page), or negative error codes.
+#[cfg(target_os = "linux")]
 fn query_page_nodes(ptr: *const u8, size: usize) -> Vec<i32> {
     let page_size = unsafe {
         let ps = libc::sysconf(libc::_SC_PAGESIZE);
@@ -64,6 +71,7 @@ fn query_page_nodes(ptr: *const u8, size: usize) -> Vec<i32> {
     status
 }
 
+#[cfg(target_os = "linux")]
 fn main() {
     // Parse args
     let args: Vec<String> = std::env::args().collect();

--- a/lib/memory/build.rs
+++ b/lib/memory/build.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Build script for dynamo-memory.
+//!
+//! On macOS, nixl-sys unconditionally links `-lstdc++` which doesn't exist
+//! (macOS uses libc++). We create an empty static archive to satisfy the
+//! linker since libc++ is already linked.
+
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        let lib_path = format!("{}/libstdc++.a", out_dir);
+
+        // Write a minimal valid static archive (just the magic header).
+        // macOS `ar` refuses to create an empty archive, so write it directly.
+        std::fs::write(&lib_path, b"!<arch>\n").expect("failed to create empty libstdc++.a");
+
+        println!("cargo:rustc-link-search=native={}", out_dir);
+    }
+}


### PR DESCRIPTION
Adds the same empty libstdc++.a workaround used by the Python bindings to dynamo-memory so macOS NIXL links can complete. Also keeps the NUMA placement diagnostic Linux-only so macOS clippy can build the crate.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added platform-specific support for NUMA validation to ensure compatibility on Linux systems.
  * Improved build system compatibility for macOS environments with enhanced linker configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->