### PR TITLE
chore: bump trtllm to v1.3.0rc15

### DIFF
--- a/.github/scripts/dep_upgrade/bump_dependency.py
+++ b/.github/scripts/dep_upgrade/bump_dependency.py
@@ -19,12 +19,11 @@ from typing import Pattern
 TRTLLM_TARGETS: list[tuple[str, Pattern[str], str]] = [
     (
         "container/context.yaml",
-        re.compile(r"^(\s*pip_wheel:\s*tensorrt-llm==).+$", re.M),
-        r"\g<1>{ver}",
-    ),
-    (
-        "container/context.yaml",
-        re.compile(r"^(\s*github_trtllm_commit:\s*v).+$", re.M),
+        # Match runtime_image_tag inside the trtllm: block (first sub-block,
+        # e.g. cuda13.1) without colliding with vllm/sglang earlier in the file.
+        re.compile(
+            r"(?ms)(^trtllm:\s*?\n(?:[ \t]+.*\n)*?[ \t]+runtime_image_tag:\s+)\S+",
+        ),
         r"\g<1>{ver}",
     ),
     (

--- a/.github/scripts/dep_upgrade/detect_latest_versions.py
+++ b/.github/scripts/dep_upgrade/detect_latest_versions.py
@@ -21,7 +21,11 @@ GH_API = "https://api.github.com"
 FRAMEWORK_SOURCES: dict[str, dict[str, object]] = {
     "trtllm": {
         "github_repo": "NVIDIA/TensorRT-LLM",
-        "current_regex": re.compile(r"^\s*pip_wheel:\s*tensorrt-llm==(\S+)\s*$", re.M),
+        # Anchored inside the trtllm: block so we don't pick up
+        # vllm/sglang runtime_image_tag lines earlier in the file.
+        "current_regex": re.compile(
+            r"(?ms)^trtllm:\s*?\n(?:[ \t]+.*\n)*?[ \t]+runtime_image_tag:\s*(\S+)\s*$",
+        ),
     },
 }
 

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -4,6 +4,8 @@
 name: Auto Dependency Upgrade - Trigger
 
 on:
+  push:
+    branches: [anants/fix-auto-dep-upgrade-trtllm-shape]  # TEMP: e2e on push
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: main
+          ref: anants/fix-auto-dep-upgrade-trtllm-shape  # TEMP: e2e the fixed scripts before merging to main
           fetch-depth: 0
           token: ${{ secrets.OPS_BOT_PAT }}
 

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -96,7 +96,7 @@ trtllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: nvcr.io/nvidia/tensorrt-llm/release
     base_image_tag: 26.02-cuda13.1-devel-ubuntu24.04
-    runtime_image_tag: 1.3.0rc14
+    runtime_image_tag: 1.3.0rc15
   nixl_ref: 0.10.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.11` | `1.3.0rc14` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.11` | `1.3.0rc15` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.1** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.3.0rc14",
+    "tensorrt-llm==1.3.0rc15",
 ]
 
 vllm = [


### PR DESCRIPTION
## Automated dependency upgrade — trtllm v1.3.0rc15

Post-merge CI did not pass (conclusion: `failure`). Investigate before merging.

- **Framework:** trtllm
- **Target version:** v1.3.0rc15
- **Branch:** deps/upgrade-trtllm-v1.3.0rc15
- **Validating run:** https://github.com/ai-dynamo/dynamo/actions/runs/26412527280