### PR TITLE
test: add --json-out for structured data reporting

### DIFF
--- a/tests/utils/profile_pytest.py
+++ b/tests/utils/profile_pytest.py
@@ -46,6 +46,8 @@ Single-pass profiling (no binary search, just measure one run using default RAM)
 The report is written to stdout after the test finishes.
 The raw CSV samples are saved to ``--csv`` if specified.
 Use ``--no-recommend`` to suppress the marker recommendation section.
+Use ``--json-out PATH`` to emit a structured JSON summary (schema_version=1)
+for automation (see ``_write_json_payload`` for the schema).
 """
 
 import argparse
@@ -829,6 +831,70 @@ def _run_once(
     return rc, wall_secs, reports, sampler.samples, captured_stdout
 
 
+def _detect_framework(pytest_args: list[str]) -> str:
+    """Best-effort framework detection for the structured JSON output."""
+    if _is_sglang_test(pytest_args):
+        return "sglang"
+    if _is_trtllm_test(pytest_args):
+        return "trtllm"
+    return "vllm"
+
+
+def _extract_pytest_nodeid(pytest_args: list[str]) -> str:
+    """First positional arg (typically the pytest nodeid)."""
+    for a in pytest_args:
+        if not a.startswith("-"):
+            return a
+    return ""
+
+
+def _write_json_payload(
+    path: str,
+    *,
+    nodeid: str,
+    status: str,
+    framework: str,
+    wall_secs: float | None = None,
+    num_runs: int = 0,
+    model: str | None = None,
+    recommendations: "list[MarkerRecommendation] | None" = None,
+    warnings: list[str] | None = None,
+    gpu_reports: "list[GpuReport] | None" = None,
+    error: str | None = None,
+) -> None:
+    """Emit a structured JSON summary of this profile run.
+
+    Consumed by the dynamo-profiler bot. Bump ``schema_version`` on any
+    breaking change to the contract.
+    """
+    payload: dict = {
+        "schema_version": 1,
+        "nodeid": nodeid,
+        "status": status,
+        "framework": framework,
+        "wall_secs": wall_secs,
+        "num_runs": num_runs,
+        "model": model,
+        "recommendations": [
+            {"marker": r.marker, "reason": r.reason} for r in (recommendations or [])
+        ],
+        "warnings": list(warnings or []),
+        "gpu_reports": [
+            {
+                "gpu_idx": r.gpu_idx,
+                "peak_mib": r.peak_mib,
+                "baseline_mib": r.baseline_mib,
+                "leaked_mib": r.leaked_mib,
+            }
+            for r in (gpu_reports or [])
+        ],
+    }
+    if error:
+        payload["error"] = error
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2)
+
+
 def _find_min_vram(
     pytest_args: list[str],
     interval: float = 0.1,
@@ -838,6 +904,7 @@ def _find_min_vram(
     csv_path: str | None = None,
     kv_bytes_mode: bool = False,
     gpu_indices: list[int] | None = None,
+    json_out: str | None = None,
 ) -> int:
     """Binary search to find the minimum VRAM a test needs.
 
@@ -1009,6 +1076,16 @@ def _find_min_vram(
             else "test broken (not OOM)"
         )
         print(f"  [FAIL] Cannot determine minimum KV cache: {reason}.")
+        if json_out:
+            _write_json_payload(
+                json_out,
+                nodeid=_extract_pytest_nodeid(pytest_args),
+                status="failed",
+                framework=_detect_framework(pytest_args),
+                model=model_name,
+                gpu_reports=reports,
+                error=f"validation run failed: {reason}",
+            )
         return rc
 
     peak_mib = max((r.peak_mib for r in reports), default=0)
@@ -1334,8 +1411,12 @@ def _find_min_vram(
     requested_trtllm_kv_tokens = safe_tokens if is_trtllm else None
     requested_vllm_kv_cache_bytes = safe_kv_bytes if kv_bytes_mode else None
     min_kv_value = int(last_pass_value)
+    recs: list[MarkerRecommendation] = []
+    warnings: list[str] = []
+    avg_pass_wall = (
+        sum(pass_wall_times) / len(pass_wall_times) if pass_wall_times else 0.0
+    )
     if recommend:
-        avg_pass_wall = sum(pass_wall_times) / len(pass_wall_times)
         recs, warnings = _recommend_markers(
             last_pass_reports,
             avg_pass_wall,
@@ -1351,6 +1432,20 @@ def _find_min_vram(
     if csv_path and last_pass_samples:
         _write_csv(last_pass_samples, csv_path)
         print(f"Raw samples (last passing run) written to {csv_path}")
+
+    if json_out:
+        _write_json_payload(
+            json_out,
+            nodeid=_extract_pytest_nodeid(pytest_args),
+            status="ok",
+            framework=_detect_framework(pytest_args),
+            wall_secs=avg_pass_wall,
+            num_runs=len(pass_wall_times),
+            model=model_name,
+            recommendations=recs,
+            warnings=warnings,
+            gpu_reports=last_pass_reports,
+        )
 
     return 0
 
@@ -1421,6 +1516,14 @@ def main(argv: list[str] | None = None) -> int:
         "tests where the launch script pins workers to separate GPUs, pass all "
         "indices (e.g. --gpus 0,1) so the subprocess can see them.",
     )
+    parser.add_argument(
+        "--json-out",
+        metavar="PATH",
+        default=None,
+        help="Write a structured JSON summary (schema_version=1) of the profile "
+        "result and marker recommendations to PATH. Intended for automation "
+        "(e.g. the dynamo-profiler bot).",
+    )
 
     raw = argv if argv is not None else sys.argv[1:]
 
@@ -1477,6 +1580,7 @@ def main(argv: list[str] | None = None) -> int:
             csv_path=args.csv,
             kv_bytes_mode=args.kv_bytes,
             gpu_indices=gpu_indices,
+            json_out=args.json_out,
         )
 
     model_name = _extract_model_from_markers(pytest_args)
@@ -1494,6 +1598,8 @@ def main(argv: list[str] | None = None) -> int:
 
     _print_report(reports, rc, wall_secs, model_name=model_name)
 
+    recs: list[MarkerRecommendation] = []
+    warnings: list[str] = []
     if not args.no_recommend and reports:
         requested_sglang_kv_tokens = None
         requested_trtllm_kv_tokens = None
@@ -1514,7 +1620,47 @@ def main(argv: list[str] | None = None) -> int:
         _write_csv(samples, args.csv)
         print(f"Raw samples written to {args.csv}")
 
+    if args.json_out:
+        _write_json_payload(
+            args.json_out,
+            nodeid=_extract_pytest_nodeid(pytest_args),
+            status="ok" if rc == 0 else "failed",
+            framework=_detect_framework(pytest_args),
+            wall_secs=wall_secs,
+            num_runs=1,
+            model=model_name,
+            recommendations=recs,
+            warnings=warnings,
+            gpu_reports=reports,
+            error=None if rc == 0 else f"pytest exit code {rc}",
+        )
+
     return rc
+
+
+def _emit_failure_json_on_crash(argv: list[str], exc: BaseException) -> None:
+    """If --json-out was given on the command line, ensure a failed payload
+    is written even when main() raises (NVML errors, validation errors, etc.).
+    The bot relies on every dispatched run producing exactly one JSON file.
+    """
+    try:
+        idx = argv.index("--json-out")
+    except ValueError:
+        return
+    if idx + 1 >= len(argv):
+        return
+    json_out = argv[idx + 1]
+    pytest_args = argv[idx + 2 :]
+    try:
+        _write_json_payload(
+            json_out,
+            nodeid=_extract_pytest_nodeid(pytest_args),
+            status="failed",
+            framework=_detect_framework(pytest_args),
+            error=f"{type(exc).__name__}: {exc}",
+        )
+    except Exception:  # noqa: BLE001 — last-ditch crash handler
+        pass
 
 
 if __name__ == "__main__":
@@ -1525,4 +1671,10 @@ if __name__ == "__main__":
     ):
         print("ERROR: profile_pytest.py must not run in CI.", file=sys.stderr)
         raise SystemExit(1)
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except BaseException as _exc:  # noqa: BLE001 — propagate after recording
+        _emit_failure_json_on_crash(sys.argv[1:], _exc)
+        raise

--- a/tests/utils/profile_pytest.py
+++ b/tests/utils/profile_pytest.py
@@ -671,6 +671,7 @@ def _print_recommendations(
 
 _SGLANG_NODEID_MARKERS = ["test_sglang", "sglang"]
 _TRTLLM_NODEID_MARKERS = ["test_trtllm", "trtllm"]
+_VLLM_NODEID_MARKERS = ["test_vllm", "vllm"]
 
 
 def _is_sglang_test(pytest_args: list[str]) -> bool:
@@ -685,6 +686,11 @@ def _is_trtllm_test(pytest_args: list[str]) -> bool:
     return any(
         marker in arg for arg in pytest_args for marker in _TRTLLM_NODEID_MARKERS
     )
+
+
+def _is_vllm_test(pytest_args: list[str]) -> bool:
+    """Check if any pytest arg looks like a vLLM test node ID."""
+    return any(marker in arg for arg in pytest_args for marker in _VLLM_NODEID_MARKERS)
 
 
 _OOM_PATTERNS = [
@@ -831,19 +837,32 @@ def _run_once(
     return rc, wall_secs, reports, sampler.samples, captured_stdout
 
 
-def _detect_framework(pytest_args: list[str]) -> str:
-    """Best-effort framework detection for the structured JSON output."""
+def _detect_framework(pytest_args: list[str]) -> str | None:
+    """Classify the test by inference framework for the JSON output.
+
+    Each backend has its own positive check. Returns ``None`` when no
+    framework can be identified, so automation can skip tests it cannot
+    classify rather than silently assuming a default.
+    """
     if _is_sglang_test(pytest_args):
         return "sglang"
     if _is_trtllm_test(pytest_args):
         return "trtllm"
-    return "vllm"
+    if _is_vllm_test(pytest_args):
+        return "vllm"
+    return None
 
 
 def _extract_pytest_nodeid(pytest_args: list[str]) -> str:
-    """First positional arg (typically the pytest nodeid)."""
+    """Return the first arg that looks like a pytest nodeid.
+
+    A nodeid contains ``::`` (file::test selector) or ends with ``.py``
+    (a whole-file selection). This skips option values like ``-k expr``
+    where ``expr`` is positional from argparse's perspective but is not a
+    test path.
+    """
     for a in pytest_args:
-        if not a.startswith("-"):
+        if "::" in a or a.endswith(".py"):
             return a
     return ""
 
@@ -853,8 +872,7 @@ def _write_json_payload(
     *,
     nodeid: str,
     status: str,
-    framework: str,
-    wall_secs: float | None = None,
+    framework: str | None,
     num_runs: int = 0,
     model: str | None = None,
     recommendations: "list[MarkerRecommendation] | None" = None,
@@ -865,14 +883,15 @@ def _write_json_payload(
     """Emit a structured JSON summary of this profile run.
 
     Consumed by the dynamo-profiler bot. Bump ``schema_version`` on any
-    breaking change to the contract.
+    breaking change to the contract. Wall-time decisions (e.g. e2e vs
+    pre_merge) are already captured by the marker recommendations'
+    ``reason`` field, so the raw wall time is not surfaced separately.
     """
     payload: dict = {
         "schema_version": 1,
         "nodeid": nodeid,
         "status": status,
         "framework": framework,
-        "wall_secs": wall_secs,
         "num_runs": num_runs,
         "model": model,
         "recommendations": [
@@ -893,6 +912,33 @@ def _write_json_payload(
         payload["error"] = error
     with open(path, "w") as f:
         json.dump(payload, f, indent=2)
+
+
+def _maybe_emit_failed_json(
+    json_out: str | None,
+    *,
+    pytest_args: list[str],
+    model_name: str | None = None,
+    gpu_reports: "list[GpuReport] | None" = None,
+    error: str,
+) -> None:
+    """Emit a ``status='failed'`` JSON payload if ``--json-out`` was requested.
+
+    Centralises the ``framework=`` / ``nodeid=`` extraction so every early
+    failure path inside ``_find_min_vram`` produces a payload with the same
+    fields. No-op when ``json_out`` is None.
+    """
+    if not json_out:
+        return
+    _write_json_payload(
+        json_out,
+        nodeid=_extract_pytest_nodeid(pytest_args),
+        status="failed",
+        framework=_detect_framework(pytest_args),
+        model=model_name,
+        gpu_reports=gpu_reports,
+        error=error,
+    )
 
 
 def _find_min_vram(
@@ -1076,16 +1122,13 @@ def _find_min_vram(
             else "test broken (not OOM)"
         )
         print(f"  [FAIL] Cannot determine minimum KV cache: {reason}.")
-        if json_out:
-            _write_json_payload(
-                json_out,
-                nodeid=_extract_pytest_nodeid(pytest_args),
-                status="failed",
-                framework=_detect_framework(pytest_args),
-                model=model_name,
-                gpu_reports=reports,
-                error=f"validation run failed: {reason}",
-            )
+        _maybe_emit_failed_json(
+            json_out,
+            pytest_args=pytest_args,
+            model_name=model_name,
+            gpu_reports=reports,
+            error=f"validation run failed: {reason}",
+        )
         return rc
 
     peak_mib = max((r.peak_mib for r in reports), default=0)
@@ -1109,6 +1152,13 @@ def _find_min_vram(
                     "  [ERROR] Could not extract max_tokens from TensorRT-LLM output.\n"
                     "  The launch script must log '[MemUsageChange] Allocated ... for max tokens in paged KV cache (N)'."
                 )
+                _maybe_emit_failed_json(
+                    json_out,
+                    pytest_args=pytest_args,
+                    model_name=model_name,
+                    gpu_reports=reports,
+                    error="could not extract max_tokens from TensorRT-LLM output",
+                )
                 return 4
             backend_label = "TensorRT-LLM"
         else:
@@ -1117,6 +1167,13 @@ def _find_min_vram(
                 print(
                     "  [ERROR] Could not extract max_total_tokens from SGLang output.\n"
                     "  The launch script must log 'max_total_tokens=N' (SGLang does this by default)."
+                )
+                _maybe_emit_failed_json(
+                    json_out,
+                    pytest_args=pytest_args,
+                    model_name=model_name,
+                    gpu_reports=reports,
+                    error="could not extract max_total_tokens from SGLang output",
                 )
                 return 4
             backend_label = "SGLang"
@@ -1274,6 +1331,11 @@ def _find_min_vram(
                 break
 
     # -- Results --
+    # Track whether the final safe-KV validation probe passed. If it fails,
+    # the recommended `requested_*` marker is for a configuration that was
+    # just observed not to work, so we report status="failed" rather than
+    # let automation accept the unvalidated recommendation.
+    final_probe_failed = False
     test_name = next(
         (a for a in pytest_args if "::" in a or a.endswith(".py")),
         " ".join(pytest_args),
@@ -1319,6 +1381,7 @@ def _find_min_vram(
                 f"peak {_format_mib(last_pass_peak_mib)}, wall {wall_final:.0f}s"
             )
         else:
+            final_probe_failed = True
             print(
                 f"  [FAIL] kv_cache={safe_kv_mib} MiB failed unexpectedly, "
                 f"using VRAM from min_kv_bytes={min_kv_mib} MiB instead"
@@ -1387,6 +1450,7 @@ def _find_min_vram(
                 f"wall {wall_final:.0f}s"
             )
         else:
+            final_probe_failed = True
             print(
                 f"  [FAIL] tokens={safe_tokens} failed unexpectedly, "
                 f"using VRAM from min_tokens={min_tokens} instead"
@@ -1437,24 +1501,28 @@ def _find_min_vram(
         _write_json_payload(
             json_out,
             nodeid=_extract_pytest_nodeid(pytest_args),
-            status="ok",
+            status="failed" if final_probe_failed else "ok",
             framework=_detect_framework(pytest_args),
-            wall_secs=avg_pass_wall,
             num_runs=len(pass_wall_times),
             model=model_name,
             recommendations=recs,
             warnings=warnings,
             gpu_reports=last_pass_reports,
+            error=(
+                "final safe-KV validation probe failed; the recommended "
+                "`requested_*` marker is for a configuration that was just "
+                "observed not to run"
+                if final_probe_failed
+                else None
+            ),
         )
 
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(levelname)s: %(message)s",
-    )
+def _build_argparser() -> argparse.ArgumentParser:
+    """Construct the CLI parser. Factored out so the top-level crash handler
+    can reuse the exact same option definitions to split argv on failure."""
     parser = argparse.ArgumentParser(
         description="Profile GPU memory during a pytest run.",
         usage="%(prog)s [options] [-- ] pytest-args...",
@@ -1524,15 +1592,32 @@ def main(argv: list[str] | None = None) -> int:
         "result and marker recommendations to PATH. Intended for automation "
         "(e.g. the dynamo-profiler bot).",
     )
+    return parser
 
-    raw = argv if argv is not None else sys.argv[1:]
 
-    if "--" in raw:
-        split_idx = raw.index("--")
-        args = parser.parse_args(raw[:split_idx])
-        pytest_args = raw[split_idx + 1 :]
+def _split_argv(
+    parser: argparse.ArgumentParser, argv: list[str]
+) -> tuple[argparse.Namespace, list[str]]:
+    """Apply the same ``--``-aware splitting both ``main()`` and the crash
+    handler use, so option values like ``-k expr`` are never misread as
+    pytest nodeids."""
+    if "--" in argv:
+        split_idx = argv.index("--")
+        args = parser.parse_args(argv[:split_idx])
+        pytest_args = argv[split_idx + 1 :]
     else:
-        args, pytest_args = parser.parse_known_args(raw)
+        args, pytest_args = parser.parse_known_args(argv)
+    return args, pytest_args
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+    parser = _build_argparser()
+    raw = argv if argv is not None else sys.argv[1:]
+    args, pytest_args = _split_argv(parser, raw)
 
     if not pytest_args:
         parser.error("No pytest arguments provided")
@@ -1626,7 +1711,6 @@ def main(argv: list[str] | None = None) -> int:
             nodeid=_extract_pytest_nodeid(pytest_args),
             status="ok" if rc == 0 else "failed",
             framework=_detect_framework(pytest_args),
-            wall_secs=wall_secs,
             num_runs=1,
             model=model_name,
             recommendations=recs,
@@ -1638,19 +1722,39 @@ def main(argv: list[str] | None = None) -> int:
     return rc
 
 
+def _find_json_out_in_raw_argv(argv: list[str]) -> str | None:
+    """Last-resort scan that handles both ``--json-out PATH`` and
+    ``--json-out=PATH`` and is robust to argparse already having failed."""
+    for i, token in enumerate(argv):
+        if token == "--json-out" and i + 1 < len(argv):
+            return argv[i + 1]
+        if token.startswith("--json-out="):
+            return token.split("=", 1)[1]
+    return None
+
+
 def _emit_failure_json_on_crash(argv: list[str], exc: BaseException) -> None:
     """If --json-out was given on the command line, ensure a failed payload
-    is written even when main() raises (NVML errors, validation errors, etc.).
-    The bot relies on every dispatched run producing exactly one JSON file.
+    is written even when main() raises (NVML errors, validation errors,
+    nonzero argparse SystemExit, etc.). The bot relies on every dispatched
+    run producing exactly one JSON file.
+
+    Reuses the real argparse setup so profiler options (``--gpus 0``,
+    ``-k expr``) never get misread as pytest nodeids.
     """
+    json_out = _find_json_out_in_raw_argv(argv)
+    if json_out is None:
+        return
+
+    # Best-effort: use the real parser to recover pytest_args. If parsing
+    # itself blew up (e.g. unknown option), fall through with an empty list
+    # so we still emit *something*.
+    pytest_args: list[str] = []
     try:
-        idx = argv.index("--json-out")
-    except ValueError:
-        return
-    if idx + 1 >= len(argv):
-        return
-    json_out = argv[idx + 1]
-    pytest_args = argv[idx + 2 :]
+        _args, pytest_args = _split_argv(_build_argparser(), argv)
+    except SystemExit:
+        pass
+
     try:
         _write_json_payload(
             json_out,
@@ -1660,7 +1764,7 @@ def _emit_failure_json_on_crash(argv: list[str], exc: BaseException) -> None:
             error=f"{type(exc).__name__}: {exc}",
         )
     except Exception:  # noqa: BLE001 — last-ditch crash handler
-        pass
+        logger.exception("failed to emit crash JSON to %s", json_out)
 
 
 if __name__ == "__main__":
@@ -1672,9 +1776,16 @@ if __name__ == "__main__":
         print("ERROR: profile_pytest.py must not run in CI.", file=sys.stderr)
         raise SystemExit(1)
     try:
-        raise SystemExit(main())
-    except SystemExit:
+        exit_code = main()
+    except SystemExit as _exc:
+        # argparse and other callers raise SystemExit. Only treat nonzero
+        # exits as crashes worth recording — successful returns from main()
+        # already wrote their own JSON.
+        code = _exc.code
+        if isinstance(code, int) and code != 0:
+            _emit_failure_json_on_crash(sys.argv[1:], _exc)
         raise
     except BaseException as _exc:  # noqa: BLE001 — propagate after recording
         _emit_failure_json_on_crash(sys.argv[1:], _exc)
         raise
+    raise SystemExit(exit_code)

--- a/tests/utils/profile_pytest.py
+++ b/tests/utils/profile_pytest.py
@@ -47,7 +47,9 @@ The report is written to stdout after the test finishes.
 The raw CSV samples are saved to ``--csv`` if specified.
 Use ``--no-recommend`` to suppress the marker recommendation section.
 Use ``--json-out PATH`` to emit a structured JSON summary (schema_version=1)
-for automation (see ``_write_json_payload`` for the schema).
+for automation (see ``_write_json_payload`` for the schema). When invoking
+from automation, also pass ``--pytest-nodeid NODEID`` so the JSON's
+``nodeid`` field never depends on heuristic extraction from pytest args.
 """
 
 import argparse
@@ -854,17 +856,33 @@ def _detect_framework(pytest_args: list[str]) -> str | None:
 
 
 def _extract_pytest_nodeid(pytest_args: list[str]) -> str:
-    """Return the first arg that looks like a pytest nodeid.
+    """Best-effort: return the first arg that looks like a pytest nodeid.
 
     A nodeid contains ``::`` (file::test selector) or ends with ``.py``
     (a whole-file selection). This skips option values like ``-k expr``
     where ``expr`` is positional from argparse's perspective but is not a
     test path.
+
+    Only used when ``--pytest-nodeid`` is not set (manual invocations).
+    Automation should set ``--pytest-nodeid`` explicitly; see
+    ``_resolve_nodeid``.
     """
     for a in pytest_args:
         if "::" in a or a.endswith(".py"):
             return a
     return ""
+
+
+def _resolve_nodeid(explicit: str | None, pytest_args: list[str]) -> str:
+    """Canonical nodeid for the JSON output.
+
+    Prefers the explicit ``--pytest-nodeid`` flag (set by automation) so
+    the JSON is authoritative; falls back to heuristic extraction for
+    interactive use.
+    """
+    if explicit:
+        return explicit
+    return _extract_pytest_nodeid(pytest_args)
 
 
 def _write_json_payload(
@@ -917,6 +935,7 @@ def _write_json_payload(
 def _maybe_emit_failed_json(
     json_out: str | None,
     *,
+    nodeid: str,
     pytest_args: list[str],
     model_name: str | None = None,
     gpu_reports: "list[GpuReport] | None" = None,
@@ -924,15 +943,18 @@ def _maybe_emit_failed_json(
 ) -> None:
     """Emit a ``status='failed'`` JSON payload if ``--json-out`` was requested.
 
-    Centralises the ``framework=`` / ``nodeid=`` extraction so every early
-    failure path inside ``_find_min_vram`` produces a payload with the same
-    fields. No-op when ``json_out`` is None.
+    The ``nodeid`` is supplied by the caller (pre-resolved via
+    ``_resolve_nodeid``) so the authoritative ``--pytest-nodeid`` value
+    is honoured everywhere. Framework is still derived from
+    ``pytest_args`` since there's no equivalent override flag.
+
+    No-op when ``json_out`` is None.
     """
     if not json_out:
         return
     _write_json_payload(
         json_out,
-        nodeid=_extract_pytest_nodeid(pytest_args),
+        nodeid=nodeid,
         status="failed",
         framework=_detect_framework(pytest_args),
         model=model_name,
@@ -951,6 +973,7 @@ def _find_min_vram(
     kv_bytes_mode: bool = False,
     gpu_indices: list[int] | None = None,
     json_out: str | None = None,
+    pytest_nodeid: str | None = None,
 ) -> int:
     """Binary search to find the minimum VRAM a test needs.
 
@@ -973,6 +996,9 @@ def _find_min_vram(
     """
     if gpu_indices is None:
         gpu_indices = [0]
+    # Resolve once. Automation passes ``--pytest-nodeid`` so the JSON
+    # output never depends on heuristic extraction from ``pytest_args``.
+    nodeid = _resolve_nodeid(pytest_nodeid, pytest_args)
     is_sglang = _is_sglang_test(pytest_args)
     is_trtllm = _is_trtllm_test(pytest_args)
 
@@ -1124,6 +1150,7 @@ def _find_min_vram(
         print(f"  [FAIL] Cannot determine minimum KV cache: {reason}.")
         _maybe_emit_failed_json(
             json_out,
+            nodeid=nodeid,
             pytest_args=pytest_args,
             model_name=model_name,
             gpu_reports=reports,
@@ -1154,6 +1181,7 @@ def _find_min_vram(
                 )
                 _maybe_emit_failed_json(
                     json_out,
+                    nodeid=nodeid,
                     pytest_args=pytest_args,
                     model_name=model_name,
                     gpu_reports=reports,
@@ -1170,6 +1198,7 @@ def _find_min_vram(
                 )
                 _maybe_emit_failed_json(
                     json_out,
+                    nodeid=nodeid,
                     pytest_args=pytest_args,
                     model_name=model_name,
                     gpu_reports=reports,
@@ -1500,7 +1529,7 @@ def _find_min_vram(
     if json_out:
         _write_json_payload(
             json_out,
-            nodeid=_extract_pytest_nodeid(pytest_args),
+            nodeid=nodeid,
             status="failed" if final_probe_failed else "ok",
             framework=_detect_framework(pytest_args),
             num_runs=len(pass_wall_times),
@@ -1592,6 +1621,15 @@ def _build_argparser() -> argparse.ArgumentParser:
         "result and marker recommendations to PATH. Intended for automation "
         "(e.g. the dynamo-profiler bot).",
     )
+    parser.add_argument(
+        "--pytest-nodeid",
+        metavar="NODEID",
+        default=None,
+        help="Authoritative nodeid recorded in the --json-out payload. "
+        "Set this when invoking from automation so the JSON's `nodeid` "
+        "field never depends on heuristic parsing of pytest args. When "
+        "omitted, falls back to a best-effort scan of pytest_args.",
+    )
     return parser
 
 
@@ -1666,6 +1704,7 @@ def main(argv: list[str] | None = None) -> int:
             kv_bytes_mode=args.kv_bytes,
             gpu_indices=gpu_indices,
             json_out=args.json_out,
+            pytest_nodeid=args.pytest_nodeid,
         )
 
     model_name = _extract_model_from_markers(pytest_args)
@@ -1708,7 +1747,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json_out:
         _write_json_payload(
             args.json_out,
-            nodeid=_extract_pytest_nodeid(pytest_args),
+            nodeid=_resolve_nodeid(args.pytest_nodeid, pytest_args),
             status="ok" if rc == 0 else "failed",
             framework=_detect_framework(pytest_args),
             num_runs=1,
@@ -1746,19 +1785,22 @@ def _emit_failure_json_on_crash(argv: list[str], exc: BaseException) -> None:
     if json_out is None:
         return
 
-    # Best-effort: use the real parser to recover pytest_args. If parsing
-    # itself blew up (e.g. unknown option), fall through with an empty list
-    # so we still emit *something*.
+    # Best-effort: use the real parser to recover pytest_args and any
+    # --pytest-nodeid override. If parsing itself blew up (e.g. unknown
+    # option), fall through with an empty list so we still emit
+    # *something*.
     pytest_args: list[str] = []
+    explicit_nodeid: str | None = None
     try:
-        _args, pytest_args = _split_argv(_build_argparser(), argv)
+        parsed, pytest_args = _split_argv(_build_argparser(), argv)
+        explicit_nodeid = getattr(parsed, "pytest_nodeid", None)
     except SystemExit:
         pass
 
     try:
         _write_json_payload(
             json_out,
-            nodeid=_extract_pytest_nodeid(pytest_args),
+            nodeid=_resolve_nodeid(explicit_nodeid, pytest_args),
             status="failed",
             framework=_detect_framework(pytest_args),
             error=f"{type(exc).__name__}: {exc}",


### PR DESCRIPTION
#### Overview:

Adds a `--json-out PATH` flag to `tests/utils/profile_pytest.py`, emitting a single JSON file (`schema_version=1`) per invocation with the recommended pytest markers and key metrics. This lets automation consume profile results without parsing stdout.

Motivation: a background bot profiles new GPU tests that lack `@pytest.mark.profiled_vram_gib(...)` and surfaces the recommended patch back to humans. The bot needs a stable, structured contract; stdout scraping would be too brittle as the human-readable report evolves.

#### Details:

- New flag `--json-out PATH` on both code paths (`_find_min_vram` binary-search mode and the single-pass mode triggered by `--no-find-min-vram`).
- New helpers near `_find_min_vram`:
  - `_detect_framework(pytest_args) -> 'vllm' | 'sglang' | 'trtllm'`
  - `_extract_pytest_nodeid(pytest_args) -> str`
  - `_write_json_payload(path, *, nodeid, status, framework, ...)` — single emitter, schema is its docstring.
- Top-level crash handler `_emit_failure_json_on_crash` in the `__main__` block: if `--json-out` is set and `main()` raises (NVML error, GPU not found, parser error, etc.), a `status="failed"` payload with `error="<ExcType>: <msg>"` is still written. This way every dispatched run produces exactly one JSON file, which the bot's idempotency relies on.

Schema (`schema_version: 1`):

```json
{
  \"schema_version\": 1,
  \"nodeid\": \"tests/serve/test_vllm.py::test_tool_calling[v1-aggregated]\",
  \"status\": \"ok\",                            // or \"failed\"
  \"framework\": \"vllm\",                       // vllm | sglang | trtllm
  \"wall_secs\": 78.4,
  \"num_runs\": 1,
  \"model\": \"meta-llama/Llama-3.1-8B-Instruct\",
  \"recommendations\": [
    {\"marker\": \"profiled_vram_gib(18)\", \"reason\": \"...\"},
    {\"marker\": \"requested_vllm_kv_cache_bytes(2147483648)\", \"reason\": \"...\"}
  ],
  \"warnings\": [],
  \"gpu_reports\": [
    {\"gpu_idx\": 0, \"peak_mib\": 17612, \"baseline_mib\": 412, \"leaked_mib\": 0}
  ],
  \"error\": \"...\"                             // only when status=failed
}
```

Existing stdout/CSV/recommendation output is unchanged. When `--json-out` is not passed, this is a no-op.

#### Where should the reviewer start?

- Schema is defined in one place: \`_write_json_payload\` (docstring + body). Bump \`schema_version\` on any breaking change.
- The crash handler at the very bottom of \`tests/utils/profile_pytest.py\` is the trickiest piece — please sanity-check that the argv parsing matches \`argparse\`'s behavior (it only looks for \`--json-out PATH\` and treats everything after as pytest args).
- Two integration points in existing code: end of \`_find_min_vram\` (success path), early-\`return rc\` failure path inside \`_find_min_vram\`, and the single-pass path in \`main()\`.

#### Related Issues:

None — this is enabling work for a separate, out-of-tree consumer.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json-out PATH` command-line option enabling export of profiling results as structured JSON. Reports capture execution status, performance timing, framework details, recommendations, warnings, and GPU memory analytics including peak usage, baselines, and leak detection for programmatic consumption and external integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->