### PR TITLE
fix(parsers): close <think> markup leak in force_reasoning batch path

### DIFF
--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -157,8 +157,7 @@ impl ReasoningParser for BasicReasoningParser {
         //     normal_text. Without `&& !has_think_tag`, the implicit-reasoning
         //     span would absorb the literal <think> token into reasoning_text
         //     as a markup leak (parser-owned syntax surfacing to consumers).
-        let mut currently_reasoning =
-            (self._in_reasoning && !has_think_tag) || has_dangling_end;
+        let mut currently_reasoning = (self._in_reasoning && !has_think_tag) || has_dangling_end;
 
         while cursor < text.len() {
             if currently_reasoning {
@@ -706,8 +705,7 @@ mod tests {
         // into reasoning_text as a markup leak.
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
-        let result = parser
-            .detect_and_parse_reasoning("before <think>thinking</think> after", &[]);
+        let result = parser.detect_and_parse_reasoning("before <think>thinking</think> after", &[]);
         assert_eq!(result.reasoning_text, "thinking");
         assert_eq!(result.normal_text, "before  after");
         assert!(

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -148,10 +148,17 @@ impl ReasoningParser for BasicReasoningParser {
         let mut normal_parts = Vec::new();
         let mut cursor = 0;
         let mut exited_on_tool_start = false;
-        // Dangling-end case enters the loop already in reasoning so the prefix
-        // before `</think>` is captured (the loop's normal-text branch would
-        // otherwise treat it as plain text and re-leak the closer).
-        let mut currently_reasoning = self._in_reasoning || has_dangling_end;
+        // Initial loop state combines two concerns:
+        //   - dangling-end recovery: enter reasoning at cursor 0 so the prefix
+        //     before `</think>` is captured (otherwise the normal-text branch
+        //     would re-leak the closer).
+        //   - force_reasoning + a literal <think> later in the text: defer to
+        //     the explicit-marker path so the prefix before <think> stays in
+        //     normal_text. Without `&& !has_think_tag`, the implicit-reasoning
+        //     span would absorb the literal <think> token into reasoning_text
+        //     as a markup leak (parser-owned syntax surfacing to consumers).
+        let mut currently_reasoning =
+            (self._in_reasoning && !has_think_tag) || has_dangling_end;
 
         while cursor < text.len() {
             if currently_reasoning {
@@ -687,6 +694,43 @@ mod tests {
         let result = parser.detect_and_parse_reasoning("no think tags here", &[]);
         assert_eq!(result.normal_text, "");
         assert_eq!(result.reasoning_text, "no think tags here");
+    }
+
+    #[test]
+    fn test_force_reasoning_with_literal_think_prefix_does_not_leak() {
+        // Regression: when force_reasoning=true but the model output also
+        // contains a literal <think> later in the text, the explicit tag
+        // must win. The prefix before <think> belongs in normal_text.
+        // Without the `&& !has_think_tag` guard on currently_reasoning,
+        // the implicit-reasoning span would absorb the literal <think>
+        // into reasoning_text as a markup leak.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let result = parser
+            .detect_and_parse_reasoning("before <think>thinking</think> after", &[]);
+        assert_eq!(result.reasoning_text, "thinking");
+        assert_eq!(result.normal_text, "before  after");
+        assert!(
+            !result.reasoning_text.contains("<think>"),
+            "literal <think> must be stripped, not absorbed; got {:?}",
+            result.reasoning_text
+        );
+    }
+
+    #[test]
+    fn test_force_reasoning_with_multiple_literal_spans() {
+        // Pins multi-span behavior for force_reasoning=true callers: the
+        // cursor-based loop extracts every closed <think>...</think> span
+        // and concatenates their bodies, while the surrounding text stays
+        // in normal_text.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), true, true);
+        let result = parser.detect_and_parse_reasoning(
+            "<think>first</think> middle <think>second</think> done",
+            &[],
+        );
+        assert_eq!(result.reasoning_text, "firstsecond");
+        assert_eq!(result.normal_text, "middle  done");
     }
 
     #[test] // REASONING.batch.6.b — streaming parity for stray close after complete pair

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -145,9 +145,9 @@ _FAMILY_METADATA = {
     },
     "nemotron_deci": {
         "models": [
-            "Nemotron-Super / -Ultra / -Deci",
+            "Nemotron-Super-v1 / Nemotron-Ultra-v1 / Nemotron-Deci-v1",
             "Llama-Nemotron",
-            "GLM-4.5 / GLM-4.7 via glm45 alias",
+            "GLM-4.5 / GLM-4.6 via glm45 alias",
         ],
         "rust_enum": "ReasoningParserType::NemotronDeci",
         "implementation": "BasicReasoningParser `<think>` / `</think>`",


### PR DESCRIPTION
#### Overview

Two small fixes in the reasoning parser stack.

*Markup leak.* When a `force_reasoning=true` parser sees a literal `<think>` past position 0, today it drags the tag into `reasoning_text`. Downstream consumers that surface `reasoning_content` end up rendering the parser's own delimiter syntax.

```
input:  "before <think>thinking</think> after"
before: reasoning_text = "before <think>thinking"   normal_text = " after"
after:  reasoning_text = "thinking"                 normal_text = "before  after"
```

*Metadata fix.* The parity dashboard listed `GLM-4.7` under the `nemotron_deci` row, but GLM-4.7's chat template pre-injects `<think>`:

```
zai-org/GLM-4.7/chat_template.jinja
  <|assistant|>{{- '</think>'
      if (enable_thinking is defined and not enable_thinking)
      else '<think>' -}}
```

That puts it in the force-reasoning group, not `nemotron_deci`. The `nemotron_deci` row actually covers Nemotron Super/Ultra/Deci v1, Llama-Nemotron, and GLM-4.5/4.6, all of which leave the assistant prompt untouched (GLM-4.5 quoted as proof):

```
zai-org/GLM-4.5/chat_template.jinja
  <|assistant|>{{- '\n<think></think>'
      if (enable_thinking is defined and not enable_thinking) else '' -}}
```

Swap GLM-4.7 -> GLM-4.6 in the model list and add the `v1` suffix to the Nemotron entries.

#### Details

`lib/parsers/src/reasoning/base_parser.rs::detect_and_parse_reasoning` — change the cursor-loop initializer from `self._in_reasoning || has_dangling_end` to `(self._in_reasoning && !has_think_tag) || has_dangling_end`. When `force_reasoning=true` and the text also carries a literal opener, defer to the explicit-marker path. Two new unit tests pin prefix-and-multi-span behavior.

`tests/parity/reasoning/table.py` — drop GLM-4.7 from `_FAMILY_METADATA["nemotron_deci"]["models"]`, add GLM-4.6, prefix the Nemotron entries with `v1`.

#### Where should the reviewer start?

`lib/parsers/src/reasoning/base_parser.rs:154` — the one-line guard, and the two tests directly under `test_force_reasoning_mode`.

#### Related Issues

None.