### PR TITLE
fix(epp): exclude Istio sidecar injection from EPP pod for GAIE (#9935)

### DIFF
--- a/deploy/inference-gateway/standalone/helm/dynamo-gaie/templates/dynamo-epp.yaml
+++ b/deploy/inference-gateway/standalone/helm/dynamo-gaie/templates/dynamo-epp.yaml
@@ -40,6 +40,11 @@ spec:
     metadata:
       labels:
         app: {{ .Values.model.shortName }}-epp
+      annotations:
+        # Exclude Istio sidecar injection: EPP serves TLS on port 9002
+        # (--secure-serving true); an Istio sidecar in STRICT mTLS mode
+        # causes a double-TLS handshake failure on that port.
+        sidecar.istio.io/inject: "false"
     spec:
       terminationGracePeriodSeconds: 130
 

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -42,6 +42,12 @@ const (
 
 	KubeAnnotationEnableGrove = "nvidia.com/enable-grove"
 
+	// KubeAnnotationIstioSidecarInject is the standard Istio annotation that
+	// controls whether the mutating webhook injects an istio-proxy sidecar into
+	// a pod. Setting it to "false" opts the pod out of sidecar injection even
+	// when the namespace carries istio-injection=enabled.
+	KubeAnnotationIstioSidecarInject = "sidecar.istio.io/inject"
+
 	KubeAnnotationDisableImagePullSecretDiscovery = "nvidia.com/disable-image-pull-secret-discovery"
 	KubeAnnotationDynamoDiscoveryBackend          = "nvidia.com/dynamo-discovery-backend"
 	KubeAnnotationDynamoKubeDiscoveryMode         = "nvidia.com/dynamo-kube-discovery-mode"

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -376,6 +376,25 @@ func generateSingleDCD(
 		}
 	}
 
+	// Stamp sidecar.istio.io/inject: "false" on EPP pod templates before
+	// DGD-level annotations are merged in. EPP serves its own TLS on port 9002
+	// (--secure-serving true); an Istio sidecar intercepting that port causes a
+	// double-TLS handshake failure when the namespace has STRICT mTLS, which
+	// surfaces as cx_connect_fail / HTTP 500 on the gateway.
+	//
+	// Placement before applyDGDTemplateDefaults is intentional: the merge
+	// function (mergeLowPriorityMetadata) does not overwrite keys already
+	// present in the destination map, so a graph-wide DGD Spec.Annotations
+	// entry of sidecar.istio.io/inject: "true" cannot silently bypass the
+	// EPP opt-out. An explicit per-EPP podTemplate annotation set by the user
+	// is preserved by the !exists guard.
+	if component.ComponentType == commonconsts.ComponentTypeEPP {
+		podTemplate := ensurePodTemplate(&deployment.Spec.DynamoComponentDeploymentSharedSpec)
+		if _, exists := podTemplate.Annotations[commonconsts.KubeAnnotationIstioSidecarInject]; !exists {
+			podTemplate.Annotations[commonconsts.KubeAnnotationIstioSidecarInject] = "false"
+		}
+	}
+
 	applyDGDTemplateDefaults(&deployment.Spec.DynamoComponentDeploymentSharedSpec, parentDGD)
 
 	// Apply restart annotation if this component should be restarted.


### PR DESCRIPTION
## Summary
- Cherry-pick of #9935 to release/1.2.0.
- Applies the EPP `sidecar.istio.io/inject: "false"` default before graph-level metadata is merged, preventing graph-wide annotations from overriding the EPP opt-out.

Fixes DYN-3108

## Original PR
- Main PR: #9935
- Merge commit: 014cc221a18d120a3086ee580c4a1f55a0f5d5fb

## Test plan
- [ ] CI passes on release/1.2.0
- [ ] EPP pod confirmed to start without sidecar