### PR TITLE
test(kv-router): stabilize ZMQ pushes-to-channel test

### DIFF
--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -966,10 +966,7 @@ mod tests_startup_helpers {
             start_zmq_listener(endpoint.to_string(), topic, 1, tx, token, 4, next_event_id)
         });
 
-        // Give time for the connection to establish
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-        // Send synthetic 3-frame message: [topic, seq(8B), payload]
+        // Build synthetic 3-frame message: [topic, seq(8B), payload]
         let seq: u64 = 77;
 
         let events = vec![
@@ -1003,14 +1000,29 @@ mod tests_startup_helpers {
             payload.clone().to_vec(),
         ];
 
-        // Send the multipart message
-        send_multipart(&pub_socket, frames).await.unwrap();
+        // Republish on a 50ms interval until the listener forwards an event
+        // (or the 5s deadline trips). ZMQ PUB drops messages destined for
+        // subscribers whose SUBSCRIBE handshake has not yet completed, so a
+        // one-shot send + fixed sleep is racy on contended runners.
+        let event = tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
+            let mut publish_interval =
+                tokio::time::interval(tokio::time::Duration::from_millis(50));
+            loop {
+                tokio::select! {
+                    event = rx.recv() => {
+                        return event.expect("listener channel closed").event;
+                    }
+                    _ = publish_interval.tick() => {
+                        send_multipart(&pub_socket, frames.clone())
+                            .await
+                            .expect("failed to send ZMQ test event");
+                    }
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for listener event");
 
-        // Wait for message to be received
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-        // Check that we received the message
-        let event = rx.try_recv().expect("no message received").event;
         assert_eq!(event.event_id, 0);
 
         let KvCacheEventData::Stored(KvCacheStoreData {


### PR DESCRIPTION
## Overview

Stabilize `test_start_zmq_listener_pushes_to_channel` against ZMQ's slow-joiner race using the same fix #8949 applied to its sibling test.

Flaky Failing Run [[Ref](https://github.com/ai-dynamo/dynamo/actions/runs/26428856297/job/77798291957)]:
```
...
2026-05-26T02:43:36.0599100Z thread 'kv_router::publisher::tests::tests_startup_helpers::test_start_zmq_listener_pushes_to_channel' (101710) panicked at lib/llm/src/kv_router/publisher/tests.rs:1013:35:
2026-05-26T02:43:36.0600247Z no message received: Empty
2026-05-26T02:43:36.0600784Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
...
2026-05-26T02:43:36.0611291Z test kv_router::publisher::tests::tests_startup_helpers::test_start_zmq_listener_pushes_to_channel ... FAILED
...
2026-05-26T02:43:42.8598542Z failures:
2026-05-26T02:43:42.8598703Z     kv_router::publisher::tests::tests_startup_helpers::test_start_zmq_listener_pushes_to_channel
2026-05-26T02:43:42.8599622Z test result: FAILED. 1274 passed; 1 failed; 10 ignored; 0 measured; 0 filtered out; finished in 7.99s
```

## Why

ZMQ PUB drops messages destined for subscribers whose SUBSCRIBE handshake has not yet completed. The test slept 100ms after spawning the listener, sent once, slept 100ms, then called `rx.try_recv()`. On contended runners the handshake can take longer than 100ms, the published message is dropped, and `try_recv` returns `Empty`, panicking the test.

## Details

Drop the two fixed sleeps and the one-shot send. Wrap `rx.recv()` in `tokio::time::timeout(5s)` with a `tokio::select!` that republishes the frames every 50ms until the listener forwards an event. Downstream assertions unchanged.

Pattern matches the fix #8949 applied to `test_start_zmq_listener_connects_before_publisher_bind` in the same module.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of ZMQ listener unit test by replacing timing-dependent checks with a retry mechanism and extended timeout to reduce flaky test failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->