### PR TITLE
fix(kv-router): sort sibling children by hash in dump_router_events

### DIFF
--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -527,7 +527,14 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
         let mut event_id = 0u64;
         let mut queue = VecDeque::new();
 
-        for child in self.root.children.iter() {
+        let mut root_children: Vec<_> = self
+            .root
+            .children
+            .iter()
+            .map(|e| (*e.key(), e.value().clone()))
+            .collect();
+        root_children.sort_by_key(|(hash, _)| *hash);
+        for (_, child) in root_children {
             queue.push_back((child.clone(), None, None::<FxHashSet<WorkerWithDpRank>>));
         }
 
@@ -571,7 +578,13 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 event_id += 1;
             }
 
-            for child in node.children.iter() {
+            let mut node_children: Vec<_> = node
+                .children
+                .iter()
+                .map(|e| (*e.key(), e.value().clone()))
+                .collect();
+            node_children.sort_by_key(|(hash, _)| *hash);
+            for (_, child) in node_children {
                 queue.push_back((child.clone(), Some(block_hash), Some(live_workers.clone())));
             }
         }
@@ -1734,5 +1747,57 @@ mod tests {
                 "dump replay changed scores for query {query:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn dump_events_is_deterministic_for_sibling_nodes() {
+        // Workers 0 and 1 share prefix [1,2] but diverge at depth 3,
+        // creating sibling routing nodes whose DashMap iteration order
+        // is non-deterministic without an explicit sort.
+        let index = make_indexer(2, 3);
+        index.apply_event(store_event(0, &[1, 2, 3, 4])).await;
+        index.apply_event(store_event(1, &[1, 2, 5, 6])).await;
+        index.flush().await;
+
+        let dump1 = index.dump_events().await.unwrap();
+        let dump2 = index.dump_events().await.unwrap();
+
+        assert_eq!(
+            dump1, dump2,
+            "dump_events must produce identical event order across calls for sibling nodes"
+        );
+    }
+
+    #[tokio::test]
+    async fn dump_events_sibling_order_is_sorted_by_hash() {
+        // depth=4, sequences length 3 — all blocks stay in the router trie,
+        // none forwarded to backend shards. Sibling nodes at depth 3 must
+        // appear in sorted hash order.
+        let index = make_indexer(2, 4);
+        index.apply_event(store_event(0, &[1, 2, 3])).await;
+        index.apply_event(store_event(1, &[1, 2, 5])).await;
+        index.apply_event(store_event(2, &[1, 2, 7])).await;
+        index.apply_event(store_event(3, &[1, 2, 9])).await;
+        index.flush().await;
+
+        let dump = index.dump_events().await.unwrap();
+
+        let hashes: Vec<_> = dump
+            .iter()
+            .filter_map(|e| {
+                if let KvCacheEventData::Stored(s) = &e.event.data {
+                    s.blocks.first().map(|b| b.tokens_hash)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut sorted = hashes.clone();
+        sorted.sort();
+        assert_eq!(
+            hashes, sorted,
+            "dump_router_events must emit sibling nodes in sorted hash order"
+        );
     }
 }


### PR DESCRIPTION
#### Overview:

`dump_router_events` iterates `RoutingNode.children` via `DashMap`, which provides non-deterministic ordering. This makes dump→replay→dump not byte-stable for sibling nodes, the second dump may reorder siblings relative to the first. This PR fixes that by sorting children by `LocalBlockHash` at both BFS traversal sites, and adds tests to enforce the guarantee.

#### Details:

- In `dump_router_events`, replace direct `DashMap` iteration with a collected `Vec` sorted by `LocalBlockHash` key, at both the root children site and the inner BFS node children site
- Consistent with the sort already applied in `concurrent_radix_tree_compressed/mod.rs`
- Adds `dump_events_sibling_order_is_sorted_by_hash`: fails reliably without the fix due to DashMap iteration nondeterminism, passes with it
- Adds `dump_events_is_deterministic_for_sibling_nodes`: two consecutive dumps of the same state produce identical event sequences

#### Where should the reviewer start?

`lib/kv-router/src/indexer/branch_sharded.rs` — the two sort additions in `dump_router_events` (lines ~529 and ~579), then the two new tests at the bottom of the test module.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Resolves the TODO comment in `dump_router_events`: *"it does not yet make sibling traversal canonical by original creation order, so byte-stable dump → replay → dump comparisons are not guaranteed for siblings"*
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Router events are now reliably emitted in a deterministic and consistent order during operations, ensuring predictable and stable system behavior across multiple executions.

* **Tests**
  * Enhanced test suite with regression tests to verify that event emission remains deterministic and properly ordered, confirming consistent behavior across all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->