### PR TITLE
feat(operator): InferenceGatewayReady status condition — kill the silent gateway 404

### DIFF
--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -139,6 +139,14 @@ rules:
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
   - httproutes
   verbs:
   - create

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -55,6 +55,18 @@ const (
 	// means same namespace as the generated HTTPRoute / InferencePool.
 	KubeAnnotationInferenceGatewayNamespace = "nvidia.com/inference-gateway-namespace"
 
+	// ConditionTypeInferenceGatewayReady is a DGD status condition surfacing
+	// whether the generated HTTPRoute can actually attach to its Gateway. It
+	// turns otherwise-silent gateway misconfigurations (missing gateway, a
+	// listener that doesn't admit this namespace, a not-yet-programmed gateway)
+	// into an actionable `kubectl get dgd` signal.
+	ConditionTypeInferenceGatewayReady = "InferenceGatewayReady"
+	// Reasons for ConditionTypeInferenceGatewayReady.
+	ReasonInferenceGatewayReady           = "Ready"
+	ReasonInferenceGatewayNotFound        = "GatewayNotFound"
+	ReasonInferenceGatewayNamespaceDenied = "GatewayNamespaceNotAllowed"
+	ReasonInferenceGatewayNotProgrammed   = "GatewayNotProgrammed"
+
 	KubeLabelDynamoGraphDeploymentName = "nvidia.com/dynamo-graph-deployment-name"
 	KubeLabelDynamoComponent           = "nvidia.com/dynamo-component"
 	KubeLabelDynamoNamespace           = "nvidia.com/dynamo-namespace"

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -102,6 +102,7 @@ type DynamoGraphDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=scheduling.run.ai,resources=queues,verbs=get;list
 // +kubebuilder:rbac:groups=inference.networking.k8s.io,resources=inferencepools,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaimtemplates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses,verbs=get;list;watch
@@ -1976,6 +1977,37 @@ func (r *DynamoGraphDeploymentReconciler) reconcileEPPResources(ctx context.Cont
 			return fmt.Errorf("failed to sync EPP HTTPRoute: %w", err)
 		}
 		logger.Info("Reconciled EPP HTTPRoute", "gateway", gatewayName)
+
+		// Preflight the Gateway and surface the result on the DGD status. The
+		// HTTPRoute attaching is asynchronous and silent on failure (a missing
+		// gateway, a listener that doesn't admit this namespace, or a
+		// not-yet-programmed gateway all just 404 with no signal). Turn that into
+		// an actionable InferenceGatewayReady condition.
+		gwNamespace := gatewayNamespace
+		if gwNamespace == "" {
+			gwNamespace = dgd.Namespace
+		}
+		gw := &gatewayv1.Gateway{}
+		var gwPtr *gatewayv1.Gateway
+		if gerr := r.Get(ctx, client.ObjectKey{Name: gatewayName, Namespace: gwNamespace}, gw); gerr == nil {
+			gwPtr = gw
+		} else if !errors.IsNotFound(gerr) {
+			logger.Error(gerr, "Failed to read Gateway for preflight", "gateway", gatewayName)
+		}
+		pf := epp.PreflightGateway(gwPtr, dgd.Namespace)
+		condStatus := metav1.ConditionFalse
+		if pf.Ready {
+			condStatus = metav1.ConditionTrue
+		}
+		dgd.AddStatusCondition(metav1.Condition{
+			Type:    consts.ConditionTypeInferenceGatewayReady,
+			Status:  condStatus,
+			Reason:  pf.Reason,
+			Message: pf.Message,
+		})
+		if !pf.Ready {
+			logger.Info("Inference gateway not ready", "reason", pf.Reason, "message", pf.Message)
+		}
 	}
 
 	// 3. Reconcile service mesh resources (e.g., Istio DestinationRule).

--- a/deploy/operator/internal/controller/dynamographdeployment_igw_status_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_igw_status_test.go
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func igwScheme(t testing.TB) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme, v1beta1.AddToScheme, gaiev1.Install, gatewayv1.Install,
+	} {
+		if err := add(s); err != nil {
+			t.Fatalf("add to scheme: %v", err)
+		}
+	}
+	return s
+}
+
+func igwDGD() *v1beta1.DynamoGraphDeployment {
+	return &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "graph",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				commonconsts.KubeAnnotationInferenceGatewayName:      "inference-gateway",
+				commonconsts.KubeAnnotationInferenceGatewayNamespace: "gw-ns",
+			},
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "Epp",
+				ComponentType: v1beta1.ComponentTypeEPP,
+				EPPConfig:     &v1beta1.EPPConfig{Config: &apixv1alpha1.EndpointPickerConfig{}},
+			}},
+		},
+	}
+}
+
+func igwReconciler(t testing.TB) (*DynamoGraphDeploymentReconciler, *v1beta1.DynamoGraphDeployment) {
+	t.Helper()
+	dgd := igwDGD()
+	r := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(igwScheme(t)).WithObjects(dgd).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &commoncontroller.RuntimeConfig{},
+		Recorder:      record.NewFakeRecorder(10),
+	}
+	return r, dgd
+}
+
+func conditionReason(dgd *v1beta1.DynamoGraphDeployment) (string, metav1.ConditionStatus) {
+	c := apimeta.FindStatusCondition(dgd.Status.Conditions, commonconsts.ConditionTypeInferenceGatewayReady)
+	if c == nil {
+		return "", ""
+	}
+	return c.Reason, c.Status
+}
+
+// No Gateway exists -> condition surfaces GatewayNotFound (not a silent 404).
+func TestReconcileEPP_SetsConditionGatewayNotFound(t *testing.T) {
+	g := gomega.NewWithT(t)
+	r, dgd := igwReconciler(t)
+	g.Expect(r.reconcileEPPResources(context.Background(), dgd)).To(gomega.Succeed())
+	reason, status := conditionReason(dgd)
+	g.Expect(status).To(gomega.Equal(metav1.ConditionFalse))
+	g.Expect(reason).To(gomega.Equal(commonconsts.ReasonInferenceGatewayNotFound))
+}
+
+// A programmed, allowedRoutes=All gateway in its own ns -> Ready (cross-namespace).
+func TestReconcileEPP_SetsConditionReady(t *testing.T) {
+	g := gomega.NewWithT(t)
+	dgd := igwDGD()
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "inference-gateway", Namespace: "gw-ns"},
+		Spec: gatewayv1.GatewaySpec{Listeners: []gatewayv1.Listener{{
+			Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+			AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: ptr.To(gatewayv1.NamespacesFromAll)},
+			},
+		}}},
+		Status: gatewayv1.GatewayStatus{Conditions: []metav1.Condition{{
+			Type: "Programmed", Status: metav1.ConditionTrue,
+			Reason: "Programmed", LastTransitionTime: metav1.Now(),
+		}}},
+	}
+	r := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(igwScheme(t)).WithObjects(dgd, gw).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &commoncontroller.RuntimeConfig{},
+		Recorder:      record.NewFakeRecorder(10),
+	}
+	g.Expect(r.reconcileEPPResources(context.Background(), dgd)).To(gomega.Succeed())
+	reason, status := conditionReason(dgd)
+	g.Expect(status).To(gomega.Equal(metav1.ConditionTrue))
+	g.Expect(reason).To(gomega.Equal(commonconsts.ReasonInferenceGatewayReady))
+}

--- a/deploy/operator/internal/dynamo/epp/preflight.go
+++ b/deploy/operator/internal/dynamo/epp/preflight.go
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package epp
+
+import (
+	"fmt"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// GatewayPreflightResult reports whether a generated HTTPRoute in routeNamespace
+// can actually attach to gw, with an actionable reason/message when it can't.
+// It converts the silent failure modes (the route is created but never attaches,
+// so requests 404 at the gateway with no signal) into a status condition.
+type GatewayPreflightResult struct {
+	Ready   bool
+	Reason  string // one of consts.ReasonInferenceGateway*
+	Message string
+}
+
+// reason/message strings are kept here as plain literals so this package has no
+// dependency on internal/consts; the controller maps Reason onto the consts.
+const (
+	reasonReady           = "Ready"
+	reasonNotFound        = "GatewayNotFound"
+	reasonNamespaceDenied = "GatewayNamespaceNotAllowed"
+	reasonNotProgrammed   = "GatewayNotProgrammed"
+	gatewayProgrammedType = "Programmed"
+)
+
+// PreflightGateway checks, in order: the gateway exists, at least one listener
+// admits routeNamespace (the allowedRoutes check — the cross-namespace silent
+// 404 we hit in practice), and the gateway is Programmed. gw==nil means the
+// controller's Get returned NotFound.
+//
+// allowedRoutes semantics (Gateway API): a listener's
+// allowedRoutes.namespaces.from of "All" admits any namespace; "Same" admits
+// only the gateway's own namespace; nil defaults to "Same". "Selector" can't be
+// fully evaluated here (needs a namespace-label lookup), so it is treated as
+// admissible-but-unverified to avoid false negatives.
+func PreflightGateway(gw *gatewayv1.Gateway, routeNamespace string) GatewayPreflightResult {
+	if gw == nil {
+		return GatewayPreflightResult{
+			Ready:   false,
+			Reason:  reasonNotFound,
+			Message: "referenced Gateway not found; create it (or fix inferenceGateway.gatewayName/gatewayNamespace) — the EPP InferencePool is created but no traffic will route until the Gateway exists",
+		}
+	}
+
+	if !listenerAdmitsNamespace(gw, routeNamespace) {
+		return GatewayPreflightResult{
+			Ready:  false,
+			Reason: reasonNamespaceDenied,
+			Message: fmt.Sprintf(
+				"Gateway %q (ns %q) has no listener admitting routes from namespace %q; "+
+					"the HTTPRoute will not attach and requests will 404. Fix: set the "+
+					"Gateway listener's spec.listeners[].allowedRoutes.namespaces.from to \"All\" "+
+					"(or a selector matching %q).",
+				gw.Name, gw.Namespace, routeNamespace, routeNamespace),
+		}
+	}
+
+	if !gatewayProgrammed(gw) {
+		return GatewayPreflightResult{
+			Ready:   false,
+			Reason:  reasonNotProgrammed,
+			Message: fmt.Sprintf("Gateway %q is not Programmed yet; its data plane is still coming up", gw.Name),
+		}
+	}
+
+	return GatewayPreflightResult{
+		Ready:   true,
+		Reason:  reasonReady,
+		Message: fmt.Sprintf("HTTPRoute attaches to Gateway %q in namespace %q", gw.Name, gw.Namespace),
+	}
+}
+
+// listenerAdmitsNamespace returns true if any listener admits routeNamespace.
+func listenerAdmitsNamespace(gw *gatewayv1.Gateway, routeNamespace string) bool {
+	for _, l := range gw.Spec.Listeners {
+		from := gatewayv1.NamespacesFromSame // Gateway API default when unset
+		if l.AllowedRoutes != nil && l.AllowedRoutes.Namespaces != nil && l.AllowedRoutes.Namespaces.From != nil {
+			from = *l.AllowedRoutes.Namespaces.From
+		}
+		switch from {
+		case gatewayv1.NamespacesFromAll:
+			return true
+		case gatewayv1.NamespacesFromSame:
+			if routeNamespace == gw.Namespace {
+				return true
+			}
+		case gatewayv1.NamespacesFromSelector:
+			// Can't evaluate the label selector here without a Namespace lookup;
+			// treat as admissible to avoid a false "denied" (the gateway
+			// controller is the source of truth for selector matching).
+			return true
+		}
+	}
+	return false
+}
+
+// gatewayProgrammed returns true if the Gateway's Programmed condition is True.
+func gatewayProgrammed(gw *gatewayv1.Gateway) bool {
+	for _, c := range gw.Status.Conditions {
+		if c.Type == gatewayProgrammedType {
+			return c.Status == "True"
+		}
+	}
+	return false
+}

--- a/deploy/operator/internal/dynamo/epp/preflight_test.go
+++ b/deploy/operator/internal/dynamo/epp/preflight_test.go
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package epp
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func gw(ns string, from *gatewayv1.FromNamespaces, programmed bool) *gatewayv1.Gateway {
+	g := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "inference-gateway", Namespace: ns},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+		},
+	}
+	if from != nil {
+		g.Spec.Listeners[0].AllowedRoutes = &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{From: from},
+		}
+	}
+	if programmed {
+		g.Status.Conditions = []metav1.Condition{{Type: "Programmed", Status: metav1.ConditionTrue}}
+	}
+	return g
+}
+
+func TestPreflight_NotFound(t *testing.T) {
+	r := PreflightGateway(nil, "igw-demo")
+	if r.Ready || r.Reason != reasonNotFound {
+		t.Fatalf("nil gateway: got ready=%v reason=%q, want not-ready GatewayNotFound", r.Ready, r.Reason)
+	}
+}
+
+func TestPreflight_CrossNamespaceAllowedAll(t *testing.T) {
+	// shared gateway in its own ns, allowedRoutes=All, programmed → ready cross-ns.
+	r := PreflightGateway(gw("inference-gateway", ptr.To(gatewayv1.NamespacesFromAll), true), "igw-demo")
+	if !r.Ready || r.Reason != reasonReady {
+		t.Fatalf("All+programmed cross-ns: got ready=%v reason=%q, want Ready", r.Ready, r.Reason)
+	}
+}
+
+func TestPreflight_SameNamespaceDeniesCrossNs(t *testing.T) {
+	// the silent-404 we hit: shared gateway, allowedRoutes=Same, route in a
+	// different namespace → not ready, with the actionable reason.
+	r := PreflightGateway(gw("inference-gateway", ptr.To(gatewayv1.NamespacesFromSame), true), "igw-demo")
+	if r.Ready || r.Reason != reasonNamespaceDenied {
+		t.Fatalf("Same cross-ns: got ready=%v reason=%q, want GatewayNamespaceNotAllowed", r.Ready, r.Reason)
+	}
+}
+
+func TestPreflight_DefaultAllowedRoutesIsSame(t *testing.T) {
+	// nil allowedRoutes defaults to Same → cross-ns denied.
+	r := PreflightGateway(gw("inference-gateway", nil, true), "igw-demo")
+	if r.Ready || r.Reason != reasonNamespaceDenied {
+		t.Fatalf("nil allowedRoutes cross-ns: got ready=%v reason=%q, want GatewayNamespaceNotAllowed", r.Ready, r.Reason)
+	}
+}
+
+func TestPreflight_SameNamespaceAllowedWhenColocated(t *testing.T) {
+	// allowedRoutes=Same and the route is in the gateway's own ns → ready.
+	r := PreflightGateway(gw("igw-demo", ptr.To(gatewayv1.NamespacesFromSame), true), "igw-demo")
+	if !r.Ready {
+		t.Fatalf("Same same-ns: got ready=%v reason=%q, want Ready", r.Ready, r.Reason)
+	}
+}
+
+func TestPreflight_NotProgrammed(t *testing.T) {
+	r := PreflightGateway(gw("inference-gateway", ptr.To(gatewayv1.NamespacesFromAll), false), "igw-demo")
+	if r.Ready || r.Reason != reasonNotProgrammed {
+		t.Fatalf("not programmed: got ready=%v reason=%q, want GatewayNotProgrammed", r.Ready, r.Reason)
+	}
+}
+
+func TestPreflight_SelectorTreatedAdmissible(t *testing.T) {
+	// Selector can't be evaluated here; treat as admissible to avoid false denial.
+	r := PreflightGateway(gw("inference-gateway", ptr.To(gatewayv1.NamespacesFromSelector), true), "igw-demo")
+	if !r.Ready {
+		t.Fatalf("Selector: got ready=%v reason=%q, want Ready (admissible-unverified)", r.Ready, r.Reason)
+	}
+}


### PR DESCRIPTION
Draft — **stacked on #9910** (base \`feat/dgdr-inference-gateway\`). The highest-leverage *setup-UX* fix from our IGW design proposal: make the worst silent failure loud.

## Problem (hit live)
#9910's reconcile hook emits the HTTPRoute but **never checks the Gateway**. So the failure modes that actually bite are all silent — the route is created, then just 404s with no signal:
- the named Gateway doesn't exist;
- a listener's \`allowedRoutes.namespaces.from\` doesn't admit the route's namespace (the **cross-namespace \`Same\` 404** I hit standing this up — a shared gateway in its own ns rejects the route unless \`allowedRoutes: All\`);
- the Gateway isn't \`Programmed\` yet.

You only find out by reading EPP/agentgateway logs. That's the #1 setup pain.

## Fix
- **`epp.PreflightGateway(gw, routeNamespace)`** — gateway exists? a listener admits this namespace (full \`allowedRoutes\` semantics: All / Same / Selector→admissible-unverified / nil→Same)? programmed? Returns a reason + an **actionable message** (e.g. *"set the Gateway listener's allowedRoutes.namespaces.from to \"All\""*).
- The reconcile hook fetches the Gateway and sets an **`InferenceGatewayReady`** condition on the DGD status (`GatewayNotFound` / `GatewayNamespaceNotAllowed` / `GatewayNotProgrammed` / `Ready`). Converts log-spelunking into `kubectl get dgd`.
- `+kubebuilder:rbac` for `gateways` get/list (regenerated role.yaml).

## Tests (all green, Go 1.25)
- `preflight_test.go` — 7 cases: not-found, cross-ns All→ready, Same→denied (the live bug), nil-allowedRoutes→Same, Same-colocated→ready, not-programmed, Selector→admissible.
- `dynamographdeployment_igw_status_test.go` — 2 fake-client controller cases: no gateway ⇒ condition `GatewayNotFound`; programmed All gateway ⇒ `Ready`.
- `go build` · `go vet` · conversion-fuzz · epp pkg — green.

## Scope / notes
- Additive: a new status condition + read-only gateway RBAC. No API/spec change.
- Route attachment is async; this reports the preflightable causes synchronously and re-evaluates each reconcile. Reading the HTTPRoute's own `Accepted` condition back is a possible follow-up.
- Part of the broader "two-commands, zero-silent-failures" setup proposal (design doc in the work-vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)