### PR TITLE
docs(sglang-hicache): correct --shared-cache-multiplier default to 0.5

### DIFF
--- a/docs/backends/sglang/sglang-hicache.md
+++ b/docs/backends/sglang/sglang-hicache.md
@@ -179,7 +179,7 @@ python -m dynamo.frontend \
 | Flag                        | Env var                       | Default | Description                                                                                                                                                        |
 | --------------------------- | ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--shared-cache-type`       | `DYN_SHARED_CACHE_TYPE`       | `none`  | `none` disables shared-pool lookups; `hicache` enables Mooncake queries.                                                                                           |
-| `--shared-cache-multiplier` | `DYN_SHARED_CACHE_MULTIPLIER` | `0.0`   | Discount factor for shared-pool hits. `0.0` queries but ignores them; `0.5` treats a shared hit as half a device hit; `1.0` treats shared and device hits equally. |
+| `--shared-cache-multiplier` | `DYN_SHARED_CACHE_MULTIPLIER` | `0.5`   | Discount factor for shared-pool hits. `0.0` queries but ignores them; `0.5` treats a shared hit as half a device hit; `1.0` treats shared and device hits equally. |
 
 Per-request overrides are available via `RouterConfigOverride.shared_cache_multiplier` for A/B experimentation without restarting the router.
 


### PR DESCRIPTION
## Overview

`docs/backends/sglang/sglang-hicache.md` table lists `--shared-cache-multiplier` default as `0.0`. The actual runtime default is `0.5` — verified via `python -m dynamo.frontend --help` and source.

## Changes

- `docs/backends/sglang/sglang-hicache.md` — change default value cell from `0.0` to `0.5`

No code, examples, or yaml changes.

## Test plan

- [x] No code paths affected
- [x] Default value confirmed via `python -m dynamo.frontend --help`
- [x] No bug-tracker IDs leak into rendered docs

Fixes NVBug 6212597 / DYN-3101.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default value for `--shared-cache-multiplier` configuration from `0.0` to `0.5` in the SGLang backend documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->