### PR TITLE
feat(vllm): gate chat-shaped Prometheus collectors on embedding worker

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -412,7 +412,7 @@ def setup_vllm_engine(
     config: Config,
     stat_logger: Optional[StatLoggerFactory] = None,
     fpm_worker_id: Optional[str] = None,
-) -> tuple[AsyncLLM, VllmConfig, Any, Any, LLMBackendMetrics]:
+) -> tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]:
     # vLLM v0.11.0 bug: vllm/v1.metrics/prometheus.py:79 passes TemporaryDirectory object
     # instead of .name string, causing false error on exit. Set PROMETHEUS_MULTIPROC_DIR
     # ourselves to avoid this and handle cleanup properly.
@@ -437,16 +437,24 @@ def setup_vllm_engine(
 
     # Construct Prometheus gauges AFTER setup_multiprocess_prometheus() so Gauge objects
     # see the correct ValueClass (multiprocess vs in-memory).
-    component_gauges = LLMBackendMetrics(
-        registry=DYNAMO_COMPONENT_REGISTRY,
-        model_name=config.served_model_name or "",
-        component_name=config.component or "",
-    )
+    #
+    # Embedding workers (pooling engines) have no KV cache, no scheduler
+    # gauges, and no model_load_time hook -- registering the chat-shaped
+    # LLMBackendMetrics on them publishes zeros forever. Skip the
+    # construction entirely on that path so /metrics stays clean.
+    embedding_worker = stat_logger is not None and stat_logger.embedding_worker
+    component_gauges: Optional[LLMBackendMetrics] = None
+    if not embedding_worker:
+        component_gauges = LLMBackendMetrics(
+            registry=DYNAMO_COMPONENT_REGISTRY,
+            model_name=config.served_model_name or "",
+            component_name=config.component or "",
+        )
 
-    # If a StatLoggerFactory was provided, give it the gauges so the loggers
-    # it creates can publish Prometheus metrics.
-    if stat_logger is not None:
-        stat_logger.component_gauges = component_gauges
+        # If a StatLoggerFactory was provided, give it the gauges so the loggers
+        # it creates can publish Prometheus metrics.
+        if stat_logger is not None:
+            stat_logger.component_gauges = component_gauges
 
     os.environ["VLLM_NO_USAGE_STATS"] = "1"  # Avoid internal HTTP requests
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -583,8 +583,12 @@ def setup_vllm_engine(
     )
     load_time = time.time() - start_time
 
-    # Record model load time
-    component_gauges.set_model_load_time(load_time)
+    # Record model load time. ``component_gauges`` is None on the
+    # embedding-worker path -- pooling engines have no chat-shaped gauges
+    # registered (DIS-2107), so model_load_time has no collector to
+    # publish to. Skip rather than fabricating a zero-valued sample.
+    if component_gauges is not None:
+        component_gauges.set_model_load_time(load_time)
 
     logger.info(f"VllmWorker for {config.served_model_name} has been initialized")
 

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -585,8 +585,8 @@ def setup_vllm_engine(
 
     # Record model load time. ``component_gauges`` is None on the
     # embedding-worker path -- pooling engines have no chat-shaped gauges
-    # registered (DIS-2107), so model_load_time has no collector to
-    # publish to. Skip rather than fabricating a zero-valued sample.
+    # registered, so model_load_time has no collector to publish to.
+    # Skip rather than fabricating a zero-valued sample.
     if component_gauges is not None:
         component_gauges.set_model_load_time(load_time)
 

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -91,13 +91,21 @@ class _NoopStatLogger(StatLoggerBase):
     chat-shaped publish path (KV cache usage, scheduler gauges) has no
     meaning on a pooling engine."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        vllm_config: Optional[VllmConfig] = None,
+        engine_index: int = 0,
+    ) -> None:
         # vLLM's ``StatLoggerBase`` declares ``__init__`` as abstract, so
         # subclasses must provide one even when they hold no state.
         # Without this, instantiation raises ``TypeError: Can't
         # instantiate abstract class _NoopStatLogger without an
-        # implementation for abstract method '__init__'``.
-        pass
+        # implementation for abstract method '__init__'``. The
+        # ``(vllm_config, engine_index)`` signature mirrors what vLLM
+        # passes to concrete ``StatLoggerBase`` subclasses, so this
+        # logger remains a drop-in if vLLM ever wires the factory call
+        # to invoke the constructor directly.
+        del vllm_config, engine_index
 
     def record(
         self,

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -85,11 +85,18 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         pass
 
 
-class _NoopStatLogger(StatLoggerBase):
-    """Stat logger that drops every record. Installed on embedding workers,
-    where vLLM still calls the factory during engine init but the
-    chat-shaped publish path (KV cache usage, scheduler gauges) has no
-    meaning on a pooling engine."""
+class NoopStatLogger(StatLoggerBase):
+    """Stat logger that drops every record.
+
+    vLLM's ``AsyncLLM`` always invokes a ``StatLoggerBase`` subclass
+    during engine init, but for some worker shapes the chat-style
+    publish path (KV cache usage, scheduler gauges) is meaningless --
+    embedding/pooling workers are the current driver, but the same
+    no-op semantics fit any future worker that wants to satisfy vLLM's
+    factory contract without registering Prometheus collectors. Reach
+    for this class instead of writing a new throwaway subclass each
+    time.
+    """
 
     def __init__(
         self,
@@ -99,7 +106,7 @@ class _NoopStatLogger(StatLoggerBase):
         # vLLM's ``StatLoggerBase`` declares ``__init__`` as abstract, so
         # subclasses must provide one even when they hold no state.
         # Without this, instantiation raises ``TypeError: Can't
-        # instantiate abstract class _NoopStatLogger without an
+        # instantiate abstract class NoopStatLogger without an
         # implementation for abstract method '__init__'``. The
         # ``(vllm_config, engine_index)`` signature mirrors what vLLM
         # passes to concrete ``StatLoggerBase`` subclasses, so this
@@ -141,7 +148,7 @@ class StatLoggerFactory:
         # publishing -- short-circuit before constructing the chat-shaped
         # WorkerMetricsPublisher and skipping the component_gauges check.
         if self.embedding_worker:
-            return _NoopStatLogger()
+            return NoopStatLogger()
         # component_gauges must be set by setup_vllm_engine() before vLLM
         # calls create_stat_logger() during engine initialization.
         assert (

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -91,6 +91,14 @@ class _NoopStatLogger(StatLoggerBase):
     chat-shaped publish path (KV cache usage, scheduler gauges) has no
     meaning on a pooling engine."""
 
+    def __init__(self) -> None:
+        # vLLM's ``StatLoggerBase`` declares ``__init__`` as abstract, so
+        # subclasses must provide one even when they hold no state.
+        # Without this, instantiation raises ``TypeError: Can't
+        # instantiate abstract class _NoopStatLogger without an
+        # implementation for abstract method '__init__'``.
+        pass
+
     def record(
         self,
         scheduler_stats: Optional[SchedulerStats],

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -85,6 +85,27 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         pass
 
 
+class _NoopStatLogger(StatLoggerBase):
+    """Stat logger that drops every record. Installed on embedding workers,
+    where vLLM still calls the factory during engine init but the
+    chat-shaped publish path (KV cache usage, scheduler gauges) has no
+    meaning on a pooling engine."""
+
+    def record(
+        self,
+        scheduler_stats: Optional[SchedulerStats],
+        iteration_stats: Optional[IterationStats],
+        mm_cache_stats: object = None,
+        engine_idx: int = 0,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        return
+
+    def log_engine_initialized(self) -> None:
+        pass
+
+
 class StatLoggerFactory:
     """Factory for creating stat logger publishers. Required by vLLM."""
 
@@ -92,12 +113,19 @@ class StatLoggerFactory:
         self,
         endpoint: Endpoint,
         component_gauges: Optional[LLMBackendMetrics] = None,
+        embedding_worker: bool = False,
     ) -> None:
         self.endpoint = endpoint
         self.component_gauges = component_gauges
+        self.embedding_worker = embedding_worker
         self.created_logger: Optional[DynamoStatLoggerPublisher] = None
 
     def create_stat_logger(self, dp_rank: int) -> StatLoggerBase:
+        # Embedding workers have no KV cache and no scheduler stats worth
+        # publishing -- short-circuit before constructing the chat-shaped
+        # WorkerMetricsPublisher and skipping the component_gauges check.
+        if self.embedding_worker:
+            return _NoopStatLogger()
         # component_gauges must be set by setup_vllm_engine() before vLLM
         # calls create_stat_logger() during engine initialization.
         assert (

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -20,7 +20,7 @@ import dynamo.vllm.publisher as publisher_mod
 from dynamo.vllm.publisher import (
     DynamoStatLoggerPublisher,
     StatLoggerFactory,
-    _NoopStatLogger,
+    NoopStatLogger,
 )
 
 pytestmark = [
@@ -33,7 +33,7 @@ pytestmark = [
 
 
 def test_factory_returns_noop_logger_for_embedding_worker(monkeypatch):
-    """``create_stat_logger`` returns a ``_NoopStatLogger`` on the
+    """``create_stat_logger`` returns a ``NoopStatLogger`` on the
     embedding path -- no ``DynamoStatLoggerPublisher`` /
     ``WorkerMetricsPublisher`` / NATS endpoint construction.
 
@@ -58,7 +58,7 @@ def test_factory_returns_noop_logger_for_embedding_worker(monkeypatch):
 
     logger = factory.create_stat_logger(dp_rank=0)
 
-    assert isinstance(logger, _NoopStatLogger)
+    assert isinstance(logger, NoopStatLogger)
     # Embedding factory never tracks a created chat logger, so the
     # downstream ``init_publish`` / ``set_num_gpu_blocks_all`` calls in
     # the chat path are safe no-ops if anyone ever wires them on the
@@ -72,7 +72,7 @@ def test_noop_stat_logger_record_is_safe_with_none_stats():
     ``scheduler_stats is None``; the embedding noop must accept the same
     shape (and the variadic mm/engine_idx args vLLM passes) without
     raising."""
-    logger = _NoopStatLogger()
+    logger = NoopStatLogger()
 
     # Mirrors the call shape from vllm/v1/metrics/loggers.py.
     logger.record(None, None)
@@ -100,7 +100,7 @@ def test_factory_embedding_flag_skips_component_gauges_assert():
 
     # Would AssertionError on the chat path; must succeed here.
     logger = factory.create_stat_logger(dp_rank=0)
-    assert isinstance(logger, _NoopStatLogger)
+    assert isinstance(logger, NoopStatLogger)
 
 
 def test_factory_default_is_chat_path(monkeypatch):

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -19,8 +19,8 @@ import pytest
 import dynamo.vllm.publisher as publisher_mod
 from dynamo.vllm.publisher import (
     DynamoStatLoggerPublisher,
-    StatLoggerFactory,
     NoopStatLogger,
+    StatLoggerFactory,
 )
 
 pytestmark = [

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -26,6 +26,7 @@ from dynamo.vllm.publisher import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the vLLM stat-logger factory.
+
+These tests focus on the embedding-worker gating path: vLLM workers run
+either a chat/decode engine or a pooling (embedding) engine, and the
+chat-shaped Prometheus collectors are only meaningful on the former.
+The factory is the single seam where vLLM calls into dynamo per dp_rank,
+so it is also the seam where the embedding worker must short-circuit
+the chat-shaped pipeline.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import dynamo.vllm.publisher as publisher_mod
+from dynamo.vllm.publisher import (
+    DynamoStatLoggerPublisher,
+    StatLoggerFactory,
+    _NoopStatLogger,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_factory_returns_noop_logger_for_embedding_worker(monkeypatch):
+    """``create_stat_logger`` returns a ``_NoopStatLogger`` on the
+    embedding path -- no ``DynamoStatLoggerPublisher`` /
+    ``WorkerMetricsPublisher`` / NATS endpoint construction.
+
+    Why this matters: ``DynamoStatLoggerPublisher.__init__`` schedules a
+    ``create_endpoint`` task on the runtime and registers chat-shaped
+    publish callbacks. On a pooling engine there is no kv_cache_usage to
+    publish (vLLM never emits ``SchedulerStats``) and the endpoint is
+    never queried -- so the factory must not construct it at all.
+    """
+
+    def _explode(*_a, **_kw):
+        raise AssertionError(
+            "embedding-worker path must not construct DynamoStatLoggerPublisher"
+        )
+
+    monkeypatch.setattr(publisher_mod, "DynamoStatLoggerPublisher", _explode)
+
+    factory = StatLoggerFactory(
+        endpoint=SimpleNamespace(),
+        embedding_worker=True,
+    )
+
+    logger = factory.create_stat_logger(dp_rank=0)
+
+    assert isinstance(logger, _NoopStatLogger)
+    # Embedding factory never tracks a created chat logger, so the
+    # downstream ``init_publish`` / ``set_num_gpu_blocks_all`` calls in
+    # the chat path are safe no-ops if anyone ever wires them on the
+    # embedding branch by mistake.
+    assert factory.created_logger is None
+
+
+def test_noop_stat_logger_record_is_safe_with_none_stats():
+    """vLLM calls ``record`` every iteration even when the engine has
+    nothing useful to report. The chat-path publisher returns early on
+    ``scheduler_stats is None``; the embedding noop must accept the same
+    shape (and the variadic mm/engine_idx args vLLM passes) without
+    raising."""
+    logger = _NoopStatLogger()
+
+    # Mirrors the call shape from vllm/v1/metrics/loggers.py.
+    logger.record(None, None)
+    logger.record(None, None, None, 0)
+    logger.record(
+        scheduler_stats=None,
+        iteration_stats=None,
+        mm_cache_stats=None,
+        engine_idx=0,
+    )
+    logger.log_engine_initialized()
+
+
+def test_factory_embedding_flag_skips_component_gauges_assert():
+    """On the chat path the factory asserts
+    ``component_gauges is not None`` because ``setup_vllm_engine`` is
+    responsible for setting it before vLLM invokes the factory. The
+    embedding path skips that step entirely (no chat-shaped gauges to
+    register), so the factory must not blow up when it stays None."""
+    factory = StatLoggerFactory(
+        endpoint=SimpleNamespace(),
+        embedding_worker=True,
+    )
+    assert factory.component_gauges is None
+
+    # Would AssertionError on the chat path; must succeed here.
+    logger = factory.create_stat_logger(dp_rank=0)
+    assert isinstance(logger, _NoopStatLogger)
+
+
+def test_factory_default_is_chat_path(monkeypatch):
+    """Sibling check: the default (``embedding_worker=False``) still
+    constructs ``DynamoStatLoggerPublisher`` so the gating doesn't
+    accidentally swallow the chat path."""
+    constructed = []
+
+    def _fake_publisher(*args, **kwargs):
+        constructed.append(kwargs)
+        return Mock(spec=DynamoStatLoggerPublisher)
+
+    monkeypatch.setattr(publisher_mod, "DynamoStatLoggerPublisher", _fake_publisher)
+
+    endpoint = SimpleNamespace()
+    component_gauges = SimpleNamespace()
+    factory = StatLoggerFactory(endpoint=endpoint, component_gauges=component_gauges)
+
+    factory.create_stat_logger(dp_rank=3)
+
+    assert len(constructed) == 1
+    assert constructed[0]["endpoint"] is endpoint
+    assert constructed[0]["dp_rank"] == 3
+    assert constructed[0]["component_gauges"] is component_gauges

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -41,7 +41,10 @@ from .publisher import StatLoggerFactory
 logger = logging.getLogger(__name__)
 
 # (engine_client, vllm_config, default_sampling_params, prometheus_temp_dir, component_gauges)
-EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, LLMBackendMetrics]
+# component_gauges is None on the embedding-worker path: pooling engines
+# have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
+# LLMBackendMetrics registration there.
+EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]
 
 
 async def _wait_and_load_benchmark(bench_cfg: dict, vllm_config: VllmConfig) -> dict:
@@ -254,7 +257,15 @@ class WorkerFactory:
         shutdown_endpoints[:] = [generate_endpoint]
 
         fpm_worker_id = str(generate_endpoint.connection_id())
-        factory = StatLoggerFactory(endpoint=generate_endpoint)
+        # Embedding workers run on pooling engines: no KV cache, no
+        # scheduler stats, no decode loop. The factory still has to exist
+        # because vLLM unconditionally invokes it during AsyncLLM init,
+        # but it returns a no-op stat logger and setup_vllm_engine() skips
+        # the chat-shaped LLMBackendMetrics registration.
+        factory = StatLoggerFactory(
+            endpoint=generate_endpoint,
+            embedding_worker=True,
+        )
         (
             engine_client,
             vllm_config,


### PR DESCRIPTION
#### Overview:

Mirrors the SGLang publisher gating ([PR #9830](https://github.com/ai-dynamo/dynamo/pull/9830)) for the vLLM backend.

vLLM's ``StatLoggerFactory`` previously constructed a ``DynamoStatLoggerPublisher`` (with its ``WorkerMetricsPublisher`` / NATS endpoint + chat-shaped ``LLMBackendMetrics`` gauges -- ``total_blocks``, ``gpu_cache_usage``, ``model_load_time``) on every worker, including embedding workers running pooling engines that emit no ``SchedulerStats``. The result on an embedding deployment was a ``/metrics`` scrape full of gauges stuck at zero, drowning out the embedding-shaped collectors that operators actually want to alert on.

#### Details:

**``components/src/dynamo/vllm/publisher.py``** -- ``StatLoggerFactory`` gains an ``embedding_worker: bool`` flag. When set, ``create_stat_logger`` returns a new ``_NoopStatLogger`` (``record`` + ``log_engine_initialized`` are pass-through) and the chat-shaped ``DynamoStatLoggerPublisher`` is never constructed. The ``component_gauges is not None`` assert that guards the chat path is also skipped on the embedding branch, since the factory no longer needs gauges to wire up.

**``components/src/dynamo/vllm/main.py``** -- ``setup_vllm_engine`` inspects ``stat_logger.embedding_worker`` and skips the ``LLMBackendMetrics(registry=DYNAMO_COMPONENT_REGISTRY, ...)`` registration entirely on the embedding path, so no chat-shaped collectors land on the embedding worker's registry. Return-type element widens to ``Optional[LLMBackendMetrics]``.

**``components/src/dynamo/vllm/worker_factory.py``** -- ``_create_embedding_worker`` flips ``embedding_worker=True`` on the factory it constructs. ``EngineSetupResult`` widens the trailing element to match. The chat/decode and prefill paths pass through unchanged.

vLLM still calls the factory unconditionally during ``AsyncLLM`` init, so the no-op logger is necessary to keep that seam happy without leaking chat-shaped state into the embedding worker.

Embedding-shaped metrics (e.g. ``dynamo_embedding_batch_size``, ``dynamo_embedding_input_tokens``, ``dynamo_embedding_latency_seconds``) are registered on the Rust frontend, not this worker -- so this change removes the irrelevant gauges without taking any embedding observability with it.

#### Where should the reviewer start?

1. ``components/src/dynamo/vllm/publisher.py`` -- the ``StatLoggerFactory.create_stat_logger`` short-circuit and the new ``_NoopStatLogger``. This is the meat of the change.
2. ``components/src/dynamo/vllm/main.py`` -- the ``setup_vllm_engine`` branch that decides whether to register ``LLMBackendMetrics``.
3. ``components/src/dynamo/vllm/worker_factory.py`` -- single call-site flip in ``_create_embedding_worker``.
4. ``components/src/dynamo/vllm/tests/test_vllm_publisher.py`` -- four unit tests. The embedding-worker test patches ``DynamoStatLoggerPublisher`` to ``raise`` to prove the constructor doesn't run on that path; the chat-worker sibling test verifies the default path still wires up the publisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved initialization issues for embedding worker configurations by properly handling optional metrics collection.

* **Tests**
  * Added comprehensive unit tests verifying embedding worker behavior and no-op logging functionality.

* **Refactor**
  * Optimized metrics collection system to skip unnecessary gauge tracking for embedding workers, improving resource efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->