### PR TITLE
build: pypi rejects direct URL deps in published wheel metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@2103aa286a822d112ea83781ad14e3e022b603d9",
+    # No direct URL: it blocks the wheel release (PyPI/Warehouse rejects direct references).
+    "aiconfigurator>=0.8.0",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
#### Overview:

pypi rejects direct URL deps in published wheel metadata. Fixing the git reference for aiconfigurator in pyproject.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `mocker` dependency to use PyPI package reference, enabling improved distribution and installation compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->