### PR TITLE
docs(global-router): runnable bare-process example + common pitfalls

### DIFF
--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -283,9 +283,33 @@ The preprocessor forwards `nvext.router` to the backend as the typed `router` fi
 5. Local router forwards to a worker that handles both prefill and decode
 6. Tokens stream back through the chain
 
+## Common Pitfalls (bare-process / shared etcd+NATS)
+
+These bite when wiring the global router by hand outside Kubernetes (on K8s, DGD-per-namespace
+isolation hides most of them):
+
+- **Discovery merges same-named workers across namespaces → frontend silently bypasses the global
+  router.** Frontend model discovery is *global* over the shared etcd/NATS; `--namespace` only sets a
+  component's *own* namespace, it does **not** scope what the frontend discovers. If your pool workers
+  register the same model name as the public-facing model, the frontend discovers them directly and
+  routes to them, never reaching the global router — you'll see a fast (~ms) `500 bootstrap_info is
+  required` because the request skipped the bootstrap-setup step. **Fix:** give the pool workers a
+  distinct `--served-model-name` per pool so they don't merge into the public model.
+- **The local router's `--endpoint` must match where the backend actually registers.** It is
+  backend-specific (e.g. workers register under `prefill` / `backend`), not a free-form string. A
+  mismatch surfaces only as a runtime connection failure, not a config error.
+- **Disagg workers need `--host 0.0.0.0`.** Otherwise the prefill bootstrap server binds `127.0.0.1`
+  while advertising the node IP, and the decode side's NIXL KV transfer fails with "connection refused."
+- **The global router raises at init if a pool's local router isn't up yet.** Bring up pool routers
+  before the global router (there is no readiness gating / retry today).
+
 ## Example
 
-See `examples/global_planner/` for a complete example with:
+For a runnable **bare-process** example (no Kubernetes, CPU-only mocker pools), see
+`examples/global_planner/local/` — `./launch.sh` brings up two aggregated mocker pools, their local
+routers, the global router, and a frontend, and `./client.sh` shows SLA-based pool selection.
+
+See `examples/global_planner/` for the Kubernetes example with:
 - Global router configuration
 - Local router setup for each pool
 - Mocker workers for testing

--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -285,8 +285,9 @@ The preprocessor forwards `nvext.router` to the backend as the typed `router` fi
 
 ## Common Pitfalls (bare-process / shared etcd+NATS)
 
-These bite when wiring the global router by hand outside Kubernetes (on K8s, DGD-per-namespace
-isolation hides most of them):
+These bite when wiring the global router by hand outside Kubernetes. (K8s avoids the shared-discovery
+merge below via DGD-per-namespace isolation, but introduces its own traps — see
+[Kubernetes-specific pitfalls](#kubernetes-specific-pitfalls).)
 
 - **Discovery merges same-named workers across namespaces → frontend silently bypasses the global
   router.** Frontend model discovery is *global* over the shared etcd/NATS; `--namespace` only sets a
@@ -300,8 +301,32 @@ isolation hides most of them):
   mismatch surfaces only as a runtime connection failure, not a config error.
 - **Disagg workers need `--host 0.0.0.0`.** Otherwise the prefill bootstrap server binds `127.0.0.1`
   while advertising the node IP, and the decode side's NIXL KV transfer fails with "connection refused."
+- **Disagg prefill workers need an explicit `--kv-transfer-config`.** Recent vLLM removed the
+  `--connector` default and deprecates `--is-prefill-worker`; a prefill worker now exits at startup with
+  a `ValueError` unless you pass `--disaggregation-mode prefill --kv-transfer-config
+  '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'`.
 - **The global router raises at init if a pool's local router isn't up yet.** Bring up pool routers
   before the global router (there is no readiness gating / retry today).
+
+## Kubernetes-specific pitfalls
+
+DGD-per-namespace isolation removes the shared-discovery merge above, but the operator adds its own:
+
+- **Workers run under a hashed namespace suffix — all three routing hops must use it.** The operator
+  gives each worker pool a spec-hash serving namespace `<base>-<workerhash>` (e.g.
+  `myns-prefill-0-81790195`). The global router config's `*_pool_dynamo_namespaces` **and** each local
+  router's `--endpoint` must reference the **suffixed** namespace, not the base — base names fail at
+  runtime with `no endpoints available to route work` / `no instances found for endpoint`. (The local
+  router registers `router.generate` in *its* `--endpoint`'s namespace, so the global router only finds
+  it when both are suffixed.) **The suffix re-hashes on any worker spec change** (editing args,
+  resources, etc.), silently desyncing a pinned router config — re-read the DGD's
+  `nvidia.com/current-worker-hash` annotation after such edits.
+- **Air-gapped / offline model card.** The frontend and global router both fetch the model's HF card;
+  in an offline cluster set `HF_HUB_OFFLINE=1` and mount the cache, or the fetch hangs / returns
+  `429 Too Many Requests`.
+- **Python/`_core` ABI skew.** A mismatched `dynamo` Python vs compiled `_core` (e.g. top-of-tree
+  Python overlaid on an older runtime image) surfaces as `KvRouterConfig` keyword errors or an
+  `AttributeError` on router metric names (e.g. `router has no attribute 'KV_HIT_RATE'`). Use a matched pair.
 
 ## Example
 

--- a/examples/global_planner/README.md
+++ b/examples/global_planner/README.md
@@ -8,10 +8,15 @@ SPDX-License-Identifier: Apache-2.0
 Examples demonstrating **GlobalPlanner** — the centralized scaling execution layer that
 enforces shared scaling policy across multiple DGDs.
 
+> **Just want to see the Global Router route across pools locally?** See
+> [`local/`](./local/) for a GPU-free, bare-process example (mocker pools, no Kubernetes) you can
+> run with `./launch.sh` + `./client.sh`.
+
 ## Example Manifests
 
 | File | Pattern | Backend | Description |
 |------|---------|---------|-------------|
+| `local/` (dir) | Bare-process, multi-pool | Mocker | **No K8s, CPU-only.** GlobalRouter + frontend + 2 agg mocker pools as local processes |
 | `global-planner-gpu-budget.yaml` | Multi-model, GPU budget | vLLM | 2 independent model DGDs + 1 control DGD with `--max-total-gpus` |
 | `global-planner-vllm-test.yaml` | Single-endpoint, multi-pool | vLLM | 1 Frontend + GlobalRouter + GlobalPlanner, 2 prefill pools (TP1, TP2) + 1 decode pool |
 | `global-planner-mocker-test.yaml` | Single-endpoint, multi-pool | Mocker | Same as above with Mocker workers; GlobalPlanner in `--no-operation` mode |

--- a/examples/global_planner/local/README.md
+++ b/examples/global_planner/local/README.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Global Router — local bare-process example (mocker, CPU-only)
+
+A runnable, GPU-free way to see the **Global Router** route across multiple pools as plain
+local processes — no Kubernetes, no model download for inference (the [mocker](../../../components/src/dynamo/mocker)
+simulates the engine; only a tokenizer is fetched). The sibling YAMLs in this directory cover the
+Kubernetes path; this is the local equivalent that the other backends provide under `launch/`.
+
+## Topology
+
+```
+client --> frontend (ns: grdemo) --> global router (ns: grdemo)
+                                       |-- agg pool 0: local router + mocker  (ns: agg_pool_0)
+                                       +-- agg pool 1: local router + mocker  (ns: agg_pool_1)
+```
+
+Two **aggregated** pools (each pool does prefill+decode). The global router selects a pool from the
+request's SLA target using the 2D grid in [`agg_config.json`](./agg_config.json): with
+`ttft_resolution: 2` and `agg_pool_mapping: [[0],[1]]`, a **tight** TTFT target routes to **pool 0**
+and a **relaxed** one to **pool 1**.
+
+## Prerequisites
+
+- `etcd` (`:2379`) and `NATS` (`:4222`) running — e.g. `docker compose -f deploy/docker-compose.yml up -d`.
+- The `dynamo` Python package available (`pip install "ai-dynamo[...]"`, or an editable source install on `PYTHONPATH`).
+
+## Run
+
+```bash
+cd examples/global_planner/local
+./launch.sh                 # starts mockers, per-pool routers, global router, frontend on :8000
+# in another shell:
+./client.sh 8000            # sends a default request + a tight-TTFT (pool 0) + a relaxed-TTFT (pool 1)
+```
+
+`launch.sh` honors `MODEL`, `PORT`, and `DYN_LOG` env vars. Stop everything with:
+
+```bash
+pkill -f 'dynamo.(mocker|router|global_router|frontend)'
+```
+
+Which pool served a request is shown in `logs/global_router.log`.
+
+## How it maps to the config
+
+| Piece | Command | Why |
+|---|---|---|
+| Pool worker | `dynamo.mocker --endpoint dyn://agg_pool_N.backend.generate --disaggregation-mode agg` | Registers under the pool's namespace. `backend` is where agg workers register; the pool's local router must point at the same endpoint. |
+| Pool router | `dynamo.router --endpoint agg_pool_N.backend.generate` | The "local router" the global router forwards to for that pool. |
+| Global router | `dynamo.global_router --config agg_config.json --model-name <HF id> --namespace grdemo` | `--model-name` **must be a real HuggingFace id** — the global router fetches its model card (a fake name returns `401`). |
+| Frontend | `dynamo.frontend --namespace grdemo` | Public entrypoint; runs in the global router's namespace. |
+
+## Gotchas (the same ones documented in the [global_router README](../../../components/src/dynamo/global_router/README.md#common-pitfalls))
+
+- **Distinct `--model-name` for the pool workers** (`qwen-pool-demo` here). Discovery is global across
+  namespaces, so if the pool workers registered the public model name, the frontend would discover them
+  directly and bypass the global router (you'd see a fast `500 bootstrap_info is required`).
+- **Bring pool routers up before the global router** — it errors at init if a pool's local router isn't registered yet.
+- **agg vs disagg**: this example uses `mode: "agg"`. For disaggregated pools (separate prefill/decode),
+  use a `mode: "disagg"` config; note the SGLang/TRT-LLM bootstrap paths are backend-dependent (see the global_router README).
+
+## Note on verification
+
+The config and process wiring here were validated against the `main` global-router config loader/validator
+and the documented module interfaces; the control-plane topology (global router + per-pool local router +
+namespace-scoped frontend + distinct served-model-name) was exercised end-to-end during testing. Run it on a
+clean `dynamo` install — a mismatched `dynamo` Python/`_core` pair will surface as `KvRouterConfig` keyword
+errors (see the version-skew notes in the troubleshooting docs).

--- a/examples/global_planner/local/README.md
+++ b/examples/global_planner/local/README.md
@@ -62,6 +62,11 @@ Which pool served a request is shown in `logs/global_router.log`.
 - **Bring pool routers up before the global router** — it errors at init if a pool's local router isn't registered yet.
 - **agg vs disagg**: this example uses `mode: "agg"`. For disaggregated pools (separate prefill/decode),
   use a `mode: "disagg"` config; note the SGLang/TRT-LLM bootstrap paths are backend-dependent (see the global_router README).
+- **This demo routes by config grid, not measured performance.** The two mocker pools are identical, so
+  pool selection here is purely the `agg_pool_mapping` × SLA grid — it demonstrates the *control plane*,
+  not a perf/cost win. A real benefit requires pools tuned differently (e.g. TP1 vs TP4), ISL-diverse
+  traffic, and an SLA in the band where the cheaper pool meets short prompts but not long ones; with
+  identical pools or a uniform workload, routing changes nothing observable.
 
 ## Note on verification
 

--- a/examples/global_planner/local/agg_config.json
+++ b/examples/global_planner/local/agg_config.json
@@ -1,0 +1,16 @@
+{
+  "mode": "agg",
+  "enable_priority_retry": false,
+  "num_agg_pools": 2,
+  "agg_pool_dynamo_namespaces": ["agg_pool_0", "agg_pool_1"],
+  "agg_pool_selection_strategy": {
+    "ttft_min_ms": 0,
+    "ttft_max_ms": 1000,
+    "ttft_resolution": 2,
+    "itl_min_ms": 0,
+    "itl_max_ms": 1000,
+    "itl_resolution": 1,
+    "agg_pool_mapping": [[0], [1]],
+    "priority_overrides": []
+  }
+}

--- a/examples/global_planner/local/client.sh
+++ b/examples/global_planner/local/client.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Send chat completions through the frontend -> global router -> a selected agg pool.
+# The optional `nvext.router.ttft_target` (ms) drives pool selection per agg_config.json:
+# a tight TTFT target lands in pool 0; a relaxed one lands in pool 1.
+set -u
+PORT="${1:-8000}"
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+URL="http://localhost:${PORT}/v1/chat/completions"
+
+send() { # $1 = label, $2 = ttft_target (ms, empty for default)
+  local label="$1" ttft="$2" nvext=""
+  [ -n "$ttft" ] && nvext=",\"nvext\":{\"router\":{\"ttft_target\":${ttft}}}"
+  echo "== ${label} =="
+  curl -s "$URL" -H 'Content-Type: application/json' -d "{
+    \"model\": \"${MODEL}\",
+    \"messages\": [{\"role\":\"user\",\"content\":\"One-sentence fun fact about the moon.\"}],
+    \"max_tokens\": 32, \"stream\": false ${nvext}
+  }" | python3 -m json.tool
+  echo
+}
+
+echo "== models =="; curl -s "http://localhost:${PORT}/v1/models" | python3 -m json.tool; echo
+send "default routing"            ""
+send "tight TTFT target -> pool 0" 100
+send "relaxed TTFT target -> pool 1" 900
+
+echo "Tip: which pool served a request is visible in the global router log (logs/global_router.log)."

--- a/examples/global_planner/local/launch.sh
+++ b/examples/global_planner/local/launch.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bare-process Global Router demo: two aggregated mocker pools, CPU-only (no GPU).
+#
+# Topology (all on one host, over a shared etcd + NATS):
+#
+#   client --> frontend (ns: grdemo) --> global router (ns: grdemo)
+#                                          |-- agg pool 0: local router + mocker (ns: agg_pool_0)
+#                                          +-- agg pool 1: local router + mocker (ns: agg_pool_1)
+#
+# The global router picks a pool from the request's SLA target (TTFT here) using the
+# 2D grid in agg_config.json, then forwards to that pool's local router.
+#
+# Prerequisites: a running etcd (:2379) and NATS (:4222) -- e.g. `docker compose -f
+# deploy/docker-compose.yml up -d` -- and the `dynamo` Python package installed
+# (`pip install ai-dynamo[...]` or an editable source install on PYTHONPATH).
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG="$HERE/logs"; mkdir -p "$LOG"
+export DYN_LOG="${DYN_LOG:-info}"
+
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"   # real HF id: the global router fetches this model's card
+POOL_MODEL="qwen-pool-demo"         # distinct served-model-name so the frontend does NOT discover
+                                    # the pool workers directly and merge them into the public model
+GR_NS="grdemo"                      # global router + frontend namespace
+PORT="${PORT:-8000}"
+
+echo "== launching 2 agg mocker pools, logs in $LOG =="
+for i in 0 1; do
+  python3 -m dynamo.mocker \
+    --endpoint "dyn://agg_pool_${i}.backend.generate" \
+    --model-path "$MODEL" --model-name "$POOL_MODEL" \
+    --block-size 64 --disaggregation-mode agg --speedup-ratio 10 \
+    > "$LOG/pool${i}_worker.log" 2>&1 &
+  python3 -m dynamo.router \
+    --endpoint "agg_pool_${i}.backend.generate" --router-block-size 64 \
+    > "$LOG/pool${i}_router.log" 2>&1 &
+done
+
+echo "== waiting 25s for pool routers to register (the global router errors if a pool router isn't up yet) =="
+sleep 25
+
+echo "== launching global router (ns: $GR_NS) =="
+python3 -m dynamo.global_router \
+  --config "$HERE/agg_config.json" --model-name "$MODEL" --namespace "$GR_NS" \
+  > "$LOG/global_router.log" 2>&1 &
+sleep 8
+
+# Frontend is scoped to the global router's namespace. NOTE: discovery is global across
+# namespaces, so the distinct POOL_MODEL above (not --namespace) is what keeps the frontend
+# from bypassing the global router. See ../README.md and the global_router README "Common Pitfalls".
+echo "== launching frontend on :$PORT (ns: $GR_NS) =="
+python3 -m dynamo.frontend --http-port "$PORT" --namespace "$GR_NS" \
+  > "$LOG/frontend.log" 2>&1 &
+
+echo "== started. settling 6s, then listing models =="
+sleep 6
+curl -s "http://localhost:${PORT}/v1/models"; echo
+echo "== ready. PIDs: $(jobs -p | tr '\n' ' ') =="
+echo "   send a request: $HERE/client.sh $PORT"
+echo "   tail logs:      tail -f $LOG/*.log"
+echo "   stop all:       pkill -f 'dynamo.(mocker|router|global_router|frontend)'"
+wait


### PR DESCRIPTION
I had Claude add a runnable **bare-process example** for the global router. Every other backend ships a `launch/` script, but the global router only had Kubernetes CRD examples, so a local bring-up had to be reverse-engineered from prose.

**`examples/global_planner/local/`** spins up two aggregated **mocker** pools (CPU, no GPU), their per-pool local routers, the global router, and a namespace-scoped frontend:
- `launch.sh` / `client.sh` — `client.sh` demonstrates SLA-based pool selection (tight TTFT → pool 0, relaxed → pool 1)
- `agg_config.json` — validated against the `main` `global_router` `load_config`/`validate`

It also documents, in the global_router README **"Common Pitfalls"**, the version-independent traps we hit wiring it by hand:
- discovery merges same-named workers across namespaces → the frontend bypasses the global router (use a distinct `--served-model-name` per pool)
- the local router `--endpoint` must match where the backend registers
- disagg workers need `--host 0.0.0.0`
- the global router errors if a pool router isn't up yet

Cross-linked from the `global_router` and `global_planner` READMEs. Docs-only; opening as draft for feedback on placement/wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
