### PR TITLE
docs: move Agents section between Reasoning and Multimodal

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -174,6 +174,16 @@ navigation:
             path: reasoning/dynamo.md
           - page: Reasoning Parsing (Engine Fallback)
             path: reasoning/engine-fallback.md
+      - section: Agents
+        slug: agents
+        path: agents/README.md
+        contents:
+          - page: Agent Tracing
+            path: agents/agent-tracing.md
+          - page: Agent Hints
+            path: agents/agent-hints.md
+          - page: SGLang for Agentic Workloads
+            path: backends/sglang/agents.md
       - section: Multimodal
         path: features/multimodal/README.md
         contents:
@@ -200,16 +210,6 @@ navigation:
         path: features/lora/README.md
       - page: Fastokens Tokenizer
         path: features/tokenizer/README.md
-      - section: Agents
-        slug: agents
-        path: agents/README.md
-        contents:
-          - page: Agent Tracing
-            path: agents/agent-tracing.md
-          - page: Agent Hints
-            path: agents/agent-hints.md
-          - page: SGLang for Agentic Workloads
-            path: backends/sglang/agents.md
       - section: Observability (Local)
         path: observability/README.md
         contents:


### PR DESCRIPTION
## Summary
- Cherry-pick of #9725 to release/1.2.0
- Moves the existing release Agents section between Reasoning and Multimodal under User Guides.
- Preserves the release/1.2.0 Agents entries so the nav does not reference main-only docs pages.
- Request from @harryskim 

## Original PR
- Main PR: #9725
- Merge commit: ad997e7741f1681327928ff9dd6f56abc43868fc

## Test plan
- [x] git diff --check origin/release/1.2.0..HEAD
- [x] fern check
- [ ] fern docs broken-links (reports existing unrelated broken links in docs/kubernetes/README.md, docs/mocker/mocker.md, and docs/development backend guides)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->