### PR TITLE
fix(common): use typing_extensions.Self so Python 3.10 hosts can import

### DIFF
--- a/components/src/dynamo/common/configuration/config_base.py
+++ b/components/src/dynamo/common/configuration/config_base.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import argparse
-from typing import Self
+
+# typing.Self is 3.11+; pyproject declares requires-python>=3.10 so use the
+# typing_extensions back-port (transitively available via the pydantic dep).
+from typing_extensions import Self
 
 
 class ConfigBase:

--- a/components/src/dynamo/common/configuration/groups/http_args.py
+++ b/components/src/dynamo/common/configuration/groups/http_args.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-from typing import Optional, Self
+from typing import Optional
+
+# typing.Self is 3.11+; pyproject declares requires-python>=3.10 so use the
+# typing_extensions back-port (transitively available via the pydantic dep).
+from typing_extensions import Self
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase


### PR DESCRIPTION
## Summary

`typing.Self` is Python 3.11+. Both root `pyproject.toml` and `lib/bindings/python/pyproject.toml` declare `requires-python = ">=3.10"`, so importing either:

- `dynamo.common.configuration.config_base`
- `dynamo.common.configuration.groups.http_args`

on a 3.10 interpreter fails at module load with:

```
ImportError: cannot import name 'Self' from 'typing'
```

This blocks all downstream importers on the `rocm/sgl-dev:nightly` container (Python 3.10) used by the AMD MI355X PoC.

Swap to `typing_extensions.Self`, which is unconditionally available (transitively required by `pydantic`, already a dynamo dep) and re-exports the 3.11+ `typing.Self` on newer interpreters.

Part of a 3-PR series splitting the AMD PoC's "PR 1" per NVIDIA's review guidance.

## Test plan

Verified on Python 3.10.12 (Hotaisle MI300X):
- Before: `python3 -c "from typing import Self"` → `ImportError`
- After:  patched modules import cleanly; `Self` resolves to `typing_extensions.Self`

- [x] Both files imported successfully on Py 3.10
- [ ] Existing test suite passes on Py 3.11+ (CI default)
- [ ] Py 3.10 CI smoke (if matrix exists, else this PR adds the missing coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)