### PR TITLE
fix(epp): exclude Istio sidecar injection from EPP pod for GAIE

### DIFF
--- a/deploy/inference-gateway/standalone/helm/dynamo-gaie/templates/dynamo-epp.yaml
+++ b/deploy/inference-gateway/standalone/helm/dynamo-gaie/templates/dynamo-epp.yaml
@@ -40,6 +40,11 @@ spec:
     metadata:
       labels:
         app: {{ .Values.model.shortName }}-epp
+      annotations:
+        # Exclude Istio sidecar injection: EPP serves TLS on port 9002
+        # (--secure-serving true); an Istio sidecar in STRICT mTLS mode
+        # causes a double-TLS handshake failure on that port.
+        sidecar.istio.io/inject: "false"
     spec:
       terminationGracePeriodSeconds: 130
 

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -42,6 +42,12 @@ const (
 
 	KubeAnnotationEnableGrove = "nvidia.com/enable-grove"
 
+	// KubeAnnotationIstioSidecarInject is the standard Istio annotation that
+	// controls whether the mutating webhook injects an istio-proxy sidecar into
+	// a pod. Setting it to "false" opts the pod out of sidecar injection even
+	// when the namespace carries istio-injection=enabled.
+	KubeAnnotationIstioSidecarInject = "sidecar.istio.io/inject"
+
 	KubeAnnotationDisableImagePullSecretDiscovery = "nvidia.com/disable-image-pull-secret-discovery"
 	KubeAnnotationDynamoDiscoveryBackend          = "nvidia.com/dynamo-discovery-backend"
 	KubeAnnotationDynamoKubeDiscoveryMode         = "nvidia.com/dynamo-kube-discovery-mode"

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -378,6 +378,25 @@ func generateSingleDCD(
 		}
 	}
 
+	// Stamp sidecar.istio.io/inject: "false" on EPP pod templates before
+	// DGD-level annotations are merged in. EPP serves its own TLS on port 9002
+	// (--secure-serving true); an Istio sidecar intercepting that port causes a
+	// double-TLS handshake failure when the namespace has STRICT mTLS, which
+	// surfaces as cx_connect_fail / HTTP 500 on the gateway.
+	//
+	// Placement before applyDGDTemplateDefaults is intentional: the merge
+	// function (mergeLowPriorityMetadata) does not overwrite keys already
+	// present in the destination map, so a graph-wide DGD Spec.Annotations
+	// entry of sidecar.istio.io/inject: "true" cannot silently bypass the
+	// EPP opt-out. An explicit per-EPP podTemplate annotation set by the user
+	// is preserved by the !exists guard.
+	if component.ComponentType == commonconsts.ComponentTypeEPP {
+		podTemplate := ensurePodTemplate(&deployment.Spec.DynamoComponentDeploymentSharedSpec)
+		if _, exists := podTemplate.Annotations[commonconsts.KubeAnnotationIstioSidecarInject]; !exists {
+			podTemplate.Annotations[commonconsts.KubeAnnotationIstioSidecarInject] = "false"
+		}
+	}
+
 	applyDGDTemplateDefaults(&deployment.Spec.DynamoComponentDeploymentSharedSpec, parentDGD)
 
 	// Topology label controller marker: set on the DCD so it propagates to pods.


### PR DESCRIPTION
## Overview

Follow-up to [#9839](https://github.com/ai-dynamo/dynamo/pull/9839). That PR fixed the Istio sidecar / double-TLS handshake failure for the kgateway-proxy pod by setting `sidecar.istio.io/inject: "false"` via GatewayParameters. The EPP pod has the same problem — Istio sidecar intercepts EPP's ext_proc gRPC port 9002, EPP runs `--secure-serving true`, double-TLS handshake fails, kgateway-proxy reports `cx_connect_fail` and returns HTTP 500.

This PR mirrors the same exclusion on the EPP pod template.

## Changes

- `deploy/inference-gateway/standalone/helm/dynamo-gaie/templates/dynamo-epp.yaml` — adds `sidecar.istio.io/inject: "false"` annotation to the standalone EPP Deployment's `spec.template.metadata.annotations`, matching the kgateway-proxy pattern from #9839.
- `deploy/operator/internal/dynamo/graph.go` — in `generateSingleDCD`, stamp the same annotation on the EPP DCD's pod-template metadata when the component type is EPP, so the operator-managed install path also bypasses the sidecar. Mirrors the existing planner-specific branch one block above. Respects user overrides (only set when not already present).
- `deploy/operator/internal/consts/consts.go` — introduce `KubeAnnotationIstioSidecarInject` constant for the Istio annotation key so the operator code references a named constant rather than a literal string.

## Test plan

- [ ] Deploy with Istio namespace-level injection enabled
- [ ] Verify EPP pod does not get the sidecar (`kubectl get pod -o jsonpath='{.spec.containers[*].name}'` shows only the EPP container)
- [ ] Verify inference requests through kgateway succeed (no `cx_connect_fail`)

Fixes NVBug 6215475 / DYN-3108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Istio sidecar injection configuration for EPP deployment to ensure secure TLS communication.

* **Chores**
  * Updated Kubernetes deployment templates with improved Istio service mesh configuration management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->