### PR TITLE
fix(kv-router): repair DP-rank sticky routing [DYN-3175]

### DIFF
--- a/lib/llm/src/kv_router/agent_controller.rs
+++ b/lib/llm/src/kv_router/agent_controller.rs
@@ -69,6 +69,20 @@ impl SessionCloseAction {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionLifecycleOutcome {
+    NoSessionControl,
+    NoAction,
+    OpenSucceeded,
+    NoSessionControlEndpoint,
+    CloseRequested,
+}
+
+pub struct AgentRouteOutcome {
+    pub lifecycle: SessionLifecycleOutcome,
+    pub deferred_close: Option<SessionCloseAction>,
+}
+
 /// Session lifecycle controller.
 ///
 /// Owns a lazy event plane client for the `session_control` endpoint
@@ -114,33 +128,33 @@ impl AgentController {
         });
     }
 
-    /// Called after worker selection. Fires open_session if needed,
-    /// returns a deferred close action for RequestGuard::finish().
-    ///
-    /// Also manages sticky session bindings: Open inserts affinity,
-    /// Close removes it.
-    ///
-    /// Returns `Ok(None)` if session control is unavailable or no action
-    /// is needed. The request proceeds normally without session isolation.
+    /// Called after worker selection. Fires open_session if needed and returns
+    /// a deferred close action for RequestGuard::finish().
     pub async fn on_routed(
         &self,
         request: &crate::preprocessor::PreprocessedRequest,
         instance_id: u64,
         context_id: &str,
         sticky: Option<&StickySessionRouter>,
-    ) -> Result<Option<SessionCloseAction>> {
+    ) -> Result<AgentRouteOutcome> {
         let sc = request
             .routing
             .as_ref()
             .and_then(|r| r.session_control.as_ref());
 
         let Some(sc) = sc else {
-            return Ok(None);
+            return Ok(AgentRouteOutcome {
+                lifecycle: SessionLifecycleOutcome::NoSessionControl,
+                deferred_close: None,
+            });
         };
 
         let Some(action) = sc.action.as_ref() else {
             // No action -- just session_id for sticky routing (handled by StickySessionRouter)
-            return Ok(None);
+            return Ok(AgentRouteOutcome {
+                lifecycle: SessionLifecycleOutcome::NoAction,
+                deferred_close: None,
+            });
         };
 
         match action {
@@ -148,7 +162,10 @@ impl AgentController {
                 let Some(client) = self.get_session_control_client().await else {
                     // No session_control endpoint available -- skip session
                     // lifecycle and let the request proceed without isolation.
-                    return Ok(None);
+                    return Ok(AgentRouteOutcome {
+                        lifecycle: SessionLifecycleOutcome::NoSessionControlEndpoint,
+                        deferred_close: None,
+                    });
                 };
                 let worker_timeout_secs = sc
                     .timeout
@@ -181,7 +198,10 @@ impl AgentController {
                 // Affinity is bound at the routing layer after worker selection;
                 // this controller only owns the open/close RPC lifecycle.
 
-                Ok(None)
+                Ok(AgentRouteOutcome {
+                    lifecycle: SessionLifecycleOutcome::OpenSucceeded,
+                    deferred_close: None,
+                })
             }
             SessionAction::Close => {
                 // Remove affinity immediately
@@ -190,14 +210,18 @@ impl AgentController {
                 }
 
                 // Defer close to after generation completes
-                match self.get_session_control_client().await {
-                    Some(client) => Ok(Some(SessionCloseAction {
-                        session_id: sc.session_id.clone(),
-                        client,
-                        instance_id,
-                    })),
-                    None => Ok(None),
-                }
+                let deferred_close =
+                    self.get_session_control_client()
+                        .await
+                        .map(|client| SessionCloseAction {
+                            session_id: sc.session_id.clone(),
+                            client,
+                            instance_id,
+                        });
+                Ok(AgentRouteOutcome {
+                    lifecycle: SessionLifecycleOutcome::CloseRequested,
+                    deferred_close,
+                })
             }
         }
     }

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -23,6 +23,7 @@ impl PrefillRouter {
     /// Otherwise, query for the best worker (KV mode) or select next worker (non-KV modes).
     pub(super) async fn resolve_prefill_worker(
         &self,
+        context_id: &str,
         req: &PreprocessedRequest,
         preselected_worker: Option<u64>,
     ) -> PrefillResolveDecision {
@@ -33,8 +34,21 @@ impl PrefillRouter {
             return PrefillResolveDecision::NotActivated;
         }
 
+        let sticky_worker = if preselected_worker.is_none() {
+            self.resolve_sticky_prefill_worker(context_id, req).await
+        } else {
+            None
+        };
+
         // Worker selection
-        let (worker_id, dp_rank) = if let Some(id) = preselected_worker {
+        let (worker_id, dp_rank) = if let Some(worker) = sticky_worker {
+            tracing::debug!(
+                worker_id = worker.worker_id,
+                dp_rank = worker.dp_rank,
+                "Using sticky prefill worker for bootstrap"
+            );
+            (worker.worker_id, Some(worker.dp_rank))
+        } else if let Some(id) = preselected_worker {
             let dp_rank = req
                 .routing
                 .as_ref()
@@ -119,6 +133,31 @@ impl PrefillRouter {
                 bootstrap_port: port,
                 bootstrap_room,
             },
+        }
+    }
+
+    async fn resolve_sticky_prefill_worker(
+        &self,
+        context_id: &str,
+        req: &PreprocessedRequest,
+    ) -> Option<dynamo_kv_router::protocols::WorkerWithDpRank> {
+        let router = self.prefill_router.get()?;
+        let worker = router.sticky_worker_for_prefill(req)?;
+        match router
+            .validate_sticky_prefill_worker(context_id, req, worker)
+            .await
+        {
+            Ok(worker) => Some(worker),
+            Err(error) => {
+                tracing::warn!(
+                    request_id = %context_id,
+                    worker_id = worker.worker_id,
+                    dp_rank = worker.dp_rank,
+                    error = %error,
+                    "Sticky prefill worker failed validation; falling back to normal prefill routing"
+                );
+                None
+            }
         }
     }
 

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -34,6 +34,8 @@ impl PrefillRouter {
             return PrefillResolveDecision::NotActivated;
         }
 
+        // Treat a preselected prefill worker as a caller/external pin. Otherwise,
+        // sticky affinity wins before this router writes generated bootstrap hints.
         let sticky_worker = if preselected_worker.is_none() {
             self.resolve_sticky_prefill_worker(context_id, req).await
         } else {

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -62,36 +62,7 @@ impl PrefillRouter {
             );
             (id, dp_rank)
         } else {
-            // Use shared worker selection logic (update_states=false for peek behavior)
-            // Extract LORA name and priority jump from routing hints
-            let lora_name = req.routing.as_ref().and_then(|r| r.lora_name.clone());
-            let priority_jump = req
-                .routing
-                .as_ref()
-                .and_then(|r| r.priority_jump)
-                .unwrap_or(0.0);
-            let allowed_worker_ids = req
-                .routing
-                .as_ref()
-                .and_then(|r| r.allowed_worker_ids.clone());
-            let routing_constraints = req
-                .routing
-                .as_ref()
-                .and_then(|r| r.routing_constraints.clone())
-                .unwrap_or_default();
-            let (routing_token_ids, block_mm_infos) = req.block_mm_routing_info();
-            match self
-                .query_prefill_worker(
-                    routing_token_ids,
-                    block_mm_infos,
-                    false,
-                    lora_name,
-                    priority_jump,
-                    allowed_worker_ids,
-                    routing_constraints,
-                )
-                .await
-            {
+            match self.query_prefill_worker_for_request(req).await {
                 Ok((worker_id, dp_rank)) => (worker_id, dp_rank),
                 Err(_) => return PrefillResolveDecision::Unavailable,
             }
@@ -149,7 +120,10 @@ impl PrefillRouter {
             .validate_sticky_prefill_worker(context_id, req, worker)
             .await
         {
-            Ok(worker) => Some(worker),
+            Ok(worker) => {
+                router.refresh_sticky_prefill_worker(req);
+                Some(worker)
+            }
             Err(error) => {
                 tracing::warn!(
                     request_id = %context_id,
@@ -161,6 +135,39 @@ impl PrefillRouter {
                 None
             }
         }
+    }
+
+    async fn query_prefill_worker_for_request(
+        &self,
+        req: &PreprocessedRequest,
+    ) -> Result<(WorkerId, Option<u32>)> {
+        let lora_name = req.routing.as_ref().and_then(|r| r.lora_name.clone());
+        let priority_jump = req
+            .routing
+            .as_ref()
+            .and_then(|r| r.priority_jump)
+            .unwrap_or(0.0);
+        let allowed_worker_ids = req
+            .routing
+            .as_ref()
+            .and_then(|r| r.allowed_worker_ids.clone());
+        let routing_constraints = req
+            .routing
+            .as_ref()
+            .and_then(|r| r.routing_constraints.clone())
+            .unwrap_or_default();
+        let (routing_token_ids, block_mm_infos) = req.block_mm_routing_info();
+
+        self.query_prefill_worker(
+            routing_token_ids,
+            block_mm_infos,
+            false,
+            lora_name,
+            priority_jump,
+            allowed_worker_ids,
+            routing_constraints,
+        )
+        .await
     }
 
     /// Execute prefill with the given router and extract structured result.

--- a/lib/llm/src/kv_router/prefill_router/inner.rs
+++ b/lib/llm/src/kv_router/prefill_router/inner.rs
@@ -87,4 +87,10 @@ impl InnerPrefillRouter {
             InnerPrefillRouter::SimpleRouter(_) => Ok(worker),
         }
     }
+
+    pub(super) fn refresh_sticky_prefill_worker(&self, request: &PreprocessedRequest) {
+        if let InnerPrefillRouter::KvRouter(router) = self {
+            router.refresh_sticky_worker_for_phase(request, RequestPhase::Prefill);
+        }
+    }
 }

--- a/lib/llm/src/kv_router/prefill_router/inner.rs
+++ b/lib/llm/src/kv_router/prefill_router/inner.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use dynamo_kv_router::protocols::WorkerWithDpRank;
 
 use dynamo_runtime::{
     pipeline::{AsyncEngine, ManyOut, PushRouter, SingleIn},
@@ -12,7 +13,10 @@ use dynamo_runtime::{
 
 use crate::{
     kv_router::KvPushRouter,
-    protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest},
+    protocols::common::{
+        llm_backend::{LLMEngineOutput, PreprocessedRequest},
+        timing::RequestPhase,
+    },
 };
 
 /// The inner router used by PrefillRouter
@@ -50,6 +54,37 @@ impl InnerPrefillRouter {
         match self {
             InnerPrefillRouter::SimpleRouter(router) => router.select_next_worker(),
             InnerPrefillRouter::KvRouter(_) => None,
+        }
+    }
+
+    pub(super) fn sticky_worker_for_prefill(
+        &self,
+        request: &PreprocessedRequest,
+    ) -> Option<WorkerWithDpRank> {
+        match self {
+            InnerPrefillRouter::KvRouter(router) => {
+                router.sticky_worker_for_phase(request, RequestPhase::Prefill)
+            }
+            InnerPrefillRouter::SimpleRouter(_) => None,
+        }
+    }
+
+    pub(super) async fn validate_sticky_prefill_worker(
+        &self,
+        context_id: &str,
+        request: &PreprocessedRequest,
+        worker: WorkerWithDpRank,
+    ) -> Result<WorkerWithDpRank> {
+        match self {
+            InnerPrefillRouter::KvRouter(router) => Ok(router
+                .validate_sticky_worker_for_phase(
+                    context_id,
+                    request,
+                    RequestPhase::Prefill,
+                    worker,
+                )
+                .await?),
+            InnerPrefillRouter::SimpleRouter(_) => Ok(worker),
         }
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -129,7 +129,7 @@ impl
         }
 
         let prefill_result = match self
-            .resolve_prefill_worker(&prefill_req, preselected_worker)
+            .resolve_prefill_worker(&request_id, &prefill_req, preselected_worker)
             .await
         {
             PrefillResolveDecision::Resolved {

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -502,6 +502,8 @@ impl KvPushRouter {
             return None;
         }
 
+        // Open/close lifecycle actions only peek so failed opens or closes do not
+        // renew stale affinity. Action-less session turns refresh TTL as active use.
         match sc.action.as_ref() {
             Some(crate::protocols::openai::nvext::SessionAction::Open)
             | Some(crate::protocols::openai::nvext::SessionAction::Close) => {
@@ -707,6 +709,9 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 .as_ref()
                 .and_then(|r| r.session_control.as_ref())
         {
+            // Bind/rebind only after the worker accepted open_session. This keeps
+            // first ambiguous opens on normal KV routing while repeated opens renew
+            // the timeout for the selected worker/rank.
             self.sticky_sessions.bind(
                 &sc.session_id,
                 WorkerWithDpRank::new(instance_id, dp_rank),
@@ -846,6 +851,9 @@ fn sticky_allowed_for_phase(phase: RequestPhase, routing: Option<&RoutingHints>)
         return false;
     }
 
+    // Routing precedence: caller-visible pins win over sticky affinity. Sticky is
+    // only considered for requests with session_control, so the default KV/direct
+    // routing paths stay unchanged.
     match phase {
         RequestPhase::Prefill => {
             routing.prefill_worker_id.is_none()

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -22,7 +22,7 @@ use tracing::Instrument;
 use crate::{
     kv_router::{
         KvRouter,
-        agent_controller::{AgentController, SessionCloseAction},
+        agent_controller::{AgentController, SessionCloseAction, SessionLifecycleOutcome},
         metrics::RouterRequestMetrics,
         sticky_sessions::{InMemoryAffinityStore, StickySessionRouter},
     },
@@ -490,6 +490,44 @@ impl KvPushRouter {
             scheduler_tracked: !is_query_only && resolved_dp_rank.is_some(),
         })
     }
+
+    pub(crate) fn sticky_worker_for_phase(
+        &self,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+    ) -> Option<WorkerWithDpRank> {
+        let routing = request.routing.as_ref()?;
+        let sc = routing.session_control.as_ref()?;
+        if !sticky_allowed_for_phase(phase, Some(routing)) {
+            return None;
+        }
+
+        match sc.action.as_ref() {
+            Some(crate::protocols::openai::nvext::SessionAction::Open)
+            | Some(crate::protocols::openai::nvext::SessionAction::Close) => {
+                self.sticky_sessions.peek_session(&sc.session_id)
+            }
+            None => self.sticky_sessions.resolve_session(&sc.session_id),
+        }
+    }
+
+    pub(crate) async fn validate_sticky_worker_for_phase(
+        &self,
+        context_id: &str,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+        worker: WorkerWithDpRank,
+    ) -> Result<WorkerWithDpRank, Error> {
+        let mut validation_request = request.clone();
+        write_sticky_backend_pin(&mut validation_request, worker);
+        let selection = self
+            .select_worker(context_id, &validation_request, phase, true)
+            .await?;
+        Ok(WorkerWithDpRank::new(
+            selection.instance_id,
+            selection.dp_rank,
+        ))
+    }
 }
 
 #[async_trait]
@@ -525,38 +563,22 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // Simple query-only detection: presence of query_instance_id annotation means query-only mode
         let is_query_only = request.get_annotation_value("query_instance_id").is_some();
 
-        // Pin a bound session to its (worker, dp_rank) before selection so it
-        // stays on the rank where its prefix is warm. Pinning dp_rank (not just
-        // the worker) is what stops a multi-rank engine from drifting the
-        // conversation across ranks. A miss is bound after routing, below.
-        let mut bind_session_after_route = false;
-        if request
-            .routing
-            .as_ref()
-            .and_then(|r| r.session_control.as_ref())
-            .is_some()
-            && request
-                .routing
-                .as_ref()
-                .and_then(|r| r.backend_instance_id)
-                .is_none()
-        {
-            match self.sticky_sessions.resolve(&request) {
-                Some(worker) => {
-                    let routing = request.routing_mut();
-                    routing.backend_instance_id = Some(worker.worker_id);
-                    routing.dp_rank = Some(worker.dp_rank);
-                }
-                None => bind_session_after_route = true,
-            }
-        }
-
         // Get phase from tracker (defaults to Aggregated if no tracker or phase not set)
         let phase = request
             .tracker
             .as_ref()
             .map(|t| t.phase())
             .unwrap_or(RequestPhase::Aggregated);
+
+        // Pin a bound session to its (worker, dp_rank) before selection so it
+        // stays on the rank where its prefix is warm. Pinning dp_rank (not just
+        // the worker) is what stops a multi-rank engine from drifting the
+        // conversation across ranks. All sticky work is gated on session_control
+        // so ordinary requests stay on the existing path.
+        if let Some(worker) = self.sticky_worker_for_phase(&request, phase) {
+            write_sticky_backend_pin(&mut request, worker);
+        }
+
         let phase_label = phase.to_string();
         let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
 
@@ -668,10 +690,18 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let track_output_blocks = self.chooser.kv_router_config().router_track_output_blocks;
         let tracker = request.tracker.clone();
 
-        // Bind a new session to the (worker, dp_rank) it just landed on so its
-        // later turns stick to that rank. Routing-layer only -- no worker RPC.
-        // Bound sessions are kept alive by the sliding TTL refresh in resolve().
-        if bind_session_after_route
+        // Session lifecycle RPCs via agent controller.
+        // Fails fast if session_control.open is requested but the client can't be created.
+        let route_outcome = self
+            .agent_controller
+            .on_routed(
+                &request,
+                instance_id,
+                &context_id,
+                Some(&*self.sticky_sessions),
+            )
+            .await?;
+        if route_outcome.lifecycle == SessionLifecycleOutcome::OpenSucceeded
             && let Some(sc) = request
                 .routing
                 .as_ref()
@@ -683,18 +713,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 Duration::from_secs(sc.timeout),
             );
         }
-
-        // Session lifecycle RPCs via agent controller.
-        // Fails fast if session_control.open is requested but the client can't be created.
-        let deferred_close = self
-            .agent_controller
-            .on_routed(
-                &request,
-                instance_id,
-                &context_id,
-                Some(&*self.sticky_sessions),
-            )
-            .await?;
+        let deferred_close = route_outcome.deferred_close;
 
         let (mut backend_input, context) = request.into_parts();
         backend_input.routing_mut().dp_rank = Some(dp_rank);
@@ -819,6 +838,37 @@ fn pinned_worker_hint(
     }
 }
 
+fn sticky_allowed_for_phase(phase: RequestPhase, routing: Option<&RoutingHints>) -> bool {
+    let Some(routing) = routing else {
+        return false;
+    };
+    if routing.session_control.is_none() {
+        return false;
+    }
+
+    match phase {
+        RequestPhase::Prefill => {
+            routing.prefill_worker_id.is_none()
+                && routing.prefill_dp_rank.is_none()
+                && routing.backend_instance_id.is_none()
+        }
+        RequestPhase::Decode => {
+            routing.decode_worker_id.is_none()
+                && routing.dp_rank.is_none()
+                && routing.backend_instance_id.is_none()
+        }
+        RequestPhase::Aggregated => {
+            routing.backend_instance_id.is_none() && routing.dp_rank.is_none()
+        }
+    }
+}
+
+fn write_sticky_backend_pin(request: &mut PreprocessedRequest, worker: WorkerWithDpRank) {
+    let routing = request.routing_mut();
+    routing.backend_instance_id = Some(worker.worker_id);
+    routing.dp_rank = Some(worker.dp_rank);
+}
+
 /// A direct routing wrapper for `RouterMode::Direct`.
 ///
 /// This wraps a `PushRouter` and reads worker IDs from each request's routing hints,
@@ -866,8 +916,18 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
 #[cfg(test)]
 mod tests {
-    use super::pinned_worker_hint;
+    use super::{pinned_worker_hint, sticky_allowed_for_phase, write_sticky_backend_pin};
     use crate::protocols::common::{preprocessor::RoutingHints, timing::RequestPhase};
+    use crate::protocols::openai::nvext::SessionControl;
+    use dynamo_kv_router::protocols::WorkerWithDpRank;
+
+    fn session_control() -> SessionControl {
+        SessionControl {
+            session_id: "sess-1".to_string(),
+            action: None,
+            timeout: 300,
+        }
+    }
 
     #[test]
     fn pinned_worker_hint_prefill_uses_prefill_worker_before_backend() {
@@ -906,5 +966,111 @@ mod tests {
 
         let hint = pinned_worker_hint(RequestPhase::Aggregated, Some(&routing));
         assert_eq!(hint, Some((9, Some(7))));
+    }
+
+    #[test]
+    fn sticky_is_noop_without_session_control() {
+        let routing = RoutingHints::default();
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Aggregated,
+            Some(&routing)
+        ));
+    }
+
+    #[test]
+    fn sticky_allowed_when_only_session_control_is_present() {
+        let routing = RoutingHints {
+            session_control: Some(session_control()),
+            ..Default::default()
+        };
+        assert!(sticky_allowed_for_phase(
+            RequestPhase::Aggregated,
+            Some(&routing)
+        ));
+        assert!(sticky_allowed_for_phase(
+            RequestPhase::Prefill,
+            Some(&routing)
+        ));
+        assert!(sticky_allowed_for_phase(
+            RequestPhase::Decode,
+            Some(&routing)
+        ));
+    }
+
+    #[test]
+    fn sticky_skips_phase_specific_explicit_pins() {
+        let prefill = RoutingHints {
+            session_control: Some(session_control()),
+            prefill_worker_id: Some(1),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Prefill,
+            Some(&prefill)
+        ));
+
+        let prefill_rank = RoutingHints {
+            session_control: Some(session_control()),
+            prefill_dp_rank: Some(2),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Prefill,
+            Some(&prefill_rank)
+        ));
+
+        let decode = RoutingHints {
+            session_control: Some(session_control()),
+            decode_worker_id: Some(3),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Decode,
+            Some(&decode)
+        ));
+
+        let decode_rank = RoutingHints {
+            session_control: Some(session_control()),
+            dp_rank: Some(4),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Decode,
+            Some(&decode_rank)
+        ));
+
+        let aggregated = RoutingHints {
+            session_control: Some(session_control()),
+            backend_instance_id: Some(5),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Aggregated,
+            Some(&aggregated)
+        ));
+    }
+
+    #[test]
+    fn sticky_backend_pin_writes_worker_and_rank_together() {
+        let mut request = crate::protocols::common::preprocessor::PreprocessedRequest::builder()
+            .model("test".to_string())
+            .token_ids(vec![1, 2, 3])
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default())
+            .routing(Some(RoutingHints {
+                session_control: Some(session_control()),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap();
+
+        write_sticky_backend_pin(&mut request, WorkerWithDpRank::new(11, 7));
+
+        let routing = request.routing.unwrap();
+        assert_eq!(routing.backend_instance_id, Some(11));
+        assert_eq!(routing.dp_rank, Some(7));
+        assert_eq!(routing.prefill_worker_id, None);
+        assert_eq!(routing.decode_worker_id, None);
     }
 }

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -296,6 +296,7 @@ impl KvPushRouter {
         request: &PreprocessedRequest,
         phase: RequestPhase,
         is_query_only: bool,
+        sticky_worker: Option<WorkerWithDpRank>,
     ) -> Result<WorkerSelection, Error> {
         let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
         let routing = request.routing.as_ref();
@@ -307,7 +308,10 @@ impl KvPushRouter {
             .and_then(|r| r.routing_constraints.clone())
             .unwrap_or_default();
         let (routing_token_ids, block_mm_infos) = request.block_mm_routing_info();
-        let Some((pinned_worker_id, requested_dp_rank)) = pinned_worker_hint(phase, routing) else {
+        let sticky_pin = sticky_worker.map(|worker| (worker.worker_id, Some(worker.dp_rank)));
+        let Some((pinned_worker_id, requested_dp_rank)) =
+            pinned_worker_hint(phase, routing).or(sticky_pin)
+        else {
             let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
             let selection = self
                 .chooser
@@ -363,7 +367,7 @@ impl KvPushRouter {
             .or_else(|| self.chooser.unique_dp_rank_for_worker(pinned_worker_id))
             .map(|dp_rank| WorkerWithDpRank::new(pinned_worker_id, dp_rank));
 
-        if !is_query_only && let Some(pinned_worker) = resolved_pinned_worker {
+        if let Some(pinned_worker) = resolved_pinned_worker {
             let selection = self
                 .chooser
                 .find_best_match_details(
@@ -371,7 +375,7 @@ impl KvPushRouter {
                     routing_token_ids,
                     block_mm_infos,
                     request.router_config_override.as_ref(),
-                    true,
+                    !is_query_only,
                     lora_name.clone(),
                     priority_jump,
                     expected_output_tokens,
@@ -391,7 +395,7 @@ impl KvPushRouter {
                 overlap_amount,
                 effective_overlap_blocks,
                 cached_tokens,
-                scheduler_tracked: true,
+                scheduler_tracked: !is_query_only,
             });
         }
 
@@ -502,15 +506,25 @@ impl KvPushRouter {
             return None;
         }
 
-        // Open/close lifecycle actions only peek so failed opens or closes do not
-        // renew stale affinity. Action-less session turns refresh TTL as active use.
-        match sc.action.as_ref() {
-            Some(crate::protocols::openai::nvext::SessionAction::Open)
-            | Some(crate::protocols::openai::nvext::SessionAction::Close) => {
-                self.sticky_sessions.peek_session(&sc.session_id)
-            }
-            None => self.sticky_sessions.resolve_session(&sc.session_id),
+        self.sticky_sessions.peek_session(&sc.session_id)
+    }
+
+    pub(crate) fn refresh_sticky_worker_for_phase(
+        &self,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+    ) {
+        let Some(routing) = request.routing.as_ref() else {
+            return;
+        };
+        let Some(sc) = routing.session_control.as_ref() else {
+            return;
+        };
+        if sc.action.is_some() || !sticky_allowed_for_phase(phase, Some(routing)) {
+            return;
         }
+
+        self.sticky_sessions.resolve_session(&sc.session_id);
     }
 
     pub(crate) async fn validate_sticky_worker_for_phase(
@@ -520,10 +534,8 @@ impl KvPushRouter {
         phase: RequestPhase,
         worker: WorkerWithDpRank,
     ) -> Result<WorkerWithDpRank, Error> {
-        let mut validation_request = request.clone();
-        write_sticky_backend_pin(&mut validation_request, worker);
         let selection = self
-            .select_worker(context_id, &validation_request, phase, true)
+            .select_worker(context_id, request, phase, true, Some(worker))
             .await?;
         Ok(WorkerWithDpRank::new(
             selection.instance_id,
@@ -557,7 +569,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
     /// prefill/completion lifecycle for proper KV cache management.
     async fn generate(
         &self,
-        mut request: SingleIn<PreprocessedRequest>,
+        request: SingleIn<PreprocessedRequest>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
         // Extract context ID for request tracking
         let context_id = request.context().id().to_string();
@@ -572,23 +584,41 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             .map(|t| t.phase())
             .unwrap_or(RequestPhase::Aggregated);
 
-        // Pin a bound session to its (worker, dp_rank) before selection so it
-        // stays on the rank where its prefix is warm. Pinning dp_rank (not just
-        // the worker) is what stops a multi-rank engine from drifting the
-        // conversation across ranks. All sticky work is gated on session_control
-        // so ordinary requests stay on the existing path.
-        if let Some(worker) = self.sticky_worker_for_phase(&request, phase) {
-            write_sticky_backend_pin(&mut request, worker);
-        }
-
         let phase_label = phase.to_string();
         let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
 
         let block_size = self.chooser.block_size() as usize;
-        let selection = self
-            .select_worker(&context_id, &request, phase, is_query_only)
+        // Treat sticky affinity as a best-effort candidate. The scheduler still
+        // validates the candidate against current worker eligibility before it
+        // becomes the route; if validation fails, fall back to normal routing.
+        let sticky_worker = self.sticky_worker_for_phase(&request, phase);
+        let selection = match self
+            .select_worker(&context_id, &request, phase, is_query_only, sticky_worker)
             .instrument(tracing::info_span!("kv_router.select_worker"))
-            .await?;
+            .await
+        {
+            Ok(selection) => {
+                if sticky_worker.is_some() && !is_query_only {
+                    self.refresh_sticky_worker_for_phase(&request, phase);
+                }
+                selection
+            }
+            Err(error) if sticky_worker.is_some() => {
+                if let Some(worker) = sticky_worker {
+                    tracing::warn!(
+                        request_id = %context_id,
+                        worker_id = worker.worker_id,
+                        dp_rank = worker.dp_rank,
+                        error = %error,
+                        "Sticky worker failed validation; falling back to normal routing"
+                    );
+                }
+                self.select_worker(&context_id, &request, phase, is_query_only, None)
+                    .instrument(tracing::info_span!("kv_router.select_worker_fallback"))
+                    .await?
+            }
+            Err(error) => return Err(error),
+        };
         let WorkerSelection {
             instance_id,
             dp_rank,
@@ -871,6 +901,7 @@ fn sticky_allowed_for_phase(phase: RequestPhase, routing: Option<&RoutingHints>)
     }
 }
 
+#[cfg(test)]
 fn write_sticky_backend_pin(request: &mut PreprocessedRequest, worker: WorkerWithDpRank) {
     let routing = request.routing_mut();
     routing.backend_instance_id = Some(worker.worker_id);

--- a/lib/llm/src/kv_router/sticky_sessions.rs
+++ b/lib/llm/src/kv_router/sticky_sessions.rs
@@ -33,6 +33,9 @@ pub trait AffinityStore: Send + Sync {
     /// or expired. Implementations should refresh the TTL on hit.
     fn get(&self, session_id: &str) -> Option<WorkerWithDpRank>;
 
+    /// Look up the `(worker, dp_rank)` for a session without refreshing TTL.
+    fn peek(&self, session_id: &str) -> Option<WorkerWithDpRank>;
+
     /// Bind a session to a `(worker, dp_rank)` with the given TTL.
     fn put(&self, session_id: &str, worker: WorkerWithDpRank, ttl: Duration);
 
@@ -97,26 +100,61 @@ impl InMemoryAffinityStore {
             alive
         });
     }
+
+    fn lookup(&self, session_id: &str, refresh: bool) -> Option<WorkerWithDpRank> {
+        let now = Instant::now();
+        let mut entry = self.map.get_mut(session_id)?;
+        if entry.expires_at <= now {
+            let worker = entry.worker;
+            let expires_at = entry.expires_at;
+            drop(entry);
+            self.remove_expired_if_current(session_id, worker, expires_at);
+            return None;
+        }
+
+        let worker = entry.worker;
+        if refresh {
+            entry.expires_at = now + entry.ttl;
+        }
+        tracing::info!(
+            %session_id,
+            worker_id = worker.worker_id,
+            dp_rank = worker.dp_rank,
+            refreshed = refresh,
+            "Sticky session hit"
+        );
+        Some(worker)
+    }
+
+    fn remove_expired_if_current(
+        &self,
+        session_id: &str,
+        worker: WorkerWithDpRank,
+        expires_at: Instant,
+    ) {
+        let removed = self.map.remove_if(session_id, |_, entry| {
+            entry.worker == worker
+                && entry.expires_at == expires_at
+                && entry.expires_at <= Instant::now()
+        });
+        if removed.is_none() {
+            return;
+        }
+
+        tracing::debug!(%session_id, "Session affinity expired during resolve");
+        if let Some(handler) = &self.on_expire {
+            handler(session_id.to_owned(), worker.worker_id);
+        }
+    }
 }
 
 impl AffinityStore for InMemoryAffinityStore {
     fn get(&self, session_id: &str) -> Option<WorkerWithDpRank> {
-        let mut entry = self.map.get_mut(session_id)?;
-        if entry.expires_at <= Instant::now() {
-            let worker = entry.worker;
-            drop(entry);
-            self.map.remove(session_id);
-            tracing::debug!(%session_id, "Session affinity expired during resolve");
-            if let Some(handler) = &self.on_expire {
-                handler(session_id.to_owned(), worker.worker_id);
-            }
-            return None;
-        }
-        // Refresh TTL on access (sliding window)
-        entry.expires_at = Instant::now() + entry.ttl;
-        let worker = entry.worker;
-        tracing::info!(%session_id, worker_id = worker.worker_id, dp_rank = worker.dp_rank, "Sticky session hit");
-        Some(worker)
+        self.lookup(session_id, true)
+    }
+
+    fn peek(&self, session_id: &str) -> Option<WorkerWithDpRank> {
+        self.lookup(session_id, false)
     }
 
     fn put(&self, session_id: &str, worker: WorkerWithDpRank, ttl: Duration) {
@@ -162,6 +200,26 @@ impl StickySessionRouter {
             .as_ref()
             .map(|sc| sc.session_id.as_str())?;
         self.store.get(session_id)
+    }
+
+    /// Resolve a request's session without refreshing the sticky TTL.
+    pub fn peek(&self, request: &PreprocessedRequest) -> Option<WorkerWithDpRank> {
+        let routing = request.routing.as_ref()?;
+        let session_id = routing
+            .session_control
+            .as_ref()
+            .map(|sc| sc.session_id.as_str())?;
+        self.store.peek(session_id)
+    }
+
+    /// Resolve a session id directly and refresh its sticky TTL.
+    pub fn resolve_session(&self, session_id: &str) -> Option<WorkerWithDpRank> {
+        self.store.get(session_id)
+    }
+
+    /// Resolve a session id directly without refreshing its sticky TTL.
+    pub fn peek_session(&self, session_id: &str) -> Option<WorkerWithDpRank> {
+        self.store.peek(session_id)
     }
 
     /// Bind a session to a `(worker, dp_rank)` with the given TTL.
@@ -245,6 +303,52 @@ mod tests {
     }
 
     #[test]
+    fn peek_returns_worker_without_refreshing_ttl() {
+        let map = Arc::new(DashMap::new());
+        let ttl = Duration::from_secs(60);
+        let expires_at = Instant::now() + Duration::from_secs(5);
+        map.insert(
+            "sess-peek".to_owned(),
+            AffinityEntry {
+                worker: worker(7, 2),
+                ttl,
+                expires_at,
+            },
+        );
+        let store = InMemoryAffinityStore {
+            map: map.clone(),
+            on_expire: None,
+        };
+        let router = StickySessionRouter::new(store);
+
+        let req = make_request(Some("sess-peek"));
+        assert_eq!(router.peek(&req), Some(worker(7, 2)));
+
+        let entry = map.get("sess-peek").unwrap();
+        assert_eq!(entry.expires_at, expires_at);
+    }
+
+    #[test]
+    fn bind_overwrites_worker_rank_and_ttl() {
+        let map = Arc::new(DashMap::new());
+        let store = InMemoryAffinityStore {
+            map: map.clone(),
+            on_expire: None,
+        };
+        let router = StickySessionRouter::new(store);
+        router.bind("sess-1", worker(1, 0), Duration::from_secs(10));
+        router.bind("sess-1", worker(2, 3), Duration::from_secs(90));
+
+        let req = make_request(Some("sess-1"));
+        assert_eq!(router.peek(&req), Some(worker(2, 3)));
+
+        let entry = map.get("sess-1").unwrap();
+        assert_eq!(entry.worker, worker(2, 3));
+        assert_eq!(entry.ttl, Duration::from_secs(90));
+        assert!(entry.expires_at > Instant::now() + Duration::from_secs(80));
+    }
+
+    #[test]
     fn unbind_removes_affinity() {
         let store = InMemoryAffinityStore {
             map: Arc::new(DashMap::new()),
@@ -278,7 +382,7 @@ mod tests {
         let req = make_request(Some("sess-expired"));
         assert!(router.resolve(&req).is_none());
         // Entry should be cleaned up
-        assert!(router.store.get("sess-expired").is_none());
+        assert!(router.store.peek("sess-expired").is_none());
     }
 
     #[test]
@@ -345,6 +449,43 @@ mod tests {
             expired_sessions.lock().unwrap().as_slice(),
             &[("sess-expired".to_string(), 99)]
         );
+    }
+
+    #[test]
+    fn expired_lookup_does_not_remove_newer_binding() {
+        let expired_sessions = Arc::new(Mutex::new(Vec::new()));
+        let on_expire = {
+            let expired_sessions = expired_sessions.clone();
+            Arc::new(move |session_id: String, worker_id: u64| {
+                expired_sessions
+                    .lock()
+                    .unwrap()
+                    .push((session_id, worker_id));
+            })
+        };
+        let store = InMemoryAffinityStore {
+            map: Arc::new(DashMap::new()),
+            on_expire: Some(on_expire),
+        };
+        store.map.insert(
+            "sess-race".to_owned(),
+            AffinityEntry {
+                worker: worker(1, 0),
+                ttl: Duration::from_secs(1),
+                expires_at: Instant::now() - Duration::from_secs(1),
+            },
+        );
+
+        let stale = store.map.get("sess-race").unwrap();
+        let stale_worker = stale.worker;
+        let stale_expires_at = stale.expires_at;
+        drop(stale);
+
+        store.put("sess-race", worker(2, 1), Duration::from_secs(300));
+        store.remove_expired_if_current("sess-race", stale_worker, stale_expires_at);
+
+        assert_eq!(store.peek("sess-race"), Some(worker(2, 1)));
+        assert!(expired_sessions.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/lib/llm/src/kv_router/sticky_sessions.rs
+++ b/lib/llm/src/kv_router/sticky_sessions.rs
@@ -28,6 +28,10 @@ const REAPER_INTERVAL: Duration = Duration::from_secs(30);
 type ExpiryHandler = Arc<dyn Fn(String, u64) + Send + Sync>;
 
 /// Trait for session affinity storage backends.
+///
+/// Stores `(worker, dp_rank)` as an atomic routing target. `get` is the
+/// action-less-turn path and refreshes sliding TTL; `peek` is for lifecycle
+/// actions that must not extend affinity until the worker confirms success.
 pub trait AffinityStore: Send + Sync {
     /// Look up the `(worker, dp_rank)` for a session. Returns `None` if unknown
     /// or expired. Implementations should refresh the TTL on hit.

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -32,7 +32,9 @@ use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::{
     component::Component,
     engine::AsyncEngineContextProvider,
-    pipeline::{AsyncEngine, Error, ManyOut, ResponseStream, SingleIn, async_trait},
+    pipeline::{
+        AsyncEngine, Error, ManyOut, ResponseStream, SingleIn, async_trait, network::Ingress,
+    },
     traits::DistributedRuntimeProvider,
 };
 use futures::StreamExt;
@@ -357,6 +359,47 @@ pub struct MockEngine {
     _fpm_publisher: OnceCell<crate::fpm_publisher::FpmDirectPublisher>,
 }
 
+struct MockSessionControlEngine;
+
+#[async_trait]
+impl AsyncEngine<SingleIn<serde_json::Value>, ManyOut<Annotated<serde_json::Value>>, Error>
+    for MockSessionControlEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<serde_json::Value>,
+    ) -> Result<ManyOut<Annotated<serde_json::Value>>, Error> {
+        let (body, context) = request.into_parts();
+        let action = body.get("action").and_then(|value| value.as_str());
+        let session_id = body.get("session_id").and_then(|value| value.as_str());
+
+        let response = match (action, session_id) {
+            (Some("open_session" | "close_session"), Some(session_id)) => {
+                serde_json::json!({
+                    "status": "ok",
+                    "session_id": session_id,
+                })
+            }
+            (_, None) => {
+                serde_json::json!({
+                    "status": "error",
+                    "message": "session_id required",
+                })
+            }
+            (other, Some(session_id)) => {
+                serde_json::json!({
+                    "status": "error",
+                    "session_id": session_id,
+                    "message": format!("unsupported action {:?}", other),
+                })
+            }
+        };
+
+        let stream = futures::stream::iter(vec![Annotated::from_data(response)]);
+        Ok(ResponseStream::new(Box::pin(stream), context.context()))
+    }
+}
+
 impl MockEngine {
     /// Create a new MockEngine with the given parameters
     pub fn new(engine_args: MockEngineArgs) -> Self {
@@ -393,6 +436,8 @@ impl MockEngine {
             tokio::time::sleep(Duration::from_secs_f64(startup_time_secs)).await;
             tracing::info!("Engine startup simulation completed");
         }
+
+        Self::start_session_control_endpoint(component.clone());
 
         // Start bootstrap server for prefill workers in disaggregated mode
         if self.engine_args.is_prefill()
@@ -445,6 +490,29 @@ impl MockEngine {
         let _ = self._schedulers.set(schedulers);
 
         Ok(())
+    }
+
+    fn start_session_control_endpoint(component: Component) {
+        let ingress = match Ingress::for_engine(Arc::new(MockSessionControlEngine)) {
+            Ok(ingress) => ingress,
+            Err(e) => {
+                tracing::error!("Failed to build mocker session_control ingress: {e}");
+                return;
+            }
+        };
+
+        tokio::spawn(async move {
+            if let Err(e) = component
+                .endpoint("session_control")
+                .endpoint_builder()
+                .handler(ingress)
+                .graceful_shutdown(true)
+                .start()
+                .await
+            {
+                tracing::error!("Mocker session_control endpoint failed: {e}");
+            }
+        });
     }
 
     /// Send a request to the appropriate scheduler, waiting for initialization if needed.

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2259,6 +2259,18 @@ def _test_disagg_background_prefill_sticky_routing(
                 timeout=120,
             )
 
+            runtime = get_runtime(
+                store_backend=store_backend, request_plane=request_plane
+            )
+            prefill_endpoint = runtime.endpoint(
+                f"{prefill_workers.namespace}.prefill.generate"
+            )
+            await poll_for_worker_instances(
+                prefill_endpoint,
+                prefill_workers.num_workers,
+                max_wait_time=120,
+            )
+
             suffix = random.randint(100_000, 999_999)
             session_a = f"sticky-a-{suffix}"
             session_b = f"sticky-b-{suffix}"

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2168,6 +2168,182 @@ def _test_router_decisions_disagg(
         )
 
 
+def _test_disagg_background_prefill_sticky_routing(
+    prefill_workers,
+    decode_workers,
+    block_size: int,
+    request,
+    frontend_port: int,
+    model_name: str,
+    store_backend: str = "file",
+    request_plane: str = "tcp",
+    event_plane: str = "zmq",
+    frontend_already_running: bool = False,
+):
+    """Verify sticky prefill routing overrides normal KV choice in bootstrap disagg."""
+
+    frontend_context = contextlib.nullcontext()
+    if not frontend_already_running:
+        frontend_context = FrontendRouterProcess(
+            request,
+            block_size,
+            frontend_port,
+            decode_workers.namespace,
+            store_backend,
+            enforce_disagg=True,
+            request_plane=request_plane,
+            event_plane=event_plane,
+            durable_kv_events=False,
+            min_initial_workers=decode_workers.num_workers,
+        )
+
+    with frontend_context:
+        frontend_url = f"http://localhost:{frontend_port}"
+        chat_url = f"{frontend_url}/v1/chat/completions"
+
+        async def send_chat(
+            session: aiohttp.ClientSession,
+            content: str,
+            *,
+            session_control: Optional[dict[str, Any]] = None,
+        ) -> tuple[int, int]:
+            payload: dict[str, Any] = {
+                "model": model_name,
+                "messages": [{"role": "user", "content": content}],
+                "stream": True,
+                "max_tokens": 2,
+                "nvext": {"extra_fields": ["worker_id", "timing"]},
+            }
+            if session_control is not None:
+                payload["nvext"]["session_control"] = session_control
+
+            async with session.post(chat_url, json=payload) as response:
+                body = []
+                assert response.status == 200, (
+                    f"Request failed with status {response.status}: "
+                    f"{await response.text()}"
+                )
+
+                prefill_worker_id = None
+                prefill_dp_rank = None
+                async for line in response.content:
+                    line_str = line.decode("utf-8", errors="replace").strip()
+                    body.append(line_str)
+                    if not line_str.startswith("data:"):
+                        continue
+                    data_str = line_str[5:].strip()
+                    if data_str == "[DONE]":
+                        break
+                    try:
+                        data = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+                    worker_id = data.get("nvext", {}).get("worker_id", {})
+                    prefill_worker_id = worker_id.get(
+                        "prefill_worker_id", prefill_worker_id
+                    )
+                    prefill_dp_rank = worker_id.get("prefill_dp_rank", prefill_dp_rank)
+
+                assert (
+                    prefill_worker_id is not None
+                ), "Missing prefill_worker_id in response body: " + "\n".join(body)
+                assert (
+                    prefill_dp_rank is not None
+                ), "Missing prefill_dp_rank in response body: " + "\n".join(body)
+                return int(prefill_worker_id), int(prefill_dp_rank)
+
+        async def test_sync():
+            await wait_for_frontend_ready(
+                frontend_url=frontend_url,
+                expected_num_workers=decode_workers.num_workers,
+                timeout=120,
+            )
+
+            suffix = random.randint(100_000, 999_999)
+            session_a = f"sticky-a-{suffix}"
+            session_b = f"sticky-b-{suffix}"
+            prompt_a = (
+                f"session alpha {suffix}: "
+                "redwood vectors amber matrix northbound lantern " * 20
+            )
+
+            async with aiohttp.ClientSession() as session:
+                session_a_pair = await send_chat(
+                    session,
+                    prompt_a,
+                    session_control={
+                        "session_id": session_a,
+                        "action": "open",
+                        "timeout": 300,
+                    },
+                )
+
+                competing_pair = None
+                competing_prompt = None
+                for attempt in range(6):
+                    candidate = (
+                        f"session beta {suffix} attempt {attempt}: "
+                        "cerulean ledger quartz valley transit cacheline " * 20
+                    )
+                    pair = await send_chat(
+                        session,
+                        candidate,
+                        session_control={
+                            "session_id": f"{session_b}-{attempt}",
+                            "action": "open",
+                            "timeout": 300,
+                        },
+                    )
+                    if pair != session_a_pair:
+                        competing_pair = pair
+                        competing_prompt = candidate
+                        break
+
+                assert competing_pair is not None, (
+                    "Could not warm a competing prefill worker/rank different from "
+                    f"session A pair {session_a_pair}"
+                )
+
+                control_pair = None
+                for _ in range(10):
+                    control_pair = await send_chat(
+                        session,
+                        competing_prompt
+                        + " control continuation proving normal kv routing",
+                    )
+                    if control_pair == competing_pair:
+                        break
+                    await asyncio.sleep(0.5)
+
+                assert control_pair == competing_pair, (
+                    "No-sticky control did not follow normal KV overlap routing: "
+                    f"expected {competing_pair}, got {control_pair}"
+                )
+
+                followups = [
+                    competing_prompt + f" sticky continuation {idx} {suffix}"
+                    for idx in range(3)
+                ]
+                results = await asyncio.gather(
+                    *[
+                        send_chat(
+                            session,
+                            content,
+                            session_control={"session_id": session_a},
+                        )
+                        for content in followups
+                    ]
+                )
+
+            assert results == [session_a_pair] * len(results), (
+                "Sticky follow-ups should stay pinned to session A prefill pair "
+                f"{session_a_pair}, but got {results}; competing pair was "
+                f"{competing_pair}"
+            )
+
+        asyncio.run(test_sync())
+
+
 def _test_router_decisions_disagg_round_robin_prefill_dp_rank(
     prefill_workers,
     decode_workers,

--- a/tests/router/router_process.py
+++ b/tests/router/router_process.py
@@ -33,6 +33,7 @@ class FrontendRouterProcess(ManagedProcess):
         router_aic_config: dict[str, str | int] | None = None,
         serve_indexer: bool = False,
         use_remote_indexer: bool = False,
+        event_plane: str | None = None,
     ):
         command = [
             sys.executable,
@@ -100,6 +101,10 @@ class FrontendRouterProcess(ManagedProcess):
 
         env = os.environ.copy()
         env["DYN_REQUEST_PLANE"] = request_plane
+        if event_plane is not None:
+            env["DYN_EVENT_PLANE"] = event_plane
+        if event_plane == "zmq":
+            env.pop("NATS_SERVER", None)
         if min_initial_workers is not None:
             env["DYN_ROUTER_MIN_INITIAL_WORKERS"] = str(min_initial_workers)
 

--- a/tests/router/router_process.py
+++ b/tests/router/router_process.py
@@ -103,7 +103,7 @@ class FrontendRouterProcess(ManagedProcess):
         env["DYN_REQUEST_PLANE"] = request_plane
         if event_plane is not None:
             env["DYN_EVENT_PLANE"] = event_plane
-        if event_plane == "zmq":
+        if event_plane == "zmq" and request_plane != "nats":
             env.pop("NATS_SERVER", None)
         if min_initial_workers is not None:
             env["DYN_ROUTER_MIN_INITIAL_WORKERS"] = str(min_initial_workers)

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1578,15 +1578,22 @@ def test_router_decisions_disagg(
 
 
 @pytest.mark.timeout(180)
+@pytest.mark.parametrize("discovery_backend", ["file"], indirect=True)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.parametrize(
+    "durable_kv_events", [False], ids=["nondurable"], indirect=True
+)
 def test_disagg_background_prefill_sticky(
     request,
+    runtime_services_dynamic_ports,
     file_storage_backend,
     predownload_tokenizers,
+    discovery_backend,
+    request_plane,
+    durable_kv_events,
 ):
     """Sticky session affinity pins disagg background prefill on TCP/ZMQ."""
-    _ = (file_storage_backend, predownload_tokenizers)
-    discovery_backend = "file"
-    request_plane = "tcp"
+    _ = (runtime_services_dynamic_ports, file_storage_backend, durable_kv_events)
 
     namespace_suffix = generate_random_suffix()
     shared_namespace = f"test-namespace-{namespace_suffix}"

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1578,22 +1578,15 @@ def test_router_decisions_disagg(
 
 
 @pytest.mark.timeout(180)
-@pytest.mark.parametrize("discovery_backend", ["file"], indirect=True)
-@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
-@pytest.mark.parametrize(
-    "durable_kv_events", [False], ids=["nondurable"], indirect=True
-)
 def test_disagg_background_prefill_sticky(
     request,
-    runtime_services_dynamic_ports,
     file_storage_backend,
     predownload_tokenizers,
-    discovery_backend,
-    request_plane,
-    durable_kv_events,
 ):
     """Sticky session affinity pins disagg background prefill on TCP/ZMQ."""
-    _ = (runtime_services_dynamic_ports, file_storage_backend, durable_kv_events)
+    _ = (file_storage_backend, predownload_tokenizers)
+    discovery_backend = "file"
+    request_plane = "tcp"
 
     namespace_suffix = generate_random_suffix()
     shared_namespace = f"test-namespace-{namespace_suffix}"

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -685,7 +685,7 @@ class DisaggMockerProcess:
         env["DYN_REQUEST_PLANE"] = request_plane
         if event_plane is not None:
             env["DYN_EVENT_PLANE"] = event_plane
-        if event_plane == "zmq":
+        if event_plane == "zmq" and request_plane != "nats":
             env.pop("NATS_SERVER", None)
 
         self._process = ManagedProcess(

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -13,6 +13,7 @@ import logging
 import os
 import sys
 import tempfile
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
@@ -22,6 +23,7 @@ import pytest
 
 from tests.router.common import (
     _test_busy_threshold_endpoint,
+    _test_disagg_background_prefill_sticky_routing,
     _test_disagg_direct_mode,
     _test_python_router_bindings,
     _test_remote_indexer_decisions,
@@ -42,6 +44,7 @@ from tests.router.helper import (
     get_runtime,
     wait_for_indexer_workers_active,
 )
+from tests.router.router_process import FrontendRouterProcess
 from tests.utils.constants import ROUTER_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (
@@ -624,6 +627,8 @@ class DisaggMockerProcess:
         store_backend: str = "etcd",
         request_plane: str = "nats",
         enable_bootstrap: bool = False,
+        event_plane: Optional[str] = None,
+        zmq_kv_events: bool = False,
     ):
         if worker_type not in ("prefill", "decode"):
             raise ValueError(
@@ -634,6 +639,7 @@ class DisaggMockerProcess:
         self.worker_type = worker_type
         self.num_workers = num_mockers
         self._bootstrap_ports: list[int] = []
+        self._zmq_kv_events_ports: list[int] = []
 
         # Set component name and endpoint based on worker type
         if worker_type == "prefill":
@@ -655,6 +661,18 @@ class DisaggMockerProcess:
                 f"Allocated bootstrap ports {self._bootstrap_ports} for {num_mockers} prefill workers"
             )
 
+        if zmq_kv_events:
+            dp_size = mocker_args.get("dp_size", 1)
+            self._zmq_kv_events_ports = allocate_contiguous_ports(
+                num_mockers, dp_size, BASE_PORT_ZMQ
+            )
+            bases = [self._zmq_kv_events_ports[i * dp_size] for i in range(num_mockers)]
+            mocker_args["zmq_kv_events_ports"] = ",".join(str(p) for p in bases)
+            logger.info(
+                f"Allocated ZMQ KV event ports {self._zmq_kv_events_ports} "
+                f"(bases: {bases}) for {num_mockers} {worker_type} workers"
+            )
+
         command = _build_mocker_command(
             endpoint=self.endpoint,
             store_backend=store_backend,
@@ -665,6 +683,10 @@ class DisaggMockerProcess:
 
         env = os.environ.copy()
         env["DYN_REQUEST_PLANE"] = request_plane
+        if event_plane is not None:
+            env["DYN_EVENT_PLANE"] = event_plane
+        if event_plane == "zmq":
+            env.pop("NATS_SERVER", None)
 
         self._process = ManagedProcess(
             command=command,
@@ -702,6 +724,10 @@ class DisaggMockerProcess:
             deallocate_ports(self._bootstrap_ports)
             logger.info(f"Deallocated bootstrap ports {self._bootstrap_ports}")
             self._bootstrap_ports = []
+        if self._zmq_kv_events_ports:
+            deallocate_ports(self._zmq_kv_events_ports)
+            logger.info(f"Deallocated ZMQ KV event ports {self._zmq_kv_events_ports}")
+            self._zmq_kv_events_ports = []
 
 
 class CounterWorkerProcess:
@@ -827,7 +853,10 @@ def _launch_disagg_workers(
     num_prefill_mockers: int,
     num_decode_mockers: int,
     enable_disagg_bootstrap: bool,
+    store_backend: str = "etcd",
     request_plane: str = "nats",
+    event_plane: Optional[str] = None,
+    zmq_kv_events: bool = False,
 ) -> Iterator[tuple[DisaggMockerProcess, DisaggMockerProcess]]:
     if registration_order not in ("prefill_first", "decode_first"):
         raise ValueError(f"Unexpected registration order: {registration_order}")
@@ -840,8 +869,11 @@ def _launch_disagg_workers(
             worker_type="prefill",
             mocker_args=prefill_mocker_args,
             num_mockers=num_prefill_mockers,
+            store_backend=store_backend,
             request_plane=request_plane,
             enable_bootstrap=enable_disagg_bootstrap,
+            event_plane=event_plane,
+            zmq_kv_events=zmq_kv_events,
         ) as prefill_workers:
             logger.info(f"Prefill workers using endpoint: {prefill_workers.endpoint}")
 
@@ -854,7 +886,10 @@ def _launch_disagg_workers(
                 worker_type="decode",
                 mocker_args=decode_mocker_args,
                 num_mockers=num_decode_mockers,
+                store_backend=store_backend,
                 request_plane=request_plane,
+                event_plane=event_plane,
+                zmq_kv_events=zmq_kv_events,
             ) as decode_workers:
                 logger.info(f"Decode workers using endpoint: {decode_workers.endpoint}")
                 yield prefill_workers, decode_workers
@@ -867,7 +902,10 @@ def _launch_disagg_workers(
         worker_type="decode",
         mocker_args=decode_mocker_args,
         num_mockers=num_decode_mockers,
+        store_backend=store_backend,
         request_plane=request_plane,
+        event_plane=event_plane,
+        zmq_kv_events=zmq_kv_events,
     ) as decode_workers:
         logger.info(f"Decode workers using endpoint: {decode_workers.endpoint}")
 
@@ -880,8 +918,11 @@ def _launch_disagg_workers(
             worker_type="prefill",
             mocker_args=prefill_mocker_args,
             num_mockers=num_prefill_mockers,
+            store_backend=store_backend,
             request_plane=request_plane,
             enable_bootstrap=enable_disagg_bootstrap,
+            event_plane=event_plane,
+            zmq_kv_events=zmq_kv_events,
         ) as prefill_workers:
             logger.info(f"Prefill workers using endpoint: {prefill_workers.endpoint}")
             yield prefill_workers, decode_workers
@@ -1534,6 +1575,82 @@ def test_router_decisions_disagg(
             request_plane="nats",
             enable_bootstrap=enable_disagg_bootstrap,
         )
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize("discovery_backend", ["file"], indirect=True)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.parametrize(
+    "durable_kv_events", [False], ids=["nondurable"], indirect=True
+)
+def test_disagg_background_prefill_sticky(
+    request,
+    runtime_services_dynamic_ports,
+    file_storage_backend,
+    predownload_tokenizers,
+    discovery_backend,
+    request_plane,
+    durable_kv_events,
+):
+    """Sticky session affinity pins disagg background prefill on TCP/ZMQ."""
+    _ = (runtime_services_dynamic_ports, file_storage_backend, durable_kv_events)
+
+    namespace_suffix = generate_random_suffix()
+    shared_namespace = f"test-namespace-{namespace_suffix}"
+    prefill_mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+        "dp_size": 2,
+    }
+    decode_mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+    }
+
+    frontend_port = get_unique_ports(
+        request,
+        num_ports=1,
+        store_backend=discovery_backend,
+        request_plane=request_plane,
+    )[0]
+    with FrontendRouterProcess(
+        request,
+        BLOCK_SIZE,
+        frontend_port,
+        shared_namespace,
+        discovery_backend,
+        enforce_disagg=True,
+        request_plane=request_plane,
+        event_plane="zmq",
+        durable_kv_events=False,
+    ):
+        time.sleep(1.0)
+        with _launch_disagg_workers(
+            request,
+            shared_namespace,
+            "prefill_first",
+            prefill_mocker_args=prefill_mocker_args,
+            decode_mocker_args=decode_mocker_args,
+            num_prefill_mockers=3,
+            num_decode_mockers=2,
+            enable_disagg_bootstrap=True,
+            store_backend=discovery_backend,
+            request_plane=request_plane,
+            event_plane="zmq",
+            zmq_kv_events=True,
+        ) as (prefill_workers, decode_workers):
+            _test_disagg_background_prefill_sticky_routing(
+                prefill_workers=prefill_workers,
+                decode_workers=decode_workers,
+                block_size=BLOCK_SIZE,
+                request=request,
+                frontend_port=frontend_port,
+                model_name=MODEL_NAME,
+                store_backend=discovery_backend,
+                request_plane=request_plane,
+                event_plane="zmq",
+                frontend_already_running=True,
+            )
 
 
 @pytest.mark.parametrize("registration_order", ["prefill_first", "decode_first"])


### PR DESCRIPTION
Fixes DP-rank sticky session precedence, lifecycle binding, and TTL renewal on top of the DP-rank sticky routing branch. Adds mocker coverage for disaggregated background-prefill sticky routing.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session-sticky routing to maintain consistent worker assignment across related requests, improving performance and reliability.
  * Enhanced session lifecycle management with explicit control outcomes and better error handling for session operations.

* **Tests**
  * Added comprehensive test coverage for sticky session routing behavior in disaggregated deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->