### PR TITLE
fix: track trtllm version with upstream container in auto upgrade pipeline

### DIFF
--- a/.github/scripts/dep_upgrade/bump_dependency.py
+++ b/.github/scripts/dep_upgrade/bump_dependency.py
@@ -19,12 +19,11 @@ from typing import Pattern
 TRTLLM_TARGETS: list[tuple[str, Pattern[str], str]] = [
     (
         "container/context.yaml",
-        re.compile(r"^(\s*pip_wheel:\s*tensorrt-llm==).+$", re.M),
-        r"\g<1>{ver}",
-    ),
-    (
-        "container/context.yaml",
-        re.compile(r"^(\s*github_trtllm_commit:\s*v).+$", re.M),
+        # Match runtime_image_tag inside the trtllm: block (first sub-block,
+        # e.g. cuda13.1) without colliding with vllm/sglang earlier in the file.
+        re.compile(
+            r"(?ms)(^trtllm:\s*?\n(?:[ \t]+.*\n)*?[ \t]+runtime_image_tag:\s+)\S+",
+        ),
         r"\g<1>{ver}",
     ),
     (

--- a/.github/scripts/dep_upgrade/bump_dependency.py
+++ b/.github/scripts/dep_upgrade/bump_dependency.py
@@ -22,7 +22,7 @@ TRTLLM_TARGETS: list[tuple[str, Pattern[str], str]] = [
         # Match runtime_image_tag inside the trtllm: block (first sub-block,
         # e.g. cuda13.1) without colliding with vllm/sglang earlier in the file.
         re.compile(
-            r"(?ms)(^trtllm:\s*?\n(?:[ \t]+.*\n)*?[ \t]+runtime_image_tag:\s+)\S+",
+            r"(?m)(^trtllm:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s+)\S+",
         ),
         r"\g<1>{ver}",
     ),

--- a/.github/scripts/dep_upgrade/detect_latest_versions.py
+++ b/.github/scripts/dep_upgrade/detect_latest_versions.py
@@ -21,7 +21,11 @@ GH_API = "https://api.github.com"
 FRAMEWORK_SOURCES: dict[str, dict[str, object]] = {
     "trtllm": {
         "github_repo": "NVIDIA/TensorRT-LLM",
-        "current_regex": re.compile(r"^\s*pip_wheel:\s*tensorrt-llm==(\S+)\s*$", re.M),
+        # Anchored inside the trtllm: block so we don't pick up
+        # vllm/sglang runtime_image_tag lines earlier in the file.
+        "current_regex": re.compile(
+            r"(?ms)^trtllm:\s*?\n(?:[ \t]+.*\n)*?[ \t]+runtime_image_tag:\s*(\S+)\s*$",
+        ),
     },
 }
 

--- a/.github/scripts/dep_upgrade/detect_latest_versions.py
+++ b/.github/scripts/dep_upgrade/detect_latest_versions.py
@@ -24,7 +24,7 @@ FRAMEWORK_SOURCES: dict[str, dict[str, object]] = {
         # Anchored inside the trtllm: block so we don't pick up
         # vllm/sglang runtime_image_tag lines earlier in the file.
         "current_regex": re.compile(
-            r"(?ms)^trtllm:\s*?\n(?:[ \t]+.*\n)*?[ \t]+runtime_image_tag:\s*(\S+)\s*$",
+            r"(?m)^trtllm:\s*?\n(?:[ \t]+[^\n]*\n)*?[ \t]+runtime_image_tag:\s*(\S+)\s*$",
         ),
     },
 }

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -4,6 +4,8 @@
 name: Auto Dependency Upgrade - Trigger
 
 on:
+  push:
+    branches: [anants/fix-auto-dep-upgrade-trtllm-shape]  # TEMP: e2e on push
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -4,8 +4,6 @@
 name: Auto Dependency Upgrade - Trigger
 
 on:
-  push:
-    branches: [anants/fix-auto-dep-upgrade-trtllm-shape]  # TEMP: e2e on push
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: main
+          ref: anants/fix-auto-dep-upgrade-trtllm-shape  # TEMP: e2e the fixed scripts before merging to main
           fetch-depth: 0
           token: ${{ secrets.OPS_BOT_PAT }}
 

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: anants/fix-auto-dep-upgrade-trtllm-shape  # TEMP: e2e the fixed scripts before merging to main
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.OPS_BOT_PAT }}
 


### PR DESCRIPTION
PR https://github.com/ai-dynamo/dynamo/pull/9654 switched TRT-LLM to an upstream-base image layout, dropping the
pip_wheel: tensorrt-llm== and github_trtllm_commit: v keys the auto dependency upgrade scripts were targeting. The version now lives in runtime_image_tag under the trtllm: cuda13.1 sub-block.

Re-point detect_latest_versions.py's current_regex and the first TRTLLM_TARGETS entry in bump_dependency.py at runtime_image_tag, anchored inside the trtllm: block so we don't pick up vllm/sglang runtime_image_tag lines earlier in the file. The pyproject.toml and support-matrix.md targets are unchanged.

Tested with, https://github.com/ai-dynamo/dynamo/actions/runs/26412498877/job/77749822177

closes: OPS-6692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TRT-LLM framework dependency detection and upgrade logic for more accurate version management in automated dependency update processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->