### PR TITLE
chore: Add XPU device visibility normalization for vLLM-Omni stage workers

### DIFF
--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -735,7 +735,11 @@ def _normalize_single_stage_runtime_devices(stage_arg: dict) -> None:
 
 
 def _get_visible_devices() -> list[str]:
-    for env_var in ("CUDA_VISIBLE_DEVICES", "ASCEND_RT_VISIBLE_DEVICES"):
+    for env_var in (
+        "CUDA_VISIBLE_DEVICES",
+        "ASCEND_RT_VISIBLE_DEVICES",
+        "ZE_AFFINITY_MASK",
+    ):
         if devices := os.environ.get(env_var):
             return _parse_runtime_devices(devices)
     return []

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -592,6 +592,36 @@ def test_single_stage_runtime_devices_preserve_visible_subset(monkeypatch):
     assert stage_arg["runtime"]["devices"] == "1"
 
 
+def test_single_stage_runtime_devices_normalized_for_xpu_visibility(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("ASCEND_RT_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv("ZE_AFFINITY_MASK", "2")
+    stage_arg = {
+        "stage_id": 0,
+        "stage_type": "diffusion",
+        "runtime": {"devices": "2"},
+    }
+
+    _normalize_single_stage_runtime_devices(stage_arg)
+
+    assert stage_arg["runtime"]["devices"] == "0"
+
+
+def test_single_stage_runtime_devices_preserve_xpu_visible_subset(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("ASCEND_RT_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv("ZE_AFFINITY_MASK", "0,1")
+    stage_arg = {
+        "stage_id": 0,
+        "stage_type": "diffusion",
+        "runtime": {"devices": "1"},
+    }
+
+    _normalize_single_stage_runtime_devices(stage_arg)
+
+    assert stage_arg["runtime"]["devices"] == "1"
+
+
 def test_fetch_stage_inputs_raises_on_missing_connector():
     worker = _make_worker_at_stage(1, connectors={}, engine_input_source=[0])
     with pytest.raises(RuntimeError, match="no connector for edge"):


### PR DESCRIPTION
#### Overview:

Please merge with #8492

Add XPU device visibility support to vLLM-Omni stage workers so `ZE_AFFINITY_MASK` is handled like CUDA/Ascend visibility masks.

#### Details:

 - Include `ZE_AFFINITY_MASK` in `_get_visible_devices()`.
 - Allow XPU stage-local `runtime.devices` to be normalized to vLLM-Omni logical device IDs.
 - Add unit tests.

#### Where should the reviewer start?

 - `components/src/dynamo/vllm/omni/stage_worker.py`
 - `components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device visibility detection for Intel XPU hardware configurations.

* **Tests**
  * Added test coverage for Intel XPU device visibility constraints and behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->