### PR TITLE
fix(snapshot): preserve vLLM torch compile cache

### DIFF
--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -167,7 +167,6 @@ config:
       - /sys
       - /dev
       - "*/.cache/huggingface"
-      - "*/.cache/vllm/torch_compile_cache"
       - "*/__pycache__"
       - "*.pyc"
 

--- a/deploy/snapshot/internal/runtime/overlay_test.go
+++ b/deploy/snapshot/internal/runtime/overlay_test.go
@@ -43,13 +43,12 @@ func TestBuildExclusions(t *testing.T) {
 		{
 			name: "glob patterns starting with * are untouched",
 			settings: types.OverlaySettings{
-				Exclusions: []string{"*/.cache/huggingface", "*/.cache/vllm/torch_compile_cache", "*.pyc", "*/__pycache__"},
+				Exclusions: []string{"*/.cache/huggingface", "*.pyc", "*/__pycache__"},
 			},
 			want: map[string]bool{
-				"*/.cache/huggingface":              true,
-				"*/.cache/vllm/torch_compile_cache": true,
-				"*.pyc":                             true,
-				"*/__pycache__":                     true,
+				"*/.cache/huggingface": true,
+				"*.pyc":                true,
+				"*/__pycache__":        true,
 			},
 		},
 		{


### PR DESCRIPTION
## Description

Remove the default snapshot overlay exclusion for `*/.cache/vllm/torch_compile_cache`. vLLM/Torch can mmap generated Triton shared objects from this cache; excluding it from `rootfs-diff.tar` can make CRIU restore fail with `Can't open file ... __triton_launcher...so on restore: No such file or directory`.

The remaining cache exclusion for Hugging Face model data stays in place. In the GMS benchmark smoke runs, the vLLM torch compile cache added only tens of MiB to the rootfs diff (~44 MiB for Qwen3-0.6B, ~35 MiB for gpt-oss-120b).

## Testing

- `cd deploy/snapshot && go test ./internal/runtime`
- Validated on nscale `s2877` by overriding the live snapshot Helm values and rerunning a Qwen3-0.6B GMS restore; CRIU restore progressed past the missing Triton launcher file and completed external restore.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated snapshot agent configuration to refine which cache files are excluded from snapshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->