### PR TITLE
fix: align sglang prefill cuda graph bs with dp (#9962)

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -67,8 +67,8 @@ def test_build_dgd_config_shapes_multinode_worker_resources() -> None:
     assert decode_service.get("multinode") is None
 
 
-def test_build_dgd_config_sglang_prefill_mrr_one_sets_cuda_graph_bs() -> None:
-    """SGLang prefill with one running request must capture bs=1 explicitly."""
+def test_build_dgd_config_sglang_prefill_mrr_one_sets_dp_safe_cuda_graph_bs() -> None:
+    """SGLang prefill capture bs must remain valid with DP attention."""
     modifier = CONFIG_MODIFIERS["sglang"]
     dgd_config = modifier.build_dgd_config(
         mode="disagg",
@@ -106,7 +106,7 @@ def test_build_dgd_config_sglang_prefill_mrr_one_sets_cuda_graph_bs() -> None:
     prefill_args = prefill_service["extraPodSpec"]["mainContainer"]["args"]
 
     assert prefill_args.count("--cuda-graph-bs") == 1
-    assert prefill_args[prefill_args.index("--cuda-graph-bs") + 1] == "1"
+    assert prefill_args[prefill_args.index("--cuda-graph-bs") + 1] == "2"
 
 
 def test_build_dgd_config_sglang_prefill_keeps_existing_cuda_graph_bs() -> None:
@@ -158,6 +158,7 @@ def test_sglang_set_prefill_config_uses_effective_mrr_override() -> None:
     )
     service["extraPodSpec"]["mainContainer"]["args"] = [
         "--max-running-requests=512",
+        "--dp=2",
     ]
 
     result = modifier.set_prefill_config(
@@ -174,7 +175,7 @@ def test_sglang_set_prefill_config_uses_effective_mrr_override() -> None:
 
     assert args[args.index("--max-running-requests") + 1] == "1"
     assert args.count("--cuda-graph-bs") == 1
-    assert args[args.index("--cuda-graph-bs") + 1] == "1"
+    assert args[args.index("--cuda-graph-bs") + 1] == "2"
 
 
 def test_build_dgd_config_multinode_when_tp_exceeds_node() -> None:

--- a/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/sglang.py
@@ -46,14 +46,26 @@ DEFAULT_SGLANG_AGG_CONFIG_PATH = resolve_deploy_path(
 )
 
 
-def _arg_value(args: list[str], key: str) -> str | None:
+def _arg_value_any(args: list[str], keys: tuple[str, ...]) -> str | None:
     for idx in range(len(args) - 1, -1, -1):
         arg = args[idx]
-        if arg.startswith(f"{key}="):
-            return arg.split("=", 1)[1]
-        if arg == key:
-            return args[idx + 1] if idx + 1 < len(args) else None
+        for key in keys:
+            if arg.startswith(f"{key}="):
+                return arg.split("=", 1)[1]
+            if arg == key:
+                return args[idx + 1] if idx + 1 < len(args) else None
     return None
+
+
+def _arg_value(args: list[str], key: str) -> str | None:
+    return _arg_value_any(args, (key,))
+
+
+def _int_arg_value(args: list[str], keys: tuple[str, ...], default: int) -> int:
+    try:
+        return int(_arg_value_any(args, keys) or "")
+    except ValueError:
+        return default
 
 
 def _has_arg(args: list[str], key: str) -> bool:
@@ -62,17 +74,26 @@ def _has_arg(args: list[str], key: str) -> bool:
 
 def _ensure_safe_prefill_cuda_graph_bs(args: list[str]) -> list[str]:
     args = list(args)
-    if _has_arg(args, "--cuda-graph-bs") or _has_arg(args, "--disable-cuda-graph"):
+    parsed_args = break_arguments(args)
+    if _has_arg(parsed_args, "--cuda-graph-bs") or _has_arg(
+        parsed_args, "--disable-cuda-graph"
+    ):
         return args
 
-    max_running_requests = _arg_value(args, "--max-running-requests")
+    max_running_requests = _arg_value(parsed_args, "--max-running-requests")
     try:
         max_running_requests_int = int(max_running_requests or "")
     except ValueError:
         return args
 
     if max_running_requests_int == 1:
-        args = append_argument(args, ["--cuda-graph-bs", "1"])
+        dp_size = _int_arg_value(
+            parsed_args,
+            ("--data-parallel-size", "--dp-size", "--dp"),
+            default=1,
+        )
+        safe_bs = max(1, dp_size)
+        args = append_argument(args, ["--cuda-graph-bs", str(safe_bs)])
     return args
 
 


### PR DESCRIPTION
## Summary
- Cherry-pick #9962 to release/1.2.0.
- Inject a DP-safe `--cuda-graph-bs` for SGLang prefill when rapid profiling sets `--max-running-requests 1`.
- Cover the DP-safe generated DGD path and effective MRR override path in profiler protocol tests.

## Testing
- `.venv/bin/python -m py_compile components/src/dynamo/profiler/utils/config_modifiers/sglang.py components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py`
- `.venv/bin/python -m pytest components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py -v`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->