### PR TITLE
fix(vllm-omni): remove TTS dummy tokenizer workaround (#9954)

### DIFF
--- a/components/src/dynamo/vllm/omni/main.py
+++ b/components/src/dynamo/vllm/omni/main.py
@@ -22,10 +22,6 @@ from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.stage_router import init_omni_stage_router
 from dynamo.vllm.omni.stage_worker import init_omni_stage
-from dynamo.vllm.omni.utils import (
-    cleanup_dummy_tokenizer_for_tts,
-    ensure_dummy_tokenizer_for_tts,
-)
 
 from .args import OmniConfig, parse_omni_args
 
@@ -75,15 +71,6 @@ async def init_omni(
     if model_type is None:
         model_type = ModelType.Images
 
-    # Audio/TTS models (e.g., Qwen3-TTS) don't ship a standard tokenizer.json,
-    # which causes register_model to fail when building the ModelDeploymentCard.
-    # Create a minimal placeholder so the Rust card loader doesn't bail,
-    # then delete it immediately after so vLLM-Omni's inference-time
-    # AutoTokenizer.from_pretrained() doesn't pick up the fake file.
-    dummy_tokenizer_paths = []
-    if "audio" in config.output_modalities:
-        dummy_tokenizer_paths = ensure_dummy_tokenizer_for_tts(config.model)
-
     await register_model(
         ModelInput.Text,
         model_type,
@@ -92,9 +79,6 @@ async def init_omni(
         config.served_model_name,
         kv_cache_block_size=config.engine_args.block_size,
     )
-
-    if dummy_tokenizer_paths:
-        cleanup_dummy_tokenizer_for_tts(dummy_tokenizer_paths)
 
     logger.info("Starting to serve Omni worker endpoint...")
 

--- a/components/src/dynamo/vllm/omni/utils.py
+++ b/components/src/dynamo/vllm/omni/utils.py
@@ -3,12 +3,9 @@
 
 """Shared utilities for the vLLM-Omni backend."""
 
-import json
 import logging
-from pathlib import Path
 from typing import Any, cast
 
-from huggingface_hub import scan_cache_dir
 from vllm.sampling_params import SamplingParams
 from vllm_omni.distributed.omni_connectors.utils.serialization import OmniSerializer
 from vllm_omni.entrypoints.stage_utils import shm_read_bytes
@@ -252,55 +249,3 @@ def _build_sampling_params(stage_config: Any, overrides: dict | None) -> list | 
             if hasattr(llm_params, arg):
                 setattr(llm_params, arg, value)
     return [llm_params]
-
-
-def ensure_dummy_tokenizer_for_tts(model: str) -> list[Path]:
-    """Create a minimal tokenizer.json for TTS models that lack one.
-
-    Audio/TTS models (e.g., Qwen3-TTS) use a custom speech tokenizer and don't
-    ship the standard tokenizer.json expected by the Rust ModelDeploymentCard
-    loader. This writes a placeholder so register_model doesn't fail.
-
-    Returns the list of created dummy paths so the caller can delete them
-    after registration (otherwise the fake tokenizer poisons vLLM-Omni's
-    inference-time AutoTokenizer.from_pretrained call).
-
-    This is a short-term workaround. The long-term fix is making TokenizerKind
-    optional in ModelDeploymentCard::from_repo_checkout().
-    """
-    created: list[Path] = []
-    cache_info = scan_cache_dir()
-    for repo in cache_info.repos:
-        if repo.repo_id == model:
-            for revision in repo.revisions:
-                tokenizer_path = Path(revision.snapshot_path) / "tokenizer.json"
-                if not tokenizer_path.exists():
-                    logging.warning(
-                        "TTS model %s has no tokenizer.json; "
-                        "creating a minimal placeholder at %s",
-                        model,
-                        tokenizer_path,
-                    )
-                    minimal_tokenizer = {
-                        "version": "1.0",
-                        "model": {"type": "BPE", "vocab": {}, "merges": []},
-                    }
-                    tokenizer_path.write_text(json.dumps(minimal_tokenizer))
-                    created.append(tokenizer_path)
-            return created
-    return created
-
-
-def cleanup_dummy_tokenizer_for_tts(paths: list[Path]):
-    """Remove dummy tokenizer.json files created by ensure_dummy_tokenizer_for_tts.
-
-    Must be called after register_model() completes so the fake tokenizer
-    doesn't interfere with vLLM-Omni's inference-time tokenizer loading
-    (AutoTokenizer.from_pretrained picks up our stub and crashes).
-    """
-    for path in paths:
-        try:
-            path.unlink(missing_ok=True)
-            logging.info("Removed dummy tokenizer placeholder: %s", path)
-        except OSError as e:
-            logging.warning("Failed to remove dummy tokenizer %s: %s", path, e)


### PR DESCRIPTION
## Summary
Release-compatible backport of #9954 (Ayush Agarwal). Removes the
`ensure_dummy_tokenizer_for_tts` / `cleanup_dummy_tokenizer_for_tts`
workaround in `vllm-omni` that was deleting the dummy `tokenizer.json`
placeholder before `discovery::watcher` could read it — causing TTS
model registration to fail in online HF mode (when `HF_HUB_OFFLINE`
is not set).

The workaround is no longer needed on release/1.2.0 because:
- `lib/llm/src/model_card.rs:1660-1710` — the tokenizer-loading
  `probe()` function already returns `Ok(None)` for models without
  `tokenizer.json`, propagating cleanly through the loader.
- `lib/llm/src/discovery/watcher.rs:752` — the watcher already
  handles `tokenizer = None` for Qwen3-Omni / Qwen3-TTS-class models.

## Note: not a direct cherry-pick of d32af25793

Main's `omni/main.py` has been restructured by #9395
(`WorkerType` / `needs` populated at registration sites) which is
NOT present on release/1.2.0. A direct cherry-pick would pull in
that restructure as a transitive dependency. Instead this PR
applies only the workaround removal — the existing single
`register_model` call on release/1.2.0 stays unchanged.

## Changes
- `omni/main.py`: drop `ensure_dummy_tokenizer_for_tts` /
  `cleanup_dummy_tokenizer_for_tts` import + their call sites
  around `register_model`.
- `omni/utils.py`: drop the two helper functions and their
  no-longer-used `json`, `Path`, `scan_cache_dir` imports.

Fixes DYN-3064
Fixes https://nvbugs/6189644

## Original PR
- Main PR: #9954
- Merge commit (main): d32af25793552a833e8b21fa50c6dab322bc6903

## Test plan
- [ ] CI passes on release/1.2.0
- [ ] Ayush validates TTS model registration on release/1.2.0
      with `HF_HUB_OFFLINE` unset (the original repro from
      DYN-3064)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->