### PR TITLE
fix: [cherry-pick] preserve original model casing on frontend lifecycle guards (DYN-3073)

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1018,7 +1018,7 @@ impl Metrics {
 
         InflightGuard::new(
             self.clone(),
-            model.to_string().to_lowercase(),
+            model.to_string(),
             endpoint,
             request_type,
             request_id.to_string(),
@@ -1027,7 +1027,7 @@ impl Metrics {
 
     /// Create a new [`ResponseMetricCollector`] for collecting per-response metrics (i.e., TTFT, ITL)
     pub fn create_response_collector(self: Arc<Self>, model: &str) -> ResponseMetricCollector {
-        ResponseMetricCollector::new(self, model.to_string().to_lowercase())
+        ResponseMetricCollector::new(self, model.to_string())
     }
 
     /// Create a new [`HttpQueueGuard`] for tracking HTTP processing queue
@@ -1035,7 +1035,7 @@ impl Metrics {
     /// This guard tracks requests from HTTP handler start until first token generation,
     /// providing visibility into HTTP processing queue time before actual LLM processing begins.
     pub fn create_http_queue_guard(self: Arc<Self>, model: &str) -> HttpQueueGuard {
-        HttpQueueGuard::new(self, model.to_string().to_lowercase())
+        HttpQueueGuard::new(self, model.to_string())
     }
 }
 
@@ -2453,6 +2453,53 @@ mod tests {
                 .get(),
             0
         );
+    }
+
+    #[test]
+    fn test_lifecycle_constructors_preserve_model_label_casing() {
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+
+        let model = "Llama-3.1-8B-Instruct";
+
+        let _inflight = metrics.clone().create_inflight_guard(
+            model,
+            Endpoint::ChatCompletions,
+            true,
+            "req-case",
+        );
+        let mut collector = metrics.clone().create_response_collector(model);
+        collector.observe_response(100, 1);
+        let _queue = metrics.clone().create_http_queue_guard(model);
+
+        // Drop the lifecycle guards so their Drop impls record
+        // completion-time metrics (request_counter, request_duration,
+        // detokenize observations) before we gather. Without this the
+        // regression only covers constructor-time labels.
+        drop(_inflight);
+        drop(collector);
+        drop(_queue);
+
+        let metric_families = registry.gather();
+        let observed: Vec<String> = metric_families
+            .iter()
+            .flat_map(|mf| mf.get_metric())
+            .flat_map(|m| m.get_label())
+            .filter(|l| l.name() == "model")
+            .map(|l| l.value().to_string())
+            .collect();
+
+        assert!(
+            !observed.is_empty(),
+            "expected at least one metric to carry a model label"
+        );
+        for value in &observed {
+            assert_eq!(
+                value, model,
+                "model label was modified; expected original casing to be preserved"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cherry-pick of #9775 to `release/1.2.0`.

- Removes the three `.to_lowercase()` calls on the `model` label in `InflightGuard`, `ResponseMetricCollector`, and `HttpQueueGuard` in `lib/llm/src/http/service/metrics.rs`, so every `dynamo_frontend_*` metric family emits the same casing as the originally-registered model card. Dashboards filtering by `model="$model"` will then match across all metric families for the same logical model.

**Original PR:** https://github.com/ai-dynamo/dynamo/pull/9775
**Linear:** DYN-3073

## Test plan

- [ ] CI passes on `release/1.2.0` branch
- [ ] Verify changed files match the original PR diff (1 file, +50/-3 — confirmed locally)