### PR TITLE
fix(container): cuda libnixl LD path + promote qwen3-vl-2b frontend-decoding to pre_merge

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -20,6 +20,9 @@ ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 ARG VLLM_OMNI_REF
 ARG NIXL_REF
+{% if device == "cuda" %}
+ARG CUDA_MAJOR
+{% endif %}
 
 WORKDIR /workspace
 
@@ -45,6 +48,18 @@ ENV NIXL_PLUGIN_DIR=${NIXL_LIB_DIR}/plugins
 ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:${TORCH_LIB_DIR}:${LD_LIBRARY_PATH:-}
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+{% else %}
+# Expose libnixl.so from the upstream nixl-cu${CUDA_MAJOR} PyPI wheel on
+# LD_LIBRARY_PATH so dlopen() can find it from processes that don't import
+# the `nixl` Python package — chiefly `dynamo.frontend`, which is pure-Rust
+# from a process perspective. Without this, Rust nixl-sys's stub-mode runtime
+# loader returns is_stub()=true and the frontend rejects any model card
+# carrying a `media_decoder` (i.e. workers launched with --frontend-decoding)
+# with "OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode".
+# The wheel installs libnixl.so under a hidden ".libs/" sibling that only the
+# wheel's own RPATH knows about; standard LD search can't find it without help.
+ARG SITE_PACKAGES=/usr/local/lib/python${PYTHON_VERSION}/dist-packages
+ENV LD_LIBRARY_PATH=${SITE_PACKAGES}/.nixl_cu${CUDA_MAJOR}.mesonpy.libs:${LD_LIBRARY_PATH:-}
 {% endif %}
 
 # Install NATS and ETCD

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -75,20 +75,26 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         payload=make_image_payload_b64(["green"]),
                     ),
                     # --frontend-decoding (HTTP-URL): exercises strip_inline_data_urls
-                    # + NIXL RDMA. post_merge-only — local pre-merge builds outside
-                    # docker can pick up NIXL stubs that don't support this path;
-                    # CI post_merge runs in a container with real NIXL.
+                    # + NIXL RDMA. Promoted to pre_merge — the cuda vllm-runtime
+                    # image now exposes libnixl.so on LD_LIBRARY_PATH (the wheel's
+                    # hidden `.nixl_cu${CUDA_MAJOR}.mesonpy.libs/` sibling), so
+                    # the frontend instantiates real NIXL and stub fallback is
+                    # no longer a risk in pre-merge runs. Per-MmCase marks
+                    # override the topology's post_merge default.
                     MmCase(
                         suffix="frontend_decoding",
                         payload=make_image_payload(["green"]),
                         extra_script_args=["--frontend-decoding"],
+                        marks=[pytest.mark.pre_merge],
                     ),
-                    # --frontend-decoding (inline base64). Same NIXL stub
-                    # caveat as the HTTP-URL variant above.
+                    # --frontend-decoding (inline base64). Same libnixl
+                    # rationale as the HTTP-URL variant above; promoted to
+                    # pre_merge alongside it.
                     MmCase(
                         suffix="b64_frontend_decoding",
                         payload=make_image_payload_b64(["green"]),
                         extra_script_args=["--frontend-decoding"],
+                        marks=[pytest.mark.pre_merge],
                     ),
                 ],
             ),


### PR DESCRIPTION
## Summary

Two stacked commits, retargeted directly at `main` so pre-merge CI runs them as one unit:

1. **Container fix** (commit `7c1a792108`, identical to #9911): prepends the upstream `nixl-cu${CUDA_MAJOR}` PyPI wheel's hidden `.nixl_cu${CUDA_MAJOR}.mesonpy.libs/` sibling to `LD_LIBRARY_PATH` in the cuda vllm-runtime stage of `container/templates/vllm_runtime.Dockerfile`. Without this, `dynamo.frontend` (pure-Rust from a process perspective, never imports the `nixl` Python module) hits `nixl-sys` stub-mode `dlopen("libnixl.so")`, `is_stub()` returns true, and any model card carrying a `media_decoder` (i.e. workers launched with `--frontend-decoding`) is rejected with `OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode`.

2. **Test promotion** (commit `ed0d699e43`): promotes two MmCase entries on the qwen3-vl-2b `agg` topology from `post_merge` to `pre_merge` by setting per-case `marks=[pytest.mark.pre_merge]`, which overrides the topology default (`tests/utils/multimodal.py:351`):
   - `test_serve_deployment[mm_agg_qwen3-vl-2b_frontend_decoding-2]` (HTTP-URL `--frontend-decoding`)
   - `test_serve_deployment[mm_agg_qwen3-vl-2b_b64_frontend_decoding-2]` (inline base64 `--frontend-decoding`)

   These were originally pinned to `post_merge` because pre-merge runs hit the NIXL-stub fallback that commit (1) fixes. With (1) in the same PR, the stub-fallback risk is gone and the cases can guard the frontend-decoding path on every PR.

Bundling both commits in one PR (rather than stacking on #9911) so pre-merge CI exercises (2) with (1) already applied — gives a real signal on the promoted cases before merge. #9911 will be closed in favor of this PR.

## Test Plan

- Built dynamo against `vllm/vllm-openai:v0.21.0-ubuntu2404` with commit (1) applied; the frontend instantiates NIXL and both HTTP-URL and inline-base64 `--frontend-decoding` requests return the expected `GREEN`.
- Watch this PR's pre-merge `vllm-runtime / Test cuda{12.9,13.0}, amd64` GPU stages — both promoted cases must pass.
- Confirm `pytest --collect-only -m pre_merge tests/serve/test_vllm.py` lists `mm_agg_qwen3-vl-2b_frontend_decoding-2` and `mm_agg_qwen3-vl-2b_b64_frontend_decoding-2`.
- Verify the other qwen3-vl-2b `agg` cases (`mm_agg_qwen3-vl-2b-2`, `mm_agg_qwen3-vl-2b_b64-2`) still land under `post_merge` — topology default is unchanged.
- Watch post-merge `vllm-runtime / Test cuda{12.9,13.0}, amd64` GPU stages after merge for the remaining post_merge coverage.
