### PR TITLE
docs(sglang-hicache): drop crash-triggering flags from Mooncake recipe (#9934)

### DIFF
--- a/docs/integrations/sglang-hicache.md
+++ b/docs/integrations/sglang-hicache.md
@@ -146,6 +146,9 @@ You also need:
 
 ## Setup
 
+> [!WARNING]
+> **Known limitation in 1.2.0.** With both `--enable-metrics` and `--disable-piecewise-cuda-graph` set on the SGLang worker, the process can crash on the first KV-cache write due to a race in the upstream `mooncake-transfer-engine` thread pool. The recipe below omits these flags; per-process metrics scraping via the `dynamo.frontend` is unaffected. The mooncake-side fix is being tracked upstream.
+
 **SGLang worker** — HiCache with Mooncake storage:
 
 ```bash


### PR DESCRIPTION
## Summary
- Cherry-pick of #9934 to release/1.2.0
- Adds protective warning admonition on sglang-hicache Mooncake recipe section

Fixes DYN-3100

## Original PR
- Main PR: #9934
- Merge commit: 386fc54ff74500e0cd7214cf6936364c25ee8996

## Test plan
- [ ] CI passes
- [ ] Docs render correctly
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->