### PR TITLE
fix(container): add libnixl.so to LD_LIBRARY_PATH in cuda vllm-runtime

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -20,6 +20,9 @@ ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 ARG VLLM_OMNI_REF
 ARG NIXL_REF
+{% if device == "cuda" %}
+ARG CUDA_MAJOR
+{% endif %}
 
 WORKDIR /workspace
 
@@ -45,6 +48,18 @@ ENV NIXL_PLUGIN_DIR=${NIXL_LIB_DIR}/plugins
 ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:${TORCH_LIB_DIR}:${LD_LIBRARY_PATH:-}
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+{% else %}
+# Expose libnixl.so from the upstream nixl-cu${CUDA_MAJOR} PyPI wheel on
+# LD_LIBRARY_PATH so dlopen() can find it from processes that don't import
+# the `nixl` Python package — chiefly `dynamo.frontend`, which is pure-Rust
+# from a process perspective. Without this, Rust nixl-sys's stub-mode runtime
+# loader returns is_stub()=true and the frontend rejects any model card
+# carrying a `media_decoder` (i.e. workers launched with --frontend-decoding)
+# with "OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode".
+# The wheel installs libnixl.so under a hidden ".libs/" sibling that only the
+# wheel's own RPATH knows about; standard LD search can't find it without help.
+ARG SITE_PACKAGES=/usr/local/lib/python${PYTHON_VERSION}/dist-packages
+ENV LD_LIBRARY_PATH=${SITE_PACKAGES}/.nixl_cu${CUDA_MAJOR}.mesonpy.libs:${LD_LIBRARY_PATH:-}
 {% endif %}
 
 # Install NATS and ETCD


### PR DESCRIPTION
## Why

Cuda vllm-runtime inherits libnixl.so from the upstream `vllm/vllm-openai` image's `nixl-cu{12,13}` PyPI wheels, which stage libnixl under a hidden `.nixl_cu${CUDA_MAJOR}.mesonpy.libs/` sibling that only each wheel's own RPATH knows. `dynamo.frontend` never imports the `nixl` Python module, so Rust nixl-sys's stub-mode `dlopen("libnixl.so")` fails and `is_stub()` returns true. Result: every model card that carries a `media_decoder` (i.e. workers launched with `--frontend-decoding`) is rejected at the frontend with `OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode`, and the four `--frontend-decoding` multimodal serve tests fail in post-merge CI. Worker-side ImageLoader works because importing `nixl` side-loads libnixl via the wheel's RPATH; the frontend never does that.

## What Change

- Redeclare `ARG CUDA_MAJOR` in the cuda vllm-runtime stage.
- Prepend `${SITE_PACKAGES}/.nixl_cu${CUDA_MAJOR}.mesonpy.libs` to `LD_LIBRARY_PATH` (cuda branch only — xpu/cpu unchanged).

## Test Plan

- Built dynamo against `vllm/vllm-openai:v0.21.0-ubuntu2404`; with the new path on `LD_LIBRARY_PATH` the frontend instantiates NIXL and both HTTP-URL and inline-base64 `--frontend-decoding` requests return the expected `GREEN`.
- Put tests as pre-merge in [PR#9913](https://github.com/ai-dynamo/dynamo/pull/9913) and confirmed they passed