### PR TITLE
fix(routing) [v1.1.2-test]: cherry-pick #9516 — reservoir-sample tie-breaks for LeastLoaded

### DIFF
--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -13,6 +13,7 @@ use anyhow::Result;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use futures::StreamExt;
+use rand::Rng;
 use tokio::net::unix::pipe::Receiver;
 
 use crate::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId};
@@ -44,7 +45,30 @@ impl RoutingOccupancyState {
 
     pub(crate) async fn select_exact_min_and_increment(&self, instance_ids: &[u64]) -> Option<u64> {
         let _guard = self.exact_selection_lock.lock().await;
-        let id = *instance_ids.iter().min_by_key(|&&id| self.load(id))?;
+
+        let mut min_load = u64::MAX;
+        let mut selected = None;
+        let mut tie_count = 0usize;
+        let mut rng = rand::rng();
+        for &id in instance_ids {
+            let load = self.load(id);
+            if load < min_load {
+                min_load = load;
+                selected = Some(id);
+                tie_count = 1;
+                continue;
+            }
+
+            if load == min_load {
+                tie_count += 1;
+                // Reservoir sampling keeps tied minima uniform without allocating in this locked hot path.
+                if rng.random_range(0..tie_count) == 0 {
+                    selected = Some(id);
+                }
+            }
+        }
+
+        let id = selected?;
         self.increment(id);
         Some(id)
     }
@@ -738,6 +762,31 @@ mod tests {
         assert_eq!(state.load(100), 30);
         assert_eq!(state.load(200), 30);
         assert_eq!(state.load(300), 30);
+    }
+
+    #[tokio::test]
+    async fn test_select_exact_min_and_increment_randomizes_ties() {
+        let mut selected = [false; 3];
+
+        for _ in 0..120 {
+            let state = RoutingOccupancyState::default();
+            let picked = state
+                .select_exact_min_and_increment(&[10, 20, 30])
+                .await
+                .unwrap();
+            match picked {
+                10 => selected[0] = true,
+                20 => selected[1] = true,
+                30 => selected[2] = true,
+                _ => panic!("unexpected worker id: {picked}"),
+            }
+        }
+
+        let selected_count = selected.into_iter().filter(|seen| *seen).count();
+        assert!(
+            selected_count > 1,
+            "tie-breaking should not always select the first minimum-load worker"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Cherry-picks the LeastLoaded tie-breaking fix from main commit [`147dccaa47`](https://github.com/ai-dynamo/dynamo/commit/147dccaa47) (originally PR #9516) onto `nnshah1/v1.1.2-test`.

`RoutingOccupancyState::select_exact_min_and_increment` previously used `min_by_key`, which always returns the **first** instance_id with the minimum load. With identically-loaded workers — common during ramp-up, after restarts, or when load is balanced — this always favored the first-indexed worker. Replacing with reservoir sampling makes the selection uniformly random among tied minima while preserving the existing selection lock and increment ordering.

## Scope

Cherry-picks **only the `lib/runtime/src/component/client.rs` portion** of #9516. The original PR also touched `lib/kv-router/src/scheduling/selector.rs`, but that file diverges between `main` and `v1.1.2-test` — the v1.1.2-test version has a tree-size tie-breaker (smaller routing tree wins, with random only as a sub-tie-breaker if tree sizes are also equal). #9516 removed that on main. Keeping v1.1.2-test's existing KV-router tie-breaker semantics unchanged.

Diff: **+50 / −1** in `client.rs`, including the regression test from #9516 that asserts the tie-break randomizes across ≥2 distinct workers over 120 trials.

## Why this matters here

The cascade-reproduction work (cycles 7–9 on `dis-2105-v1.1.1-*` images) showed every decode pod's `dynamo_component_inflight_requests` pegging at exactly the configured `DYN_TCP_WORKER_POOL_SIZE` simultaneously. That observation is consistent with both the pre- and post-#9516 behavior because `min_by_key` + `increment()` already gives round-robin-like spreading. The fix here is about non-determinism per-request, not aggregate load distribution: with the cherry-pick, the per-request pod choice among tied minima is randomized instead of strictly ordered by instance_id.

## Test plan

- [x] Cherry-pick applied via `git cherry-pick`, conflict in `client.rs` (an unused `tokio::net::unix::pipe::Receiver` import line conflicting with new `use rand::Rng;`) resolved by keeping both imports
- [x] Pre-commit hooks pass (DCO sign-off, ruff, pytest marker check)
- [x] Inherited regression test from #9516: `test_select_exact_min_and_increment_randomizes_ties` — 120 picks across 3 equally-loaded workers, asserts at least 2 distinct workers selected
- [ ] CI on this branch
- [ ] Verify behavior in a follow-up cascade test (orthogonal — cycle-10 image plans)

Cherry-picked from `147dccaa47` on main.