### PR TITLE
fix: DeepSeek V4 tool call parser stream DSML finalize recovery

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -12,7 +12,7 @@ use dynamo_parsers::tool_calling::json::try_tool_call_parse_basic_json;
 use dynamo_parsers::tool_calling::parsers::get_tool_parser_map;
 use dynamo_parsers::tool_calling::{
     detect_tool_call_start, find_tool_call_end_position, try_tool_call_parse_aggregate,
-    try_tool_call_parse_aggregate_finalize,
+    try_tool_call_parse_aggregate_stream_finalize,
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
@@ -983,7 +983,7 @@ impl JailedStream {
                 // Traditional marker-based tool call parsing
                 let tools_slice = self.tool_definitions.as_deref();
                 let parse_result = if is_finalize {
-                    try_tool_call_parse_aggregate_finalize(
+                    try_tool_call_parse_aggregate_stream_finalize(
                         accumulated_content,
                         self.tool_call_parser.as_deref(),
                         tools_slice,

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1345,6 +1345,46 @@ mod tests {
         run_deepseek_v4_tool_call_fixture(&file_path).await;
     }
 
+    /// `PARSER.stream.4.a` — stream ends after a complete invoke but before
+    /// `</｜DSML｜tool_calls>`. Finalization should recover the complete invoke
+    /// without enabling early stream exit on unterminated DSML wrappers.
+    #[tokio::test]
+    async fn test_deepseek_v4_stream_finalize_recovers_complete_invoke_without_outer_close() {
+        let input_stream = stream::iter(vec![make_chunk(
+            "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>",
+            Some(FinishReason::Stop),
+        )]);
+
+        let output_chunks = parse_response_stream(
+            input_stream,
+            true,
+            false,
+            Some("deepseek_v4".to_string()),
+            None,
+        )
+        .await;
+
+        let aggregated = aggregate_content_from_chunks(&output_chunks);
+        assert_eq!(aggregated.normal_content, "");
+        assert!(aggregated.has_tool_calls);
+        assert_tool_calls(
+            &aggregated.tool_calls,
+            &[serde_json::json!({
+                "function": {
+                    "name": "get_weather",
+                    "arguments": "{\"location\":\"NYC\"}"
+                }
+            })],
+        );
+        assert!(
+            validate_finish_reason(&output_chunks, FinishReason::ToolCalls),
+            "finish_reason validation failed for finalized DSML tool call"
+        );
+    }
+
     // ---- Kimi K2 streaming jail reproduction tests ----
     //
     // These reproduce the customer-reported issue (DIS-1765): Kimi K2 agentic

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -155,6 +155,11 @@ pub struct DsmlParserConfig {
     pub parameter_prefix: String,
     /// End token for parameter (e.g., "</｜DSML｜parameter>")
     pub parameter_end: String,
+
+    /// See [`JsonParserConfig::allow_eof_recovery`]. Streaming jails MUST
+    /// leave this `false`.
+    #[serde(default)]
+    pub allow_eof_recovery: bool,
 }
 
 impl Default for DsmlParserConfig {
@@ -166,6 +171,7 @@ impl Default for DsmlParserConfig {
             invoke_end: "</｜DSML｜invoke>".to_string(),
             parameter_prefix: "<｜DSML｜parameter name=".to_string(),
             parameter_end: "</｜DSML｜parameter>".to_string(),
+            allow_eof_recovery: false,
         }
     }
 }

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -56,21 +56,6 @@ pub fn find_tool_call_end_position_dsml(chunk: &str, config: &DsmlParserConfig) 
     }
 }
 
-/// Build the regex that matches a complete DSML tool_calls / function_calls block.
-/// Shared by `extract_tool_calls_with_regex` and `try_tool_call_parse_dsml` so
-/// the two stay in lockstep on how a block is recognised.
-fn build_block_regex(config: &DsmlParserConfig) -> anyhow::Result<Regex> {
-    // Matches: <｜DSML｜function_calls> ... </｜DSML｜function_calls>
-    // Pattern: (?s) = dot matches newlines
-    //          \s*(.*?)\s* = capture content between start/end tags (non-greedy)
-    let block_pattern = format!(
-        r"(?s){}\s*(.*?)\s*{}",
-        regex::escape(&config.block_start),
-        regex::escape(&config.block_end)
-    );
-    Ok(Regex::new(&block_pattern)?)
-}
-
 /// Parse DSML formatted tool calls from a message.
 ///
 /// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
@@ -101,9 +86,9 @@ pub fn try_tool_call_parse_dsml(
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
-    // Extract tool calls blocks
-    let block_regex = build_block_regex(config)?;
-    let tool_calls = extract_tool_calls_with_regex(trimmed, &block_regex, config)?;
+    // Extract tool calls blocks. Finalize paths can opt into EOF recovery so
+    // a missing outer block end still yields any complete inner invokes.
+    let tool_calls = extract_tool_calls(trimmed, config)?;
 
     // Whether or not invokes parsed, normal_text is the prefix before the
     // first block_start — mirrors vLLM's success path. On no-invokes the
@@ -155,22 +140,37 @@ pub fn try_tool_call_parse_dsml(
     Ok((tool_calls, Some(pre_block_text)))
 }
 
-/// Extract all tool calls matched by `block_regex` from the DSML formatted text.
-fn extract_tool_calls_with_regex(
+/// Extract all tool calls from DSML formatted text.
+fn extract_tool_calls(
     text: &str,
-    block_regex: &Regex,
     config: &DsmlParserConfig,
 ) -> anyhow::Result<Vec<ToolCallResponse>> {
     let mut tool_calls = Vec::new();
+    let mut cursor = 0;
 
-    for block_match in block_regex.captures_iter(text) {
-        if let Some(block_content) = block_match.get(1) {
-            let block = block_content.as_str();
+    while cursor < text.len() {
+        let Some(rel_start) = text[cursor..].find(config.block_start.as_str()) else {
+            break;
+        };
+        let block_content_start = cursor + rel_start + config.block_start.len();
+        let after_start = &text[block_content_start..];
 
-            // Extract individual invokes from this block
-            let invokes = extract_invokes(block, config)?;
-            tool_calls.extend(invokes);
-        }
+        let (block, next_cursor) =
+            if let Some(rel_end) = after_start.find(config.block_end.as_str()) {
+                (
+                    &after_start[..rel_end],
+                    block_content_start + rel_end + config.block_end.len(),
+                )
+            } else if config.allow_eof_recovery {
+                (&text[block_content_start..], text.len())
+            } else {
+                break;
+            };
+
+        let invokes = extract_invokes(block, config)?;
+        tool_calls.extend(invokes);
+
+        cursor = next_cursor;
     }
 
     Ok(tool_calls)
@@ -290,6 +290,13 @@ mod tests {
         }
     }
 
+    fn get_v4_recovery_test_config() -> DsmlParserConfig {
+        DsmlParserConfig {
+            allow_eof_recovery: true,
+            ..get_v4_test_config()
+        }
+    }
+
     #[test] // helper
     fn test_detect_tool_call_start() {
         let config = get_test_config();
@@ -353,6 +360,15 @@ mod tests {
     //                  string="true|false" type hints, so XML entity decoding
     //                  and schema-aware coercion don't apply.
     //   - TOOLCALLING.harmony.1 / TOOLCALLING.harmony.2 N/A — Harmony-only.
+    //
+    // EOF recovery:
+    //   - TOOLCALLING.stream.4.a  Stream finalization sets
+    //             `allow_eof_recovery=true` and recovers complete
+    //             <｜DSML｜invoke>...</｜DSML｜invoke> pairs even when the
+    //             outer close fence is absent at EOS. Streaming early-exit and
+    //             batch/non-streaming aggregate paths keep recovery disabled so
+    //             they do not claim DSML calls before `</｜DSML｜tool_calls>`
+    //             actually arrives.
     //
     // TODO — bugs pinned, parser still needs to be fixed:
     //   - TOOLCALLING.batch.5  BUG: parser drops all calls when </｜DSML｜tool_calls> is
@@ -898,27 +914,14 @@ mod tests {
     // full mapping from TOOLCALLING.* → test. Each test's doc-comment names the
     // specific CASE it pins.
 
-    /// `TOOLCALLING.batch.5` — missing end-token recovery.
-    /// **Pinned as broken** — parser drops the call; see the TODO block above.
+    /// `TOOLCALLING.batch.5` — missing end-token, streaming-safe path.
     ///
-    /// If a DeepSeek V4 stream is truncated before `</｜DSML｜tool_calls>`
-    /// arrives (max_tokens cut-off, EOS mid-generation, connection drop),
-    /// the block regex requires both fences and matches zero times. The
-    /// entire DSML-looking payload falls through as raw `normal_text`; no
-    /// tool calls are recovered.
-    ///
-    /// This is the same structural failure mode Kimi K2 had before its
-    /// parser gained end-token recovery; see
-    /// `kimi_k2_parser.rs::test_parse_malformed_no_section_end` for the
-    /// post-fix recovery pattern.
-    ///
-    /// Note: post-hardening, the parser no longer leaks raw DSML markup
-    /// into `normal_text` when block-start appears but no invokes parse —
-    /// it returns the pre-block text only (empty here, since the input
-    /// starts with the block-start fence). The call is still dropped.
+    /// Without EOF recovery, the parser must not claim a complete tool call
+    /// before `</｜DSML｜tool_calls>` arrives. Streaming early-exit uses this
+    /// path and keeps buffering until stream finalization.
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml.
     #[test] // TOOLCALLING.batch.5, TOOLCALLING.fmt.3 — V4 variant
-    fn test_parse_deepseek_v4_missing_end_token() {
+    fn test_parse_deepseek_v4_missing_end_token_without_recovery() {
         // Start fence + complete invoke, but no </｜DSML｜tool_calls>.
         let input = "<｜DSML｜tool_calls>\n\
 <｜DSML｜invoke name=\"get_weather\">\n\
@@ -930,9 +933,8 @@ mod tests {
 
         assert!(
             calls.is_empty(),
-            "V4 DSML parser currently drops tool calls when \
-             </｜DSML｜tool_calls> is missing. \
-             If recovery is added, flip this assertion."
+            "Streaming-safe DSML parser must wait for </｜DSML｜tool_calls> \
+             instead of recovering early."
         );
         assert_eq!(
             normal_text.as_deref(),
@@ -967,6 +969,51 @@ mod tests {
             "Even two fully-formed invokes are dropped when the outer \
              </｜DSML｜tool_calls> is missing."
         );
+    }
+
+    /// `TOOLCALLING.stream.4.a` — missing end-token recovery at stream finalize.
+    ///
+    /// Stream finalization flips `allow_eof_recovery=true`, treating an
+    /// unterminated outer block as extending to EOF and recovering complete
+    /// inner invokes. Batch/non-streaming aggregate parsing remains strict.
+    #[test] // TOOLCALLING.stream.4.a — V4 variant
+    fn test_parse_deepseek_v4_missing_end_token_with_recovery() {
+        let input = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"city\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>";
+
+        let config = get_v4_recovery_test_config();
+        let (calls, normal_text) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(normal_text.as_deref(), Some(""));
+        let (name, args) = extract_name_and_args(calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["city"], "NYC");
+    }
+
+    /// Stream-finalize recovery with multiple complete invokes and no outer end fence.
+    #[test]
+    fn test_parse_deepseek_v4_missing_end_token_multiple_calls_with_recovery() {
+        let input = "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"a\">\n\
+<｜DSML｜parameter name=\"x\" string=\"true\">1</｜DSML｜parameter>\n\
+</｜DSML｜invoke>\n\
+<｜DSML｜invoke name=\"b\">\n\
+<｜DSML｜parameter name=\"y\" string=\"true\">2</｜DSML｜parameter>\n\
+</｜DSML｜invoke>";
+
+        let config = get_v4_recovery_test_config();
+        let (calls, _) = try_tool_call_parse_dsml(input, &config).unwrap();
+
+        assert_eq!(calls.len(), 2);
+        let (name1, args1) = extract_name_and_args(calls[0].clone());
+        let (name2, args2) = extract_name_and_args(calls[1].clone());
+        assert_eq!(name1, "a");
+        assert_eq!(args1["x"], "1");
+        assert_eq!(name2, "b");
+        assert_eq!(args2["y"], "2");
     }
 
     /// `TOOLCALLING.batch.4` — malformed JSON in a `string="false"` parameter value falls back

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -41,7 +41,7 @@ pub use response::{
 };
 pub use tools::{
     try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
-    try_tool_call_parse_stream,
+    try_tool_call_parse_aggregate_stream_finalize, try_tool_call_parse_stream,
 };
 pub use xml::try_tool_call_parse_kimi_k2;
 pub use xml::try_tool_call_parse_xml;

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -116,8 +116,8 @@ pub async fn try_tool_call_parse(
 }
 
 /// Same as [`detect_and_parse_tool_call`] but flips `allow_eof_recovery=true`
-/// on the JSON / XML / GLM-4.7 configs so finalize / non-streaming aggregate
-/// paths recover from missing-end-token / truncated-JSON instead of silently
+/// on the JSON / XML configs so finalize / non-streaming aggregate paths
+/// recover from missing-end-token / truncated-JSON instead of silently
 /// dropping the call. Streaming jails MUST keep using the non-recovery
 /// variant — otherwise `should_exit_jail_early` fires before the end-token
 /// has actually arrived (see jail.rs).
@@ -125,6 +125,29 @@ pub async fn detect_and_parse_tool_call_with_recovery(
     message: &str,
     parser_str: Option<&str>,
     tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, false).await
+}
+
+/// Stream-end finalize variant of [`detect_and_parse_tool_call_with_recovery`].
+///
+/// DeepSeek V4's vLLM streaming parser emits a tool call once a complete
+/// `<｜DSML｜invoke>...</｜DSML｜invoke>` arrives, even if the outer
+/// `</｜DSML｜tool_calls>` wrapper never appears before EOS. Keep that recovery
+/// scoped to stream finalization so batch/non-streaming parity remains strict.
+pub async fn detect_and_parse_tool_call_with_stream_finalize_recovery(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    detect_and_parse_tool_call_with_recovery_options(message, parser_str, tools, true).await
+}
+
+async fn detect_and_parse_tool_call_with_recovery_options(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+    recover_dsml_eof: bool,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let parser_map = get_tool_parser_map();
     let parser_key = match parser_str {
@@ -152,6 +175,11 @@ pub async fn detect_and_parse_tool_call_with_recovery(
                 c.allow_eof_recovery = true;
             }
             ParserConfig::Xml(c)
+        }
+        ParserConfig::Dsml(c) if recover_dsml_eof => {
+            let mut c = c.clone();
+            c.allow_eof_recovery = true;
+            ParserConfig::Dsml(c)
         }
         // GLM-4.7 intentionally omitted: match upstream vLLM/SGLang behavior
         // (drop the call when </tool_call> is missing).
@@ -1881,6 +1909,46 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
         assert_eq!(args["timezone"], "Asia/Shanghai");
     }
+    #[tokio::test]
+    async fn test_deepseek_v4_common_recovery_stays_strict_without_outer_close() {
+        let input = r#"<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_datetime">
+<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
+</｜DSML｜invoke>"#;
+
+        let (tool_calls, normal_text) =
+            detect_and_parse_tool_call_with_recovery(input, Some("deepseek_v4"), None)
+                .await
+                .expect("Failed to parse");
+
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal_text, Some("".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_v4_stream_finalize_recovery_recovers_without_outer_close() {
+        let input = r#"<｜DSML｜tool_calls>
+<｜DSML｜invoke name="get_datetime">
+<｜DSML｜parameter name="timezone" string="true">Asia/Shanghai</｜DSML｜parameter>
+</｜DSML｜invoke>"#;
+
+        let (tool_calls, normal_text) = detect_and_parse_tool_call_with_stream_finalize_recovery(
+            input,
+            Some("deepseek_v4"),
+            None,
+        )
+        .await
+        .expect("Failed to parse");
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_datetime");
+        assert_eq!(normal_text, Some("".to_string()));
+
+        let args: serde_json::Value =
+            serde_json::from_str(&tool_calls[0].function.arguments).unwrap();
+        assert_eq!(args["timezone"], "Asia/Shanghai");
+    }
+
     /// Alias registration: verifies `deepseek-v4` and `deepseekv4` route to the same parser as `deepseek_v4`. Not a TOOLCALLING.*; covers registry plumbing.
     #[tokio::test]
     async fn test_deepseek_v4_compatibility_aliases() {

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use super::config::ToolCallConfig;
-pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
+pub use super::parsers::{
+    detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery,
+    detect_and_parse_tool_call_with_stream_finalize_recovery,
+};
 pub use super::response::{
     CalledFunctionStream, ToolCallResponse, ToolCallResponseChunk, ToolCallType,
 };
@@ -34,9 +37,11 @@ pub async fn try_tool_call_parse_aggregate(
 }
 
 /// Finalize-only variant of [`try_tool_call_parse_aggregate`] that enables
-/// EOF recovery (missing outer end-token, truncated JSON args). Use this from
-/// stream-end / non-streaming aggregator paths only — never from streaming
-/// jail early-exit logic.
+/// the common EOF recovery paths (missing outer end-token, truncated JSON args).
+/// Use this from non-streaming aggregator paths — never from streaming jail
+/// early-exit logic. Stream-end jail finalization uses
+/// [`try_tool_call_parse_aggregate_stream_finalize`] so DSML can salvage
+/// completed invokes without changing batch/non-streaming behavior.
 pub async fn try_tool_call_parse_aggregate_finalize(
     message: &str,
     parser_str: Option<&str>,
@@ -44,6 +49,25 @@ pub async fn try_tool_call_parse_aggregate_finalize(
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let (parsed, content) =
         detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await?;
+    if parsed.is_empty() {
+        return Ok((vec![], content));
+    }
+    Ok((parsed, content))
+}
+
+/// Stream-end variant of [`try_tool_call_parse_aggregate_finalize`].
+///
+/// It keeps the normal finalize recovery for JSON/XML and additionally lets
+/// DSML recover complete invokes from an unterminated outer wrapper. This is
+/// intentionally not used by batch/non-streaming aggregate paths.
+pub async fn try_tool_call_parse_aggregate_stream_finalize(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[super::ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    let (parsed, content) =
+        detect_and_parse_tool_call_with_stream_finalize_recovery(message, parser_str, tools)
+            .await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.stream.4.yaml
@@ -24,21 +24,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      sglang:
+      dynamo: &d_4_a
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
+      sglang: *d_4_a
+      vllm: *d_4_a
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from TOOLCALLING.batch.5.c

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.stream.4.yaml
@@ -24,17 +24,15 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      sglang:
-        unavailable: SGLang has no detector for family='deepseek_v4'
-      vllm:
+      dynamo: &d_4_a
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *d_4_a
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from TOOLCALLING.batch.5.c


### PR DESCRIPTION
## Summary

Fix DeepSeek V4 tool-calling stream parity for `TOOLCALLING.stream.4.a`.

When a stream ends after a complete DSML `<｜DSML｜invoke>...</｜DSML｜invoke>` but before the outer `</｜DSML｜tool_calls>` wrapper, Dynamo previously kept buffering until stream end and then dropped the completed call because the DSML parser required the outer wrapper to close.

This PR keeps streaming early-exit strict, but adds a stream-finalize-only recovery path that can salvage complete DSML invokes from an unterminated outer wrapper. Batch/non-streaming aggregate parsing remains strict, so `TOOLCALLING.batch.5` is intentionally unchanged for this PR.

## Changes

- Add `allow_eof_recovery` to `DsmlParserConfig`.
- Add a stream-finalize recovery parser path that enables DSML EOF recovery only for stream finalization.
- Update the jail finalization path to use that stream-specific recovery helper.
- Teach the DSML parser to scan blocks so EOF can act as the outer block end only when recovery is enabled.
- Update `TOOLCALLING.stream.4.a` expectations and add Rust coverage for the stream-finalize case.

## Validation

- `cargo fmt`
- `cargo test -p dynamo-parsers deepseek_v4 -- --nocapture`
- `cargo test -p dynamo-llm --test test_streaming_tool_parsers test_deepseek_v4_stream_finalize_recovers_complete_invoke_without_outer_close -- --nocapture`
- `git diff --check origin/main...HEAD`
- `python3 tests/parity/generate_parity_table.py toolcalling --mode stream | rg "DeepSeek V4"` -> `| DeepSeek V4 | dsml -> deepseek_v4§ | = | = | = | = | = | = |`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stream-finalization-aware tool call parsing to reliably extract tool calls even when streams end before proper closing markers.
  * Introduced configurable end-of-file recovery for tool-call extraction.

* **Bug Fixes**
  * Improved handling of incomplete tool-call blocks in streaming scenarios.

* **Tests**
  * Added test coverage for stream finalization and EOF recovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->