### PR TITLE
chore: update parity table UI labels

### DIFF
--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -693,7 +693,7 @@ def _markdown(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
     no_vllm, no_sglang = _derive_no_peer_sets(rows)
     header = [
         "model",
-        "Reasoning Parser Family",
+        "Reasoning family",
         *[_display_case_id(c) for c in columns],
     ]
     out.append("| " + " | ".join(header) + " |")
@@ -791,10 +791,8 @@ def _column_control_header_html(
 
 def _case_group_headers_html(columns: list[str]) -> str:
     headers = [
-        _column_control_header_html("model", "Model", default_visible=False),
-        _column_control_header_html(
-            "parser", "Reasoning Parser Family", default_visible=True
-        ),
+        _column_control_header_html("model", "Model", default_visible=True),
+        _column_control_header_html("parser", "Reasoning family", default_visible=True),
     ]
     for run in _case_runs(columns):
         label = _case_group_label(run[0])
@@ -2045,7 +2043,7 @@ def _html(
         _make_jinja_env()
         .get_template("parity_table.html.j2")
         .render(
-            title="Dynamo Reasoning - Parity Table",
+            title="Dynamo Reasoning Parser - Parity Table",
             stamp=generated,
             sha=sha,
             short_sha=sha[:12] if sha else "",

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -677,7 +677,7 @@ def render_markdown(
     others: list[tuple[str, str]],
 ) -> str:
     inheritance = _build_family_inheritance(_build_family_to_rust_ref())
-    header = "| model | Tool calling parser | " + " | ".join(sub_cases) + " |"
+    header = "| model | Tool calling family | " + " | ".join(sub_cases) + " |"
     sep = "|---|---|" + ":-:|" * len(sub_cases)
     lines = [header, sep]
     lines.append("| **Top-N models** |   |" + "   |" * len(sub_cases))
@@ -1243,9 +1243,9 @@ def _column_control_header_html(
 def _subcase_group_headers_html(mode: str, sub_cases: list[str]) -> str:
     """Build semantic group headers spanning the displayed sub-case columns."""
     spans: list[str] = [
-        _column_control_header_html("model", "Model", default_visible=False),
+        _column_control_header_html("model", "Model", default_visible=True),
         _column_control_header_html(
-            "parser", "Tool calling parser", default_visible=True
+            "parser", "Tool calling family", default_visible=True
         ),
     ]
     for run in _subcase_runs(mode, sub_cases):

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -50,6 +50,11 @@ def test_generate_parser_parity_table_html() -> None:
     assert "<html" in html.lower()
     assert "<table" in html.lower()
     assert "Dynamo Tool Calling Parser - Parity Table" in html
+    assert re.search(
+        r'data-col-toggle="model"[^>]+data-default-visible="true"[^>]+aria-pressed="true"',
+        html,
+    )
+    assert "Tool calling family" in html
     assert "generate_parity_table.py toolcalling --html" in html
     assert "TOOLCALLING.batch.*" in html
     assert "TOOLCALLING.stream.*" in html
@@ -77,7 +82,12 @@ def test_generate_parser_parity_table_batch_mode_excludes_stream_links() -> None
 def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> None:
     html = _render_html_for("reasoning")
 
-    assert "Dynamo Reasoning - Parity Table" in html
+    assert "Dynamo Reasoning Parser - Parity Table" in html
+    assert "Reasoning family" in html
+    assert re.search(
+        r'data-col-toggle="model"[^>]+data-default-visible="true"[^>]+aria-pressed="true"',
+        html,
+    )
     assert re.search(
         r'<td class="cell na[^"]*"[^>]*><a href="fixtures/qwen3/REASONING\.batch\.yaml">n/a</a>'
         r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.b — qwen3',


### PR DESCRIPTION
#### Overview:

This PR updates the parity table UI labels so the Tool Calling Parser and Reasoning Parser pages use consistent names and show model names by default.

#### Details:

- **How is this fixed?** Update the tool calling and reasoning table generators to make the Model column default-visible and rename the second column to `Tool calling family` / `Reasoning family`.
- Rename the reasoning HTML page title from `Dynamo Reasoning - Parity Table` to `Dynamo Reasoning Parser - Parity Table`.
- Update the generator tests to assert the new labels and model-column default state.

#### Verification:

`python3 -m pytest tests/parity/toolcalling/test_generate_parity_table.py -q` passed in the `dynamo3` vLLM devcontainer.

#### Where should the reviewer start?

`tests/parity/toolcalling/table.py`, then `tests/parity/reasoning/table.py`

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined column header labels in reasoning and tool calling parity tables for improved clarity
  * Adjusted default visibility settings for the Model column in parity table UI controls
  * Updated title text in the reasoning parity table display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->