### PR TITLE
fix(parser): handle Gemma4 batch reasoning multi-spans

### DIFF
--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -138,37 +138,8 @@ impl ReasoningParser for Gemma4ReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
         // Non-streaming path: we have the complete text, so we can use plain
         // string operations.
-        let start_idx = text.find(START_TOKEN);
-        let end_idx = text.find(END_TOKEN);
-        match (start_idx, end_idx) {
-            (None, None) => {
-                // No reasoning markers visible at all (either model didn't
-                // emit them, or skip_special_tokens stripped them).
-                ParserResult {
-                    normal_text: text.to_string(),
-                    reasoning_text: String::new(),
-                }
-            }
-            (Some(s), end_opt) => {
-                let pre = &text[..s];
-                let rest = &text[s + START_TOKEN.len()..];
-                let (reasoning_raw, post) = match end_opt
-                    .filter(|e| *e > s + START_TOKEN.len())
-                    .map(|e| e - (s + START_TOKEN.len()))
-                {
-                    Some(end_rel) => (&rest[..end_rel], &rest[end_rel + END_TOKEN.len()..]),
-                    None => (rest, ""),
-                };
-                let reasoning = strip_thought_prefix(reasoning_raw).to_string();
-                let mut normal = String::with_capacity(pre.len() + post.len());
-                normal.push_str(pre);
-                normal.push_str(post);
-                ParserResult {
-                    normal_text: normal,
-                    reasoning_text: reasoning,
-                }
-            }
-            (None, Some(e)) => {
+        if !text.contains(START_TOKEN) {
+            if let Some(e) = text.find(END_TOKEN) {
                 // Dangling end marker without start marker — upstream's
                 // offline parser still treats text-before as reasoning. Mirror
                 // that so model emissions where the start tag was stripped
@@ -177,11 +148,45 @@ impl ReasoningParser for Gemma4ReasoningParser {
                 let reasoning_raw = &text[..e];
                 let post = &text[e + END_TOKEN.len()..];
                 let reasoning = strip_thought_prefix(reasoning_raw).to_string();
-                ParserResult {
+                return ParserResult {
                     normal_text: post.to_string(),
                     reasoning_text: reasoning,
-                }
+                };
             }
+
+            return ParserResult {
+                normal_text: text.to_string(),
+                reasoning_text: String::new(),
+            };
+        }
+
+        // We have at least one start marker. Extract reasoning spans iteratively until we run out of markers.
+        let mut normal = String::new();
+        let mut reasoning = String::new();
+        let mut cursor = 0;
+
+        while let Some(start_rel) = text[cursor..].find(START_TOKEN) {
+            let start = cursor + start_rel;
+            normal.push_str(&text[cursor..start]);
+
+            let reasoning_start = start + START_TOKEN.len();
+            let Some(end_rel) = text[reasoning_start..].find(END_TOKEN) else {
+                reasoning.push_str(strip_thought_prefix(&text[reasoning_start..]));
+                return ParserResult {
+                    normal_text: normal,
+                    reasoning_text: reasoning,
+                };
+            };
+
+            let end = reasoning_start + end_rel;
+            reasoning.push_str(strip_thought_prefix(&text[reasoning_start..end]));
+            cursor = end + END_TOKEN.len();
+        }
+
+        normal.push_str(&text[cursor..]);
+        ParserResult {
+            normal_text: normal,
+            reasoning_text: reasoning,
         }
     }
 
@@ -472,7 +477,17 @@ mod tests {
         assert_eq!(r.normal_text, "plain text only");
     }
 
-    #[test] // REASONING.batch.6.a — multiple reasoning spans back-to-back
+    #[test] // REASONING.batch.6.a — multiple reasoning spans separated by normal text
+    fn detect_multiple_reasoning_spans() {
+        let mut p = Gemma4ReasoningParser::new();
+        let input =
+            "<|channel>thought\nfirst<channel|> middle <|channel>thought\nsecond<channel|> done";
+        let r = p.detect_and_parse_reasoning(input, &[]);
+        assert_eq!(r.reasoning_text, "firstsecond");
+        assert_eq!(r.normal_text, " middle  done");
+    }
+
+    #[test] // REASONING.stream.2.b — multiple reasoning spans in one stream chunk
     fn streaming_multiple_reasoning_spans() {
         let mut p = Gemma4ReasoningParser::new();
         let input =
@@ -510,8 +525,6 @@ mod tests {
     // FRONTEND.tool_choice, PIPELINE.finish_reason — `tool_choice` and `finish_reason`: tool-call concerns,
     //          N/A for reasoning. (Universal cross-parser gap regardless;
     //          see notes in `tool_calling/gemma4/parser.rs`.)
-    // REASONING.batch.6.* — Multi-span reasoning is covered by
-    //          `streaming_multiple_reasoning_spans`.
     // TOOLCALLING.xml.1 / TOOLCALLING.xml.2 — XML-family only. N/A.
     // TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 — Harmony only. N/A.
 }

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -152,16 +152,20 @@ cases:
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'
   REASONING.batch.6.a:
-    description: Gemma batch parser stops after the first reasoning channel
+    description: Multiple reasoning spans are concatenated by Dynamo
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
     model_text: |-
       <|channel>thought
       first<channel|> middle <|channel>thought
       second<channel|> done
     expected:
       dynamo: &d_9
+        reasoning_text: firstsecond
+        normal_text: ' middle  done'
+      vllm:
         reasoning_text: first
         normal_text: " middle <|channel>thought\nsecond<channel|> done"
-      vllm: *d_9
+        reason: Multi-span reasoning is out-of-spec model output; Dynamo preserves all reasoning and non-reasoning text without leaking protocol markers, while vLLM leaves the later complete channel in normal_text.
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'gemma4'


### PR DESCRIPTION
#### Overview:

This PR fixes Gemma4 batch reasoning parsing for `REASONING.batch.6.a`, where a response contains multiple complete Gemma thought channels.

The fix aligns Dynamo’s Gemma4 batch reasoning behavior with the reasoning parity rubric for multi-span reasoning: complete reasoning spans should be extracted into `reasoning_text`, while protocol markers should not leak into `normal_text`. This also matches Dynamo’s existing Gemma4 streaming behavior for multiple reasoning spans.

As of 2026-05-26, multi-span reasoning is out-of-spec model output. Dynamo’s interpretation is to preserve all reasoning and all non-reasoning text, without leaking protocol markers or dropping information.

#### Details:

Before this fix, the batch parser stopped after the first Gemma reasoning channel. A later complete channel was left in `normal_text`, leaking Gemma protocol markup into visible content.

Input fixture:

```text
<|channel>thought
first<channel|> middle <|channel>thought
second<channel|> done
```

Dynamo before fix:

```text
reasoning_text='first'
normal_text=' middle <|channel>thought
second<channel|> done'
```

Dynamo after fix:

```text
reasoning_text='firstsecond'
normal_text=' middle  done'
```

After this fix, the batch parser scans all complete Gemma reasoning channels, concatenates their reasoning content, and keeps only user-visible text in `normal_text`.

Dynamo follows the no-leak alignment rule and extracts every complete Gemma thought channel. This intentionally diverges from vLLM for this fixture: vLLM extracts the first channel but leaves the later complete channel in `normal_text`.

I also updated the test annotation/name split. The existing `streaming_multiple_reasoning_spans` test uses `parse_reasoning_streaming_incremental`, so it belongs to `REASONING.stream.2.b`, not `REASONING.batch.6.a`. This PR adds a dedicated batch test using `detect_and_parse_reasoning` for `REASONING.batch.6.a`.

#### Where should the reviewer start?

- `lib/parsers/src/reasoning/gemma4_parser.rs`
- `tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml`

#### Related Issues:

- PR #9583 for the parser parity alignment rubric

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parser now supports extraction of multiple reasoning spans from model outputs, properly concatenating reasoning content while preserving intervening text segments.

* **Tests**
  * Updated test fixtures and added coverage for parsing multiple consecutive reasoning spans with various text patterns.
  * Enhanced edge case handling for standalone reasoning markers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->