### PR TITLE
docs(kubernetes): fix broken Volcano doc links (cherry-pick #9963)

### DIFF
--- a/docs/kubernetes/deployment/multinode-deployment.md
+++ b/docs/kubernetes/deployment/multinode-deployment.md
@@ -65,7 +65,7 @@ KAI-Scheduler is optional but recommended for advanced scheduling capabilities.
 LWS is a simple multinode deployment mechanism that allows you to deploy a workload across multiple nodes.
 
 - **LWS**: [LWS Installation](https://github.com/kubernetes-sigs/lws#installation)
-- **Volcano**: [Volcano Installation](https://volcano.sh/en/docs/installation/)
+- **Volcano**: [Volcano Installation](https://github.com/volcano-sh/volcano#quick-start-guide)
 
 Volcano is a Kubernetes native scheduler optimized for AI workloads at scale. It is used in conjunction with LWS to provide gang scheduling support.
 

--- a/docs/kubernetes/installation-guide.md
+++ b/docs/kubernetes/installation-guide.md
@@ -157,7 +157,7 @@ For the `enabled=true` path, install Grove and KAI Scheduler separately first. S
 
 #### LWS + Volcano
 
-If you are not using Grove for multinode, you can use [LeaderWorkerSet (LWS)](https://lws.sigs.k8s.io/docs/installation/) (>= v0.7.0) with [Volcano](https://volcano.sh/en/docs/installation/) for gang scheduling. Both must be installed before deploying multinode workloads.
+If you are not using Grove for multinode, you can use [LeaderWorkerSet (LWS)](https://lws.sigs.k8s.io/docs/installation/) (>= v0.7.0) with [Volcano](https://github.com/volcano-sh/volcano#quick-start-guide) for gang scheduling. Both must be installed before deploying multinode workloads.
 
 1. Install Volcano:
 
@@ -179,7 +179,7 @@ helm install lws oci://registry.k8s.io/lws/charts/lws \
   --wait --timeout 300s
 ```
 
-See the [LWS docs](https://lws.sigs.k8s.io/docs/) and [Volcano docs](https://volcano.sh/en/docs/) for configuration options, and the [Multinode Deployment Guide](./deployment/multinode-deployment.md) for orchestrator selection.
+See the [LWS docs](https://lws.sigs.k8s.io/docs/) and [Volcano docs](https://github.com/volcano-sh/volcano#quick-start-guide) for configuration options, and the [Multinode Deployment Guide](./deployment/multinode-deployment.md) for orchestrator selection.
 
 ### Network Operator / RDMA
 


### PR DESCRIPTION
## Summary

- Cherry-pick of [#9963](https://github.com/ai-dynamo/dynamo/pull/9963) (commit `70660a94c8b`) onto `release/1.2.0`.
- Volcano restructured their docs site, so `https://volcano.sh/en/docs/...` now 404s. Replaces three links with `https://github.com/volcano-sh/volcano#quick-start-guide`.
- `main` already has this fix; `release/1.2.0` does not, which is why the `Pre Merge` lychee job is failing for any PR opened against the release branch (e.g. #10008).

## Test plan

- [ ] `Pre Merge` workflow's lychee step passes on this PR
- [ ] After merge, PR #10008's lychee step turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->