### PR TITLE
fix(operator): restore setSucceededCondition in updatePhaseWithCondition

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -2356,6 +2356,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 	}
 
 	dgdr.AddStatusCondition(condition)
+	setSucceededCondition(dgdr, phase)
 
 	if err := r.Status().Update(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
## Summary

- The cherry-pick #9902 of #9890 onto `release/1.2.0` dropped the `setSucceededCondition(dgdr, phase)` call in `updatePhaseWithCondition` instead of moving it after `AddStatusCondition` the way main did.
- Without it, the aggregate `Succeeded` condition is never written when phases are updated through this path — including the initial Pending transition.
- This is breaking the `release/1.2.0` post-merge operator job: [`run 26486144436`](https://github.com/ai-dynamo/dynamo/actions/runs/26486144436/job/77993925847) fails the `DGDR Error Handling > Should set Succeeded condition at each phase transition` ginkgo spec at `dynamographdeploymentrequest_controller_test.go:2190` (expected non-nil, got nil).

Fix: re-add `setSucceededCondition(dgdr, phase)` immediately after `dgdr.AddStatusCondition(condition)` so the specific condition is surfaced through the aggregate, matching main's ordering.

## Test plan

- [ ] CI: operator job on `release/1.2.0` post-merge pipeline turns green
- [ ] `make test` locally inside the operator container (envtest binaries unavailable on my host, so verified via `go build ./...` and `go vet ./internal/controller/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->