### PR TITLE
fix(trtllm): restore deps, default CMD, and reduce layer count after upstream base switch

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -7,26 +7,20 @@
 ########## Runtime Image #########
 ##################################
 
-# Workspace transport stage: gather all workspace contents so the runtime
-# pulls them in one COPY layer instead of nine. Reduces overlayfs depth on
-# top of the 226-layer upstream TRT-LLM base.
+# Transport stage — runtime pulls /workspace_src/ in one cross-stage COPY.
 FROM scratch AS workspace_files
-COPY --chmod=775 tests /tests
-COPY --chmod=775 examples /examples
-COPY --chmod=775 deploy /deploy
-COPY --chmod=775 dev /dev
-COPY --chmod=775 components/src/dynamo/common /components/src/dynamo/common
-COPY --chmod=775 components/src/dynamo/frontend /components/src/dynamo/frontend
-COPY --chmod=775 components/src/dynamo/trtllm /components/src/dynamo/trtllm
-COPY --chmod=775 components/src/dynamo/mocker /components/src/dynamo/mocker
-COPY --chmod=775 lib /lib
+COPY --chmod=775 tests /workspace_src/tests
+COPY --chmod=775 examples /workspace_src/examples
+COPY --chmod=775 deploy /workspace_src/deploy
+COPY --chmod=775 dev /workspace_src/dev
+COPY --chmod=775 components/src/dynamo/common /workspace_src/components/src/dynamo/common
+COPY --chmod=775 components/src/dynamo/frontend /workspace_src/components/src/dynamo/frontend
+COPY --chmod=775 components/src/dynamo/trtllm /workspace_src/components/src/dynamo/trtllm
+COPY --chmod=775 components/src/dynamo/mocker /workspace_src/components/src/dynamo/mocker
+COPY --chmod=775 lib /workspace_src/lib
 
-# Transport stage for dynamo_base artifacts — same one-layer trick as
-# workspace_files. Each file is placed at its final runtime path so the
-# runtime stage pulls all four with a single cross-stage COPY.
-# Note: place uv/uvx at /usr/bin (not /bin) — upstream tensorrt-llm/release is
-# usrmerged (/bin -> /usr/bin), and a cross-stage COPY of / / chokes on the
-# symlink target. The runtime's PATH includes /usr/bin so this is equivalent.
+# Transport stage for dynamo_base artifacts. uv/uvx go to /usr/bin (not /bin)
+# because upstream is usrmerged and cross-stage COPY chokes on the symlink.
 FROM scratch AS dynamo_base_export
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
@@ -38,7 +32,6 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 ARG TARGETARCH
-ARG DYNAMO_COMMIT_SHA
 
 # DYNAMO_HOME points at /workspace so bundled TRT-LLM scripts that reference
 # $DYNAMO_HOME/examples/... resolve. LD_PRELOAD/NIXL_PLUGIN_DIR are a workaround
@@ -52,18 +45,17 @@ ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
     PATH=/usr/local/bin/etcd:${PATH} \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
-    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
-    DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
 
 # Not in upstream nvcr.io/nvidia/tensorrt-llm/release.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssh-server \
         librdmacm1 \
         rdma-core && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean
 
 WORKDIR /workspace
 
@@ -90,13 +82,10 @@ RUN test -f /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libni
 # One COPY pulls nats-server, etcd/, uv, uvx into their final paths.
 COPY --from=dynamo_base_export / /
 
-# Create dynamo user with group 0 for OpenShift compatibility, clear upstream's
-# /workspace baggage (README.md, tutorials/, docker-examples/, license.txt —
-# pytest collection picks up broken tutorial test files otherwise), and (for
-# non-dev targets) create the dynamo venv. Upstream tensorrt-llm/release marks
-# system Python as PEP 668 externally-managed, so we install Dynamo wheels into
-# a venv with --system-site-packages so upstream's solve stays importable while
-# our wheels live in their own namespace.
+# dynamo user (group 0 for OpenShift), clear upstream /workspace baggage
+# (otherwise pytest collects broken tutorial test files), and create the
+# Dynamo venv on non-dev. --system-site-packages keeps upstream's solve
+# importable since system Python is PEP 668 externally-managed.
 RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     && useradd -m -s /bin/bash -g 0 dynamo \
     && [ `id -u dynamo` -eq 1000 ] \
@@ -146,13 +135,17 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 
 # Still root from above; collapse workspace COPY + launch-screen prep into one
 # pair of layers and only switch to dynamo at the very end.
-COPY --chmod=775 --chown=dynamo:0 --from=workspace_files / /workspace/
+COPY --chmod=775 --chown=dynamo:0 --from=workspace_files /workspace_src/ /workspace/
 RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen && \
     chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
 
 USER dynamo
+
+# Kept at the bottom — SHA changes per build; layers above stay cached.
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 
 # Reset upstream TRT-LLM image's entrypoint so derived runtimes behave like
 # other Dynamo images and can execute arbitrary commands directly.

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -77,6 +77,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ldconfig && \
     rm -f /usr/local/bin/etcd && \
     mkdir -p /opt/dynamo && \
+    test -f "/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6" && \
     ln -sf "/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6" /opt/dynamo/libstdc++.so.6
 
 # One COPY pulls nats-server, etcd/, uv, uvx into their final paths.

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -21,11 +21,39 @@ COPY --chmod=775 components/src/dynamo/trtllm /components/src/dynamo/trtllm
 COPY --chmod=775 components/src/dynamo/mocker /components/src/dynamo/mocker
 COPY --chmod=775 lib /lib
 
+# Transport stage for dynamo_base artifacts — same one-layer trick as
+# workspace_files. Each file is placed at its final runtime path so the
+# runtime stage pulls all four with a single cross-stage COPY.
+# Note: place uv/uvx at /usr/bin (not /bin) — upstream tensorrt-llm/release is
+# usrmerged (/bin -> /usr/bin), and a cross-stage COPY of / / chokes on the
+# symlink target. The runtime's PATH includes /usr/bin so this is equivalent.
+FROM scratch AS dynamo_base_export
+COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
+COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
+COPY --from=dynamo_base /bin/uv /usr/bin/uv
+COPY --from=dynamo_base /bin/uvx /usr/bin/uvx
+
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 ARG TARGETARCH
+ARG DYNAMO_COMMIT_SHA
+
+# DYNAMO_HOME points at /workspace so bundled TRT-LLM scripts that reference
+# $DYNAMO_HOME/examples/... resolve. LD_PRELOAD/NIXL_PLUGIN_DIR are a workaround
+# for ai-dynamo/nixl#1668: nixl-cu13's bundled UCX 1.20.0 hangs in
+# `uct_md_query_tl_resources` (md_resources realloc loop, >1 GiB) when two NIXL
+# agents init on the same host. Force-load TRT-LLM's bundled libnixl 0.9.0
+# (uses system UCX, no bug). LD_PRELOAD is the only lever: nixl-cu13's
+# _bindings.so has DT_RPATH which beats LD_LIBRARY_PATH. Drop the two NIXL
+# vars when the upstream issue is fixed.
+ENV DYNAMO_HOME=/workspace \
+    HOME=/home/dynamo \
+    PATH=/usr/local/bin/etcd:${PATH} \
+    LD_PRELOAD=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
+    DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 
 # Not in upstream nvcr.io/nvidia/tensorrt-llm/release.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -39,29 +67,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /workspace
 
-# DYNAMO_HOME points at /workspace so bundled TRT-LLM scripts that reference
-# $DYNAMO_HOME/examples/... resolve. Examples and tests are copied below.
-ENV DYNAMO_HOME=/workspace
-ENV HOME=/home/dynamo
-ENV PATH=/usr/local/bin/etcd:${PATH}
-
-# Workaround for ai-dynamo/nixl#1668: nixl-cu13's bundled UCX 1.20.0 hangs in
-# `uct_md_query_tl_resources` (md_resources realloc loop, >1 GiB) when two NIXL
-# agents init on the same host — blocks every TRT-LLM native-disagg multi-process
-# test. Force-load TRT-LLM's bundled libnixl 0.9.0 (uses system UCX, no bug).
-# LD_PRELOAD is the only lever: nixl-cu13's _bindings.so has DT_RPATH which beats
-# LD_LIBRARY_PATH. Drop this block when the upstream issue is fixed.
-ENV LD_PRELOAD=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so
-ENV NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
-# Fail the build loudly if upstream moves these paths — otherwise LD_PRELOAD
-# silently logs "cannot be preloaded: ignored" and the hang returns at runtime.
-RUN test -f "${LD_PRELOAD}" && test -d "${NIXL_PLUGIN_DIR}"
-
-# Upstream's /etc/shinit_v2 prepends /usr/local/tensorrt/lib (and others) to
-# LD_LIBRARY_PATH, but only when a shell starts. K8s spawns python3 directly,
-# so the libs aren't found and `import tensorrt` fails. Register the paths
-# with ldconfig instead so they resolve regardless of launch method.
-RUN ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
+# 1. Sanity check the LD_PRELOAD/NIXL_PLUGIN_DIR paths exist (otherwise
+#    LD_PRELOAD silently logs "cannot be preloaded: ignored" and the hang
+#    returns at runtime).
+# 2. Upstream's /etc/shinit_v2 prepends /usr/local/tensorrt/lib (and others)
+#    to LD_LIBRARY_PATH only when a shell starts. K8s spawns python3 directly,
+#    so register the paths with ldconfig instead.
+# 3. Upstream ships /usr/local/bin/etcd as a single binary; remove it so we
+#    can install dynamo_base's etcd directory at the same path below.
+RUN test -f "${LD_PRELOAD}" && test -d "${NIXL_PLUGIN_DIR}" && \
+    ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
     printf '%s\n' \
         "/usr/local/tensorrt/lib" \
         "/usr/local/cuda/lib64" \
@@ -69,20 +84,19 @@ RUN ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64")
         "/opt/nvidia/nvda_nixl/lib/${ARCH_ALT}-linux-gnu" \
         "/opt/nvidia/nvda_nixl/lib64" \
         > /etc/ld.so.conf.d/00-dynamo-trtllm.conf && \
-    ldconfig
+    ldconfig && \
+    rm -f /usr/local/bin/etcd
 
-# Upstream ships /usr/local/bin/etcd as a single binary; remove it so we can
-# install dynamo_base's etcd directory (etcd+etcdctl+etcdutl) at the same path.
-RUN rm -f /usr/local/bin/etcd
-COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
-COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
-# Copy uv from dynamo_base so the venv symlink below resolves even if a future
-# upstream tensorrt-llm/release tag drops /usr/local/bin/uv from its image.
-COPY --from=dynamo_base /bin/uv /bin/uvx /bin/
+# One COPY pulls nats-server, etcd/, uv, uvx into their final paths.
+COPY --from=dynamo_base_export / /
 
-# Create dynamo user with group 0 for OpenShift compatibility.
-# Also clear upstream's /workspace baggage (README.md, tutorials/, docker-examples/,
-# license.txt) — pytest collection picks up broken tutorial test files otherwise.
+# Create dynamo user with group 0 for OpenShift compatibility, clear upstream's
+# /workspace baggage (README.md, tutorials/, docker-examples/, license.txt —
+# pytest collection picks up broken tutorial test files otherwise), and (for
+# non-dev targets) create the dynamo venv. Upstream tensorrt-llm/release marks
+# system Python as PEP 668 externally-managed, so we install Dynamo wheels into
+# a venv with --system-site-packages so upstream's solve stays importable while
+# our wheels live in their own namespace.
 RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     && useradd -m -s /bin/bash -g 0 dynamo \
     && [ `id -u dynamo` -eq 1000 ] \
@@ -91,20 +105,19 @@ RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     && rm -rf /workspace && mkdir /workspace \
     && chown dynamo:0 /home/dynamo /home/dynamo/.cache /opt/dynamo /workspace \
     && mkdir -p /etc/profile.d \
-    && echo 'umask 002' > /etc/profile.d/00-umask.sh
+    && echo 'umask 002' > /etc/profile.d/00-umask.sh{% if target not in ("dev", "local-dev") %} \
+    && python3 -m venv --system-site-packages /opt/dynamo/venv \
+    && ln -sf /usr/bin/uv /opt/dynamo/venv/bin/uv{% endif %}
+
+{% if target not in ("dev", "local-dev") %}
+ENV VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH=/opt/dynamo/venv/bin:${PATH}
+{% endif %}
 
 COPY --chmod=664 --chown=dynamo:0 ATTRIBUTION* LICENSE /workspace/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
 {% if target not in ("dev", "local-dev") %}
-# Upstream tensorrt-llm/release marks system Python as PEP 668 externally-managed.
-# Install Dynamo wheels into a venv with --system-site-packages so upstream's
-# solve stays importable while our wheels live in their own namespace.
-RUN python3 -m venv --system-site-packages /opt/dynamo/venv \
-    && ln -sf /usr/bin/uv /opt/dynamo/venv/bin/uv
-ENV VIRTUAL_ENV=/opt/dynamo/venv \
-    PATH=/opt/dynamo/venv/bin:${PATH}
-
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
     export UV_CACHE_DIR=/root/.cache/uv && \
@@ -131,23 +144,15 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     fi
 {% endif %}
 
-USER dynamo
-
-# Copy the workspace surface needed by trtllm pre-merge tests in a single
-# layer (see workspace_files stage above).
+# Still root from above; collapse workspace COPY + launch-screen prep into one
+# pair of layers and only switch to dynamo at the very end.
 COPY --chmod=775 --chown=dynamo:0 --from=workspace_files / /workspace/
-
 RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
-    sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen
-
-USER root
-RUN chmod 755 /opt/dynamo/.launch_screen && \
+    sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen && \
+    chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc
 
 USER dynamo
-
-ARG DYNAMO_COMMIT_SHA
-ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 
 # Reset upstream TRT-LLM image's entrypoint so derived runtimes behave like
 # other Dynamo images and can execute arbitrary commands directly.

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -77,8 +77,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ldconfig && \
     rm -f /usr/local/bin/etcd && \
     mkdir -p /opt/dynamo && \
-    test -f "/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6" && \
-    ln -sf "/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6" /opt/dynamo/libstdc++.so.6
+    LIBSTDCPP=/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6 && \
+    test -f "$LIBSTDCPP" && ln -sf "$LIBSTDCPP" /opt/dynamo/libstdc++.so.6
 
 # One COPY pulls nats-server, etcd/, uv, uvx into their final paths.
 COPY --from=dynamo_base_export / /
@@ -104,17 +104,15 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
     PATH=/opt/dynamo/venv/bin:${PATH}
 {% endif %}
 
+# Place wheels in /opt/dynamo/wheelhouse unconditionally — dev/local-dev images
+# install from source and skip the pip install RUN below, but they still need
+# the wheels on disk because tests/dependencies/test_kvbm_imports.py greps
+# this path and runs in dev-derived test images.
+COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+
 {% if target not in ("dev", "local-dev") %}
-# Persist wheels in /opt/dynamo/wheelhouse (tests/dependencies/test_kvbm_imports.py
-# greps for them) while installing them in the same RUN — saves the standalone
-# COPY layer for *.whl.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
-    --mount=type=bind,from=wheel_builder,source=/opt/dynamo/dist,target=/tmp/wheels \
-    mkdir -p /opt/dynamo/wheelhouse && \
-    cp /tmp/wheels/*.whl /opt/dynamo/wheelhouse/ && \
-    chown -R dynamo:0 /opt/dynamo/wheelhouse && \
-    chmod -R 775 /opt/dynamo/wheelhouse && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     \
     # Dynamo's own wheels — --no-deps preserves upstream's solve.

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -7,7 +7,7 @@
 ########## Runtime Image #########
 ##################################
 
-# Transport stage — runtime pulls /workspace_src/ in one cross-stage COPY.
+# Transport stage — runtime pulls /workspace_src/ in one bind-mount cp.
 FROM scratch AS workspace_files
 COPY --chmod=775 tests /workspace_src/tests
 COPY --chmod=775 examples /workspace_src/examples
@@ -18,6 +18,7 @@ COPY --chmod=775 components/src/dynamo/frontend /workspace_src/components/src/dy
 COPY --chmod=775 components/src/dynamo/trtllm /workspace_src/components/src/dynamo/trtllm
 COPY --chmod=775 components/src/dynamo/mocker /workspace_src/components/src/dynamo/mocker
 COPY --chmod=775 lib /workspace_src/lib
+COPY --chmod=664 ATTRIBUTION* LICENSE /workspace_src/
 
 # Transport stage for dynamo_base artifacts. uv/uvx go to /usr/bin (not /bin)
 # because upstream is usrmerged and cross-stage COPY chokes on the symlink.
@@ -47,7 +48,14 @@ ENV DYNAMO_HOME=/workspace \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
     NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
 
-# Not in upstream nvcr.io/nvidia/tensorrt-llm/release.
+WORKDIR /workspace
+
+# Install packages missing from upstream, sanity-check libnixl, register
+# TRT-LLM lib paths with ldconfig (upstream's /etc/shinit_v2 only sets them
+# for shells, not K8s python3 launches), swap upstream's single-binary etcd
+# for dynamo_base's directory, and symlink system libstdc++ to a stable
+# path for LD_PRELOAD — keeps PyInstaller-bundled tools (`jet`) from
+# shadowing it with an older copy.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
@@ -55,16 +63,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         openssh-server \
         librdmacm1 \
         rdma-core && \
-    apt-get clean
-
-WORKDIR /workspace
-
-# Sanity-check libnixl exists, register TRT-LLM lib paths with ldconfig
-# (upstream's /etc/shinit_v2 only sets them for shells, not K8s python3),
-# swap upstream's single-binary etcd for dynamo_base's directory, and
-# symlink system libstdc++ to a stable path for LD_PRELOAD — keeps
-# PyInstaller-bundled tools (`jet`) from shadowing it with an older copy.
-RUN test -f /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so && \
+    test -f /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so && \
     test -d "${NIXL_PLUGIN_DIR}" && \
     ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
     printf '%s\n' \
@@ -103,12 +102,17 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
     PATH=/opt/dynamo/venv/bin:${PATH}
 {% endif %}
 
-COPY --chmod=664 --chown=dynamo:0 ATTRIBUTION* LICENSE /workspace/
-COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
-
 {% if target not in ("dev", "local-dev") %}
+# Persist wheels in /opt/dynamo/wheelhouse (tests/dependencies/test_kvbm_imports.py
+# greps for them) while installing them in the same RUN — saves the standalone
+# COPY layer for *.whl.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
+    --mount=type=bind,from=wheel_builder,source=/opt/dynamo/dist,target=/tmp/wheels \
+    mkdir -p /opt/dynamo/wheelhouse && \
+    cp /tmp/wheels/*.whl /opt/dynamo/wheelhouse/ && \
+    chown -R dynamo:0 /opt/dynamo/wheelhouse && \
+    chmod -R 775 /opt/dynamo/wheelhouse && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     \
     # Dynamo's own wheels — --no-deps preserves upstream's solve.
@@ -133,10 +137,13 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     fi
 {% endif %}
 
-# Still root from above; collapse workspace COPY + launch-screen prep into one
-# pair of layers and only switch to dynamo at the very end.
-COPY --chmod=775 --chown=dynamo:0 --from=workspace_files /workspace_src/ /workspace/
-RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
+# Pull /workspace_src (incl. ATTRIBUTION/LICENSE) from the transport stage and
+# wire up the launch screen in a single RUN — saves the standalone workspace COPY layer.
+RUN --mount=type=bind,from=workspace_files,source=/workspace_src,target=/tmp/workspace_src \
+    --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
+    cp -a /tmp/workspace_src/. /workspace/ && \
+    chown -R dynamo:0 /workspace && \
+    chmod -R g+w /workspace && \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen && \
     chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -13,6 +13,16 @@ ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 ARG TARGETARCH
 
+# Not in upstream nvcr.io/nvidia/tensorrt-llm/release.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        openssh-server \
+        librdmacm1 \
+        rdma-core && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 # DYNAMO_HOME points at /workspace so bundled TRT-LLM scripts that reference

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -54,8 +54,9 @@ WORKDIR /workspace
 # TRT-LLM lib paths with ldconfig (upstream's /etc/shinit_v2 only sets them
 # for shells, not K8s python3 launches), swap upstream's single-binary etcd
 # for dynamo_base's directory, and symlink system libstdc++ to a stable
-# path for LD_PRELOAD — keeps PyInstaller-bundled tools (`jet`) from
-# shadowing it with an older copy.
+# path for LD_PRELOAD — keeps PyInstaller-bundled tools (specifically `jet`,
+# NVIDIA's internal PyInstaller-packaged CI runner) from shadowing it with an
+# older copy.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -143,7 +143,6 @@ RUN --mount=type=bind,from=workspace_files,source=/workspace_src,target=/tmp/wor
     --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
     cp -a /tmp/workspace_src/. /workspace/ && \
     chown -R dynamo:0 /workspace && \
-    chmod -R g+w /workspace && \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen && \
     chmod 755 /opt/dynamo/.launch_screen && \
     echo 'cat /opt/dynamo/.launch_screen' >> /etc/bash.bashrc

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -7,6 +7,20 @@
 ########## Runtime Image #########
 ##################################
 
+# Workspace transport stage: gather all workspace contents so the runtime
+# pulls them in one COPY layer instead of nine. Reduces overlayfs depth on
+# top of the 226-layer upstream TRT-LLM base.
+FROM scratch AS workspace_files
+COPY --chmod=775 tests /tests
+COPY --chmod=775 examples /examples
+COPY --chmod=775 deploy /deploy
+COPY --chmod=775 dev /dev
+COPY --chmod=775 components/src/dynamo/common /components/src/dynamo/common
+COPY --chmod=775 components/src/dynamo/frontend /components/src/dynamo/frontend
+COPY --chmod=775 components/src/dynamo/trtllm /components/src/dynamo/trtllm
+COPY --chmod=775 components/src/dynamo/mocker /components/src/dynamo/mocker
+COPY --chmod=775 lib /lib
+
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
 ARG ENABLE_KVBM
@@ -119,18 +133,9 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 
 USER dynamo
 
-# Copy the workspace surface needed by trtllm pre-merge tests.
-# Keep optional framework trees out of /workspace so the upstream runtime does
-# not look like a fully-expanded generic image.
-COPY --chmod=775 --chown=dynamo:0 tests /workspace/tests
-COPY --chmod=775 --chown=dynamo:0 examples /workspace/examples
-COPY --chmod=775 --chown=dynamo:0 deploy /workspace/deploy
-COPY --chmod=775 --chown=dynamo:0 dev /workspace/dev
-COPY --chmod=775 --chown=dynamo:0 components/src/dynamo/common /workspace/components/src/dynamo/common
-COPY --chmod=775 --chown=dynamo:0 components/src/dynamo/frontend /workspace/components/src/dynamo/frontend
-COPY --chmod=775 --chown=dynamo:0 components/src/dynamo/trtllm /workspace/components/src/dynamo/trtllm
-COPY --chmod=775 --chown=dynamo:0 components/src/dynamo/mocker /workspace/components/src/dynamo/mocker
-COPY --chmod=775 --chown=dynamo:0 lib /workspace/lib
+# Copy the workspace surface needed by trtllm pre-merge tests in a single
+# layer (see workspace_files stage above).
+COPY --chmod=775 --chown=dynamo:0 --from=workspace_files / /workspace/
 
 RUN --mount=type=bind,source=./container/launch_message/runtime.txt,target=/opt/dynamo/launch_message.txt \
     sed '/^#\s/d' /opt/dynamo/launch_message.txt > /opt/dynamo/.launch_screen

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -67,20 +67,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /workspace
 
-# 1. Sanity check the libnixl/NIXL_PLUGIN_DIR paths exist (otherwise
-#    LD_PRELOAD silently logs "cannot be preloaded: ignored" and the hang
-#    returns at runtime). LD_PRELOAD entry 1 (libstdc++) is verified by the
-#    ln -sf below; entry 2 (libnixl) is verified here.
-# 2. Upstream's /etc/shinit_v2 prepends /usr/local/tensorrt/lib (and others)
-#    to LD_LIBRARY_PATH only when a shell starts. K8s spawns python3 directly,
-#    so register the paths with ldconfig instead.
-# 3. Upstream ships /usr/local/bin/etcd as a single binary; remove it so we
-#    can install dynamo_base's etcd directory at the same path below.
-# 4. Stable arch-independent symlink to the system libstdc++. LD_PRELOAD'd
-#    by the ENV above so external PyInstaller-bundled tools (e.g. NVIDIA's
-#    `jet` CI runner) that ship an older libstdc++ in their _MEI extraction
-#    dir don't shadow upstream's GCC 13.2 libstdc++ when they dlopen our
-#    libnixl / nvda_nixl libs. Drop this once jet stops bundling libstdc++.
+# Sanity-check libnixl exists, register TRT-LLM lib paths with ldconfig
+# (upstream's /etc/shinit_v2 only sets them for shells, not K8s python3),
+# swap upstream's single-binary etcd for dynamo_base's directory, and
+# symlink system libstdc++ to a stable path for LD_PRELOAD — keeps
+# PyInstaller-bundled tools (`jet`) from shadowing it with an older copy.
 RUN test -f /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so && \
     test -d "${NIXL_PLUGIN_DIR}" && \
     ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -147,3 +147,4 @@ ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 # Reset upstream TRT-LLM image's entrypoint so derived runtimes behave like
 # other Dynamo images and can execute arbitrary commands directly.
 ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -51,7 +51,7 @@ ARG DYNAMO_COMMIT_SHA
 ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
     PATH=/usr/local/bin/etcd:${PATH} \
-    LD_PRELOAD=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
+    LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
     NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
     DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 
@@ -67,15 +67,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /workspace
 
-# 1. Sanity check the LD_PRELOAD/NIXL_PLUGIN_DIR paths exist (otherwise
+# 1. Sanity check the libnixl/NIXL_PLUGIN_DIR paths exist (otherwise
 #    LD_PRELOAD silently logs "cannot be preloaded: ignored" and the hang
-#    returns at runtime).
+#    returns at runtime). LD_PRELOAD entry 1 (libstdc++) is verified by the
+#    ln -sf below; entry 2 (libnixl) is verified here.
 # 2. Upstream's /etc/shinit_v2 prepends /usr/local/tensorrt/lib (and others)
 #    to LD_LIBRARY_PATH only when a shell starts. K8s spawns python3 directly,
 #    so register the paths with ldconfig instead.
 # 3. Upstream ships /usr/local/bin/etcd as a single binary; remove it so we
 #    can install dynamo_base's etcd directory at the same path below.
-RUN test -f "${LD_PRELOAD}" && test -d "${NIXL_PLUGIN_DIR}" && \
+# 4. Stable arch-independent symlink to the system libstdc++. LD_PRELOAD'd
+#    by the ENV above so external PyInstaller-bundled tools (e.g. NVIDIA's
+#    `jet` CI runner) that ship an older libstdc++ in their _MEI extraction
+#    dir don't shadow upstream's GCC 13.2 libstdc++ when they dlopen our
+#    libnixl / nvda_nixl libs. Drop this once jet stops bundling libstdc++.
+RUN test -f /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so && \
+    test -d "${NIXL_PLUGIN_DIR}" && \
     ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
     printf '%s\n' \
         "/usr/local/tensorrt/lib" \
@@ -85,7 +92,9 @@ RUN test -f "${LD_PRELOAD}" && test -d "${NIXL_PLUGIN_DIR}" && \
         "/opt/nvidia/nvda_nixl/lib64" \
         > /etc/ld.so.conf.d/00-dynamo-trtllm.conf && \
     ldconfig && \
-    rm -f /usr/local/bin/etcd
+    rm -f /usr/local/bin/etcd && \
+    mkdir -p /opt/dynamo && \
+    ln -sf "/usr/lib/${ARCH_ALT}-linux-gnu/libstdc++.so.6" /opt/dynamo/libstdc++.so.6
 
 # One COPY pulls nats-server, etcd/, uv, uvx into their final paths.
 COPY --from=dynamo_base_export / /

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -28,7 +28,13 @@ COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
 COPY --from=dynamo_base /bin/uv /usr/bin/uv
 COPY --from=dynamo_base /bin/uvx /usr/bin/uvx
 
+{% if target == "runtime" %}
+# Renamed `runtime` → `runtime_full` so the final stage can re-FROM upstream
+# and overlay our changes as a single layer (cuts depth for downstream wrappers).
+FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime_full
+{% else %}
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
+{% endif %}
 
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
@@ -157,3 +163,34 @@ ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 # other Dynamo images and can execute arbitrary commands directly.
 ENTRYPOINT []
 CMD ["/bin/bash"]
+
+{% if target == "runtime" %}
+# Rebase on upstream so this stage inherits upstream's image config
+# (ENV/WORKDIR/USER/CMD) and then overlay runtime_full's filesystem as a
+# single layer. Only Dynamo-specific env needs redeclaring below.
+FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
+# Whiteout paths runtime_full removed — COPY can't represent deletions, so
+# without this, upstream's /workspace, /home/ubuntu, and single-file
+# /usr/local/bin/etcd would leak alongside our content.
+RUN rm -rf /workspace /home/ubuntu /usr/local/bin/etcd
+COPY --from=runtime_full / /
+
+# Mirrors runtime_full's ENV — must stay in sync. Re-declaration is required
+# because `FROM ${RUNTIME_IMAGE}` here does not inherit runtime_full's config.
+ENV DYNAMO_HOME=/workspace \
+    HOME=/home/dynamo \
+    VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH=/opt/dynamo/venv/bin:/usr/local/bin/etcd:${PATH} \
+    LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
+
+WORKDIR /workspace
+
+ARG DYNAMO_COMMIT_SHA
+ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
+
+USER dynamo
+
+ENTRYPOINT []
+CMD ["/bin/bash"]
+{% endif %}


### PR DESCRIPTION
Three regressions from PR #9654 (TRT-LLM upstream base switch).

## 1. Restore missing system packages (`openssh-server`, `librdmacm1`, `rdma-core`)

#9654 dropped Dynamo's explicit apt block on the assumption upstream `nvcr.io/nvidia/tensorrt-llm/release` had everything we need. Three packages turned out to be missing:

- `openssh-server` — upstream ships `openssh-client` but no `sshd`. Breaks multi-node MPI-over-SSH (kimi-k2.5 K8s benchmark).
- `librdmacm1` + `rdma-core` — RDMA Connection Manager userspace; needed for NCCL IB transport and UCX rdmacm mode.

Verified empirically against `tensorrt-llm/release:1.3.0rc14`. Everything else from the pre-#9654 apt block (`build-essential`, `python3.12-dev`, `python3-pip`, `jq`, `numactl`, `libibverbs1`, `libnuma1`, `libcudnn9-cuda-13`, `libnvshmem3-cuda-13`, `libzmq3-dev`, `openssh-client`, `curl`, `git`, etc.) is correctly provided by upstream and intentionally not re-added.

After local rebuild: `sshd` is on PATH at `/usr/sbin/sshd`, host keys generated by postinst, `librdmacm.so.1` loadable via ldconfig, `rdma-core` package installed.

## 2. Set default `CMD ["/bin/bash"]`

#9654 cleared upstream's `ENTRYPOINT` (`/opt/nvidia/nvidia_entrypoint.sh`) to let derived runtimes execute arbitrary commands directly, but did not set a CMD. Upstream `tensorrt-llm/release` has no CMD either, so bare `docker run <image>` now fails with `Error response from daemon: no command specified` — breaking downstream pipelines that smoke-test the image without passing an explicit command.

K8s deploy manifests are unaffected: they set `command:` and `args:` explicitly, which override CMD.

## 3. Reduce layer count to clear overlay2's 128-layer cap

Downstream wrapper images (`tensorrt-llm_dynamo_trtllm-runtime-with-k8s-wrapper-arm64-benchmarks`) were hitting `docker: failed to register layer: max depth exceeded` at pull time because the runtime image (~111 layers post-#9654) plus the wrapper's additions (~20 layers) plus the upstream PyTorch base (101 layers underneath) was sitting near or above overlay2's 128-layer cap on some hosts.

### Architecture: runtime_full + rebase split

The template now produces two different stage chains depending on the build target:

- **`target=runtime`** (production image): a layered `runtime_full` stage does all the build work (apt install, ldconfig, wheels, workspace_src cp), then a final `FROM ${RUNTIME_IMAGE} AS runtime` stage **rebases** by `COPY --from=runtime_full / /` overlaying the entire filesystem as a single layer. Upstream image config (ENV/WORKDIR/USER/CMD — ~40 NVIDIA/CUDA/MPI vars) inherits automatically via `FROM upstream`; only Dynamo-specific env (`DYNAMO_HOME`, `LD_PRELOAD`, `NIXL_PLUGIN_DIR`, `VIRTUAL_ENV`, `PATH`) is redeclared. A `RUN rm -rf /workspace /home/ubuntu /usr/local/bin/etcd` before the COPY whiteouts upstream paths that `runtime_full` deleted (COPY can't represent deletions).

- **`target=dev` / `target=local-dev`**: the original layered `runtime` stage stays as-is; `dev`/`dynamo_tools` build directly `FROM runtime` for fast iteration. No rebase. Wheelhouse COPY is unconditional so `tests/dependencies/test_kvbm_imports.py` finds the wheels.

Net effect: runtime image drops from 108 → 104 fs layers, with upstream env inheritance preserved (no redeclaration of OPAL_PREFIX, CUDA_HOME, NVIDIA_REQUIRE_CUDA, ~37 other vars).

In-Dockerfile cleanup also included: collapsed transport stages (`workspace_files`, `dynamo_base_export`) for one-COPY workspace + dynamo_base imports, consolidated metadata + setup RUNs, restored unconditional wheel COPY (fix for dev/local-dev wheelhouse regression), assert `libstdc++.so.6` target exists before symlinking, factor LIBSTDCPP path into a variable.

## Test plan

- [ ] Standard CI builds the trtllm container image successfully.
- [ ] Single-node trtllm smoke tests pass (no regression from the added apt layer).
- [ ] `docker run nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:<tag>` no longer errors with "no command specified" — drops into bash.
- [ ] Downstream pipeline `test_distroless` stage no longer fails with `max depth exceeded`.
- [ ] kimi-k2.5 disagg-eagle-kv-router K8s benchmark on GB200 cluster comes back green (multi-node MPI ranks come up).
- [ ] Confirm in container: `which sshd` returns `/usr/sbin/sshd`, `ldconfig -p | grep librdmacm` shows the lib, `dpkg -s rdma-core` shows installed, `/workspace/{tests,examples,deploy,lib,components/src/dynamo/{common,frontend,trtllm,mocker}}` all present and owned by `dynamo:0`.

### Layer-count fix verification (new for §3)

- [x] `docker inspect dynamo:<runtime-tag> --format '{{len .RootFS.Layers}}'` returns ≤104 on amd64.
- [ ] Same check on arm64 (build via `--platform=linux/arm64`).
- [x] `docker run --rm <runtime-tag> env | grep -E '^(OPAL_PREFIX|CUDA_HOME|NVIDIA_REQUIRE_CUDA|LD_LIBRARY_PATH)='` returns upstream's values (inheritance via FROM works).
- [x] Disagg smoke test on the rebased runtime image (`run_trtllm_disagg.sh` with Qwen3-0.6B): `POST /v1/chat/completions` returns 200; prefill→decode handoff fires with matching request_id.
- [x] `docker run --rm <runtime-tag> ls /workspace` shows only Dynamo content (no upstream `tensorrt_llm/` leak from overlay shadowing).
- [x] `docker run --rm <runtime-tag> ls /opt/dynamo/wheelhouse/` shows `kvbm`, `ai_dynamo_runtime`, `ai_dynamo`, `gpu_memory_service` wheels.
- [ ] `--target=dev` and `--target=local-dev` builds complete successfully (use the layered `runtime` stage, not the rebased one — dev iteration speed must remain unaffected).
- [ ] `--target=dev` arm64 build also succeeds (QEMU emulation OK for verification).
- [ ] `tests/dependencies/test_kvbm_imports.py::test_kvbm_wheel_exists_trtllm` passes on the dev test image (wheelhouse populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
