### PR TITLE
fix: fix DGDR profiling RBAC escalation for pods/log

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml
@@ -230,6 +230,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -25,6 +25,7 @@ rules:
   - ""
   resources:
   - nodes
+  - pods/log
   verbs:
   - get
 - apiGroups:

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -433,6 +433,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) FinalizeResource(ctx context.Co
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamographdeployments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 


### PR DESCRIPTION
## Summary

Fixes fresh cluster-wide Dynamo operator installs where DGDR profiling stalls because the operator cannot create the profiling job RoleBinding.

## Problem

The DGDR profiling ClusterRole grants `pods/log: get`, but the operator manager ClusterRole did not include that same permission. On fresh installs, when `EnsureServiceAccountWithRBAC` creates the `dgdr-profiling-job-binding` RoleBinding, Kubernetes rejects it as RBAC privilege escalation because the operator is attempting to grant a permission it does not currently hold.

Existing clusters with a pre-existing RoleBinding could mask the issue because the operator only GETs the binding and skips creation.

## Changes

- Add `pods/log: get` to the Helm manager RBAC template.
- Add the same rule to the generated operator RBAC manifest.
- Add the kubebuilder RBAC marker so future generated RBAC keeps the permission.


Closes DYN-3087

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator RBAC permissions across Helm charts and Kubernetes configurations to include pod log access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->