### PR TITLE
test: update reasoning parity fixtures (part 2)

### DIFF
--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -40,8 +40,8 @@ require the opening tag to be present in the model output.
 
 | Parser Name | Models | Upstream name | Force-reasoning | Notes |
 |---|---|---|---|---|
-| `kimi_k25` | Kimi K2.5 | Dynamo-only | Yes | `<think>...</think>` with force-reasoning |
-| `kimi` | Kimi K2 Instruct / Thinking | Dynamo-only | No | `◁think▷...◁/think▷` |
+| `kimi_k25` | Kimi K2.5 / Kimi K2.6 format-compatible thinking models | Dynamo-only | Yes | `<think>...</think>` with force-reasoning |
+| `kimi` | Kimi K2 Instruct / Thinking with Unicode delimiters | Dynamo-only | No | `◁think▷...◁/think▷` |
 | `minimax_append_think` | MiniMax M2 / M2.1 | Dynamo-only | No | Implicit opening `<think>` prepended |
 | `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseek-v4` | No | `<think>...</think>`. Aliases: `deepseek-v4`, `deepseekv4` |
 | `deepseek_r1` | DeepSeek R1, DeepSeek V3.1, DeepSeek V3.2 | | Yes | Pass explicitly for V3.1/V3.2 (no alias) |
@@ -53,7 +53,7 @@ require the opening tag to be present in the model output.
 | `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | No | `<\|channel>thought\n...<channel\|>` with `thought\n` role label stripped. Aliases: `gemma-4` |
 | `gpt_oss` | gpt-oss-20b / -120b | Dynamo-only | No | Harmony channel reasoning format |
 | `mistral` | Magistral | | Yes | `[THINK]...[/THINK]` |
-| `granite` | Granite 3.x | | No | `Here's my thought process:` / `Here's my response:` |
+| `granite` | IBM Granite 3.x / Granite 3.2 language models | | No | `Here's my thought process:` / `Here's my response:` |
 | `step3` | Step-3 / Step-3-Reasoning | Dynamo-only | Yes | `<think>...</think>` |
 | `basic` | Generic CoT models | Dynamo-only | No | Plain `<think>...</think>` |
 
@@ -64,7 +64,7 @@ Some models need both parsers configured together. Common pairings include:
 - `openai/gpt-oss-*`: `--dyn-tool-call-parser harmony --dyn-reasoning-parser gpt_oss`
 - `deepseek-ai/DeepSeek-V4-*`: `--dyn-tool-call-parser deepseek_v4 --dyn-reasoning-parser deepseek_v4`
 - `zai-org/GLM-4.7`: `--dyn-tool-call-parser glm47 --dyn-reasoning-parser glm45`
-- `moonshotai/Kimi-K2.5*`: `--dyn-tool-call-parser kimi_k2 --dyn-reasoning-parser kimi_k25`
+- `moonshotai/Kimi-K2.5*` / Kimi K2.6 format-compatible outputs: `--dyn-tool-call-parser kimi_k2 --dyn-reasoning-parser kimi_k25`
 - `google/gemma-4-*` thinking models: `--dyn-tool-call-parser gemma4 --dyn-reasoning-parser gemma4 --custom-jinja-template examples/chat_templates/gemma4_tool.jinja`
 - `Qwen/Qwen3.5*`: `--dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3`
 - MiniMax M2.1 style outputs: `--dyn-tool-call-parser minimax_m2 --dyn-reasoning-parser minimax_append_think`

--- a/lib/llm/PREPROCESSOR_CASES.md
+++ b/lib/llm/PREPROCESSOR_CASES.md
@@ -140,7 +140,7 @@ if you know the answer, fill it in.
 | Parser | PRE.1 needs special tokens | PRE.2 reasoning gate | PRE.6 disabled-Nemotron leading `<think>` strip | PRE.3 force-reasoning override on tool-continuation | Notes |
 |---|---|---|---|---|---|
 | `harmony` (tool) / `gpt_oss` (reasoning) | **YES** | — | — | — | Channels: `<\|channel\|>analysis<\|message\|>...<\|end\|>`. gpt-oss-20B/120B. |
-| `gemma4` (tool + reasoning) | **YES** | `enable_thinking=false` | — | — | `<\|think\|>...<\|/think\|>`. |
+| `gemma4` (tool + reasoning) | **YES** | `enable_thinking=false` | — | — | Prompt trigger: `<\|think\|>` in the system turn. Parser-visible reasoning output: `<\|channel>thought\n...<channel\|>`. |
 | `kimi_k25` (reasoning) | ? — markers are `<\|tool_calls_section_*\|>`, likely YES | `thinking=false` | — | OFF when last_is_tool (currently global) | Special-token markers in K2/K2.5/K2.6. |
 | `deepseek_v3` (tool) | ? — Unicode markers (`<｜tool_calls_section_begin｜>`); likely YES | — | — | — | DSv3 grammar. |
 | `deepseek_v3_2` / `deepseek_v4` (DSML) | ? — DSML markers (`<｜DSML｜tool_calls>`); likely YES | `thinking=false` / `thinking_mode=chat` | — | **NEEDS ON** even when last_is_tool (V4 formatter seeds `<think>`); see #8901 | DSv3.2 / DSv4 grammar. |

--- a/lib/parsers/REASONING_CASES.md
+++ b/lib/parsers/REASONING_CASES.md
@@ -35,31 +35,82 @@ rows and miss the contract that is actually being tested.
 |---|---|---|---|
 | Explicit `<think>` block | `qwen3`, `deepseek_v4`, `nemotron_deci`, `glm45`, `basic` | Reasoning is inside `<think>...</think>`. Text outside the markers is normal text. | Most reusable cases are `REASONING.batch.{1,2,3,4,5,6}` and `REASONING.stream.{1,2,3,4}`. |
 | Force-reasoning `<think>` block | `deepseek_r1`, `deepseek_v3`, `deepseek_v3_1`, `deepseek_v3_2`, `step3`, `nemotron_nano`, `nemotron3`, `nemotron_v3` | Same delimiter, but generation may start already inside reasoning. Marker-free text can be reasoning until an end marker or stop condition. | Reuses the explicit `<think>` cases, but the plain-text/no-start behavior is different. |
-| Kimi K2.5 force-reasoning block | `kimi_k25` | `<think>` reasoning with a tool-section marker that can end an open reasoning span. | Keep separate from generic force-reasoning because tool-section boundaries are part of the reasoning contract. |
-| Kimi delimiter block | `kimi` | `◁think▷...◁/think▷` | Same block semantics as `<think>`, different marker spelling and more Unicode boundary risk. |
+| Kimi K2.5 / K2.6 force-reasoning block | `kimi_k25` | `<think>` reasoning with a tool-section marker that can end an open reasoning span. | Keep separate from generic force-reasoning because tool-section boundaries are part of the reasoning contract. |
+| Kimi Unicode delimiter block | `kimi` | `◁think▷...◁/think▷` | Same block semantics as `<think>`, different marker spelling and more Unicode boundary risk. |
 | Mistral bracket block | `mistral` | `[THINK]...[/THINK]` | Same paired-marker cases with bracket tokens. |
 | Gemma channel block | `gemma4` | `<|channel>thought...<channel|>` | Needs prefix-disambiguation coverage: `thought` vs similar prefixes and partial channel markers. |
-| Granite phrase block | `granite` | `Here is my thought process:` followed by `Here is my response:` | Phrase-prefix buffering matters because partial phrases look like ordinary text until enough bytes arrive. |
+| Granite phrase block | `granite` | `Here is my thought process:` followed by `Here is my response:` | IBM Granite 3.x / Granite 3.2 language model format; phrase-prefix buffering matters because partial phrases look like ordinary text until enough bytes arrive. |
 | Harmony channel block | `gpt_oss` | Harmony channels, especially `analysis`, `final`, `commentary`, and tool-call envelopes. | Some upstream tests are token/tag-level rather than plain text; convert what is portable and mark token-ID-only cases separately. |
 | Append-think content wrapper | `minimax_append_think` | Does not expose reasoning in the same way; vLLM prepends/preserves `<think>` as output content. | Treat as its own contract instead of forcing it into the normal "separate reasoning text" model. |
+
+### Reasoning mode and frontend gates
+
+Reasoning parser behavior is not determined by the parser family alone.
+There are static parser choices, request-time gates, and frontend-specific
+knobs that decide whether the reasoning parser runs at all.
+
+```text
+OpenAI chat request
+  -> parser selection
+       --dyn-reasoning-parser <name>     Dynamo-native Rust parser
+       --reasoning-parser <name>         vLLM/SGLang fallback parser
+       unset                             no reasoning parser
+  -> request gates
+       tool_choice=required/named        skip reasoning parser before tool call jail
+       SGLang separate_reasoning=false   leave thinking text in normal content
+  -> thinking controls
+       enable_thinking=false             disables several explicit-marker families
+       thinking=false                    disables Kimi / DeepSeek-style paths
+       thinking_mode="chat"              disables DeepSeek V4-style thinking
+       thinking=true                     enables opt-in families such as DeepSeek V3
+  -> parser state
+       explicit markers                  wait for <think> / family marker
+       force reasoning                   start inside reasoning until end marker
+       prompt-injected marker            set_in_reasoning(true)
+  -> output split
+       reasoning_text                    hidden reasoning content
+       normal_text                       visible content or downstream tool call parser input
+```
+
+The follow-up parity table folds this into the **Reasoning Parser Family**
+popup. That popup should show the implementation, public parser family,
+row-level parser mode, and static parser configuration. Exact
+parser-level harness flags should live in each result-cell tooltip;
+production request gates should live in the serving-flow panel above
+the table instead of being repeated in every row.
+
+| Mode | Static parser behavior | Production caveat |
+|---|---|---|
+| Explicit markers | Parser waits for an opening marker such as `<think>`, Harmony `analysis`, Gemma channel markers, or Granite phrases. | Frontend/template flags may decide whether the model emits markers or whether the parser starts with `set_in_reasoning(true)`. |
+| Force reasoning | Parser begins inside reasoning; marker-free text may be `reasoning_text` until an end marker, stop condition, or family-specific boundary. | Request flags can still disable some force-reasoning paths before the parser runs. |
+| Mostly static custom parsers | Parser has parser-specific contract, such as Harmony channels, Granite phrases, or MiniMax append-think behavior. | Generic gates still apply: omit the parser, use guided tool choice, or use SGLang `separate_reasoning=false`. |
+
+For exact parity-result reproduction once the follow-up harness lands,
+use the generated table tooltip on each cell. The tooltip should list
+the parser-level harness flags actually used for Dynamo, vLLM, and
+SGLang. Frontend gates such as `tool_choice` and `separate_reasoning`
+are not part of these parser-level fixtures unless the tooltip says so.
 
 ### Reasoning, batch mode
 
 The numbering is organized by behavior, not by the order cases were
-added. Keep no-op / empty input first, simple reasoning extraction
-second, and batch tool call boundary cases third.
+added. Keep no-op / empty input first, keep all ordinary reasoning
+extraction under `REASONING.batch.2.*`, and keep batch tool call boundary
+cases third. Do not split `2.a` / `2.c` away from `2.b` / `2.d` / `2.e`
+/ `2.f`; they are the same extraction bucket with different surrounding
+content.
 
 - **`REASONING.batch.1.a`** Empty input — empty model text. Parser must not crash and must produce coherent empty output.
 - **`REASONING.batch.1.b`** Plain text, no reasoning markers — non-empty model text with no reasoning wrapper. Parser must not invent `reasoning_text`.
 - **`REASONING.batch.1.c`** Whitespace-only input — whitespace with no reasoning wrapper. Parser must preserve or normalize according to the family contract.
-- **`REASONING.batch.1.d`** Null / missing upstream content — upstream content is absent rather than an empty string. Parser dispatch must not crash.
-- **`REASONING.batch.2.a`** Basic complete reasoning span — `<think>...</think>` (or analog) present, no downstream tool call. `normal_text` may be empty or may contain the family-specific final-answer section.
-- **`REASONING.batch.2.b`** Normal text before reasoning — user-visible text appears before the reasoning span.
-- **`REASONING.batch.2.c`** Reasoning followed by normal text — reasoning content goes to `reasoning_text`; final answer text goes to `normal_text`.
-- **`REASONING.batch.2.d`** Normal text around reasoning — user-visible text appears on both sides of the reasoning span.
-- **`REASONING.batch.2.e`** Empty reasoning content — `<think></think>` (or analog with zero bytes between markers). Must still register as a reasoning span if the family exposes empty spans.
-- **`REASONING.batch.2.f`** Complex reasoning content — large blocks, multi-paragraph, special characters, Unicode, newlines, and marker-looking strings inside the reasoning body.
-- **`REASONING.batch.3.a`** Closed reasoning followed by downstream tool-call text — reasoning parser must extract the think content **and leave the tool-call markers intact in `normal_text`** for the downstream tool-call parser to consume.
+- **`REASONING.batch.1.d`** Null / missing upstream content — upstream content is absent rather than an empty string. This is a frontend/wrapper dispatch case unless the fixture schema explicitly allows `model_text: null`.
+- **`REASONING.batch.2.a`** Reasoning-only span — `<think>...</think>` (or analog) present, with no visible answer text outside the span.
+- **`REASONING.batch.2.b`** Visible prefix before reasoning — user-visible text appears before the reasoning span.
+- **`REASONING.batch.2.c`** Reasoning followed by visible answer text — reasoning content goes to `reasoning_text`; final answer text goes to `normal_text`.
+- **`REASONING.batch.2.d`** Visible text around reasoning — user-visible text appears on both sides of the reasoning span.
+- **`REASONING.batch.2.e`** Empty reasoning span — `<think></think>` (or analog with zero bytes between markers). Must still register as a reasoning span if the family exposes empty spans.
+- **`REASONING.batch.2.f`** Complex reasoning body — large blocks, multi-paragraph, special characters, Unicode, newlines, and marker-looking strings inside the reasoning body.
+- **`REASONING.batch.3.a`** Closed reasoning followed by downstream tool-call text — reasoning parser must extract the think content **and leave a valid paired-parser tool-call payload intact in `normal_text`** for the downstream tool-call parser to consume.
 - **`REASONING.batch.3.b`** Open reasoning interrupted by downstream tool-call text — tool-call markers can terminate or escape an open reasoning span for families that define that boundary.
 - **`REASONING.batch.4`** Malformed reasoning marker syntax — dangling close marker, invalid channel marker, or marker that does not belong to the family grammar.
 - **`REASONING.batch.5`** Missing end-marker recovery — engine hit `max_tokens` mid-think; pin behavior: recover partial reasoning, surface as truncated, or treat all as `normal_text`.
@@ -69,7 +120,8 @@ second, and batch tool call boundary cases third.
 ### Reasoning, stream mode
 
 Stream buckets follow the same shape as batch: no-op / empty stream
-first, ordinary reasoning extraction second, then boundary cases.
+first, ordinary reasoning extraction second, multi-span extraction next,
+then chunk-boundary cases.
 
 - **`REASONING.stream.1.a`** Empty stream chunk — no emitted content. Parser must not crash, buffer forever, or invent reasoning text.
 - **`REASONING.stream.1.b`** Plain text stream, no reasoning markers — chunks contain user-visible text only. Explicit-marker parsers should pass it through as `normal_text`; force-reasoning parsers may keep it in `reasoning_text`.
@@ -77,7 +129,7 @@ first, ordinary reasoning extraction second, then boundary cases.
 - **`REASONING.stream.2.b`** Multiple reasoning spans across chunks — same contract as `REASONING.batch.6.*`, but state must reset between spans.
 - **`REASONING.stream.3.a`** Start-marker chunk-boundary split — opening `<think>` (or analog) straddles a chunk boundary; partial-token matching must keep buffering instead of flushing as plain text.
 - **`REASONING.stream.3.b`** End-marker chunk-boundary split — closing `</think>` straddles a chunk boundary; same buffering contract as `REASONING.stream.3.a`.
-- **`REASONING.stream.3.c`** Partial marker prefix later diverges into normal text — accumulated text starts like a marker but later proves it is not one.
+- **`REASONING.stream.3.c`** Partial marker prefix later proves not to be a marker — emit the buffered text according to the parser's current state.
 
 ### Upstream test inventory
 
@@ -146,7 +198,7 @@ whitespace-only input, and null / missing upstream content.
 - This bucket is first because no-op behavior is the baseline for
   routing and fallback.
 
-## `REASONING.batch.2.*` — Simple reasoning extraction
+## `REASONING.batch.2.*` — Reasoning extraction
 
 `<think>...</think>` (or analog: `<seed:think>`, harmony's
 `<|channel|>analysis`) is present and the content is not part of a
@@ -167,7 +219,10 @@ Model emits reasoning content and then tool-call tokens:
 extract the reasoning content and preserve the tool-call-shaped text in
 `normal_text` so the downstream tool-call parser can consume it.
 
-- Applies to every (reasoning, tool-call) parser pair.
+- `3.a` applies to paired parser families where the reasoning span is
+  closed before downstream tool-call text begins.
+- `3.b` applies only to parser families that intentionally configure a
+  downstream boundary while reasoning is still open.
 - Failure mode: greedy reasoning parser eats the tool-call content
   that follows. Pin the boundary explicitly.
 
@@ -225,7 +280,9 @@ A downstream tool-call section marker appears while the reasoning
 parser is still processing reasoning. The reasoning parser must stop at
 the right boundary and preserve the downstream parser's input.
 
-- Applies to every reasoning parser.
+- Applies only to reasoning parser families with an explicit downstream
+  boundary. For other families, this bucket is an N/A stub until the
+  production path wires such a boundary.
 
 ---
 
@@ -241,9 +298,12 @@ fn test_unclosed_think_tag_no_longer_swallows_tool_call() { ... }
 
 ---
 
-## Adding a new reasoning parser: what you must include
+## Adding a new reasoning parser: target complete coverage
 
-Minimum viable set:
+The current fixture PR is seed coverage: it establishes the YAML
+contract, provenance, and representative cases, but it does not claim
+that every family already has the complete taxonomy below. Before a
+parser family is considered complete, add:
 
 1. `REASONING.batch.1.*` — no reasoning content: plain text, empty
    input, whitespace, and null / missing upstream content.
@@ -256,7 +316,8 @@ Minimum viable set:
    recovery. Pin behavior; silent drop is the failure mode.
 5. `REASONING.batch.6.*` — multiple reasoning spans. Document the
    contract.
-6. `REASONING.stream.{1, 2, 3, 4}` — streaming. Essentially
-   non-negotiable for any parser behind a streaming frontend.
+6. `REASONING.stream.{1, 2, 3, 4}` — streaming. Add `stream.4.*`
+   before declaring complete coverage for any parser with an explicit
+   downstream tool-call boundary.
 7. Format tags where applicable: `PARSER.harmony.1` for parsers
    consuming Harmony-format input, etc.

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,11 +1,11 @@
-# Cross-impl parity test suite
+# Cross-implementation parity test suite
 
 Shared test infrastructure for diffing parser / preprocess / postprocess
-behavior across Dynamo, vLLM, and SGLang. Tool call parser parity lives
-in `parser/`; reasoning parser parity lives in `reasoning/`. Other stages
-slot in as siblings as they land.
+behavior across Dynamo, vLLM, and SGLang. Tool calling parser parity
+lives in `parser/`; reasoning parser parity lives in `reasoning/`.
+Other stages slot in as siblings as they land.
 
-> **Triaging a tool-call issue from a user?** Before stepping into the
+> **Triaging a tool call issue from a user?** Before stepping into the
 > parity harness, point them at
 > [docs/tool-calling/troubleshooting.md](../../docs/tool-calling/troubleshooting.md).
 > That page asks users to re-run with `logprobs: true` and share the
@@ -22,58 +22,50 @@ tests/parity/
 ├── README.md                       (this file)
 ├── conftest.py                     ← session-scoped fixtures (server boots, etc.)
 ├── common.py                       ← ParseResult, canonical-JSON diff, decode_arguments
-├── generate_parity_table.py        ← common table CLI: parser / reasoning
+├── generate_parity_table.py        ← parser table CLI
 ├── parity_table.html.j2            ← shared HTML template
 ├── parser/
-    ├── fixtures/                   ← static YAML, generated from Dynamo as oracle
-│   └── <family>/PARSER.batch.yaml         (and per-case files like PARSER.batch.4.yaml; see Fixture file schema)
-    ├── capture_parser_outputs.py     ← drift-check (default) or merge any impl's output into `expected.{dynamo,vllm,sglang}`
-    ├── table.py                    ← parser table adapter
-    │
-    ├── dynamo.py                   ← M2 in-process wrapper (PyO3 binding)
-    ├── vllm.py                     ← M2 in-process wrapper (ToolParserManager)
-    ├── sglang.py                   ← M2 in-process wrapper (per-module detectors)
-    ├── test_parity_parser.py       ← M2 harness (parser-class parity)
-    │
-    ├── server.py                   ← M3 subprocess boot helper
-    ├── client.py                   ← M3 HTTP client (vllm + sglang)
-    └── test_parity_e2e.py          ← M3 harness (server-stack parity over HTTP)
+│   ├── fixtures/                   ← static YAML, generated from Dynamo as oracle
+│   │   └── <family>/PARSER.batch.yaml
+│   │       (and per-case files like PARSER.batch.4.yaml; see Fixture file schema)
+│   ├── capture_parser_outputs.py   ← drift-check or merge impl output into expected.*
+│   ├── table.py                    ← parser table adapter
+│   ├── dynamo.py                   ← M2 in-process wrapper (PyO3 binding)
+│   ├── vllm.py                     ← M2 in-process wrapper (ToolParserManager)
+│   ├── sglang.py                   ← M2 in-process wrapper (per-module detectors)
+│   ├── test_parity_parser.py       ← M2 harness (parser-class parity)
+│   ├── server.py                   ← M3 subprocess boot helper
+│   ├── client.py                   ← M3 HTTP client (vLLM + SGLang)
+│   └── test_parity_e2e.py          ← M3 harness (server-stack parity over HTTP)
 └── reasoning/
     ├── fixtures/                   ← static YAML contracts for REASONING.batch.* and REASONING.stream.*
-    ├── table.py                    ← reasoning table adapter
-    ├── dynamo.py                   ← Dynamo Rust reasoning parser via PyO3 binding
-    ├── vllm.py                     ← vLLM reasoning parser wrapper
-    ├── sglang.py                   ← SGLang reasoning parser wrapper
-    └── test_parity_reasoning.py    ← M2 harness for reasoning parser parity
 ```
 
 ## Reasoning parity status
 
-The initial reasoning harness uses the same contract shape as `parser/`:
-each `REASONING.*.yaml` fixture records `expected.dynamo`,
-`expected.vllm`, and `expected.sglang`. A peer block can anchor to Dynamo,
-document a divergence, mark an expected error, or say the peer parser is
-unavailable.
-
-Generate the reasoning table from repo root:
-
-```bash
-python3 tests/parity/generate_parity_table.py reasoning --html > tests/parity/reasoning/PARITY.html
-```
-
-`PARITY.html` is for local review, like the parser table. The YAML fixtures
-remain the source of truth.
+Reasoning fixtures use the same contract shape as `parser/`: each
+`REASONING.*.yaml` fixture records `expected.dynamo`, `expected.vllm`,
+and `expected.sglang`. A peer block can anchor to Dynamo, document a
+divergence, mark an expected error, or say the peer parser is unavailable.
+This part 2 PR is the seed fixture inventory and schema contract. The
+fixture files are the source of truth; the reasoning table/test harness
+lands in the follow-up code PR, so broad three-way coverage should not be
+inferred from these files yet. Each fixture carries `ref` / `spec_ref`
+provenance where available, and unavailable peer blocks must say whether
+the peer parser does not exist, is not wired, or was not captured.
 
 ## Three methods (M1, M2, M3) — what each one really means
 
 Three increasingly-realistic ways to drive the same parser logic.
 They differ in **what's substituted vs what's real**, which decides
-which bug class each method can catch:
+which bug class each method can catch. This diagram uses tool calling as
+the concrete example; reasoning follows the same boundary, but splits
+text into `reasoning_content` and normal `content` instead of `tool_calls`.
 
 ```
                                                   ┌─ engine ──────────┐
                                                   │                   │
-   client ─request→ chat-template ─→ tokenize ─→ engine ─→ detokenize ─→ text ─→ PARSER ─→ tool_calls JSON ─→ client
+   client ─request→ chat-template ─→ tokenize ─→ engine ─→ detokenize ─→ text ─→ PARSER ─→ structured output ─→ client
               ↑                                                              ↑
               └── M1 / M3 exercise this (real)                               └── M2 starts here (skips everything left)
                   M2 skips it (substituted by direct call)
@@ -81,13 +73,13 @@ which bug class each method can catch:
 
 ### Method 1 — fallback-path test *(upcoming, next step)*
 
-**What's run:** `python -m dynamo.frontend --dyn-chat-processor <vllm|sglang>`. Dynamo's frontend chat processor delegates tool parsing to upstream's Python parser instead of Dynamo's Rust parser. Reference path is the default `python -m dynamo.frontend` (Dynamo's Rust parser).
+**What's run:** `python -m dynamo.frontend --dyn-chat-processor <vllm|sglang>`. Dynamo's frontend chat processor delegates tool calling and reasoning parsing to upstream's Python parser instead of Dynamo's Rust parser. Reference path is the default `python -m dynamo.frontend` (Dynamo's Rust parser).
 
 **What it surfaces:** gaps in Dynamo's Rust parser that the fallback masks; bugs in Dynamo's frontend code that wraps upstream parsers.
 
 **Status:** not yet implemented. Lives in its own harness file when added (M1 tests *Dynamo's wrapping* of upstream parsers, not parity *between* impls).
 
-### Method 2 — parser-class test (this PR's primary harness)
+### Method 2 — parser-class test
 
 **What's run:** in-process Python imports, all three impls in one process — no HTTP, no model, no tokenizer, no chat-template materialization:
 
@@ -107,9 +99,15 @@ from sglang.srt.function_call.kimik2_detector import KimiK2Detector
 result = KimiK2Detector().detect_and_parse(text, tools)
 ```
 
-**What it surfaces:** parser-logic divergences between Dynamo's Rust parser class and upstream's Python parser classes. The bug class isolated from everything else in the request lifecycle.
+Reasoning uses the same M2 boundary once the reasoning harness is present:
+`parse_reasoning_batch` / `parse_reasoning_stream`, vLLM's
+`ReasoningParserManager`, and SGLang's `ReasoningParser`.
 
-**File:** `tests/parity/parser/test_parity_parser.py`.
+**What it surfaces:** parser-logic divergences between Dynamo's Rust parser class and upstream's Python parser classes. The bug class is isolated from everything else in the request lifecycle.
+
+**File:** Tool calling uses `tests/parity/parser/test_parity_parser.py`.
+Reasoning uses the same M2 boundary, but the runnable harness lands in
+the follow-up code PR as `tests/parity/reasoning/test_parity_reasoning.py`.
 
 #### Batch vs stream mode inside M2
 
@@ -125,11 +123,11 @@ Stream fixtures are stateful: the fixture provides ordered `chunks`, the wrapper
 chunk N -> parser state -> maybe content/tool delta -> aggregate -> next chunk
 ```
 
-That stateful middle is the thing stream parity is trying to test. Concatenating `chunks[*].delta_text` and calling the batch parser would miss boundary bugs: partial start markers, partial argument payloads, tool-call deltas split across chunks, finish-reason timing, and vLLM cases that require `delta_token_ids`.
+That stateful middle is the thing stream parity is trying to test. Concatenating `chunks[*].delta_text` and calling the batch parser would miss boundary bugs: partial start markers, partial argument payloads, tool call deltas split across chunks, finish-reason timing, and vLLM cases that require `delta_token_ids`.
 
-`tests/parity/common.py` deliberately stays at the final comparison boundary (`ParseResult`, argument decoding, canonical JSON). It can host small shared helpers for aggregating stream tool-call deltas, but it cannot replace the implementation-specific stream state machine. Dynamo stream parity enters Rust through the PyO3 binding; runtime-image pytest must not compile helper binaries with `cargo run`.
+`tests/parity/common.py` deliberately stays at the final comparison boundary (`ParseResult`, argument decoding, canonical JSON). It can host small shared helpers for aggregating stream tool call deltas, but it cannot replace the implementation-specific stream state machine. Dynamo stream parity enters Rust through the PyO3 binding; runtime-image pytest must not compile helper binaries with `cargo run`.
 
-### Method 3 — end-to-end HTTP test *(upcoming, next step — sibling PR #9189)*
+### Method 3 — end-to-end HTTP test *(upcoming, next step)*
 
 **What's run:** real upstream serving binaries; constrained decoding forces them to emit the fixture text:
 
@@ -144,11 +142,11 @@ Both servers receive identical chat-completion requests with `structured_outputs
 
 **What it surfaces:** server-stack divergences between vLLM's and SGLang's HTTP pipelines — request preprocessing, tokenizer round-trip, streaming chunk boundaries, response shaping — that class-level testing (M2) can't see.
 
-**File:** `tests/parity/parser/test_parity_e2e.py` (lands in #9189).
+**File:** `tests/parity/parser/test_parity_e2e.py`.
 
 ### Comparison
 
-| | M1 (upcoming) | M2 (this PR) | M3 (upcoming, #9189) |
+| | M1 (upcoming) | M2 | M3 (upcoming) |
 |---|---|---|---|
 | **What's tested** | Dynamo frontend wrapping upstream parsers | parser **class**, in isolation | parser inside its **server** (full HTTP stack) |
 | **Invocation** | `python -m dynamo.frontend` subprocess | in-process Python imports | HTTP over `/v1/chat/completions` |
@@ -156,7 +154,7 @@ Both servers receive identical chat-completion requests with `structured_outputs
 | **Real tokenizer?** | yes | no | yes |
 | **Real chat template?** | yes | no | yes |
 | **Real HTTP?** | yes | no | yes |
-| **Cost** | (TBD) | ~5 s for 1350 tests (693 pass / 545 skip / 112 xfail with sglang skipped locally) | ~60 s for 30 tests (server boot dominates) |
+| **Cost** | (TBD) | seconds; exact count changes with fixture coverage and installed peers | ~60 s for 30 tests (server boot dominates) |
 | **GPU** | yes | none | yes (`--load-format dummy` still allocates ~2.5 GiB) |
 | **CI markers** | (TBD) | `unit, pre_merge, gpu_0` | `e2e, pre_merge, gpu_1` |
 
@@ -172,7 +170,7 @@ They're stacked diagnostics:
 - M1 says: *"Dynamo's wrapper layer disagrees with the upstream
   parser it's wrapping"*
 
-## Current parity status (M2, batch mode)
+## Tool calling parser parity status (M2)
 
 Each row is one **parser** (one family of input wire format). Each row
 also names the **model(s)** that parser is wired up for — many parsers
@@ -186,8 +184,8 @@ PR description.
 
 Cell values show how each engine's recorded `expected.<impl>` block relates to Dynamo (the oracle). **Convention:** a divergent peer block carries a `reason:` field iff the divergence is *intentional* (documented contract difference, vendor behavior, etc.). No `reason:` = **research-needed** — we observed the divergence but haven't classified it yet.
 
-- `=` — both engines match Dynamo (peer block is an anchor ref `*d_<case>` to dynamo's).
-- `V` — vLLM diverges, **intentional** (engine block has `reason:` field). Rendered the same color as = in the HTML table since the divergence is accounted for.
+- `=` — all captured peers match Dynamo (peer block is an anchor ref `*d_<case>` to dynamo's, or only one peer is available and it matches).
+- `V` — vLLM diverges, **intentional** (engine block has `reason:` field).
 - `V?` — vLLM diverges, **research-needed** (engine block has no `reason:` yet; we observed the divergence but haven't classified it).
 - `V!` — vLLM is expected to crash; `expected.vllm.error: <substring>` records the matching error.
 - `S`, `S?`, `S!` — same as V/V?/V! for SGLang.
@@ -205,21 +203,21 @@ somewhere you can browse:
 
 ```bash
 # Markdown — paste into a PR description or browse in any editor.
-python3 tests/parity/generate_parity_table.py parser > PARITY.md
+python3 tests/parity/generate_parity_table.py parser
 
 # HTML table — clickable cells link to the source fixture YAML; hover over any
 # non-= cell to see the case description and the divergence reason.
-python3 tests/parity/generate_parity_table.py parser --html > PARITY.html
+python3 tests/parity/generate_parity_table.py parser --html > tests/parity/parser/PARITY.html
 ```
 
 Run from the repo root so the HTML's relative `<a href=...>` links to
-fixture YAMLs resolve when you open `PARITY.html` in a browser. Both
-`PARITY.md` and `PARITY.html` are for local viewing only — don't check
-them in; the generator is the contract. Rows are the 19 parsers (Top-N
-first, then Others, alphabetical within each). Columns are the sub-case
-IDs from [`PARSER_CASES.md`](../../lib/parsers/PARSER_CASES.md). The
-generator reads every `fixtures/<family>/PARSER.*.yaml` and emits one
-cell per `(family, sub-case)` using the legend above.
+fixture YAMLs resolve when you open `tests/parity/parser/PARITY.html`
+in a browser. Generated table output is for local viewing only — don't
+check it in; the generator is the contract. Rows are the 19 parsers
+(Top-N first, then Others, alphabetical within each). Columns are the
+sub-case IDs from [`PARSER_CASES.md`](../../lib/parsers/PARSER_CASES.md).
+The generator reads every `fixtures/<family>/PARSER.*.yaml` and emits
+one cell per `(family, sub-case)` using the legend above.
 
 **Example output** (illustrative — cell values are made up, **not** a
 snapshot of current fixtures; run the script for the real table):
@@ -233,10 +231,11 @@ snapshot of current fixtures; run the script for the real table):
 | gpt-oss     | harmony †  | S | S   | n/a | S?  | S?  | = | ... | = | S  |
 ```
 
-Read a row left-to-right: `=` = both engines match Dynamo, `V` / `S` =
-that engine diverges with a documented reason (rendered same color as =
-in the HTML table), `V?` / `S?` = divergence not yet classified
-(research-needed), `n/a` = case doesn't apply or peer is unavailable.
+Read a row left-to-right: `=` = all captured peers match Dynamo,
+`V` / `S` = that engine diverges with a documented reason (rendered
+as documented divergence in the HTML table), `V?` / `S?` = divergence
+not yet classified (research-needed), `n/a` = case doesn't apply or a
+peer is unavailable.
 
 ### Footnotes
 
@@ -251,7 +250,7 @@ in the HTML table), `V?` / `S?` = divergence not yet classified
 `nemotron_deci` and `nemotron_nano` carry both daggers (`†§`) — neither
 upstream has a peer parser, so the rows are fully `n/a`. They live under
 **Others** for completeness; Dynamo-only self-parity could be added in a
-follow-up but yields no cross-impl signal.
+follow-up but yields no cross-implementation signal.
 
 ### Coverage gaps — missing upstream peer parsers
 
@@ -276,7 +275,7 @@ Wrapper enumeration: `tests/parity/parser/sglang.py::_FAMILY_TO_SGLANG_DETECTOR`
 (missing keys = missing detectors). Adding an SGLang detector for any
 `§`-marked family above (either upstream-shipped in a newer SGLang release,
 or by us standing up a Dynamo-side stub) would let the harness surface
-`S`/`VS` divergences on those rows; today they carry only `V`/`✓`
+`S`/`VS` divergences on those rows; today they carry only `V`/`=`
 (vLLM-side).
 
 **Hot columns:**
@@ -291,10 +290,10 @@ or by us standing up a Dynamo-side stub) would let the harness surface
   `<|start|>assistant<|channel|>commentary` envelope where Dynamo
   accepts bare commentary.
 
-What's **not** covered yet: `PARSER.fmt.*`, `PARSER.xml.*`,
-`PARSER.harmony.*`, `PARSER.stream.*` — those case classes still
-live in Rust unit tests only and would be added to the YAML corpus
-in follow-up PRs.
+What's **not** fully covered yet: format-specific surfaces such as
+`PARSER.fmt.*`, `PARSER.xml.*`, and `PARSER.harmony.*` still have
+Rust-only coverage in places. `PARSER.stream.*` fixtures exist, but
+coverage is still being expanded family by family.
 
 ## Run the parity harness
 
@@ -326,13 +325,13 @@ to run (otherwise they skip cleanly).
 `docker exec <container> bash -c 'cd /workspace && …'`. Find the
 container with `docker ps --format '{{.Names}}' | grep vsc-dynamo2 | head -1`.
 
-**Baseline:** on `main` post-Variant-A, expect roughly **1,150 passed /
-275 skipped / ~5 s** wall clock across 450 cases × 3 impls (Dynamo +
-vLLM + SGLang). There is no `xfail` count — divergent peers are
-recorded with concrete `expected.<impl>` blocks and assert positively
-against them. Failure modes are **assertion mismatches** when an engine
-drifts away from its recorded block; perfect parity is when every cell
-is `=` (all three engines produce byte-identical output on every
+**Baseline:** exact counts change as fixture coverage lands and as the
+local devcontainer gains or loses vLLM/SGLang packages. There is no
+`xfail` count — divergent peers are recorded with concrete
+`expected.<impl>` blocks and assert positively against them. Failure
+modes are **assertion mismatches** when an engine drifts away from its
+recorded block; captured-peer parity is when every non-`n/a`, non-missing
+cell is `=` (all captured peers produce byte-identical output on every
 fixture).
 
 ## Resolving divergences (8 steps)
@@ -347,8 +346,9 @@ side is wrong. Worked example: `kimi_k2 / PARSER.batch.1.c → V`
 
 ### 1. Pick a cell
 
-Run `generate_parity_table.py`; pick any `V` / `S` / `VS` cell from the
-output.
+Run `generate_parity_table.py`; pick any `V?` / `S?` / `V?S?` cell if
+you are classifying unknown divergences, or any `V` / `S` / `VS` cell
+if you are intentionally changing an already-classified behavior.
 
 ### 2. Look up the side-by-side diff in the YAML
 
@@ -371,7 +371,7 @@ PARSER.batch.1.c:
     vllm:
       calls: [...]
       normal_text: ''                                 # vLLM (drops trailing)
-      reason: "drops trailing normal_text after tool-call wrapper end"
+      reason: "drops trailing normal_text after tool call wrapper end"
     sglang: *d_8_b                                    # SGLang matches Dynamo
 ```
 
@@ -538,16 +538,13 @@ PARSER.batch.1.c:
 Then regenerate the table so the cell flips:
 
 ```bash
-python3 tests/parity/generate_parity_table.py parser > PARITY.md
+python3 tests/parity/generate_parity_table.py parser --html > tests/parity/parser/PARITY.html
 ```
 
 Pytest should now be fully green; the table cell flips to `=`.
 
-```bash
-git add lib/parsers/ tests/parity/parser/
-git commit -s -m "fix(parser): align <family> with <impl> on PARSER.batch.N.x"
-git push
-```
+Then follow the repo PR workflow, staging only the files changed for the
+parser fix and fixture refresh.
 
 ## When *not* to fix — permanent divergences
 
@@ -630,6 +627,33 @@ cases:
   passes if the engine's actual error contains the substring.
 - **`{unavailable: <msg>}`** — no parser registered for this family.
   Test skips with the message.
+
+### Reasoning fixture schema
+
+Reasoning fixtures live under `tests/parity/reasoning/fixtures/` and use
+the same top-level shape, but their concrete output blocks are:
+
+```yaml
+reasoning_text: ...
+normal_text: ...
+```
+
+They do not use `calls`. `reasoning_text` is the hidden reasoning split.
+`normal_text` is user-visible text or the text handed to a downstream
+tool call parser.
+
+Case-level parser inputs may also include `chat_template_kwargs` when a
+peer parser needs explicit template flags such as `enable_thinking`.
+
+A case with `description` and `reason` but no `expected` block is an
+explicit not-applicable/table-only stub. The harness skips it rather
+than treating it as missing coverage.
+
+`dynamo_leak: true` is a temporary table annotation for a known Dynamo
+reasoning split bug. Use it only when Dynamo leaks reasoning-owned
+syntax or final-answer text into the wrong reasoning field. Do not use
+it when valid downstream tool call text is preserved in `normal_text`;
+that is the intended handoff to the tool call parser.
 
 The `ref` field is required on per-sub-case files
 (`PARSER.<mode>.<n>.yaml`) and takes one of three forms:
@@ -744,7 +768,8 @@ qwen3_coder/batch.4 expected.calls[0].arguments = {"location": "NYC"}
 Both are valid per-family Dynamo contracts. Cross-impl divergences
 (vLLM and SGLang doing something *different* from Dynamo on the
 same case) are visible by reading the per-case `expected.{dynamo,vllm,sglang}` triple in the YAML fixture — anchor refs (`*d_<case>`) mark agreement, concrete blocks mark divergence
-as `xfail` entries with a one-sentence reason.
+as recorded peer outputs with a one-sentence reason when the divergence
+is classified.
 
 **3. `tools`** — sometimes minor parameter-name differences
 (e.g., `city` vs `location`, `unit` field present or not), carried
@@ -791,6 +816,7 @@ accidentally drop someone else's captured engine output.
 ```
 tests/parity/
 ├── parser/         (today)
+├── reasoning/      (today)
 ├── postprocess/    (future) — parser output → OpenAI wire response
 └── preprocess/     (future) — request preprocessing, chat-template
 ```
@@ -829,7 +855,7 @@ What that buys:
   covers Dynamo (Rust harness), Dynamo-via-PyO3 (M2), and
   vLLM/SGLang servers (M3). Today, adding a Rust test means
   hand-mirroring the case into M2's YAML fixtures if you want
-  cross-impl coverage.
+  cross-implementation coverage.
 - **Rust devs keep their fast feedback loop.** `cargo test`
   still finishes in ~0.5 s; no Python build needed.
 - **Each impl is tested in its native language.** Closer to
@@ -860,7 +886,7 @@ Effort sketch (separate PRs after M2 + M3 land):
 
 Until then, M2 and the Rust suite both exist; for ~100 cases they
 test the same Dynamo contract through different surfaces. M2's
-real value-add is the cross-impl half (vLLM and SGLang).
+real value-add is the cross-implementation half (vLLM and SGLang).
 
 ## Adding a new parser family
 
@@ -870,8 +896,9 @@ real value-add is the cross-impl half (vLLM and SGLang).
    the `PARSER.batch.<n>` cases that apply (mirror an existing
    family's case shape — see `fixtures/kimi_k2/PARSER.batch.yaml`).
    Each case minimally needs `description`, `ref`, `model_text`,
-   and `tools`. Author by hand, copy-edit from an upstream test,
-   or have an AI fill in cases against `PARSER_CASES.md`.
+   and `tools`. Author by hand or copy-edit from an upstream test.
+   AI can draft case shells, but humans must review them against
+   `PARSER_CASES.md` and the model format before merging.
 3. Run `python3 -m tests.parity.parser.capture_parser_outputs --impl dynamo --merge`
    to fill in each case's `expected.dynamo` by running Dynamo against
    `model_text` + `tools`. Cases that already have `expected.dynamo`
@@ -890,4 +917,4 @@ real value-add is the cross-impl half (vLLM and SGLang).
    rather than the full volatile message. Add a `reason:` field to
    intentional divergences so they show as `V`/`S` not `V?`/`S?` in the
    table.
-6. Regenerate the table: `python3 tests/parity/generate_parity_table.py parser > PARITY.md`.
+6. Regenerate the table: `python3 tests/parity/generate_parity_table.py parser --html > tests/parity/parser/PARITY.html`.

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -4,10 +4,12 @@
 family: deepseek_r1
 model_label: DeepSeek R1 / Nemotron
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM DeepSeek R1 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_deepseekr1_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text stays in force-reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -18,7 +20,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.2.a:
     description: Force-reasoning parser with explicit think tags
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>answer
     expected:
       dynamo: &d_1
@@ -29,32 +31,22 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.3.a:
     description: Reasoning followed by downstream tool-call text
-    ref: dynamo
-    model_text: <think>choose tool</think><tool_call>{}
+    ref: *upstream_ref
+    model_text: <think>choose tool</think><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <tool_call>{}
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm: *d_2
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: <think>choose tool<tool_call>{}
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      sglang:
-        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
+    description: Open reasoning interrupted by downstream tool-call text is not configured for DeepSeek R1-family parsing
+    ref: *upstream_ref
+    reason: Dynamo's DeepSeek R1-family reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>compute</think>answer
     expected:
       dynamo: &d_3
@@ -68,7 +60,7 @@ cases:
     reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
   REASONING.batch.4:
     description: Dangling end marker exits force-reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
@@ -79,7 +71,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>partial
     expected:
       dynamo: &d_5
@@ -90,7 +82,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.2.e:
     description: Empty reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think></think>answer
     expected:
       dynamo: &d_6
@@ -101,7 +93,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.2.f:
     description: Complex reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <think>Line 1
       Unicode: café
@@ -118,7 +110,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -129,7 +121,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: deepseek_r1
 model_label: DeepSeek R1 / Nemotron
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM DeepSeek R1 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_deepseekr1_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>thin
     - king</think>
@@ -35,7 +37,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>first</think>
     - ' middle '
@@ -51,7 +53,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -66,7 +68,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -81,7 +83,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain <th
     - esis answer
@@ -94,7 +96,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -4,12 +4,14 @@
 family: deepseek_v3
 model_label: DeepSeek V3.x
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM DeepSeek V3 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_deepseekv3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 chat_template_kwargs:
   thinking: true
 cases:
   REASONING.batch.1.b:
     description: Plain text stays in force-reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -20,7 +22,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.2.a:
     description: DeepSeek V3.x thinking output with explicit think tags
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>answer
     expected:
       dynamo: &d_1
@@ -31,32 +33,30 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.3.a:
     description: Reasoning followed by downstream tool-call text
-    ref: dynamo
-    model_text: <think>choose tool</think><tool_call>{}
+    ref: *upstream_ref
+    model_text: |-
+      <think>choose tool</think><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <tool_call>{}
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm: *d_2
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: <think>choose tool<tool_call>{}
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      sglang:
-        unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
+    description: Open reasoning interrupted by downstream tool-call text is not configured for DeepSeek V3
+    ref: *upstream_ref
+    reason: Dynamo's DeepSeek V3 reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>compute</think>answer
     expected:
       dynamo: &d_3
@@ -70,7 +70,7 @@ cases:
     reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
   REASONING.batch.4:
     description: Thinking-mode completion exits on a dangling end marker
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
@@ -81,7 +81,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>partial
     expected:
       dynamo: &d_5
@@ -92,7 +92,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.2.e:
     description: Empty reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think></think>answer
     expected:
       dynamo: &d_6
@@ -103,7 +103,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.2.f:
     description: Complex reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <think>Line 1
       Unicode: café
@@ -120,7 +120,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -133,7 +133,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -4,12 +4,14 @@
 family: deepseek_v3
 model_label: DeepSeek V3.x
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM DeepSeek V3 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_deepseekv3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 chat_template_kwargs:
   thinking: true
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -21,7 +23,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>thin
     - king</think>
@@ -37,7 +39,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>first</think>
     - ' middle '
@@ -53,7 +55,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -68,7 +70,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -83,7 +85,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain <th
     - esis answer
@@ -96,7 +98,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -4,24 +4,25 @@
 family: deepseek_v4
 model_label: DeepSeek V4
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM DeepSeek V4 alias coverage in DeepSeek V3 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_deepseekv3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text without reasoning markers
-    ref: dynamo
+    ref: *upstream_ref
+    chat_template_kwargs:
+      enable_thinking: false
     model_text: plain answer
     expected:
       dynamo: &d_0
         reasoning_text: ''
         normal_text: plain answer
-      vllm:
-        reasoning_text: plain answer
-        normal_text: ''
-        reason: vLLM DeepSeek V4 batch parser treats marker-free text as reasoning when thinking is enabled.
+      vllm: *d_0
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.2.a:
     description: Single reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>
     expected:
       dynamo: &d_1
@@ -32,32 +33,32 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.3.a:
     description: Reasoning followed by downstream tool-call text
-    ref: dynamo
-    model_text: <think>choose tool</think><tool_call>{}
+    ref: *upstream_ref
+    model_text: |-
+      <think>choose tool</think><｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <tool_call>{}
+        normal_text: |-
+          <｜DSML｜tool_calls>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          </｜DSML｜tool_calls>
       vllm: *d_2
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: <think>choose tool<tool_call>{}
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      sglang:
-        unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
+    description: Open reasoning interrupted by downstream tool-call text is not configured for DeepSeek V4
+    ref: *upstream_ref
+    reason: Dynamo's DeepSeek V4 reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>answer
     expected:
       dynamo: &d_3
@@ -68,7 +69,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.2.d:
     description: Normal text around reasoning
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: before <think>thinking</think> after
     expected:
       dynamo:
@@ -77,12 +79,13 @@ cases:
       vllm:
         reasoning_text: thinking
         normal_text: ' after'
+        reason: Dynamo keeps visible text outside a complete reasoning span as normal_text; vLLM drops the prefix.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
@@ -94,19 +97,19 @@ cases:
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.5:
-    description: Missing end marker keeps the remaining text as reasoning
-    ref: dynamo
-    model_text: <think>partial reasoning
+    description: Open think marker starts reasoning from an outside-reasoning initial state
+    ref: *upstream_ref
+    model_text: <think>plain answer
     expected:
       dynamo: &d_5
-        reasoning_text: partial reasoning
+        reasoning_text: plain answer
         normal_text: ''
       vllm: *d_5
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.2.e:
     description: Empty reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think></think>answer
     expected:
       dynamo: &d_6
@@ -117,7 +120,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.2.f:
     description: Complex reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <think>Line 1
       Unicode: café
@@ -134,7 +137,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -145,7 +148,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo: &d_9
@@ -154,5 +158,6 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: deepseek_v4
 model_label: DeepSeek V4
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM DeepSeek V4 alias coverage in DeepSeek V3 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_deepseekv3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>thin
     - king</think>answer
@@ -30,11 +33,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo strips reasoning delimiters even when the block is streamed across chunks; vLLM leaks the start delimiter.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -46,11 +51,13 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span across chunks; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -61,11 +68,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo buffers a split start delimiter and strips it; vLLM leaks the reconstructed delimiter.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -76,11 +85,14 @@ cases:
       vllm:
         reasoning_text: <think>thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.stream.3.c:
     description: Partial start-marker prefix later becomes normal text
-    ref: dynamo
+    ref: *upstream_ref
+    chat_template_kwargs:
+      enable_thinking: false
     chunks:
     - plain <th
     - esis answer
@@ -88,15 +100,14 @@ cases:
       dynamo: &d_s6
         reasoning_text: ''
         normal_text: plain <thesis answer
-      vllm:
-        reasoning_text: plain <thesis answer
-        normal_text: ''
-        reason: vLLM DeepSeek V4 streaming parser treats marker-free stream text as reasoning in this shape.
+      vllm: *d_s6
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode in Dynamo
-    ref: dynamo
+    ref: *upstream_ref
+    chat_template_kwargs:
+      enable_thinking: false
     chunks:
     - plain
     - ' answer'
@@ -104,9 +115,6 @@ cases:
       dynamo: &d_s4
         reasoning_text: ''
         normal_text: plain answer
-      vllm:
-        reasoning_text: plain answer
-        normal_text: ''
-        reason: vLLM streaming parser treats plain text before a reasoning end marker as reasoning.
+      vllm: *d_s4
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -4,10 +4,12 @@
 family: gemma4
 model_label: Gemma 4
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Gemma4 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_gemma4_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.2.a:
     description: Gemma thought channel with role label stripped
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel>thought
       step one
@@ -23,36 +25,24 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.3.a:
     description: Gemma reasoning followed by downstream tool-call text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel>thought
-      choose tool<channel|><|tool_call>call<tool_call|>
+      choose tool<channel|><|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <|tool_call>call<tool_call|>
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
       vllm: *d_2
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.3.b:
-    description: Open Gemma thought channel interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: |-
-      <|channel>thought
-      choose tool<tool_call>{}
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      sglang:
-        unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
+    description: Open Gemma thought channel interrupted by downstream tool-call text is not configured
+    ref: *upstream_ref
+    reason: Dynamo's Gemma reasoning parser has no downstream tool-call boundary while the thought channel is open; closed-channel handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Gemma reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel>thought
       compute<channel|>answer
@@ -65,7 +55,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.2.d:
     description: Gemma normal text around reasoning
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: |-
       Hello. <|channel>thought
       rumination<channel|> Goodbye.
@@ -81,7 +72,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.1.b:
     description: No reasoning markers pass through as normal text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: just a plain answer
     expected:
       dynamo: &d_3
@@ -92,7 +83,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.4:
     description: Dangling Gemma channel end marker extracts text before the marker as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal<channel|>answer
     expected:
       dynamo: &d_4
@@ -103,7 +94,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.5:
     description: Open thought channel without close treats suffix as reasoning
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: |-
       intro <|channel>thought
       partial
@@ -119,7 +111,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.2.e:
     description: Empty Gemma reasoning channel
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel>thought
       <channel|>answer
@@ -132,7 +124,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.2.f:
     description: Complex Gemma reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel>thought
       Line 1
@@ -150,7 +142,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -161,7 +153,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.6.a:
     description: Gemma batch parser stops after the first reasoning channel
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel>thought
       first<channel|> middle <|channel>thought

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: gemma4
 model_label: Gemma 4
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Gemma4 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_gemma4_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.stream.2.a:
     description: Gemma thought channel across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - |
       <|channel>thought
@@ -39,11 +42,13 @@ cases:
           step one
           step two
         normal_text: The answer is 42.
+        reason: Dynamo strips Gemma channel syntax and the thought role label; vLLM leaks the channel prefix in streaming.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.stream.2.b:
     description: Multiple Gemma thought channels across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - |-
       <|channel>thought
@@ -59,11 +64,13 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: " middle <|channel>thought\nsecond<channel|> done"
+        reason: Dynamo extracts each complete Gemma thought channel across chunks; vLLM leaves the later complete channel in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <|chan
     - |-
@@ -78,11 +85,13 @@ cases:
         normal_text: |-
           <|channel>thought
           thinking<channel|>answer
+        reason: Dynamo buffers a split Gemma start delimiter and extracts the channel; vLLM leaves the full channel in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - |-
       <|channel>thought
@@ -97,11 +106,12 @@ cases:
           <|channel>thought
           thinking<channel|>answer
         normal_text: ''
+        reason: Dynamo buffers a split Gemma end delimiter and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.stream.3.c:
     description: Partial channel marker prefix later becomes normal text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain <|chan
     - ce answer
@@ -114,7 +124,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -4,95 +4,97 @@
 family: gpt_oss
 model_label: gpt-oss
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM GPT-OSS reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_gptoss_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text without Harmony channel markers
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo:
         reasoning_text: ''
         normal_text: ''
       vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+        reasoning_text: ''
+        normal_text: ''
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.a:
     description: Harmony analysis channel followed by final channel
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>analysis<|message|>thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
     expected:
       dynamo: &d_1
         reasoning_text: thinking
         normal_text: answer
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      vllm: *d_1
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.3.a:
     description: Harmony analysis followed by commentary tool-call channel
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>analysis<|message|>choose tool<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
         normal_text: '{"city":"SF"}'
       vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+        reasoning_text: choose tool
+        normal_text: ''
+        reason: vLLM gpt-oss reasoning keeps recipient commentary tool-call payload out of normal_text for the tool parser path.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.c:
     description: Harmony analysis followed by normal final answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>analysis<|message|>compute<|end|><|start|>assistant<|channel|>final<|message|>answer
     expected:
       dynamo: &d_3
         reasoning_text: compute
         normal_text: answer
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      vllm: *d_3
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.4:
     description: Final channel without prior analysis channel
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>final<|message|>answer
     expected:
       dynamo: &d_4
         reasoning_text: answer
         normal_text: ''
       vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+        reasoning_text: ''
+        normal_text: answer
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.5:
     description: Analysis channel without a final or commentary channel
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>analysis<|message|>partial reasoning<|end|>
     expected:
       dynamo: &d_5
         reasoning_text: partial reasoning
         normal_text: ''
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      vllm: *d_5
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.e:
     description: Empty analysis channel followed by final text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>analysis<|message|><|end|><|start|>assistant<|channel|>final<|message|>answer
     expected:
       dynamo: &d_6
         reasoning_text: ''
         normal_text: answer
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      vllm: *d_6
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.f:
     description: Complex Harmony analysis content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <|channel|>analysis<|message|>Line 1
       Unicode: café
@@ -104,48 +106,40 @@ cases:
           Unicode: café
           JSON-ish: {"x": [1, true]}
         normal_text: Done.
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      vllm: *d_7
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
         reasoning_text: ''
         normal_text: ''
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+      vllm: *d_8
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.6.a:
     description: Multiple Harmony analysis spans
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done
     expected:
       dynamo: &d_9
         reasoning_text: first
         normal_text: second
       vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
+        reasoning_text: |-
+          first
+          second
+        normal_text: done
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.d:
     description: Normal text before a Harmony analysis channel is not a portable parser-level fixture
     reason: Harmony reasoning content is channel-framed; prefix text before the first channel is outside this parser-level fixture contract.
   REASONING.batch.3.b:
-    description: Tool-call boundary inside an open Harmony analysis channel
-    dynamo_leak: true
-    ref: dynamo
-    model_text: <|channel|>analysis<|message|>choose tool<tool_call>{}
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        unavailable: vLLM gpt-oss batch reasoning uses token-level OpenAI parser wiring that this text harness does not call.
-      sglang:
-        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+    description: Open analysis channel interrupted by downstream tool-call text is not configured for Harmony
+    ref: *upstream_ref
+    reason: Harmony tool calls require a commentary channel envelope; the closed analysis to commentary handoff is covered by REASONING.batch.3.a.

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -4,23 +4,24 @@
 family: gpt_oss
 model_label: gpt-oss
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM GPT-OSS reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_gptoss_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
       dynamo: &d_s0
         reasoning_text: ''
         normal_text: ''
-      vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      vllm: *d_s0
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.2.a:
     description: Harmony analysis block across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <|channel|>
     - analysis<|message|>thinking
@@ -30,14 +31,13 @@ cases:
       dynamo: &d_s1
         reasoning_text: thinking
         normal_text: answer
-      vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      vllm: *d_s1
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.2.b:
     description: Multiple Harmony analysis spans across chunks
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>final<|message|>one
     - <|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>two
@@ -46,12 +46,13 @@ cases:
         reasoning_text: first
         normal_text: one<|channel|>analysis<|message|>secondtwo
       vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+        reasoning_text: first
+        normal_text: one<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>two
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.3.a:
     description: Harmony start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <|chan
     - nel|>analysis<|message|>thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
@@ -59,14 +60,13 @@ cases:
       dynamo: &d_s2
         reasoning_text: thinking
         normal_text: answer
-      vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      vllm: *d_s2
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.3.b:
     description: Harmony end marker split across chunks
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <|channel|>analysis<|message|>thinking<|e
     - nd|><|start|>assistant<|channel|>final<|message|>answer
@@ -75,12 +75,12 @@ cases:
         reasoning_text: thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
         normal_text: ''
       vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+        unavailable: vLLM gpt-oss streaming parity for a split Harmony end token needs explicit token_chunks; text-only chunks are not faithful.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.3.c:
     description: Partial Harmony channel marker prefix later becomes non-channel text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain <|chan
     - ce answer
@@ -89,12 +89,13 @@ cases:
         reasoning_text: ''
         normal_text: ''
       vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+        reasoning_text: ''
+        normal_text: ''
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.1.b:
     description: Plain text without Harmony channel markers
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'
@@ -102,7 +103,6 @@ cases:
       dynamo: &d_s4
         reasoning_text: ''
         normal_text: ''
-      vllm:
-        unavailable: vLLM gpt-oss stream reasoning needs token-level OpenAI parser wiring, not this text-only harness.
+      vllm: *d_s4
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'

--- a/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -4,10 +4,12 @@
 family: granite
 model_label: Granite
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Granite reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_granite_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text without Granite reasoning markers
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -18,7 +20,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.2.a:
     description: Granite thought-process marker
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "Here is my thought process: thinking Here is my response: answer"
     expected:
       dynamo: &d_1
@@ -27,26 +29,15 @@ cases:
       vllm:
         reasoning_text: ' thinking '
         normal_text: ' answer'
-        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.3.a:
-    description: Granite reasoning followed by downstream tool-call text
-    ref: dynamo
-    model_text: "Here is my thought process: choose tool Here is my response: <tool_call>{}"
-    expected:
-      dynamo: &d_2
-        reasoning_text: 'choose tool '
-        normal_text: <tool_call>{}
-      vllm:
-        reasoning_text: ' choose tool '
-        normal_text: ' <tool_call>{}'
-        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
-      sglang:
-        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+    description: Granite reasoning followed by downstream tool-call text is not covered by a paired Dynamo tool call parser
+    ref: *upstream_ref
+    reason: Granite reasoning parsing has no paired Dynamo tool call parser fixture, so downstream handoff is outside this seed fixture set.
   REASONING.batch.2.c:
     description: Granite reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "Here is my thought process: compute Here is my response: answer"
     expected:
       dynamo: &d_3
@@ -55,12 +46,11 @@ cases:
       vllm:
         reasoning_text: ' compute '
         normal_text: ' answer'
-        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.4:
     description: Dangling Granite response marker without a thought marker
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "normal Here is my response: answer"
     expected:
       dynamo: &d_4
@@ -71,7 +61,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.5:
     description: Start marker without response marker keeps suffix as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "Here is my thought process: partial reasoning"
     expected:
       dynamo: &d_5
@@ -84,7 +74,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.2.e:
     description: Empty Granite thought-process span
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "Here is my thought process: Here is my response: answer"
     expected:
       dynamo: &d_6
@@ -93,12 +83,11 @@ cases:
       vllm:
         reasoning_text: ''
         normal_text: ' answer'
-        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.2.f:
     description: Complex Granite reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       Here is my thought process: Line 1
       Unicode: café
@@ -110,12 +99,11 @@ cases:
       vllm:
         reasoning_text: " Line 1\nUnicode: café\nJSON-ish: {\"x\": [1, true]} "
         normal_text: ' Done.'
-        reason: vLLM Granite preserves delimiter-adjacent spaces that Dynamo trims.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -126,7 +114,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.6.a:
     description: Granite batch parser stops after the first thought-process span
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "Here is my thought process: first Here is my response: middle Here is my thought process: second Here is my response: done"
     expected:
       dynamo:
@@ -139,7 +127,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.2.d:
     description: Normal text before and after Granite thought-process markers
-    ref: dynamo
+    ref: *upstream_ref
     model_text: "before Here is my thought process: thinking Here is my response: after"
     expected:
       dynamo:
@@ -151,16 +139,6 @@ cases:
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.batch.3.b:
-    description: Tool-call boundary inside an open Granite thought-process span
-    dynamo_leak: true
-    ref: dynamo
-    model_text: "Here is my thought process: choose tool <tool_call>{}"
-    expected:
-      dynamo:
-        reasoning_text: 'choose tool <tool_call>{}'
-        normal_text: ''
-      vllm:
-        reasoning_text: ''
-        normal_text: "Here is my thought process: choose tool <tool_call>{}"
-      sglang:
-        unavailable: SGLang peer not wired for Dynamo parser family 'granite'
+    description: Open Granite reasoning interrupted by downstream tool-call text is not covered by a paired Dynamo tool call parser
+    ref: *upstream_ref
+    reason: Granite reasoning parsing has no paired Dynamo tool call parser fixture or open-reasoning tool boundary in this seed fixture set.

--- a/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: granite
 model_label: Granite
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Granite reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_granite_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.stream.2.a:
     description: Granite thought-process marker across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - "Here is my thought process: thin"
     - "king Here is my response:"
@@ -35,7 +37,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.stream.2.b:
     description: Multiple thought-process spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - 'Here is my thought process: first Here is my response:'
     - ' middle '
@@ -51,7 +53,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - "Here is my"
     - " thought process: thinking Here is my response: answer"
@@ -68,7 +70,7 @@ cases:
   REASONING.stream.3.b:
     description: End marker split across chunks
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - "Here is my thought process: thinking Here is my res"
     - "ponse: answer"
@@ -83,7 +85,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.stream.3.c:
     description: Partial phrase prefix later becomes normal text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain Here is my thou
     - ghtful answer
@@ -96,7 +98,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'granite'
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: kimi
-model_label: Kimi reasoning
+model_label: Kimi Unicode reasoning
 mode: batch
 cases:
   REASONING.batch.1.b:
@@ -32,11 +32,11 @@ cases:
   REASONING.batch.3.a:
     description: Reasoning followed by downstream tool-call text
     ref: dynamo
-    model_text: ◁think▷choose tool◁/think▷<tool_call>{}
+    model_text: ◁think▷choose tool◁/think▷<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <tool_call>{}
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       vllm:
         unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
       sglang:
@@ -145,15 +145,6 @@ cases:
       sglang:
         unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
   REASONING.batch.3.b:
-    description: Tool-call boundary inside an open Kimi reasoning span
-    dynamo_leak: true
+    description: Open reasoning interrupted by downstream tool-call text is not configured for this Kimi delimiter family
     ref: dynamo
-    model_text: ◁think▷choose tool<tool_call>{}
-    expected:
-      dynamo: &d_11
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
-      sglang:
-        unavailable: SGLang has no Kimi reasoning parser for this delimiter family.
+    reason: Dynamo's Kimi Unicode-delimiter reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: kimi
-model_label: Kimi reasoning
+model_label: Kimi Unicode reasoning
 mode: stream
 cases:
   REASONING.stream.1.a:

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -2,96 +2,103 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: kimi_k25
-model_label: Kimi K2.5
+model_label: Kimi K2.5 / K2.6
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Kimi K2/K2.5 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_kimi_k2_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text stays in force-reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo:
         reasoning_text: plain answer
         normal_text: ''
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: plain answer
+        normal_text: ''
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.2.a:
     description: Force-reasoning parser with explicit think tags
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>answer
     expected:
       dynamo: &d_1
         reasoning_text: thinking
         normal_text: answer
-      vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      vllm: *d_1
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.3.b:
     description: Tool-call section marker force-exits an open reasoning block
-    ref: dynamo
-    model_text: thinking <|tool_calls_section_begin|>tool text
+    ref: *upstream_ref
+    model_text: thinking <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     expected:
       dynamo:
         reasoning_text: thinking
-        normal_text: <|tool_calls_section_begin|>tool text
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: 'thinking '
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.2.c:
     description: Force-reasoning parser treats plain output as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: thinking without explicit tags
     expected:
       dynamo:
         reasoning_text: thinking without explicit tags
         normal_text: ''
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: thinking without explicit tags
+        normal_text: ''
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.4:
     description: Dangling end marker exits force-reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo:
         reasoning_text: normal
         normal_text: answer
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: normal
+        normal_text: answer
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: partial reasoning
     expected:
       dynamo:
         reasoning_text: partial reasoning
         normal_text: ''
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: partial reasoning
+        normal_text: ''
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.2.e:
     description: Empty reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think></think>answer
     expected:
       dynamo:
         reasoning_text: ''
         normal_text: answer
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: ''
+        normal_text: answer
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.2.f:
     description: Complex reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <think>Line 1
       Unicode: café
@@ -104,31 +111,38 @@ cases:
           JSON-ish: {"x": [1, true]}
         normal_text: Done.
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: |-
+          Line 1
+          Unicode: café
+          JSON-ish: {"x": [1, true]}
+        normal_text: Done.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo:
         reasoning_text: ''
         normal_text: ''
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: ''
+        normal_text: ''
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:
         reasoning_text: firstsecond
         normal_text: middle  done
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: first
+        normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; vLLM Kimi K2 parser leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.batch.2.d:
@@ -136,13 +150,14 @@ cases:
     reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
   REASONING.batch.3.a:
     description: Closed reasoning span followed by Kimi tool-call section marker
-    ref: dynamo
-    model_text: <think>choose tool</think><|tool_calls_section_begin|>tool text
+    ref: *upstream_ref
+    model_text: <think>choose tool</think><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     expected:
       dynamo:
         reasoning_text: choose tool
-        normal_text: <|tool_calls_section_begin|>tool text
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: choose tool
+        normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -2,25 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: kimi_k25
-model_label: Kimi K2.5
+model_label: Kimi K2.5 / K2.6
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Kimi K2/K2.5 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_kimi_k2_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
       dynamo: &d_s0
         reasoning_text: ''
         normal_text: ''
-      vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+      vllm: *d_s0
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.stream.2.a:
     description: Force-reasoning stream exits on closing think tag
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - thinking
     - </think>answer
@@ -29,12 +30,13 @@ cases:
         reasoning_text: thinking
         normal_text: answer
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: thinking
+        normal_text: answer
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>first</think>
     - ' middle '
@@ -44,12 +46,14 @@ cases:
         reasoning_text: firstsecond
         normal_text: ' middle  done'
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: <think>first
+        normal_text: ' middle <think>second</think> done'
+        reason: vLLM Kimi K2 streaming parser leaks the first start marker and leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.stream.3.a:
     description: Opening think marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <thi
     - nk>thinking</think>answer
@@ -58,12 +62,14 @@ cases:
         reasoning_text: thinking
         normal_text: answer
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: <think>thinking
+        normal_text: answer
+        reason: Dynamo buffers a split start delimiter and strips it; vLLM Kimi K2 streaming parser leaks the reconstructed delimiter.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -72,12 +78,14 @@ cases:
         reasoning_text: thinking
         normal_text: answer
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: <think>thinking</think>answer
+        normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; vLLM Kimi K2 streaming parser keeps the delimiter and answer in reasoning_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain <th
     - esis answer
@@ -86,12 +94,13 @@ cases:
         reasoning_text: plain <thesis answer
         normal_text: ''
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: plain <thesis answer
+        normal_text: ''
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'
@@ -100,6 +109,7 @@ cases:
         reasoning_text: plain answer
         normal_text: ''
       vllm:
-        unavailable: vLLM peer not wired for Dynamo parser family 'kimi_k25'
+        reasoning_text: plain answer
+        normal_text: ''
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'kimi_k25'

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
@@ -4,10 +4,12 @@
 family: minimax_append_think
 model_label: MiniMax append-think
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM MiniMax M2 append-think reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_minimax_m2_append_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text receives the synthetic think opener
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -18,7 +20,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.2.a:
     description: MiniMax appends a synthetic think opener and leaves content inline
-    ref: dynamo
+    ref: *upstream_ref
     model_text: reasoning content
     expected:
       dynamo: &d_1
@@ -29,18 +31,28 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.3.a:
     description: Reasoning-shaped text followed by downstream MiniMax tool-call text
-    ref: dynamo
-    model_text: reasoning</think><minimax:tool_call><invoke name="get_weather">
+    ref: *upstream_ref
+    model_text: |-
+      reasoning</think><minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      </minimax:tool_call>
     expected:
       dynamo: &d_2
         reasoning_text: ''
-        normal_text: <think>reasoning</think><minimax:tool_call><invoke name="get_weather">
+        normal_text: |-
+          <think>reasoning</think><minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          </minimax:tool_call>
       vllm: *d_2
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.2.c:
     description: Reasoning-shaped text followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: reasoning</think>answer
     expected:
       dynamo: &d_3
@@ -51,7 +63,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.4:
     description: Dangling end marker is left inline
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
@@ -62,7 +74,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.5:
     description: Missing end marker is left inline
-    ref: dynamo
+    ref: *upstream_ref
     model_text: partial reasoning
     expected:
       dynamo: &d_5
@@ -73,7 +85,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.2.e:
     description: Empty input still emits the synthetic think opener
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_6
@@ -84,7 +96,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.2.f:
     description: Complex content remains inline after the synthetic opener
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       Line 1
       Unicode: café
@@ -101,7 +113,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.1.a:
     description: Empty input variant
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -112,7 +124,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.6.a:
     description: Multiple think-looking spans remain inline
-    ref: dynamo
+    ref: *upstream_ref
     model_text: first</think> middle <think>second</think> done
     expected:
       dynamo: &d_9
@@ -123,7 +135,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.2.d:
     description: Normal text around think-looking markup remains inline after the synthetic opener
-    ref: dynamo
+    ref: *upstream_ref
     model_text: before <think>thinking</think> after
     expected:
       dynamo: &d_10
@@ -133,13 +145,6 @@ cases:
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.batch.3.b:
-    description: Tool-call marker remains inline after the synthetic think opener
-    ref: dynamo
-    model_text: <think>choose tool<tool_call>{}
-    expected:
-      dynamo: &d_11
-        reasoning_text: ''
-        normal_text: <think><think>choose tool<tool_call>{}
-      vllm: *d_11
-      sglang:
-        unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
+    description: Open reasoning interrupted by downstream tool-call text is not configured for MiniMax append-think
+    ref: *upstream_ref
+    reason: MiniMax append-think emits a synthetic normal-text wrapper instead of running an open reasoning-span boundary; closed-span handoff is covered by REASONING.batch.3.a.

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: minimax_append_think
 model_label: MiniMax append-think
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM MiniMax M2 append-think reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_minimax_m2_append_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk still receives the synthetic think opener
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.stream.2.a:
     description: First streamed chunk gets the synthetic think opener
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - 'reasoning '
     - content
@@ -33,7 +35,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.stream.2.b:
     description: Multiple append-think-looking spans remain normal text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - first</think>
     - ' middle '
@@ -47,7 +49,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.stream.3.a:
     description: Single chunk without a model-emitted think opener
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - reasoning content
     expected:
@@ -59,7 +61,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.stream.3.b:
     description: End marker split across chunks is still normal text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - reasoning</th
     - ink>answer
@@ -72,7 +74,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.stream.3.c:
     description: Partial marker-looking prefix remains normal text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain <th
     - esis answer
@@ -85,7 +87,7 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'minimax_append_think'
   REASONING.stream.1.b:
     description: Plain text is passed through after the synthetic opener
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -4,10 +4,12 @@
 family: mistral
 model_label: Mistral / Magistral
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Mistral reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_mistral_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text stays in force-reasoning mode in Dynamo
-    ref: dynamo
+    ref: *upstream_ref
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -21,7 +23,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.2.a:
     description: Mistral THINK block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: '[THINK]thinking[/THINK]answer'
     expected:
       dynamo: &d_1
@@ -32,32 +34,22 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.3.a:
     description: Mistral reasoning followed by downstream tool-call text
-    ref: dynamo
-    model_text: '[THINK]choose tool[/THINK]<tool_call>{}'
+    ref: *upstream_ref
+    model_text: '[THINK]choose tool[/THINK][TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <tool_call>{}
+        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
       vllm: *d_2
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: '[THINK]choose tool<tool_call>{}'
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      sglang:
-        unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
+    description: Open reasoning interrupted by downstream tool-call text is not configured for Mistral
+    ref: *upstream_ref
+    reason: Dynamo's Mistral reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Mistral reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: '[THINK]compute[/THINK]answer'
     expected:
       dynamo: &d_3
@@ -71,7 +63,7 @@ cases:
     reason: Force-reasoning parser families start inside reasoning; marker-free prefix text is not a normal-text prefix.
   REASONING.batch.4:
     description: Dangling Mistral end marker without an opening marker
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal[/THINK]answer
     expected:
       dynamo:
@@ -85,7 +77,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.5:
     description: Force-reasoning parser treats unterminated text as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: thinking without an end marker
     expected:
       dynamo: &d_5
@@ -99,7 +91,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.2.e:
     description: Empty Mistral reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: '[THINK][/THINK]answer'
     expected:
       dynamo: &d_6
@@ -110,7 +102,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.2.f:
     description: Complex Mistral reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       [THINK]Line 1
       Unicode: café
@@ -127,7 +119,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -138,7 +130,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.batch.6.a:
     description: Multiple Mistral reasoning spans are concatenated by Dynamo
-    ref: dynamo
+    ref: *upstream_ref
     model_text: '[THINK]first[/THINK] middle [THINK]second[/THINK] done'
     expected:
       dynamo:

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: mistral
 model_label: Mistral / Magistral
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Mistral reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_mistral_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.stream.2.a:
     description: Mistral THINK block across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - '[THINK]thin'
     - 'king[/THINK]answer'
@@ -34,7 +36,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.stream.2.b:
     description: Multiple Mistral THINK spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - '[THINK]first[/THINK]'
     - ' middle '
@@ -50,7 +52,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - '[TH'
     - 'INK]thinking[/THINK]answer'
@@ -65,7 +67,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - '[THINK]thinking[/TH'
     - 'INK]answer'
@@ -80,7 +82,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain [TH
     - ESIS answer
@@ -96,7 +98,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'mistral'
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -4,10 +4,13 @@
 family: nemotron_deci
 model_label: Nemotron Deci / GLM 4.5
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM GLM/Nemotron think-tag reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_glm4_moe_reasoning_parser.py and https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_nemotron_v3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text without reasoning markers
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -16,12 +19,12 @@ cases:
       vllm:
         reasoning_text: plain answer
         normal_text: ''
-        reason: vLLM GLM/Nemotron batch parser treats marker-free text as reasoning.
+        reason: vLLM GLM/Nemotron parser (`glm45`) defaults thinking on and treats marker-free text as reasoning.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.2.a:
     description: Single think-tag reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>answer
     expected:
       dynamo: &d_1
@@ -32,32 +35,22 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.3.a:
     description: Reasoning followed by downstream tool-call text
-    ref: dynamo
-    model_text: <think>choose tool</think><tool_call>{}
+    ref: *upstream_ref
+    model_text: '<think>choose tool</think><TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: <tool_call>{}
+        normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
       vllm: *d_2
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: <think>choose tool<tool_call>{}
-    expected:
-      dynamo:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      sglang:
-        unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
+    description: Open reasoning interrupted by downstream tool-call text is not configured for GLM/Nemotron
+    ref: *upstream_ref
+    reason: Dynamo's GLM/Nemotron reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>compute</think>answer
     expected:
       dynamo: &d_3
@@ -68,7 +61,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.2.d:
     description: Normal text around reasoning
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: before <think>thinking</think> after
     expected:
       dynamo:
@@ -77,12 +71,13 @@ cases:
       vllm:
         reasoning_text: thinking
         normal_text: ' after'
+        reason: Dynamo keeps visible text outside a complete reasoning span as normal_text; vLLM drops the prefix.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo:
@@ -95,7 +90,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>partial
     expected:
       dynamo: &d_5
@@ -106,7 +101,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.2.e:
     description: Empty reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think></think>answer
     expected:
       dynamo: &d_6
@@ -117,7 +112,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.2.f:
     description: Complex reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <think>Line 1
       Unicode: café
@@ -134,7 +129,7 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -145,7 +140,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:
@@ -154,5 +150,6 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: nemotron_deci
 model_label: Nemotron Deci / GLM 4.5
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM GLM/Nemotron think-tag reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_glm4_moe_reasoning_parser.py and https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_nemotron_v3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -19,7 +21,8 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>thin
     - king</think>
@@ -31,11 +34,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo strips reasoning delimiters even when the block is streamed across chunks; vLLM leaks the start delimiter.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -47,11 +52,13 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span across chunks; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -62,11 +69,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo buffers a split start delimiter and strips it; vLLM leaks the reconstructed delimiter.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -77,11 +86,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.stream.3.c:
     description: Partial start-marker prefix later becomes normal text
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - plain <th
     - esis answer
@@ -92,12 +103,13 @@ cases:
       vllm:
         reasoning_text: plain <thesis answer
         normal_text: ''
-        reason: vLLM GLM/Nemotron streaming parser treats marker-free text as reasoning.
+        reason: vLLM GLM/Nemotron parser (`glm45`) defaults thinking on and routes marker-free deltas to reasoning.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.stream.1.b:
     description: Plain text without reasoning markers
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - plain
     - ' answer'
@@ -108,6 +120,6 @@ cases:
       vllm:
         reasoning_text: plain answer
         normal_text: ''
-        reason: vLLM GLM/Nemotron streaming parser treats marker-free text as reasoning.
+        reason: vLLM GLM/Nemotron parser (`glm45`) defaults thinking on and routes marker-free deltas to reasoning.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -4,10 +4,13 @@
 family: qwen3
 model_label: Qwen 3.x
 mode: batch
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Qwen3 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_qwen3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.batch.1.b:
     description: Plain text without reasoning markers
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -20,7 +23,7 @@ cases:
       sglang: *d_0
   REASONING.batch.2.a:
     description: Single reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>thinking</think>
     expected:
       dynamo: &d_1
@@ -30,31 +33,35 @@ cases:
       sglang: *d_1
   REASONING.batch.3.a:
     description: Reasoning followed by downstream tool-call text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
-      <think>choose the weather tool</think><tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call>
+      <think>choose the weather tool</think><tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
     expected:
       dynamo: &d_2
         reasoning_text: choose the weather tool
-        normal_text: <tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call>
+        normal_text: |-
+          <tool_call>
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>
       vllm: *d_2
       sglang: *d_2
   REASONING.batch.3.b:
-    description: Open reasoning interrupted by downstream tool-call text
-    dynamo_leak: true
-    ref: dynamo
-    model_text: <think>choose tool<tool_call>{}
-    expected:
-      dynamo: &d_10
-        reasoning_text: choose tool<tool_call>{}
-        normal_text: ''
-      vllm:
-        reasoning_text: choose tool
-        normal_text: <tool_call>{}
-      sglang: *d_10
+    description: Open reasoning interrupted by downstream tool-call text is not configured for Qwen3
+    ref: *upstream_ref
+    reason: Dynamo's qwen3 reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
   REASONING.batch.2.c:
     description: Reasoning followed by normal answer text
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>compute it</think>The answer is 42.
     expected:
       dynamo: &d_3
@@ -64,7 +71,8 @@ cases:
       sglang: *d_3
   REASONING.batch.2.d:
     description: Normal text around reasoning
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: before <think>thinking</think> after
     expected:
       dynamo: &d_11
@@ -73,13 +81,15 @@ cases:
       vllm:
         reasoning_text: thinking
         normal_text: ' after'
+        reason: Dynamo keeps visible text outside a complete reasoning span as normal_text; vLLM drops the prefix.
       sglang:
         reasoning_text: before thinking
         normal_text: ' after'
+        reason: Dynamo keeps visible text outside a complete reasoning span as normal_text; SGLang folds the prefix into reasoning_text.
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
     dynamo_leak: true
-    ref: dynamo
+    ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
@@ -91,7 +101,7 @@ cases:
       sglang: *d_4
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think>partial reasoning
     expected:
       dynamo: &d_5
@@ -101,7 +111,7 @@ cases:
       sglang: *d_5
   REASONING.batch.2.e:
     description: Empty reasoning block
-    ref: dynamo
+    ref: *upstream_ref
     model_text: <think></think>Direct answer.
     expected:
       dynamo: &d_6
@@ -111,7 +121,7 @@ cases:
       sglang: *d_6
   REASONING.batch.2.f:
     description: Complex reasoning content with Unicode and newlines
-    ref: dynamo
+    ref: *upstream_ref
     model_text: |-
       <think>Line 1
       Unicode: café
@@ -127,7 +137,7 @@ cases:
       sglang: *d_7
   REASONING.batch.1.a:
     description: Empty input
-    ref: dynamo
+    ref: *upstream_ref
     model_text: ''
     expected:
       dynamo: &d_8
@@ -137,7 +147,8 @@ cases:
       sglang: *d_8
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo: &d_9
@@ -146,6 +157,8 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; vLLM leaves the later complete span in normal_text.
       sglang:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; SGLang leaves the later complete span in normal_text.

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -4,10 +4,12 @@
 family: qwen3
 model_label: Qwen 3.x
 mode: stream
+refs:
+  upstream: &upstream_ref 'inspired by vLLM Qwen3 reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_qwen3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'
 cases:
   REASONING.stream.1.a:
     description: Empty stream chunk
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - ''
     expected:
@@ -18,7 +20,7 @@ cases:
       sglang: *d_s0
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
-    ref: dynamo
+    ref: *upstream_ref
     chunks:
     - <think>thin
     - king</think>
@@ -31,7 +33,8 @@ cases:
       sglang: *d_s1
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -43,12 +46,15 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span across chunks; vLLM leaves the later complete span in normal_text.
       sglang:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span across chunks; SGLang leaves the later complete span in normal_text.
   REASONING.stream.3.a:
     description: Start marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -59,10 +65,12 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo buffers a split start delimiter and strips it; vLLM leaks the reconstructed delimiter.
       sglang: *d_s2
   REASONING.stream.3.b:
     description: End marker split across chunks
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -73,12 +81,15 @@ cases:
       vllm:
         reasoning_text: thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
       sglang:
         reasoning_text: thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; SGLang keeps the delimiter and answer in reasoning_text.
   REASONING.stream.3.c:
     description: Partial start-marker prefix later becomes normal text
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - plain <th
     - esis answer
@@ -93,7 +104,8 @@ cases:
       sglang: *d_s6
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
-    ref: dynamo
+    ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/test_reasoning_fixture_schema.py
+++ b/tests/parity/reasoning/test_reasoning_fixture_schema.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+EXPECTED_IMPLS = ("dynamo", "vllm", "sglang")
+MODES = {"batch", "stream"}
+STUB_KEYS = {"description", "reason", "ref", "spec_ref"}
+CASE_KEYS = {
+    "description",
+    "ref",
+    "spec_ref",
+    "model_text",
+    "chunks",
+    "chat_template_kwargs",
+    "expected",
+    "reason",
+    "dynamo_leak",
+}
+BLOCK_KEYS = {"reasoning_text", "normal_text", "reason", "error", "unavailable"}
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    assert isinstance(data, dict), f"{path}: fixture must be a mapping"
+    return data
+
+
+def _location(path: Path, case_id: str) -> str:
+    return f"{path.relative_to(FIXTURES_DIR.parent.parent.parent)}:{case_id}"
+
+
+def _assert_expected_block(path: Path, case_id: str, impl: str, block: object) -> None:
+    where = f"{_location(path, case_id)} expected.{impl}"
+    assert isinstance(block, dict), f"{where}: must be a mapping"
+    unknown_keys = set(block) - BLOCK_KEYS
+    assert not unknown_keys, f"{where}: unknown keys {sorted(unknown_keys)}"
+
+    terminal_keys = {"error", "unavailable"} & set(block)
+    assert len(terminal_keys) <= 1, f"{where}: use only one of error/unavailable"
+    if terminal_keys:
+        assert (
+            set(block) <= terminal_keys
+        ), f"{where}: terminal block must only contain {terminal_keys}"
+        value = block[next(iter(terminal_keys))]
+        assert (
+            isinstance(value, str) and value
+        ), f"{where}: terminal message must be non-empty"
+        return
+
+    assert "reasoning_text" in block, f"{where}: missing reasoning_text"
+    assert "normal_text" in block, f"{where}: missing normal_text"
+    assert isinstance(
+        block["reasoning_text"], str
+    ), f"{where}: reasoning_text must be a string"
+    assert isinstance(
+        block["normal_text"], str
+    ), f"{where}: normal_text must be a string"
+    if "reason" in block:
+        assert (
+            isinstance(block["reason"], str) and block["reason"]
+        ), f"{where}: reason must be non-empty"
+
+
+def test_reasoning_fixture_schema() -> None:
+    paths = sorted(FIXTURES_DIR.glob("*/REASONING.*.yaml"))
+    assert paths, "reasoning fixtures must exist"
+
+    seen_case_ids: set[tuple[str, str]] = set()
+    for path in paths:
+        data = _load_yaml(path)
+        family = data.get("family")
+        mode = data.get("mode")
+        cases = data.get("cases")
+
+        assert (
+            isinstance(family, str) and family
+        ), f"{path}: family must be a non-empty string"
+        assert mode in MODES, f"{path}: mode must be one of {sorted(MODES)}"
+        assert (
+            isinstance(cases, dict) and cases
+        ), f"{path}: cases must be a non-empty mapping"
+
+        for case_id, case in cases.items():
+            where = _location(path, case_id)
+            assert isinstance(case_id, str) and case_id.startswith(
+                f"REASONING.{mode}."
+            ), f"{where}: case id must match fixture mode"
+            seen_key = (family, case_id)
+            assert (
+                seen_key not in seen_case_ids
+            ), f"{where}: duplicate case id for family"
+            seen_case_ids.add(seen_key)
+
+            assert isinstance(case, dict), f"{where}: case must be a mapping"
+            unknown_keys = set(case) - CASE_KEYS
+            assert not unknown_keys, f"{where}: unknown keys {sorted(unknown_keys)}"
+            assert (
+                isinstance(case.get("description"), str) and case["description"]
+            ), f"{where}: description must be non-empty"
+
+            if "expected" not in case:
+                assert (
+                    set(case) <= STUB_KEYS
+                ), f"{where}: stub case must only use {sorted(STUB_KEYS)}"
+                assert (
+                    isinstance(case.get("reason"), str) and case["reason"]
+                ), f"{where}: stub case must document why it is not applicable"
+                continue
+
+            if mode == "batch":
+                assert "model_text" in case, f"{where}: batch case missing model_text"
+                assert isinstance(
+                    case["model_text"], str
+                ), f"{where}: model_text must be a string"
+            else:
+                assert "chunks" in case, f"{where}: stream case missing chunks"
+                assert isinstance(
+                    case["chunks"], list
+                ), f"{where}: chunks must be a list"
+
+            dynamo_leak = case.get("dynamo_leak", False)
+            assert isinstance(
+                dynamo_leak, bool
+            ), f"{where}: dynamo_leak must be boolean"
+            if dynamo_leak:
+                assert not case_id.startswith(
+                    "REASONING.batch.3."
+                ), f"{where}: downstream tool call handoff must not be marked as a reasoning leak"
+
+            expected = case["expected"]
+            assert isinstance(expected, dict), f"{where}: expected must be a mapping"
+            assert set(expected) == set(
+                EXPECTED_IMPLS
+            ), f"{where}: expected must include dynamo/vllm/sglang"
+            for impl in EXPECTED_IMPLS:
+                _assert_expected_block(path, case_id, impl, expected[impl])


### PR DESCRIPTION
#### Overview:

This PR updates the reasoning parity fixtures and reference docs for part 2 of the reasoning parity work.

#### Details:

- **How is this fixed?** Refresh the YAML fixture expectations and reasoning taxonomy docs so the matrix PR can consume the updated contract.
- Add upstream-inspired references for GPT-OSS, Kimi, Kimi K2.5/K2.6, and GLM/Nemotron reasoning fixtures.
- Clarify the parity table conventions that are valid for this fixture-only part.
- Keep generated HTML and harness code changes out of this part; the code/table harness lands in #9781.

#### Verification:

Pre-commit hooks passed in the Dynamo devcontainer.

#### Where should the reviewer start?

`lib/parsers/REASONING_CASES.md`, then `tests/parity/reasoning/fixtures/`

#### Related Issues:

Follows #9832; followed by #9781; DIS-2063

/coderabbit profile chill
