### PR TITLE
fix(nixl_connect): defer nixl ImportError until first actual use

### DIFF
--- a/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
+++ b/lib/bindings/python/src/dynamo/nixl_connect/__init__.py
@@ -38,13 +38,29 @@ except ImportError as e:
         "PyTorch must be installed to use this module. Please install PyTorch, ex: 'pip install torch'."
     ) from e
 
+_NIXL_IMPORT_ERROR: Optional[ImportError] = None
 try:
     import nixl._api as nixl_api
     import nixl._bindings as nixl_bindings
 except ImportError as e:
-    raise ImportError(
-        "NIXL Python bindings must be installed to use this module. Please install NIXL, ex: 'pip install nixl'."
-    ) from e
+    # Defer the error: a pip-installed `nixl` wheel only exists for CUDA
+    # (`nixl-cu12`). Allowing `import dynamo.nixl_connect` to succeed on
+    # platforms without a NIXL wheel (e.g. AMD ROCm) lets transitive
+    # importers — router, planner, frontend — load. The ImportError is
+    # re-raised by `_require_nixl()` only when an operation that
+    # actually needs NIXL is attempted (e.g. constructing a `Connector`).
+    nixl_api = None  # type: ignore[assignment]
+    nixl_bindings = None  # type: ignore[assignment]
+    _NIXL_IMPORT_ERROR = e
+
+
+def _require_nixl() -> None:
+    """Raise the deferred NIXL ImportError if the bindings are not installed."""
+    if nixl_api is None:
+        raise ImportError(
+            "NIXL Python bindings must be installed to use this module. "
+            "Please install NIXL, ex: 'pip install nixl'."
+        ) from _NIXL_IMPORT_ERROR
 
 logger = logging.getLogger(__name__)
 
@@ -576,6 +592,7 @@ class Connection:
         if number <= 0:
             raise ValueError("Argument `number` must be greater than 0.")
 
+        _require_nixl()
         self._connector: Connector = connector
         self._is_initialized = False
         self._name = f"{connector.name}-{number}"

--- a/lib/bindings/python/tests/test_nixl_connect_lazy_import.py
+++ b/lib/bindings/python/tests/test_nixl_connect_lazy_import.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify dynamo.nixl_connect imports on hosts without NIXL bindings.
+
+The NIXL pip wheel ships CUDA only (`nixl-cu12`). On platforms without a
+NIXL wheel (e.g. AMD ROCm hosts) the module must still import so that
+transitive importers — router, planner, frontend, AMD aggregated /
+Mooncake-based disaggregated paths — load. The deferred ImportError
+should be raised only when an operation that actually needs NIXL is
+attempted (e.g. constructing a `Connector` -> `Connection`).
+"""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge]
+
+
+def _reimport_without_nixl():
+    """Re-import dynamo.nixl_connect with nixl.* masked out of sys.modules."""
+    for mod in list(sys.modules):
+        if mod == "dynamo.nixl_connect" or mod.startswith("nixl"):
+            del sys.modules[mod]
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "nixl" or name.startswith("nixl."):
+            raise ImportError(f"No module named '{name}' (simulated)")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        return importlib.import_module("dynamo.nixl_connect")
+
+
+def test_module_imports_without_nixl():
+    """`import dynamo.nixl_connect` must succeed when nixl is unavailable."""
+    mod = _reimport_without_nixl()
+    assert mod.nixl_api is None
+    assert mod.nixl_bindings is None
+    assert mod._NIXL_IMPORT_ERROR is not None
+    assert isinstance(mod._NIXL_IMPORT_ERROR, ImportError)
+
+
+def test_require_nixl_raises_when_missing():
+    """`_require_nixl()` re-raises the deferred ImportError with original cause."""
+    mod = _reimport_without_nixl()
+    with pytest.raises(ImportError) as excinfo:
+        mod._require_nixl()
+    assert "NIXL Python bindings must be installed" in str(excinfo.value)
+    assert excinfo.value.__cause__ is mod._NIXL_IMPORT_ERROR
+
+
+def test_connection_construction_raises_without_nixl():
+    """Constructing a Connection without NIXL must raise the deferred error."""
+    mod = _reimport_without_nixl()
+    fake_connector = MagicMock(spec=mod.Connector)
+    fake_connector.name = "test"
+    with pytest.raises(ImportError, match="NIXL Python bindings must be installed"):
+        mod.Connection(fake_connector, 1)
+
+
+def test_module_imports_with_nixl_present():
+    """Sanity check: when nixl is available, the module exposes the real bindings.
+
+    Skipped automatically when the real nixl wheel isn't installed.
+    """
+    try:
+        import nixl._api  # noqa: F401
+    except ImportError:
+        pytest.skip("real nixl wheel not installed; covered on CUDA CI")
+
+    for cached in list(sys.modules):
+        if cached == "dynamo.nixl_connect":
+            del sys.modules[cached]
+    mod = importlib.import_module("dynamo.nixl_connect")
+    assert mod.nixl_api is not None
+    assert mod.nixl_bindings is not None
+    assert mod._NIXL_IMPORT_ERROR is None


### PR DESCRIPTION
## Summary

The `nixl` pip wheel ships CUDA only (`nixl-cu12`). On platforms without a NIXL wheel (e.g. AMD ROCm hosts) the existing `try/except` re-raises immediately at module import, so any transitive importer — router, planner, frontend — fails to load.

Defer the error: cache the `ImportError`, set `nixl_api` / `nixl_bindings` to `None` on failure, and add `_require_nixl()` which re-raises only when an operation that genuinely needs NIXL is attempted (currently the sole runtime use site is `Connection.__init__`; all other references are type annotations made lazy by `from __future__ import annotations`).

This unblocks aggregated serving and Mooncake-based disaggregated paths on AMD without runtime shims (e.g. the `nixl_stub` the AMD MI355X PoC ships today — see [andyluo7/dynamo `amd-mi355x-poc/patches/README.md`](https://github.com/andyluo7/dynamo/blob/dynamo-amd-poc/amd-mi355x-poc/patches/README.md)).

Part of a 3-PR series splitting the AMD PoC's "PR 1" per NVIDIA's review guidance.

## Test plan

New unit test `lib/bindings/python/tests/test_nixl_connect_lazy_import.py`:
- `import dynamo.nixl_connect` succeeds when `nixl` is unavailable
- `_require_nixl()` raises with the deferred `ModuleNotFoundError` chained
- `Connection(connector, 1)` raises a clear `ImportError`
- Sanity: real `nixl` wheel path (skipped when nixl not installed)

Manually verified on AMD MI300X (Hotaisle), Python 3.10.12, no `nixl` wheel:
- Before: `import dynamo.nixl_connect` → `ImportError: NIXL Python bindings must be installed...`
- After:  imports OK; deferred error raised only at `Connection(...)` construction

- [x] CPU-only existing unit tests (`test_nixl_connect_unit.py`) untouched
- [x] AMD smoke test: `python3 -c "import dynamo.nixl_connect"` succeeds without `nixl`
- [ ] CUDA CI sanity (nixl-present path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)