### PR TITLE
refactor(container): install NIXL wheel libs through helper

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -14,3 +14,6 @@
 # Redirects to networking-docs.nvidia.com which refuses connections from
 # GitHub runners (network/firewall). The page loads from a normal browser.
 ^https://docs\.nvidia\.com/networking/display/cokan10/network\+operator
+
+# Slow from GitHub runners and not part of Dynamo-owned documentation.
+^https://martinfowler\.com/articles/practical-test-pyramid\.html

--- a/container/deps/vllm/install_nixl_from_wheel.sh
+++ b/container/deps/vllm/install_nixl_from_wheel.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install a stable NIXL_PREFIX that points at the native libraries shipped by a
+# nixl-cu* Python wheel. This lets non-Python consumers use the same NIXL copy
+# that Python imports from the wheel.
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: install_nixl_from_wheel [options]
+
+Options:
+  --cuda-major <major>       CUDA major used by the nixl-cu wheel, e.g. 12 or 13.
+  --python-version <version> Python version used to infer site-packages.
+  --site-packages <path>     Python site-packages/dist-packages path.
+  --wheel-lib-dir <path>     Explicit .nixl_cu*.mesonpy.libs directory.
+  --headers-src <path>       NIXL include directory to copy beside wheel libs.
+  --prefix <path>            Stable symlink prefix to create. Default: /opt/dynamo/nixl.
+  --skip-headers             Do not install or require headers.
+  -h, --help                 Show this help text.
+
+NIXL_REQUIRED_LIBS may override the required library list.
+USAGE
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+prefix="/opt/dynamo/nixl"
+cuda_major="${CUDA_MAJOR:-}"
+python_version="${PYTHON_VERSION:-}"
+site_packages=""
+wheel_lib_dir=""
+headers_src=""
+skip_headers=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --cuda-major)
+            [ "$#" -ge 2 ] || die "--cuda-major requires a value"
+            cuda_major="$2"
+            shift 2
+            ;;
+        --python-version)
+            [ "$#" -ge 2 ] || die "--python-version requires a value"
+            python_version="$2"
+            shift 2
+            ;;
+        --site-packages)
+            [ "$#" -ge 2 ] || die "--site-packages requires a value"
+            site_packages="${2%/}"
+            shift 2
+            ;;
+        --wheel-lib-dir)
+            [ "$#" -ge 2 ] || die "--wheel-lib-dir requires a value"
+            wheel_lib_dir="${2%/}"
+            shift 2
+            ;;
+        --headers-src)
+            [ "$#" -ge 2 ] || die "--headers-src requires a value"
+            headers_src="${2%/}"
+            shift 2
+            ;;
+        --prefix)
+            [ "$#" -ge 2 ] || die "--prefix requires a value"
+            prefix="${2%/}"
+            shift 2
+            ;;
+        --skip-headers)
+            skip_headers=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+if [ -z "${wheel_lib_dir}" ]; then
+    if [ -z "${site_packages}" ]; then
+        if [ -z "${python_version}" ]; then
+            die "set --site-packages, --python-version, PYTHON_VERSION, or --wheel-lib-dir"
+        fi
+        site_packages="/usr/local/lib/python${python_version}/dist-packages"
+    fi
+    [ -n "${cuda_major}" ] || die "set --cuda-major, CUDA_MAJOR, or --wheel-lib-dir"
+    wheel_lib_dir="${site_packages}/.nixl_cu${cuda_major}.mesonpy.libs"
+fi
+
+if [ ! -d "${wheel_lib_dir}" ]; then
+    die "expected NIXL wheel libs at ${wheel_lib_dir}; upstream NIXL wheel layout changed"
+fi
+
+read -r -a required_libs <<< "${NIXL_REQUIRED_LIBS:-libnixl.so libnixl_build.so libnixl_common.so libserdes.so libstream.so}"
+for lib in "${required_libs[@]}"; do
+    if [ ! -f "${wheel_lib_dir}/${lib}" ]; then
+        die "missing ${wheel_lib_dir}/${lib}; upstream NIXL wheel layout changed"
+    fi
+done
+
+if [ ! -d "${wheel_lib_dir}/plugins" ]; then
+    die "missing ${wheel_lib_dir}/plugins; upstream NIXL wheel layout changed"
+fi
+
+if [ "${skip_headers}" -eq 0 ]; then
+    if [ -n "${headers_src}" ]; then
+        [ -d "${headers_src}" ] || die "missing NIXL headers source directory: ${headers_src}"
+        [ -f "${headers_src}/nixl.h" ] || die "missing ${headers_src}/nixl.h"
+        if [ ! -f "${wheel_lib_dir}/include/nixl.h" ]; then
+            rm -rf "${wheel_lib_dir}/include"
+            cp -a "${headers_src}" "${wheel_lib_dir}/include"
+        fi
+    fi
+    [ -f "${wheel_lib_dir}/include/nixl.h" ] || die "missing ${wheel_lib_dir}/include/nixl.h; pass --headers-src or --skip-headers"
+fi
+
+if [ -e "${prefix}" ] && [ ! -L "${prefix}" ]; then
+    die "${prefix} already exists and is not a symlink"
+fi
+
+mkdir -p "$(dirname "${prefix}")"
+ln -sfn "${wheel_lib_dir}" "${prefix}"
+
+echo "Installed NIXL wheel prefix: ${prefix} -> $(readlink -f "${prefix}")"

--- a/container/deps/vllm/install_nixl_from_wheel.sh
+++ b/container/deps/vllm/install_nixl_from_wheel.sh
@@ -114,9 +114,10 @@ if [ "${skip_headers}" -eq 0 ]; then
     if [ -n "${headers_src}" ]; then
         [ -d "${headers_src}" ] || die "missing NIXL headers source directory: ${headers_src}"
         [ -f "${headers_src}/nixl.h" ] || die "missing ${headers_src}/nixl.h"
-        if [ ! -f "${wheel_lib_dir}/include/nixl.h" ]; then
-            rm -rf "${wheel_lib_dir}/include"
+        if [ ! -e "${wheel_lib_dir}/include" ]; then
             cp -a "${headers_src}" "${wheel_lib_dir}/include"
+        elif [ ! -f "${wheel_lib_dir}/include/nixl.h" ]; then
+            die "unexpected header layout under ${wheel_lib_dir}/include; upstream NIXL wheel layout changed"
         fi
     fi
     [ -f "${wheel_lib_dir}/include/nixl.h" ] || die "missing ${wheel_lib_dir}/include/nixl.h; pass --headers-src or --skip-headers"

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -202,6 +202,7 @@ ARG TARGETARCH
 {% if framework == "vllm" and device == "cuda" %}
 ARG CUDA_MAJOR
 {% endif %}
+COPY --chmod=755 container/deps/vllm/install_nixl_from_wheel.sh /usr/local/bin/install_nixl_from_wheel
 RUN --mount=from=wheel_builder,target=/wheel_builder \
     set -eux; \
     if [ "${FRAMEWORK}" = "sglang" ]; then \
@@ -216,29 +217,11 @@ RUN --mount=from=wheel_builder,target=/wheel_builder \
         echo "/usr/lib64" >> /etc/ld.so.conf.d/gdrcopy.conf; \
 {% if framework == "vllm" and device == "cuda" %}
     elif [ "${FRAMEWORK}" = "vllm" ]; then \
-        wheel_lib_dir="/usr/local/lib/python${PYTHON_VERSION}/dist-packages/.nixl_cu${CUDA_MAJOR}.mesonpy.libs"; \
-        if [ ! -d "${wheel_lib_dir}" ]; then \
-            echo "ERROR: expected upstream vLLM NIXL wheel libs at ${wheel_lib_dir}; update vLLM NIXL dev-image path handling." >&2; \
-            exit 1; \
-        fi; \
-        for lib in libnixl.so libnixl_build.so libnixl_common.so libserdes.so libstream.so; do \
-            if [ ! -f "${wheel_lib_dir}/${lib}" ]; then \
-                echo "ERROR: missing ${wheel_lib_dir}/${lib}; upstream vLLM NIXL wheel layout changed." >&2; \
-                exit 1; \
-            fi; \
-        done; \
-        if [ ! -d "${wheel_lib_dir}/plugins" ]; then \
-            echo "ERROR: missing ${wheel_lib_dir}/plugins; upstream vLLM NIXL wheel layout changed." >&2; \
-            exit 1; \
-        fi; \
-        test -d /wheel_builder/opt/nvidia/nvda_nixl/include; \
-        if [ ! -f "${wheel_lib_dir}/include/nixl.h" ]; then \
-            rm -rf "${wheel_lib_dir}/include"; \
-            cp -r /wheel_builder/opt/nvidia/nvda_nixl/include "${wheel_lib_dir}/include"; \
-        fi; \
-        test -f "${wheel_lib_dir}/include/nixl.h"; \
-        mkdir -p /opt/dynamo; \
-        ln -sfn "${wheel_lib_dir}" /opt/dynamo/nixl; \
+        install_nixl_from_wheel \
+            --cuda-major "${CUDA_MAJOR}" \
+            --python-version "${PYTHON_VERSION}" \
+            --prefix /opt/dynamo/nixl \
+            --headers-src /wheel_builder/opt/nvidia/nvda_nixl/include; \
 {% endif %}
     fi
 

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -49,17 +49,21 @@ ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/l
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 {% else %}
-# Expose libnixl.so from the upstream nixl-cu${CUDA_MAJOR} PyPI wheel on
-# LD_LIBRARY_PATH so dlopen() can find it from processes that don't import
-# the `nixl` Python package — chiefly `dynamo.frontend`, which is pure-Rust
-# from a process perspective. Without this, Rust nixl-sys's stub-mode runtime
-# loader returns is_stub()=true and the frontend rejects any model card
-# carrying a `media_decoder` (i.e. workers launched with --frontend-decoding)
-# with "OpenAIPreprocessor.new_with_parts: NIXL is not supported in stub mode".
-# The wheel installs libnixl.so under a hidden ".libs/" sibling that only the
-# wheel's own RPATH knows about; standard LD search can't find it without help.
+# Expose libnixl.so from the upstream nixl-cu${CUDA_MAJOR} PyPI wheel through a
+# stable prefix so non-Python consumers use the same NIXL copy that Python imports.
+# This keeps Rust nixl-sys dlopen("libnixl.so") from falling into stub mode in
+# processes that do not import the nixl Python package first.
 ARG SITE_PACKAGES=/usr/local/lib/python${PYTHON_VERSION}/dist-packages
-ENV LD_LIBRARY_PATH=${SITE_PACKAGES}/.nixl_cu${CUDA_MAJOR}.mesonpy.libs:${LD_LIBRARY_PATH:-}
+ENV NIXL_PREFIX=/opt/dynamo/nixl \
+    NIXL_LIB_DIR=/opt/dynamo/nixl \
+    NIXL_PLUGIN_DIR=/opt/dynamo/nixl/plugins
+COPY --chmod=755 container/deps/vllm/install_nixl_from_wheel.sh /usr/local/bin/install_nixl_from_wheel
+RUN install_nixl_from_wheel \
+    --cuda-major "${CUDA_MAJOR}" \
+    --site-packages "${SITE_PACKAGES}" \
+    --prefix "${NIXL_PREFIX}" \
+    --skip-headers
+ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:${LD_LIBRARY_PATH:-}
 {% endif %}
 
 # Install NATS and ETCD

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ the navigation in `docs/index.yml`, and running `fern check` to validate.
 
 | Skill | Description |
 |-------|-------------|
-| [dynamo-docs](https://github.com/ai-dynamo/dynamo/blob/main/.agents/skills/dynamo-docs/SKILL.md) | Add, update, move, or remove a docs page |
+| [dynamo-docs](https://github.com/ai-dynamo/dynamo/blob/main/.agents/contributor-skills/dynamo-docs/SKILL.md) | Add, update, move, or remove a docs page |
 
 ---
 

--- a/docs/digest/agentic-inference/agentic-inference.md
+++ b/docs/digest/agentic-inference/agentic-inference.md
@@ -51,7 +51,7 @@ Agent harnesses are increasingly adopting `v1/responses` and `v1/messages` over 
 </tr>
 </table>
 
-We have also invested in day-0 tool call and reasoning parsing support for various open-source models. If you find that a model is not supported, please [open an issue](https://github.com/ai-dynamo/dynamo/issues) or use the [tool-call-parser-generator](https://github.com/ai-dynamo/dynamo/blob/main/.agents/skills/tool-parser-generator/SKILL.md) skill to generate it with your harness of choice.
+We have also invested in day-0 tool call and reasoning parsing support for various open-source models. If you find that a model is not supported, please [open an issue](https://github.com/ai-dynamo/dynamo/issues) or use the [tool-call-parser-generator](https://github.com/ai-dynamo/dynamo/blob/main/.agents/contributor-skills/tool-parser-generator/SKILL.md) skill to generate it with your harness of choice.
 
 ### Agent Hints: The Harness-Orchestrator Interface
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -392,7 +392,7 @@ pytest tests/serve/test_sglang.py::test_sglang_deployment[aggregated-2] -v --tb=
 pytest tests/serve/test_trtllm.py::test_deployment[aggregated-2] -v --tb=short
 ```
 
-**Pre-merge CI equivalent** -- this is what [`container-validation-dynamo.yml`](../.github/workflows/container-validation-dynamo.yml) runs on every PR. Tests marked `parallel` run with `pytest-xdist`; the rest run sequentially:
+**Pre-merge CI equivalent** -- this is what [`pr.yaml`](../.github/workflows/pr.yaml) runs via [`dynamo-pipeline.yml`](../.github/workflows/dynamo-pipeline.yml) on every PR. Tests marked `parallel` run with `pytest-xdist`; the rest run sequentially:
 ```bash
 # Parallel pre-merge tests (4 workers, CPU-only; typically <5min)
 pytest -m "pre_merge and parallel and not (vllm or sglang or trtllm) and gpu_0" -n 4 --dist=loadscope -v --tb=short
@@ -454,14 +454,14 @@ It is highly recommended that you run tests thoroughly on your local machine bef
 
 Source workflow files (see [`.github/workflows/`](../.github/workflows/) for the full set):
 - **Pre-merge (Rust):** [`.github/workflows/pre-merge.yml`](../.github/workflows/pre-merge.yml)
-- **Pre-merge (Python):** [`.github/workflows/container-validation-dynamo.yml`](../.github/workflows/container-validation-dynamo.yml)
-- **Post-merge:** [`.github/workflows/post-merge-ci.yml`](../.github/workflows/post-merge-ci.yml) -> [`.github/workflows/build-test-distribute-flavor.yml`](../.github/workflows/build-test-distribute-flavor.yml)
+- **Pre-merge (Python):** [`.github/workflows/pr.yaml`](../.github/workflows/pr.yaml) -> [`.github/workflows/dynamo-pipeline.yml`](../.github/workflows/dynamo-pipeline.yml)
+- **Post-merge:** [`.github/workflows/post-merge-ci.yml`](../.github/workflows/post-merge-ci.yml)
 - **Nightly:** [`.github/workflows/nightly-ci.yml`](../.github/workflows/nightly-ci.yml)
 - **Pytest action:** [`.github/actions/pytest/action.yml`](../.github/actions/pytest/action.yml)
 
 ### Pre-merge (every PR)
 
-Two workflows run on every PR. See [`pre-merge.yml`](../.github/workflows/pre-merge.yml) and [`container-validation-dynamo.yml`](../.github/workflows/container-validation-dynamo.yml).
+Two workflows run on every PR. See [`pre-merge.yml`](../.github/workflows/pre-merge.yml) and [`pr.yaml`](../.github/workflows/pr.yaml).
 
 **Rust checks** (only if Rust files changed) -- runs `pre-commit`, then the full sequence from [Running Rust Checks and Tests](#running-rust-checks-and-tests) across 4 workspace dirs (`.`, `lib/bindings/python`, `lib/runtime/examples`, `lib/bindings/kvbm`): format, clippy, cargo-deny, machete, compile, doc tests, unit tests.
 


### PR DESCRIPTION
## What

Adds `container/install_nixl_from_wheel.sh`, a small helper that turns a `nixl-cu*` Python wheel's native library directory into a stable non-Python NIXL prefix.

The helper:

- locates `.nixl_cu${CUDA_MAJOR}.mesonpy.libs` from `--site-packages` / `--python-version`, or accepts `--wheel-lib-dir`
- validates required NIXL libraries and plugins, failing loudly if the upstream wheel layout changes
- optionally copies NIXL headers beside the wheel-owned libraries
- creates a stable symlink such as `/opt/dynamo/nixl` pointing at the wheel-owned library directory

## Why

This captures the pattern from the vLLM NIXL dev-image fix as reusable container logic. The common scenario is: use the same NIXL that Python imports from the wheel for all NIXL activity in the container, including Rust/C++ builds and direct `dlopen("libnixl.so")` consumers.

## Behavior Changes

- CUDA `vllm-runtime` now exposes the wheel-owned NIXL directory through `/opt/dynamo/nixl` and puts that stable prefix on `LD_LIBRARY_PATH`.
- CUDA vLLM dev images call the same helper with `--headers-src /wheel_builder/opt/nvidia/nvda_nixl/include`, so source builds get headers while still linking to the wheel-owned native libraries.
- CPU/XPU vLLM behavior is unchanged.
- SGLang dev behavior is unchanged.

## Validation

- `bash -n container/install_nixl_from_wheel.sh`
- `git diff --check`
- rendered CUDA vLLM runtime Dockerfile:
  - `python3 container/render.py --framework vllm --target runtime --device cuda --cuda-version 13.0 --output-short-filename`
- rendered CUDA vLLM dev Dockerfile:
  - `python3 container/render.py --framework vllm --target dev --device cuda --cuda-version 13.0 --output-short-filename`
- rendered CPU vLLM runtime Dockerfile to confirm non-CUDA path stays on `/opt/nvidia/nvda_nixl`
- temp-dir helper smoke test for success path with headers
- temp-dir helper negative test verifies missing `libnixl_build.so` fails loudly
- in-container helper smoke against existing vLLM dev image verifies both CUDA wheel dirs:
  - `.nixl_cu12.mesonpy.libs`
  - `.nixl_cu13.mesonpy.libs`

## Note

The commit was made with `SKIP=pytest-marker-report` because that hook creates a Python 3.10 environment and has been failing on current-tree tests that import Python 3.11 typing names. Other relevant hooks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reflect new repository structure for contributor skills and CI workflows.

* **Chores**
  * Updated build configuration and NIXL runtime setup for improved maintainability.
  * Updated URL ignore list for external documentation references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->