### PR TITLE
fix(vllm-omni): remove TTS dummy tokenizer workaround

### DIFF
--- a/components/src/dynamo/vllm/omni/main.py
+++ b/components/src/dynamo/vllm/omni/main.py
@@ -22,10 +22,6 @@ from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.stage_router import init_omni_stage_router
 from dynamo.vllm.omni.stage_worker import init_omni_stage
-from dynamo.vllm.omni.utils import (
-    cleanup_dummy_tokenizer_for_tts,
-    ensure_dummy_tokenizer_for_tts,
-)
 
 from .args import OmniConfig, parse_omni_args
 
@@ -75,39 +71,27 @@ async def init_omni(
     if model_type is None:
         model_type = ModelType.Images
 
-    # Audio/TTS models (e.g., Qwen3-TTS) don't ship a standard tokenizer.json,
-    # which causes register_model to fail when building the ModelDeploymentCard.
-    # Create a minimal placeholder so the Rust card loader doesn't bail,
-    # then delete it immediately after so vLLM-Omni's inference-time
-    # AutoTokenizer.from_pretrained() doesn't pick up the fake file.
-    dummy_tokenizer_paths = []
-    if "audio" in config.output_modalities:
-        dummy_tokenizer_paths = ensure_dummy_tokenizer_for_tts(config.model)
-
-    await register_model(
-        ModelInput.Text,
-        model_type,
-        generate_endpoint,
-        config.model,
-        config.served_model_name,
-        kv_cache_block_size=config.engine_args.block_size,
-        # Omni workers serve the full multi-stage pipeline behind one
-        # endpoint; there is no prefill/decode split visible to the
-        # frontend, so they register as Aggregated.
-        worker_type=WorkerType.Aggregated,
-        needs=[],
-    )
-
-    if dummy_tokenizer_paths:
-        cleanup_dummy_tokenizer_for_tts(dummy_tokenizer_paths)
-
-    logger.info("Starting to serve Omni worker endpoint...")
-
-    health_check_payload = (
-        await VllmOmniHealthCheckPayload.create(handler.engine_client)
-    ).to_dict()
-
     try:
+        await register_model(
+            ModelInput.Text,
+            model_type,
+            generate_endpoint,
+            config.model,
+            config.served_model_name,
+            kv_cache_block_size=config.engine_args.block_size,
+            # Omni workers serve the full multi-stage pipeline behind one
+            # endpoint; there is no prefill/decode split visible to the
+            # frontend, so they register as Aggregated.
+            worker_type=WorkerType.Aggregated,
+            needs=[],
+        )
+
+        logger.info("Starting to serve Omni worker endpoint...")
+
+        health_check_payload = (
+            await VllmOmniHealthCheckPayload.create(handler.engine_client)
+        ).to_dict()
+
         await generate_endpoint.serve_endpoint(
             handler.generate,
             graceful_shutdown=True,
@@ -124,7 +108,7 @@ async def init_omni(
             health_check_payload=health_check_payload,
         )
     except Exception as e:
-        logger.error("Failed to serve Omni endpoint: %s", e)
+        logger.error("Omni worker failed: %s", e)
         raise
     finally:
         logger.debug("Cleaning up Omni worker")

--- a/components/src/dynamo/vllm/omni/utils.py
+++ b/components/src/dynamo/vllm/omni/utils.py
@@ -3,12 +3,9 @@
 
 """Shared utilities for the vLLM-Omni backend."""
 
-import json
 import logging
-from pathlib import Path
 from typing import Any, cast
 
-from huggingface_hub import scan_cache_dir
 from vllm.sampling_params import SamplingParams
 from vllm_omni.distributed.omni_connectors.utils.serialization import OmniSerializer
 from vllm_omni.entrypoints.stage_utils import shm_read_bytes
@@ -252,55 +249,3 @@ def _build_sampling_params(stage_config: Any, overrides: dict | None) -> list | 
             if hasattr(llm_params, arg):
                 setattr(llm_params, arg, value)
     return [llm_params]
-
-
-def ensure_dummy_tokenizer_for_tts(model: str) -> list[Path]:
-    """Create a minimal tokenizer.json for TTS models that lack one.
-
-    Audio/TTS models (e.g., Qwen3-TTS) use a custom speech tokenizer and don't
-    ship the standard tokenizer.json expected by the Rust ModelDeploymentCard
-    loader. This writes a placeholder so register_model doesn't fail.
-
-    Returns the list of created dummy paths so the caller can delete them
-    after registration (otherwise the fake tokenizer poisons vLLM-Omni's
-    inference-time AutoTokenizer.from_pretrained call).
-
-    This is a short-term workaround. The long-term fix is making TokenizerKind
-    optional in ModelDeploymentCard::from_repo_checkout().
-    """
-    created: list[Path] = []
-    cache_info = scan_cache_dir()
-    for repo in cache_info.repos:
-        if repo.repo_id == model:
-            for revision in repo.revisions:
-                tokenizer_path = Path(revision.snapshot_path) / "tokenizer.json"
-                if not tokenizer_path.exists():
-                    logging.warning(
-                        "TTS model %s has no tokenizer.json; "
-                        "creating a minimal placeholder at %s",
-                        model,
-                        tokenizer_path,
-                    )
-                    minimal_tokenizer = {
-                        "version": "1.0",
-                        "model": {"type": "BPE", "vocab": {}, "merges": []},
-                    }
-                    tokenizer_path.write_text(json.dumps(minimal_tokenizer))
-                    created.append(tokenizer_path)
-            return created
-    return created
-
-
-def cleanup_dummy_tokenizer_for_tts(paths: list[Path]):
-    """Remove dummy tokenizer.json files created by ensure_dummy_tokenizer_for_tts.
-
-    Must be called after register_model() completes so the fake tokenizer
-    doesn't interfere with vLLM-Omni's inference-time tokenizer loading
-    (AutoTokenizer.from_pretrained picks up our stub and crashes).
-    """
-    for path in paths:
-        try:
-            path.unlink(missing_ok=True)
-            logging.info("Removed dummy tokenizer placeholder: %s", path)
-        except OSError as e:
-            logging.warning("Failed to remove dummy tokenizer %s: %s", path, e)


### PR DESCRIPTION
#### Overview:

The dummy `tokenizer.json` placeholder for TTS models (Qwen3-TTS) is obsolete. The Rust ModelDeploymentCard loader already returns `Ok(None)` for models without `tokenizer.json` (`lib/llm/src/model_card.rs:1808-1860`), and the discovery watcher already supports `tokenizer = None` (`lib/llm/src/discovery/watcher.rs:732-747`, comment: "Models without tokenizer.json (e.g. Qwen3-Omni) set tokenizer = None"). The placeholder created a false-positive tokenizer path in the MDC, then `cleanup_*` deleted the file before the frontend watcher's async `handle_put` read it — that's the race in [DYN-3064](https://linear.app/nvidia/issue/DYN-3064). Remove the workaround entirely: no placeholder created, no race, no deferred cleanup, no poisoning of `AudioGenerationHandler._estimate_tts_prompt_len`'s `AutoTokenizer.from_pretrained` cache.

#### Details:

- `components/src/dynamo/vllm/omni/main.py`: dropped both helpers from the import block, removed the `if "audio" in config.output_modalities: ensure_dummy_tokenizer_for_tts(...)` block before `register_model`, removed the `cleanup_dummy_tokenizer_for_tts(...)` call from the `finally`.
- `components/src/dynamo/vllm/omni/utils.py`: deleted `ensure_dummy_tokenizer_for_tts` and `cleanup_dummy_tokenizer_for_tts`; dropped now-unused `json`, `Path`, and `scan_cache_dir` imports.
- Tests: none reference the removed helpers; the existing `omni_audio` scenario is independently `pytest.mark.skip`'d for an unrelated vllm-omni version mismatch.

Net change: 2 files, +19/-88.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/omni/main.py` `init_omni` — confirm the simpler shape.
- `lib/llm/src/discovery/watcher.rs:732-747` for the existing `tokenizer = None` contract this fix relies on.

#### Local verification (RTX PRO 6000 Blackwell, dynamo venv)

Fresh test: deleted the cached `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` from `~/.cache/huggingface/hub/` so the model downloaded from scratch. `HF_HUB_OFFLINE` unset (the racy code path from DYN-3064).

| Check | Result |
|---|---|
| `tokenizer.json` ever created | No — never appeared on disk |
| Rust card loader | `model_card: No supported tokenizer found ... Features that depend on the Rust tokenizer will not be available.` (the existing `Ok(None)` path) |
| `register_model` | `Registered base model 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice' MDC` |
| Discovery watcher | `discovery::watcher: added model` (no `Error adding model from discovery`) |
| `/v1/models` | populated immediately |
| `POST /v1/audio/speech` | HTTP 200, valid 7724-byte 16-bit/24kHz mono WAV in 4.3s |
| `AutoTokenizer.from_pretrained` poisoning (dynamo-ops concern from previous revision) | Gone — falls back to slow tokenizer via `vocab.json` + `merges.txt` + `tokenizer_config.json` |

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes Linear [DYN-3064](https://linear.app/nvidia/issue/DYN-3064)