### PR TITLE
test(parser): document gemma4 stream parity divergences

### DIFF
--- a/tests/parity/parser/fixtures/gemma4/PARSER.stream.1.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.stream.1.yaml
@@ -30,6 +30,7 @@ cases:
       vllm:
         calls: []
         normal_text: ''
+        reason: vLLM's Gemma4 streaming parser misses a complete one-chunk tool call when start and end markers arrive in the same delta; Dynamo and SGLang parse the complete call.
   PARSER.stream.1.b:
     description: Complete tool call split across parser-significant boundaries
     ref: derived from PARSER.batch.1

--- a/tests/parity/parser/fixtures/gemma4/PARSER.stream.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.stream.4.yaml
@@ -29,11 +29,13 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+        reason: SGLang recovers a call before the required `<tool_call|>` end marker; Dynamo follows Gemma4 batch.5 and drops incomplete envelopes without leaking markup.
       vllm:
         calls:
         - name: get_weather
           arguments: '{"location": "NYC'
         normal_text: ''
+        reason: vLLM emits partial arguments before the required `<tool_call|>` end marker; Dynamo follows Gemma4 batch.5 and drops incomplete envelopes without leaking markup.
   PARSER.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from PARSER.batch.5.c
@@ -58,8 +60,10 @@ cases:
         - name: get_weather
           arguments: {}
         normal_text: ''
+        reason: SGLang emits the function name from a mid-body truncated call; Dynamo follows Gemma4 batch.5 and drops incomplete envelopes without leaking markup.
       vllm:
         calls:
         - name: get_weather
           arguments: '{"location": "N'
         normal_text: ''
+        reason: vLLM emits partial arguments from a mid-body truncated call; Dynamo follows Gemma4 batch.5 and drops incomplete envelopes without leaking markup.


### PR DESCRIPTION
#### Overview:

This PR classifies the remaining Gemma4 `PARSER.stream.*` parity divergences. 

There is no Dynamo code change; Dynamo already keeps Gemma4 tool-call protocol markup out of `normal_text` and only emits structured calls when the stream contains a complete Gemma4 envelope. According to the alignment rubric, these are documented peer divergences rather than Dynamo fix targets. For complete envelopes, we prefer the non-leaking implementation that extracts the structured call. For truncated or incomplete envelopes, we preserve the no-leak rule and align with the existing Gemma4 batch truncation behavior in `PARSER.batch.5.*`.

#### Details:

`PARSER.stream.1.a` covers a complete one-chunk Gemma4 call:

```text
<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
```

Dynamo and SGLang parse this as `get_weather({"location": "NYC"})`, while vLLM returns no tool call. We diverge from vLLM because the envelope is complete and Dynamo surfaces the structured tool call without leaking protocol markup.

`PARSER.stream.4.a` and `PARSER.stream.4.b` both cover truncated Gemma4 envelopes. In `.4.a`, the argument body is complete but the required `<tool_call|>` end marker is missing. In `.4.b`, the stream terminates mid-argument body. Dynamo returns `calls=[]` and `normal_text=''` for both, matching the existing Gemma4 batch truncation contract from `PARSER.batch.5.a` and `PARSER.batch.5.c`.

The peer parsers recover differently on these incomplete streams: SGLang emits either a recovered call or a function name with `{}` arguments, while vLLM emits partial/raw argument strings such as `{"location": "NYC` and `{"location": "N`. We diverge from both because the Gemma4 envelope is incomplete, and Dynamo avoids surfacing partial or fabricated tool calls while keeping protocol markup out of user-visible text.

#### Where should the reviewer start?

- `tests/parity/parser/fixtures/gemma4/PARSER.stream.*.yaml` 

#### Related Issues:

- PR #9583 for the parser parity alignment rubric.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced parser parity test fixtures with detailed annotations explaining how different backends handle streaming edge cases, including incomplete tool calls and boundary conditions in parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->