### PR TITLE
fix(kv-router): reduce block hash cloning

### DIFF
--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -548,6 +548,7 @@ impl RouterHandles {
                 None,
                 config_override.as_ref(),
                 false,
+                false,
                 None,
                 priority_jump,
                 None,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1129,6 +1129,7 @@ impl KvRouter {
                     block_mm_infos.as_deref(),
                     router_config_override.as_ref(),
                     update_states,
+                    false,
                     lora_name.clone(),
                     0.0,
                     None,

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -846,6 +846,27 @@ mod interface_tests {
     }
 
     #[tokio::test]
+    async fn test_concurrent_compressed_approx_rejects_mismatched_hash_lengths() {
+        let index = ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTreeCompressed::new(),
+            4,
+            4,
+            PruneConfig {
+                ttl: Duration::from_secs(60),
+            },
+        );
+        let worker = WorkerWithDpRank::new(7, 0);
+        let local_hashes = [LocalBlockHash(1), LocalBlockHash(2)];
+        let sequence_hashes = [1];
+
+        let result = index
+            .process_routing_decision_hash_slices(worker, &local_hashes, &sequence_hashes)
+            .await;
+
+        assert!(matches!(result, Err(KvRouterError::IndexerDroppedRequest)));
+    }
+
+    #[tokio::test]
     #[apply(approx_indexer_template)]
     async fn test_approx_ttl_expiry_removes_match(variant: &str) {
         let ttl = Duration::from_millis(25);

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -483,6 +483,16 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         self.record_routing_decision_hashes(worker, &local_hashes, &sequence_hashes)
             .await
     }
+
+    pub async fn process_routing_decision_hash_slices(
+        &self,
+        worker: WorkerWithDpRank,
+        local_hashes: &[LocalBlockHash],
+        sequence_hashes: &[SequenceHash],
+    ) -> Result<(), KvRouterError> {
+        self.record_routing_decision_hashes(worker, local_hashes, sequence_hashes)
+            .await
+    }
 }
 
 impl<T: SyncIndexer> Drop for ThreadPoolIndexer<T> {

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -441,6 +441,15 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         local_hashes: &[LocalBlockHash],
         sequence_hashes: &[SequenceHash],
     ) -> Result<(), KvRouterError> {
+        if local_hashes.len() != sequence_hashes.len() {
+            tracing::warn!(
+                local_len = local_hashes.len(),
+                sequence_len = sequence_hashes.len(),
+                "Mismatched routing-decision hash lengths"
+            );
+            return Err(KvRouterError::IndexerDroppedRequest);
+        }
+
         let Some(prune_manager) = &self.prune_manager else {
             // Approximate routing decisions are only recorded when explicitly enabled.
             return Ok(());

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -283,6 +283,23 @@ pub struct IndexerRecordRoutingDecisionRequest {
     pub sequence_hashes: Vec<SequenceHash>,
 }
 
+/// Precomputed hashes for recording a route-time indexer update.
+#[derive(Debug, Clone)]
+pub struct RoutingDecisionHashes {
+    pub local_hashes: Vec<LocalBlockHash>,
+    pub sequence_hashes: Vec<SequenceHash>,
+}
+
+impl RoutingDecisionHashes {
+    pub fn from_local_hashes(local_hashes: Vec<LocalBlockHash>) -> Self {
+        let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
+        Self {
+            local_hashes,
+            sequence_hashes,
+        }
+    }
+}
+
 /// Response from a served approximate-mode routing-decision endpoint.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum IndexerRecordRoutingDecisionResponse {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -18,7 +18,7 @@ use dynamo_kv_router::{
         RouterBackpressureReason, RouterEvent, RouterRequest, RouterResponse, RoutingConstraints,
         TokensWithHashes, WorkerConfigLike, WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
     },
-    scheduling::{OverloadedWorkerProvider, TierOverlapBlocks},
+    scheduling::OverloadedWorkerProvider,
 };
 use dynamo_runtime::{
     component::{Client, Endpoint},
@@ -33,7 +33,6 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 use futures::stream;
-use serde::Serialize;
 use tracing::Instrument;
 use validator::Validate;
 
@@ -49,7 +48,9 @@ pub mod metrics;
 pub mod prefill_router;
 pub mod publisher;
 pub mod push_router;
+mod route_lookup;
 pub mod scheduler;
+mod scheduler_inputs;
 pub mod sequence;
 pub mod shared_cache;
 pub mod sticky_sessions;
@@ -58,15 +59,20 @@ pub use agent_controller::AgentController;
 pub use indexer::{Indexer, ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub use prefill_router::PrefillRouter;
 pub use push_router::{DirectRoutingRouter, KvPushRouter};
+pub use scheduler_inputs::{OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore};
 pub use sticky_sessions::StickySessionRouter;
+
+use route_lookup::{TieredLookupResult, query_tiered_matches, split_retained_block_hashes};
+use scheduler_inputs::{
+    CacheHitEstimates, KvRouterOverlapRefresher, WorkerCacheHitEstimate,
+    cache_hit_estimates_from_tiered_matches, cache_hit_for_worker, shared_cache_overlap_score,
+    tier_overlap_blocks_from_tiered_matches,
+};
 
 use crate::{
     discovery::RuntimeConfigWatch,
     kv_router::{
-        scheduler::{
-            DefaultWorkerSelector, KvScheduler, OverlapScoresRefresh, PotentialLoad,
-            RefreshedOverlap,
-        },
+        scheduler::{DefaultWorkerSelector, KvScheduler, PotentialLoad},
         sequence::{SequenceError, SequenceRequest},
     },
     local_model::runtime_config::ModelRuntimeConfig,
@@ -85,24 +91,6 @@ pub enum FindBestMatchOutcome {
         queued_isl_tokens: usize,
         max_queued_isl_tokens: Option<usize>,
     },
-}
-
-fn split_retained_block_hashes(
-    block_hashes: Vec<LocalBlockHash>,
-    supports_overlap_refresh: bool,
-    return_routing_hashes: bool,
-) -> (Option<Vec<LocalBlockHash>>, Option<Vec<LocalBlockHash>>) {
-    debug_assert!(supports_overlap_refresh || return_routing_hashes);
-
-    if supports_overlap_refresh && return_routing_hashes {
-        return (Some(block_hashes.clone()), Some(block_hashes));
-    }
-    if supports_overlap_refresh {
-        return (Some(block_hashes), None);
-    }
-
-    debug_assert!(return_routing_hashes);
-    (None, Some(block_hashes))
 }
 
 // [gluo TODO] shouldn't need to be public
@@ -124,256 +112,6 @@ pub const RADIX_STATE_FILE: &str = "radix-state";
 
 // for worker-local kvindexer query
 pub const WORKER_KV_INDEXER_BUFFER_SIZE: usize = 1024; // store 1024 most recent events in worker buffer
-
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct WorkerCacheHitEstimate {
-    pub effective_overlap_blocks: f64,
-    pub cached_tokens: usize,
-}
-
-impl WorkerCacheHitEstimate {
-    pub fn rounded_overlap_blocks(self) -> u32 {
-        self.effective_overlap_blocks.round() as u32
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-struct CacheHitEstimates {
-    effective_overlap_blocks: HashMap<WorkerWithDpRank, f64>,
-    cached_tokens: HashMap<WorkerWithDpRank, usize>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct WorkerOverlapScore {
-    pub worker_id: WorkerId,
-    pub dp_rank: DpRank,
-    pub device_blocks: usize,
-    pub host_pinned_blocks: usize,
-    pub disk_blocks: usize,
-    pub host_pinned_extension_blocks: usize,
-    pub disk_extension_blocks: usize,
-    pub shared_beyond_device_blocks: Option<u32>,
-    pub router_credit_blocks: f64,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct SharedCacheOverlapScore {
-    pub enabled: bool,
-    pub total_hit_blocks: u32,
-    pub ranges: Vec<(u32, u32)>,
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct OverlapScoresResponse {
-    pub block_size: u32,
-    pub num_blocks: usize,
-    pub workers: Vec<WorkerOverlapScore>,
-    pub shared_cache: SharedCacheOverlapScore,
-}
-
-fn cache_hit_weight_for_tier(
-    kv_router_config: &KvRouterConfig,
-    storage_tier: dynamo_kv_router::protocols::StorageTier,
-) -> f64 {
-    match storage_tier {
-        dynamo_kv_router::protocols::StorageTier::Device => 1.0,
-        dynamo_kv_router::protocols::StorageTier::HostPinned => {
-            kv_router_config.host_cache_hit_weight
-        }
-        dynamo_kv_router::protocols::StorageTier::Disk
-        | dynamo_kv_router::protocols::StorageTier::External => {
-            kv_router_config.disk_cache_hit_weight
-        }
-    }
-}
-
-fn cached_tokens_from_effective_overlap(block_size: u32, effective_overlap_blocks: f64) -> usize {
-    (effective_overlap_blocks * block_size as f64)
-        .round()
-        .max(0.0) as usize
-}
-
-fn cache_hit_estimates_from_tiered_matches(
-    kv_router_config: &KvRouterConfig,
-    block_size: u32,
-    tiered_matches: &indexer::TieredMatchDetails,
-) -> CacheHitEstimates {
-    let mut effective_overlap_blocks = HashMap::new();
-
-    for (worker, overlap) in &tiered_matches.device.overlap_scores.scores {
-        effective_overlap_blocks.insert(*worker, *overlap as f64);
-    }
-
-    for (storage_tier, tier_matches) in &tiered_matches.lower_tier {
-        let weight = cache_hit_weight_for_tier(kv_router_config, *storage_tier);
-        if weight == 0.0 {
-            continue;
-        }
-
-        for (worker, hits) in &tier_matches.hits {
-            if *hits == 0 {
-                continue;
-            }
-            *effective_overlap_blocks.entry(*worker).or_insert(0.0) += *hits as f64 * weight;
-        }
-    }
-
-    let cached_tokens = effective_overlap_blocks
-        .iter()
-        .map(|(worker, overlap)| {
-            (
-                *worker,
-                cached_tokens_from_effective_overlap(block_size, *overlap),
-            )
-        })
-        .collect();
-
-    CacheHitEstimates {
-        effective_overlap_blocks,
-        cached_tokens,
-    }
-}
-
-fn cache_hit_for_worker(
-    cache_hit_estimates: &CacheHitEstimates,
-    worker: WorkerWithDpRank,
-) -> WorkerCacheHitEstimate {
-    WorkerCacheHitEstimate {
-        effective_overlap_blocks: cache_hit_estimates
-            .effective_overlap_blocks
-            .get(&worker)
-            .copied()
-            .unwrap_or(0.0),
-        cached_tokens: cache_hit_estimates
-            .cached_tokens
-            .get(&worker)
-            .copied()
-            .unwrap_or(0),
-    }
-}
-
-fn tier_overlap_blocks_from_tiered_matches(
-    tiered_matches: &indexer::TieredMatchDetails,
-) -> TierOverlapBlocks {
-    let mut tier_overlap_blocks = TierOverlapBlocks::default();
-
-    tier_overlap_blocks.device.extend(
-        tiered_matches
-            .device
-            .overlap_scores
-            .scores
-            .iter()
-            .map(|(worker, hits)| (*worker, *hits as usize)),
-    );
-
-    if let Some(host_matches) = tiered_matches
-        .lower_tier
-        .get(&dynamo_kv_router::protocols::StorageTier::HostPinned)
-    {
-        tier_overlap_blocks.host_pinned.extend(
-            host_matches
-                .hits
-                .iter()
-                .map(|(worker, hits)| (*worker, *hits)),
-        );
-    }
-
-    // Disk and External share the same weighting (see `storage_tier_weight`),
-    // so accumulate both into the disk bucket.
-    for tier in [
-        dynamo_kv_router::protocols::StorageTier::Disk,
-        dynamo_kv_router::protocols::StorageTier::External,
-    ] {
-        if let Some(matches) = tiered_matches.lower_tier.get(&tier) {
-            for (worker, hits) in &matches.hits {
-                *tier_overlap_blocks.disk.entry(*worker).or_default() += *hits;
-            }
-        }
-    }
-
-    tier_overlap_blocks
-}
-
-fn shared_cache_overlap_score(
-    enabled: bool,
-    hits: Option<&dynamo_kv_router::protocols::SharedCacheHits>,
-    error: Option<String>,
-) -> SharedCacheOverlapScore {
-    let Some(hits) = hits else {
-        return SharedCacheOverlapScore {
-            enabled,
-            total_hit_blocks: 0,
-            ranges: Vec::new(),
-            error,
-        };
-    };
-
-    SharedCacheOverlapScore {
-        enabled,
-        total_hit_blocks: hits.total_hits,
-        ranges: hits
-            .ranges
-            .iter()
-            .map(|range| (range.start, range.end))
-            .collect(),
-        error,
-    }
-}
-
-/// Re-queries the indexer to refresh stale overlap scores for requests that have been
-/// waiting in the scheduler queue. Wired into the scheduler's
-/// [`OverlapScoresRefresh`](dynamo_kv_router::scheduling::OverlapScoresRefresh) slot at
-/// router startup.
-///
-/// `Remote` and `None` indexer variants intentionally don't get a refresher: remote
-/// indexer queries are too expensive to repeat per request, and `None` has nothing to query.
-struct KvRouterOverlapRefresher {
-    indexer: Indexer,
-    kv_router_config: KvRouterConfig,
-    block_size: u32,
-}
-
-impl KvRouterOverlapRefresher {
-    fn for_indexer(
-        indexer: Indexer,
-        kv_router_config: KvRouterConfig,
-        block_size: u32,
-    ) -> Option<Self> {
-        match &indexer {
-            Indexer::KvIndexer { .. } | Indexer::Concurrent { .. } => Some(Self {
-                indexer,
-                kv_router_config,
-                block_size,
-            }),
-            Indexer::Remote { .. } | Indexer::None => None,
-        }
-    }
-}
-
-#[async_trait]
-impl OverlapScoresRefresh for KvRouterOverlapRefresher {
-    async fn refresh(&self, block_hashes: &[LocalBlockHash]) -> Option<RefreshedOverlap> {
-        let tiered = match self.indexer.find_matches_by_tier_ref(block_hashes).await {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::warn!(error = ?e, "overlap refresh: find_matches_by_tier failed");
-                return None;
-            }
-        };
-        let tier_overlap_blocks = tier_overlap_blocks_from_tiered_matches(&tiered);
-        let estimates = cache_hit_estimates_from_tiered_matches(
-            &self.kv_router_config,
-            self.block_size,
-            &tiered,
-        );
-        Some(RefreshedOverlap {
-            tier_overlap_blocks,
-            effective_overlap_blocks: estimates.effective_overlap_blocks,
-            effective_cached_tokens: estimates.cached_tokens,
-        })
-    }
-}
 
 fn map_scheduler_error(error: scheduling::KvSchedulerError) -> anyhow::Error {
     if !error.is_overload() {
@@ -694,104 +432,21 @@ where
         let supports_overlap_refresh = self.scheduler.supports_overlap_refresh();
         let retain_block_hashes = supports_overlap_refresh || return_routing_hashes;
 
-        let (
+        let TieredLookupResult {
             tiered_matches,
             shared_cache_hits,
             indexer_duration,
             shared_cache_duration,
             retained_block_hashes,
-        ) = if retain_block_hashes {
-            // Query indexer (tiered) and shared cache in parallel when shared cache is configured.
-            // Time each independently so metrics can separate indexer vs shared cache latency.
-            let (tiered, shared_hits, idx_dur, sc_dur) =
-                if let Some(ref shared_cache) = self.shared_cache {
-                    let indexer_fut = self
-                        .indexer
-                        .find_matches_by_tier_ref(&block_hashes)
-                        .instrument(tracing::info_span!("kv_router.find_matches"));
-                    let shared_fut = shared_cache
-                        .check_blocks(tokens, self.block_size)
-                        .instrument(tracing::info_span!("kv_router.shared_cache_check"));
-
-                    let indexer_timed = async {
-                        let t = Instant::now();
-                        let r = indexer_fut.await;
-                        (r, t.elapsed())
-                    };
-                    let shared_timed = async {
-                        let t = Instant::now();
-                        let r = shared_fut.await;
-                        (r, t.elapsed())
-                    };
-
-                    let ((indexer_result, idx_dur), (shared_result, sc_dur)) =
-                        tokio::join!(indexer_timed, shared_timed);
-                    let tiered = indexer_result?;
-                    // Shared cache failure is non-fatal: log warning and fall back to empty hits.
-                    let hits = match shared_result {
-                        Ok(hits) => Some(hits),
-                        Err(e) => {
-                            tracing::warn!(error = %e, "Shared cache query failed, ignoring");
-                            if let Some(m) = metrics::RoutingOverheadMetrics::get() {
-                                m.inc_shared_cache_errors();
-                            }
-                            None
-                        }
-                    };
-                    (tiered, hits, idx_dur, Some(sc_dur))
-                } else {
-                    let t = Instant::now();
-                    let tiered = self
-                        .indexer
-                        .find_matches_by_tier_ref(&block_hashes)
-                        .instrument(tracing::info_span!("kv_router.find_matches"))
-                        .await?;
-                    (tiered, None, t.elapsed(), None)
-                };
-            (tiered, shared_hits, idx_dur, sc_dur, Some(block_hashes))
-        } else if let Some(ref shared_cache) = self.shared_cache {
-            let indexer_fut = self
-                .indexer
-                .find_matches_by_tier(block_hashes)
-                .instrument(tracing::info_span!("kv_router.find_matches"));
-            let shared_fut = shared_cache
-                .check_blocks(tokens, self.block_size)
-                .instrument(tracing::info_span!("kv_router.shared_cache_check"));
-
-            let indexer_timed = async {
-                let t = Instant::now();
-                let r = indexer_fut.await;
-                (r, t.elapsed())
-            };
-            let shared_timed = async {
-                let t = Instant::now();
-                let r = shared_fut.await;
-                (r, t.elapsed())
-            };
-
-            let ((indexer_result, idx_dur), (shared_result, sc_dur)) =
-                tokio::join!(indexer_timed, shared_timed);
-            let tiered = indexer_result?;
-            let hits = match shared_result {
-                Ok(hits) => Some(hits),
-                Err(e) => {
-                    tracing::warn!(error = %e, "Shared cache query failed, ignoring");
-                    if let Some(m) = metrics::RoutingOverheadMetrics::get() {
-                        m.inc_shared_cache_errors();
-                    }
-                    None
-                }
-            };
-            (tiered, hits, idx_dur, Some(sc_dur), None)
-        } else {
-            let t = Instant::now();
-            let tiered = self
-                .indexer
-                .find_matches_by_tier(block_hashes)
-                .instrument(tracing::info_span!("kv_router.find_matches"))
-                .await?;
-            (tiered, None, t.elapsed(), None, None)
-        };
+        } = query_tiered_matches(
+            &self.indexer,
+            self.shared_cache.as_deref(),
+            tokens,
+            self.block_size,
+            block_hashes,
+            retain_block_hashes,
+        )
+        .await?;
 
         let (block_hashes_for_refresh, routing_block_hashes) = retained_block_hashes
             .map(|block_hashes| {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use dynamo_kv_router::{
     KvSchedulerError, PrefillLoadEstimator, SharedKvCache,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
-    indexer::KvRouterError,
+    indexer::{KvRouterError, RoutingDecisionHashes},
     protocols::KV_EVENT_SUBJECT,
     protocols::{
         BlockExtraInfo, BlockHashOptions, DpRank, LocalBlockHash, PrefillLoadHint,
@@ -78,12 +78,31 @@ pub enum FindBestMatchOutcome {
         overlap_blocks: u32,
         effective_overlap_blocks: f64,
         cached_tokens: usize,
+        routing_hashes: Option<RoutingDecisionHashes>,
     },
     Backpressure {
         reason: RouterBackpressureReason,
         queued_isl_tokens: usize,
         max_queued_isl_tokens: Option<usize>,
     },
+}
+
+fn split_retained_block_hashes(
+    block_hashes: Vec<LocalBlockHash>,
+    supports_overlap_refresh: bool,
+    return_routing_hashes: bool,
+) -> (Option<Vec<LocalBlockHash>>, Option<Vec<LocalBlockHash>>) {
+    debug_assert!(supports_overlap_refresh || return_routing_hashes);
+
+    if supports_overlap_refresh && return_routing_hashes {
+        return (Some(block_hashes.clone()), Some(block_hashes));
+    }
+    if supports_overlap_refresh {
+        return (Some(block_hashes), None);
+    }
+
+    debug_assert!(return_routing_hashes);
+    (None, Some(block_hashes))
 }
 
 // [gluo TODO] shouldn't need to be public
@@ -335,11 +354,7 @@ impl KvRouterOverlapRefresher {
 #[async_trait]
 impl OverlapScoresRefresh for KvRouterOverlapRefresher {
     async fn refresh(&self, block_hashes: &[LocalBlockHash]) -> Option<RefreshedOverlap> {
-        let tiered = match self
-            .indexer
-            .find_matches_by_tier(block_hashes.to_vec())
-            .await
-        {
+        let tiered = match self.indexer.find_matches_by_tier_ref(block_hashes).await {
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!(error = ?e, "overlap refresh: find_matches_by_tier failed");
@@ -614,6 +629,16 @@ where
             .await
     }
 
+    pub(crate) async fn record_routing_decision_hashes(
+        &self,
+        hashes: RoutingDecisionHashes,
+        worker: WorkerWithDpRank,
+    ) -> Result<(), KvRouterError> {
+        self.indexer
+            .record_routing_decision_hashes(worker, hashes)
+            .await
+    }
+
     /// Give these tokens, find the worker with the best weighted cache hit.
     /// Returns the full match details for the selected worker.
     ///
@@ -629,6 +654,7 @@ where
         block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
         router_config_override: Option<&RouterConfigOverride>,
         update_states: bool,
+        return_routing_hashes: bool,
         lora_name: Option<String>,
         priority_jump: f64,
         expected_output_tokens: Option<u32>,
@@ -665,61 +691,117 @@ where
         });
         let seq_hash_elapsed = start.elapsed();
 
-        // Only retain a copy of the block hashes when this scheduler can actually use
-        // them for dequeue-time overlap refresh.
-        // TODO: Optimize this by adding a borrowed indexer lookup path to avoid cloning hashes for immediate admissions.
-        let block_hashes_for_refresh = self
-            .scheduler
-            .supports_overlap_refresh()
-            .then(|| block_hashes.clone());
+        let supports_overlap_refresh = self.scheduler.supports_overlap_refresh();
+        let retain_block_hashes = supports_overlap_refresh || return_routing_hashes;
 
-        // Query indexer (tiered) and shared cache in parallel when shared cache is configured.
-        // Time each independently so metrics can separate indexer vs shared cache latency.
-        let (tiered_matches, shared_cache_hits, indexer_duration, shared_cache_duration) =
-            if let Some(ref shared_cache) = self.shared_cache {
-                let indexer_fut = self
-                    .indexer
-                    .find_matches_by_tier(block_hashes)
-                    .instrument(tracing::info_span!("kv_router.find_matches"));
-                let shared_fut = shared_cache
-                    .check_blocks(tokens, self.block_size)
-                    .instrument(tracing::info_span!("kv_router.shared_cache_check"));
+        let (
+            tiered_matches,
+            shared_cache_hits,
+            indexer_duration,
+            shared_cache_duration,
+            retained_block_hashes,
+        ) = if retain_block_hashes {
+            // Query indexer (tiered) and shared cache in parallel when shared cache is configured.
+            // Time each independently so metrics can separate indexer vs shared cache latency.
+            let (tiered, shared_hits, idx_dur, sc_dur) =
+                if let Some(ref shared_cache) = self.shared_cache {
+                    let indexer_fut = self
+                        .indexer
+                        .find_matches_by_tier_ref(&block_hashes)
+                        .instrument(tracing::info_span!("kv_router.find_matches"));
+                    let shared_fut = shared_cache
+                        .check_blocks(tokens, self.block_size)
+                        .instrument(tracing::info_span!("kv_router.shared_cache_check"));
 
-                let indexer_timed = async {
-                    let t = Instant::now();
-                    let r = indexer_fut.await;
-                    (r, t.elapsed())
-                };
-                let shared_timed = async {
-                    let t = Instant::now();
-                    let r = shared_fut.await;
-                    (r, t.elapsed())
-                };
+                    let indexer_timed = async {
+                        let t = Instant::now();
+                        let r = indexer_fut.await;
+                        (r, t.elapsed())
+                    };
+                    let shared_timed = async {
+                        let t = Instant::now();
+                        let r = shared_fut.await;
+                        (r, t.elapsed())
+                    };
 
-                let ((indexer_result, idx_dur), (shared_result, sc_dur)) =
-                    tokio::join!(indexer_timed, shared_timed);
-                let tiered = indexer_result?;
-                // Shared cache failure is non-fatal: log warning and fall back to empty hits.
-                let hits = match shared_result {
-                    Ok(hits) => Some(hits),
-                    Err(e) => {
-                        tracing::warn!(error = %e, "Shared cache query failed, ignoring");
-                        if let Some(m) = metrics::RoutingOverheadMetrics::get() {
-                            m.inc_shared_cache_errors();
+                    let ((indexer_result, idx_dur), (shared_result, sc_dur)) =
+                        tokio::join!(indexer_timed, shared_timed);
+                    let tiered = indexer_result?;
+                    // Shared cache failure is non-fatal: log warning and fall back to empty hits.
+                    let hits = match shared_result {
+                        Ok(hits) => Some(hits),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "Shared cache query failed, ignoring");
+                            if let Some(m) = metrics::RoutingOverheadMetrics::get() {
+                                m.inc_shared_cache_errors();
+                            }
+                            None
                         }
-                        None
-                    }
+                    };
+                    (tiered, hits, idx_dur, Some(sc_dur))
+                } else {
+                    let t = Instant::now();
+                    let tiered = self
+                        .indexer
+                        .find_matches_by_tier_ref(&block_hashes)
+                        .instrument(tracing::info_span!("kv_router.find_matches"))
+                        .await?;
+                    (tiered, None, t.elapsed(), None)
                 };
-                (tiered, hits, idx_dur, Some(sc_dur))
-            } else {
+            (tiered, shared_hits, idx_dur, sc_dur, Some(block_hashes))
+        } else if let Some(ref shared_cache) = self.shared_cache {
+            let indexer_fut = self
+                .indexer
+                .find_matches_by_tier(block_hashes)
+                .instrument(tracing::info_span!("kv_router.find_matches"));
+            let shared_fut = shared_cache
+                .check_blocks(tokens, self.block_size)
+                .instrument(tracing::info_span!("kv_router.shared_cache_check"));
+
+            let indexer_timed = async {
                 let t = Instant::now();
-                let tiered = self
-                    .indexer
-                    .find_matches_by_tier(block_hashes)
-                    .instrument(tracing::info_span!("kv_router.find_matches"))
-                    .await?;
-                (tiered, None, t.elapsed(), None)
+                let r = indexer_fut.await;
+                (r, t.elapsed())
             };
+            let shared_timed = async {
+                let t = Instant::now();
+                let r = shared_fut.await;
+                (r, t.elapsed())
+            };
+
+            let ((indexer_result, idx_dur), (shared_result, sc_dur)) =
+                tokio::join!(indexer_timed, shared_timed);
+            let tiered = indexer_result?;
+            let hits = match shared_result {
+                Ok(hits) => Some(hits),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Shared cache query failed, ignoring");
+                    if let Some(m) = metrics::RoutingOverheadMetrics::get() {
+                        m.inc_shared_cache_errors();
+                    }
+                    None
+                }
+            };
+            (tiered, hits, idx_dur, Some(sc_dur), None)
+        } else {
+            let t = Instant::now();
+            let tiered = self
+                .indexer
+                .find_matches_by_tier(block_hashes)
+                .instrument(tracing::info_span!("kv_router.find_matches"))
+                .await?;
+            (tiered, None, t.elapsed(), None, None)
+        };
+
+        let (block_hashes_for_refresh, routing_block_hashes) = retained_block_hashes
+            .map(|block_hashes| {
+                split_retained_block_hashes(
+                    block_hashes,
+                    supports_overlap_refresh,
+                    return_routing_hashes,
+                )
+            })
+            .unwrap_or((None, None));
 
         let tier_overlap_blocks = tier_overlap_blocks_from_tiered_matches(&tiered_matches);
         let cache_hit_estimates = self.cache_hit_estimates_from_tiered_matches(&tiered_matches);
@@ -769,6 +851,7 @@ where
             Err(error) => return Err(map_scheduler_error(error)),
         };
         let total_elapsed = start.elapsed();
+        let routing_hashes = routing_block_hashes.map(RoutingDecisionHashes::from_local_hashes);
 
         if let Some(m) = metrics::RoutingOverheadMetrics::get() {
             m.observe(
@@ -809,6 +892,7 @@ where
             overlap_blocks: response.effective_overlap_blocks.round() as u32,
             effective_overlap_blocks: response.effective_overlap_blocks,
             cached_tokens: response.cached_tokens,
+            routing_hashes,
         })
     }
 
@@ -835,6 +919,7 @@ where
                 block_mm_infos,
                 router_config_override,
                 update_states,
+                false,
                 lora_name,
                 priority_jump,
                 expected_output_tokens,
@@ -1010,6 +1095,19 @@ where
         worker: WorkerWithDpRank,
         lora_name: Option<&str>,
     ) -> Result<WorkerCacheHitEstimate, KvRouterError> {
+        self.get_cache_hit_estimate_with_hashes(tokens, block_mm_infos, worker, lora_name, false)
+            .await
+            .map(|(estimate, _)| estimate)
+    }
+
+    pub(crate) async fn get_cache_hit_estimate_with_hashes(
+        &self,
+        tokens: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        worker: WorkerWithDpRank,
+        lora_name: Option<&str>,
+        return_routing_hashes: bool,
+    ) -> Result<(WorkerCacheHitEstimate, Option<RoutingDecisionHashes>), KvRouterError> {
         let block_hashes = compute_block_hash_for_seq(
             tokens,
             self.block_size,
@@ -1019,9 +1117,20 @@ where
                 is_eagle: Some(self.is_eagle),
             },
         );
-        let tiered_matches = self.indexer.find_matches_by_tier(block_hashes).await?;
+        let (tiered_matches, routing_hashes) = if return_routing_hashes {
+            let tiered_matches = self.indexer.find_matches_by_tier_ref(&block_hashes).await?;
+            (
+                tiered_matches,
+                Some(RoutingDecisionHashes::from_local_hashes(block_hashes)),
+            )
+        } else {
+            (self.indexer.find_matches_by_tier(block_hashes).await?, None)
+        };
         let cache_hit_estimates = self.cache_hit_estimates_from_tiered_matches(&tiered_matches);
-        Ok(self.cache_hit_for_worker(&cache_hit_estimates, worker))
+        Ok((
+            self.cache_hit_for_worker(&cache_hit_estimates, worker),
+            routing_hashes,
+        ))
     }
 
     /// Get potential prefill and decode loads for all workers
@@ -1226,6 +1335,7 @@ where
                         block_mm_infos.as_deref(),
                         None,
                         true,
+                        false,
                         None,
                         0.0,
                         None,
@@ -1294,7 +1404,7 @@ mod tests {
     use async_trait::async_trait;
     use dynamo_kv_router::{
         indexer::{LowerTierMatchDetails, MatchDetails},
-        protocols::{OverlapScores, StorageTier},
+        protocols::{OverlapScores, StorageTier, compute_seq_hash_for_block},
     };
     use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
     use tokio::sync::watch;
@@ -1561,6 +1671,93 @@ mod tests {
             err.to_string()
                 .contains("all eligible workers are overloaded")
         );
+    }
+
+    #[tokio::test]
+    async fn test_find_best_match_details_returns_routing_hashes_when_requested() {
+        let router = make_test_router(
+            InspectingSelector {
+                expected_hits: None,
+                selected_worker: WorkerWithDpRank::from_worker_id(0),
+            },
+            None,
+        )
+        .await;
+        let tokens = [11, 12, 21, 22];
+
+        let outcome = router
+            .find_best_match_details(
+                None,
+                &tokens,
+                None,
+                None,
+                false,
+                true,
+                None,
+                0.0,
+                None,
+                None,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+        let FindBestMatchOutcome::Routed {
+            routing_hashes: Some(hashes),
+            ..
+        } = outcome
+        else {
+            panic!("expected routed outcome with routing hashes");
+        };
+        let expected_local = compute_block_hash_for_seq(
+            &tokens,
+            2,
+            BlockHashOptions {
+                block_mm_infos: None,
+                lora_name: None,
+                is_eagle: Some(false),
+            },
+        );
+        let expected_sequence = compute_seq_hash_for_block(&expected_local);
+
+        assert_eq!(hashes.local_hashes, expected_local);
+        assert_eq!(hashes.sequence_hashes, expected_sequence);
+    }
+
+    #[tokio::test]
+    async fn test_find_best_match_details_omits_routing_hashes_when_not_requested() {
+        let router = make_test_router(
+            InspectingSelector {
+                expected_hits: None,
+                selected_worker: WorkerWithDpRank::from_worker_id(0),
+            },
+            None,
+        )
+        .await;
+
+        let outcome = router
+            .find_best_match_details(
+                None,
+                &[11, 12, 21, 22],
+                None,
+                None,
+                false,
+                false,
+                None,
+                0.0,
+                None,
+                None,
+                None,
+                RoutingConstraints::default(),
+            )
+            .await
+            .unwrap();
+
+        let FindBestMatchOutcome::Routed { routing_hashes, .. } = outcome else {
+            panic!("expected routed outcome");
+        };
+        assert!(routing_hashes.is_none());
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/indexer/lookup.rs
+++ b/lib/llm/src/kv_router/indexer/lookup.rs
@@ -12,6 +12,31 @@ use dynamo_kv_router::{
 
 use super::{Indexer, SideIndexer, TieredMatchDetails, remote::RemoteIndexer};
 
+pub(super) enum HashInput<'a> {
+    Borrowed(&'a [LocalBlockHash]),
+    Owned(Vec<LocalBlockHash>),
+}
+
+impl<'a> HashInput<'a> {
+    pub(super) fn as_slice(&self) -> &[LocalBlockHash] {
+        match self {
+            Self::Borrowed(sequence) => sequence,
+            Self::Owned(sequence) => sequence,
+        }
+    }
+
+    pub(super) fn clone_for_boundary(&self) -> Vec<LocalBlockHash> {
+        self.as_slice().to_vec()
+    }
+
+    pub(super) fn into_owned_at_boundary(self) -> Vec<LocalBlockHash> {
+        match self {
+            Self::Borrowed(sequence) => sequence.to_vec(),
+            Self::Owned(sequence) => sequence,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum PrimaryLookup<'a> {
     KvIndexer(&'a KvIndexer),
@@ -65,21 +90,14 @@ impl Indexer {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) async fn find_matches(
-        &self,
-        sequence: Vec<LocalBlockHash>,
-    ) -> Result<OverlapScores, KvRouterError> {
-        self.find_match_details(sequence)
-            .await
-            .map(|details| details.overlap_scores)
-    }
-
+    #[cfg(test)]
     pub(crate) async fn find_match_details(
         &self,
         sequence: Vec<LocalBlockHash>,
     ) -> Result<MatchDetails, KvRouterError> {
-        self.lookup_pipeline().find_match_details(sequence).await
+        self.lookup_pipeline()
+            .find_match_details(HashInput::Owned(sequence))
+            .await
     }
 
     pub(crate) async fn find_primary_match_details(
@@ -87,7 +105,7 @@ impl Indexer {
         sequence: Vec<LocalBlockHash>,
     ) -> Result<MatchDetails, KvRouterError> {
         self.lookup_pipeline()
-            .find_primary_match_details(sequence)
+            .find_primary_match_details(HashInput::Owned(sequence))
             .await
     }
 
@@ -95,7 +113,18 @@ impl Indexer {
         &self,
         sequence: Vec<LocalBlockHash>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
-        self.lookup_pipeline().find_matches_by_tier(sequence).await
+        self.lookup_pipeline()
+            .find_matches_by_tier(HashInput::Owned(sequence))
+            .await
+    }
+
+    pub(crate) async fn find_matches_by_tier_ref(
+        &self,
+        sequence: &[LocalBlockHash],
+    ) -> Result<TieredMatchDetails, KvRouterError> {
+        self.lookup_pipeline()
+            .find_matches_by_tier(HashInput::Borrowed(sequence))
+            .await
     }
 
     pub(crate) async fn find_primary_matches_by_tier(
@@ -103,30 +132,35 @@ impl Indexer {
         sequence: Vec<LocalBlockHash>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         self.lookup_pipeline()
-            .find_primary_matches_by_tier(sequence)
+            .find_primary_matches_by_tier(HashInput::Owned(sequence))
             .await
     }
 }
 
 impl<'a> LookupPipeline<'a> {
+    #[cfg(test)]
     async fn find_match_details(
         &self,
-        sequence: Vec<LocalBlockHash>,
+        sequence: HashInput<'_>,
     ) -> Result<MatchDetails, KvRouterError> {
-        let primary_details = self.find_primary_match_details(sequence.clone()).await?;
+        if self.side.is_none() {
+            return self.find_primary_match_details(sequence).await;
+        }
+
+        let primary_details = self.primary.find_match_details_retained(&sequence).await?;
         Ok(merge_side_or_warn(self.side, primary_details, sequence).await)
     }
 
     async fn find_primary_match_details(
         &self,
-        sequence: Vec<LocalBlockHash>,
+        sequence: HashInput<'_>,
     ) -> Result<MatchDetails, KvRouterError> {
         self.primary.find_match_details(sequence).await
     }
 
     async fn find_matches_by_tier(
         &self,
-        sequence: Vec<LocalBlockHash>,
+        sequence: HashInput<'_>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         match self.primary {
             PrimaryLookup::KvIndexer(_) | PrimaryLookup::Concurrent(_) => {
@@ -138,8 +172,8 @@ impl<'a> LookupPipeline<'a> {
                 // them as lower-tier anchors would over-credit host/disk cache
                 // hits and break the score/hash lockstep `query_lower_tiers`
                 // expects.
-                let primary_device = self.find_primary_match_details(sequence.clone()).await?;
-                let lt = query_lower_tiers(lower_tier, &sequence, &primary_device);
+                let primary_device = self.primary.find_match_details_retained(&sequence).await?;
+                let lt = query_lower_tiers(lower_tier, sequence.as_slice(), &primary_device);
                 let device = merge_side_or_warn(self.side, primary_device, sequence).await;
 
                 Ok(TieredMatchDetails {
@@ -148,14 +182,23 @@ impl<'a> LookupPipeline<'a> {
                 })
             }
             PrimaryLookup::Remote(primary) => {
+                let Some(side) = self.side else {
+                    return primary
+                        .find_matches_by_tier(sequence.into_owned_at_boundary(), false)
+                        .await
+                        .map_err(|e| {
+                            tracing::warn!(error = %e, "Remote indexer tiered query failed");
+                            KvRouterError::IndexerOffline
+                        });
+                };
                 let mut tiered = primary
-                    .find_matches_by_tier(sequence.clone(), false)
+                    .find_matches_by_tier(sequence.clone_for_boundary(), false)
                     .await
                     .map_err(|e| {
                         tracing::warn!(error = %e, "Remote indexer tiered query failed");
                         KvRouterError::IndexerOffline
                     })?;
-                tiered.device = merge_side_or_warn(self.side, tiered.device, sequence).await;
+                tiered.device = merge_side_or_warn(Some(side), tiered.device, sequence).await;
                 Ok(tiered)
             }
             PrimaryLookup::None => Ok(TieredMatchDetails::default()),
@@ -164,22 +207,22 @@ impl<'a> LookupPipeline<'a> {
 
     async fn find_primary_matches_by_tier(
         &self,
-        sequence: Vec<LocalBlockHash>,
+        sequence: HashInput<'_>,
     ) -> Result<TieredMatchDetails, KvRouterError> {
         match self.primary {
             PrimaryLookup::KvIndexer(_) | PrimaryLookup::Concurrent(_) => {
                 let Some(lower_tier) = self.lower_tier else {
                     return Ok(TieredMatchDetails::default());
                 };
-                let device = self.find_primary_match_details(sequence.clone()).await?;
-                let lt = query_lower_tiers(lower_tier, &sequence, &device);
+                let device = self.primary.find_match_details_retained(&sequence).await?;
+                let lt = query_lower_tiers(lower_tier, sequence.as_slice(), &device);
                 Ok(TieredMatchDetails {
                     device,
                     lower_tier: lt,
                 })
             }
             PrimaryLookup::Remote(primary) => primary
-                .find_matches_by_tier(sequence.clone(), false)
+                .find_matches_by_tier(sequence.into_owned_at_boundary(), false)
                 .await
                 .map_err(|e| {
                     tracing::warn!(error = %e, "Remote indexer tiered query failed");
@@ -193,16 +236,49 @@ impl<'a> LookupPipeline<'a> {
 impl<'a> PrimaryLookup<'a> {
     async fn find_match_details(
         &self,
-        sequence: Vec<LocalBlockHash>,
+        sequence: HashInput<'_>,
     ) -> Result<MatchDetails, KvRouterError> {
         let primary_details = match self {
-            Self::KvIndexer(primary) => primary.find_match_details(sequence.clone()).await?,
-            Self::Concurrent(primary) => {
-                primary.backend().find_match_details_impl(&sequence, false)
+            Self::KvIndexer(primary) => {
+                primary
+                    .find_match_details(sequence.into_owned_at_boundary())
+                    .await?
             }
+            Self::Concurrent(primary) => primary
+                .backend()
+                .find_match_details_impl(sequence.as_slice(), false),
             Self::Remote(primary) => {
                 let tiered = primary
-                    .find_matches_by_tier(sequence.clone(), true)
+                    .find_matches_by_tier(sequence.into_owned_at_boundary(), true)
+                    .await
+                    .map_err(|e| {
+                        tracing::warn!(error = %e, "Remote indexer query failed");
+                        KvRouterError::IndexerOffline
+                    })?;
+                tiered.device
+            }
+            Self::None => return Ok(MatchDetails::new()),
+        };
+
+        Ok(primary_details)
+    }
+
+    async fn find_match_details_retained(
+        &self,
+        sequence: &HashInput<'_>,
+    ) -> Result<MatchDetails, KvRouterError> {
+        let primary_details = match self {
+            Self::KvIndexer(primary) => {
+                primary
+                    .find_match_details(sequence.clone_for_boundary())
+                    .await?
+            }
+            Self::Concurrent(primary) => primary
+                .backend()
+                .find_match_details_impl(sequence.as_slice(), false),
+            Self::Remote(primary) => {
+                let tiered = primary
+                    .find_matches_by_tier(sequence.clone_for_boundary(), true)
                     .await
                     .map_err(|e| {
                         tracing::warn!(error = %e, "Remote indexer query failed");
@@ -262,12 +338,12 @@ fn merge_overlap_scores(mut primary: MatchDetails, side: OverlapScores) -> Match
 async fn merge_side_or_warn(
     side: Option<&SideIndexer>,
     primary: MatchDetails,
-    sequence: Vec<LocalBlockHash>,
+    sequence: HashInput<'_>,
 ) -> MatchDetails {
     let Some(side) = side else {
         return primary;
     };
-    match side.find_matches(sequence).await {
+    match side.find_matches_input(sequence).await {
         Ok(side_scores) => merge_overlap_scores(primary, side_scores),
         Err(error) => {
             tracing::warn!(

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -414,7 +414,7 @@ mod tests {
     use dynamo_kv_router::{
         ConcurrentRadixTreeCompressed, ThreadPoolIndexer,
         approx::PruneConfig,
-        indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics},
+        indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics, RoutingDecisionHashes},
         protocols::{
             BlockHashOptions, LocalBlockHash, StorageTier, TokensWithHashes, WorkerWithDpRank,
             compute_block_hash_for_seq, compute_seq_hash_for_block,
@@ -698,6 +698,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_records_precomputed_routing_hashes() {
+        let indexer = make_test_concurrent_approx_indexer();
+        assert!(indexer.records_routing_decisions());
+
+        let worker = WorkerWithDpRank::new(7, 0);
+        let local_hashes = vec![LocalBlockHash(91), LocalBlockHash(92)];
+        let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
+        indexer
+            .record_routing_decision_hashes(
+                worker,
+                RoutingDecisionHashes {
+                    local_hashes: local_hashes.clone(),
+                    sequence_hashes,
+                },
+            )
+            .await
+            .unwrap();
+        flush_indexer(&indexer).await;
+
+        let matches = indexer.find_matches_by_tier(local_hashes).await.unwrap();
+        assert_eq!(matches.device.overlap_scores.scores.get(&worker), Some(&2));
+    }
+
+    #[tokio::test]
     async fn event_driven_primary_without_side_skips_route_recording() {
         let indexer = make_test_indexer();
         assert!(!indexer.records_routing_decisions());
@@ -852,6 +876,97 @@ mod tests {
         assert!(
             !host.next_continuations.contains_key(&side_only_worker),
             "side-only worker must not appear in lower-tier continuations"
+        );
+    }
+
+    #[tokio::test]
+    async fn borrowed_tiered_lookup_matches_owned_with_lower_tier_and_side_overlay() {
+        let primary = Arc::new(ThreadPoolIndexer::new(
+            ConcurrentRadixTreeCompressed::new(),
+            2,
+            4,
+        ));
+        let side = Arc::new(ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTreeCompressed::new(),
+            1,
+            4,
+            PruneConfig {
+                ttl: Duration::from_secs(60),
+            },
+        ));
+        let side_for_flush = side.clone();
+        let indexer = Indexer::Concurrent {
+            primary,
+            lower_tier: LowerTierIndexers::new(2, 4),
+            approx: Some(super::SideIndexer::Concurrent(side)),
+            primary_records_routing_decisions: false,
+        };
+
+        let primary_worker = WorkerWithDpRank::new(10, 0);
+        let side_worker = WorkerWithDpRank::new(20, 0);
+        indexer
+            .apply_event(store_event(10, 0, 1, &[], &[11, 12], StorageTier::Device))
+            .await;
+        indexer
+            .apply_event(store_event(
+                10,
+                0,
+                2,
+                &[11, 12],
+                &[13],
+                StorageTier::HostPinned,
+            ))
+            .await;
+
+        let side_hashes = vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)];
+        indexer
+            .record_routing_decision_hashes(
+                side_worker,
+                RoutingDecisionHashes {
+                    local_hashes: side_hashes.clone(),
+                    sequence_hashes: compute_seq_hash_for_block(&side_hashes),
+                },
+            )
+            .await
+            .unwrap();
+        flush_indexer(&indexer).await;
+        side_for_flush.flush().await;
+
+        let query = vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)];
+        let borrowed = indexer.find_matches_by_tier_ref(&query).await.unwrap();
+        let owned = indexer.find_matches_by_tier(query).await.unwrap();
+
+        assert_eq!(
+            borrowed.device.overlap_scores.scores,
+            owned.device.overlap_scores.scores
+        );
+        assert_eq!(
+            borrowed
+                .lower_tier
+                .get(&StorageTier::HostPinned)
+                .map(|tier| &tier.hits),
+            owned
+                .lower_tier
+                .get(&StorageTier::HostPinned)
+                .map(|tier| &tier.hits)
+        );
+        assert_eq!(
+            borrowed
+                .device
+                .overlap_scores
+                .scores
+                .get(&primary_worker)
+                .copied(),
+            Some(2)
+        );
+        assert_eq!(
+            borrowed
+                .device
+                .overlap_scores
+                .scores
+                .get(&side_worker)
+                .copied(),
+            Some(3)
         );
     }
 

--- a/lib/llm/src/kv_router/indexer/recording.rs
+++ b/lib/llm/src/kv_router/indexer/recording.rs
@@ -3,7 +3,9 @@
 
 use dynamo_kv_router::{
     ConcurrentRadixTreeCompressed,
-    indexer::{KvIndexer, KvIndexerInterface, KvRouterError, ThreadPoolIndexer},
+    indexer::{
+        KvIndexer, KvIndexerInterface, KvRouterError, RoutingDecisionHashes, ThreadPoolIndexer,
+    },
     protocols::{LocalBlockHash, TokensWithHashes, WorkerWithDpRank},
 };
 use dynamo_tokens::SequenceHash;
@@ -71,7 +73,23 @@ impl Indexer {
         sequence_hashes: Vec<SequenceHash>,
     ) -> Result<(), KvRouterError> {
         self.recording_target()
-            .record_hashed(worker, local_hashes, sequence_hashes)
+            .record_routing_hashes(
+                worker,
+                RoutingDecisionHashes {
+                    local_hashes,
+                    sequence_hashes,
+                },
+            )
+            .await
+    }
+
+    pub(crate) async fn record_routing_decision_hashes(
+        &self,
+        worker: WorkerWithDpRank,
+        hashes: RoutingDecisionHashes,
+    ) -> Result<(), KvRouterError> {
+        self.recording_target()
+            .record_routing_hashes(worker, hashes)
             .await
     }
 
@@ -93,41 +111,51 @@ impl Indexer {
         let local_hashes = tokens_with_hashes.get_or_compute_block_hashes().to_vec();
         let sequence_hashes = tokens_with_hashes.get_or_compute_seq_hashes().to_vec();
         target
-            .record_hashed(worker, local_hashes, sequence_hashes)
+            .record_routing_hashes(
+                worker,
+                RoutingDecisionHashes {
+                    local_hashes,
+                    sequence_hashes,
+                },
+            )
             .await
     }
 }
 
 impl<'a> RouteRecordingTarget<'a> {
-    async fn record_hashed(
+    async fn record_routing_hashes(
         self,
         worker: WorkerWithDpRank,
-        local_hashes: Vec<LocalBlockHash>,
-        sequence_hashes: Vec<SequenceHash>,
+        hashes: RoutingDecisionHashes,
     ) -> Result<(), KvRouterError> {
         match self {
             Self::Disabled => Ok(()),
             Self::PrimaryLocal(primary) => {
                 primary
-                    .process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
+                    .process_routing_decision_with_hashes(
+                        worker,
+                        hashes.local_hashes,
+                        hashes.sequence_hashes,
+                    )
                     .await
             }
             Self::PrimaryConcurrent(primary) => {
                 primary
-                    .process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
+                    .process_routing_decision_hash_slices(
+                        worker,
+                        &hashes.local_hashes,
+                        &hashes.sequence_hashes,
+                    )
                     .await
             }
             Self::PrimaryRemote(primary) => primary
-                .record_hashed_routing_decision(worker, local_hashes, sequence_hashes)
+                .record_hashed_routing_decision(worker, hashes.local_hashes, hashes.sequence_hashes)
                 .await
                 .map_err(|error| {
                     tracing::warn!(error = %error, "Remote indexer write failed");
                     KvRouterError::IndexerDroppedRequest
                 }),
-            Self::SideOverlay(side) => {
-                side.process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
-                    .await
-            }
+            Self::SideOverlay(side) => side.process_routing_decision_hashes(worker, hashes).await,
         }
     }
 }

--- a/lib/llm/src/kv_router/indexer/side.rs
+++ b/lib/llm/src/kv_router/indexer/side.rs
@@ -8,11 +8,15 @@ use dynamo_kv_router::{
     ConcurrentRadixTreeCompressed,
     approx::PruneConfig,
     config::KvRouterConfig,
-    indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, ThreadPoolIndexer},
-    protocols::{DpRank, LocalBlockHash, OverlapScores, WorkerId, WorkerWithDpRank},
+    indexer::{
+        KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, RoutingDecisionHashes,
+        SyncIndexer, ThreadPoolIndexer,
+    },
+    protocols::{DpRank, OverlapScores, WorkerId, WorkerWithDpRank},
 };
 use dynamo_runtime::{component::Component, traits::DistributedRuntimeProvider};
-use dynamo_tokens::SequenceHash;
+
+use super::lookup::HashInput;
 
 #[derive(Clone)]
 pub enum SideIndexer {
@@ -57,31 +61,44 @@ impl SideIndexer {
         )))
     }
 
-    pub(super) async fn find_matches(
+    pub(super) async fn find_matches_input(
         &self,
-        sequence: Vec<LocalBlockHash>,
+        sequence: HashInput<'_>,
     ) -> Result<OverlapScores, KvRouterError> {
         match self {
-            Self::KvIndexer(indexer) => indexer.find_matches(sequence).await,
-            Self::Concurrent(indexer) => indexer.find_matches(sequence).await,
+            Self::KvIndexer(indexer) => {
+                indexer
+                    .find_matches(sequence.into_owned_at_boundary())
+                    .await
+            }
+            Self::Concurrent(indexer) => {
+                Ok(indexer.backend().find_matches(sequence.as_slice(), false))
+            }
         }
     }
 
-    pub(super) async fn process_routing_decision_with_hashes(
+    pub(super) async fn process_routing_decision_hashes(
         &self,
         worker: WorkerWithDpRank,
-        local_hashes: Vec<LocalBlockHash>,
-        sequence_hashes: Vec<SequenceHash>,
+        hashes: RoutingDecisionHashes,
     ) -> Result<(), KvRouterError> {
         match self {
             Self::KvIndexer(indexer) => {
                 indexer
-                    .process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
+                    .process_routing_decision_with_hashes(
+                        worker,
+                        hashes.local_hashes,
+                        hashes.sequence_hashes,
+                    )
                     .await
             }
             Self::Concurrent(indexer) => {
                 indexer
-                    .process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
+                    .process_routing_decision_hash_slices(
+                        worker,
+                        &hashes.local_hashes,
+                        &hashes.sequence_hashes,
+                    )
                     .await
             }
         }

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -320,6 +320,7 @@ impl PrefillRouter {
                         block_mm_infos,
                         None,
                         update_states,
+                        false,
                         lora_name,
                         priority_jump,
                         None,

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -4,7 +4,10 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_kv_router::protocols::{TokensWithHashes, WorkerConfigLike, WorkerWithDpRank};
+use dynamo_kv_router::{
+    indexer::RoutingDecisionHashes,
+    protocols::{TokensWithHashes, WorkerConfigLike, WorkerWithDpRank},
+};
 use dynamo_runtime::{
     dynamo_nvtx_range,
     error::{DynamoError, ErrorType as DynamoErrorType},
@@ -50,6 +53,7 @@ struct WorkerSelection {
     overlap_amount: u32,
     effective_overlap_blocks: f64,
     cached_tokens: usize,
+    routing_hashes: Option<RoutingDecisionHashes>,
     /// Whether the scheduler is tracking this request (add_request or
     /// find_best_match_details with update_states=true was called).
     scheduler_tracked: bool,
@@ -296,6 +300,7 @@ impl KvPushRouter {
         request: &PreprocessedRequest,
         phase: RequestPhase,
         is_query_only: bool,
+        return_routing_hashes: bool,
     ) -> Result<WorkerSelection, Error> {
         let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
         let routing = request.routing.as_ref();
@@ -317,6 +322,7 @@ impl KvPushRouter {
                     block_mm_infos,
                     request.router_config_override.as_ref(),
                     !is_query_only,
+                    return_routing_hashes,
                     lora_name,
                     priority_jump,
                     expected_output_tokens,
@@ -325,37 +331,44 @@ impl KvPushRouter {
                     routing_constraints.clone(),
                 )
                 .await?;
-            let (best_worker, effective_overlap_blocks, cached_tokens, overlap_amount) =
-                match outcome {
-                    crate::kv_router::FindBestMatchOutcome::Routed {
-                        worker,
-                        overlap_blocks,
-                        effective_overlap_blocks,
-                        cached_tokens,
-                    } => (
-                        worker,
-                        effective_overlap_blocks,
-                        cached_tokens,
-                        overlap_blocks,
-                    ),
-                    crate::kv_router::FindBestMatchOutcome::Backpressure {
-                        reason,
-                        queued_isl_tokens,
-                        max_queued_isl_tokens,
-                    } => {
-                        // TODO(DEP-8189 / ai-dynamo#8189): classify queue-depth
-                        // saturation distinctly from generic resource exhaustion
-                        // (operator-facing 429 vs 503) once the shared rejection
-                        // layer lands.
-                        return Err(DynamoError::builder()
+            let (
+                best_worker,
+                effective_overlap_blocks,
+                cached_tokens,
+                overlap_amount,
+                routing_hashes,
+            ) = match outcome {
+                crate::kv_router::FindBestMatchOutcome::Routed {
+                    worker,
+                    overlap_blocks,
+                    effective_overlap_blocks,
+                    cached_tokens,
+                    routing_hashes,
+                } => (
+                    worker,
+                    effective_overlap_blocks,
+                    cached_tokens,
+                    overlap_blocks,
+                    routing_hashes,
+                ),
+                crate::kv_router::FindBestMatchOutcome::Backpressure {
+                    reason,
+                    queued_isl_tokens,
+                    max_queued_isl_tokens,
+                } => {
+                    // TODO(DEP-8189 / ai-dynamo#8189): classify queue-depth
+                    // saturation distinctly from generic resource exhaustion
+                    // (operator-facing 429 vs 503) once the shared rejection
+                    // layer lands.
+                    return Err(DynamoError::builder()
                         .error_type(DynamoErrorType::ResourceExhausted)
                         .message(format!(
                             "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
                         ))
                         .build()
                         .into());
-                    }
-                };
+                }
+            };
 
             if !is_query_only {
                 let total_blocks = routing_token_ids
@@ -382,6 +395,7 @@ impl KvPushRouter {
                 overlap_amount,
                 effective_overlap_blocks,
                 cached_tokens,
+                routing_hashes,
                 scheduler_tracked: !is_query_only,
             });
         };
@@ -399,6 +413,7 @@ impl KvPushRouter {
                     block_mm_infos,
                     request.router_config_override.as_ref(),
                     true,
+                    return_routing_hashes,
                     lora_name.clone(),
                     priority_jump,
                     expected_output_tokens,
@@ -407,35 +422,42 @@ impl KvPushRouter {
                     routing_constraints.clone(),
                 )
                 .await?;
-            let (best_worker, effective_overlap_blocks, cached_tokens, overlap_amount) =
-                match outcome {
-                    crate::kv_router::FindBestMatchOutcome::Routed {
-                        worker,
-                        overlap_blocks,
-                        effective_overlap_blocks,
-                        cached_tokens,
-                    } => (
-                        worker,
-                        effective_overlap_blocks,
-                        cached_tokens,
-                        overlap_blocks,
-                    ),
-                    crate::kv_router::FindBestMatchOutcome::Backpressure {
-                        reason,
-                        queued_isl_tokens,
-                        max_queued_isl_tokens,
-                    } => {
-                        // TODO(DEP-8189 / ai-dynamo#8189): same classification
-                        // refinement applies on the pinned-worker path.
-                        return Err(DynamoError::builder()
+            let (
+                best_worker,
+                effective_overlap_blocks,
+                cached_tokens,
+                overlap_amount,
+                routing_hashes,
+            ) = match outcome {
+                crate::kv_router::FindBestMatchOutcome::Routed {
+                    worker,
+                    overlap_blocks,
+                    effective_overlap_blocks,
+                    cached_tokens,
+                    routing_hashes,
+                } => (
+                    worker,
+                    effective_overlap_blocks,
+                    cached_tokens,
+                    overlap_blocks,
+                    routing_hashes,
+                ),
+                crate::kv_router::FindBestMatchOutcome::Backpressure {
+                    reason,
+                    queued_isl_tokens,
+                    max_queued_isl_tokens,
+                } => {
+                    // TODO(DEP-8189 / ai-dynamo#8189): same classification
+                    // refinement applies on the pinned-worker path.
+                    return Err(DynamoError::builder()
                         .error_type(DynamoErrorType::ResourceExhausted)
                         .message(format!(
                             "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
                         ))
                         .build()
                         .into());
-                    }
-                };
+                }
+            };
 
             return Ok(WorkerSelection {
                 instance_id: best_worker.worker_id,
@@ -443,6 +465,7 @@ impl KvPushRouter {
                 overlap_amount,
                 effective_overlap_blocks,
                 cached_tokens,
+                routing_hashes,
                 scheduler_tracked: true,
             });
         }
@@ -489,13 +512,14 @@ impl KvPushRouter {
         // estimate query and won't affect scheduler state.
         let effective_dp_rank = resolved_dp_rank.unwrap_or(0);
         let worker = WorkerWithDpRank::new(pinned_worker_id, effective_dp_rank);
-        let cache_hit = self
+        let (cache_hit, routing_hashes) = self
             .chooser
-            .get_cache_hit_estimate(
+            .get_cache_hit_estimate_with_hashes(
                 routing_token_ids,
                 block_mm_infos,
                 worker,
                 lora_name.as_deref(),
+                return_routing_hashes,
             )
             .await?;
         let effective_overlap_blocks = cache_hit.effective_overlap_blocks;
@@ -539,6 +563,7 @@ impl KvPushRouter {
             overlap_amount: overlap_blocks,
             effective_overlap_blocks,
             cached_tokens,
+            routing_hashes,
             scheduler_tracked: !is_query_only && resolved_dp_rank.is_some(),
         })
     }
@@ -604,9 +629,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let phase_label = phase.to_string();
         let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
 
+        let should_record = !is_query_only && self.chooser.indexer().records_routing_decisions();
         let block_size = self.chooser.block_size() as usize;
         let selection = self
-            .select_worker(&context_id, &request, phase, is_query_only)
+            .select_worker(&context_id, &request, phase, is_query_only, should_record)
             .instrument(tracing::info_span!("kv_router.select_worker"))
             .await?;
         let WorkerSelection {
@@ -615,31 +641,33 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             overlap_amount,
             effective_overlap_blocks,
             cached_tokens,
+            routing_hashes,
             scheduler_tracked,
         } = selection;
 
-        // The indexer owns route-time recording policy: primary approximate
-        // mode records into the primary, predict-on-route records into the
-        // side overlay, and event-only mode with no side overlay skips this.
-        let should_record = !is_query_only && self.chooser.indexer().records_routing_decisions();
         if should_record {
-            let lora_name = request.routing.as_ref().and_then(|r| r.lora_name.clone());
-            let (routing_token_ids, block_mm_infos) = request.block_mm_routing_info();
             let worker = WorkerWithDpRank::new(instance_id, dp_rank);
-            let mut tokens_with_hashes =
-                TokensWithHashes::new(routing_token_ids.to_vec(), self.chooser.block_size())
-                    .with_is_eagle(self.chooser.is_eagle());
-            if let Some(infos) = block_mm_infos {
-                tokens_with_hashes = tokens_with_hashes.with_mm_infos(infos.to_vec());
-            }
-            if let Some(lora_name) = lora_name {
-                tokens_with_hashes = tokens_with_hashes.with_lora_name(lora_name);
-            }
-            if let Err(e) = self
-                .chooser
-                .record_routing_decision(tokens_with_hashes, worker)
-                .await
-            {
+            let record_result = if let Some(hashes) = routing_hashes {
+                self.chooser
+                    .record_routing_decision_hashes(hashes, worker)
+                    .await
+            } else {
+                let lora_name = request.routing.as_ref().and_then(|r| r.lora_name.clone());
+                let (routing_token_ids, block_mm_infos) = request.block_mm_routing_info();
+                let mut tokens_with_hashes =
+                    TokensWithHashes::new(routing_token_ids.to_vec(), self.chooser.block_size())
+                        .with_is_eagle(self.chooser.is_eagle());
+                if let Some(infos) = block_mm_infos {
+                    tokens_with_hashes = tokens_with_hashes.with_mm_infos(infos.to_vec());
+                }
+                if let Some(lora_name) = lora_name {
+                    tokens_with_hashes = tokens_with_hashes.with_lora_name(lora_name);
+                }
+                self.chooser
+                    .record_routing_decision(tokens_with_hashes, worker)
+                    .await
+            };
+            if let Err(e) = record_result {
                 tracing::warn!(
                     request_id = %context_id,
                     worker_id = instance_id,

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -356,7 +356,7 @@ impl KvPushRouter {
                     queued_isl_tokens,
                     max_queued_isl_tokens,
                 } => {
-                    // TODO(DEP-8189 / ai-dynamo#8189): classify queue-depth
+                    // TODO(#8189): classify queue-depth
                     // saturation distinctly from generic resource exhaustion
                     // (operator-facing 429 vs 503) once the shared rejection
                     // layer lands.
@@ -447,7 +447,7 @@ impl KvPushRouter {
                     queued_isl_tokens,
                     max_queued_isl_tokens,
                 } => {
-                    // TODO(DEP-8189 / ai-dynamo#8189): same classification
+                    // TODO(#8189): same classification
                     // refinement applies on the pinned-worker path.
                     return Err(DynamoError::builder()
                         .error_type(DynamoErrorType::ResourceExhausted)

--- a/lib/llm/src/kv_router/route_lookup.rs
+++ b/lib/llm/src/kv_router/route_lookup.rs
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    future::Future,
+    time::{Duration, Instant},
+};
+
+use dynamo_kv_router::{
+    SharedKvCache,
+    indexer::KvRouterError,
+    protocols::{LocalBlockHash, SharedCacheHits},
+};
+use tracing::Instrument;
+
+use super::{Indexer, indexer::TieredMatchDetails, metrics};
+
+pub(super) struct TieredLookupResult {
+    pub(super) tiered_matches: TieredMatchDetails,
+    pub(super) shared_cache_hits: Option<SharedCacheHits>,
+    pub(super) indexer_duration: Duration,
+    pub(super) shared_cache_duration: Option<Duration>,
+    pub(super) retained_block_hashes: Option<Vec<LocalBlockHash>>,
+}
+
+pub(super) fn split_retained_block_hashes(
+    block_hashes: Vec<LocalBlockHash>,
+    supports_overlap_refresh: bool,
+    return_routing_hashes: bool,
+) -> (Option<Vec<LocalBlockHash>>, Option<Vec<LocalBlockHash>>) {
+    debug_assert!(supports_overlap_refresh || return_routing_hashes);
+
+    if supports_overlap_refresh && return_routing_hashes {
+        return (Some(block_hashes.clone()), Some(block_hashes));
+    }
+    if supports_overlap_refresh {
+        return (Some(block_hashes), None);
+    }
+
+    debug_assert!(return_routing_hashes);
+    (None, Some(block_hashes))
+}
+
+pub(super) async fn query_tiered_matches(
+    indexer: &Indexer,
+    shared_cache: Option<&dyn SharedKvCache>,
+    tokens: &[u32],
+    block_size: u32,
+    block_hashes: Vec<LocalBlockHash>,
+    retain_block_hashes: bool,
+) -> Result<TieredLookupResult, KvRouterError> {
+    if retain_block_hashes {
+        let (tiered_matches, shared_cache_hits, indexer_duration, shared_cache_duration) =
+            query_retained(indexer, shared_cache, tokens, block_size, &block_hashes).await?;
+
+        return Ok(TieredLookupResult {
+            tiered_matches,
+            shared_cache_hits,
+            indexer_duration,
+            shared_cache_duration,
+            retained_block_hashes: Some(block_hashes),
+        });
+    }
+
+    let (tiered_matches, shared_cache_hits, indexer_duration, shared_cache_duration) =
+        query_owned(indexer, shared_cache, tokens, block_size, block_hashes).await?;
+
+    Ok(TieredLookupResult {
+        tiered_matches,
+        shared_cache_hits,
+        indexer_duration,
+        shared_cache_duration,
+        retained_block_hashes: None,
+    })
+}
+
+async fn query_retained(
+    indexer: &Indexer,
+    shared_cache: Option<&dyn SharedKvCache>,
+    tokens: &[u32],
+    block_size: u32,
+    block_hashes: &[LocalBlockHash],
+) -> Result<
+    (
+        TieredMatchDetails,
+        Option<SharedCacheHits>,
+        Duration,
+        Option<Duration>,
+    ),
+    KvRouterError,
+> {
+    let Some(shared_cache) = shared_cache else {
+        let t = Instant::now();
+        let tiered = indexer
+            .find_matches_by_tier_ref(block_hashes)
+            .instrument(tracing::info_span!("kv_router.find_matches"))
+            .await?;
+        return Ok((tiered, None, t.elapsed(), None));
+    };
+
+    let indexer_fut = indexer
+        .find_matches_by_tier_ref(block_hashes)
+        .instrument(tracing::info_span!("kv_router.find_matches"));
+    join_indexer_and_shared_cache(indexer_fut, shared_cache, tokens, block_size).await
+}
+
+async fn query_owned(
+    indexer: &Indexer,
+    shared_cache: Option<&dyn SharedKvCache>,
+    tokens: &[u32],
+    block_size: u32,
+    block_hashes: Vec<LocalBlockHash>,
+) -> Result<
+    (
+        TieredMatchDetails,
+        Option<SharedCacheHits>,
+        Duration,
+        Option<Duration>,
+    ),
+    KvRouterError,
+> {
+    let Some(shared_cache) = shared_cache else {
+        let t = Instant::now();
+        let tiered = indexer
+            .find_matches_by_tier(block_hashes)
+            .instrument(tracing::info_span!("kv_router.find_matches"))
+            .await?;
+        return Ok((tiered, None, t.elapsed(), None));
+    };
+
+    let indexer_fut = indexer
+        .find_matches_by_tier(block_hashes)
+        .instrument(tracing::info_span!("kv_router.find_matches"));
+    join_indexer_and_shared_cache(indexer_fut, shared_cache, tokens, block_size).await
+}
+
+async fn join_indexer_and_shared_cache<I>(
+    indexer_fut: I,
+    shared_cache: &dyn SharedKvCache,
+    tokens: &[u32],
+    block_size: u32,
+) -> Result<
+    (
+        TieredMatchDetails,
+        Option<SharedCacheHits>,
+        Duration,
+        Option<Duration>,
+    ),
+    KvRouterError,
+>
+where
+    I: Future<Output = Result<TieredMatchDetails, KvRouterError>>,
+{
+    let shared_fut = shared_cache
+        .check_blocks(tokens, block_size)
+        .instrument(tracing::info_span!("kv_router.shared_cache_check"));
+
+    let indexer_timed = async {
+        let t = Instant::now();
+        let r = indexer_fut.await;
+        (r, t.elapsed())
+    };
+    let shared_timed = async {
+        let t = Instant::now();
+        let r = shared_fut.await;
+        (r, t.elapsed())
+    };
+
+    let ((indexer_result, indexer_duration), (shared_result, shared_cache_duration)) =
+        tokio::join!(indexer_timed, shared_timed);
+    let tiered_matches = indexer_result?;
+    let shared_cache_hits = match shared_result {
+        Ok(hits) => Some(hits),
+        Err(e) => {
+            tracing::warn!(error = %e, "Shared cache query failed, ignoring");
+            if let Some(m) = metrics::RoutingOverheadMetrics::get() {
+                m.inc_shared_cache_errors();
+            }
+            None
+        }
+    };
+
+    Ok((
+        tiered_matches,
+        shared_cache_hits,
+        indexer_duration,
+        Some(shared_cache_duration),
+    ))
+}

--- a/lib/llm/src/kv_router/scheduler_inputs.rs
+++ b/lib/llm/src/kv_router/scheduler_inputs.rs
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use dynamo_kv_router::{
+    config::KvRouterConfig,
+    protocols::{DpRank, LocalBlockHash, SharedCacheHits, StorageTier, WorkerId, WorkerWithDpRank},
+    scheduling::TierOverlapBlocks,
+};
+use dynamo_runtime::pipeline::async_trait;
+use serde::Serialize;
+
+use super::{
+    indexer::{Indexer, TieredMatchDetails},
+    scheduler::{OverlapScoresRefresh, RefreshedOverlap},
+};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct WorkerCacheHitEstimate {
+    pub effective_overlap_blocks: f64,
+    pub cached_tokens: usize,
+}
+
+impl WorkerCacheHitEstimate {
+    pub fn rounded_overlap_blocks(self) -> u32 {
+        self.effective_overlap_blocks.round() as u32
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct CacheHitEstimates {
+    pub(super) effective_overlap_blocks: HashMap<WorkerWithDpRank, f64>,
+    pub(super) cached_tokens: HashMap<WorkerWithDpRank, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkerOverlapScore {
+    pub worker_id: WorkerId,
+    pub dp_rank: DpRank,
+    pub device_blocks: usize,
+    pub host_pinned_blocks: usize,
+    pub disk_blocks: usize,
+    pub host_pinned_extension_blocks: usize,
+    pub disk_extension_blocks: usize,
+    pub shared_beyond_device_blocks: Option<u32>,
+    pub router_credit_blocks: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SharedCacheOverlapScore {
+    pub enabled: bool,
+    pub total_hit_blocks: u32,
+    pub ranges: Vec<(u32, u32)>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OverlapScoresResponse {
+    pub block_size: u32,
+    pub num_blocks: usize,
+    pub workers: Vec<WorkerOverlapScore>,
+    pub shared_cache: SharedCacheOverlapScore,
+}
+
+fn cache_hit_weight_for_tier(kv_router_config: &KvRouterConfig, storage_tier: StorageTier) -> f64 {
+    match storage_tier {
+        StorageTier::Device => 1.0,
+        StorageTier::HostPinned => kv_router_config.host_cache_hit_weight,
+        StorageTier::Disk | StorageTier::External => kv_router_config.disk_cache_hit_weight,
+    }
+}
+
+fn cached_tokens_from_effective_overlap(block_size: u32, effective_overlap_blocks: f64) -> usize {
+    (effective_overlap_blocks * block_size as f64)
+        .round()
+        .max(0.0) as usize
+}
+
+pub(super) fn cache_hit_estimates_from_tiered_matches(
+    kv_router_config: &KvRouterConfig,
+    block_size: u32,
+    tiered_matches: &TieredMatchDetails,
+) -> CacheHitEstimates {
+    let mut effective_overlap_blocks = HashMap::new();
+
+    for (worker, overlap) in &tiered_matches.device.overlap_scores.scores {
+        effective_overlap_blocks.insert(*worker, *overlap as f64);
+    }
+
+    for (storage_tier, tier_matches) in &tiered_matches.lower_tier {
+        let weight = cache_hit_weight_for_tier(kv_router_config, *storage_tier);
+        if weight == 0.0 {
+            continue;
+        }
+
+        for (worker, hits) in &tier_matches.hits {
+            if *hits == 0 {
+                continue;
+            }
+            *effective_overlap_blocks.entry(*worker).or_insert(0.0) += *hits as f64 * weight;
+        }
+    }
+
+    let cached_tokens = effective_overlap_blocks
+        .iter()
+        .map(|(worker, overlap)| {
+            (
+                *worker,
+                cached_tokens_from_effective_overlap(block_size, *overlap),
+            )
+        })
+        .collect();
+
+    CacheHitEstimates {
+        effective_overlap_blocks,
+        cached_tokens,
+    }
+}
+
+pub(super) fn cache_hit_for_worker(
+    cache_hit_estimates: &CacheHitEstimates,
+    worker: WorkerWithDpRank,
+) -> WorkerCacheHitEstimate {
+    WorkerCacheHitEstimate {
+        effective_overlap_blocks: cache_hit_estimates
+            .effective_overlap_blocks
+            .get(&worker)
+            .copied()
+            .unwrap_or(0.0),
+        cached_tokens: cache_hit_estimates
+            .cached_tokens
+            .get(&worker)
+            .copied()
+            .unwrap_or(0),
+    }
+}
+
+pub(super) fn tier_overlap_blocks_from_tiered_matches(
+    tiered_matches: &TieredMatchDetails,
+) -> TierOverlapBlocks {
+    let mut tier_overlap_blocks = TierOverlapBlocks::default();
+
+    tier_overlap_blocks.device.extend(
+        tiered_matches
+            .device
+            .overlap_scores
+            .scores
+            .iter()
+            .map(|(worker, hits)| (*worker, *hits as usize)),
+    );
+
+    if let Some(host_matches) = tiered_matches.lower_tier.get(&StorageTier::HostPinned) {
+        tier_overlap_blocks.host_pinned.extend(
+            host_matches
+                .hits
+                .iter()
+                .map(|(worker, hits)| (*worker, *hits)),
+        );
+    }
+
+    // Disk and External share the same weighting, so accumulate both into the disk bucket.
+    for tier in [StorageTier::Disk, StorageTier::External] {
+        if let Some(matches) = tiered_matches.lower_tier.get(&tier) {
+            for (worker, hits) in &matches.hits {
+                *tier_overlap_blocks.disk.entry(*worker).or_default() += *hits;
+            }
+        }
+    }
+
+    tier_overlap_blocks
+}
+
+pub(super) fn shared_cache_overlap_score(
+    enabled: bool,
+    hits: Option<&SharedCacheHits>,
+    error: Option<String>,
+) -> SharedCacheOverlapScore {
+    let Some(hits) = hits else {
+        return SharedCacheOverlapScore {
+            enabled,
+            total_hit_blocks: 0,
+            ranges: Vec::new(),
+            error,
+        };
+    };
+
+    SharedCacheOverlapScore {
+        enabled,
+        total_hit_blocks: hits.total_hits,
+        ranges: hits
+            .ranges
+            .iter()
+            .map(|range| (range.start, range.end))
+            .collect(),
+        error,
+    }
+}
+
+/// Re-queries the indexer to refresh stale overlap scores for requests that have been
+/// waiting in the scheduler queue. Wired into the scheduler's
+/// [`OverlapScoresRefresh`](dynamo_kv_router::scheduling::OverlapScoresRefresh) slot at
+/// router startup.
+///
+/// `Remote` and `None` indexer variants intentionally don't get a refresher: remote
+/// indexer queries are too expensive to repeat per request, and `None` has nothing to query.
+pub(super) struct KvRouterOverlapRefresher {
+    indexer: Indexer,
+    kv_router_config: KvRouterConfig,
+    block_size: u32,
+}
+
+impl KvRouterOverlapRefresher {
+    pub(super) fn for_indexer(
+        indexer: Indexer,
+        kv_router_config: KvRouterConfig,
+        block_size: u32,
+    ) -> Option<Self> {
+        match &indexer {
+            Indexer::KvIndexer { .. } | Indexer::Concurrent { .. } => Some(Self {
+                indexer,
+                kv_router_config,
+                block_size,
+            }),
+            Indexer::Remote { .. } | Indexer::None => None,
+        }
+    }
+}
+
+#[async_trait]
+impl OverlapScoresRefresh for KvRouterOverlapRefresher {
+    async fn refresh(&self, block_hashes: &[LocalBlockHash]) -> Option<RefreshedOverlap> {
+        let tiered = match self.indexer.find_matches_by_tier_ref(block_hashes).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = ?e, "overlap refresh: find_matches_by_tier failed");
+                return None;
+            }
+        };
+        let tier_overlap_blocks = tier_overlap_blocks_from_tiered_matches(&tiered);
+        let estimates = cache_hit_estimates_from_tiered_matches(
+            &self.kv_router_config,
+            self.block_size,
+            &tiered,
+        );
+        Some(RefreshedOverlap {
+            tier_overlap_blocks,
+            effective_overlap_blocks: estimates.effective_overlap_blocks,
+            effective_cached_tokens: estimates.cached_tokens,
+        })
+    }
+}


### PR DESCRIPTION
Reduce avoidable block-hash cloning in KV router lookup and route-time recording paths while keeping actor and RPC ownership boundaries explicit.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional routing decision hash information to worker selection queries for improved decision tracking and observability

* **Improvements**
  * Optimized routing indexer performance by improving memory efficiency in hash processing and tiered matching operations
  * Enhanced routing decision recording with more efficient hash handling mechanisms

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->