### PR TITLE
docs(sglang): note SGLang FPM is unavailable in the 1.2.0 runtime image (#9883)

### DIFF
--- a/docs/backends/sglang/sglang-observability.md
+++ b/docs/backends/sglang/sglang-observability.md
@@ -113,6 +113,8 @@ For the complete and authoritative list of all SGLang metrics, see the [official
 
 ## Forward Pass Metrics (FPM)
 
+> **Availability in the 1.2.0 SGLang runtime.** The published `sglang-runtime:1.2.0` image does not yet include the upstream `sglang.srt.observability.forward_pass_metrics` module or the corresponding `ServerArgs` fields (`enable_forward_pass_metrics`, `forward_pass_metrics_worker_id`, `forward_pass_metrics_ipc_name`). Setting `DYN_FORWARDPASS_METRIC_PORT` starts the Dynamo-side relay successfully and the worker continues to serve requests, but no SGLang-side FPM payloads are emitted to the NATS event plane. **The pipeline and schema below describe the intended architecture and will become functional once the upstream SGLang FPM module is included in a future SGLang runtime image.** For load-based Planner scaling on 1.2.0, use a vLLM or TensorRT-LLM (non-attention-DP) backend; see the [Planner FPM support matrix](../../components/planner/README.md#load-based-scaling).
+
 Forward Pass Metrics provide **per-iteration scheduler telemetry** pushed over ZMQ, giving the [Planner](../../components/planner/README.md) real-time visibility into batch composition, queue depth, and GPU forward pass duration. Unlike Prometheus metrics (which are scraped asynchronously and reflect only the latest gauge value), FPM emits a structured message after every scheduler iteration with the exact batch state.
 
 ### Pipeline

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -471,5 +471,5 @@ For the full list of metrics, configuration options, and architecture details, s
 - [Distributed Runtime Architecture](../design-docs/distributed-runtime.md)
 - [Dynamo Architecture Overview](../design-docs/architecture.md)
 - [Backend Guide](../development/backend-guide.md)
-- [Forward Pass Metrics (SGLang)](../backends/sglang/sglang-observability.md#forward-pass-metrics-fpm) - Per-iteration scheduler telemetry via ZMQ/NATS for planner-driven scaling
+- [Forward Pass Metrics (SGLang)](../backends/sglang/sglang-observability.md#forward-pass-metrics-fpm) — Per-iteration scheduler telemetry via ZMQ/NATS for planner-driven scaling (intended architecture; not available in the 1.2.0 SGLang runtime image)
 - [Forward Pass Metrics RFC](../proposals/vllm-rfc-forward-pass-metrics.md) - Design rationale for per-iteration metrics


### PR DESCRIPTION
## Summary
- Cherry-pick of #9883 to release/1.2.0
- Adds availability note to SGLang FPM section: pipeline is wired but upstream SGLang FPM module is not in the 1.2.0 runtime image

Fixes DYN-3094
Fixes https://nvbugs/6204779

## Original PR
- Main PR: #9883
- Merge commit: 7ae2c7ce2051d3d1e666042946310a6f78177caf

## Test plan
- [ ] CI passes
- [ ] Docs render correctly
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->