### PR TITLE
fix(snapshot): poll restore containers before pod running

### DIFF
--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -375,9 +375,11 @@ func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string 
 }
 
 func isRestorePodEligible(pod *corev1.Pod) bool {
-	return pod.DeletionTimestamp == nil &&
-		pod.Status.Phase != corev1.PodSucceeded &&
-		pod.Status.Phase != corev1.PodFailed
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	return pod.Status.Phase == corev1.PodPending ||
+		pod.Status.Phase == corev1.PodRunning
 }
 
 func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName string) (*corev1.Pod, bool) {
@@ -397,7 +399,7 @@ func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *cor
 		return nil, false
 	}
 	if !isRestorePodEligible(livePod) {
-		w.log.V(1).Info("Skipping restore; pod became terminal or deleting while polling runtime",
+		w.log.V(1).Info("Skipping restore; pod became ineligible while polling runtime",
 			"pod", podKey,
 			"container", containerName,
 			"phase", livePod.Status.Phase,

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
@@ -301,9 +302,7 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
-	if pod.DeletionTimestamp != nil ||
-		pod.Status.Phase == corev1.PodSucceeded ||
-		pod.Status.Phase == corev1.PodFailed {
+	if !isRestorePodEligible(pod) {
 		return
 	}
 
@@ -375,6 +374,39 @@ func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string 
 	return ""
 }
 
+func isRestorePodEligible(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp == nil &&
+		pod.Status.Phase != corev1.PodSucceeded &&
+		pod.Status.Phase != corev1.PodFailed
+}
+
+func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName string) (*corev1.Pod, bool) {
+	livePod, err := w.clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			w.log.V(1).Info("Skipping restore; pod disappeared while polling runtime",
+				"pod", podKey,
+				"container", containerName,
+			)
+			return nil, false
+		}
+		w.log.Error(err, "Failed to refresh restore pod state before starting restore",
+			"pod", podKey,
+			"container", containerName,
+		)
+		return nil, false
+	}
+	if !isRestorePodEligible(livePod) {
+		w.log.V(1).Info("Skipping restore; pod became terminal or deleting while polling runtime",
+			"pod", podKey,
+			"container", containerName,
+			"phase", livePod.Status.Phase,
+		)
+		return nil, false
+	}
+	return livePod, true
+}
+
 func (w *NodeController) pollForContainerID(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -391,12 +423,16 @@ func (w *NodeController) pollForContainerID(
 		containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
 		cancel()
 		if err == nil && containerID != "" {
+			livePod, ok := w.refreshRestorePodForStart(ctx, pod, podKey, containerName)
+			if !ok {
+				return
+			}
 			w.log.V(1).Info("Resolved restore container via node runtime",
 				"pod", podKey,
 				"container", containerName,
 				"container_id", containerID,
 			)
-			w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+			w.startRestoreForContainer(ctx, livePod, containerName, containerID, checkpointID, podKey)
 			return
 		}
 

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -301,7 +301,9 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
-	if pod.Status.Phase != corev1.PodRunning {
+	if pod.DeletionTimestamp != nil ||
+		pod.Status.Phase == corev1.PodSucceeded ||
+		pod.Status.Phase == corev1.PodFailed {
 		return
 	}
 

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -302,7 +302,8 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
-	if !isRestorePodEligible(pod) {
+	if pod.DeletionTimestamp != nil ||
+		(pod.Status.Phase != corev1.PodPending && pod.Status.Phase != corev1.PodRunning) {
 		return
 	}
 
@@ -374,14 +375,6 @@ func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string 
 	return ""
 }
 
-func isRestorePodEligible(pod *corev1.Pod) bool {
-	if pod.DeletionTimestamp != nil {
-		return false
-	}
-	return pod.Status.Phase == corev1.PodPending ||
-		pod.Status.Phase == corev1.PodRunning
-}
-
 func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName string) (*corev1.Pod, bool) {
 	livePod, err := w.clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
@@ -398,7 +391,8 @@ func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *cor
 		)
 		return nil, false
 	}
-	if !isRestorePodEligible(livePod) {
+	if livePod.DeletionTimestamp != nil ||
+		(livePod.Status.Phase != corev1.PodPending && livePod.Status.Phase != corev1.PodRunning) {
 		w.log.V(1).Info("Skipping restore; pod became ineligible while polling runtime",
 			"pod", podKey,
 			"container", containerName,

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -563,9 +563,27 @@ func TestReconcileRestorePod(t *testing.T) {
 			want:      false,
 		},
 		{
-			name:      "not running",
+			name:      "pending pod with status container id still restores",
 			nodeName:  testNodeName,
 			phase:     corev1.PodPending,
+			ready:     false,
+			hash:      "abc123",
+			createDir: true,
+			want:      true,
+		},
+		{
+			name:      "succeeded pod does not restore",
+			nodeName:  testNodeName,
+			phase:     corev1.PodSucceeded,
+			ready:     false,
+			hash:      "abc123",
+			createDir: true,
+			want:      false,
+		},
+		{
+			name:      "failed pod does not restore",
+			nodeName:  testNodeName,
+			phase:     corev1.PodFailed,
 			ready:     false,
 			hash:      "abc123",
 			createDir: true,
@@ -806,6 +824,40 @@ func TestReconcileRestorePodResolvesContainerBeforePodStatus(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("expected RestoreRequested event after node-runtime container resolution; actions=%#v", clientset.Actions())
+}
+
+func TestReconcileRestorePodPollsRuntimeBeforePodRunning(t *testing.T) {
+	labels := map[string]string{
+		snapshotprotocol.CheckpointIDLabel: "abc123",
+	}
+	w := makeTestController(t)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
+
+	pod := makePod("test-pod", "default", testNodeName, corev1.PodPending, false, labels, nil)
+	pod.Status.ContainerStatuses = nil
+	dir := filepath.Join(w.config.Storage.BasePath, "abc123", "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	w.reconcileRestorePod(context.Background(), pod)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		for _, action := range clientset.Actions() {
+			create, ok := action.(clientgotesting.CreateAction)
+			if !ok || create.GetResource().Resource != "events" {
+				continue
+			}
+			event, ok := create.GetObject().(*corev1.Event)
+			if ok && event.Reason == "RestoreRequested" {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected RestoreRequested event from runtime polling before PodRunning; actions=%#v", clientset.Actions())
 }
 
 func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -796,12 +796,12 @@ func TestReconcileRestorePodResolvesContainerBeforePodStatus(t *testing.T) {
 	labels := map[string]string{
 		snapshotprotocol.CheckpointIDLabel: "abc123",
 	}
-	w := makeTestController(t)
-	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
-	clientset := w.clientset.(*fake.Clientset)
 
 	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
 	pod.Status.ContainerStatuses = nil
+	w := makeTestController(t, pod)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
 	dir := filepath.Join(w.config.Storage.BasePath, "abc123", "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("failed to create checkpoint dir: %v", err)
@@ -830,12 +830,12 @@ func TestReconcileRestorePodPollsRuntimeBeforePodRunning(t *testing.T) {
 	labels := map[string]string{
 		snapshotprotocol.CheckpointIDLabel: "abc123",
 	}
-	w := makeTestController(t)
-	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
-	clientset := w.clientset.(*fake.Clientset)
 
 	pod := makePod("test-pod", "default", testNodeName, corev1.PodPending, false, labels, nil)
 	pod.Status.ContainerStatuses = nil
+	w := makeTestController(t, pod)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
 	dir := filepath.Join(w.config.Storage.BasePath, "abc123", "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("failed to create checkpoint dir: %v", err)
@@ -860,6 +860,43 @@ func TestReconcileRestorePodPollsRuntimeBeforePodRunning(t *testing.T) {
 	t.Fatalf("expected RestoreRequested event from runtime polling before PodRunning; actions=%#v", clientset.Actions())
 }
 
+func TestPollForContainerIDSkipsTerminalLivePod(t *testing.T) {
+	checkpointID := "abc123"
+	labels := map[string]string{
+		snapshotprotocol.CheckpointIDLabel: checkpointID,
+	}
+	stalePod := makePod("test-pod", "default", testNodeName, corev1.PodPending, false, labels, nil)
+	stalePod.Status.ContainerStatuses = nil
+	livePod := stalePod.DeepCopy()
+	livePod.Status.Phase = corev1.PodSucceeded
+
+	w := makeTestController(t, livePod)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
+	dir := filepath.Join(w.config.Storage.BasePath, checkpointID, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	resolveKey := "default/test-pod/main/resolve"
+	w.inFlight[resolveKey] = struct{}{}
+	w.pollForContainerID(context.Background(), stalePod, "main", checkpointID, "default/test-pod", resolveKey)
+
+	if _, held := w.inFlight[resolveKey]; held {
+		t.Fatal("expected resolver key to be released")
+	}
+	for _, action := range clientset.Actions() {
+		create, ok := action.(clientgotesting.CreateAction)
+		if !ok || create.GetResource().Resource != "events" {
+			continue
+		}
+		event, ok := create.GetObject().(*corev1.Event)
+		if ok && event.Reason == "RestoreRequested" {
+			t.Fatalf("stale resolver should not start restore for terminal live pod; actions=%#v", clientset.Actions())
+		}
+	}
+}
+
 func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {
 	checkpointID := "abc123"
 	labels := map[string]string{
@@ -868,7 +905,7 @@ func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {
 	stalePod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
 	stalePod.Status.ContainerStatuses = nil
 
-	w := makeTestController(t)
+	w := makeTestController(t, stalePod)
 	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
 	clientset := w.clientset.(*fake.Clientset)
 	dir := filepath.Join(w.config.Storage.BasePath, checkpointID, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -590,6 +590,15 @@ func TestReconcileRestorePod(t *testing.T) {
 			want:      false,
 		},
 		{
+			name:      "unknown pod does not restore",
+			nodeName:  testNodeName,
+			phase:     corev1.PodUnknown,
+			ready:     false,
+			hash:      "abc123",
+			createDir: true,
+			want:      false,
+		},
+		{
 			name:      "ready placeholder still restores",
 			nodeName:  testNodeName,
 			phase:     corev1.PodRunning,


### PR DESCRIPTION
## Description

Reduce snapshot restore trigger latency by allowing restore pods to enter the existing runtime container-ID polling path before Kubernetes marks the pod Running. The controller still skips deleting and terminal pods, requires the restore metadata, and only starts restore once the target container can be resolved.

This avoids waiting for kubelet PodStatus propagation when the target container exists in the node runtime before PodStatus has published ContainerID/Running.

## Testing

- `cd deploy/snapshot && go test ./internal/controller`\n- `cd deploy/snapshot && go test ./...`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pod restore operations by better handling pods in intermediate states and avoiding unnecessary processing of completed or terminating pods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->