### PR TITLE
fix(container): add libnixl.so to LD_LIBRARY_PATH in cuda vllm-runtime

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -24,11 +24,34 @@
 
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
+ARG PYTHON_VERSION
+ARG ENABLE_KVBM
+ARG ENABLE_GPU_MEMORY_SERVICE
+ARG VLLM_OMNI_REF
+ARG NIXL_REF
+{% if device == "cuda" %}
+ARG CUDA_MAJOR
+{% endif %}
+
 ARG DEVICE
 WORKDIR /workspace
 ENV DYNAMO_HOME=/opt/dynamo
 ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+{% if device == "cuda" %}
+# Expose libnixl.so from the upstream nixl-cu${CUDA_MAJOR} PyPI wheel on
+# LD_LIBRARY_PATH so dlopen() can find it from processes that don't import
+# the `nixl` Python package — chiefly `dynamo.frontend`, which is pure-Rust
+# from a process perspective. Without this, Rust nixl-sys's stub-mode runtime
+# loader returns is_stub()=true and the frontend rejects any model card
+# carrying a `media_decoder` (i.e. workers launched with --frontend-decoding)
+# with "OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode".
+# The wheel installs libnixl.so under a hidden ".libs/" sibling that only the
+# wheel's own RPATH knows about; standard LD search can't find it without help.
+ARG SITE_PACKAGES=/usr/local/lib/python${PYTHON_VERSION}/dist-packages
+ENV LD_LIBRARY_PATH=${SITE_PACKAGES}/.nixl_cu${CUDA_MAJOR}.mesonpy.libs:${LD_LIBRARY_PATH:-}
+{% endif %}
 
 {% if device == "xpu" %}
 RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null && \


### PR DESCRIPTION
Cherry-pick of #9911 onto `release/1.2.0`.

Original PR: https://github.com/ai-dynamo/dynamo/pull/9911
Merge commit: 4093c504281b1c82fcb01615cfcb9e7bd798395b

Conflict in `container/templates/vllm_runtime.Dockerfile`: `release/1.2.0` has diverged structurally from `main` (no multi-arch FROM block, no shared `{% if device != "cuda" %}` block in this stage). The patch's `{% else %}` arm had nothing to attach to and was rewritten as a standalone `{% if device == "cuda" %} ... {% endif %}` block placed before the existing `{% if device == "xpu" %}` block. The cuda-side semantics (CUDA_MAJOR ARG redeclare + `LD_LIBRARY_PATH` prepend of the wheel's `.nixl_cu${CUDA_MAJOR}.mesonpy.libs/`) are unchanged.

## Test Plan
- Same as #9911; no additional changes in this cherry-pick beyond the structural re-wrap noted above.