### PR TITLE
fix(parser): handle gpt-oss bare harmony stream markers

### DIFF
--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1919,6 +1919,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_jailed_stream_harmony_bare_commentary_marker_split() {
+        // PARSER.stream.3: gpt-oss may start a tool call directly at the
+        // commentary channel marker, and the marker can split across chunks.
+        let chunks = vec![
+            create_mock_response_chunk("<|".to_string(), 0),
+            create_mock_response_chunk("cha".to_string(), 0),
+            create_mock_response_chunk("nnel|".to_string(), 0),
+            create_mock_response_chunk(">commentary".to_string(), 0),
+            create_mock_response_chunk(" to=functions.get_w".to_string(), 0),
+            create_mock_response_chunk("ea".to_string(), 0),
+            create_mock_response_chunk("the".to_string(), 0),
+            create_mock_response_chunk("r <|c".to_string(), 0),
+            create_mock_response_chunk("onstrain|>j".to_string(), 0),
+            create_mock_response_chunk("son<|message|>{\"loc".to_string(), 0),
+            create_mock_response_chunk("at".to_string(), 0),
+            create_mock_response_chunk("ion".to_string(), 0),
+            create_mock_response_chunk("\":\"NY".to_string(), 0),
+            create_mock_response_chunk("C\"}<|call|>".to_string(), 0),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let jail = JailedStream::builder().tool_call_parser("harmony").build();
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, "");
+        assert!(!content.contains("<|channel|>"));
+        let tool_call_idx = results
+            .iter()
+            .position(test_utils::has_tool_call)
+            .expect("Should have a tool call result");
+        test_utils::assert_tool_call(
+            &results[tool_call_idx],
+            "get_weather",
+            json!({"location": "NYC"}),
+        );
+    }
+
+    #[tokio::test]
     async fn test_jailed_stream_harmony_analysis_only_drops_content() {
         let chunks = vec![create_mock_response_chunk(
             "<|channel|>analysis<|message|>Need to inspect the request.<|end|>".to_string(),

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -391,7 +391,10 @@ impl ToolCallConfig {
     pub fn harmony() -> Self {
         Self {
             parser_config: ParserConfig::Harmony(JsonParserConfig {
-                tool_call_start_tokens: vec!["<|start|>assistant<|channel|>commentary".to_string()],
+                tool_call_start_tokens: vec![
+                    "<|start|>assistant<|channel|>commentary".to_string(),
+                    "<|channel|>commentary".to_string(),
+                ],
                 tool_call_end_tokens: vec!["<|call|>".to_string()],
                 ..Default::default()
             }),

--- a/tests/parity/parser/fixtures/harmony/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.stream.2.yaml
@@ -67,5 +67,6 @@ cases:
           arguments:
             location: NYC
         normal_text: rt|>assistant<|channel|>commentary to=functions.get_time <|constrain|>js
+        reason: SGLang emits only the first split Harmony call and leaks the second call envelope into normal_text; Dynamo parses both complete `<|call|>`-terminated calls.
       vllm:
         unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks

--- a/tests/parity/parser/fixtures/harmony/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.stream.3.yaml
@@ -34,10 +34,14 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
-        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>j
+        reason: SGLang leaks a split Harmony commentary block into normal_text; Dynamo buffers the split marker and parses the complete `<|call|>`-terminated call.
       vllm:
         unavailable: vLLM streaming parser for family='harmony' requires `delta_token_ids` in fixture chunks


### PR DESCRIPTION
#### Overview:

This PR updates gpt-oss `PARSER.stream.*` parity expectations and fixes Dynamo’s Harmony streaming detection for tool calls that start directly at the commentary channel marker.

For `PARSER.stream.3`, Dynamo previously leaked the complete Harmony tool-call envelope into `normal_text` because the streaming jail only detected `<|start|>assistant<|channel|>commentary` as a Harmony tool-call start. The fixture starts directly with a split `<|channel|>commentary` marker, which is valid Harmony output for gpt-oss.

Dynamo output before:

```text
normal_text='<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>'
calls=[]
```

Dynamo output after:

```text
normal_text=''
calls=[get_weather({"location": "NYC"})]
```

For `PARSER.stream.2`, Dynamo was already correct, so this PR only documents the SGLang divergence: SGLang emits only the first split Harmony call and leaks the second call envelope into `normal_text`.

For both cases, we comply with the alignment rubric from PR #9583: Harmony protocol/tool-call markup must not reach user-visible `normal_text`, and complete `<|call|>`-terminated calls should be surfaced as structured tool calls.

Spec reference:
https://cookbook.openai.com/articles/openai-harmony/

#### Details:

- Add bare `<|channel|>commentary` as a Harmony streaming tool-call start marker.
- Update `PARSER.stream.3` expected Dynamo output to parse the complete split Harmony call.
- Add documented SGLang divergence reasons for `PARSER.stream.2` and `PARSER.stream.3`.
- Add a regression test for split bare Harmony commentary markers.

#### Where should the reviewer start?

- `lib/parsers/src/tool_calling/config.rs`
- `lib/llm/tests/test_jail.rs`
- `tests/parity/parser/fixtures/harmony/PARSER.stream.*.yaml`

#### Related Issues:

- PR #9583 for alignment rubric


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Harmony tool-call parsing when markers span multiple streamed chunks.
  * Updated test fixtures to reflect parsing behavior across different backends when tool-call markers are split across streaming boundaries.

* **Refactor**
  * Enhanced Harmony tool-call configuration to recognize multiple marker variants in streaming scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->