### PR TITLE
docs(sglang-hicache): correct --shared-cache-multiplier default to 0.5 (#9933)

### DIFF
--- a/docs/integrations/sglang-hicache.md
+++ b/docs/integrations/sglang-hicache.md
@@ -177,7 +177,7 @@ python -m dynamo.frontend \
 | Flag                        | Env var                       | Default | Description                                                                                                                                                       |
 | --------------------------- | ----------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--shared-cache-type`       | `DYN_SHARED_CACHE_TYPE`       | `none`  | `none` disables shared-pool lookups; `hicache` enables Mooncake queries.                                                                                          |
-| `--shared-cache-multiplier` | `DYN_SHARED_CACHE_MULTIPLIER` | `0.0`   | Discount factor for shared-pool hits. `0.0` queries but ignores them; `0.5` treats a shared hit as half a device hit; `1.0` treats shared and device hits equally. |
+| `--shared-cache-multiplier` | `DYN_SHARED_CACHE_MULTIPLIER` | `0.5`   | Discount factor for shared-pool hits. `0.0` queries but ignores them; `0.5` treats a shared hit as half a device hit; `1.0` treats shared and device hits equally. |
 
 Per-request overrides are available via `RouterConfigOverride.shared_cache_multiplier` for A/B experimentation without restarting the router.
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #9933 to release/1.2.0
- Corrects \`--shared-cache-multiplier\` default in sglang-hicache docs (0.0 → 0.5)

Note: Resolved a path conflict — release/1.2.0 still has the file at \`docs/integrations/sglang-hicache.md\` (main moved it to \`docs/backends/sglang/\`). Only the value change was applied to the release-branch path.

Fixes DYN-3101
Fixes https://nvbugs/6204789

## Original PR
- Main PR: #9933
- Merge commit: c77b3da0ebb45c081b2b5c96b4413387df6e02c6

## Test plan
- [ ] CI passes
- [ ] Docs render correctly
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9989" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->