### PR TITLE
ci(nvskills): add NVSkills CI dispatch workflow

### DIFF
--- a/.github/workflows/nvskills-ci.yml
+++ b/.github/workflows/nvskills-ci.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 name: NVSkills CI
 
 on:

--- a/.github/workflows/nvskills-ci.yml
+++ b/.github/workflows/nvskills-ci.yml
@@ -1,0 +1,16 @@
+name: NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  team-request:
+    uses: ./.github/workflows/nvskills-team-request.yml
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/.github/workflows/nvskills-ci.yml
+++ b/.github/workflows/nvskills-ci.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
 
 name: NVSkills CI
 

--- a/.github/workflows/nvskills-team-request.yml
+++ b/.github/workflows/nvskills-team-request.yml
@@ -1,0 +1,193 @@
+name: Team Request NVSkills CI
+
+on:
+  workflow_call:
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-nvskill-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: nvskills-ci-request-${{ github.repository }}-${{ github.event.issue.number || github.sha }}
+      cancel-in-progress: true
+    steps:
+      - name: Validate requester permission
+        if: ${{ github.event_name == 'issue_comment' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          permission="$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/collaborators/${ACTOR}/permission" \
+            | jq -r '.permission')"
+          case "${permission}" in
+            admin|maintain) ;;
+            *) echo "Requester must have maintain or admin permission"; exit 1 ;;
+          esac
+
+      - name: Resolve request context
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          ISSUE_PR_NUMBER: ${{ github.event.issue.number || '' }}
+          HEAD_SHA: ${{ github.sha }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
+          SIGNATURE_COMMIT_TITLE: ${{ vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures' }}
+          SIGNATURE_PUSH_ACTOR: ${{ vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-nvskill-ci[bot]' }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          owner="${REPO%%/*}"
+          repo="${REPO#*/}"
+          pr_number="${ISSUE_PR_NUMBER}"
+          commit_title="$(printf '%s' "${HEAD_COMMIT_MESSAGE}" | sed -n '1p')"
+
+          if [ "${EVENT_NAME}" = "push" ]; then
+            if [ "${commit_title}" != "${SIGNATURE_COMMIT_TITLE}" ]; then
+              echo "Push is not the configured NVSkills signature commit; skipping dispatch."
+              exit 0
+            fi
+            if [ "${ACTOR}" != "${SIGNATURE_PUSH_ACTOR}" ]; then
+              echo "Push actor ${ACTOR} is not the configured NVSkills signing actor; skipping dispatch."
+              exit 0
+            fi
+
+            prs_json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${owner}/${repo}/commits/${HEAD_SHA}/pulls")"
+            pr_number="$(printf '%s' "${prs_json}" | jq -r '[.[] | select(.state == "open")][0].number // empty')"
+            if [ -z "${pr_number}" ]; then
+              echo "No open pull request is associated with the signature commit; skipping dispatch."
+              exit 0
+            fi
+          fi
+
+          if [ -z "${pr_number}" ]; then
+            echo "Pull request number could not be resolved."
+            exit 1
+          fi
+
+          pr_json="$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}")"
+          head_sha="$(printf '%s' "${pr_json}" | jq -r '.head.sha')"
+          base_ref="$(printf '%s' "${pr_json}" | jq -r '.base.ref')"
+
+          if [ "${EVENT_NAME}" != "push" ]; then
+            commit_json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${owner}/${repo}/commits/${head_sha}")"
+            commit_title="$(printf '%s' "${commit_json}" | jq -r '.commit.message | split("\n")[0]')"
+          fi
+
+          has_watched_change=false
+          page=1
+          while true; do
+            files_json="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=100&page=${page}")"
+            if printf '%s' "${files_json}" | jq -e '
+              any(.[]; .filename |
+                startswith("skills/") or
+                startswith("team-skills/") or
+                startswith("rules/team-rules/") or
+                startswith("plugins/")
+              )
+            ' >/dev/null; then
+              has_watched_change=true
+              break
+            fi
+            if [ "$(printf '%s' "${files_json}" | jq 'length')" -lt 100 ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          if [ "${has_watched_change}" != "true" ]; then
+            {
+              echo "## NVSkills CI request"
+              echo
+              echo "Skipped: no changes under \`skills/\`, \`team-skills/\`, \`rules/team-rules/\`, or \`plugins/\`."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "should_dispatch=true"
+            echo "pr_number=${pr_number}"
+            echo "head_sha=${head_sha}"
+            echo "base_ref=${base_ref}"
+            echo "commit_title=${commit_title}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Dispatch NVSkills CI
+        if: steps.context.outputs.should_dispatch == 'true'
+        env:
+          DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          REQUEST_HEAD_SHA: ${{ steps.context.outputs.head_sha }}
+          REQUEST_BASE_REF: ${{ steps.context.outputs.base_ref }}
+          REQUEST_COMMIT_TITLE: ${{ steps.context.outputs.commit_title }}
+          REQUEST_COMMENT_ID: ${{ github.event.comment.id || '' }}
+          REQUEST_RUN_ID: ${{ github.run_id }}
+          REQUESTED_BY: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISPATCH_TOKEN}" ]; then
+            echo "Missing NVSKILLS_CI_DISPATCH_TOKEN secret."
+            exit 1
+          fi
+
+          owner="${REPO%%/*}"
+          repo="${REPO#*/}"
+
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/NVIDIA/nvskills-ci/actions/workflows/nvskills-ci.yml/dispatches" \
+            -d "$(jq -n \
+              --arg ref "main" \
+              --arg source_owner "${owner}" \
+              --arg source_repo "${repo}" \
+              --arg pr_number "${PR_NUMBER}" \
+              --arg request_run_id "${REQUEST_RUN_ID}" \
+              --arg request_head_sha "${REQUEST_HEAD_SHA}" \
+              --arg request_base_ref "${REQUEST_BASE_REF}" \
+              --arg request_commit_title "${REQUEST_COMMIT_TITLE}" \
+              --arg request_comment_id "${REQUEST_COMMENT_ID}" \
+              --arg requested_by "${REQUESTED_BY}" \
+              '{ref: $ref, inputs: {
+                source_owner: $source_owner,
+                source_repo: $source_repo,
+                pr_number: $pr_number,
+                request_run_id: $request_run_id,
+                request_head_sha: $request_head_sha,
+                request_base_ref: $request_base_ref,
+                request_commit_title: $request_commit_title,
+                request_comment_id: $request_comment_id,
+                requested_by: $requested_by
+              }}')"

--- a/.github/workflows/nvskills-team-request.yml
+++ b/.github/workflows/nvskills-team-request.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Vendored from NVIDIA/skills/.github/workflows/team-request.yml @ 6b92ccf5d498d42394487eab30ef7afbc4206d00
+# Keep aligned with upstream; the supported watched paths are fixed.
+
 name: Team Request NVSkills CI
 
 on:
@@ -15,14 +21,16 @@ jobs:
     if: >
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+        (github.event.comment.body == '/nvskills-ci' ||
+          startsWith(github.event.comment.body, '/nvskills-ci ') ||
+          startsWith(github.event.comment.body, format('/nvskills-ci{0}', '\n')))) ||
       (github.event_name == 'push' &&
         github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-nvskill-ci[bot]') &&
         startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
     runs-on: ubuntu-latest
     concurrency:
-      group: nvskills-ci-request-${{ github.repository }}-${{ github.event.issue.number || github.sha }}
-      cancel-in-progress: true
+      group: nvskills-ci-request-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.sha }}
+      cancel-in-progress: ${{ github.event_name == 'issue_comment' }}
     steps:
       - name: Validate requester permission
         if: ${{ github.event_name == 'issue_comment' }}
@@ -104,7 +112,7 @@ jobs:
 
           has_watched_change=false
           page=1
-          while true; do
+          while [ "${page}" -le 30 ]; do
             files_json="$(curl -fsSL \
               -H "Authorization: Bearer ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/nvskills-team-request.yml
+++ b/.github/workflows/nvskills-team-request.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
 #
 # Vendored from NVIDIA/skills/.github/workflows/team-request.yml @ 6b92ccf5d498d42394487eab30ef7afbc4206d00
 # Keep aligned with upstream; the supported watched paths are fixed.


### PR DESCRIPTION
## Summary
- Vendors `NVIDIA/skills/.github/workflows/team-request.yml` as `.github/workflows/nvskills-team-request.yml` (reusable workflow, watched paths kept identical to the upstream-supported set: `skills/`, `team-skills/`, `rules/team-rules/`, `plugins/`).
- Adds `.github/workflows/nvskills-ci.yml` as a thin caller that fires on `issue_comment` (created) and `push`, invoking the reusable workflow and passing `NVSKILLS_CI_DISPATCH_TOKEN` through.
- Repo secret `NVSKILLS_CI_DISPATCH_TOKEN` has already been set on `ai-dynamo/dynamo`.

## Notes
- The `/nvskills-ci` PR-comment trigger only fires when the workflow file is on the **default branch**, so the comment dispatch path won't be live until this PR is merged to `main`. The `push` signature-commit path will work on this branch once merged.
- None of the upstream-watched paths (`skills/`, `team-skills/`, `rules/team-rules/`, `plugins/`) exist in this repo yet, so until they're added (e.g. via the `.agents/skills/` canonical layout), every run skips with the "no changes" summary.
- `push:` is currently unscoped; the job-level `if:` filters to the bot's signature commit. If the queued-but-skipped runs are noisy we can scope by `branches:` later.

## Test plan
- [ ] Merge to `main` and confirm the workflow appears in Actions on `ai-dynamo/dynamo`.
- [ ] Once a PR touches one of the watched paths, comment `/nvskills-ci` from a maintainer/admin account and verify a dispatch is sent to `NVIDIA/nvskills-ci/.github/workflows/nvskills-ci.yml`.
- [ ] Verify the bot signature-push path (`nv-nvskill-ci[bot]` pushing the `Attach NVSkills validation signatures` commit) successfully dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD automation configuration to enhance workflow integration and security controls for automated processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->