### PR TITLE
fix(kv-router): preserve prefill DP rank for decode

### DIFF
--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -44,7 +44,7 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.llm import ModelInput
-from dynamo.sglang._compat import get_scheduler_info
+from dynamo.sglang._compat import filter_supported_async_generate_kwargs, get_scheduler_info
 from dynamo.sglang._disagg import (
     SGLANG_WORKER_GROUP_ID_KEY,
     compute_bootstrap_address,
@@ -288,6 +288,18 @@ class SglangLLMEngine(LLMEngine):
             bootstrap_kwargs = self._resolve_prefill_bootstrap(request)
         elif self.serving_mode == DisaggregationMode.DECODE:
             bootstrap_kwargs = self._resolve_decode_bootstrap(request)
+            routing = request.get("routing") or {}
+            prefill_dp_rank = routing.get("prefill_dp_rank")
+            if prefill_dp_rank is not None:
+                # SGLang uses data_parallel_rank/routed_dp_rank for the decode
+                # worker selection. disagg_prefill_dp_rank is the separate rank
+                # used by decode to query the matching prefill bootstrap peer.
+                bootstrap_kwargs.update(
+                    filter_supported_async_generate_kwargs(
+                        self.engine,
+                        {"disagg_prefill_dp_rank": prefill_dp_rank},
+                    )
+                )
 
         # Honour the router's DP rank decision; without it SGLang picks
         # its own rank and KV events land on the wrong publisher.

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -466,6 +466,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # Extract dp_rank from routing info (set by KV router)
             routing = request.get("routing") or {}
             dp_rank = routing.get("dp_rank")
+            prefill_dp_rank = routing.get("prefill_dp_rank")
+            prefill_dp_rank_kwargs = (
+                filter_supported_async_generate_kwargs(
+                    self.engine, {"disagg_prefill_dp_rank": prefill_dp_rank}
+                )
+                if prefill_dp_rank is not None
+                else {}
+            )
 
             decode = await self.engine.async_generate(
                 **input_param,
@@ -478,6 +486,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 external_trace_header=trace_header,
                 rid=trace_id,
                 data_parallel_rank=dp_rank,
+                **prefill_dp_rank_kwargs,
                 **self._session_kwargs(request),
                 lora_path=lora_path,
                 **logprob_kwargs,

--- a/components/src/dynamo/sglang/tests/test_sglang_disagg.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_disagg.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
 pytest.importorskip("sglang", reason="sglang not installed in this container")
@@ -57,3 +60,62 @@ def test_decode_bootstrap_raises_when_router_left_no_info():
     # leave the decode worker waiting on a phantom KV transfer.
     with pytest.raises(ValueError, match="bootstrap"):
         SglangLLMEngine._resolve_decode_bootstrap({"token_ids": [1, 2, 3]})
+
+@pytest.mark.asyncio
+async def test_decode_forwards_decode_and_prefill_dp_ranks_separately():
+    calls: dict[str, Any] = {}
+
+    async def fake_stream():
+        yield {
+            "output_ids": [7],
+            "meta_info": {
+                "finish_reason": {"type": "stop"},
+                "prompt_tokens": 2,
+                "completion_tokens": 1,
+            },
+        }
+
+    class FakeSglangEngine:
+        async def async_generate(
+            self,
+            input_ids=None,
+            sampling_params=None,
+            stream=False,
+            rid=None,
+            data_parallel_rank=None,
+            disagg_prefill_dp_rank=None,
+            bootstrap_host=None,
+            bootstrap_port=None,
+            bootstrap_room=None,
+        ):
+            calls.update(locals())
+            return fake_stream()
+
+    engine = SglangLLMEngine.__new__(SglangLLMEngine)
+    engine.engine = FakeSglangEngine()
+    engine.serving_mode = DisaggregationMode.DECODE
+    engine.enable_trace = False
+    engine._use_sglang_tokenizer = False
+    engine._input_param_manager = SimpleNamespace(
+        get_input_param=lambda request, use_tokenizer: request["token_ids"]
+    )
+    engine._dp_start = 0
+    engine._dp_size = 8
+
+    context = SimpleNamespace(trace_id="rid-1", is_stopped=lambda: False)
+    request = {
+        "token_ids": [1, 2],
+        "routing": {"dp_rank": 5, "prefill_dp_rank": 2},
+        "bootstrap_info": {
+            "bootstrap_host": "prefill.host",
+            "bootstrap_port": 9000,
+            "bootstrap_room": 123,
+        },
+    }
+
+    chunks = [chunk async for chunk in engine.generate(request, context)]
+
+    assert chunks[-1]["finish_reason"] == "stop"
+    assert calls["data_parallel_rank"] == 5
+    assert calls["disagg_prefill_dp_rank"] == 2
+    assert calls["bootstrap_room"] == 123

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     discovery::ModelManager,
     protocols::common::{
         llm_backend::{LLMEngineOutput, PreprocessedRequest},
+        preprocessor::RoutingHints,
         timing::{RequestPhase, RequestTracker},
     },
 };
@@ -32,6 +33,16 @@ mod types;
 use inner::InnerPrefillRouter;
 pub use types::{PrefillError, PrefillQueryOutcome};
 use types::{PrefillOutcome, PrefillResolveDecision, build_decode_router_override};
+
+fn record_selected_prefill_route(
+    routing: &mut RoutingHints,
+    worker_id: u64,
+    dp_rank: Option<u32>,
+) {
+    routing.prefill_worker_id = Some(worker_id);
+    routing.dp_rank = dp_rank;
+    routing.prefill_dp_rank = dp_rank;
+}
 
 /// PrefillRouter is a forward-only operator that sits between Migration and the decode router.
 /// It optionally calls a prefill worker before routing to decode, extracting disaggregated_params
@@ -129,6 +140,8 @@ impl
             ));
         }
 
+        let mut selected_prefill_dp_rank = None;
+
         let prefill_result = match self
             .resolve_prefill_worker(&prefill_req, preselected_worker)
             .await
@@ -147,9 +160,9 @@ impl
                     router.select_next_worker();
                 }
 
-                let routing = prefill_req.routing_mut();
-                routing.prefill_worker_id = Some(worker_id);
-                routing.dp_rank = dp_rank;
+                selected_prefill_dp_rank = dp_rank;
+
+                record_selected_prefill_route(prefill_req.routing_mut(), worker_id, dp_rank);
                 prefill_req.bootstrap_info = Some(bootstrap_info.clone());
 
                 // NVBugs 5969206: Do NOT link prefill as child of engine context.
@@ -258,6 +271,14 @@ impl
 
                 let mut decode_req = req;
 
+                // Preserve the prefill router's DP-rank choice for decode-side
+                // adapters. The decode router may overwrite `routing.dp_rank`
+                // with its own decode DP rank before the backend receives the
+                // request, so the prefill rank must live in its dedicated field.
+                if let Some(dp_rank) = selected_prefill_dp_rank {
+                    decode_req.routing_mut().prefill_dp_rank = Some(dp_rank);
+                }
+
                 match outcome {
                     PrefillOutcome::Bootstrap(info) => {
                         decode_req.bootstrap_info = Some(info);
@@ -303,6 +324,17 @@ impl
 mod tests {
     use super::*;
     use dynamo_kv_router::config::RouterConfigOverride;
+
+    #[test]
+    fn selected_prefill_route_sets_prefill_and_backend_dp_rank() {
+        let mut routing = RoutingHints::default();
+
+        record_selected_prefill_route(&mut routing, 12, Some(3));
+
+        assert_eq!(routing.prefill_worker_id, Some(12));
+        assert_eq!(routing.dp_rank, Some(3));
+        assert_eq!(routing.prefill_dp_rank, Some(3));
+    }
 
     #[test]
     fn decode_router_override_disables_overlap_and_prefill_tracking() {


### PR DESCRIPTION
#### Overview:

Preserve the DP rank selected by the prefill router across the disaggregated prefill -> decode handoff.

In disaggregated SGLang serving, the prefill router can choose a specific prefill DP rank. That value must be forwarded to the decode-side backend adapter as the prefill DP rank. The decode routing path can later use `routing.dp_rank` for the decode DP rank, so the selected prefill rank must be preserved separately in `routing.prefill_dp_rank`.

This can make SGLang decode query the prefill bootstrap server with a decode DP rank instead of the selected prefill DP rank, especially when `prefill_dp_size != decode_dp_size`.

#### Details:

- Store the prefill router's selected rank in `routing.prefill_dp_rank` and keep `routing.dp_rank` on the cloned prefill request for existing prefill backend/direct-router paths.
- Carry the selected prefill DP rank onto the original decode request before entering the decode phase.
- Forward `routing.prefill_dp_rank` to SGLang as `disagg_prefill_dp_rank`, while keeping `routing.dp_rank` as the decode request's `data_parallel_rank`.
- Use SGLang async-generate kwarg filtering so older SGLang builds that do not expose `disagg_prefill_dp_rank` do not receive an unsupported kwarg.

#### Where should the reviewer start?

- `lib/llm/src/kv_router/prefill_router/mod.rs`
- `components/src/dynamo/sglang/llm_engine.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to SGLang disaggregated serving with Dynamo KV routing and different prefill/decode DP sizes.

#### Validation:

- `git diff --check`
- `python3 -m py_compile components/src/dynamo/sglang/llm_engine.py components/src/dynamo/sglang/request_handlers/llm/decode_handler.py components/src/dynamo/sglang/tests/test_sglang_disagg.py`
- Added unit coverage for forwarding decode DP rank and prefill DP rank separately to SGLang.
- Added Rust unit coverage for preserving both prefill `dp_rank` and `prefill_dp_rank` on the cloned prefill request.
- Internal AA-RWLT repro: with this routing-field fix in the runtime overlay, the Dynamo+SGLang DEP4 prefill / DEP8 decode run progressed into measurement instead of losing the selected prefill DP rank at the decode handoff.
