### PR TITLE
fix(gms): batch restore FD exports

### DIFF
--- a/benchmarks/gpu_memory_service/phase_a_microbench.py
+++ b/benchmarks/gpu_memory_service/phase_a_microbench.py
@@ -179,7 +179,11 @@ def _close_fds(fds: Iterable[int]) -> None:
             pass
 
 
-def _cleanup_mappings(vas: Sequence[int], sizes: Sequence[int], handles: Sequence[int]) -> None:
+def _cleanup_mappings(
+    vas: Sequence[int],
+    sizes: Sequence[int],
+    handles: Sequence[int],
+) -> None:
     for va, size in zip(vas, sizes, strict=False):
         if va:
             try:
@@ -200,7 +204,13 @@ def _cleanup_mappings(vas: Sequence[int], sizes: Sequence[int], handles: Sequenc
                 pass
 
 
-def _cleanup_arena(arena_va: int, arena_size: int, offsets: Sequence[int], sizes: Sequence[int], handles: Sequence[int]) -> None:
+def _cleanup_arena(
+    arena_va: int,
+    arena_size: int,
+    offsets: Sequence[int],
+    sizes: Sequence[int],
+    handles: Sequence[int],
+) -> None:
     for offset, size in zip(offsets, sizes, strict=False):
         try:
             cumem_unmap(arena_va + offset, size)
@@ -225,7 +235,12 @@ def _allocate(mm: GMSClientMemoryManager, sizes: Sequence[int], timings: list[St
     return allocations
 
 
-def _metadata_put_loop(mm: GMSClientMemoryManager, allocations, count: int, timings: list[StepTiming]) -> None:
+def _metadata_put_loop(
+    mm: GMSClientMemoryManager,
+    allocations,
+    count: int,
+    timings: list[StepTiming],
+) -> None:
     payload = b'{"shape":[1],"dtype":"torch.float16","stride":[1],"tensor_type":"parameter"}'
     with Timer(timings, "metadata_put_loop", count=count, bytes=len(payload) * count):
         for i, alloc in enumerate(allocations[:count]):
@@ -234,15 +249,55 @@ def _metadata_put_loop(mm: GMSClientMemoryManager, allocations, count: int, timi
                 raise RuntimeError(f"metadata_put failed at index {i}")
 
 
-def _run_per_allocation(mm: GMSClientMemoryManager, sizes: Sequence[int], *, metadata_count: int, timings: list[StepTiming]) -> None:
+def _export_allocations(
+    mm: GMSClientMemoryManager,
+    allocations,
+    timings: list[StepTiming],
+    *,
+    batch: bool,
+    chunk_size: int,
+) -> list[int]:
+    fds: list[int] = []
+    if not batch:
+        with Timer(timings, "export_loop", count=len(allocations)):
+            for alloc in allocations:
+                fds.append(mm.export_handle(alloc.allocation_id))
+        return fds
+
+    allocation_ids = [alloc.allocation_id for alloc in allocations]
+    with Timer(
+        timings,
+        "export_many_loop",
+        count=len(allocation_ids),
+        extra={"chunk_size": chunk_size},
+    ):
+        for start in range(0, len(allocation_ids), chunk_size):
+            chunk = allocation_ids[start : start + chunk_size]
+            fds.extend(mm.export_handles(chunk))
+    return fds
+
+
+def _run_per_allocation(
+    mm: GMSClientMemoryManager,
+    sizes: Sequence[int],
+    *,
+    metadata_count: int,
+    timings: list[StepTiming],
+    batch_export: bool = False,
+    export_chunk_size: int = 128,
+) -> None:
     allocations = _allocate(mm, sizes, timings)
     fds: list[int] = []
     vas: list[int] = []
     handles: list[int] = []
     try:
-        with Timer(timings, "export_loop", count=len(allocations)):
-            for alloc in allocations:
-                fds.append(mm.export_handle(alloc.allocation_id))
+        fds = _export_allocations(
+            mm,
+            allocations,
+            timings,
+            batch=batch_export,
+            chunk_size=export_chunk_size,
+        )
 
         with Timer(timings, "reserve_va_loop", count=len(sizes), bytes=sum(sizes)):
             for size in sizes:
@@ -257,14 +312,29 @@ def _run_per_allocation(mm: GMSClientMemoryManager, sizes: Sequence[int], *, met
             for va, size, handle in zip(vas, sizes, handles, strict=True):
                 cumem_map(va, size, handle)
 
-        with Timer(timings, "cu_mem_set_access_loop", count=len(handles), bytes=sum(sizes)):
+        with Timer(
+            timings,
+            "cu_mem_set_access_loop",
+            count=len(handles),
+            bytes=sum(sizes),
+        ):
             for va, size in zip(vas, sizes, strict=True):
                 cumem_set_access(va, size, mm.device, GrantedLockType.RW)
 
         if metadata_count:
-            _metadata_put_loop(mm, allocations, min(metadata_count, len(allocations)), timings)
+            _metadata_put_loop(
+                mm,
+                allocations,
+                min(metadata_count, len(allocations)),
+                timings,
+            )
 
-        with Timer(timings, "local_unmap_release_free_loop", count=len(handles), bytes=sum(sizes)):
+        with Timer(
+            timings,
+            "local_unmap_release_free_loop",
+            count=len(handles),
+            bytes=sum(sizes),
+        ):
             _cleanup_mappings(vas, sizes, handles)
             vas.clear()
             handles.clear()
@@ -276,7 +346,16 @@ def _run_per_allocation(mm: GMSClientMemoryManager, sizes: Sequence[int], *, met
         _cleanup_mappings(vas, sizes, handles)
 
 
-def _run_arena(mm: GMSClientMemoryManager, sizes: Sequence[int], *, one_set_access: bool, metadata_count: int, timings: list[StepTiming]) -> None:
+def _run_arena(
+    mm: GMSClientMemoryManager,
+    sizes: Sequence[int],
+    *,
+    one_set_access: bool,
+    metadata_count: int,
+    timings: list[StepTiming],
+    batch_export: bool = False,
+    export_chunk_size: int = 128,
+) -> None:
     allocations = _allocate(mm, sizes, timings)
     fds: list[int] = []
     handles: list[int] = []
@@ -288,9 +367,13 @@ def _run_arena(mm: GMSClientMemoryManager, sizes: Sequence[int], *, one_set_acce
         offsets.append(pos)
         pos += size
     try:
-        with Timer(timings, "export_loop", count=len(allocations)):
-            for alloc in allocations:
-                fds.append(mm.export_handle(alloc.allocation_id))
+        fds = _export_allocations(
+            mm,
+            allocations,
+            timings,
+            batch=batch_export,
+            chunk_size=export_chunk_size,
+        )
 
         with Timer(timings, "arena_reserve_va", count=1, bytes=total):
             arena_va = cumem_address_reserve(total, mm.granularity)
@@ -300,7 +383,12 @@ def _run_arena(mm: GMSClientMemoryManager, sizes: Sequence[int], *, one_set_acce
                 handles.append(cumem_import_from_shareable_handle_close_fd(fd))
             fds.clear()
 
-        with Timer(timings, "cu_mem_map_loop", count=len(handles), bytes=total):
+        with Timer(
+            timings,
+            "cu_mem_map_loop",
+            count=len(handles),
+            bytes=total,
+        ):
             for offset, size, handle in zip(offsets, sizes, handles, strict=True):
                 cumem_map(arena_va + offset, size, handle)
 
@@ -319,18 +407,38 @@ def _run_arena(mm: GMSClientMemoryManager, sizes: Sequence[int], *, one_set_acce
                 )
             )
             if not ok:
-                with Timer(timings, "cu_mem_set_access_loop_after_once_failed", count=len(handles), bytes=total):
+                with Timer(
+                    timings,
+                    "cu_mem_set_access_loop_after_once_failed",
+                    count=len(handles),
+                    bytes=total,
+                ):
                     for offset, size in zip(offsets, sizes, strict=True):
                         cumem_set_access(arena_va + offset, size, mm.device, GrantedLockType.RW)
         else:
-            with Timer(timings, "cu_mem_set_access_loop", count=len(handles), bytes=total):
+            with Timer(
+                timings,
+                "cu_mem_set_access_loop",
+                count=len(handles),
+                bytes=total,
+            ):
                 for offset, size in zip(offsets, sizes, strict=True):
                     cumem_set_access(arena_va + offset, size, mm.device, GrantedLockType.RW)
 
         if metadata_count:
-            _metadata_put_loop(mm, allocations, min(metadata_count, len(allocations)), timings)
+            _metadata_put_loop(
+                mm,
+                allocations,
+                min(metadata_count, len(allocations)),
+                timings,
+            )
 
-        with Timer(timings, "local_unmap_release_arena_free", count=len(handles), bytes=total):
+        with Timer(
+            timings,
+            "local_unmap_release_arena_free",
+            count=len(handles),
+            bytes=total,
+        ):
             _cleanup_arena(arena_va, total, offsets, sizes, handles)
             arena_va = 0
             handles.clear()
@@ -343,7 +451,12 @@ def _run_arena(mm: GMSClientMemoryManager, sizes: Sequence[int], *, one_set_acce
             _cleanup_arena(arena_va, total, offsets, sizes, handles)
 
 
-def run_once(args: argparse.Namespace, variant: str, sizes: Sequence[int], iteration: int) -> dict[str, object]:
+def run_once(
+    args: argparse.Namespace,
+    variant: str,
+    sizes: Sequence[int],
+    iteration: int,
+) -> dict[str, object]:
     socket_path = args.socket_path or get_socket_path(args.device, "weights")
     timings: list[StepTiming] = []
     mm = GMSClientMemoryManager(socket_path, device=args.device, tag="weights")
@@ -353,13 +466,62 @@ def run_once(args: argparse.Namespace, variant: str, sizes: Sequence[int], itera
             mm.connect(RequestedLockType.RW, timeout_ms=args.timeout_ms)
             connected = True
         if variant == "per-allocation":
-            _run_per_allocation(mm, sizes, metadata_count=args.metadata_count, timings=timings)
+            _run_per_allocation(
+                mm,
+                sizes,
+                metadata_count=args.metadata_count,
+                timings=timings,
+            )
             connected = False  # commit closed it
+        elif variant == "batch-export":
+            _run_per_allocation(
+                mm,
+                sizes,
+                metadata_count=args.metadata_count,
+                timings=timings,
+                batch_export=True,
+                export_chunk_size=args.export_chunk_size,
+            )
+            connected = False
         elif variant == "arena-loop-access":
-            _run_arena(mm, sizes, one_set_access=False, metadata_count=args.metadata_count, timings=timings)
+            _run_arena(
+                mm,
+                sizes,
+                one_set_access=False,
+                metadata_count=args.metadata_count,
+                timings=timings,
+            )
+            connected = False
+        elif variant == "arena-loop-access-batch-export":
+            _run_arena(
+                mm,
+                sizes,
+                one_set_access=False,
+                metadata_count=args.metadata_count,
+                timings=timings,
+                batch_export=True,
+                export_chunk_size=args.export_chunk_size,
+            )
             connected = False
         elif variant == "arena-once-access":
-            _run_arena(mm, sizes, one_set_access=True, metadata_count=args.metadata_count, timings=timings)
+            _run_arena(
+                mm,
+                sizes,
+                one_set_access=True,
+                metadata_count=args.metadata_count,
+                timings=timings,
+            )
+            connected = False
+        elif variant == "arena-once-access-batch-export":
+            _run_arena(
+                mm,
+                sizes,
+                one_set_access=True,
+                metadata_count=args.metadata_count,
+                timings=timings,
+                batch_export=True,
+                export_chunk_size=args.export_chunk_size,
+            )
             connected = False
         else:
             raise ValueError(f"unknown variant: {variant}")
@@ -393,9 +555,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--variant",
         action="append",
-        choices=("per-allocation", "arena-loop-access", "arena-once-access"),
+        choices=(
+            "per-allocation",
+            "batch-export",
+            "arena-loop-access",
+            "arena-loop-access-batch-export",
+            "arena-once-access",
+            "arena-once-access-batch-export",
+        ),
         help="Variant to run. May be passed multiple times. Default: per-allocation.",
     )
+    parser.add_argument("--export-chunk-size", type=int, default=128)
     parser.add_argument("--json-out", default=None)
     args = parser.parse_args(argv)
 
@@ -405,7 +575,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.manifest:
         sizes = _sizes_from_manifest(args.manifest, granularity)
     else:
-        sizes = _sizes_from_total(args.count, _parse_total_bytes(args.total_bytes), granularity)
+        sizes = _sizes_from_total(
+            args.count,
+            _parse_total_bytes(args.total_bytes),
+            granularity,
+        )
 
     variants = args.variant or ["per-allocation"]
     results: list[dict[str, object]] = []

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -338,6 +338,10 @@ class GMSClientMemoryManager:
         """Export allocation as POSIX FD."""
         return self._client_rpc.export(allocation_id)
 
+    def export_handles(self, allocation_ids: List[str]) -> List[int]:
+        """Export multiple allocations as POSIX FDs in one RPC."""
+        return self._client_rpc.export_many(allocation_ids)
+
     def get_handle_info(self, allocation_id: str):
         """Query allocation info from server."""
         return self._client_rpc.get_allocation(allocation_id)

--- a/lib/gpu_memory_service/client/rpc.py
+++ b/lib/gpu_memory_service/client/rpc.py
@@ -21,7 +21,11 @@ from gpu_memory_service.common.protocol.messages import (
     HandshakeRequest,
     HandshakeResponse,
 )
-from gpu_memory_service.common.protocol.wire import recv_message_sync, send_message_sync
+from gpu_memory_service.common.protocol.wire import (
+    recv_message_sync,
+    recv_message_sync_with_fds,
+    send_message_sync,
+)
 
 T = TypeVar("T")
 
@@ -100,26 +104,48 @@ class _GMSRPCTransport:
         *,
         error_prefix: Optional[str] = None,
     ) -> Tuple[T, int]:
-        response, fd = self._send_recv(request, error_prefix=error_prefix)
+        response, fds = self.request_with_fds(
+            request, response_type, error_prefix=error_prefix
+        )
+        for extra_fd in fds[1:]:
+            os.close(extra_fd)
+        return response, (fds[0] if fds else -1)
+
+    def request_with_fds(
+        self,
+        request,
+        response_type: Type[T],
+        *,
+        error_prefix: Optional[str] = None,
+    ) -> Tuple[T, list[int]]:
+        response, fds = self._send_recv_fds(request, error_prefix=error_prefix)
         if not isinstance(response, response_type):
             prefix = error_prefix or f"GMS request {type(request).__name__}"
-            if fd >= 0:
+            for fd in fds:
                 os.close(fd)
             raise RuntimeError(
                 f"{prefix} returned unexpected response type: {type(response)}"
             )
-        return response, fd
+        return response, fds
 
     def _send_recv(
         self, request, *, error_prefix: Optional[str] = None
     ) -> Tuple[object, int]:
+        response, fds = self._send_recv_fds(request, error_prefix=error_prefix)
+        for extra_fd in fds[1:]:
+            os.close(extra_fd)
+        return response, (fds[0] if fds else -1)
+
+    def _send_recv_fds(
+        self, request, *, error_prefix: Optional[str] = None
+    ) -> Tuple[object, list[int]]:
         if self._socket is None:
             raise RuntimeError("Attempted GMS request on disconnected transport")
 
         prefix = error_prefix or f"GMS request {type(request).__name__}"
         try:
             send_message_sync(self._socket, request)
-            response, fd, self._recv_buffer = recv_message_sync(
+            response, fds, self._recv_buffer = recv_message_sync_with_fds(
                 self._socket, self._recv_buffer
             )
         except Exception as exc:
@@ -131,10 +157,10 @@ class _GMSRPCTransport:
             raise ConnectionError(f"{prefix} failed: {exc}") from exc
 
         if isinstance(response, ErrorResponse):
-            if fd >= 0:
+            for fd in fds:
                 os.close(fd)
             raise RuntimeError(f"{prefix} error: {response.error}")
-        return response, fd
+        return response, fds
 
     def close(self) -> None:
         if self._socket is None:

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import List, Optional, Tuple
 
 from gpu_memory_service.client.rpc import _GMSRPCTransport
@@ -19,6 +20,8 @@ from gpu_memory_service.common.protocol.messages import (
     CommitResponse,
     ExportAllocationRequest,
     ExportAllocationResponse,
+    ExportAllocationsRequest,
+    ExportAllocationsResponse,
     FreeAllocationRequest,
     FreeAllocationResponse,
     GetAllocationRequest,
@@ -161,6 +164,39 @@ class _GMSClientSession:
                 f"GMS export returned no FD for allocation_id={allocation_id}"
             )
         return fd
+
+    def export_many(self, allocation_ids: List[str]) -> List[int]:
+        if not allocation_ids:
+            return []
+        response, fds = self._transport.request_with_fds(
+            ExportAllocationsRequest(allocation_ids=allocation_ids),
+            ExportAllocationsResponse,
+        )
+        if len(response.allocations) != len(allocation_ids):
+            for fd in fds:
+                os.close(fd)
+            raise RuntimeError(
+                "GMS export_many response count mismatch: "
+                f"{len(response.allocations)} vs {len(allocation_ids)}"
+            )
+        if len(fds) != len(allocation_ids):
+            for fd in fds:
+                os.close(fd)
+            raise RuntimeError(
+                "GMS export_many FD count mismatch: "
+                f"{len(fds)} vs {len(allocation_ids)}"
+            )
+        for expected_id, allocation in zip(
+            allocation_ids, response.allocations, strict=True
+        ):
+            if allocation.allocation_id != expected_id:
+                for fd in fds:
+                    os.close(fd)
+                raise RuntimeError(
+                    "GMS export_many allocation order mismatch: "
+                    f"{allocation.allocation_id} vs {expected_id}"
+                )
+        return fds
 
     def get_allocation(self, allocation_id: str) -> GetAllocationResponse:
         return self._transport.request(

--- a/lib/gpu_memory_service/common/protocol/messages.py
+++ b/lib/gpu_memory_service/common/protocol/messages.py
@@ -86,6 +86,14 @@ class ExportAllocationResponse(msgspec.Struct, tag="export_allocation_response")
     layout_slot: int
 
 
+class ExportAllocationsRequest(msgspec.Struct, tag="export_allocations_request"):
+    allocation_ids: List[str]
+
+
+class ExportAllocationsResponse(msgspec.Struct, tag="export_allocations_response"):
+    allocations: List[ExportAllocationResponse]
+
+
 class GetAllocationRequest(msgspec.Struct, tag="get_allocation_request"):
     allocation_id: str
 
@@ -208,6 +216,8 @@ Message = Union[
     AllocateManyResponse,
     ExportAllocationRequest,
     ExportAllocationResponse,
+    ExportAllocationsRequest,
+    ExportAllocationsResponse,
     GetAllocationRequest,
     GetAllocationResponse,
     ListAllocationsRequest,

--- a/lib/gpu_memory_service/common/protocol/wire.py
+++ b/lib/gpu_memory_service/common/protocol/wire.py
@@ -12,6 +12,7 @@ from typing import Optional, Tuple
 from .messages import Message, decode_message, encode_message
 
 HEADER_SIZE = 4  # 4-byte big-endian length prefix
+MAX_FDS_PER_MESSAGE = 128
 
 
 def _frame_message(msg: Message) -> bytes:
@@ -46,31 +47,47 @@ def _try_extract_message(
 
 async def send_message(writer, msg: Message, fd: int = -1) -> None:
     """Send a length-prefixed message with optional FD via SCM_RIGHTS."""
+    fds = [fd] if fd >= 0 else []
+    await send_message_with_fds(writer, msg, fds)
+
+
+async def send_message_with_fds(
+    writer,
+    msg: Message,
+    fds: list[int] | tuple[int, ...],
+) -> None:
+    """Send a length-prefixed message with optional FDs via SCM_RIGHTS."""
     frame = _frame_message(msg)
-
-    if fd >= 0:
-        transport_sock = writer.get_extra_info("socket")
-        if transport_sock is None:
-            raise RuntimeError("Cannot get socket from transport for FD passing")
-
-        def do_send_fd():
-            raw_fd = transport_sock.fileno()
-            dup_fd = os.dup(raw_fd)
-            try:
-                sock = socket.socket(fileno=dup_fd)
-                try:
-                    sock.setblocking(True)
-                    socket.send_fds(sock, [frame], [fd])
-                finally:
-                    sock.detach()
-            except Exception:
-                os.close(dup_fd)
-                raise
-
-        await asyncio.get_running_loop().run_in_executor(None, do_send_fd)
-    else:
+    if not fds:
         writer.write(frame)
         await writer.drain()
+        return
+    if len(fds) > MAX_FDS_PER_MESSAGE:
+        raise ValueError(
+            f"too many FDs for one message: {len(fds)} > {MAX_FDS_PER_MESSAGE}"
+        )
+
+    transport_sock = writer.get_extra_info("socket")
+    if transport_sock is None:
+        raise RuntimeError("Cannot get socket from transport for FD passing")
+
+    def do_send_fds():
+        raw_fd = transport_sock.fileno()
+        dup_fd = os.dup(raw_fd)
+        sock = None
+        try:
+            sock = socket.socket(fileno=dup_fd)
+            sock.setblocking(True)
+            socket.send_fds(sock, [frame], list(fds))
+        except Exception:
+            if sock is None:
+                os.close(dup_fd)
+            raise
+        finally:
+            if sock is not None:
+                sock.close()
+
+    await asyncio.get_running_loop().run_in_executor(None, do_send_fds)
 
 
 async def recv_message(
@@ -79,43 +96,47 @@ async def recv_message(
     """Receive a length-prefixed message with optional FD.
 
     Returns (message, fd, remaining_buffer). fd is -1 if none sent.
+    Additional FDs, if any, are closed for compatibility.
     """
+    msg, fds, remaining = await recv_message_with_fds(reader, recv_buffer, raw_sock)
+    for extra_fd in fds[1:]:
+        os.close(extra_fd)
+    return msg, (fds[0] if fds else -1), remaining
+
+
+async def recv_message_with_fds(
+    reader, recv_buffer: Optional[bytearray] = None, raw_sock=None
+) -> Tuple[Optional[Message], list[int], bytearray]:
+    """Receive a length-prefixed message with optional FDs."""
     if recv_buffer is None:
         recv_buffer = bytearray()
 
-    # Check if complete message already in buffer
     msg, remaining, _ = _try_extract_message(recv_buffer)
     if msg is not None:
-        return msg, -1, remaining
+        return msg, [], remaining
 
     loop = asyncio.get_running_loop()
-    fd = -1
-
-    # Receive more data
+    fds: list[int] = []
     if raw_sock is not None:
-        raw_msg, fds, _flags, _addr = await loop.run_in_executor(
-            None, lambda: socket.recv_fds(raw_sock, 65536, 1)
+        raw_msg, got_fds, _flags, _addr = await loop.run_in_executor(
+            None, lambda: socket.recv_fds(raw_sock, 65536, MAX_FDS_PER_MESSAGE)
         )
-        for extra_fd in fds[1:]:
-            os.close(extra_fd)
         if not raw_msg:
-            if fds:
-                os.close(fds[0])
+            for fd in got_fds:
+                os.close(fd)
             raise ConnectionResetError("Connection closed")
         recv_buffer.extend(raw_msg)
-        fd = fds[0] if fds else -1
+        fds = list(got_fds)
     else:
         chunk = await reader.read(65536)
         if not chunk:
             raise ConnectionResetError("Connection closed")
         recv_buffer.extend(chunk)
 
-    # Try to extract message, read more if needed
     try:
         msg, remaining, bytes_needed = _try_extract_message(recv_buffer)
         while msg is None and bytes_needed > 0:
             if raw_sock is not None:
-                # Continue reading from raw socket to avoid buffer inconsistency
                 chunk = await loop.run_in_executor(
                     None, lambda n=bytes_needed: raw_sock.recv(n)
                 )
@@ -125,9 +146,9 @@ async def recv_message(
                 raise ConnectionResetError("Connection closed")
             remaining.extend(chunk)
             msg, remaining, bytes_needed = _try_extract_message(remaining)
-        return msg, fd, remaining
+        return msg, fds, remaining
     except Exception:
-        if fd >= 0:
+        for fd in fds:
             os.close(fd)
         raise
 
@@ -137,9 +158,23 @@ async def recv_message(
 
 def send_message_sync(sock, msg: Message, fd: int = -1) -> None:
     """Send a length-prefixed message with optional FD via SCM_RIGHTS."""
+    fds = [fd] if fd >= 0 else []
+    send_message_sync_with_fds(sock, msg, fds)
+
+
+def send_message_sync_with_fds(
+    sock,
+    msg: Message,
+    fds: list[int] | tuple[int, ...],
+) -> None:
+    """Send a length-prefixed message with optional FDs via SCM_RIGHTS."""
     frame = _frame_message(msg)
-    if fd >= 0:
-        socket.send_fds(sock, [frame], [fd])
+    if fds:
+        if len(fds) > MAX_FDS_PER_MESSAGE:
+            raise ValueError(
+                f"too many FDs for one message: {len(fds)} > {MAX_FDS_PER_MESSAGE}"
+            )
+        socket.send_fds(sock, [frame], list(fds))
     else:
         sock.sendall(frame)
 
@@ -150,27 +185,33 @@ def recv_message_sync(
     """Receive a length-prefixed message with optional FD.
 
     Returns (message, fd, remaining_buffer). fd is -1 if none sent.
+    Additional FDs, if any, are closed for compatibility.
     """
+    msg, fds, remaining = recv_message_sync_with_fds(sock, recv_buffer)
+    for extra_fd in fds[1:]:
+        os.close(extra_fd)
+    return msg, (fds[0] if fds else -1), remaining
+
+
+def recv_message_sync_with_fds(
+    sock, recv_buffer: Optional[bytearray] = None
+) -> Tuple[Optional[Message], list[int], bytearray]:
+    """Receive a length-prefixed message with optional FDs."""
     if recv_buffer is None:
         recv_buffer = bytearray()
 
-    # Check if complete message already in buffer
     msg, remaining, _ = _try_extract_message(recv_buffer)
     if msg is not None:
-        return msg, -1, remaining
+        return msg, [], remaining
 
-    # Receive more data (with potential FD)
-    raw_msg, fds, _flags, _addr = socket.recv_fds(sock, 65536, 1)
-    for extra_fd in fds[1:]:
-        os.close(extra_fd)
+    raw_msg, got_fds, _flags, _addr = socket.recv_fds(sock, 65536, MAX_FDS_PER_MESSAGE)
     if not raw_msg:
-        if fds:
-            os.close(fds[0])
+        for fd in got_fds:
+            os.close(fd)
         raise ConnectionResetError("Connection closed")
     recv_buffer.extend(raw_msg)
-    fd = fds[0] if fds else -1
+    fds = list(got_fds)
 
-    # Try to extract message, read more if needed
     try:
         msg, remaining, bytes_needed = _try_extract_message(recv_buffer)
         while msg is None and bytes_needed > 0:
@@ -179,8 +220,8 @@ def recv_message_sync(
                 raise ConnectionResetError("Connection closed")
             remaining.extend(chunk)
             msg, remaining, bytes_needed = _try_extract_message(remaining)
-        return msg, fd, remaining
+        return msg, fds, remaining
     except Exception:
-        if fd >= 0:
+        for fd in fds:
             os.close(fd)
         raise

--- a/lib/gpu_memory_service/server/gms.py
+++ b/lib/gpu_memory_service/server/gms.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 from collections import deque
 from dataclasses import dataclass
 from typing import Callable, Optional
@@ -21,6 +22,8 @@ from gpu_memory_service.common.protocol.messages import (
     CommitResponse,
     ExportAllocationRequest,
     ExportAllocationResponse,
+    ExportAllocationsRequest,
+    ExportAllocationsResponse,
     FreeAllocationRequest,
     FreeAllocationResponse,
     GetAllocationRequest,
@@ -230,7 +233,7 @@ class GMS:
         conn: Connection,
         msg,
         is_connected: Callable[[], bool],
-    ) -> tuple[object, int, bool]:
+    ) -> tuple[object, int | list[int], bool]:
         msg_type = type(msg)
         self._sessions.check_operation(msg_type, conn)
 
@@ -343,6 +346,39 @@ class GMS:
                     layout_slot=info.layout_slot,
                 ),
                 fd,
+                False,
+            )
+
+        if msg_type is ExportAllocationsRequest:
+            infos = [
+                self._allocations.get_allocation(allocation_id)
+                for allocation_id in msg.allocation_ids
+            ]
+            fds: list[int] = []
+            try:
+                for info in infos:
+                    fds.append(self._allocations.export_allocation(info.allocation_id))
+            except Exception:
+                for fd in fds:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                raise
+            return (
+                ExportAllocationsResponse(
+                    allocations=[
+                        ExportAllocationResponse(
+                            allocation_id=info.allocation_id,
+                            size=info.size,
+                            aligned_size=info.aligned_size,
+                            tag=info.tag,
+                            layout_slot=info.layout_slot,
+                        )
+                        for info in infos
+                    ]
+                ),
+                fds,
                 False,
             )
 

--- a/lib/gpu_memory_service/server/rpc.py
+++ b/lib/gpu_memory_service/server/rpc.py
@@ -19,7 +19,11 @@ from gpu_memory_service.common.protocol.messages import (
     HandshakeRequest,
     HandshakeResponse,
 )
-from gpu_memory_service.common.protocol.wire import recv_message, send_message
+from gpu_memory_service.common.protocol.wire import (
+    recv_message,
+    send_message,
+    send_message_with_fds,
+)
 from gpu_memory_service.common.utils import fail
 
 from .allocations import AllocationNotFoundError
@@ -272,7 +276,10 @@ class GMSRPCServer:
                 fail("fatal server error", exc_info=exc)
 
             try:
-                await send_message(conn.writer, response, fd)
+                if isinstance(fd, list):
+                    await send_message_with_fds(conn.writer, response, fd)
+                else:
+                    await send_message(conn.writer, response, fd)
             except Exception as exc:
                 logger.warning(
                     "Response send failed for %s on session %s: %s",
@@ -282,7 +289,10 @@ class GMSRPCServer:
                 )
                 return
             finally:
-                if fd >= 0:
+                if isinstance(fd, list):
+                    for one_fd in fd:
+                        os.close(one_fd)
+                elif fd >= 0:
                     os.close(fd)
 
             if should_close:

--- a/lib/gpu_memory_service/server/session.py
+++ b/lib/gpu_memory_service/server/session.py
@@ -15,6 +15,7 @@ from gpu_memory_service.common.protocol.messages import (
     AllocateRequest,
     CommitRequest,
     ExportAllocationRequest,
+    ExportAllocationsRequest,
     FreeAllocationRequest,
     GetAllocationRequest,
     GetAllocationStateRequest,
@@ -48,6 +49,7 @@ RW_REQUIRED: frozenset[type] = frozenset(
 RO_ALLOWED: frozenset[type] = frozenset(
     {
         ExportAllocationRequest,
+        ExportAllocationsRequest,
         GetAllocationRequest,
         ListAllocationsRequest,
         MetadataGetRequest,

--- a/lib/gpu_memory_service/snapshot/storage_client.py
+++ b/lib/gpu_memory_service/snapshot/storage_client.py
@@ -44,11 +44,13 @@ logger = logging.getLogger(__name__)
 try:
     from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
     from gpu_memory_service.common.locks import RequestedLockType
+    from gpu_memory_service.common.protocol.wire import MAX_FDS_PER_MESSAGE
 
     _GMS_CORE_IMPORTS_AVAILABLE = True
 except ImportError:
     _GMS_CORE_IMPORTS_AVAILABLE = False
     GMSClientMemoryManager = None  # type: ignore[assignment,misc]
+    MAX_FDS_PER_MESSAGE = 128  # type: ignore[assignment]
     RequestedLockType = None  # type: ignore[assignment]
 
 
@@ -280,45 +282,75 @@ class GMSStorageClient:
         reserve_elapsed = 0.0
         map_elapsed = 0.0
         target_elapsed = 0.0
-        for entry, allocation in zip(
-            manifest.allocations, allocations, strict=True
-        ):
-            if int(allocation.aligned_size) != int(entry.aligned_size):
-                raise RuntimeError(
-                    "GMS restore allocation size mismatch for "
-                    f"{entry.allocation_id}: {allocation.aligned_size} vs "
-                    f"{entry.aligned_size}"
-                )
-            old_id = entry.allocation_id
 
-            step_t0 = time.monotonic()
-            fd = mm.export_handle(allocation.allocation_id)
-            export_elapsed += time.monotonic() - step_t0
+        export_chunk_size = MAX_FDS_PER_MESSAGE
+        for start in range(0, len(allocations), export_chunk_size):
+            allocation_chunk = allocations[start : start + export_chunk_size]
+            manifest_chunk = manifest.allocations[start : start + export_chunk_size]
+            chunk_fds: list[int] = []
+            try:
+                allocation_ids = [
+                    allocation.allocation_id for allocation in allocation_chunk
+                ]
+                step_t0 = time.monotonic()
+                chunk_fds = mm.export_handles(allocation_ids)
+                export_elapsed += time.monotonic() - step_t0
+                if len(chunk_fds) != len(allocation_chunk):
+                    raise RuntimeError(
+                        "GMS export_many FD count mismatch: "
+                        f"{len(chunk_fds)} vs {len(allocation_chunk)}"
+                    )
 
-            step_t0 = time.monotonic()
-            va = mm.reserve_va(allocation.aligned_size)
-            reserve_elapsed += time.monotonic() - step_t0
+                for fd_idx, (entry, allocation) in enumerate(
+                    zip(manifest_chunk, allocation_chunk, strict=True)
+                ):
+                    if int(allocation.aligned_size) != int(entry.aligned_size):
+                        raise RuntimeError(
+                            "GMS restore allocation size mismatch for "
+                            f"{entry.allocation_id}: {allocation.aligned_size} vs "
+                            f"{entry.aligned_size}"
+                        )
+                    old_id = entry.allocation_id
+                    fd = chunk_fds[fd_idx]
 
-            step_t0 = time.monotonic()
-            mm.map_va(
-                fd,
-                va,
-                entry.size,
-                allocation.allocation_id,
-                entry.tag,
-                allocation.layout_slot,
-            )
-            map_elapsed += time.monotonic() - step_t0
+                    step_t0 = time.monotonic()
+                    va = mm.reserve_va(allocation.aligned_size)
+                    reserve_elapsed += time.monotonic() - step_t0
 
-            step_t0 = time.monotonic()
-            id_map[old_id] = allocation.allocation_id
-            targets[old_id] = GMSTransferTarget(
-                allocation_id=old_id,
-                va=va,
-                device=self.device,
-                byte_count=entry.aligned_size,
-            )
-            target_elapsed += time.monotonic() - step_t0
+                    step_t0 = time.monotonic()
+                    try:
+                        mm.map_va(
+                            fd,
+                            va,
+                            entry.size,
+                            allocation.allocation_id,
+                            entry.tag,
+                            allocation.layout_slot,
+                        )
+                    finally:
+                        # map_va imports and closes the POSIX FD, even if the
+                        # CUDA import/map fails. Mark it consumed so the chunk
+                        # cleanup only closes FDs never handed to CUDA.
+                        chunk_fds[fd_idx] = -1
+                    map_elapsed += time.monotonic() - step_t0
+
+                    step_t0 = time.monotonic()
+                    id_map[old_id] = allocation.allocation_id
+                    targets[old_id] = GMSTransferTarget(
+                        allocation_id=old_id,
+                        va=va,
+                        device=self.device,
+                        byte_count=entry.aligned_size,
+                    )
+                    target_elapsed += time.monotonic() - step_t0
+            finally:
+                for fd in chunk_fds:
+                    if fd < 0:
+                        continue
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
 
         total_elapsed = time.monotonic() - t0
         logger.info(

--- a/lib/gpu_memory_service/tests/test_batch_restore_layout.py
+++ b/lib/gpu_memory_service/tests/test_batch_restore_layout.py
@@ -98,9 +98,16 @@ def test_restore_phase_a_uses_batched_allocation_api():
             raise AssertionError("restore should not allocate through create_mapping()")
 
         def export_handle(self, allocation_id):
-            read_fd, write_fd = os.pipe()
-            os.close(write_fd)
-            return read_fd
+            raise AssertionError("restore should use export_handles()")
+
+        def export_handles(self, allocation_ids):
+            fds = []
+            for allocation_id in allocation_ids:
+                assert allocation_id in {"new-0", "new-1"}
+                read_fd, write_fd = os.pipe()
+                os.close(write_fd)
+                fds.append(read_fd)
+            return fds
 
         def reserve_va(self, size):
             va = self._next_va

--- a/lib/gpu_memory_service/tests/test_protocol_wire.py
+++ b/lib/gpu_memory_service/tests/test_protocol_wire.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import socket
+
+from gpu_memory_service.common.protocol.messages import GetAllocationStateResponse
+from gpu_memory_service.common.protocol.wire import (
+    recv_message_sync_with_fds,
+    send_message_sync_with_fds,
+)
+
+
+def _close_all(fds: list[int]) -> None:
+    for fd in fds:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def test_sync_wire_roundtrips_multiple_fds() -> None:
+    left, right = socket.socketpair()
+    sent_read_fds: list[int] = []
+    sent_write_fds: list[int] = []
+    received_fds: list[int] = []
+    try:
+        for _ in range(3):
+            read_fd, write_fd = os.pipe()
+            sent_read_fds.append(read_fd)
+            sent_write_fds.append(write_fd)
+
+        send_message_sync_with_fds(
+            left,
+            GetAllocationStateResponse(allocation_count=3),
+            sent_read_fds,
+        )
+        message, received_fds, remaining = recv_message_sync_with_fds(right)
+
+        assert isinstance(message, GetAllocationStateResponse)
+        assert message.allocation_count == 3
+        assert len(received_fds) == len(sent_read_fds)
+        assert remaining == bytearray()
+        for fd in received_fds:
+            os.fstat(fd)
+    finally:
+        _close_all(received_fds)
+        _close_all(sent_read_fds)
+        _close_all(sent_write_fds)
+        left.close()
+        right.close()


### PR DESCRIPTION
## Description

Stacked on #10013.

Batches restore-side GMS allocation FD export so Phase A no longer performs one Unix-socket RPC/FD receive per allocation.

Changes:

- Extend the GMS wire protocol with multi-FD send/receive helpers and `MAX_FDS_PER_MESSAGE=128`.
- Add `ExportAllocationsRequest/Response` plus client APIs `export_many()` / `export_handles()`.
- Add server-side batched export handling. If FD duplication fails partway through a batch, partial duplicate FDs are closed before propagating the error.
- Update restore Phase A to export/map in chunks of 128. This keeps FD pressure bounded while reducing GPT-OSS-sized export RPCs from 3435 to ~27.
- Add tests for multi-FD wire roundtrip and restore Phase A using `export_handles()` instead of per-allocation `export_handle()`.

## Testing

- `PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest lib/gpu_memory_service/tests/test_protocol_wire.py lib/gpu_memory_service/tests/test_batch_restore_layout.py lib/gpu_memory_service/tests/test_snapshot_loader.py lib/gpu_memory_service/tests/test_snapshot_nixl_staging.py lib/gpu_memory_service/tests/test_snapshot_sharded_ssd.py -q` (27 passed)
- Included in final stack test: `PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest lib/gpu_memory_service/tests/test_runtime_flows.py lib/gpu_memory_service/tests/test_batch_restore_layout.py lib/gpu_memory_service/tests/test_protocol_wire.py lib/gpu_memory_service/tests/test_snapshot_loader.py lib/gpu_memory_service/tests/test_snapshot_nixl_staging.py lib/gpu_memory_service/tests/test_snapshot_sharded_ssd.py -q` (48 passed)
- `python3 -m compileall -q` over modified GMS files
- `git diff --check`

## Benchmark results

Built and measured image:

- Build On Demand: https://github.com/ai-dynamo/dynamo/actions/runs/26487040282
- image: `dynamoci.azurecr.io/ai-dynamo/dynamo:fff4d07c368e30e6257a0acc167cfed40da14d57-vllm-runtime-cuda13`
- node: `s2877`
- microbench pod: `gms-phase-a-microbench-fdexp-fff4-0527023529`
- log: `gms-auto-bench/microbench/gms-phase-a-microbench-fdexp-fff4-0527023529-bench.log`
- shape: 3435 allocations, 134.28 GiB, 723 metadata keys

Warm medians dropping first iteration:

| Step | Per-allocation export | Batch export |
|---|---:|---:|
| export | `export_loop` 0.1769s | `export_many_loop` 0.0074s |
| `server_allocate_many` | 0.2563s | 0.2495s |
| `cuda_import_loop` | 0.1427s | 0.1358s |
| `reserve_va_loop` | 0.1228s | 0.1213s |
| `cu_mem_set_access_loop` | 0.1850s | 0.1835s |

Result: the export component drops by about **170 ms** for this allocation count.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->