### PR TITLE
refactor(parsers): decouple dynamo-parsers from dynamo-protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ package-lock.json
 # macOS
 .DS_Store
 **/.DS_Store
+
+# HuggingFace hub cache downloaded by tests (never commit; committed fixtures use plain dir names)
+lib/llm/tests/data/sample-models/models--*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,7 +2637,6 @@ name = "dynamo-parsers"
 version = "1.2.0"
 dependencies = [
  "anyhow",
- "dynamo-protocols",
  "num-traits",
  "openai-harmony",
  "regex",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1678,7 +1678,6 @@ name = "dynamo-parsers"
 version = "1.2.0"
 dependencies = [
  "anyhow",
- "dynamo-protocols",
  "num-traits",
  "openai-harmony",
  "regex",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2238,7 +2238,6 @@ name = "dynamo-parsers"
 version = "1.2.0"
 dependencies = [
  "anyhow",
- "dynamo-protocols",
  "num-traits",
  "openai-harmony",
  "regex",

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -24,6 +24,54 @@ pub mod jail;
 pub use aggregator::DeltaAggregator;
 pub use delta::DeltaGenerator;
 
+use dynamo_parsers::tool_calling::{ToolCallResponse, ToolCallResponseChunk};
+use dynamo_protocols::types::{
+    ChatCompletionMessageToolCall, ChatCompletionMessageToolCallChunk, FunctionCall,
+    FunctionCallStream, FunctionType,
+};
+
+/// Map a parser-native [`ToolCallResponse`] onto the protocol/wire
+/// [`ChatCompletionMessageToolCall`].
+///
+/// `dynamo-parsers` is decoupled from `dynamo-protocols`, so this consumer —
+/// which already depends on both — owns the mapping between the parser-native
+/// types and the OpenAI wire types. The field shapes are identical, so this is
+/// a straight re-map that preserves the previous wire output.
+pub(crate) fn tool_call_response_to_protocol(
+    parsed: ToolCallResponse,
+) -> ChatCompletionMessageToolCall {
+    ChatCompletionMessageToolCall {
+        id: parsed.id,
+        r#type: FunctionType::Function,
+        function: FunctionCall {
+            name: parsed.function.name,
+            arguments: parsed.function.arguments,
+        },
+    }
+}
+
+/// Map a parser-native [`ToolCallResponseChunk`] onto the protocol/wire
+/// [`ChatCompletionMessageToolCallChunk`]. See
+/// [`tool_call_response_to_protocol`] for the rationale.
+///
+/// Exposed so consumers of the decoupled streaming parser entrypoint
+/// ([`dynamo_parsers::tool_calling::try_tool_call_parse_stream`]) can recover
+/// the wire type without `dynamo-parsers` depending on `dynamo-protocols`.
+#[allow(dead_code)]
+pub(crate) fn tool_call_response_chunk_to_protocol(
+    parsed: ToolCallResponseChunk,
+) -> ChatCompletionMessageToolCallChunk {
+    ChatCompletionMessageToolCallChunk {
+        index: parsed.index,
+        id: parsed.id,
+        r#type: parsed.tp.map(|_| FunctionType::Function),
+        function: parsed.function.map(|f| FunctionCallStream {
+            name: f.name,
+            arguments: f.arguments,
+        }),
+    }
+}
+
 /// A request structure for creating a chat completion, extending OpenAI's
 /// `CreateChatCompletionRequest` with [`NvExt`] extensions and common fields.
 ///

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -649,4 +649,151 @@ mod tests {
 
         assert!(ValidateRequest::validate(&request).is_err());
     }
+
+    // -----------------------------------------------------------------------
+    // Parser -> protocol mapping (decoupling guard).
+    //
+    // `dynamo-parsers` no longer depends on `dynamo-protocols`; the mapping
+    // moved into this consumer. These tests pin the mapper output to the
+    // *exact* struct + serialized JSON the old protocol-typed parser path
+    // produced, proving the wire output is unchanged.
+    // -----------------------------------------------------------------------
+    use dynamo_parsers::tool_calling::{
+        CalledFunction, CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
+    };
+
+    fn native_call(id: &str, name: &str, args: &str) -> ToolCallResponse {
+        ToolCallResponse {
+            id: id.to_string(),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name: name.to_string(),
+                arguments: args.to_string(),
+            },
+        }
+    }
+
+    fn native_chunk(index: u32, id: &str, name: &str, args: &str) -> ToolCallResponseChunk {
+        ToolCallResponseChunk {
+            index,
+            id: Some(id.to_string()),
+            tp: Some(ToolCallType::Function),
+            function: Some(CalledFunctionStream {
+                name: Some(name.to_string()),
+                arguments: Some(args.to_string()),
+            }),
+        }
+    }
+
+    /// Reference reconstruction of the pre-decoupling unary mapping that lived
+    /// inside `dynamo-parsers`. Kept inline so a divergence in the live mapper
+    /// fails the test.
+    fn legacy_unary(id: &str, name: &str, args: &str) -> ChatCompletionMessageToolCall {
+        ChatCompletionMessageToolCall {
+            id: id.to_string(),
+            r#type: FunctionType::Function,
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: args.to_string(),
+            },
+        }
+    }
+
+    /// Reference reconstruction of the pre-decoupling streaming mapping.
+    fn legacy_chunk(
+        index: u32,
+        id: &str,
+        name: &str,
+        args: &str,
+    ) -> ChatCompletionMessageToolCallChunk {
+        ChatCompletionMessageToolCallChunk {
+            index,
+            id: Some(id.to_string()),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: Some(name.to_string()),
+                arguments: Some(args.to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn unary_mapping_matches_legacy_struct_and_json() {
+        for (id, name, args) in [
+            (
+                "call_1",
+                "get_weather",
+                r#"{"location":"SF","unit":"celsius"}"#,
+            ),
+            ("call_2", "ping", "{}"), // empty arguments
+        ] {
+            let mapped = tool_call_response_to_protocol(native_call(id, name, args));
+            let legacy = legacy_unary(id, name, args);
+            assert_eq!(mapped, legacy, "struct mismatch for {name}");
+            assert_eq!(
+                serde_json::to_string(&mapped).unwrap(),
+                serde_json::to_string(&legacy).unwrap(),
+                "serialized JSON mismatch for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn unary_mapping_multi_call_matches_legacy() {
+        let inputs = [
+            ("a", "first", r#"{"k":"v1"}"#),
+            ("b", "second", r#"{"k":"v2"}"#),
+        ];
+        let mapped: Vec<_> = inputs
+            .iter()
+            .map(|(id, n, a)| tool_call_response_to_protocol(native_call(id, n, a)))
+            .collect();
+        let legacy: Vec<_> = inputs
+            .iter()
+            .map(|(id, n, a)| legacy_unary(id, n, a))
+            .collect();
+        assert_eq!(mapped, legacy);
+        assert_eq!(
+            serde_json::to_string(&mapped).unwrap(),
+            serde_json::to_string(&legacy).unwrap()
+        );
+    }
+
+    #[test]
+    fn stream_mapping_matches_legacy_struct_and_json() {
+        for (idx, id, name, args) in [
+            (0u32, "call_1", "get_weather", r#"{"location":"SF"}"#),
+            (1u32, "call_2", "ping", "{}"), // empty arguments
+        ] {
+            let mapped = tool_call_response_chunk_to_protocol(native_chunk(idx, id, name, args));
+            let legacy = legacy_chunk(idx, id, name, args);
+            assert_eq!(mapped, legacy, "struct mismatch for {name}");
+            assert_eq!(
+                serde_json::to_string(&mapped).unwrap(),
+                serde_json::to_string(&legacy).unwrap(),
+                "serialized JSON mismatch for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn stream_mapping_multi_call_indexes_and_matches_legacy() {
+        let inputs = [
+            (0u32, "a", "first", r#"{"k":"v1"}"#),
+            (1u32, "b", "second", r#"{"k":"v2"}"#),
+        ];
+        let mapped: Vec<_> = inputs
+            .iter()
+            .map(|(i, id, n, a)| tool_call_response_chunk_to_protocol(native_chunk(*i, id, n, a)))
+            .collect();
+        let legacy: Vec<_> = inputs
+            .iter()
+            .map(|(i, id, n, a)| legacy_chunk(*i, id, n, a))
+            .collect();
+        assert_eq!(mapped, legacy);
+        assert_eq!(
+            serde_json::to_string(&mapped).unwrap(),
+            serde_json::to_string(&legacy).unwrap()
+        );
+    }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -390,7 +390,12 @@ impl DeltaAggregator {
                     };
 
                 if !tool_calls.is_empty() {
-                    choice.tool_calls = Some(tool_calls);
+                    choice.tool_calls = Some(
+                        tool_calls
+                            .into_iter()
+                            .map(super::tool_call_response_to_protocol)
+                            .collect(),
+                    );
                     choice.text = content.unwrap_or_default();
                 } else if is_harmony_parser(parser) && contains_harmony_protocol(&choice.text) {
                     choice.text = content.unwrap_or_default();

--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -26,7 +26,6 @@ keywords.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-dynamo-protocols = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 tokio = { workspace = true }

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -36,7 +36,9 @@ pub use parsers::{
     try_tool_call_parse,
 };
 pub use pythonic::try_tool_call_parse_pythonic;
-pub use response::{CalledFunction, ToolCallResponse, ToolCallType};
+pub use response::{
+    CalledFunction, CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
+};
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
     try_tool_call_parse_stream,

--- a/lib/parsers/src/tool_calling/response.rs
+++ b/lib/parsers/src/tool_calling/response.rs
@@ -26,3 +26,25 @@ pub struct ToolCallResponse {
     pub tp: ToolCallType,
     pub function: CalledFunction,
 }
+
+/// Streaming (delta) variant of a parsed tool call.
+///
+/// Mirrors the field shape of a streaming tool-call chunk so consumers can map
+/// it onto their own wire types without `dynamo-parsers` depending on those
+/// types. Field semantics match the unary [`ToolCallResponse`]: `name` and
+/// `arguments` live under `function`, and `index` orders parallel calls.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ToolCallResponseChunk {
+    pub index: u32,
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    pub tp: Option<ToolCallType>,
+    pub function: Option<CalledFunctionStream>,
+}
+
+/// Streaming variant of [`CalledFunction`] where both fields are optional.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CalledFunctionStream {
+    pub name: Option<String>,
+    pub arguments: Option<String>,
+}

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -80,3 +80,144 @@ pub async fn try_tool_call_parse_stream(
         content,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Hermes-style single tool call.
+    const SINGLE: &str = r#"<tool_call>{"name":"get_weather","arguments":{"location":"San Francisco, CA","unit":"celsius"}}</tool_call>"#;
+
+    // Two parallel hermes-style tool calls.
+    const PARALLEL: &str = r#"<tool_call>{"name":"a","arguments":{"k":"v1"}}</tool_call>
+<tool_call>{"name":"b","arguments":{"k":"v2"}}</tool_call>"#;
+
+    // Tool call with empty arguments object.
+    const EMPTY_ARGS: &str = r#"<tool_call>{"name":"ping","arguments":{}}</tool_call>"#;
+
+    /// `try_tool_call_parse_aggregate` returns native `ToolCallResponse`
+    /// values with the parsed id/type/name/arguments.
+    #[tokio::test]
+    async fn aggregate_returns_native_tool_call_response() {
+        let (calls, _content): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate(SINGLE, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(!calls[0].id.is_empty());
+        assert!(matches!(calls[0].tp, ToolCallType::Function));
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(
+            calls[0].function.arguments,
+            r#"{"location":"San Francisco, CA","unit":"celsius"}"#
+        );
+    }
+
+    /// Parallel calls preserve ordering and per-call argument byte spans.
+    #[tokio::test]
+    async fn aggregate_returns_native_for_parallel_calls() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate(PARALLEL, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "a");
+        assert_eq!(calls[0].function.arguments, r#"{"k":"v1"}"#);
+        assert_eq!(calls[1].function.name, "b");
+        assert_eq!(calls[1].function.arguments, r#"{"k":"v2"}"#);
+    }
+
+    /// The finalize variant also returns native `ToolCallResponse`.
+    #[tokio::test]
+    async fn aggregate_finalize_returns_native_tool_call_response() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate_finalize(SINGLE, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(
+            calls[0].function.arguments,
+            r#"{"location":"San Francisco, CA","unit":"celsius"}"#
+        );
+    }
+
+    /// `try_tool_call_parse_stream` returns native `ToolCallResponseChunk`
+    /// values populating index/id/type and the nested `CalledFunctionStream`.
+    #[tokio::test]
+    async fn stream_returns_native_tool_call_response_chunk() {
+        let (chunks, _content): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream(SINGLE, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(chunks.len(), 1);
+        let chunk = &chunks[0];
+        assert_eq!(chunk.index, 0);
+        assert!(chunk.id.as_deref().is_some_and(|id| !id.is_empty()));
+        assert!(matches!(chunk.tp, Some(ToolCallType::Function)));
+        let func = chunk.function.as_ref().expect("function present");
+        assert_eq!(func.name.as_deref(), Some("get_weather"));
+        assert_eq!(
+            func.arguments.as_deref(),
+            Some(r#"{"location":"San Francisco, CA","unit":"celsius"}"#)
+        );
+    }
+
+    /// Streaming chunks are indexed sequentially for parallel calls.
+    #[tokio::test]
+    async fn stream_indexes_parallel_calls_sequentially() {
+        let (chunks, _): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream(PARALLEL, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].index, 0);
+        assert_eq!(chunks[1].index, 1);
+        assert_eq!(
+            chunks[0].function.as_ref().unwrap().name.as_deref(),
+            Some("a")
+        );
+        assert_eq!(
+            chunks[1].function.as_ref().unwrap().name.as_deref(),
+            Some("b")
+        );
+    }
+
+    /// Empty arguments objects survive as `{}` through both entrypoints.
+    #[tokio::test]
+    async fn empty_arguments_preserved() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate(EMPTY_ARGS, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "ping");
+        assert_eq!(calls[0].function.arguments, "{}");
+
+        let (chunks, _): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream(EMPTY_ARGS, Some("hermes"), None)
+                .await
+                .unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(
+            chunks[0].function.as_ref().unwrap().arguments.as_deref(),
+            Some("{}")
+        );
+    }
+
+    /// No tool call -> empty result, content passed through.
+    #[tokio::test]
+    async fn no_tool_call_returns_empty() {
+        let (calls, _): (Vec<ToolCallResponse>, _) =
+            try_tool_call_parse_aggregate("just some prose", Some("hermes"), None)
+                .await
+                .unwrap();
+        assert!(calls.is_empty());
+
+        let (chunks, _): (Vec<ToolCallResponseChunk>, _) =
+            try_tool_call_parse_stream("just some prose", Some("hermes"), None)
+                .await
+                .unwrap();
+        assert!(chunks.is_empty());
+    }
+}

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -3,10 +3,14 @@
 
 pub use super::config::ToolCallConfig;
 pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
+pub use super::response::{
+    CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
+};
 
 /// Try parsing a string as a structured tool call, for aggregation usage.
 ///
-/// If successful, returns a `ChatCompletionMessageToolCall`.
+/// If successful, returns the parser-native [`ToolCallResponse`] values.
+/// Consumers that need protocol/wire types map these locally.
 ///
 /// Streaming jail callers (`should_exit_jail_early`, mid-stream early-exit
 /// confirmation) MUST keep using this function — `allow_eof_recovery` stays
@@ -16,10 +20,7 @@ pub async fn try_tool_call_parse_aggregate(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(
-    Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>,
-    Option<String>,
-)> {
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     if parser_str.is_none() {
         tracing::debug!("No tool parser provided. Trying parsing with default parser.");
     } else {
@@ -29,22 +30,7 @@ pub async fn try_tool_call_parse_aggregate(
     if parsed.is_empty() {
         return Ok((vec![], content));
     }
-    Ok((
-        parsed
-            .into_iter()
-            .map(
-                |parsed| dynamo_protocols::types::ChatCompletionMessageToolCall {
-                    id: parsed.id,
-                    r#type: dynamo_protocols::types::FunctionType::Function,
-                    function: dynamo_protocols::types::FunctionCall {
-                        name: parsed.function.name,
-                        arguments: parsed.function.arguments,
-                    },
-                },
-            )
-            .collect(),
-        content,
-    ))
+    Ok((parsed, content))
 }
 
 /// Finalize-only variant of [`try_tool_call_parse_aggregate`] that enables
@@ -55,44 +41,24 @@ pub async fn try_tool_call_parse_aggregate_finalize(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(
-    Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>,
-    Option<String>,
-)> {
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let (parsed, content) =
         detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }
-    Ok((
-        parsed
-            .into_iter()
-            .map(
-                |parsed| dynamo_protocols::types::ChatCompletionMessageToolCall {
-                    id: parsed.id,
-                    r#type: dynamo_protocols::types::FunctionType::Function,
-                    function: dynamo_protocols::types::FunctionCall {
-                        name: parsed.function.name,
-                        arguments: parsed.function.arguments,
-                    },
-                },
-            )
-            .collect(),
-        content,
-    ))
+    Ok((parsed, content))
 }
 
 /// Try parsing a string as a structured tool call, for streaming (delta) usage.
 ///
-/// If successful, returns a `ChatCompletionMessageToolCallChunk`.
+/// If successful, returns parser-native [`ToolCallResponseChunk`] values.
+/// Consumers that need protocol/wire types map these locally.
 pub async fn try_tool_call_parse_stream(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[super::ToolDefinition]>,
-) -> anyhow::Result<(
-    Vec<dynamo_protocols::types::ChatCompletionMessageToolCallChunk>,
-    Option<String>,
-)> {
+) -> anyhow::Result<(Vec<ToolCallResponseChunk>, Option<String>)> {
     let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
@@ -101,18 +67,15 @@ pub async fn try_tool_call_parse_stream(
         parsed
             .into_iter()
             .enumerate()
-            .map(
-                |(idx, parsed)| dynamo_protocols::types::ChatCompletionMessageToolCallChunk {
-                    index: idx as u32,
-                    id: Some(parsed.id),
-                    r#type: Some(dynamo_protocols::types::FunctionType::Function),
-                    function: Some(dynamo_protocols::types::FunctionCallStream {
-                        name: Some(parsed.function.name),
-                        arguments: Some(parsed.function.arguments),
-                    }),
-                    // Add other fields as needed if required by the struct definition
-                },
-            )
+            .map(|(idx, parsed)| ToolCallResponseChunk {
+                index: idx as u32,
+                id: Some(parsed.id),
+                tp: Some(ToolCallType::Function),
+                function: Some(CalledFunctionStream {
+                    name: Some(parsed.function.name),
+                    arguments: Some(parsed.function.arguments),
+                }),
+            })
             .collect(),
         content,
     ))


### PR DESCRIPTION
## Motivation

`dynamo-parsers` depended on `dynamo-protocols` for a single reason: the three
public tool-call entrypoints in `lib/parsers/src/tool_calling/tools.rs` re-mapped
the crate's own parser-native types (`ToolCallResponse` / `CalledFunction`) into
the OpenAI wire types (`ChatCompletionMessageToolCall` / `...Chunk`) before
returning them. The protocol types added zero parsing value — the field shapes
are identical — so this coupling blocked publishing/adopting `dynamo-parsers` as
a standalone crate (e.g. from the frontend-crates mirror) without dragging in
`dynamo-protocols`.

## Approach (Option A — full removal)

Chosen over the optional-feature fallback (Option B) because the blast radius is
small and fully contained in one consumer crate (`dynamo-llm`): 5 call sites, all
already accessing `.id` / `.function.name` / `.function.arguments`, which exist
identically on the native types.

- Removed `dynamo-protocols` from `lib/parsers/Cargo.toml`.
- `try_tool_call_parse_aggregate` / `try_tool_call_parse_aggregate_finalize` now
  return the native `Vec<ToolCallResponse>`; `try_tool_call_parse_stream` returns
  a new native `ToolCallResponseChunk` (mirrors `ChatCompletionMessageToolCallChunk`:
  `index`, `id`, `type`, `function{name, arguments}`).
- Added `ToolCallResponseChunk` + `CalledFunctionStream` to
  `lib/parsers/src/tool_calling/response.rs` and re-exported them.
- The `ToolCallResponse -> ChatCompletionMessageToolCall` mapping now lives in the
  consumer that already depends on **both** crates (`lib/llm` chat_completions),
  not in `dynamo-protocols`. **`dynamo-protocols` does NOT gain a dependency on
  `dynamo-parsers`** (that would just reverse the coupling).

### Mapping / call sites
- New local helpers `tool_call_response_to_protocol` /
  `tool_call_response_chunk_to_protocol` in
  `lib/llm/src/protocols/openai/chat_completions.rs`.
- `aggregator.rs` finalize site: maps native results to wire types before
  assigning to `choice.tool_calls`.
- `jail.rs` sites (`create_tool_call_choice`, the guided-decoding fallback,
  `should_exit_jail_early`, early-exit confirmation) consume the native fields
  directly — identical field shapes — so emitted wire output is unchanged.

## Compatibility

API-breaking for `dynamo-parsers` public return types (now native instead of
protocol types); warrants a minor / 0.x version bump. Runtime behavior and wire
output of `dynamo` are unchanged.

## Regression tests added

To guard that the decoupling does not change behavior or wire output:

- **`lib/parsers/src/tool_calling/tools.rs`** (`#[cfg(test)] mod tests`): exercises
  the three now-native entrypoints (`try_tool_call_parse_aggregate`, `_finalize`,
  `try_tool_call_parse_stream`), asserting the native `ToolCallResponse` /
  `ToolCallResponseChunk` + `CalledFunctionStream` values (id/type/name/arguments),
  plus parallel-call indexing, empty-arguments (`{}`), and no-call cases.
- **`lib/llm/src/protocols/openai/chat_completions.rs`** (`mod tests`): tests the
  local mapping helpers (`tool_call_response_to_protocol` /
  `tool_call_response_chunk_to_protocol`) against an inline reconstruction of the
  pre-decoupling protocol-typed parser path, asserting **both struct equality and
  byte-for-byte serialized JSON**. Covers empty-arguments and multi-call cases.
  This is the key guard proving the wire output is unchanged.

## Verification

CI lint gates (matching `.github/workflows/pre-merge.yml`):

- `cargo fmt --all -- --check` — **clean**
- `cargo clippy --no-deps --all-targets -- -D warnings` (workspace) — **clean**

Tests (Rust-only change; default features incl. `block-manager` on CPU):

- `cargo test --locked -p dynamo-parsers` — **534 passed, 0 failed** (527 prior + 7 new)
- `cargo test --locked -p dynamo-protocols` — **48 passed + 3 integration, 0 failed**
- `cargo test --locked -p dynamo-llm --lib` — **1224 passed, 0 failed** (incl. 4 new mapping tests + aggregator/jail unit tests)
- `cargo test --locked -p dynamo-llm` integration targets touching the tool-call /
  aggregation path — all passed:
  `test_jail` (62), `aggregators` (8), `parallel_tool_call_integration` (8),
  `test_streaming_tool_parsers` (27), `postprocessor_parsing_stream` (19),
  `tool_choice` (36), `tool_choice_finish_reasons` (6), `test_reasoning_parser` (12),
  `openai_completions` (6), `backend` (1)
- `cargo tree -p dynamo-parsers -i dynamo-protocols` — no match (decoupling confirmed)

**Scope note:** A single `cargo test --workspace --all-targets` run could not complete
locally due to disk exhaustion on the build volume while linking the many large
`dynamo-llm` test binaries (`block-manager` statically links aws-lc/ravif/etc.) —
a local environment limit, not a code failure. The workspace-wide clippy `-D warnings`
pass above compiled every crate (incl. `dynamo-llm`, `kvbm-*`, `bindings/c`) cleanly,
so the full workspace builds; tests were then run per-crate/per-target as listed.
The `preprocessor` integration test was **skipped** — its 10 cases fail with HTTP 401
fetching a gated HF model (`meta-llama/Llama-3.1-70B-Instruct`); they require network
+ HF credentials and are unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming support for tool-call responses, enabling progressive delivery of function-calling results during generation.
  * Extended model support to include OpenAI GPT-OSS-120B with complete configuration and tokenization settings.

* **Improvements**
  * Enhanced tool-call response handling for improved consistency and reliability across OpenAI integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->