### PR TITLE
fix(container): copy NIXL SDK into sglang runtime image

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -40,22 +40,17 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}
-# Stage NIXL SDK + UCX on the system linker path so the stub-built nixl-sys
-# can dlopen libnixl_capi.so at runtime; mirrors vllm_runtime / trtllm_runtime.
-COPY --chown=dynamo: --from=wheel_builder /usr/local/ucx /usr/local/ucx
-COPY --chown=dynamo: --from=wheel_builder /opt/nvidia/nvda_nixl /opt/nvidia/nvda_nixl
-
-ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
-    NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
-    NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
-
-ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:${LD_LIBRARY_PATH:-}
-
-RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
-    echo "$NIXL_PLUGIN_DIR" >> /etc/ld.so.conf.d/nixl.conf && \
-    echo "/usr/local/ucx/lib" > /etc/ld.so.conf.d/ucx.conf && \
-    echo "/usr/local/ucx/lib/ucx" >> /etc/ld.so.conf.d/ucx.conf && \
-    ldconfig
+# Expose upstream lmsysorg/sglang's bundled libnixl_capi.so on ld.so so the
+# stub-built nixl-sys (in dynamo's Rust wheel) can dlopen it. The wheel ships
+# libs only under .nixl_cu*.mesonpy.libs/, which ld.so never searches.
+RUN NIXL_DIR=$(python3 -c "import sysconfig, glob, os; \
+        d = sysconfig.get_paths()['purelib']; \
+        cands = sorted(glob.glob(os.path.join(d, '.nixl_cu*.mesonpy.libs'))); \
+        print(cands[0] if cands else '')") && \
+    test -n "$NIXL_DIR" && test -f "$NIXL_DIR/libnixl_capi.so" && \
+    echo "$NIXL_DIR" > /etc/ld.so.conf.d/nixl-upstream.conf && \
+    ldconfig && \
+    ldconfig -p | grep -q libnixl_capi.so
 
 # Runtime target installs only the prebuilt Dynamo wheels. SGLang and its NIXL
 # packages come from the upstream lmsysorg/sglang runtime image; --no-deps keeps

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -40,15 +40,8 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}
-# Native NIXL SDK + UCX from dynamo's wheel_builder. The dynamo Rust wheel is
-# built in runtime_wheel_builder without NIXL headers, so nixl-sys falls back
-# to stubs that dlopen("libnixl_capi.so") by bare name at runtime (see
-# ai-dynamo/nixl src/bindings/rust/stubs.cpp). The upstream lmsysorg/sglang
-# image ships libnixl_capi.so only under .nixl_cu*.mesonpy.libs/, a path not
-# on the dynamic linker's search list — the dlopen happens to succeed on
-# cu12.9 and fails on cu13.0. Mirror vllm_runtime / trtllm_runtime: drop our
-# own NIXL SDK onto a system path and ldconfig so dlopen resolves the same
-# way across all CUDA variants and any future upstream image change.
+# Stage NIXL SDK + UCX on the system linker path so the stub-built nixl-sys
+# can dlopen libnixl_capi.so at runtime; mirrors vllm_runtime / trtllm_runtime.
 COPY --chown=dynamo: --from=wheel_builder /usr/local/ucx /usr/local/ucx
 COPY --chown=dynamo: --from=wheel_builder /opt/nvidia/nvda_nixl /opt/nvidia/nvda_nixl
 

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -40,6 +40,30 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}
+# Native NIXL SDK + UCX from dynamo's wheel_builder. The dynamo Rust wheel is
+# built in runtime_wheel_builder without NIXL headers, so nixl-sys falls back
+# to stubs that dlopen("libnixl_capi.so") by bare name at runtime (see
+# ai-dynamo/nixl src/bindings/rust/stubs.cpp). The upstream lmsysorg/sglang
+# image ships libnixl_capi.so only under .nixl_cu*.mesonpy.libs/, a path not
+# on the dynamic linker's search list — the dlopen happens to succeed on
+# cu12.9 and fails on cu13.0. Mirror vllm_runtime / trtllm_runtime: drop our
+# own NIXL SDK onto a system path and ldconfig so dlopen resolves the same
+# way across all CUDA variants and any future upstream image change.
+COPY --chown=dynamo: --from=wheel_builder /usr/local/ucx /usr/local/ucx
+COPY --chown=dynamo: --from=wheel_builder /opt/nvidia/nvda_nixl /opt/nvidia/nvda_nixl
+
+ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
+    NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
+    NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
+
+ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:${LD_LIBRARY_PATH:-}
+
+RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
+    echo "$NIXL_PLUGIN_DIR" >> /etc/ld.so.conf.d/nixl.conf && \
+    echo "/usr/local/ucx/lib" > /etc/ld.so.conf.d/ucx.conf && \
+    echo "/usr/local/ucx/lib/ucx" >> /etc/ld.so.conf.d/ucx.conf && \
+    ldconfig
+
 # Runtime target installs only the prebuilt Dynamo wheels. SGLang and its NIXL
 # packages come from the upstream lmsysorg/sglang runtime image; --no-deps keeps
 # pip from replacing that stack. Dev/local-dev build from source later in the

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -394,6 +394,9 @@ sglang_configs = {
             # TODO: bisect via tests/utils/profile_pytest.py for a tighter bound.
             pytest.mark.requested_sglang_kv_tokens(4096),
             pytest.mark.timeout(300),
+            # TEMPORARY pre_merge to validate the sglang cu13.0 NIXL fix in
+            # this PR; revert to post_merge-only before merge. See PR #9892.
+            pytest.mark.pre_merge,
             # post_merge: NIXL stubs outside docker can lack the Decoded
             # transport path. Same gating as vLLM's FD case
             # (tests/serve/multimodal_profiles/vllm.py:67-70).


### PR DESCRIPTION
## Summary

- The sglang cu13.0 amd64 post-merge job fails on `tests/serve/test_sglang.py::test_sglang_deployment[multimodal_agg_fd_qwen-2]` with `OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode`. Triage: https://github.com/ai-dynamo/dynamo/actions/runs/26292249289/job/77395986533
- Root cause: the dynamo Rust wheel is built in `runtime_wheel_builder` (no NIXL), so `nixl-sys` falls back to stubs that dlopen `libnixl_capi.so` by bare name. Upstream `lmsysorg/sglang` installs that lib only under `.nixl_cu*.mesonpy.libs/` — a path no dynamic linker searches. The dlopen happens to succeed on `v0.5.10.post1-runtime` (cu12.9) and fails on `v0.5.10.post1-cu130-runtime`.
- Fix: COPY `/opt/nvidia/nvda_nixl` and `/usr/local/ucx` from `wheel_builder` into the sglang runtime image, set `LD_LIBRARY_PATH`, and `ldconfig`. This mirrors what `vllm_runtime` / `trtllm_runtime` already do — the sglang runtime template was the outlier trusting upstream to put the lib in a discoverable spot.

## Test plan

- [ ] CI: `sglang-runtime / Test cuda13.0, amd64` (Post-Merge CI Pipeline) — `multimodal_agg_fd_qwen-2` passes; previously hit 300s pytest-timeout
- [ ] CI: `sglang-runtime / Test cuda12.9, amd64` — no regression (the prior incidental dlopen success path is replaced with an explicit one)
- [ ] CI: arm64 variants of both cuda versions — no regression
- [ ] Local: `python container/render.py --target=runtime --framework=sglang --platform=amd64 --cuda-version=13.0` produces a Dockerfile containing the NIXL COPY + ldconfig block
- [ ] Manual: build the cu13.0 image, exec into it, confirm `ldconfig -p | grep libnixl_capi.so` lists `/opt/nvidia/nvda_nixl/lib64/libnixl_capi.so`

## Follow-up (not in this PR)

The underlying fragility — `runtime_wheel_builder` building `nixl-sys` in stub mode and relying on runtime dlopen — affects vllm and trtllm too; they just happen to copy NIXL into their runtime images. A future refactor could restructure `runtime_wheel_builder` to have NIXL at build time so nixl-sys links the real library directly. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime container build to conditionally integrate native SDK and library dependencies, ensuring optimal hardware compatibility across different deployment targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->