### PR TITLE
fix: persist discovered DGDR hardware metadata

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -410,6 +410,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) gpuDiscoveryEnabled() bool {
 	return *r.Config.GPU.DiscoveryEnabled
 }
 
+func (r *DynamoGraphDeploymentRequestReconciler) gpuDiscoveryReader() (client.Reader, bool) {
+	if r == nil || r.APIReader == nil {
+		return nil, false
+	}
+	return r.APIReader, true
+}
+
 // FinalizeResource implements commonController.Finalizer interface
 func (r *DynamoGraphDeploymentRequestReconciler) FinalizeResource(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
@@ -1270,9 +1277,18 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx con
 		return nil
 	}
 
+	reader, ok := r.gpuDiscoveryReader()
+	if !ok {
+		logger.Info("GPU discovery unavailable; APIReader is not configured")
+		return fmt.Errorf(
+			"GPU hardware info required but auto-discovery failed. " +
+				"Verify DCGM exporter is reachable from the operator's namespace, " +
+				"or set spec.hardware.{gpuSku,vramMb,numGpusPerNode} explicitly.")
+	}
+
 	// DCGM exporter is a cluster-level Service — reachable from any namespace.
 	if r.GPUDiscovery != nil {
-		if _, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, r.APIReader, r.GPUDiscoveryCache); err == nil {
+		if _, err := r.GPUDiscovery.DiscoverGPUsFromDCGM(ctx, reader, r.GPUDiscoveryCache); err == nil {
 			return nil
 		} else {
 			logger.Info("DCGM discovery unavailable", "error", err.Error())
@@ -1281,7 +1297,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx con
 
 	// Node-label fallback
 	if r.gpuDiscoveryEnabled() {
-		if _, err := gpu.DiscoverGPUs(ctx, r.APIReader); err == nil {
+		if _, err := gpu.DiscoverGPUs(ctx, reader); err == nil {
 			return nil
 		} else {
 			logger.Info("Node-label discovery unavailable", "error", err.Error())
@@ -1767,8 +1783,17 @@ func (r *DynamoGraphDeploymentRequestReconciler) discoverHardwareForEnrichment(c
 	logger := log.FromContext(ctx)
 	logger.Info("Attempting GPU discovery for profiling job")
 
+	reader, ok := r.gpuDiscoveryReader()
+	if !ok {
+		if discoveryRequired {
+			return nil, fmt.Errorf("auto-discovery failed: APIReader is not configured")
+		}
+		logger.Info("Optional hardware metadata discovery skipped because APIReader is not configured")
+		return nil, nil
+	}
+
 	if r.GPUDiscovery != nil {
-		discoveredInfo, err := r.GPUDiscovery.DiscoverGPUsFromDCGMFiltered(ctx, r.APIReader, r.GPUDiscoveryCache, hw.GPUSKU)
+		discoveredInfo, err := r.GPUDiscovery.DiscoverGPUsFromDCGMFiltered(ctx, reader, r.GPUDiscoveryCache, hw.GPUSKU)
 		if err == nil {
 			return discoveredInfo, nil
 		}
@@ -1785,7 +1810,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) discoverHardwareForEnrichment(c
 		}
 	}
 
-	discoveredInfo, err := gpu.DiscoverGPUsFiltered(ctx, r.APIReader, hw.GPUSKU)
+	discoveredInfo, err := gpu.DiscoverGPUsFiltered(ctx, reader, hw.GPUSKU)
 	if err == nil {
 		return discoveredInfo, nil
 	}

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -403,6 +403,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) GetRecorder() record.EventRecor
 	return r.Recorder
 }
 
+func (r *DynamoGraphDeploymentRequestReconciler) gpuDiscoveryEnabled() bool {
+	if r == nil || r.Config == nil || r.Config.GPU.DiscoveryEnabled == nil {
+		return true
+	}
+	return *r.Config.GPU.DiscoveryEnabled
+}
+
 // FinalizeResource implements commonController.Finalizer interface
 func (r *DynamoGraphDeploymentRequestReconciler) FinalizeResource(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
@@ -1273,7 +1280,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) validateGPUHardwareInfo(ctx con
 	}
 
 	// Node-label fallback
-	if ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
+	if r.gpuDiscoveryEnabled() {
 		if _, err := gpu.DiscoverGPUs(ctx, r.APIReader); err == nil {
 			return nil
 		} else {
@@ -1769,7 +1776,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) discoverHardwareForEnrichment(c
 		reason := GetGPUDiscoveryFailureReason(err)
 		logger.Info("DCGM discovery failed, falling back to node-label discovery",
 			"reason", reason, "error", err.Error())
-		if !ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
+		if !r.gpuDiscoveryEnabled() {
 			if discoveryRequired {
 				return nil, fmt.Errorf("auto-discovery failed: %w", err)
 			}

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1684,51 +1684,25 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 
 	logger := log.FromContext(ctx)
 
-	var gpuInfo *gpu.GPUInfo
-	logger.Info("Attempting GPU discovery for profiling job")
-	var discoveredInfo *gpu.GPUInfo
-	var err error
-	if r.GPUDiscovery != nil {
-		discoveredInfo, err = r.GPUDiscovery.DiscoverGPUsFromDCGMFiltered(ctx, r.APIReader, r.GPUDiscoveryCache, hw.GPUSKU)
-		if err != nil {
-			reason := GetGPUDiscoveryFailureReason(err)
-			logger.Info("DCGM discovery failed, falling back to node-label discovery",
-				"reason", reason, "error", err.Error())
-			if !ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
-				if discoveryRequired {
-					return changed, fmt.Errorf("auto-discovery failed: %w", err)
-				}
-				logger.Info("Optional hardware metadata discovery skipped because node-label discovery is disabled")
-				return changed, nil
-			}
-		}
+	gpuInfo, err := r.discoverHardwareForEnrichment(ctx, hw, discoveryRequired)
+	if err != nil {
+		return changed, err
 	}
-	if discoveredInfo == nil {
-		discoveredInfo, err = gpu.DiscoverGPUsFiltered(ctx, r.APIReader, hw.GPUSKU)
-		if err != nil {
-			logger.Info("Node-label discovery also failed", "error", err.Error())
-			if discoveryRequired {
-				return changed, fmt.Errorf("auto-discovery failed: %w", err)
-			}
-			logger.Info("Optional hardware metadata discovery unavailable; leaving unset fields unchanged")
-			return changed, nil
-		}
+	if gpuInfo == nil {
+		return changed, nil
 	}
-	gpuInfo = discoveredInfo
-	if gpuInfo != nil {
-		logger.Info("GPU discovery completed successfully",
-			"gpusPerNode", gpuInfo.GPUsPerNode,
-			"nodesWithGPUs", gpuInfo.NodesWithGPUs,
-			"totalGpus", gpuInfo.GPUsPerNode*gpuInfo.NodesWithGPUs,
-			"model", gpuInfo.Model,
-			"vramMiB", gpuInfo.VRAMPerGPU,
-			"system", gpuInfo.System,
-			"cloudprovider", gpuInfo.CloudProvider,
-			"interconnect", gpuInfo.Interconnect,
-			"interconnectTier", gpuInfo.InterconnectTier,
-			"rdma", gpuInfo.RDMAEnabled,
-			"rdmaType", gpuInfo.RDMAType)
-	}
+	logger.Info("GPU discovery completed successfully",
+		"gpusPerNode", gpuInfo.GPUsPerNode,
+		"nodesWithGPUs", gpuInfo.NodesWithGPUs,
+		"totalGpus", gpuInfo.GPUsPerNode*gpuInfo.NodesWithGPUs,
+		"model", gpuInfo.Model,
+		"vramMiB", gpuInfo.VRAMPerGPU,
+		"system", gpuInfo.System,
+		"cloudprovider", gpuInfo.CloudProvider,
+		"interconnect", gpuInfo.Interconnect,
+		"interconnectTier", gpuInfo.InterconnectTier,
+		"rdma", gpuInfo.RDMAEnabled,
+		"rdmaType", gpuInfo.RDMAType)
 
 	if hw.GPUSKU == "" {
 		inferred := gpu.InferHardwareSystem(gpuInfo.Model)
@@ -1780,6 +1754,41 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		changed = true
 	}
 	return changed, nil
+}
+
+func (r *DynamoGraphDeploymentRequestReconciler) discoverHardwareForEnrichment(ctx context.Context, hw *nvidiacomv1beta1.HardwareSpec, discoveryRequired bool) (*gpu.GPUInfo, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Attempting GPU discovery for profiling job")
+
+	if r.GPUDiscovery != nil {
+		discoveredInfo, err := r.GPUDiscovery.DiscoverGPUsFromDCGMFiltered(ctx, r.APIReader, r.GPUDiscoveryCache, hw.GPUSKU)
+		if err == nil {
+			return discoveredInfo, nil
+		}
+
+		reason := GetGPUDiscoveryFailureReason(err)
+		logger.Info("DCGM discovery failed, falling back to node-label discovery",
+			"reason", reason, "error", err.Error())
+		if !ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
+			if discoveryRequired {
+				return nil, fmt.Errorf("auto-discovery failed: %w", err)
+			}
+			logger.Info("Optional hardware metadata discovery skipped because node-label discovery is disabled")
+			return nil, nil
+		}
+	}
+
+	discoveredInfo, err := gpu.DiscoverGPUsFiltered(ctx, r.APIReader, hw.GPUSKU)
+	if err == nil {
+		return discoveredInfo, nil
+	}
+
+	logger.Info("Node-label discovery also failed", "error", err.Error())
+	if discoveryRequired {
+		return nil, fmt.Errorf("auto-discovery failed: %w", err)
+	}
+	logger.Info("Optional hardware metadata discovery unavailable; leaving unset fields unchanged")
+	return nil, nil
 }
 
 // extractModelCachePVCConfig reads model cache PVC settings from the typed v1beta1 spec.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -1792,22 +1792,28 @@ func (r *DynamoGraphDeploymentRequestReconciler) discoverHardwareForEnrichment(c
 		return nil, nil
 	}
 
+	var dcgmErr error
 	if r.GPUDiscovery != nil {
 		discoveredInfo, err := r.GPUDiscovery.DiscoverGPUsFromDCGMFiltered(ctx, reader, r.GPUDiscoveryCache, hw.GPUSKU)
 		if err == nil {
 			return discoveredInfo, nil
 		}
+		dcgmErr = err
 
 		reason := GetGPUDiscoveryFailureReason(err)
 		logger.Info("DCGM discovery failed, falling back to node-label discovery",
 			"reason", reason, "error", err.Error())
-		if !r.gpuDiscoveryEnabled() {
-			if discoveryRequired {
-				return nil, fmt.Errorf("auto-discovery failed: %w", err)
+	}
+
+	if !r.gpuDiscoveryEnabled() {
+		if discoveryRequired {
+			if dcgmErr != nil {
+				return nil, fmt.Errorf("auto-discovery failed: %w", dcgmErr)
 			}
-			logger.Info("Optional hardware metadata discovery skipped because node-label discovery is disabled")
-			return nil, nil
+			return nil, fmt.Errorf("auto-discovery failed: node-label discovery is disabled")
 		}
+		logger.Info("Optional hardware metadata discovery skipped because node-label discovery is disabled")
+		return nil, nil
 	}
 
 	discoveredInfo, err := gpu.DiscoverGPUsFiltered(ctx, reader, hw.GPUSKU)

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -522,9 +522,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.
 	logger.Info("Handling pending phase", "name", dgdr.Name)
 
 	// Create profiling job (online or AIC)
-	if err := r.createProfilingJob(ctx, dgdr); err != nil {
+	requeue, err := r.createProfilingJob(ctx, dgdr)
+	if err != nil {
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonProfilingJobFailed, err.Error())
 		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, MessageJobCreationFailed, err.Error())
+	}
+	if requeue {
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Record event with appropriate message
@@ -1329,15 +1333,38 @@ func GetGPUDiscoveryFailureReason(err error) string {
 	return "unknown"
 }
 
-// createProfilingJob creates a Kubernetes Job for profiling using SyncResource
-func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
+// createProfilingJob creates a Kubernetes Job for profiling using SyncResource.
+// It returns requeue=true when it persists discovered hardware and intentionally
+// skips job creation until the next reconcile sees the updated generation.
+func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (bool, error) {
 	logger := log.FromContext(ctx)
+
+	// Enrich hardware from GPU discovery before marshalling the spec.
+	// This fills in any missing hardware fields and persists them so the DGDR
+	// reflects the profiler input.
+	hardwareChanged, err := r.enrichHardwareFromDiscovery(ctx, dgdr)
+	if err != nil {
+		return false, err
+	}
+	if hardwareChanged {
+		if err := r.Update(ctx, dgdr); err != nil {
+			return false, fmt.Errorf("failed to update DGDR with auto-discovered hardware: %w", err)
+		}
+		logger.Info("Persisted auto-discovered hardware fields",
+			"gpuSku", dgdr.Spec.Hardware.GPUSKU,
+			"vramMiB", ptr.Deref(dgdr.Spec.Hardware.VRAMMB, 0),
+			"numGpusPerNode", ptr.Deref(dgdr.Spec.Hardware.NumGPUsPerNode, 0),
+			"totalGpus", ptr.Deref(dgdr.Spec.Hardware.TotalGPUs, 0),
+			"interconnect", dgdr.Spec.Hardware.Interconnect,
+			"rdma", ptr.Deref(dgdr.Spec.Hardware.RDMA, false))
+		return true, nil
+	}
 
 	// Delete any existing output ConfigMap to ensure fresh profiling results
 	// This prevents using stale data from previous profiling runs
 	outputConfigMapName := getOutputConfigMapName(dgdr)
 	existingCM := &corev1.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      outputConfigMapName,
 		Namespace: dgdr.Namespace,
 	}, existingCM)
@@ -1346,13 +1373,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		logger.Info("Deleting existing output ConfigMap to ensure fresh profiling results", "configMap", outputConfigMapName)
 		if err := r.Delete(ctx, existingCM); err != nil && !apierrors.IsNotFound(err) {
 			logger.Error(err, "Failed to delete existing output ConfigMap", "configMap", outputConfigMapName)
-			return fmt.Errorf("failed to delete existing output ConfigMap: %w", err)
+			return false, fmt.Errorf("failed to delete existing output ConfigMap: %w", err)
 		}
 		logger.Info("Successfully deleted old output ConfigMap", "configMap", outputConfigMapName)
 	} else if !apierrors.IsNotFound(err) {
 		// Unexpected error checking for ConfigMap
 		logger.Error(err, "Failed to check for existing output ConfigMap", "configMap", outputConfigMapName)
-		return fmt.Errorf("failed to check for existing output ConfigMap: %w", err)
+		return false, fmt.Errorf("failed to check for existing output ConfigMap: %w", err)
 	}
 
 	// Ensure profiling job RBAC exists (only for cluster-wide installation)
@@ -1364,14 +1391,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 			r.Config.RBAC.DGDRProfilingClusterRoleName,
 		); err != nil {
 			logger.Error(err, "Failed to ensure profiling job RBAC")
-			return fmt.Errorf("failed to ensure profiling job RBAC: %w", err)
+			return false, fmt.Errorf("failed to ensure profiling job RBAC: %w", err)
 		}
-	}
-
-	// Enrich hardware from GPU discovery before marshalling the spec.
-	// This fills in any missing hardware fields (gpuSku, vramMb, numGpusPerNode, totalGpus).
-	if err := r.enrichHardwareFromDiscovery(ctx, dgdr); err != nil {
-		return err
 	}
 
 	// Use SyncResource to create/update the job
@@ -1610,7 +1631,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 	})
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if modified {
@@ -1620,7 +1641,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 	// Store the job name in status for observability
 	dgdr.Status.ProfilingJobName = job.Name
 
-	return nil
+	return false, nil
 }
 
 // marshalDGDRSpec produces the JSON string passed to the profiler via --config.
@@ -1634,25 +1655,32 @@ func marshalDGDRSpec(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (strin
 }
 
 // enrichHardwareFromDiscovery fills in hardware fields that the user didn't set.
-// Called before marshalDGDRSpec(). Mutates dgdr.Spec.Hardware in-place (memory only, not persisted).
+// Called before marshalDGDRSpec(). Mutates dgdr.Spec.Hardware in-place; the caller
+// persists the DGDR when this returns changed=true.
 //
-// Discovery is attempted whenever any required field (GPUSKU, VRAMMB, NumGPUsPerNode) is absent,
-// regardless of whether other fields are already set. This prevents a nil-pointer panic that
-// occurred when hasManualConfig was true (at least one field set) but gpuInfo was never populated
-// because discovery was gated on !hasManualConfig, yet the enrichment code below still
-// dereferenced gpuInfo for whichever fields were still nil.
+// Discovery is attempted whenever any required field (GPUSKU, VRAMMB, NumGPUsPerNode,
+// TotalGPUs) or optional metadata field (Interconnect, RDMA) is absent. This intentionally
+// changes the old "required fields complete means skip discovery" behavior so manually
+// specified hardware can still receive best-effort metadata. Discovery failures remain fatal
+// when required fields are missing, but optional metadata is best-effort.
 //
 // DCGM is tried first; node-label discovery (DiscoverGPUs) is used as a fallback to support
-// environments such as vCluster where DCGM sockets are exclusive to the host cluster.
-func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
+// environments such as vCluster where DCGM sockets are exclusive to the host cluster. A
+// successful DCGM result is accepted as authoritative; if it lacks optional metadata, missing
+// optional fields are left unset rather than forcing a second discovery backend.
+func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (bool, error) {
+	changed := false
 	if dgdr.Spec.Hardware == nil {
 		dgdr.Spec.Hardware = &nvidiacomv1beta1.HardwareSpec{}
 	}
 	hw := dgdr.Spec.Hardware
 
-	if hw.GPUSKU != "" && hw.VRAMMB != nil && hw.NumGPUsPerNode != nil && hw.TotalGPUs != nil {
-		return nil
+	requiredComplete := hw.GPUSKU != "" && hw.VRAMMB != nil && hw.NumGPUsPerNode != nil && hw.TotalGPUs != nil
+	metadataComplete := hw.Interconnect != "" && hw.RDMA != nil
+	if requiredComplete && metadataComplete {
+		return changed, nil
 	}
+	discoveryRequired := !requiredComplete
 
 	logger := log.FromContext(ctx)
 
@@ -1667,7 +1695,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 			logger.Info("DCGM discovery failed, falling back to node-label discovery",
 				"reason", reason, "error", err.Error())
 			if !ptr.Deref(r.Config.GPU.DiscoveryEnabled, true) {
-				return fmt.Errorf("auto-discovery failed: %w", err)
+				if discoveryRequired {
+					return changed, fmt.Errorf("auto-discovery failed: %w", err)
+				}
+				logger.Info("Optional hardware metadata discovery skipped because node-label discovery is disabled")
+				return changed, nil
 			}
 		}
 	}
@@ -1675,7 +1707,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		discoveredInfo, err = gpu.DiscoverGPUsFiltered(ctx, r.APIReader, hw.GPUSKU)
 		if err != nil {
 			logger.Info("Node-label discovery also failed", "error", err.Error())
-			return fmt.Errorf("auto-discovery failed: %w", err)
+			if discoveryRequired {
+				return changed, fmt.Errorf("auto-discovery failed: %w", err)
+			}
+			logger.Info("Optional hardware metadata discovery unavailable; leaving unset fields unchanged")
+			return changed, nil
 		}
 	}
 	gpuInfo = discoveredInfo
@@ -1687,7 +1723,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 			"model", gpuInfo.Model,
 			"vramMiB", gpuInfo.VRAMPerGPU,
 			"system", gpuInfo.System,
-			"cloudprovider", gpuInfo.CloudProvider)
+			"cloudprovider", gpuInfo.CloudProvider,
+			"interconnect", gpuInfo.Interconnect,
+			"interconnectTier", gpuInfo.InterconnectTier,
+			"rdma", gpuInfo.RDMAEnabled,
+			"rdmaType", gpuInfo.RDMAType)
 	}
 
 	if hw.GPUSKU == "" {
@@ -1700,14 +1740,17 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 		default:
 			hw.GPUSKU = nvidiacomv1beta1.GPUSKUType(gpuInfo.Model)
 		}
+		changed = true
 	}
 	if hw.VRAMMB == nil && gpuInfo != nil {
 		vram := float64(gpuInfo.VRAMPerGPU)
 		hw.VRAMMB = &vram
+		changed = true
 	}
 	if hw.NumGPUsPerNode == nil && gpuInfo != nil {
 		n := int32(gpuInfo.GPUsPerNode)
 		hw.NumGPUsPerNode = &n
+		changed = true
 	}
 	if hw.TotalGPUs == nil && gpuInfo != nil {
 		// TODO: This is a temporary limit to prevent the profiler from using too many GPUs.
@@ -1720,8 +1763,23 @@ func (r *DynamoGraphDeploymentRequestReconciler) enrichHardwareFromDiscovery(ctx
 			total = defaultMaxAutoGPUs
 		}
 		hw.TotalGPUs = &total
+		changed = true
 	}
-	return nil
+	if hw.Interconnect == "" && gpuInfo != nil && gpuInfo.Interconnect != "" {
+		hw.Interconnect = gpuInfo.Interconnect
+		changed = true
+	}
+	// Unlike RDMA, interconnect has no bool-like "checked and absent" value in
+	// the API. Leave it empty when discovery cannot classify the transport so
+	// consumers continue to treat it as unknown.
+	if hw.RDMA == nil && gpuInfo != nil {
+		// Persist false as "discovery ran and did not find RDMA" so consumers can
+		// distinguish it from nil, which means "not checked / unknown".
+		rdma := gpuInfo.RDMAEnabled
+		hw.RDMA = &rdma
+		changed = true
+	}
+	return changed, nil
 }
 
 // extractModelCachePVCConfig reads model cache PVC settings from the typed v1beta1 spec.
@@ -2227,6 +2285,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseAndRequeue(ctx conte
 	logger := log.FromContext(ctx)
 	logger.Info("Updating DGDR phase", "name", dgdr.Name, "phase", phase, "message", message)
 	dgdr.Status.Phase = phase
+	dgdr.Status.ObservedGeneration = dgdr.Generation
 	setSucceededCondition(dgdr, phase)
 	if err := r.Status().Update(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
@@ -2245,6 +2304,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 	message string,
 ) (ctrl.Result, error) {
 	dgdr.Status.Phase = phase
+	dgdr.Status.ObservedGeneration = dgdr.Generation
 
 	// Set the specific condition first so setSucceededCondition can surface it.
 	dgdr.AddStatusCondition(metav1.Condition{

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -1290,7 +1290,7 @@ var _ = Describe("DGDR Profiler Arguments", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &fetchedDGDR)).Should(Succeed())
 
 			// Create profiling job with properly initialized DGDR
-			err := reconciler.createProfilingJob(ctx, &fetchedDGDR)
+			_, err := reconciler.createProfilingJob(ctx, &fetchedDGDR)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify job was created
@@ -1355,7 +1355,7 @@ var _ = Describe("DGDR Profiler Arguments", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &fetchedDGDR)).Should(Succeed())
 
 			// Create profiling job with properly initialized DGDR
-			err := reconciler.createProfilingJob(ctx, &fetchedDGDR)
+			_, err := reconciler.createProfilingJob(ctx, &fetchedDGDR)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify job was created
@@ -1419,7 +1419,7 @@ var _ = Describe("DGDR Profiler Arguments", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &fetchedDGDR)).Should(Succeed())
 
 			// Create profiling job with properly initialized DGDR
-			err := reconciler.createProfilingJob(ctx, &fetchedDGDR)
+			_, err := reconciler.createProfilingJob(ctx, &fetchedDGDR)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify job was created

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -77,6 +77,21 @@ func dcgmPod(name, ip string) *corev1.Pod {
 	}
 }
 
+func TestGPUDiscoveryEnabledDefaults(t *testing.T) {
+	assert.True(t, (*DynamoGraphDeploymentRequestReconciler)(nil).gpuDiscoveryEnabled())
+	assert.True(t, (&DynamoGraphDeploymentRequestReconciler{}).gpuDiscoveryEnabled())
+	assert.True(t, (&DynamoGraphDeploymentRequestReconciler{
+		Config: &configv1alpha1.OperatorConfiguration{},
+	}).gpuDiscoveryEnabled())
+	assert.False(t, (&DynamoGraphDeploymentRequestReconciler{
+		Config: &configv1alpha1.OperatorConfiguration{
+			GPU: configv1alpha1.GPUConfiguration{
+				DiscoveryEnabled: ptr.To(false),
+			},
+		},
+	}).gpuDiscoveryEnabled())
+}
+
 func TestEnrichHardwareFromDiscovery(t *testing.T) {
 	tests := []struct {
 		name string

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -92,6 +92,44 @@ func TestGPUDiscoveryEnabledDefaults(t *testing.T) {
 	}).gpuDiscoveryEnabled())
 }
 
+func TestEnrichHardwareFromDiscovery_SkipsOptionalMetadataWithoutAPIReader(t *testing.T) {
+	r := &DynamoGraphDeploymentRequestReconciler{
+		Config: &configv1alpha1.OperatorConfiguration{},
+	}
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
+				VRAMMB:         ptr.To(81920.0),
+				NumGPUsPerNode: ptr.To(int32(8)),
+				TotalGPUs:      ptr.To(int32(16)),
+			},
+		},
+	}
+
+	changed, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Empty(t, dgdr.Spec.Hardware.Interconnect)
+	assert.Nil(t, dgdr.Spec.Hardware.RDMA)
+}
+
+func TestEnrichHardwareFromDiscovery_RequiredFieldsMissingWithoutAPIReaderFails(t *testing.T) {
+	r := &DynamoGraphDeploymentRequestReconciler{
+		Config: &configv1alpha1.OperatorConfiguration{},
+	}
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{},
+		},
+	}
+
+	changed, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "APIReader is not configured")
+	assert.False(t, changed)
+}
+
 func TestEnrichHardwareFromDiscovery(t *testing.T) {
 	tests := []struct {
 		name string

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -130,6 +130,30 @@ func TestEnrichHardwareFromDiscovery_RequiredFieldsMissingWithoutAPIReaderFails(
 	assert.False(t, changed)
 }
 
+func TestEnrichHardwareFromDiscovery_SkipsOptionalMetadataWhenNodeDiscoveryDisabled(t *testing.T) {
+	node := gpuNode("gpu-node-rdma", "H100-SXM5-80GB", 8, 81920)
+	node.Labels[gpupkg.LabelNFDRDMAAvailable] = "true"
+	r := newFakeReconciler(node)
+	r.GPUDiscovery = nil
+	r.Config.GPU.DiscoveryEnabled = ptr.To(false)
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
+				VRAMMB:         ptr.To(81920.0),
+				NumGPUsPerNode: ptr.To(int32(8)),
+				TotalGPUs:      ptr.To(int32(16)),
+			},
+		},
+	}
+
+	changed, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Nil(t, dgdr.Spec.Hardware.RDMA)
+}
+
 func TestEnrichHardwareFromDiscovery(t *testing.T) {
 	tests := []struct {
 		name string
@@ -394,6 +418,52 @@ func TestCreateProfilingJobPersistsDiscoveredHardware(t *testing.T) {
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
 		Name:      getProfilingJobName(&stored),
 		Namespace: stored.Namespace,
+	}, job))
+}
+
+func TestCreateProfilingJobWithManualHardwareDoesNotRequireAPIReader(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "manual-hardware",
+			Namespace: "default",
+		},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Model:   "test-model",
+			Backend: nvidiacomv1beta1.BackendTypeVllm,
+			Image:   "test-profiler:latest",
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
+				VRAMMB:         ptr.To(81920.0),
+				NumGPUsPerNode: ptr.To(int32(8)),
+				TotalGPUs:      ptr.To(int32(16)),
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dgdr).Build()
+	r := &DynamoGraphDeploymentRequestReconciler{
+		Client:      fakeClient,
+		Recorder:    &record.FakeRecorder{},
+		Config:      &configv1alpha1.OperatorConfiguration{},
+		RBACManager: &MockRBACManager{},
+	}
+
+	var fetched nvidiacomv1beta1.DynamoGraphDeploymentRequest
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, &fetched))
+
+	requeue, err := r.createProfilingJob(ctx, &fetched)
+	require.NoError(t, err)
+	require.False(t, requeue)
+
+	job := &batchv1.Job{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Name:      getProfilingJobName(&fetched),
+		Namespace: fetched.Namespace,
 	}, job))
 }
 

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -21,13 +21,16 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -90,29 +93,30 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 		wantVRAM      float64
 		wantGPUsNode  int32
 		wantTotalGPUs int32
+		wantChanged   bool
 	}{
 		{
-			name: "all four fields set, discovery skipped",
+			name: "required fields set, no discovery available",
 			hardware: &nvidiacomv1beta1.HardwareSpec{
 				GPUSKU: "h100_sxm", VRAMMB: ptr.To(81920.0),
 				NumGPUsPerNode: ptr.To(int32(8)), TotalGPUs: ptr.To(int32(16)),
 			},
-			wantGPUSKU: "h100_sxm", wantVRAM: 81920, wantGPUsNode: 8, wantTotalGPUs: 16,
+			wantGPUSKU: "h100_sxm", wantVRAM: 81920, wantGPUsNode: 8, wantTotalGPUs: 16, wantChanged: false,
 		},
 		{
 			name:          "nothing set, full discovery",
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 8, Model: "H100-SXM5-80GB", VRAMPerGPU: 81920},
-			wantGPUSKU:    "h100_sxm", wantVRAM: 81920, wantGPUsNode: 8, wantTotalGPUs: 8,
+			wantGPUSKU:    "h100_sxm", wantVRAM: 81920, wantGPUsNode: 8, wantTotalGPUs: 8, wantChanged: true,
 		},
 		{
 			name:          "nothing set, V100 discovered",
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 8, Model: "Tesla-V100-SXM2-16GB", VRAMPerGPU: 16384},
-			wantGPUSKU:    "v100_sxm", wantVRAM: 16384, wantGPUsNode: 8, wantTotalGPUs: 8,
+			wantGPUSKU:    "v100_sxm", wantVRAM: 16384, wantGPUsNode: 8, wantTotalGPUs: 8, wantChanged: true,
 		},
 		{
 			name:          "nothing set, unknown GPU falls back to model name",
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 4, Model: "FutureGPU-X1000", VRAMPerGPU: 65536},
-			wantGPUSKU:    "FutureGPU-X1000", wantVRAM: 65536, wantGPUsNode: 4, wantTotalGPUs: 4,
+			wantGPUSKU:    "FutureGPU-X1000", wantVRAM: 65536, wantGPUsNode: 4, wantTotalGPUs: 4, wantChanged: true,
 		},
 		{
 			name: "only totalGpus missing, discovery fills it",
@@ -120,7 +124,7 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 				GPUSKU: "b200_sxm", VRAMMB: ptr.To(141312.0), NumGPUsPerNode: ptr.To(int32(8)),
 			},
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 8, Model: "B200-SXM-180GB", VRAMPerGPU: 141312},
-			wantGPUSKU:    "b200_sxm", wantVRAM: 141312, wantGPUsNode: 8, wantTotalGPUs: 8,
+			wantGPUSKU:    "b200_sxm", wantVRAM: 141312, wantGPUsNode: 8, wantTotalGPUs: 8, wantChanged: true,
 		},
 		{
 			name: "only gpuSku missing, discovery fills it",
@@ -128,7 +132,7 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 				VRAMMB: ptr.To(81920.0), NumGPUsPerNode: ptr.To(int32(8)), TotalGPUs: ptr.To(int32(16)),
 			},
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 8, Model: "H200-SXM5-141GB", VRAMPerGPU: 141312},
-			wantGPUSKU:    "h200_sxm", wantVRAM: 81920, wantGPUsNode: 8, wantTotalGPUs: 16, // user overrides win
+			wantGPUSKU:    "h200_sxm", wantVRAM: 81920, wantGPUsNode: 8, wantTotalGPUs: 16, wantChanged: true, // user overrides win
 		},
 		{
 			name: "vramMb and numGpusPerNode override discovery",
@@ -136,7 +140,7 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 				GPUSKU: "a100_sxm", VRAMMB: ptr.To(40960.0), NumGPUsPerNode: ptr.To(int32(4)),
 			},
 			discoveredGPU: &gpupkg.GPUInfo{NodeName: "n1", GPUsPerNode: 8, Model: "A100-SXM4-80GB", VRAMPerGPU: 81920},
-			wantGPUSKU:    "a100_sxm", wantVRAM: 40960, wantGPUsNode: 4, wantTotalGPUs: 8,
+			wantGPUSKU:    "a100_sxm", wantVRAM: 40960, wantGPUsNode: 4, wantTotalGPUs: 8, wantChanged: true,
 		},
 		{
 			name:    "no fields set, discovery fails",
@@ -179,7 +183,7 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 				},
 			}
 
-			err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+			changed, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -187,6 +191,7 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, changed)
 			require.NotNil(t, dgdr.Spec.Hardware)
 			assert.Equal(t, tt.wantGPUSKU, string(dgdr.Spec.Hardware.GPUSKU))
 			assert.Equal(t, tt.wantVRAM, *dgdr.Spec.Hardware.VRAMMB)
@@ -194,6 +199,149 @@ func TestEnrichHardwareFromDiscovery(t *testing.T) {
 			assert.Equal(t, tt.wantTotalGPUs, *dgdr.Spec.Hardware.TotalGPUs)
 		})
 	}
+}
+
+func TestEnrichHardwareFromDiscovery_WritesOptionalHardwareMetadata(t *testing.T) {
+	r := newFakeReconciler()
+	r.GPUDiscovery = gpupkg.NewGPUDiscovery(nil)
+	r.GPUDiscoveryCache = gpupkg.NewGPUDiscoveryCache()
+	r.GPUDiscoveryCache.Set("", &gpupkg.GPUInfo{
+		NodeName:      "n1",
+		GPUsPerNode:   8,
+		NodesWithGPUs: 2,
+		Model:         "NVIDIA H100 80GB HBM3",
+		VRAMPerGPU:    81079,
+		System:        nvidiacomv1beta1.GPUSKUTypeH100PCIe,
+		Interconnect:  "pcie",
+		RDMAEnabled:   true,
+		RDMAType:      "rdma",
+	}, time.Minute)
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{},
+		},
+	}
+
+	changed, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NotNil(t, dgdr.Spec.Hardware)
+	assert.Equal(t, nvidiacomv1beta1.GPUSKUTypeH100PCIe, dgdr.Spec.Hardware.GPUSKU)
+	assert.Equal(t, "pcie", dgdr.Spec.Hardware.Interconnect)
+	require.NotNil(t, dgdr.Spec.Hardware.RDMA)
+	assert.True(t, *dgdr.Spec.Hardware.RDMA)
+}
+
+func TestEnrichHardwareFromDiscovery_FillsOptionalMetadataWhenRequiredFieldsSet(t *testing.T) {
+	r := newFakeReconciler()
+	r.GPUDiscovery = gpupkg.NewGPUDiscovery(nil)
+	r.GPUDiscoveryCache = gpupkg.NewGPUDiscoveryCache()
+	r.GPUDiscoveryCache.Set(nvidiacomv1beta1.GPUSKUTypeH100PCIe, &gpupkg.GPUInfo{
+		NodeName:      "n1",
+		GPUsPerNode:   8,
+		NodesWithGPUs: 4,
+		Model:         "NVIDIA H100 80GB HBM3",
+		VRAMPerGPU:    81079,
+		System:        nvidiacomv1beta1.GPUSKUTypeH100PCIe,
+		Interconnect:  "pcie",
+		RDMAEnabled:   true,
+		RDMAType:      "rdma",
+	}, time.Minute)
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Hardware: &nvidiacomv1beta1.HardwareSpec{
+				GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100PCIe,
+				VRAMMB:         ptr.To(81920.0),
+				NumGPUsPerNode: ptr.To(int32(8)),
+				TotalGPUs:      ptr.To(int32(16)),
+			},
+		},
+	}
+
+	changed, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	require.NoError(t, err)
+	require.True(t, changed)
+	assert.Equal(t, nvidiacomv1beta1.GPUSKUTypeH100PCIe, dgdr.Spec.Hardware.GPUSKU)
+	assert.Equal(t, float64(81920), *dgdr.Spec.Hardware.VRAMMB)
+	assert.Equal(t, int32(8), *dgdr.Spec.Hardware.NumGPUsPerNode)
+	assert.Equal(t, int32(16), *dgdr.Spec.Hardware.TotalGPUs)
+	assert.Equal(t, "pcie", dgdr.Spec.Hardware.Interconnect)
+	require.NotNil(t, dgdr.Spec.Hardware.RDMA)
+	assert.True(t, *dgdr.Spec.Hardware.RDMA)
+}
+
+func TestCreateProfilingJobPersistsDiscoveredHardware(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
+
+	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "persist-hardware",
+			Namespace: "default",
+		},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+			Model:   "test-model",
+			Backend: nvidiacomv1beta1.BackendTypeVllm,
+			Image:   "test-profiler:latest",
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dgdr).Build()
+
+	cache := gpupkg.NewGPUDiscoveryCache()
+	cache.Set("", &gpupkg.GPUInfo{
+		NodeName:      "n1",
+		GPUsPerNode:   8,
+		NodesWithGPUs: 2,
+		Model:         "NVIDIA H100 80GB HBM3",
+		VRAMPerGPU:    81079,
+		System:        nvidiacomv1beta1.GPUSKUTypeH100PCIe,
+		Interconnect:  "pcie",
+		RDMAEnabled:   true,
+		RDMAType:      "rdma",
+	}, time.Minute)
+
+	r := &DynamoGraphDeploymentRequestReconciler{
+		Client:            fakeClient,
+		APIReader:         fakeClient,
+		Recorder:          &record.FakeRecorder{},
+		Config:            &configv1alpha1.OperatorConfiguration{},
+		GPUDiscovery:      gpupkg.NewGPUDiscovery(nil),
+		GPUDiscoveryCache: cache,
+		RBACManager:       &MockRBACManager{},
+	}
+
+	var fetched nvidiacomv1beta1.DynamoGraphDeploymentRequest
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, &fetched))
+
+	requeue, err := r.createProfilingJob(ctx, &fetched)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	var stored nvidiacomv1beta1.DynamoGraphDeploymentRequest
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, &stored))
+	require.NotNil(t, stored.Spec.Hardware)
+	assert.Equal(t, nvidiacomv1beta1.GPUSKUTypeH100PCIe, stored.Spec.Hardware.GPUSKU)
+	assert.Equal(t, float64(81079), *stored.Spec.Hardware.VRAMMB)
+	assert.Equal(t, int32(8), *stored.Spec.Hardware.NumGPUsPerNode)
+	assert.Equal(t, int32(16), *stored.Spec.Hardware.TotalGPUs)
+	assert.Equal(t, "pcie", stored.Spec.Hardware.Interconnect)
+	require.NotNil(t, stored.Spec.Hardware.RDMA)
+	assert.True(t, *stored.Spec.Hardware.RDMA)
+
+	requeue, err = r.createProfilingJob(ctx, &stored)
+	require.NoError(t, err)
+	require.False(t, requeue)
+
+	job := &batchv1.Job{}
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{
+		Name:      getProfilingJobName(&stored),
+		Namespace: stored.Namespace,
+	}, job))
 }
 
 // TestEnrichHardwareFromDiscovery_NormalizesBareModelFromDCGM is the regression test for
@@ -262,7 +410,7 @@ func TestEnrichHardwareFromDiscovery_NormalizesBareModelFromDCGM(t *testing.T) {
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{},
 			}
 
-			err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+			_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
 			require.NoError(t, err)
 			require.NotNil(t, dgdr.Spec.Hardware)
 			assert.Equal(t, tt.expectedGPUSKU, string(dgdr.Spec.Hardware.GPUSKU),
@@ -287,7 +435,7 @@ func TestEnrichHardwareFromDiscovery_FallsBackToModelForUnknownGPU(t *testing.T)
 		},
 	}
 
-	err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
+	_, err := r.enrichHardwareFromDiscovery(context.Background(), dgdr)
 	require.NoError(t, err)
 	require.NotNil(t, dgdr.Spec.Hardware)
 	assert.Equal(t, "Tesla-V100-SXM2-16GB", string(dgdr.Spec.Hardware.GPUSKU),

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -63,6 +63,7 @@ const (
 	LabelNVIDIARDMAPresent          = "nvidia.com/rdma.present"
 	LabelNFDRDMAAvailable           = "feature.node.kubernetes.io/rdma.available"
 	LabelNFDNetworkSRIOVCapable     = "feature.node.kubernetes.io/network-sriov.capable"
+	labelValueTrue                  = "true"
 )
 
 // --- Normalization helpers ---
@@ -1152,13 +1153,13 @@ func detectRDMAFromNode(ctx context.Context, k8sClient client.Reader, nodeName s
 		return false, strNone
 	}
 	labels := node.Labels
-	if labels[LabelNVIDIARDMAPresent] == "true" {
+	if labels[LabelNVIDIARDMAPresent] == labelValueTrue {
 		return true, "rdma"
 	}
-	if labels[LabelNFDRDMAAvailable] == "true" {
+	if labels[LabelNFDRDMAAvailable] == labelValueTrue {
 		return true, "rdma"
 	}
-	if labels[LabelNFDNetworkSRIOVCapable] == "true" {
+	if labels[LabelNFDNetworkSRIOVCapable] == labelValueTrue {
 		return true, "sriov"
 	}
 	return false, strNone

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -60,6 +60,9 @@ const (
 	CloudProviderAKS                = "aks"
 	CloudProviderOther              = "other"
 	CloudProviderUnknown            = "unknown"
+	LabelNVIDIARDMAPresent          = "nvidia.com/rdma.present"
+	LabelNFDRDMAAvailable           = "feature.node.kubernetes.io/rdma.available"
+	LabelNFDNetworkSRIOVCapable     = "feature.node.kubernetes.io/network-sriov.capable"
 )
 
 // --- Normalization helpers ---
@@ -384,7 +387,9 @@ func (g *GPUDiscovery) discoverGPUsFromDCGMFilteredUncached(ctx context.Context,
 	}
 
 	// Count only nodes with the same SKU as the selected best node,
-	// and detect RDMA on matching nodes only.
+	// and detect RDMA on matching nodes only. On a cold cache and a no-RDMA
+	// cluster, this performs one Node read per matching node; that keeps a
+	// single negative node from masking RDMA on another node.
 	nodesWithGPUs := 0
 	var rdmaDetected bool
 	var rdmaType string
@@ -402,7 +407,8 @@ func (g *GPUDiscovery) discoverGPUsFromDCGMFilteredUncached(ctx context.Context,
 		}
 	}
 
-	// Detect InfiniBand presence
+	// InfiniBand operator pods are a stronger cluster-wide RDMA signal than
+	// generic node labels, so they intentionally refine the transport type.
 	ib := detectIBPods(ctx, k8sClient)
 	if ib {
 		rdmaType = "infiniband"
@@ -837,22 +843,47 @@ func DiscoverGPUsFiltered(ctx context.Context, k8sClient client.Reader, filterSK
 			len(nodeList.Items), LabelGPUCount, LabelGPUProduct, LabelGPUMemory)
 	}
 
-	// Count only nodes with the same SKU as the selected best node.
+	// Count only nodes with the same SKU as the selected best node,
+	// and detect RDMA on matching nodes only. On a cold cache and a no-RDMA
+	// cluster, this performs one Node read per matching node; that keeps a
+	// single negative node from masking RDMA on another node.
 	nodesWithGPUs := 0
+	var rdmaDetected bool
+	var rdmaType string
 	for _, n := range allNodes {
 		if n.sku == bestSKU {
 			nodesWithGPUs++
+			if !rdmaDetected {
+				rdma, rType := detectRDMAFromNode(ctx, k8sClient, n.info.NodeName)
+				if rdma {
+					rdmaDetected = true
+					rdmaType = rType
+				}
+			}
 		}
 	}
+
+	// InfiniBand operator pods are a stronger cluster-wide RDMA signal than
+	// generic node labels, so they intentionally refine the transport type.
+	ib := detectIBPods(ctx, k8sClient)
+	if ib {
+		rdmaType = "infiniband"
+		rdmaDetected = true
+	}
+
 	bestNode.System = bestSKU
 	bestNode.NodesWithGPUs = nodesWithGPUs
+	bestNode.RDMAEnabled = rdmaDetected
+	bestNode.RDMAType = rdmaType
 	logger.Info("GPU discovery completed",
 		"gpusPerNode", bestNode.GPUsPerNode,
 		"nodesWithGPUs", bestNode.NodesWithGPUs,
 		"totalGpus", bestNode.GPUsPerNode*bestNode.NodesWithGPUs,
 		"model", bestNode.Model,
 		"vram", bestNode.VRAMPerGPU,
-		"system", bestNode.System)
+		"system", bestNode.System,
+		"rdma", bestNode.RDMAEnabled,
+		"rdmaType", bestNode.RDMAType)
 	return bestNode, nil
 }
 
@@ -1104,6 +1135,7 @@ func isAWSInstanceType(instanceType string) bool {
 // Detection logic:
 //   - Checks node labels:
 //   - "nvidia.com/rdma.present" = "true" → RDMA detected
+//   - "feature.node.kubernetes.io/rdma.available" = "true" → RDMA detected
 //   - "feature.node.kubernetes.io/network-sriov.capable" = "true" → SR-IOV detected
 //
 // Parameters:
@@ -1120,10 +1152,13 @@ func detectRDMAFromNode(ctx context.Context, k8sClient client.Reader, nodeName s
 		return false, strNone
 	}
 	labels := node.Labels
-	if labels["nvidia.com/rdma.present"] == "true" {
+	if labels[LabelNVIDIARDMAPresent] == "true" {
 		return true, "rdma"
 	}
-	if labels["feature.node.kubernetes.io/network-sriov.capable"] == "true" {
+	if labels[LabelNFDRDMAAvailable] == "true" {
+		return true, "rdma"
+	}
+	if labels[LabelNFDNetworkSRIOVCapable] == "true" {
 		return true, "sriov"
 	}
 	return false, strNone

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -318,6 +318,56 @@ func TestDiscoverGPUsFiltered_HomogeneousCountsAllNodes(t *testing.T) {
 	assert.Equal(t, 2, info.NodesWithGPUs)
 }
 
+func TestDiscoverGPUsFiltered_DetectsRDMAAvailableLabel(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "h100-node-rdma",
+			Labels: map[string]string{
+				LabelGPUCount:         "8",
+				LabelGPUProduct:       "H100-SXM5-80GB",
+				LabelGPUMemory:        "81920",
+				LabelNFDRDMAAvailable: "true",
+			},
+		},
+	}
+	k8sClient := newFakeClient(node)
+
+	info, err := DiscoverGPUsFiltered(ctx, k8sClient, "")
+	require.NoError(t, err)
+	assert.True(t, info.RDMAEnabled)
+	assert.Equal(t, "rdma", info.RDMAType)
+}
+
+func TestDiscoverGPUsFiltered_IBPodsOverrideGenericRDMAType(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "h100-node-rdma",
+			Labels: map[string]string{
+				LabelGPUCount:          "8",
+				LabelGPUProduct:        "H100-SXM5-80GB",
+				LabelGPUMemory:         "81920",
+				LabelNVIDIARDMAPresent: "true",
+			},
+		},
+	}
+	ibPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rdma-shared-device-plugin",
+			Namespace: LabelValueNvidiaNetworkOperator,
+		},
+	}
+	k8sClient := newFakeClient(node, ibPod)
+
+	info, err := DiscoverGPUsFiltered(ctx, k8sClient, "")
+	require.NoError(t, err)
+	assert.True(t, info.RDMAEnabled)
+	assert.Equal(t, "infiniband", info.RDMAType)
+}
+
 func TestDiscoverGPUs_NoGPUNodes(t *testing.T) {
 	ctx := context.Background()
 
@@ -1102,6 +1152,46 @@ func TestDiscoverGPUsFromDCGMFiltered_MixedSKU(t *testing.T) {
 	})
 }
 
+func TestDiscoverGPUsFromDCGMFiltered_DetectsRDMAAvailableLabel(t *testing.T) {
+	ctx := context.Background()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-h100",
+			Labels: map[string]string{
+				LabelNFDRDMAAvailable: "true",
+			},
+		},
+	}
+	dcgmPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dcgm-h100",
+			Namespace: "gpu-operator",
+			Labels:    map[string]string{LabelApp: LabelValueNvidiaDCGMExporter},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-h100"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.1",
+		},
+	}
+
+	k8sClient := newFakeClient(node, dcgmPod)
+	discovery := NewGPUDiscovery(func(_ context.Context, _ string) (*GPUInfo, error) {
+		return &GPUInfo{
+			NodeName:    "node-h100",
+			GPUsPerNode: 8,
+			Model:       "H100-SXM5-80GB",
+			VRAMPerGPU:  81920,
+		}, nil
+	})
+
+	info, err := discovery.DiscoverGPUsFromDCGMFiltered(ctx, k8sClient, nil, "")
+	require.NoError(t, err)
+	assert.True(t, info.RDMAEnabled)
+	assert.Equal(t, "rdma", info.RDMAType)
+}
+
 func TestDiscoverGPUsFromDCGM_GPUOperatorInstalled_DCgmNotEnabled(t *testing.T) {
 	ctx := context.Background()
 
@@ -1432,11 +1522,25 @@ func TestDetectRDMAFromNode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-rdma",
 					Labels: map[string]string{
-						"nvidia.com/rdma.present": "true",
+						LabelNVIDIARDMAPresent: "true",
 					},
 				},
 			},
 			nodeName:    "node-rdma",
+			expectedOK:  true,
+			expectedTyp: "rdma",
+		},
+		{
+			name: "nfd rdma available detected",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-nfd-rdma",
+					Labels: map[string]string{
+						LabelNFDRDMAAvailable: "true",
+					},
+				},
+			},
+			nodeName:    "node-nfd-rdma",
 			expectedOK:  true,
 			expectedTyp: "rdma",
 		},
@@ -1446,7 +1550,7 @@ func TestDetectRDMAFromNode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-sriov",
 					Labels: map[string]string{
-						"feature.node.kubernetes.io/network-sriov.capable": "true",
+						LabelNFDNetworkSRIOVCapable: "true",
 					},
 				},
 			},
@@ -1460,8 +1564,8 @@ func TestDetectRDMAFromNode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-both",
 					Labels: map[string]string{
-						"nvidia.com/rdma.present":                          "true",
-						"feature.node.kubernetes.io/network-sriov.capable": "true",
+						LabelNVIDIARDMAPresent:      "true",
+						LabelNFDNetworkSRIOVCapable: "true",
 					},
 				},
 			},
@@ -1487,8 +1591,9 @@ func TestDetectRDMAFromNode(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-false",
 					Labels: map[string]string{
-						"nvidia.com/rdma.present":                          "false",
-						"feature.node.kubernetes.io/network-sriov.capable": "false",
+						LabelNVIDIARDMAPresent:      "false",
+						LabelNFDRDMAAvailable:       "false",
+						LabelNFDNetworkSRIOVCapable: "false",
 					},
 				},
 			},


### PR DESCRIPTION
#### Overview:

This MR extends enrichHardwareFromDiscovery to return (bool, error) so callers can detect mutations and populates Interconnect and RDMA (with documented nil-vs-false semantics) from GPU discovery results

#### Details:

- Persist auto-discovered DGDR hardware before profiling job creation, then requeue for a clean second reconcile pass
- Write back discovered `spec.hardware.interconnect` and `spec.hardware.rdma`
- Detect RDMA from `feature.node.kubernetes.io/rdma.available=true` across DCGM and node-label discovery paths
- Add tests for persisted hardware writeback, optional metadata discovery, RDMA label detection, and InfiniBand precedence
- Stamp `observedGeneration` during DGDR status updates

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU and hardware discovery accuracy with improved RDMA capability detection for deployment profiling operations.
  * Strengthened hardware auto-enrichment with better requeue handling when deployment specifications are automatically updated.
  * Improved persistence of discovered GPU metadata including SKU, VRAM, and RDMA support information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->