### PR TITLE
docs(fern): port Agents nav reorder to v1.1.1

### DIFF
--- a/fern/versions/v1.1.1.yml
+++ b/fern/versions/v1.1.1.yml
@@ -168,6 +168,16 @@ navigation:
             path: ../pages-v1.1.1/reasoning/dynamo.md
           - page: Reasoning Parsing (Engine Fallback)
             path: ../pages-v1.1.1/reasoning/engine-fallback.md
+      - section: Agents
+        slug: agents
+        path: ../pages-v1.1.1/agents/README.md
+        contents:
+          - page: Agent Tracing
+            path: ../pages-v1.1.1/agents/agent-tracing.md
+          - page: Agent Hints
+            path: ../pages-v1.1.1/agents/agent-hints.md
+          - page: SGLang for Agentic Workloads
+            path: ../pages-v1.1.1/backends/sglang/agents.md
       - section: Multimodal
         path: ../pages-v1.1.1/features/multimodal/README.md
         contents:
@@ -192,16 +202,6 @@ navigation:
             path: ../pages-v1.1.1/backends/trtllm/trtllm-diffusion.md
       - page: LoRA Adapters
         path: ../pages-v1.1.1/features/lora/README.md
-      - section: Agents
-        slug: agents
-        path: ../pages-v1.1.1/agents/README.md
-        contents:
-          - page: Agent Tracing
-            path: ../pages-v1.1.1/agents/agent-tracing.md
-          - page: Agent Hints
-            path: ../pages-v1.1.1/agents/agent-hints.md
-          - page: SGLang for Agentic Workloads
-            path: ../pages-v1.1.1/backends/sglang/agents.md
       - section: Observability (Local)
         path: ../pages-v1.1.1/observability/README.md
         contents:


### PR DESCRIPTION
## Summary
- Port [#9725](https://github.com/ai-dynamo/dynamo/pull/9725) to the v1.1.1 versioned docs on this branch.
- Under **User Guides**, move the Agents section to sit between Reasoning and Multimodal (was between LoRA Adapters and Observability).
- Net diff is +10/-10 in `fern/versions/v1.1.1.yml`, matching the structure of #9725.

## Test plan
- [ ] `fern check` passes in CI
- [ ] On the v1.1.1 docs build, the User Guides sidebar renders Tool Calling → Reasoning → Agents → Multimodal
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->