### PR TITLE
docs(sglang-hicache): drop crash-triggering flags from Mooncake recipe

### DIFF
--- a/docs/backends/sglang/sglang-hicache.md
+++ b/docs/backends/sglang/sglang-hicache.md
@@ -148,6 +148,9 @@ You also need:
 
 ## Setup
 
+> [!WARNING]
+> **Known limitation in 1.2.0.** With both `--enable-metrics` and `--disable-piecewise-cuda-graph` set on the SGLang worker, the process can crash on the first KV-cache write due to a race in the upstream `mooncake-transfer-engine` thread pool. The recipe below omits these flags; per-process metrics scraping via the `dynamo.frontend` is unaffected. The mooncake-side fix is being tracked upstream.
+
 **SGLang worker** — HiCache with Mooncake storage:
 
 ```bash


### PR DESCRIPTION
## Overview

Adds a known-limitation admonition above the HiCache + Mooncake deployment recipe in `docs/backends/sglang/sglang-hicache.md` to warn users away from a worker-crash combination.

On the 1.2.0 sglang-runtime image (`sglang-runtime:1.2.0-post.1-rc.6`), launching the SGLang worker with **both** `--enable-metrics` and `--disable-piecewise-cuda-graph` reliably segfaults the worker on the first KV-cache write, inside `mooncake::MemcpyWorkerPool::workerThread()`. QA confirmed via a 6-variant isolation matrix that *both* flags must be removed simultaneously to bypass the crash. The two flags are functionally unrelated — root cause is a race in the upstream `mooncake-transfer-engine` C++ thread pool that any extra background-thread activity widens.

## Changes

- `docs/backends/sglang/sglang-hicache.md` — adds a `> [!WARNING]` admonition above the `## Setup` recipe, matching the file's existing `> [!IMPORTANT]` style.

3 insertions, 0 deletions. The on-disk recipe code blocks did not actually contain `--enable-metrics` or `--disable-piecewise-cuda-graph` — so the protective value of this change is **preventing users from adding them**, not removing them from the example. Frontend-side Prometheus metrics scraping is unaffected.

The mooncake-side fix is being tracked upstream; this admonition is the user-facing protective note for 1.2.0.

## Test plan

- [x] No code paths affected
- [x] Admonition renders in mkdocs and matches the file's existing voice
- [x] No bug-tracker IDs leak into rendered docs

Fixes NVBug 6212593 / DYN-3100 (Dynamo-side protective workaround).