### PR TITLE
docs(kubernetes): fix broken Volcano doc links

### DIFF
--- a/docs/kubernetes/deployment/multinode-deployment.md
+++ b/docs/kubernetes/deployment/multinode-deployment.md
@@ -65,7 +65,7 @@ KAI-Scheduler is optional but recommended for advanced scheduling capabilities.
 LWS is a simple multinode deployment mechanism that allows you to deploy a workload across multiple nodes.
 
 - **LWS**: [LWS Installation](https://github.com/kubernetes-sigs/lws#installation)
-- **Volcano**: [Volcano Installation](https://volcano.sh/en/docs/installation/)
+- **Volcano**: [Volcano Installation](https://github.com/volcano-sh/volcano#quick-start-guide)
 
 Volcano is a Kubernetes native scheduler optimized for AI workloads at scale. It is used in conjunction with LWS to provide gang scheduling support.
 

--- a/docs/kubernetes/installation-guide.md
+++ b/docs/kubernetes/installation-guide.md
@@ -157,7 +157,7 @@ For the `enabled=true` path, install Grove and KAI Scheduler separately first. S
 
 #### LWS + Volcano
 
-If you are not using Grove for multinode, you can use [LeaderWorkerSet (LWS)](https://lws.sigs.k8s.io/docs/installation/) (>= v0.7.0) with [Volcano](https://volcano.sh/en/docs/installation/) for gang scheduling. Both must be installed before deploying multinode workloads.
+If you are not using Grove for multinode, you can use [LeaderWorkerSet (LWS)](https://lws.sigs.k8s.io/docs/installation/) (>= v0.7.0) with [Volcano](https://github.com/volcano-sh/volcano#quick-start-guide) for gang scheduling. Both must be installed before deploying multinode workloads.
 
 1. Install Volcano:
 
@@ -179,7 +179,7 @@ helm install lws oci://registry.k8s.io/lws/charts/lws \
   --wait --timeout 300s
 ```
 
-See the [LWS docs](https://lws.sigs.k8s.io/docs/) and [Volcano docs](https://volcano.sh/en/docs/) for configuration options, and the [Multinode Deployment Guide](./deployment/multinode-deployment.md) for orchestrator selection.
+See the [LWS docs](https://lws.sigs.k8s.io/docs/) and [Volcano docs](https://github.com/volcano-sh/volcano#quick-start-guide) for configuration options, and the [Multinode Deployment Guide](./deployment/multinode-deployment.md) for orchestrator selection.
 
 ### Network Operator / RDMA
 


### PR DESCRIPTION
## Summary

The `volcano.sh` hosted docs site is currently returning 404 for `/en/docs/` and `/en/docs/installation/`, which fails our docs link-check CI (e.g. on [#9958](https://github.com/ai-dynamo/dynamo/pull/9958)).

This swaps the three broken references to the canonical README on the [volcano-sh/volcano](https://github.com/volcano-sh/volcano#quick-start-guide) repo — the same URL Volcano's own README links to.

- `docs/kubernetes/deployment/multinode-deployment.md` — Volcano installation link
- `docs/kubernetes/installation-guide.md` — Volcano install + Volcano docs links

## Test plan

- [x] Manually verified `https://github.com/volcano-sh/volcano#quick-start-guide` returns 200 and the `quick-start-guide` anchor exists
- [ ] Docs link-check CI passes on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Volcano installation documentation links to point to the official quick-start guide for improved accuracy and accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->