### PR TITLE
test(parity): document glm47 stream.4 EOF-truncation divergences

### DIFF
--- a/tests/parity/parser/fixtures/glm47/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.stream.4.yaml
@@ -28,11 +28,36 @@ cases:
         - name: get_weather
           arguments: '{"location": "NYC"'
         normal_text: ''
+        reason: >-
+          Impl-defined recovery for PARSER.batch.5-class missing end-token
+          (per `tests/parity/README.md` "permanent divergences"). SGLang's
+          XML-to-JSON state machine
+          (`glm47_moe_detector.py:377-407`) closes the incremental JSON
+          string with `"` when `</arg_value>` is matched but emits the
+          closing `}` only from `_finalize_tool_call` on `</tool_call>`
+          (line 729); on EOF neither flush path runs so the streamed
+          args buffer is shipped as `{"location": "NYC"` (open object).
+          Dynamo drops the truncated call instead of emitting a
+          malformed-JSON args payload (`glm47_parser.rs:194-215`,
+          `allow_eof_recovery=false` production default).
       vllm:
         calls:
         - name: get_weather
           arguments: '{"location": "NYC"'
         normal_text: ''
+        reason: >-
+          Impl-defined recovery for PARSER.batch.5-class missing end-token
+          (per `tests/parity/README.md` "permanent divergences"). vLLM's
+          `_build_args_json_so_far` (`glm4_moe_tool_parser.py:331-417`)
+          builds the args JSON from completed `<arg_key>/<arg_value>`
+          pairs and only appends the closing `}` when `is_complete=True`,
+          which `_extract_tool_call_regions` (line 293) sets after
+          observing `</tool_call>`. On EOF mid-`<tool_call>`,
+          `is_complete=False`, so the streaming diff ships
+          `{"location": "NYC"` with no closing brace. Dynamo drops the
+          truncated call (`glm47_parser.rs:194-215`,
+          `allow_eof_recovery=false` production default). Matches
+          SGLang.
   PARSER.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from PARSER.batch.5.c
@@ -57,8 +82,31 @@ cases:
         - name: get_weather
           arguments: '{"location": "N'
         normal_text: ''
+        reason: >-
+          Impl-defined recovery for PARSER.batch.5-class missing end-token
+          (per `tests/parity/README.md` "permanent divergences"). The
+          stream ends mid-`<arg_value>` with `N` and never delivers
+          `</arg_value>` or `</tool_call>`; SGLang's state machine
+          (`glm47_moe_detector.py:419-428`) has already opened the JSON
+          string and emitted `N` incrementally, but neither the closing
+          `"` (gated on `</arg_value>`, line 396) nor `}` (gated on
+          `</tool_call>`, line 729) is ever flushed. Dynamo drops the
+          truncated call (`glm47_parser.rs:194-215`,
+          `allow_eof_recovery=false` production default).
       vllm:
         calls:
         - name: get_weather
           arguments: '{"location": "N'
         normal_text: ''
+        reason: >-
+          Impl-defined recovery for PARSER.batch.5-class missing end-token
+          (per `tests/parity/README.md` "permanent divergences"). vLLM's
+          `_build_args_json_so_far` (`glm4_moe_tool_parser.py:331-417`)
+          detects a partial `<arg_value>` (`has_partial_value=True`,
+          line 365) and takes the string-type partial branch at line 403
+          (`parts.append(f'{key_json}: "{escaped}')`), opening a JSON
+          quote without closing it; the wrapping `{`/`}` follow the same
+          `is_complete=False` path (the `</tool_call>` end was never
+          observed), so the streamed args end at `{"location": "N` with
+          no closing `"` or `}`. Dynamo drops the truncated call
+          (`glm47_parser.rs:194-215`). Matches SGLang.


### PR DESCRIPTION
#### Overview:
glm47 has two research cells left in the stream parity matrix. Both are the same thing: stream cuts off inside a `<tool_call>` before the closing fence arrives. vLLM and SGLang emit the partial call with malformed JSON args; Dynamo drops it. PARSER.batch.5 already covers this shape, and the parity README flags it as permanent impl-defined recovery. minimax_m2 and qwen3_coder already carry the same `reason:` annotation on their stream.4 fixtures. Adds the equivalent for glm47.

#### Details:
Only `tests/parity/parser/fixtures/glm47/PARSER.stream.4.yaml` changes: four `reason:` strings, one per impl per case, under `expected.vllm` and `expected.sglang`. No parser code, no behavior change.

#### Before / After:
Dashboard goes from `V?S?` (research) to `VS` (documented) on both cells. Nothing else moves.

#### Cross-impl:
What each impl emits today (unchanged by this PR):

```
PARSER.stream.4.a: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value> <EOF>
  Dynamo:  calls=[],                                  normal_text=''
  vLLM:    calls=[get_weather('{"location": "NYC"')], normal_text=''
  SGLang:  calls=[get_weather('{"location": "NYC"')], normal_text=''

PARSER.stream.4.b: <tool_call>get_weather<arg_key>...<arg_value>N <EOF>
  Dynamo:  calls=[],                                  normal_text=''
  vLLM:    calls=[get_weather('{"location": "N')],    normal_text=''
  SGLang:  calls=[get_weather('{"location": "N')],    normal_text=''
```