### PR TITLE
docs(router): add test authoring guidance

### DIFF
--- a/tests/router/CLAUDE.md
+++ b/tests/router/CLAUDE.md
@@ -1,0 +1,8 @@
+# Router Test Authoring Guidance
+
+- Put reusable router test scenarios and core assertions in `tests/router/common.py`.
+- Keep backend-specific e2e files thin. Files such as `test_router_e2e_with_mockers.py`, `test_router_e2e_with_vllm.py`, `test_router_e2e_with_sglang.py`, `test_router_e2e_with_trtllm.py`, and `test_router_e2e_with_unified.py` should mostly configure the backend variant, parameterize meaningful cases, and call shared helpers.
+- Prefer parameterized wrappers over copied test bodies when a scenario should run across multiple backends, router modes, request planes, or storage backends.
+- Put low-level shared utilities in `tests/router/helper.py`; examples include request sending, readiness polling, runtime setup, indexer waits, and response parsing helpers.
+- Keep process lifecycle wrappers in `tests/router/router_process.py` or the existing backend-specific process helpers, rather than embedding subprocess management inside scenario logic.
+- New e2e tests should assert behavior through stable surfaces such as response `nvext` fields, router helper APIs, metrics, or structured event dumps. Avoid log parsing unless there is no better observable contract.

--- a/tests/router/CLAUDE.md
+++ b/tests/router/CLAUDE.md
@@ -7,3 +7,5 @@
 - Put low-level shared utilities in `tests/router/helper.py`; examples include request sending, readiness polling, runtime setup, indexer waits, and response parsing helpers.
 - Keep process lifecycle wrappers in `tests/router/router_process.py` or the existing backend-specific process helpers, rather than embedding subprocess management inside scenario logic.
 - New e2e tests should assert behavior through stable surfaces such as response `nvext` fields, router helper APIs, metrics, or structured event dumps. Avoid log parsing unless there is no better observable contract.
+- Do not add non-router tests here. Avoid tautological tests, tests that are mostly white-box assertions about implementation details, and tests that only exercise test infrastructure such as harness process construction.
+- When a test in this directory fails, do not assume the router is at fault just because the test name says router. Read the error carefully and root cause whether the failure is in the router, backend, harness, environment, or assertion before changing code.

--- a/tests/router/CLAUDE.md
+++ b/tests/router/CLAUDE.md
@@ -2,6 +2,7 @@
 
 - Put reusable router test scenarios and core assertions in `tests/router/common.py`.
 - Keep backend-specific e2e files thin. Files such as `test_router_e2e_with_mockers.py`, `test_router_e2e_with_vllm.py`, `test_router_e2e_with_sglang.py`, `test_router_e2e_with_trtllm.py`, and `test_router_e2e_with_unified.py` should mostly configure the backend variant, parameterize meaningful cases, and call shared helpers.
+- Use `tests/router/e2e_harness.py` for backend-agnostic e2e orchestration helpers that sit between thin backend wrappers and the core scenarios in `common.py`.
 - Prefer parameterized wrappers over copied test bodies when a scenario should run across multiple backends, router modes, request planes, or storage backends.
 - Put low-level shared utilities in `tests/router/helper.py`; examples include request sending, readiness polling, runtime setup, indexer waits, and response parsing helpers.
 - Keep process lifecycle wrappers in `tests/router/router_process.py` or the existing backend-specific process helpers, rather than embedding subprocess management inside scenario logic.

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -7,7 +7,6 @@
 # so we set explicit pytest timeouts to fail fast on hangs (see per-test markers below).
 import logging
 import os
-from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
 import pytest
@@ -244,63 +243,6 @@ class SGLangProcess(ManagedEngineProcessMixin):
 
     process_name = "SGLang worker"
     cleanup_name = "SGLang worker resources"
-
-
-class _FakeRequest:
-    node = SimpleNamespace(
-        name="test_sglang_dp_workers_use_contiguous_kv_event_port_blocks"
-    )
-
-    def __init__(self):
-        self.finalizers = []
-
-    def addfinalizer(self, finalizer):
-        self.finalizers.append(finalizer)
-
-
-def _kv_events_config(command: list[str]) -> str:
-    return command[command.index("--kv-events-config") + 1]
-
-
-@pytest.mark.unit
-@pytest.mark.pre_merge
-@pytest.mark.gpu_0
-def test_sglang_dp_workers_use_contiguous_kv_event_port_blocks(monkeypatch):
-    def fake_allocate_ports(count: int, start_port: int) -> list[int]:
-        assert (count, start_port) == (2, DefaultPort.SYSTEM1.value)
-        return [10000, 10010]
-
-    contiguous_calls = []
-
-    def fake_allocate_contiguous_ports(
-        count: int, block_size: int, start_port: int
-    ) -> list[int]:
-        contiguous_calls.append((count, block_size, start_port))
-        return [11000, 11001, 11010, 11011]
-
-    monkeypatch.setitem(
-        SGLangProcess.__init__.__globals__, "allocate_ports", fake_allocate_ports
-    )
-    monkeypatch.setitem(
-        SGLangProcess.__init__.__globals__,
-        "allocate_contiguous_ports",
-        fake_allocate_contiguous_ports,
-    )
-
-    process = SGLangProcess(
-        _FakeRequest(),
-        sglang_args=SGLANG_ARGS,
-        num_workers=2,
-        data_parallel_size=2,
-    )
-
-    assert contiguous_calls == [(2, 2, DefaultPort.SYSTEM1.value)]
-    assert '"endpoint":"tcp://*:11000"' in _kv_events_config(
-        process.worker_processes[0].command
-    )
-    assert '"endpoint":"tcp://*:11010"' in _kv_events_config(
-        process.worker_processes[1].command
-    )
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Adds local router test authoring guidance under `tests/router/CLAUDE.md`, covering shared scenario placement, thin backend wrappers, and utility boundaries.

Validation: staged diff whitespace check and commit hooks passed for the docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added testing guidance documentation for the router component to standardize test authoring practices and improve consistency across the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->