### PR TITLE
docs: correct TRT-LLM FPM availability and KV-transfer success metric side (#9882)

### DIFF
--- a/docs/backends/trtllm/trtllm-observability.md
+++ b/docs/backends/trtllm/trtllm-observability.md
@@ -156,7 +156,7 @@ Metric name constants are defined in `lib/runtime/src/metrics/prometheus_names.r
 
 These metrics are only recorded in disaggregated (prefill + decode) deployments when a KV cache transfer actually occurs. They are sourced from TensorRT-LLM's `RequestPerfMetrics.timing_metrics`.
 
-- `trtllm_kv_transfer_success_total` (Counter) — Total number of successful KV cache transfers (recorded on prefill side)
+- `trtllm_kv_transfer_success_total` (Counter) — Total number of successful KV cache transfers (recorded on the decode worker, when it observes non-zero KV-transfer timing in `RequestPerfMetrics.timing_metrics`). Grows in lock-step with the `_count` of the sibling `trtllm_kv_transfer_latency_seconds` / `trtllm_kv_transfer_bytes` / `trtllm_kv_transfer_speed_gb_s` histograms for the same transfer events.
   - Labels: `model_name`, `disaggregation_mode`, `engine_type`
 - `trtllm_kv_transfer_latency_seconds` (Histogram) — KV cache transfer latency per request in seconds
   - Labels: `model_name`, `disaggregation_mode`, `engine_type`

--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -126,7 +126,11 @@ See [Planner Guide](planner-guide.md) for the full workflow.
 
 Load-based scaling has the following known limitations. Throughput-based scaling is not affected by any of these.
 
-**Requires ForwardPassMetrics (FPM).** Load-based scaling uses per-engine per-iteration metrics delivered via the Dynamo event plane (ForwardPassMetrics). FPM is currently only available for vllm and is automatically enabled when the engine uses `InstrumentedScheduler` and `DYN_FORWARDPASS_METRIC_PORT` is set. The KV Router is **not** required for load-based scaling.
+**Requires ForwardPassMetrics (FPM).** Load-based scaling uses per-engine per-iteration metrics delivered via the Dynamo event plane (ForwardPassMetrics). The KV Router is **not** required for load-based scaling. FPM availability by backend:
+
+- **vLLM** — supported. Automatically enabled when the engine uses `InstrumentedScheduler` and `DYN_FORWARDPASS_METRIC_PORT` is set.
+- **TensorRT-LLM** — supported for non-attention-DP workers (`attention_dp_size == 1`); gated off when `attention_dp_size > 1` pending per-rank FPM emission.
+- **SGLang** — pipeline wired in Dynamo, but the upstream SGLang FPM module is not included in the current 1.2.0 SGLang runtime image. See the [SGLang FPM section](../../backends/sglang/sglang-observability.md#forward-pass-metrics-fpm) for the runtime-image prerequisite.
 
 ### General
 

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -313,7 +313,7 @@ backend explicitly in these cases:
 | MoE models (DeepSeek-R1, Qwen3-MoE) | `sglang` (full MoE support) |
 | Using `searchStrategy: thorough` | Any except `auto` (required) |
 | TensorRT-LLM compilation caching | `trtllm` (add a compilation cache PVC) |
-| Need load-based planner scaling (FPM) | `vllm` (only backend with ForwardPassMetrics) |
+| Need load-based planner scaling (FPM) | `vllm` (any config) or `trtllm` (non-attention-DP only). SGLang FPM is wired in Dynamo but the upstream module is not in the 1.2.0 runtime image. |
 
 > [!WARNING]
 > TensorRT-LLM does not support Python 3.11. If your environment uses


### PR DESCRIPTION
## Summary
- Cherry-pick of #9882 to release/1.2.0
- Corrects TRT-LLM observability docs: FPM availability matrix and KV-transfer success metric side

Fixes DYN-3091
Fixes https://nvbugs/6204453

## Original PR
- Main PR: #9882
- Merge commit: 4b859ffafffa84b5d5c7e4e5eef39cf8f58523db

## Test plan
- [ ] CI passes
- [ ] Docs render correctly
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->