### PR TITLE
fix(container): add NIXL build env to vLLM dev image

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -193,24 +193,53 @@ RUN if [ ! -e /usr/bin/python3 ]; then \
         fi; \
     fi
 
-# Copy UCX and NIXL libraries for dev stage compilation.
-# The upstream SGLang runtime image doesn't include NIXL, but cargo build needs to link against
-# -lnixl, -lnixl_build, and -lnixl_common. Runtime stage doesn't need this since it uses pre-built
-# wheels, but dev stage needs it for maturin develop and cargo build from source.
+# Copy NIXL SDK material for dev stage compilation.
+# cargo build needs NIXL headers plus linkable -lnixl, -lnixl_build, and -lnixl_common.
 # - SGLang: Copy NIXL/UCX/libfabric/gdrcopy binaries from wheel_builder (not in upstream lmsysorg/sglang runtime).
-# - vllm/trtllm/none: NIXL/UCX are already present in runtime (no-op).
+# - vLLM CUDA: Reuse upstream vLLM's Python-wheel NIXL libs and copy only headers beside them.
+# - trtllm/none: NIXL/UCX are already present in runtime (no-op).
 ARG TARGETARCH
+{% if framework == "vllm" and device == "cuda" %}
+ARG CUDA_MAJOR
+{% endif %}
 RUN --mount=from=wheel_builder,target=/wheel_builder \
+    set -eux; \
     if [ "${FRAMEWORK}" = "sglang" ]; then \
-        if [ -d /wheel_builder/usr/local/ucx ] && [ -d /wheel_builder/opt/nvidia/nvda_nixl ]; then \
-            mkdir -p /opt/nvidia /usr/include /usr/lib64 /etc/ld.so.conf.d; \
-            cp -r /wheel_builder/opt/nvidia/nvda_nixl /opt/nvidia/; \
-            cp -r /wheel_builder/usr/local/ucx /usr/local/; \
-            cp -r /wheel_builder/usr/local/libfabric /usr/local/; \
-            cp /wheel_builder/usr/include/gdrapi.h /usr/include/; \
-            cp /wheel_builder/usr/lib64/libgdrapi.so* /usr/lib64/; \
-            echo "/usr/lib64" >> /etc/ld.so.conf.d/gdrcopy.conf; \
+        test -d /wheel_builder/usr/local/ucx; \
+        test -d /wheel_builder/opt/nvidia/nvda_nixl; \
+        mkdir -p /opt/nvidia /usr/include /usr/lib64 /etc/ld.so.conf.d; \
+        cp -r /wheel_builder/opt/nvidia/nvda_nixl /opt/nvidia/; \
+        cp -r /wheel_builder/usr/local/ucx /usr/local/; \
+        cp -r /wheel_builder/usr/local/libfabric /usr/local/; \
+        cp /wheel_builder/usr/include/gdrapi.h /usr/include/; \
+        cp /wheel_builder/usr/lib64/libgdrapi.so* /usr/lib64/; \
+        echo "/usr/lib64" >> /etc/ld.so.conf.d/gdrcopy.conf; \
+{% if framework == "vllm" and device == "cuda" %}
+    elif [ "${FRAMEWORK}" = "vllm" ]; then \
+        wheel_lib_dir="/usr/local/lib/python${PYTHON_VERSION}/dist-packages/.nixl_cu${CUDA_MAJOR}.mesonpy.libs"; \
+        if [ ! -d "${wheel_lib_dir}" ]; then \
+            echo "ERROR: expected upstream vLLM NIXL wheel libs at ${wheel_lib_dir}; update vLLM NIXL dev-image path handling." >&2; \
+            exit 1; \
         fi; \
+        for lib in libnixl.so libnixl_build.so libnixl_common.so libserdes.so libstream.so; do \
+            if [ ! -f "${wheel_lib_dir}/${lib}" ]; then \
+                echo "ERROR: missing ${wheel_lib_dir}/${lib}; upstream vLLM NIXL wheel layout changed." >&2; \
+                exit 1; \
+            fi; \
+        done; \
+        if [ ! -d "${wheel_lib_dir}/plugins" ]; then \
+            echo "ERROR: missing ${wheel_lib_dir}/plugins; upstream vLLM NIXL wheel layout changed." >&2; \
+            exit 1; \
+        fi; \
+        test -d /wheel_builder/opt/nvidia/nvda_nixl/include; \
+        if [ ! -f "${wheel_lib_dir}/include/nixl.h" ]; then \
+            rm -rf "${wheel_lib_dir}/include"; \
+            cp -r /wheel_builder/opt/nvidia/nvda_nixl/include "${wheel_lib_dir}/include"; \
+        fi; \
+        test -f "${wheel_lib_dir}/include/nixl.h"; \
+        mkdir -p /opt/dynamo; \
+        ln -sfn "${wheel_lib_dir}" /opt/dynamo/nixl; \
+{% endif %}
     fi
 
 {% if device == "xpu" %}
@@ -222,16 +251,17 @@ ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu  \
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu/plugins
-{% elif framework == "vllm" or framework == "trtllm" %}
-# vllm/trtllm dev images inherit upstream containers that ship NIXL inside the
-# Python wheel; libnixl.so loads via the wheel's DT_RPATH, so these env vars
-# act only as a stable anchor that avoids hardcoding a CUDA-specific path.
+{% elif framework == "trtllm" or (framework == "vllm" and device == "cuda") %}
+# trtllm and vLLM CUDA dev images inherit upstream containers that ship NIXL
+# inside Python wheels. These env vars provide a stable prefix for source builds.
+# For vLLM CUDA, /opt/dynamo/nixl is a symlink to the wheel's
+# .nixl_cu${CUDA_MAJOR}.mesonpy.libs directory, with headers added by the dev stage.
 ENV NIXL_PREFIX=/opt/dynamo/nixl \
     NIXL_LIB_DIR=/opt/dynamo/nixl \
     NIXL_PLUGIN_DIR=/opt/dynamo/nixl/plugins
 {% else %}
 # NIXL is installed under lib64 (manylinux/AlmaLinux convention used by the wheel_builder).
-# For trtllm/none: this resets the same values already set in runtime.
+# For dynamo: this resets the same values already set in runtime.
 # For sglang: this sets them after copying NIXL from wheel_builder above.
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \


### PR DESCRIPTION
## What

Adds a NIXL build environment to the CUDA vLLM dev image without copying a second NIXL runtime library tree.

For CUDA vLLM dev images, the Dockerfile now:

- reuses the upstream vLLM wheel's native NIXL libs under `.nixl_cu${CUDA_MAJOR}.mesonpy.libs`
- copies only the NIXL headers from `wheel_builder` into that wheel lib directory
- exposes the result through `/opt/dynamo/nixl`, a stable symlink/prefix for `nixl-sys`, Cargo, and `maturin develop`
- fails the image build if the expected upstream wheel lib directory, required NIXL libs, or plugin directory are missing

SGLang keeps the existing full SDK copy from `wheel_builder`. CPU/XPU/runtime behavior is unchanged.

## Why

The vLLM runtime image can carry NIXL native libs via Python wheel paths, but source rebuilds need a C/C++ build environment: headers plus linkable `libnixl.so`, `libnixl_build.so`, and related libraries.

Previously, rebuilding KVBM/Dynamo in the vLLM dev image could not compile cleanly against the NIXL that existed in the container. Copying another full `/opt/nvidia/nvda_nixl` runtime tree would make the image ambiguous, so this uses the upstream wheel's native libraries as the single runtime/link source and adds headers beside them.

## Relationship to #9911

Related to #9911, but this PR does not replace it. #9911 fixes CUDA `vllm-runtime` by adding the upstream wheel's hidden NIXL lib directory to runtime `LD_LIBRARY_PATH` so frontend `dlopen("libnixl.so")` does not fall into stub mode.

This PR is for the CUDA vLLM dev image/source-build path. The dev image gets its own `/opt/dynamo/nixl` prefix and `LD_LIBRARY_PATH`, but the runtime template is not changed here.

## Validation

- `git diff --check`
- rendered CUDA vLLM dev Dockerfile:
  - `python3 container/render.py --framework vllm --target dev --device cuda --cuda-version 13.0 --output-short-filename`
- built CUDA vLLM dev image locally from latest `origin/main`:
  - `DOCKER_BUILDKIT=1 docker buildx build --progress=plain --load -t dynamo:vllm-dev-nixl-single-lib -f container/rendered.Dockerfile --build-arg USE_SCCACHE=false --secret id=aws-web-identity-token,src=/dev/null --secret id=aws-role-arn,env=AWS_ROLE_ARN .`
- verified final image layout:
  - `/opt/dynamo/nixl` is a symlink to `/usr/local/lib/python3.12/dist-packages/.nixl_cu13.mesonpy.libs`
  - headers exist at `/opt/dynamo/nixl/include/nixl.h`
  - required libs and plugins exist under the same wheel lib directory
  - `/opt/nvidia/nvda_nixl/lib64/libnixl.so` is not present, avoiding a second copied runtime lib tree
- rebuilt and imported KVBM inside the image with `maturin develop --uv`
- checked KVBM dynamic links:
  - `readelf` shows `libnixl.so` and `libnixl_build.so` dependencies
  - `ldd` resolves them via `/opt/dynamo/nixl`
  - canonical paths resolve to the upstream `.nixl_cu13.mesonpy.libs` files
  - Python `/proc/self/maps` shows the loaded NIXL libs come from `.nixl_cu13.mesonpy.libs`

## Note

The commit was made with `SKIP=pytest-marker-report` because that pre-commit hook creates a Python 3.10 environment and fails collecting current-tree tests that import Python 3.11 typing names (`Self` / `Required`). Other relevant hooks passed.
