### PR TITLE
ci(rust-gpu): run cargo from checked-out source, not baked /workspace

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -127,7 +127,11 @@ jobs:
           echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}" >> "$GITHUB_ENV"
 
       - name: Run Rust checks (block-manager + media-ffmpeg + integration tests)
-        working-directory: /workspace/lib/llm
+        # Run from the checked-out source (owned by the runner uid) rather than
+        # /workspace (baked as dynamo:0 mode 0775). The ARC pod runs as uid 1001
+        # with non-zero gid, so it falls into "other" perms on the baked tree and
+        # cargo cannot rewrite Cargo.lock when resolve mutates it.
+        working-directory: lib/llm
         env:
           SCCACHE_BUCKET: ${{ secrets.SCCACHE_S3_BUCKET }}
           SCCACHE_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -114,6 +114,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
+          # `cargo test` reads LFS-managed fixtures under lib/llm/tests/data/media via
+          # include_bytes!; without lfs:true the checkout has 132-byte pointer files and
+          # the image-decoder tests panic with "image format could not be determined".
+          lfs: true
       - name: Select cargo target dir (prefer NVMe scratch)
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

`dynamo-runtime / rust-gpu` has failed every **nightly** in ~54s since 2026-05-16 with:

```
error: failed to write /workspace/Cargo.lock
Caused by: failed to open: /workspace/Cargo.lock
Caused by: Permission denied (os error 13)
```

(example: [run 26465271837 job 77927069977](https://github.com/ai-dynamo/dynamo/actions/runs/26465271837/job/77927069977))

The same job also runs in **post-merge** (unconditional) and **PRs** (gated by `changed-files`); post-merge mostly passes (~1/15 recent failures) and PRs rarely activate it. The latent bug exists in all three — nightly just trips it deterministically, see "Why nightly hits this every time" below.

#9550 moved the job off DinD — where it ran as `--user root` — onto a native ARC container job. The image bakes the source at `/workspace` as `dynamo:0` mode `0775` (group 0 for OpenShift compatibility), but the ARC pod runs as uid 1001 with a non-zero gid, so the runner falls into "other" perms (read-only). When cargo's resolve mutates `Cargo.lock`, the rewrite fails. When resolve doesn't mutate it, the run passes.

#9550 anticipated the uid mismatch and added `HOME`/`USER` env overrides for the gitconfig and `getpwuid` symptoms — it just missed the cargo lockfile write path.

This PR makes two changes:
1. **Point `working-directory` at the checked-out source** (`lib/llm` instead of `/workspace/lib/llm`) — `$GITHUB_WORKSPACE` is owned by the runner uid, so cargo's lockfile path is always writable.
2. **Set `lfs: true` on the checkout step** — `lib/llm/tests/data/media/` contains 1 LFS-managed PNG and 5 LFS-managed MP4s; without LFS the checkout has 132-byte pointer files and the image-decoder tests panic with "image format could not be determined". `shared-build-image.yml` already does this when baking `/workspace`, which is why these tests passed before the working-directory switch.

Cargo still discovers the workspace root via upward traversal, the image's native libs (NIXL, ffmpeg, CUDA) and venv stay reachable via their absolute paths, and `use-sccache.sh` keeps its `/workspace/container/...` invocation since that script is still baked.

`mypy` uses `/workspace` too but only reads files, so it's untouched.

## Why nightly hits this every time

Nightly passes `fresh_builder: true`, `no_cache: true`, and `image_tag_suffix: -nightly` to `dynamo-pipeline.yml`, so it pulls a freshly-built `...-nightly-test` image with no buildkit cache. The wheel_builder stage produces a `Cargo.lock` that ends up baked at `/workspace/Cargo.lock`, and apparently differs slightly from the source-tree lockfile — enough that the test-time `cargo clippy/test` invocation (with `block-manager,media-ffmpeg,testing-nixl,integration` features) mutates the lock and tries to write. Post-merge reuses cache layers and usually bakes a lockfile that matches source, so resolve is idempotent and never writes.

After this PR, cargo writes go to the checkout copy regardless of which lockfile the image was baked with.

## Reproduction

Reproduced end-to-end against `27d5cc9c4b...-dynamo-runtime-cuda12` on a GPU box:

| Check | Result |
| --- | --- |
| Default uid 1000 inside image: `/workspace/Cargo.lock` is `dynamo:0` mode `0775` | ✅ matches Dockerfile |
| `--user 1001:1001`: write `/workspace/Cargo.lock` | ❌ `Permission denied` (CI failure) |
| `--user 1001:1001`: cargo from `/__w/dynamo/dynamo/lib/llm` resolves workspace at `/__w/dynamo/dynamo/Cargo.toml` | ✅ |
| `--user 1001:1001`: write `/__w/dynamo/dynamo/Cargo.lock` | ✅ |

## Test plan

- [ ] Verify the PR run's `dynamo-runtime / rust-gpu` job completes (lockfile write path + LFS-backed media tests both pass)
- [ ] Verify the next scheduled nightly's `dynamo-runtime / rust-gpu` job completes
- [ ] Confirm cargo resolves the same workspace members and feature set as before (clippy/test commands unchanged)
- [ ] Make sure sccache stats still report (script invocation paths unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)