### PR TITLE
fix(snapshot): preserve vLLM torch compile cache (#9943)

### DIFF
--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -161,7 +161,6 @@ config:
       - /sys
       - /dev
       - "*/.cache/huggingface"
-      - "*/.cache/vllm/torch_compile_cache"
       - "*/__pycache__"
       - "*.pyc"
 

--- a/deploy/snapshot/internal/runtime/overlay_test.go
+++ b/deploy/snapshot/internal/runtime/overlay_test.go
@@ -43,13 +43,12 @@ func TestBuildExclusions(t *testing.T) {
 		{
 			name: "glob patterns starting with * are untouched",
 			settings: types.OverlaySettings{
-				Exclusions: []string{"*/.cache/huggingface", "*/.cache/vllm/torch_compile_cache", "*.pyc", "*/__pycache__"},
+				Exclusions: []string{"*/.cache/huggingface", "*.pyc", "*/__pycache__"},
 			},
 			want: map[string]bool{
-				"*/.cache/huggingface":              true,
-				"*/.cache/vllm/torch_compile_cache": true,
-				"*.pyc":                             true,
-				"*/__pycache__":                     true,
+				"*/.cache/huggingface": true,
+				"*.pyc":                true,
+				"*/__pycache__":        true,
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Cherry-pick #9943 to release/1.2.0.

Preserve the vLLM/Torch compile cache in snapshot rootfs diffs so CRIU restore can find generated Triton shared objects that may be mmap'ed from the cache.

## Source PR

- #9943
- main commit: 91094d58233daa4ab7152e187c91372f51858eee

## Testing

- `cd deploy/snapshot && go test ./internal/runtime`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->