### PR TITLE
fix(http): filter empty Text/Parts chat stream chunks

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1156,6 +1156,7 @@ fn is_empty_stream_response(resp: &NvCreateChatCompletionStreamResponse) -> bool
                 Some(ChatCompletionMessageContent::Parts(p)) => p.is_empty(),
             };
             c.finish_reason.is_none()
+                && c.logprobs.is_none()
                 && content_empty
                 && function_call.is_none()
                 && tool_calls.is_none()
@@ -4615,8 +4616,8 @@ mod tests {
     #[test]
     fn test_chat_predicate_filters_text_empty_string() {
         use dynamo_protocols::types::{
-            ChatCompletionMessageContent, ChatCompletionResponseContentPart,
-            ChatCompletionResponseContentPartText,
+            ChatChoiceLogprobs, ChatCompletionMessageContent, ChatCompletionResponseContentPart,
+            ChatCompletionResponseContentPartText, ChatCompletionTokenLogprob,
         };
 
         // `Text("")` arises during multi-byte UTF-8 token assembly and must be
@@ -4629,8 +4630,7 @@ mod tests {
 
         // Structurally empty multimodal `Parts(vec![])` is also empty.
         let mut resp = make_delta(None, None, None, None, None, None, None, None);
-        resp.inner.choices[0].delta.content =
-            Some(ChatCompletionMessageContent::Parts(Vec::new()));
+        resp.inner.choices[0].delta.content = Some(ChatCompletionMessageContent::Parts(Vec::new()));
         assert!(
             is_empty_stream_response(&resp),
             "Parts(vec![]) delta should be filtered as empty",
@@ -4662,6 +4662,23 @@ mod tests {
         assert!(
             !is_empty_stream_response(&resp),
             "Text(\"\") + finish_reason must not be filtered",
+        );
+
+        // Per-token logprobs can arrive while content is still `Text("")` during
+        // multi-byte assembly; that payload is meaningful and must survive.
+        let mut resp = make_delta(Some(""), None, None, None, None, None, None, None);
+        resp.inner.choices[0].logprobs = Some(ChatChoiceLogprobs {
+            content: Some(vec![ChatCompletionTokenLogprob {
+                token: "h".to_string(),
+                logprob: -0.5,
+                bytes: Some(vec![104]),
+                top_logprobs: vec![],
+            }]),
+            refusal: None,
+        });
+        assert!(
+            !is_empty_stream_response(&resp),
+            "Text(\"\") + logprobs must not be filtered",
         );
     }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -60,6 +60,7 @@ use crate::protocols::openai::{
 use crate::protocols::unified::UnifiedRequest;
 use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
+use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
 use dynamo_runtime::logging::get_distributed_tracing_context;
@@ -1132,7 +1133,7 @@ fn make_dispatch_event(
 }
 
 /// Empty stream chunk produced by multi-byte token assembly (e.g. emoji).
-/// `role` is excluded — backends set it on every delta.
+/// `role` is excluded; backends set it on every delta.
 fn is_empty_stream_response(resp: &NvCreateChatCompletionStreamResponse) -> bool {
     if resp.nvext.is_some() {
         return false;
@@ -1147,8 +1148,15 @@ fn is_empty_stream_response(resp: &NvCreateChatCompletionStreamResponse) -> bool
                 refusal,
                 reasoning_content,
             } = &c.delta;
+            // `Text("")` happens during multi-byte UTF-8 token assembly;
+            // `Parts(vec![])` is a structurally empty multimodal payload.
+            let content_empty = match content {
+                None => true,
+                Some(ChatCompletionMessageContent::Text(t)) => t.is_empty(),
+                Some(ChatCompletionMessageContent::Parts(p)) => p.is_empty(),
+            };
             c.finish_reason.is_none()
-                && content.is_none()
+                && content_empty
                 && function_call.is_none()
                 && tool_calls.is_none()
                 && refusal.is_none()
@@ -4601,6 +4609,59 @@ mod tests {
                 }),
             )),
             "function_call present → not empty",
+        );
+    }
+
+    #[test]
+    fn test_chat_predicate_filters_text_empty_string() {
+        use dynamo_protocols::types::{
+            ChatCompletionMessageContent, ChatCompletionResponseContentPart,
+            ChatCompletionResponseContentPartText,
+        };
+
+        // `Text("")` arises during multi-byte UTF-8 token assembly and must be
+        // filtered, matching `is_empty_completion_stream_response`'s `""` case.
+        let resp = make_delta(Some(""), None, None, None, None, None, None, None);
+        assert!(
+            is_empty_stream_response(&resp),
+            "Text(\"\") delta should be filtered as empty",
+        );
+
+        // Structurally empty multimodal `Parts(vec![])` is also empty.
+        let mut resp = make_delta(None, None, None, None, None, None, None, None);
+        resp.inner.choices[0].delta.content =
+            Some(ChatCompletionMessageContent::Parts(Vec::new()));
+        assert!(
+            is_empty_stream_response(&resp),
+            "Parts(vec![]) delta should be filtered as empty",
+        );
+
+        // Non-empty multimodal Parts must be preserved.
+        let mut resp = make_delta(None, None, None, None, None, None, None, None);
+        resp.inner.choices[0].delta.content = Some(ChatCompletionMessageContent::Parts(vec![
+            ChatCompletionResponseContentPart::Text(ChatCompletionResponseContentPartText {
+                text: "hi".to_string(),
+            }),
+        ]));
+        assert!(
+            !is_empty_stream_response(&resp),
+            "Parts with content must not be filtered",
+        );
+
+        // Empty content alongside a semantic field (finish_reason) must survive.
+        let resp = make_delta(
+            Some(""),
+            None,
+            None,
+            Some(FinishReason::Stop),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(
+            !is_empty_stream_response(&resp),
+            "Text(\"\") + finish_reason must not be filtered",
         );
     }
 


### PR DESCRIPTION
#### Overview:

`is_empty_stream_response` in `lib/llm/src/http/service/openai.rs` treats a chat-stream delta as empty only when `delta.content.is_none()`, so backends that emit `Some(ChatCompletionMessageContent::Text(String::new()))` while waiting for a multi-byte UTF-8 codepoint slip through and ship to clients as `{"delta":{"content":""}}`. The completions predicate already filters empty `""` on its side; this PR brings the chat path in line.

#### Details:

- Replace the `content.is_none()` check inside `is_empty_stream_response` with a local match that treats `None`, `Text("")`, and structurally empty `Parts(vec![])` all as empty.
- Add a focused test `test_chat_predicate_filters_text_empty_string` covering:
  - `Text("")` is filtered
  - `Parts(vec![])` is filtered
  - `Parts([Text("hi")])` is preserved
  - `Text("") + finish_reason::Stop` is preserved (semantic-field survival)
- Fix an em-dash in the predicate's existing doc comment while in the area.

A follow-up audit of `is_empty_stream_response` semantic-field coverage vs the completions predicate (e.g. `logprobs`) is planned separately - kept out of this PR to keep the diff scoped to the reported symptom.

#### Where should the reviewer start?

- `lib/llm/src/http/service/openai.rs` `is_empty_stream_response` (around line 1135) for the predicate change.
- The new test in the same file for the cases that fail without the fix.

#### Related Issues:

- Resolves Linear [DIS-2108](https://linear.app/nvidia/issue/DIS-2108/chat-stream-empty-response-filter-misses-empty-text-content)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced streaming response handling for chat completions to properly filter empty text chunks and empty multimodal structures that appear during token assembly.
  * Added comprehensive test coverage for empty response detection edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->