### PR TITLE
fix(frontend): allow --dyn-chat-processor vllm on GPU-less pods

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -120,6 +120,21 @@ def parse_args() -> tuple[FrontendConfig, Optional[Namespace], Optional[Namespac
                     "Flag '--chat-processor vllm' requires vllm be installed."
                 )
                 sys.exit(1)
+
+        # On a host with no GPU and a CUDA-built wheel, vllm.platforms
+        # auto-detection picks UnspecifiedPlatform and the
+        # AsyncEngineArgs.add_cli_args call below crashes inside
+        # DeviceConfig.__post_init__. Frontend uses vLLM for parsers
+        # only and never constructs an engine, so coerce CpuPlatform.
+        # Must run before importing vllm.engine.arg_utils, which binds
+        # current_platform at module scope.
+        import vllm.platforms
+
+        if vllm.platforms.current_platform.device_type == "":
+            from vllm.platforms.cpu import CpuPlatform
+
+            vllm.platforms.current_platform = CpuPlatform()
+
         try:
             from vllm.engine.arg_utils import AsyncEngineArgs
             from vllm.entrypoints.openai.cli_args import FrontendArgs


### PR DESCRIPTION
## Summary

The recipe DGDs run the same `vllm-runtime` image as both Frontend (no GPU request) and Worker (GPU request). Adding `--dyn-chat-processor vllm` to the Frontend command currently crashes the pod on a host with no GPU, even though the frontend never instantiates a vLLM engine -- it uses vLLM only for chat / tool-call / reasoning parsers.

## Cause

`AsyncEngineArgs.add_cli_args(...)`, called from `parse_args` when `--dyn-chat-processor vllm` is selected, introspects `VllmConfig` field defaults. One field is a `DeviceConfig` constructed via `default_factory()`, and `DeviceConfig.__post_init__` reads `vllm.platforms.current_platform.device_type`.

On a CUDA-built vLLM wheel running on a host with no GPU:

- `cuda_platform_plugin()` returns `None` (nvml reports no device)
- `cpu_platform_plugin()` returns `None` (the wheel version string does not contain `"+cpu"`; that's a `VLLM_TARGET_DEVICE=cpu` build-time tag)

`current_platform` falls back to `UnspecifiedPlatform`, whose `device_type` is empty, and `DeviceConfig.__post_init__` raises `RuntimeError: Failed to infer device type`.

## Fix

Inside the existing `if config.chat_processor == "vllm":` block, detect the empty-`device_type` case and coerce `CpuPlatform` before the `AsyncEngineArgs.add_cli_args` call. The frontend never runs an engine, so CPU is always a valid platform for parser purposes.

The guard only fires when platform auto-detection has already failed -- on a GPU host `current_platform` resolves to `CudaPlatform` with `device_type == "cuda"` and the patch is a no-op.

## Verification

Reproduced on a pod with no GPU request using `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1`.

Before the patch:

```
File ".../vllm/engine/arg_utils.py", line 280, in _compute_kwargs
    default = default.default_factory()
File ".../vllm/config/device.py", line 56, in __post_init__
    raise RuntimeError(
RuntimeError: Failed to infer device type, please set the
environment variable `VLLM_LOGGING_LEVEL=DEBUG` ...
```

After the patch:

```
pre-patch  device_type=''
post-patch device_type='cpu'
INFO main.async_main: Request migration disabled (limit: 0)
... reaches main.py:213 DistributedRuntime(...)
```

The frontend now proceeds past argparse and reaches `DistributedRuntime(...)`. In the standalone test pod it then blocks on NATS, which is expected (the test pod has no NATS) and unrelated to this change -- that's the same point a healthy frontend reaches on its way to Ready.

## Test plan

- [x] Frontend pod with `--dyn-chat-processor vllm` boots past argparse on a GPU-less host using the upstream `vllm-runtime` image.
- [x] On a GPU host, the guard's `device_type == ""` check is false so the patch is a no-op (verified by inspection).
- [ ] CI: existing tests pass.

## Notes

vLLM 0.21.0 has no runtime env-var override for platform selection (the plugin selector in `vllm/platforms/__init__.py` reads no env var), so this fix mutates the platform module directly. Uses the public `vllm.platforms.current_platform` attribute; verified that subsequent `from vllm.platforms import current_platform` (the lookup `DeviceConfig.__post_init__` performs) returns the assigned `CpuPlatform`. If/when vLLM adds an env-var hook upstream, this block can be replaced with setting that env var.

The patch sits **after** the two existing `try/except ModuleNotFoundError` guards that print "requires vllm be installed" -- so a missing vLLM install still reaches the intended error path before this block runs.
