### PR TITLE
fix(gms): batch restore metadata updates

### DIFF
--- a/benchmarks/gpu_memory_service/phase_a_microbench.py
+++ b/benchmarks/gpu_memory_service/phase_a_microbench.py
@@ -249,6 +249,28 @@ def _metadata_put_loop(
                 raise RuntimeError(f"metadata_put failed at index {i}")
 
 
+def _metadata_put_many(
+    mm: GMSClientMemoryManager,
+    allocations,
+    count: int,
+    timings: list[StepTiming],
+) -> None:
+    payload = b'{"shape":[1],"dtype":"torch.float16","stride":[1],"tensor_type":"parameter"}'
+    entries = [
+        (f"bench_tensor_{i}", alloc.allocation_id, 0, payload)
+        for i, alloc in enumerate(allocations[:count])
+    ]
+    with Timer(
+        timings,
+        "metadata_put_many",
+        count=len(entries),
+        bytes=len(payload) * len(entries),
+    ):
+        ok = mm.metadata_put_many(entries)
+        if not ok:
+            raise RuntimeError("metadata_put_many failed")
+
+
 def _export_allocations(
     mm: GMSClientMemoryManager,
     allocations,
@@ -285,6 +307,7 @@ def _run_per_allocation(
     timings: list[StepTiming],
     batch_export: bool = False,
     export_chunk_size: int = 128,
+    batch_metadata: bool = False,
 ) -> None:
     allocations = _allocate(mm, sizes, timings)
     fds: list[int] = []
@@ -322,7 +345,8 @@ def _run_per_allocation(
                 cumem_set_access(va, size, mm.device, GrantedLockType.RW)
 
         if metadata_count:
-            _metadata_put_loop(
+            metadata_put = _metadata_put_many if batch_metadata else _metadata_put_loop
+            metadata_put(
                 mm,
                 allocations,
                 min(metadata_count, len(allocations)),
@@ -355,6 +379,7 @@ def _run_arena(
     timings: list[StepTiming],
     batch_export: bool = False,
     export_chunk_size: int = 128,
+    batch_metadata: bool = False,
 ) -> None:
     allocations = _allocate(mm, sizes, timings)
     fds: list[int] = []
@@ -426,7 +451,8 @@ def _run_arena(
                     cumem_set_access(arena_va + offset, size, mm.device, GrantedLockType.RW)
 
         if metadata_count:
-            _metadata_put_loop(
+            metadata_put = _metadata_put_many if batch_metadata else _metadata_put_loop
+            metadata_put(
                 mm,
                 allocations,
                 min(metadata_count, len(allocations)),
@@ -481,6 +507,29 @@ def run_once(
                 timings=timings,
                 batch_export=True,
                 export_chunk_size=args.export_chunk_size,
+            )
+            connected = False
+        elif variant == "arena-once-access-batch-export-batch-metadata":
+            _run_arena(
+                mm,
+                sizes,
+                one_set_access=True,
+                metadata_count=args.metadata_count,
+                timings=timings,
+                batch_export=True,
+                export_chunk_size=args.export_chunk_size,
+                batch_metadata=True,
+            )
+            connected = False
+        elif variant == "batch-export-batch-metadata":
+            _run_per_allocation(
+                mm,
+                sizes,
+                metadata_count=args.metadata_count,
+                timings=timings,
+                batch_export=True,
+                export_chunk_size=args.export_chunk_size,
+                batch_metadata=True,
             )
             connected = False
         elif variant == "arena-loop-access":
@@ -558,10 +607,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         choices=(
             "per-allocation",
             "batch-export",
+            "batch-export-batch-metadata",
             "arena-loop-access",
             "arena-loop-access-batch-export",
             "arena-once-access",
             "arena-once-access-batch-export",
+            "arena-once-access-batch-export-batch-metadata",
         ),
         help="Variant to run. May be passed multiple times. Default: per-allocation.",
     )

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -395,6 +395,12 @@ class GMSClientMemoryManager:
     ) -> bool:
         return self._client_rpc.metadata_put(key, allocation_id, offset_bytes, value)
 
+    def metadata_put_many(
+        self,
+        entries: List[tuple[str, str, int, bytes]],
+    ) -> bool:
+        return self._client_rpc.metadata_put_many(entries)
+
     def metadata_get(self, key: str) -> Optional[tuple[str, int, bytes]]:
         return self._client_rpc.metadata_get(key)
 

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -37,10 +37,13 @@ from gpu_memory_service.common.protocol.messages import (
     ListAllocationsResponse,
     MetadataDeleteRequest,
     MetadataDeleteResponse,
+    MetadataEntrySpec,
     MetadataGetRequest,
     MetadataGetResponse,
     MetadataListRequest,
     MetadataListResponse,
+    MetadataPutManyRequest,
+    MetadataPutManyResponse,
     MetadataPutRequest,
     MetadataPutResponse,
 )
@@ -230,6 +233,33 @@ class _GMSClientSession:
             ),
             MetadataPutResponse,
         ).success
+
+    def metadata_put_many(
+        self,
+        entries: List[tuple[str, str, int, bytes]],
+    ) -> bool:
+        if not entries:
+            return True
+        response = self._transport.request(
+            MetadataPutManyRequest(
+                entries=[
+                    MetadataEntrySpec(
+                        key=key,
+                        allocation_id=allocation_id,
+                        offset_bytes=offset_bytes,
+                        value=value,
+                    )
+                    for key, allocation_id, offset_bytes, value in entries
+                ]
+            ),
+            MetadataPutManyResponse,
+        )
+        if int(response.count) != len(entries):
+            raise RuntimeError(
+                "GMS metadata_put_many count mismatch: "
+                f"{response.count} vs {len(entries)}"
+            )
+        return response.success
 
     def metadata_get(self, key: str) -> Optional[tuple[str, int, bytes]]:
         response = self._transport.request(

--- a/lib/gpu_memory_service/common/protocol/messages.py
+++ b/lib/gpu_memory_service/common/protocol/messages.py
@@ -138,6 +138,22 @@ class MetadataPutResponse(msgspec.Struct, tag="metadata_put_response"):
     success: bool
 
 
+class MetadataEntrySpec(msgspec.Struct):
+    key: str
+    allocation_id: str
+    offset_bytes: int
+    value: bytes
+
+
+class MetadataPutManyRequest(msgspec.Struct, tag="metadata_put_many_request"):
+    entries: List[MetadataEntrySpec]
+
+
+class MetadataPutManyResponse(msgspec.Struct, tag="metadata_put_many_response"):
+    success: bool
+    count: int
+
+
 class MetadataGetRequest(msgspec.Struct, tag="metadata_get_request"):
     key: str
 
@@ -227,6 +243,8 @@ Message = Union[
     ErrorResponse,
     MetadataPutRequest,
     MetadataPutResponse,
+    MetadataPutManyRequest,
+    MetadataPutManyResponse,
     MetadataGetRequest,
     MetadataGetResponse,
     MetadataDeleteRequest,

--- a/lib/gpu_memory_service/server/gms.py
+++ b/lib/gpu_memory_service/server/gms.py
@@ -45,6 +45,8 @@ from gpu_memory_service.common.protocol.messages import (
     MetadataGetResponse,
     MetadataListRequest,
     MetadataListResponse,
+    MetadataPutManyRequest,
+    MetadataPutManyResponse,
     MetadataPutRequest,
     MetadataPutResponse,
 )
@@ -440,6 +442,36 @@ class GMS:
                 value=msg.value,
             )
             return MetadataPutResponse(success=True), -1, False
+
+        if msg_type is MetadataPutManyRequest:
+            allocations_by_id: dict[str, AllocationInfo] = {}
+            pending: list[tuple[str, AllocationInfo, int, bytes]] = []
+            for entry in msg.entries:
+                allocation = allocations_by_id.get(entry.allocation_id)
+                if allocation is None:
+                    allocation = self._allocations.get_allocation(entry.allocation_id)
+                    allocations_by_id[entry.allocation_id] = allocation
+                self._validate_metadata_target(allocation, entry.offset_bytes)
+                pending.append(
+                    (
+                        entry.key,
+                        allocation,
+                        entry.offset_bytes,
+                        entry.value,
+                    )
+                )
+
+            for key, allocation, offset_bytes, value in pending:
+                self._metadata[key] = MetadataEntry(
+                    allocation_id=allocation.allocation_id,
+                    offset_bytes=offset_bytes,
+                    value=value,
+                )
+            return (
+                MetadataPutManyResponse(success=True, count=len(pending)),
+                -1,
+                False,
+            )
 
         if msg_type is MetadataGetRequest:
             entry = self._metadata.get(msg.key)

--- a/lib/gpu_memory_service/server/session.py
+++ b/lib/gpu_memory_service/server/session.py
@@ -25,6 +25,7 @@ from gpu_memory_service.common.protocol.messages import (
     MetadataDeleteRequest,
     MetadataGetRequest,
     MetadataListRequest,
+    MetadataPutManyRequest,
     MetadataPutRequest,
 )
 
@@ -40,6 +41,7 @@ RW_REQUIRED: frozenset[type] = frozenset(
         AllocateManyRequest,
         AllocateRequest,
         FreeAllocationRequest,
+        MetadataPutManyRequest,
         MetadataPutRequest,
         MetadataDeleteRequest,
         CommitRequest,

--- a/lib/gpu_memory_service/snapshot/storage_client.py
+++ b/lib/gpu_memory_service/snapshot/storage_client.py
@@ -461,13 +461,25 @@ class GMSStorageClient:
         saved_metadata: Dict[str, Dict[str, Any]],
         id_map: Dict[str, str],
     ) -> None:
+        entries: list[tuple[str, str, int, bytes]] = []
         for key, meta in saved_metadata.items():
             old_alloc_id = meta["allocation_id"]
             new_alloc_id = id_map.get(old_alloc_id, old_alloc_id)
-            ok = mm.metadata_put(key, new_alloc_id, meta["offset_bytes"], meta["value"])
-            if not ok:
-                raise RuntimeError(f"Failed to write metadata key={key!r}")
-            logger.debug("Restored metadata key=%s -> alloc=%s", key, new_alloc_id)
+            entries.append(
+                (
+                    key,
+                    new_alloc_id,
+                    meta["offset_bytes"],
+                    meta["value"],
+                )
+            )
+
+        ok = mm.metadata_put_many(entries)
+        if not ok:
+            raise RuntimeError("Failed to write metadata batch")
+
+        for key, allocation_id, _, _ in entries:
+            logger.debug("Restored metadata key=%s -> alloc=%s", key, allocation_id)
         logger.info("Restored %d metadata keys; committing", len(saved_metadata))
 
     def _save_metadata(self, mm: Any) -> Dict[str, Any]:

--- a/lib/gpu_memory_service/tests/test_runtime_flows.py
+++ b/lib/gpu_memory_service/tests/test_runtime_flows.py
@@ -692,6 +692,34 @@ def test_invalid_metadata_offset_is_rejected_without_mutating_state(
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_metadata_put_many_is_atomic_on_validation_error(running_gms):
+    _, socket_path = running_gms
+
+    writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
+    try:
+        allocation_id, aligned_size = writer.allocate(4096, "weights")
+        with pytest.raises(RuntimeError, match="out of range"):
+            writer.metadata_put_many(
+                [
+                    ("tensor.good", allocation_id, 0, b"good"),
+                    ("tensor.bad", allocation_id, aligned_size, b"bad"),
+                ]
+            )
+        assert writer.metadata_list() == []
+
+        assert writer.metadata_put_many(
+            [
+                ("tensor.0", allocation_id, 0, b"x"),
+                ("tensor.1", allocation_id, 1, b"y"),
+            ]
+        )
+        assert writer.metadata_get("tensor.0") == (allocation_id, 0, b"x")
+        assert writer.metadata_get("tensor.1") == (allocation_id, 1, b"y")
+    finally:
+        writer.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
 def test_destroy_mapping_frees_allocation_and_metadata(running_gms):
     _, socket_path = running_gms
 


### PR DESCRIPTION
## Description

Stacked on #10015.

Batches restore metadata replay so the loader does one metadata RPC for the saved metadata table instead of one RPC per key.

Changes:

- Add nested `MetadataEntrySpec` and top-level `MetadataPutManyRequest/Response`.
- Add client APIs `_GMSClientSession.metadata_put_many()` and `GMSClientMemoryManager.metadata_put_many()`.
- Add server-side `MetadataPutManyRequest` handling under the RW lock.
  - Validates all entries first.
  - Mutates `_metadata` only after validation succeeds, so validation errors do not partially write metadata.
  - Reuses allocation lookup per allocation id within the batch.
- Update restore metadata replay to issue one `metadata_put_many()` call.
- Add microbench variants for loop vs batch metadata.
- Add runtime-flow test for successful `metadata_put_many()` and atomic rejection on invalid offset.

## Testing

- `PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest lib/gpu_memory_service/tests/test_runtime_flows.py lib/gpu_memory_service/tests/test_batch_restore_layout.py lib/gpu_memory_service/tests/test_snapshot_loader.py lib/gpu_memory_service/tests/test_snapshot_nixl_staging.py lib/gpu_memory_service/tests/test_snapshot_sharded_ssd.py -q` (47 passed)
- Final stack: `PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest lib/gpu_memory_service/tests/test_runtime_flows.py lib/gpu_memory_service/tests/test_batch_restore_layout.py lib/gpu_memory_service/tests/test_protocol_wire.py lib/gpu_memory_service/tests/test_snapshot_loader.py lib/gpu_memory_service/tests/test_snapshot_nixl_staging.py lib/gpu_memory_service/tests/test_snapshot_sharded_ssd.py -q` (48 passed)
- `python3 -m compileall -q` over modified GMS files
- `git diff --check`

## Benchmark results

Built and measured image:

- Build On Demand: https://github.com/ai-dynamo/dynamo/actions/runs/26487536885
- image: `dynamoci.azurecr.io/ai-dynamo/dynamo:08b3f90c2e9cb95504604c85311661c42f2bb7c8-vllm-runtime-cuda13`
- node: `s2877`
- metadata microbench pod: `gms-phase-a-microbench-meta-08b3-0527024849`
- log: `gms-auto-bench/microbench/gms-phase-a-microbench-meta-08b3-0527024849-bench.log`
- shape: 3435 allocations, 134.28 GiB, 723 metadata keys

Warm medians dropping first iteration:

| Metadata path | Median |
|---|---:|
| per-key `metadata_put_loop` | 0.0186s |
| batched `metadata_put_many` | 0.0014s |

Final-stack synthetic restore closeout using actual restore methods:

- pod: `gms-prod-restoreclose-meta-08b3-0527025029`
- log: `gms-auto-bench/microbench/gms-prod-restoreclose-meta-08b3-0527025029-bench.log`
- covers: RW connect, actual `_allocate_restore_targets()`, actual `_restore_metadata()`, and actual `mm.commit()`; no transfer
- warm medians dropping first iteration:
  - `connect_rw`: 0.2402s
  - Phase A: 0.5912s
  - metadata replay: 0.0018s
  - commit: 0.1722s
  - total after connect: 0.7688s

The win is small (~17 ms for 723 keys) but removes hundreds of UDS RPCs from restore closeout and reduces tail variance.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->