### PR TITLE
docs(fern): enable NVIDIA global theme and upgrade Fern CLI to 5.37.10

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -21,6 +21,8 @@ instances:
 
 title: NVIDIA Dynamo Documentation
 
+global-theme: nvidia
+
 agents:
   page-directive: "For clean Markdown content of this page, append .md to this URL. For the complete documentation index, see https://docs.nvidia.com/dynamo/llms.txt. For full content including API reference and SDK examples, see https://docs.nvidia.com/dynamo/llms-full.txt."
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -17,7 +17,7 @@
 
 instances:
   - url: dynamo.docs.buildwithfern.com/dynamo
-    custom-domain: [docs.nvidia.com/dynamo, docs.dynamo.nvidia.com]
+    custom-domain: [docs.nvidia.com/dynamo, docs.dynamo.nvidia.com/dynamo]
 
 title: NVIDIA Dynamo Documentation
 

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "4.66.1"
+  "version": "5.37.10"
 }


### PR DESCRIPTION
## Summary
- Add `global-theme: nvidia` to `fern/docs.yml` — applies the org-wide NVIDIA global theme that injects standardized branding (logo, colors, fonts, layout), legal footers, and the Adobe DTM opt-in/analytics scripts as `beforeInteractive`. Required for NVIDIA opt-in and data-collection compliance across external-facing docs.
- Bump Fern CLI version in `fern/fern.config.json` from `4.66.1` → `5.37.10` (required minimum for the global-theme feature).
- Local `colors:`, `typography:`, `logo:`, `footer:`, `layout:`, `js:`, `theme:` blocks left in place — Fern's global theme overrides these at publish time, and they remain as a local fallback for `fern docs dev`.

## Test plan
- [ ] CI `fern check` passes on this PR
- [ ] CI `fern docs broken-links` passes on this PR
- [ ] Preview deployment renders with NVIDIA logo, `#76B900` accent, and standardized layout
- [ ] Opt-in banner appears for external visitors on the preview URL
- [ ] After merge to `main`, `Fern Docs` workflow runs `fern generate --docs` and publishes to docs.nvidia.com/dynamo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied a global theme configuration to the documentation site, enhancing visual consistency and appearance across all pages.

* **Chores**
  * Updated version to 5.37.10.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->