### PR TITLE
fix(gms): reserve restore VAs in one arena

### DIFF
--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -176,6 +176,7 @@ class GMSClientMemoryManager:
         #                         prepare_scratch_for_reallocation.
         self._mappings: Dict[int, LocalMapping] = {}
         self._inverse_mapping: Dict[str, int] = {}
+        self._va_arenas: Dict[int, int] = {}
         self._scratch_mappings: Dict[int, _ScratchMapping] = {}
 
         self._unmapped = False
@@ -410,6 +411,49 @@ class GMSClientMemoryManager:
         aligned_size = align_to_granularity(size, self.granularity)
         return cumem_address_reserve(aligned_size, self.granularity)
 
+    def reserve_va_arena(self, sizes: List[int]) -> tuple[int, List[int]]:
+        """Reserve one contiguous VA arena and return per-allocation VAs.
+
+        This is a loader/restore optimization: CUDA graph stability only
+        requires the final virtual addresses to be stable, not one separate
+        `cuMemAddressReserve` call per server allocation. The server still owns
+        independent GMS allocations; this only packs the loader-side virtual
+        address reservations contiguously.
+
+        Args:
+            sizes: Allocation sizes. Each size is aligned to VMM granularity
+                before computing offsets.
+
+        Returns:
+            `(arena_base, vas)`. `arena_base` is the address that must be freed
+            with `free_va_arena()` if the caller does not subsequently register
+            all VAs with `map_va_at_reserved()`. `vas[i]` is the VA for
+            `sizes[i]`.
+        """
+        if not sizes:
+            return 0, []
+
+        aligned_sizes = [
+            align_to_granularity(size, self.granularity) for size in sizes
+        ]
+        total_size = sum(aligned_sizes)
+        arena_base = cumem_address_reserve(total_size, self.granularity)
+        self._va_arenas[arena_base] = total_size
+        vas: list[int] = []
+        offset = 0
+        for aligned_size in aligned_sizes:
+            vas.append(arena_base + offset)
+            offset += aligned_size
+        return arena_base, vas
+
+    def free_va_arena(self, arena_base: int, total_size: int) -> None:
+        """Release an arena reserved by reserve_va_arena()."""
+        if arena_base == 0:
+            return
+        aligned_size = align_to_granularity(total_size, self.granularity)
+        cumem_address_free(arena_base, aligned_size)
+        self._va_arenas.pop(arena_base, None)
+
     def map_va(
         self,
         fd: int,
@@ -441,6 +485,69 @@ class GMSClientMemoryManager:
         )
         return handle
 
+    def map_va_at_reserved(
+        self,
+        fd: int,
+        va: int,
+        size: int,
+        allocation_id: str,
+        tag: str,
+        layout_slot: int,
+        *,
+        set_access: bool = True,
+    ) -> int:
+        """Import FD, map into an already-reserved VA range, and track it.
+
+        Unlike `map_va`, this helper accepts VAs that may be slices of one
+        larger VA reservation. Tracked mappings still use the per-allocation
+        aligned size for unmap/release bookkeeping. Callers that pass
+        `set_access=False` must establish CUDA access over the mapped range
+        separately before using the memory.
+        """
+        assert self._granted_lock_type is not None
+        aligned_size = align_to_granularity(size, self.granularity)
+        handle = cumem_import_from_shareable_handle_close_fd(fd)
+        mapped = False
+        try:
+            cumem_map(va, aligned_size, handle)
+            mapped = True
+            if set_access:
+                cumem_set_access(
+                    va,
+                    aligned_size,
+                    self.device,
+                    self._granted_lock_type,
+                )
+            self._track_mapping(
+                LocalMapping(
+                    allocation_id=allocation_id,
+                    va=va,
+                    size=size,
+                    aligned_size=aligned_size,
+                    handle=handle,
+                    tag=tag,
+                    layout_slot=layout_slot,
+                )
+            )
+        except Exception:
+            if mapped:
+                try:
+                    cumem_unmap(va, aligned_size)
+                except Exception:
+                    pass
+            try:
+                cumem_release(handle)
+            except Exception:
+                pass
+            raise
+        return handle
+
+    def set_va_access(self, va: int, size: int) -> None:
+        """Set access for an already mapped VA range using current lock mode."""
+        assert self._granted_lock_type is not None
+        aligned_size = align_to_granularity(size, self.granularity)
+        cumem_set_access(va, aligned_size, self.device, self._granted_lock_type)
+
     def unmap_va(self, va: int) -> None:
         """Unmap a single VA: cuMemUnmap + release handle.
 
@@ -467,9 +574,19 @@ class GMSClientMemoryManager:
             mapping = self._mappings.get(va)
             if mapping is None:
                 return
-        cumem_address_free(va, mapping.aligned_size)
         self._mappings.pop(va, None)
         self._inverse_mapping.pop(mapping.allocation_id, None)
+        arena_base = self._arena_base_for_va(va)
+        if arena_base is None:
+            cumem_address_free(va, mapping.aligned_size)
+            return
+        arena_size = self._va_arenas[arena_base]
+        if not any(
+            arena_base <= other_va < arena_base + arena_size
+            for other_va in self._mappings
+        ):
+            cumem_address_free(arena_base, arena_size)
+            self._va_arenas.pop(arena_base, None)
 
     # ==================== Tier 2: Convenience ====================
 
@@ -570,6 +687,40 @@ class GMSClientMemoryManager:
             total_bytes / (1 << 30),
             len(self._mappings) + len(self._scratch_mappings),
         )
+
+    def set_access_all_vas(self) -> None:
+        """Set CUDA access over all tracked server-backed mappings.
+
+        When mappings live in contiguous arenas, use one `cuMemSetAccess` call
+        per arena and per discontiguous non-arena run. This keeps the general
+        memory-manager contract intact while allowing the GMS loader to avoid
+        thousands of per-allocation access calls.
+        """
+        assert self._granted_lock_type is not None
+        ranges: list[tuple[int, int]] = []
+        for va, mapping in self._mappings.items():
+            if mapping.handle == 0:
+                continue
+            ranges.append((va, va + mapping.aligned_size))
+
+        if not ranges:
+            return
+
+        ranges.sort()
+        merged: list[list[int]] = []
+        for start, end in ranges:
+            if not merged or start > merged[-1][1]:
+                merged.append([start, end])
+            else:
+                merged[-1][1] = max(merged[-1][1], end)
+
+        for start, end in merged:
+            cumem_set_access(
+                start,
+                end - start,
+                self.device,
+                self._granted_lock_type,
+            )
 
     def remap_all_vas(self) -> None:
         """Re-import existing handles at preserved VAs.
@@ -812,6 +963,7 @@ class GMSClientMemoryManager:
                 pass
             self._mappings.clear()
             self._inverse_mapping.clear()
+            self._va_arenas.clear()
             self._scratch_mappings.clear()
         else:
             cuda_synchronize()
@@ -820,6 +972,9 @@ class GMSClientMemoryManager:
             for va in list(self._mappings.keys()):
                 self.unmap_va(va)
                 self.free_va(va)
+            for arena_base, arena_size in list(self._va_arenas.items()):
+                cumem_address_free(arena_base, arena_size)
+                self._va_arenas.pop(arena_base, None)
             self.abort()
         self._unmapped = False
         self._va_preserved = False
@@ -853,3 +1008,9 @@ class GMSClientMemoryManager:
     def _track_mapping(self, m: LocalMapping) -> None:
         self._mappings[m.va] = m
         self._inverse_mapping[m.allocation_id] = m.va
+
+    def _arena_base_for_va(self, va: int) -> Optional[int]:
+        for arena_base, arena_size in self._va_arenas.items():
+            if arena_base <= va < arena_base + arena_size:
+                return arena_base
+        return None

--- a/lib/gpu_memory_service/snapshot/storage_client.py
+++ b/lib/gpu_memory_service/snapshot/storage_client.py
@@ -281,12 +281,21 @@ class GMSStorageClient:
         export_elapsed = 0.0
         reserve_elapsed = 0.0
         map_elapsed = 0.0
+        access_elapsed = 0.0
         target_elapsed = 0.0
+
+        aligned_sizes = [
+            int(allocation.aligned_size) for allocation in allocations
+        ]
+        step_t0 = time.monotonic()
+        _arena_base, reserved_vas = mm.reserve_va_arena(aligned_sizes)
+        reserve_elapsed += time.monotonic() - step_t0
 
         export_chunk_size = MAX_FDS_PER_MESSAGE
         for start in range(0, len(allocations), export_chunk_size):
             allocation_chunk = allocations[start : start + export_chunk_size]
             manifest_chunk = manifest.allocations[start : start + export_chunk_size]
+            va_chunk = reserved_vas[start : start + export_chunk_size]
             chunk_fds: list[int] = []
             try:
                 allocation_ids = [
@@ -312,20 +321,18 @@ class GMSStorageClient:
                         )
                     old_id = entry.allocation_id
                     fd = chunk_fds[fd_idx]
-
-                    step_t0 = time.monotonic()
-                    va = mm.reserve_va(allocation.aligned_size)
-                    reserve_elapsed += time.monotonic() - step_t0
+                    va = va_chunk[fd_idx]
 
                     step_t0 = time.monotonic()
                     try:
-                        mm.map_va(
+                        mm.map_va_at_reserved(
                             fd,
                             va,
                             entry.size,
                             allocation.allocation_id,
                             entry.tag,
                             allocation.layout_slot,
+                            set_access=False,
                         )
                     finally:
                         # map_va imports and closes the POSIX FD, even if the
@@ -352,23 +359,30 @@ class GMSStorageClient:
                     except OSError:
                         pass
 
+        if reserved_vas:
+            step_t0 = time.monotonic()
+            mm.set_access_all_vas()
+            access_elapsed += time.monotonic() - step_t0
+
         total_elapsed = time.monotonic() - t0
         logger.info(
             "Phase A breakdown: allocations=%d bytes=%.2f GiB "
             "allocate_many=%.3fs export=%.3fs reserve_va=%.3fs "
-            "import_map_access=%.3fs target_build=%.3fs other=%.3fs",
+            "import_map=%.3fs set_access=%.3fs target_build=%.3fs other=%.3fs",
             len(targets),
             sum(int(entry.aligned_size) for entry in manifest.allocations) / (1 << 30),
             allocate_elapsed,
             export_elapsed,
             reserve_elapsed,
             map_elapsed,
+            access_elapsed,
             target_elapsed,
             total_elapsed
             - allocate_elapsed
             - export_elapsed
             - reserve_elapsed
             - map_elapsed
+            - access_elapsed
             - target_elapsed,
         )
         logger.info(

--- a/lib/gpu_memory_service/tests/test_batch_restore_layout.py
+++ b/lib/gpu_memory_service/tests/test_batch_restore_layout.py
@@ -110,14 +110,35 @@ def test_restore_phase_a_uses_batched_allocation_api():
             return fds
 
         def reserve_va(self, size):
+            raise AssertionError("restore should use reserve_va_arena()")
+
+        def reserve_va_arena(self, sizes):
+            assert sizes == [4096, 8192]
             va = self._next_va
-            self._next_va += size
-            return va
+            self._next_va += sum(sizes)
+            return va, [va, va + 4096]
 
         def map_va(self, fd, va, size, allocation_id, tag, layout_slot):
+            raise AssertionError("restore should use map_va_at_reserved()")
+
+        def map_va_at_reserved(
+            self,
+            fd,
+            va,
+            size,
+            allocation_id,
+            tag,
+            layout_slot,
+            *,
+            set_access=True,
+        ):
+            assert set_access is False
             os.close(fd)
             self.mapped.append((va, size, 0, allocation_id, tag, layout_slot))
             return 0
+
+        def set_access_all_vas(self):
+            pass
 
     manifest = SaveManifest(
         version="1.0",


### PR DESCRIPTION
## Description

Stacked on #10014.

Adds a loader/client-side VA arena optimization for restore Phase A. This preserves one independent server-side GMS/CUDA allocation per logical allocation, but reserves one contiguous VA range on the restore loader and maps each allocation into a slice of that range.

This is intentionally **not** the packed-slab backing-allocation experiment. The packed-slab path attempted to map regions of one backing GMS allocation to the captured logical VAs and failed e2e restore with `cuMemMap: operation not supported`. This PR only changes loader-side VA reservation/access behavior.

Changes:

- Add `GMSClientMemoryManager.reserve_va_arena(sizes)`.
- Add `map_va_at_reserved(..., set_access=False)` so restore can import/map into pre-reserved VA slices and defer access setup.
- Add `set_access_all_vas()` that merges tracked mapped ranges and issues the minimum CUDA access calls. For restore's contiguous arena this becomes one `cuMemSetAccess` over the mapped range.
- Track arena reservations so cleanup/freeing remains correct.
- Update restore Phase A to reserve one arena, map targets into it, then set access once.
- Update tests to assert restore uses the arena mapping path.

## Testing

- `PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest lib/gpu_memory_service/tests/test_batch_restore_layout.py lib/gpu_memory_service/tests/test_runtime_flows.py -q` (22 passed)
- Included in final stack test: `PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest lib/gpu_memory_service/tests/test_runtime_flows.py lib/gpu_memory_service/tests/test_batch_restore_layout.py lib/gpu_memory_service/tests/test_protocol_wire.py lib/gpu_memory_service/tests/test_snapshot_loader.py lib/gpu_memory_service/tests/test_snapshot_nixl_staging.py lib/gpu_memory_service/tests/test_snapshot_sharded_ssd.py -q` (48 passed)
- `python3 -m compileall -q` over modified client/restore files
- `git diff --check`

## Benchmark results

Primitive probe on `s2877` using the batch-export image showed:

- one VA arena removes `reserve_va_loop` cost: ~0.121s -> ~0.000s
- one-shot `cuMemSetAccess` over the contiguous multi-handle mapped range succeeded in 4/4 iterations
- one-shot access was ~0.166s vs per-allocation access loop ~0.179s for the GPT-OSS-sized synthetic shape

Production-code synthetic Phase-A benchmark against actual `GMSStorageClient._allocate_restore_targets()`:

- node: `s2877`
- shape: 3435 allocations, 134.279 GiB
- batch-export-only image: `fff4d07c368e30e6257a0acc167cfed40da14d57`
- VA-arena image: `ca977bbaf3af8b71a0c013c137ba681bdb710f98`
- logs:
  - `gms-auto-bench/microbench/gms-prod-phasea-fdexp-fff4-0527024600-bench.log`
  - `gms-auto-bench/microbench/gms-prod-phasea-va-ca977-0527024618-bench.log`

Warm medians dropping first iteration:

| Step | Batch export only | VA arena |
|---|---:|---:|
| total `_allocate_restore_targets()` | 0.7955s | 0.5910s |
| `allocate_many` | 0.250s | 0.247s |
| `export` | 0.015s | 0.015s |
| `reserve_va` | 0.154s | 0.000s |
| import/map/access | 0.371s combined | 0.146s import/map + 0.178s access |
| `target_build` | 0.004s | 0.003s |

Result: this PR saves about **205 ms** on top of batch FD export for the GPT-OSS-sized synthetic allocation layout.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->