### PR TITLE
fix: add vllm divergence reasons for qwen3_coder stream parity

### DIFF
--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.1.yaml
@@ -37,6 +37,13 @@ cases:
       vllm:
         calls: []
         normal_text: ''
+        reason: >-
+          vLLM streaming parser exits at qwen3coder_tool_parser.py:412 after
+          detecting `<tool_call>` in delta_text and never re-processes the
+          remainder of the same chunk; the trailing `finish_reason=tool_calls`
+          chunk has no `delta_token_ids`, so the EOS-flush branch
+          (qwen3coder_tool_parser.py:348-370) is skipped and no tool call is
+          emitted. Dynamo handles the single-chunk burst correctly.
   PARSER.stream.1.b:
     description: Complete tool call split across parser-significant boundaries
     ref: derived from PARSER.batch.1

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.2.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.2.yaml
@@ -101,3 +101,12 @@ cases:
           </parameter>
           </function>
           </tool_call>
+        reason: >-
+          vLLM streaming parser checks for `<tool_call>` only in `delta_text`
+          (qwen3coder_tool_parser.py:402), not the accumulated `current_text`.
+          When the start token is split across chunk boundaries
+          (`<tool_cal` + `l>\n<fun`), the condition never fires and every
+          chunk falls through to the no-tool-call branch at
+          qwen3coder_tool_parser.py:422, which emits `delta_text` as content.
+          Result: the entire wire payload leaks into `normal_text` and no
+          tool calls are produced.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.3.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.3.yaml
@@ -60,3 +60,10 @@ cases:
           </parameter>
           </function>
           </tool_call>
+        reason: >-
+          Same root cause as PARSER.stream.2: vLLM checks for `<tool_call>` in
+          `delta_text` only (qwen3coder_tool_parser.py:402). With the start
+          token split across chunks (`<t` + `ool` + `_call` + `>\n…`), the
+          guard never matches and every chunk is emitted as plain content via
+          qwen3coder_tool_parser.py:422, leaking the entire payload into
+          `normal_text`.

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.stream.4.yaml
@@ -36,6 +36,14 @@ cases:
       vllm:
         calls: []
         normal_text: ''
+        reason: >-
+          Same root cause as PARSER.stream.1.a: the full body arrives in a
+          single delta, vLLM detects `<tool_call>` and returns at
+          qwen3coder_tool_parser.py:412 without reprocessing the rest of the
+          chunk. The final `finish_reason=stop` chunk has no
+          `delta_token_ids`, so the EOS-flush branch at
+          qwen3coder_tool_parser.py:348-370 is skipped. No header or arguments
+          are ever emitted.
   PARSER.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from PARSER.batch.5.c
@@ -68,8 +76,24 @@ cases:
         - name: get_weather
           arguments: {}
         normal_text: ''
+        reason: >-
+          Impl-defined recovery for PARSER.batch.5-class missing end-token
+          (per `tests/parity/README.md` "permanent divergences"). The stream
+          ends mid-argument with `NY` but no `</parameter>`; SGLang requires
+          the parameter close-token before emitting the value, so it ships
+          the header with empty `arguments` and drops the partial payload.
+          Dynamo emits the partial value (`location: "NY"`).
       vllm:
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
+        reason: >-
+          Impl-defined recovery for PARSER.batch.5-class missing end-token
+          (per `tests/parity/README.md` "permanent divergences"). vLLM's
+          per-parameter extraction loop
+          (qwen3coder_tool_parser.py:540-579) requires either `</parameter>`,
+          the next `<parameter=`, or `</function>` to delimit the value;
+          when the stream ends mid-payload none of those are present, the
+          loop breaks before emitting a json fragment, and the header ships
+          with empty `arguments`. Matches SGLang.


### PR DESCRIPTION
## Summary

Adds `reason:` blocks to vLLM expected-output entries for the qwen3_coder streaming parity fixtures, so the parity table renders the divergence rationale on hover instead of leaving it blank.

Two root causes get documented:

- **`PARSER.stream.1.a` / `PARSER.stream.4.a`** — full body arrives in one delta. vLLM detects `<tool_call>` and early-returns at `qwen3coder_tool_parser.py:412` without re-processing the rest of the chunk. The trailing `finish_reason` chunk has no `delta_token_ids`, so the EOS-flush branch at `qwen3coder_tool_parser.py:348-370` is skipped and no tool call is emitted.
- **`PARSER.stream.2` / `PARSER.stream.3`** — start token is split across chunk boundaries (`<tool_cal` + `l>…` or `<t` + `ool` + `_call` + `>…`). vLLM only checks for `<tool_call>` in `delta_text` (`qwen3coder_tool_parser.py:402`), not the accumulated `current_text`, so the guard never matches and every chunk leaks through the no-tool-call branch at `qwen3coder_tool_parser.py:422` as plain content.
- **`PARSER.stream.4.b`** — labeled as the impl-defined `PARSER.batch.5`-class missing-end-token recovery from `tests/parity/README.md`. vLLM's per-parameter extraction loop (`qwen3coder_tool_parser.py:540-579`) needs `</parameter>`, the next `<parameter=`, or `</function>` to delimit the value; with the stream ending mid-payload none are present, the loop breaks before emitting the JSON fragment, and the header ships with empty `arguments` (matches SGLang). Both SGLang and vLLM get a reason; Dynamo's emit-the-partial-value behavior is the stated divergence.

No behavior change — fixtures-only doc edits. Re-running `python3 tests/parity/generate_parity_table.py parser --html` surfaces the new reasons on the stream tab tooltips.

## Test plan

- [ ] `pytest tests/parity/parser/test_parity_parser.py -v -k "qwen3_coder and stream"` still passes (fixtures' actual expected outputs are unchanged).
- [ ] Re-render `tests/parity/parser/PARITY.html`; confirm the four cells now show divergence reasons on hover.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Qwen3 code streaming parser test fixtures with detailed documentation clarifying parser behavior during streaming operations. Added comprehensive explanations covering edge cases including token splitting across stream boundaries, incomplete payload processing, early parsing termination, and differences in handling across various parser implementations to improve overall test maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->