### PR TITLE
fix(parser): REASONING.batch.4 dangling end markers

### DIFF
--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -113,7 +113,11 @@ impl ReasoningParser for BasicReasoningParser {
         // consumed it). Without this, the `</think>` markup leaks into
         // normal_text. Matches vLLM's `partition()`-based behavior for the
         // same input.
-        let has_dangling_end = !has_think_tag && text.contains(&self.think_end_token);
+        let supports_dangling_end_recovery =
+            self.think_start_token == "<think>" && self.think_end_token == "</think>";
+        let has_dangling_end = supports_dangling_end_recovery
+            && !has_think_tag
+            && text.contains(&self.think_end_token);
         let in_reasoning = self._in_reasoning || has_think_tag || has_dangling_end;
         if !in_reasoning {
             return ParserResult {
@@ -574,6 +578,15 @@ mod tests {
         let result = parser.detect_and_parse_reasoning("normal text</think> more normal", &[]);
         assert_eq!(result.normal_text, "more normal");
         assert_eq!(result.reasoning_text, "normal text");
+    }
+
+    #[test] // REASONING.batch.4 — Kimi Unicode delimiters keep stray closer as normal text.
+    fn test_kimi_unicode_stray_closing_tag_passes_through() {
+        let mut parser =
+            BasicReasoningParser::new("◁think▷".to_string(), "◁/think▷".to_string(), false, true);
+        let result = parser.detect_and_parse_reasoning("normal◁/think▷answer", &[]);
+        assert_eq!(result.normal_text, "normal◁/think▷answer");
+        assert_eq!(result.reasoning_text, "");
     }
 
     #[test] // REASONING.batch.4

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -105,7 +105,15 @@ impl ReasoningParser for BasicReasoningParser {
 
     fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
         let has_think_tag = text.contains(&self.think_start_token);
-        let in_reasoning = self._in_reasoning || has_think_tag;
+        // Dangling end marker without an opener: treat the prefix as reasoning.
+        // Models in this family normally emit `<think>...</think>final_answer`;
+        // when the opener is absent but a `</think>` is present, the natural
+        // reading is that the opener was implicit (chat template or tokenizer
+        // consumed it). Without this, the `</think>` markup leaks into
+        // normal_text. Matches vLLM's `partition()`-based behavior for the
+        // same input.
+        let has_dangling_end = !has_think_tag && text.contains(&self.think_end_token);
+        let in_reasoning = self._in_reasoning || has_think_tag || has_dangling_end;
         if !in_reasoning {
             return ParserResult {
                 normal_text: text.to_string(),
@@ -134,7 +142,10 @@ impl ReasoningParser for BasicReasoningParser {
         let mut reasoning_parts = Vec::new();
         let mut normal_parts = Vec::new();
         let mut cursor = 0;
-        let mut currently_reasoning = self._in_reasoning;
+        // Dangling-end case enters the loop already in reasoning so the prefix
+        // before `</think>` is captured (the loop's normal-text branch would
+        // otherwise treat it as plain text and re-leak the closer).
+        let mut currently_reasoning = self._in_reasoning || has_dangling_end;
 
         while cursor < text.len() {
             if currently_reasoning {
@@ -560,8 +571,8 @@ mod tests {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
         let result = parser.detect_and_parse_reasoning("normal text</think> more normal", &[]);
-        assert_eq!(result.normal_text, "normal text</think> more normal");
-        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "more normal");
+        assert_eq!(result.reasoning_text, "normal text");
     }
 
     #[test] // REASONING.batch.4

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -105,7 +105,8 @@ impl ReasoningParser for BasicReasoningParser {
 
     fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
         let has_think_tag = text.contains(&self.think_start_token);
-        // Dangling end marker without an opener: treat the prefix as reasoning.
+        // REASONING.batch.4: dangling end marker without an opener. Treat the
+        // prefix as reasoning.
         // Models in this family normally emit `<think>...</think>final_answer`;
         // when the opener is absent but a `</think>` is present, the natural
         // reading is that the opener was implicit (chat template or tokenizer

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -84,16 +84,14 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
-    dynamo_leak: true
     ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
-        reasoning_text: ''
-        normal_text: normal</think>answer
-      vllm:
         reasoning_text: normal
         normal_text: answer
+      vllm:
+        <<: *d_4
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'deepseek_v4'
   REASONING.batch.5:

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -76,16 +76,14 @@ cases:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
-    dynamo_leak: true
     ref: *upstream_ref
     model_text: normal</think>answer
     expected:
-      dynamo:
-        reasoning_text: ''
-        normal_text: normal</think>answer
-      vllm:
+      dynamo: &d_4
         reasoning_text: normal
         normal_text: answer
+      vllm:
+        <<: *d_4
       sglang:
         unavailable: SGLang peer not wired for Dynamo parser family 'nemotron_deci'
   REASONING.batch.5:

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -88,17 +88,18 @@ cases:
         reason: Dynamo keeps visible text outside a complete reasoning span as normal_text; SGLang folds the prefix into reasoning_text.
   REASONING.batch.4:
     description: Dangling end marker without an opening think tag
-    dynamo_leak: true
     ref: *upstream_ref
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
-        reasoning_text: ''
-        normal_text: normal</think>answer
-      vllm:
         reasoning_text: normal
         normal_text: answer
-      sglang: *d_4
+      vllm:
+        <<: *d_4
+      sglang:
+        reasoning_text: ''
+        normal_text: normal</think>answer
+        reason: Dynamo and vLLM treat a dangling end marker as an implicit reasoning close; SGLang keeps the marker in normal_text.
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
     ref: *upstream_ref


### PR DESCRIPTION
#### Overview:

This PR fixes `REASONING.batch.4` for shared `<think>` `BasicReasoningParser` families so `normal</think>answer` no longer leaks `</think>` into `normal_text`.

#### Details:

- **How is this fixed?** Treat `</think>` without a visible opener as an implicit reasoning close only for `<think>` / `</think>` parser families: `reasoning_text="normal"`, `normal_text="answer"`.
- Covers DIS-2132 for DeepSeek V4 and DIS-2137 for Qwen 3 Coder; GLM/Nemotron-Deci `REASONING.batch.4` flips too because it uses the same parser.
- Keeps Kimi Unicode `◁think▷` / `◁/think▷` behavior unchanged: stray `◁/think▷` remains normal text.
- Leaves the existing documented peer divergences unchanged: DeepSeek V4 `6.a`, Qwen `2.d`, and Qwen `6.a`.

#### Before / After Matrix:

```diff
 | model | case 4 before | case 4 after |
 |---|---:|---:|
-| DeepSeek V4 | ↯V? | |
+| DeepSeek V4 | | = |
-| GLM 5.1 | ↯V? | |
+| GLM 5.1 | | = |
-| Qwen 3 Coder | ↯V? | |
+| Qwen 3 Coder | | S |
-| Nemotron (DeciLM) | ↯V? | |
+| Nemotron (DeciLM) | | = |
```

#### Verification:

`cargo fmt`; `cargo test -p dynamo-parsers reasoning::base_parser` passed 51 tests; `python3 -m pytest tests/parity/reasoning/test_reasoning_fixture_schema.py -q` passed; after rebuilding `dynamo._core`, `python3 -m pytest tests/parity/reasoning/test_parity_reasoning.py -q -k "kimi or deepseek_v4 or qwen3 or nemotron_deci"` passed 162 tests with 123 skips.

#### Where should the reviewer start?

`lib/parsers/src/reasoning/base_parser.rs`

#### Related Issues:

Closes DIS-2132
Closes DIS-2137

/coderabbit profile chill