### PR TITLE
refactor: Use delta output kind for vLLM token streaming

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -23,7 +23,11 @@ from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalKwargsItem, PlaceholderRange
 from vllm.outputs import RequestOutput
 from vllm.renderers.embed_utils import safe_load_prompt_embeds
-from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.sampling_params import (
+    RequestOutputKind,
+    SamplingParams,
+    StructuredOutputsParams,
+)
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
@@ -92,6 +96,7 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
+_DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
 
 
 class _DeferredAbort:
@@ -336,7 +341,6 @@ def build_sampling_params(
         SamplingParams configured from the request
     """
     sampling_params = SamplingParams(**default_sampling_params)
-    sampling_params.detokenize = False
 
     # Handle guided_decoding - convert to StructuredOutputsParams
     sampling_options = request.get("sampling_options", {})
@@ -425,6 +429,12 @@ def build_sampling_params(
         # Ensure at least 1 token generation by default when possible
         dynamic_default = max(1, model_max_len - input_length)
         sampling_params.max_tokens = dynamic_default
+
+    # Dynamo's internal token path consumes disjoint token deltas. This mirrors
+    # the SGLang integration and lets vLLM's stream_interval gate reduce backend
+    # bridge pressure before chunks cross into Dynamo.
+    sampling_params.detokenize = False
+    sampling_params.output_kind = _DELTA_REQUEST_OUTPUT_KIND
 
     return sampling_params
 
@@ -1949,6 +1959,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def _build_completion_usage(
         request_output: RequestOutput,
         embedding_sequence_length: int | None = None,
+        completion_token_counts: dict[int, int] | None = None,
     ) -> Dict[str, Any]:
         """
         Build completion usage statistics.
@@ -1957,6 +1968,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             request_output: vLLM RequestOutput object
             embedding_sequence_length: If using prompt embeddings, the sequence length
                                      extracted from the embeddings tensor shape
+            completion_token_counts: Optional cumulative generated-token counts by
+                                     output index. DELTA-mode streams need this
+                                     because the final vLLM chunk is not cumulative.
 
         Returns:
             Dict with prompt_tokens, completion_tokens, total_tokens, prompt_tokens_details
@@ -1971,9 +1985,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         else:
             prompt_tokens = None
 
-        completion_tokens = sum(
-            len(output.token_ids) for output in request_output.outputs
-        )
+        if completion_token_counts is not None:
+            completion_tokens = sum(completion_token_counts.values())
+        else:
+            completion_tokens = sum(
+                len(output.token_ids) for output in request_output.outputs
+            )
 
         return {
             "prompt_tokens": prompt_tokens,
@@ -2124,7 +2141,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 ),
             )
 
-            num_output_tokens_so_far: dict[int, int] = {}
+            total_output_tokens_by_index: dict[int, int] = {}
             async for res in gen:
                 # res is vllm's RequestOutput
 
@@ -2143,34 +2160,51 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     }
                     break
 
+                prepared_outputs = []
                 for output in res.outputs:
                     output_idx = getattr(output, "index", 0) or 0
-                    previous_total_toks = num_output_tokens_so_far.get(output_idx, 0)
-                    next_total_toks = len(output.token_ids)
+                    token_ids = list(output.token_ids or [])
+                    total_output_tokens_by_index[
+                        output_idx
+                    ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
+                    finish_reason = getattr(output, "finish_reason", None)
+                    stop_reason = getattr(output, "stop_reason", None)
+                    if not token_ids and not finish_reason and not stop_reason:
+                        continue
+                    prepared_outputs.append(
+                        (output, output_idx, token_ids, finish_reason, stop_reason)
+                    )
+
+                for (
+                    output,
+                    output_idx,
+                    token_ids,
+                    finish_reason,
+                    stop_reason,
+                ) in prepared_outputs:
                     out = {
                         "index": output_idx,
-                        "token_ids": output.token_ids[previous_total_toks:],
+                        "token_ids": token_ids,
                     }
 
-                    # Extract logprobs for new tokens if available
+                    # vLLM DELTA outputs already align token_ids/logprobs to this chunk.
                     tokenizer = getattr(self.engine_client, "tokenizer", None)
                     log_probs, top_logprobs = self._extract_logprobs(
-                        output, previous_total_toks, tokenizer=tokenizer
+                        output, 0, tokenizer=tokenizer
                     )
                     if log_probs is not None:
                         out["log_probs"] = log_probs
                     if top_logprobs is not None:
                         out["top_logprobs"] = top_logprobs
 
-                    if output.finish_reason:
-                        out["finish_reason"] = normalize_finish_reason(
-                            output.finish_reason
-                        )
+                    if finish_reason:
+                        out["finish_reason"] = normalize_finish_reason(finish_reason)
                         out[
                             "completion_usage"
                         ] = BaseWorkerHandler._build_completion_usage(
                             request_output=res,
                             embedding_sequence_length=embedding_sequence_length,
+                            completion_token_counts=total_output_tokens_by_index,
                         )
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
@@ -2178,13 +2212,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             "{output_tokens} output tokens, finish_reason={finish_reason}",
                             request_id,
                             lora_request,
-                            output_tokens=next_total_toks,
-                            finish_reason=output.finish_reason,
+                            output_tokens=total_output_tokens_by_index.get(
+                                output_idx, 0
+                            ),
+                            finish_reason=finish_reason,
                         )
-                    if output.stop_reason:
-                        out["stop_reason"] = output.stop_reason
+                    if stop_reason:
+                        out["stop_reason"] = stop_reason
                     yield out
-                    num_output_tokens_so_far[output_idx] = next_total_toks
 
         except EngineDeadError as e:
             logger.error(f"vLLM EngineDeadError: {e}")

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2026,8 +2026,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         if output.logprobs is None:
             return None, None
 
+        token_ids = list(output.token_ids or [])
+        if not token_ids or num_output_tokens_so_far >= len(token_ids):
+            return None, None
+
         # Get logprobs for new tokens only
         new_logprobs = output.logprobs[num_output_tokens_so_far:]
+        new_token_ids = token_ids[num_output_tokens_so_far:]
+        new_logprobs = new_logprobs[: len(new_token_ids)]
         if not new_logprobs:
             return None, None
 
@@ -2039,11 +2045,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 continue
 
             # Get the actual token_id that was generated at this position
-            actual_token_id = output.token_ids[num_output_tokens_so_far + token_idx]
+            actual_token_id = new_token_ids[token_idx]
 
             # Extract log probability for the selected token
             # vLLM guarantees the selected token is always in the logprobs dict
-            selected_logprob = token_logprobs_dict[actual_token_id]
+            selected_logprob = token_logprobs_dict.get(actual_token_id)
+            if selected_logprob is None:
+                continue
             log_probs.append(float(selected_logprob.logprob))
 
             # Build top_logprobs list for this token position

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -312,7 +312,7 @@ class VllmLLMEngine(LLMEngine):
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
 
-        num_output_tokens_so_far: dict[int, int] = {}
+        total_output_tokens_by_index: dict[int, int] = {}
         async for res in gen:
             if not res.outputs:
                 yield {
@@ -322,23 +322,30 @@ class VllmLLMEngine(LLMEngine):
                 }
                 break
 
+            prepared_outputs = []
             for output in res.outputs:
                 output_idx = getattr(output, "index", 0) or 0
-                previous_total = num_output_tokens_so_far.get(output_idx, 0)
-                next_total = len(output.token_ids)
+                token_ids = list(output.token_ids or [])
+                total_output_tokens_by_index[
+                    output_idx
+                ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
+                finish_reason = getattr(output, "finish_reason", None)
+                if not token_ids and not finish_reason:
+                    continue
+                prepared_outputs.append((output_idx, token_ids, finish_reason))
+
+            for output_idx, token_ids, finish_reason in prepared_outputs:
                 out: GenerateChunk = {
                     "index": output_idx,
-                    "token_ids": output.token_ids[previous_total:],
+                    "token_ids": token_ids,
                 }
 
-                if output.finish_reason:
-                    out["finish_reason"] = str(output.finish_reason)
+                if finish_reason:
+                    out["finish_reason"] = str(finish_reason)
                     prompt_tokens = (
                         len(res.prompt_token_ids) if res.prompt_token_ids else 0
                     )
-                    completion_tokens = sum(
-                        len(choice.token_ids) for choice in res.outputs
-                    )
+                    completion_tokens = sum(total_output_tokens_by_index.values())
                     out["completion_usage"] = {
                         "prompt_tokens": prompt_tokens,
                         "completion_tokens": completion_tokens,
@@ -354,7 +361,6 @@ class VllmLLMEngine(LLMEngine):
                             }
 
                 yield out
-                num_output_tokens_so_far[output_idx] = next_total
 
     def _kv_routing_enabled(self) -> bool:
         # Matches the legacy `setup_kv_event_publisher` gate.

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -151,6 +151,29 @@ async def test_generate_tokens_keeps_final_empty_delta_chunk_for_usage():
 
 
 @pytest.mark.asyncio
+async def test_generate_tokens_ignores_logprobs_on_empty_final_delta_chunk():
+    logprobs = [
+        {7: SimpleNamespace(logprob=-0.7, rank=1, decoded_token="a")},
+    ]
+    responses = [
+        _request_output([_output([1, 2])], prompt_token_ids=[10]),
+        _request_output(
+            [_output([], finish_reason="length", logprobs=logprobs)],
+            prompt_token_ids=[10],
+        ),
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert [chunk["token_ids"] for chunk in chunks] == [[1, 2], []]
+    assert "log_probs" not in chunks[-1]
+    assert "top_logprobs" not in chunks[-1]
+    assert chunks[-1]["finish_reason"] == "length"
+    assert chunks[-1]["completion_usage"]["completion_tokens"] == 2
+    assert chunks[-1]["completion_usage"]["total_tokens"] == 3
+
+
+@pytest.mark.asyncio
 async def test_generate_tokens_tracks_interleaved_output_indexes_independently():
     responses = [
         _request_output([_output([1], index=0), _output([10, 11], index=1)]),

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -194,6 +194,31 @@ async def test_generate_tokens_reads_delta_aligned_logprobs_from_zero_offset():
 
 
 @pytest.mark.asyncio
+async def test_generate_tokens_keeps_multichunk_delta_logprobs_aligned():
+    first_logprobs = [
+        {7: SimpleNamespace(logprob=-0.7, rank=1, decoded_token="a")},
+    ]
+    second_logprobs = [
+        {8: SimpleNamespace(logprob=-0.8, rank=1, decoded_token="b")},
+        {9: SimpleNamespace(logprob=-0.9, rank=1, decoded_token="c")},
+    ]
+    responses = [
+        _request_output([_output([7], logprobs=first_logprobs)]),
+        _request_output(
+            [_output([8, 9], finish_reason="length", logprobs=second_logprobs)]
+        ),
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert [chunk["token_ids"] for chunk in chunks] == [[7], [8, 9]]
+    assert [chunk["log_probs"] for chunk in chunks] == [[-0.7], [-0.8, -0.9]]
+    assert [
+        [entry[0]["token_id"] for entry in chunk["top_logprobs"]] for chunk in chunks
+    ] == [[7], [8, 9]]
+
+
+@pytest.mark.asyncio
 async def test_unified_llm_engine_passes_delta_chunks_and_counts_usage():
     pytest.importorskip("vllm.usage.usage_lib")
     from dynamo.vllm.llm_engine import VllmLLMEngine

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+
+from dynamo.common.constants import DisaggregationMode
+from dynamo.vllm.handlers import BaseWorkerHandler, build_sampling_params
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _FakeEngineClient:
+    tokenizer = None
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def generate(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+        async def _stream():
+            for response in self.responses:
+                yield response
+
+        return _stream()
+
+
+class _FakeContext:
+    def id(self):
+        return "req-1"
+
+    def trace_headers(self):
+        return None
+
+
+def _output(
+    token_ids,
+    *,
+    index=0,
+    finish_reason=None,
+    stop_reason=None,
+    logprobs=None,
+):
+    return SimpleNamespace(
+        index=index,
+        token_ids=token_ids,
+        finish_reason=finish_reason,
+        stop_reason=stop_reason,
+        logprobs=logprobs,
+    )
+
+
+def _request_output(outputs, *, prompt_token_ids=None):
+    return SimpleNamespace(
+        outputs=outputs,
+        prompt_token_ids=prompt_token_ids if prompt_token_ids is not None else [101],
+        num_cached_tokens=0,
+        kv_transfer_params=None,
+    )
+
+
+def _handler_with_responses(responses):
+    def _ignore_log(*args, **kwargs):
+        pass
+
+    handler = SimpleNamespace()
+    handler.engine_client = _FakeEngineClient(responses)
+    handler.runtime = SimpleNamespace(shutdown=lambda: None)
+    handler._extract_logprobs = BaseWorkerHandler._extract_logprobs
+    handler._log_with_lora_context = _ignore_log
+    return handler
+
+
+async def _collect_handler_chunks(responses):
+    handler = _handler_with_responses(responses)
+    chunks = []
+    async for chunk in BaseWorkerHandler.generate_tokens(
+        handler,
+        prompt=None,
+        sampling_params=SamplingParams(),
+        request_id="req-1",
+    ):
+        chunks.append(chunk)
+    return chunks, handler
+
+
+def test_build_sampling_params_forces_delta_token_mode():
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"output_kind": RequestOutputKind.CUMULATIVE},
+        "stop_conditions": {},
+        "output_options": {},
+    }
+
+    sampling_params = build_sampling_params(
+        request,
+        default_sampling_params={
+            "detokenize": True,
+            "output_kind": RequestOutputKind.CUMULATIVE,
+        },
+    )
+
+    assert sampling_params.detokenize is False
+    assert sampling_params.output_kind == RequestOutputKind.DELTA
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_passes_delta_chunks_without_cumulative_slicing():
+    responses = [
+        _request_output([_output([1])], prompt_token_ids=[10, 11]),
+        _request_output([_output([2, 3])], prompt_token_ids=[10, 11]),
+        _request_output(
+            [_output([4], finish_reason="length")], prompt_token_ids=[10, 11]
+        ),
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert [chunk["token_ids"] for chunk in chunks] == [[1], [2, 3], [4]]
+    assert chunks[-1]["finish_reason"] == "length"
+    assert chunks[-1]["completion_usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 4,
+        "total_tokens": 6,
+        "prompt_tokens_details": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_keeps_final_empty_delta_chunk_for_usage():
+    responses = [
+        _request_output([_output([1, 2])], prompt_token_ids=[10]),
+        _request_output([_output([], finish_reason="length")], prompt_token_ids=[10]),
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert [chunk["token_ids"] for chunk in chunks] == [[1, 2], []]
+    assert chunks[-1]["finish_reason"] == "length"
+    assert chunks[-1]["completion_usage"]["completion_tokens"] == 2
+    assert chunks[-1]["completion_usage"]["total_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_tracks_interleaved_output_indexes_independently():
+    responses = [
+        _request_output([_output([1], index=0), _output([10, 11], index=1)]),
+        _request_output(
+            [
+                _output([2], index=0, finish_reason="length"),
+                _output([12], index=1),
+            ]
+        ),
+        _request_output([_output([], index=1, finish_reason="length")]),
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert [(chunk["index"], chunk["token_ids"]) for chunk in chunks] == [
+        (0, [1]),
+        (1, [10, 11]),
+        (0, [2]),
+        (1, [12]),
+        (1, []),
+    ]
+    assert chunks[2]["completion_usage"]["completion_tokens"] == 5
+    assert chunks[-1]["completion_usage"]["completion_tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_reads_delta_aligned_logprobs_from_zero_offset():
+    logprobs = [
+        {7: SimpleNamespace(logprob=-0.7, rank=1, decoded_token="a")},
+        {8: SimpleNamespace(logprob=-0.8, rank=1, decoded_token="b")},
+    ]
+    responses = [
+        _request_output([_output([7, 8], finish_reason="length", logprobs=logprobs)])
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert chunks[0]["token_ids"] == [7, 8]
+    assert chunks[0]["log_probs"] == [-0.7, -0.8]
+    assert [entry[0]["token_id"] for entry in chunks[0]["top_logprobs"]] == [7, 8]
+
+
+@pytest.mark.asyncio
+async def test_unified_llm_engine_passes_delta_chunks_and_counts_usage():
+    pytest.importorskip("vllm.usage.usage_lib")
+    from dynamo.vllm.llm_engine import VllmLLMEngine
+
+    responses = [
+        _request_output([_output([1])], prompt_token_ids=[10, 11]),
+        _request_output(
+            [_output([2, 3], finish_reason="length")], prompt_token_ids=[10, 11]
+        ),
+    ]
+    engine = VllmLLMEngine.__new__(VllmLLMEngine)
+    engine.engine_client = _FakeEngineClient(responses)
+    engine._default_sampling_params = {}
+    engine._model_max_len = None
+    engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine._dp_range = None
+
+    chunks = [
+        chunk
+        async for chunk in VllmLLMEngine.generate(
+            engine,
+            {
+                "token_ids": [10, 11],
+                "sampling_options": {},
+                "stop_conditions": {},
+                "output_options": {},
+            },
+            _FakeContext(),
+        )
+    ]
+
+    sampling_params = engine.engine_client.calls[0][0][1]
+    assert sampling_params.output_kind == RequestOutputKind.DELTA
+    assert [chunk["token_ids"] for chunk in chunks] == [[1], [2, 3]]
+    assert chunks[-1]["completion_usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }

--- a/components/src/dynamo/vllm/tests/test_vllm_engine.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine.py
@@ -54,6 +54,8 @@ def _base_argv(env: Mapping[str, str]) -> list[str]:
         "--max-num-seqs",
         "4",
         "--enforce-eager",
+        "--stream-interval",
+        "4",
     ]
 
 
@@ -148,6 +150,7 @@ async def _check_generate_streams_chunks_with_coherent_final_usage(started_engin
     ``finish_reason`` and a ``completion_usage`` whose totals add up."""
     engine, _ = started_engine
     ctx = _FakeContext("gen-1")
+    max_tokens = 16
 
     chunks = []
     async for chunk in engine.generate(
@@ -155,8 +158,8 @@ async def _check_generate_streams_chunks_with_coherent_final_usage(started_engin
             dict,
             {
                 "token_ids": [1, 2, 3, 4, 5],
-                "stop_conditions": {"max_tokens": 16},
-                "sampling_options": {"temperature": 0.0},
+                "stop_conditions": {"max_tokens": max_tokens},
+                "sampling_options": {"temperature": 0.0, "ignore_eos": True},
             },
         ),
         cast(object, ctx),  # type: ignore[arg-type]
@@ -166,7 +169,15 @@ async def _check_generate_streams_chunks_with_coherent_final_usage(started_engin
 
     final = chunks[-1]
     assert "finish_reason" in final
+    assert final["finish_reason"] == "length"
+    token_chunks = [chunk["token_ids"] for chunk in chunks]
+    non_empty_token_chunks = [ids for ids in token_chunks if ids]
+    emitted_token_ids = [token_id for ids in token_chunks for token_id in ids]
+    assert len(non_empty_token_chunks) > 1
+    assert any(len(ids) >= 4 for ids in non_empty_token_chunks)
+    assert len(emitted_token_ids) == max_tokens
     usage = final["completion_usage"]
+    assert usage["completion_tokens"] == max_tokens
     assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
 
 


### PR DESCRIPTION
## Summary

- Force Dynamo's internal vLLM token path to use `RequestOutputKind.DELTA` with `detokenize=False`.
- Treat vLLM token outputs as disjoint delta chunks in both the legacy vLLM handler and unified `VllmLLMEngine` path.
- Track cumulative generated token counts inside Dynamo for final usage accounting, including multi-output streams and final empty chunks.
- Add focused unit coverage for delta chunk passthrough, stream-interval-shaped batching, interleaved output indexes, final empty chunks, logprobs, and the unified engine path.

## Why

vLLM's `stream_interval` only reduces backend emissions in DELTA mode because `sent_tokens_offset` advances only for `RequestOutputKind.DELTA`. Dynamo previously left vLLM in the default cumulative mode and diffed token arrays itself, so `stream_interval` did not reduce Python-to-Rust bridge chunk pressure. This makes vLLM match Dynamo's SGLang contract: backend token chunks are already disjoint deltas.

## Validation

- `python3 -m py_compile components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/llm_engine.py components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py`
- `git diff --check --cached`
- In `dynamo:latest-vllm-local-dev`, with built local bindings mounted: `pytest -q components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py` -> `31 passed`
- Commit hooks: isort, black, flake8, codespell, ruff passed. `pytest-marker-report` was skipped on commit because its pre-commit Python 3.10 env cannot import repo code that uses `typing.Required` / `typing.Self`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced vLLM token streaming to use DELTA mode for improved accuracy
  * Changed token accounting to track cumulative per-output counts for more precise completion token reporting

* **Tests**
  * Added test coverage for DELTA streaming behavior and token accounting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->