### PR TITLE
docs(parsers): clarify tool call and reasoning parser layer [release/1.2.0] 

### DIFF
--- a/docs/reasoning/README.md
+++ b/docs/reasoning/README.md
@@ -7,18 +7,35 @@ subtitle: Separate reasoning content from assistant output for chain-of-thought 
 
 Some models emit reasoning or thinking content separately from their final
 response. Dynamo can split that output into `reasoning_content` and normal
-assistant content by configuring a reasoning parser. As with tool calling,
-there are two ways to do this to ensure wide coverage and day0 model support.
+assistant content by configuring a reasoning parser.
+
+There are two ways to parse reasoning in Dynamo, depending on whether the
+parser lives in Dynamo's own registry or in an upstream engine frontend
+(`vllm serve`, `sglang serve`, or `trtllm-serve`).
 
 ## Choose a parsing path
 
 | Path | When to use | Page |
 |------|-------------|------|
-| **Dynamo** | Dynamo ships a Rust parser for the model's reasoning format. Lowest latency, the default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
+| **Dynamo** | Dynamo ships a framework-agnostic Rust parser for the model's reasoning format. Default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Use the framework's parser implementation (vLLM or SGLang today; TRTLLM in progress) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.
+
+## Why Dynamo implements tool-call and reasoning parsers
+
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and
+reasoning parsing happens in the engine's frontend server, with subtle
+behavioral differences across each. For performance purposes, Dynamo orchestrates
+routing and tokenization, passing tokens directly to each LLM engine and circumventing
+each engine's frontend OpenAI API server to avoid duplicate work per request.
+
+Dynamo therefore implements tool-call parsing and reasoning parsing in its
+frontend as a framework-agnostic Rust layer. This gives Dynamo one tested
+OpenAI-compatible contract across vLLM, SGLang, TRTLLM, and other workers,
+while keeping the serving hot path highly concurrent and scalable, avoiding
+Python GIL bottlenecks.
 
 ## See Also
 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -11,17 +11,32 @@ syntax out of raw model output and surfacing it as OpenAI-compatible
 and `tools` request parameters on the chat completions API.
 
 There are two ways to parse tool calls in Dynamo, depending on whether the
-parser lives in Dynamo's own registry or in the upstream engine (vLLM, SGLang).
+parser lives in Dynamo's own registry or in an upstream engine frontend
+(`vllm serve`, `sglang serve`, or `trtllm-serve`).
 
 ## Choose a parsing path
 
 | Path | When to use | Page |
 |------|-------------|------|
-| **Dynamo** | Dynamo ships a Rust parser for the model's tool-call format. Lowest latency, the default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
+| **Dynamo** | Dynamo ships a framework-agnostic Rust parser for the model's tool-call format. Default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Use the framework's parser implementation (vLLM or SGLang today; TRTLLM in progress) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.
+
+## Why Dynamo implements tool-call and reasoning parsers
+
+In `vllm serve`, `sglang serve`, and `trtllm-serve`, tool-call parsing and
+reasoning parsing happens in the engine's frontend server, with subtle
+behavioral differences across each. For performance purposes, Dynamo orchestrates
+routing and tokenization, passing tokens directly to each LLM engine and circumventing
+each engine's frontend OpenAI API server to avoid duplicate work per request.
+
+Dynamo therefore implements tool-call parsing and reasoning parsing in its
+frontend as a framework-agnostic Rust layer. This gives Dynamo one tested
+OpenAI-compatible contract across vLLM, SGLang, TRTLLM, and other workers,
+while keeping the serving hot path highly concurrent and scalable, avoiding
+Python GIL bottlenecks.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #9874 to release/1.2.0
- Clarifies why Dynamo implements tool-call and reasoning parsers in the framework-agnostic Rust frontend layer.
- Updates top-level tool-calling and reasoning parser docs for vLLM, SGLang, and TRTLLM wording.

## Original PR
- Main PR: #9874
- Merge commit: 5a9c7849fe7d29f878b61a797fdd2f004820fb1a

## Test plan
- [x] `pre-commit run trailing-whitespace --files docs/tool-calling/README.md docs/reasoning/README.md`
- [x] Cherry-pick commit hooks passed with `pytest-marker-report` skipped after failing locally under Python 3.10 on existing Python 3.11 typing imports (`typing.Self`, `typing.Required`).
- [ ] CI passes

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->