### PR TITLE
fix(frontend): emit llm_metrics annotation from vllm chat processor

### DIFF
--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -325,21 +325,36 @@ class TestRoutedEnginePath:
 
         chunks = await _run_generate(processor, _base_preproc())
 
-        assert chunks == [
-            {
-                "id": "request-id",
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {"content": "x"},
-                        "finish_reason": None,
-                    }
-                ],
-                "created": chunks[0]["created"],
-                "model": MODEL,
-                "object": "chat.completion.chunk",
-            }
-        ]
+        # VllmProcessor emits a data chunk followed by an llm_metrics
+        # annotation envelope on every worker iteration. The annotation is
+        # consumed by the HTTP-service metric observer (TTFT/ITL/OSL
+        # histograms) and stripped before reaching the SSE response.
+        assert len(chunks) == 2
+        data_chunk, annotation = chunks
+
+        assert data_chunk == {
+            "id": "request-id",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "x"},
+                    "finish_reason": None,
+                }
+            ],
+            "created": data_chunk["created"],
+            "model": MODEL,
+            "object": "chat.completion.chunk",
+        }
+
+        assert annotation["_dynamo_annotated"] is True
+        assert annotation["event"] == "llm_metrics"
+        assert len(annotation["comment"]) == 1
+        payload = json.loads(annotation["comment"][0])
+        assert payload == {
+            "input_tokens": 3,
+            "output_tokens": 1,
+            "chunk_tokens": 1,
+        }
 
 
 OBJECT_TYPED_TOOL_REQUEST = {

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -325,14 +325,13 @@ class TestRoutedEnginePath:
 
         chunks = await _run_generate(processor, _base_preproc())
 
-        # VllmProcessor emits a data chunk followed by an llm_metrics
-        # annotation envelope on every worker iteration. The annotation is
-        # consumed by the HTTP-service metric observer (TTFT/ITL/OSL
-        # histograms) and stripped before reaching the SSE response.
-        assert len(chunks) == 2
-        data_chunk, annotation = chunks
+        # One annotated envelope per iteration carries both data and the
+        # llm_metrics annotation; observer strips the annotation before SSE.
+        assert len(chunks) == 1
+        envelope = chunks[0]
 
-        assert data_chunk == {
+        assert envelope["_dynamo_annotated"] is True
+        assert envelope["data"] == {
             "id": "request-id",
             "choices": [
                 {
@@ -341,16 +340,14 @@ class TestRoutedEnginePath:
                     "finish_reason": None,
                 }
             ],
-            "created": data_chunk["created"],
+            "created": envelope["data"]["created"],
             "model": MODEL,
             "object": "chat.completion.chunk",
         }
 
-        assert annotation["_dynamo_annotated"] is True
-        assert annotation["event"] == "llm_metrics"
-        assert len(annotation["comment"]) == 1
-        payload = json.loads(annotation["comment"][0])
-        assert payload == {
+        assert envelope["event"] == "llm_metrics"
+        assert len(envelope["comment"]) == 1
+        assert json.loads(envelope["comment"][0]) == {
             "input_tokens": 3,
             "output_tokens": 1,
             "chunk_tokens": 1,

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -669,6 +669,7 @@ class VllmProcessor:
                     pass
 
                 choices = []
+                postprocess_error = False
                 if vllm_out.request_outputs:
                     for output in vllm_out.request_outputs[0].outputs:
                         post = post_processors.get(output.index)
@@ -682,10 +683,14 @@ class VllmProcessor:
                                     "type": "internal_error",
                                 }
                             }
+                            postprocess_error = True
                             break
                         choice = post.process_output(output)
                         if choice:
                             choices.append(choice)
+
+                if postprocess_error:
+                    continue
 
                 # One envelope per iteration carries both data and metrics so
                 # client cancellation can't drop the annotation between yields.

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -6,6 +6,7 @@
 #
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -581,6 +582,15 @@ class VllmProcessor:
                 output_request_ids[output_idx] = child_request_id
                 registered_request_ids.append(child_request_id)
 
+        # Per-request running totals needed by the HTTP-service metric
+        # observer (lib/llm/src/http/service/metrics.rs) to record TTFT
+        # and ITL. The default Rust postprocessor emits an equivalent
+        # LLMMetricAnnotation per chunk; this Python path replaces that
+        # postprocessor for vllm-specific tokenization, so it must emit
+        # the annotation itself or the observer sees no samples.
+        input_tokens = len(tokens)
+        cumulative_output_tokens = 0
+
         try:
             _inject_routing_metadata(dynamo_preproc, dynamo_preproc, mm_routing_info)
             with _nvtx.annotate("mm_frontend:routed_engine_generate", color="red"):
@@ -690,6 +700,31 @@ class VllmProcessor:
                         dynamo_out["usage"] = usage
 
                     yield dynamo_out
+
+                    # Emit an llm_metrics annotation envelope on the
+                    # same stream. The FFI shim recognises the
+                    # `_dynamo_annotated` sentinel and forwards the
+                    # event/comment fields verbatim into an
+                    # `Annotated<T>`; the HTTP-service observer reads
+                    # the comment payload to update TTFT/ITL/OSL
+                    # histograms and then strips the annotation before
+                    # it reaches the client.
+                    chunk_tokens = len(engine_response.get("token_ids") or [])
+                    if chunk_tokens > 0:
+                        cumulative_output_tokens += chunk_tokens
+                        yield {
+                            "_dynamo_annotated": True,
+                            "event": "llm_metrics",
+                            "comment": [
+                                json.dumps(
+                                    {
+                                        "input_tokens": input_tokens,
+                                        "output_tokens": cumulative_output_tokens,
+                                        "chunk_tokens": chunk_tokens,
+                                    }
+                                )
+                            ],
+                        }
             _nvtx.end_range(rng_stream)
         except Exception as e:
             logger.exception("Error generating response for request %s", request_id)

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -582,12 +582,9 @@ class VllmProcessor:
                 output_request_ids[output_idx] = child_request_id
                 registered_request_ids.append(child_request_id)
 
-        # Per-request running totals needed by the HTTP-service metric
-        # observer (lib/llm/src/http/service/metrics.rs) to record TTFT
-        # and ITL. The default Rust postprocessor emits an equivalent
-        # LLMMetricAnnotation per chunk; this Python path replaces that
-        # postprocessor for vllm-specific tokenization, so it must emit
-        # the annotation itself or the observer sees no samples.
+        # Totals for the llm_metrics annotation emitted below — the
+        # Rust postprocessor that normally produces these is bypassed
+        # on the vllm chat processor path.
         input_tokens = len(tokens)
         cumulative_output_tokens = 0
 
@@ -701,29 +698,18 @@ class VllmProcessor:
 
                     yield dynamo_out
 
-                    # Emit an llm_metrics annotation envelope on the
-                    # same stream. The FFI shim recognises the
-                    # `_dynamo_annotated` sentinel and forwards the
-                    # event/comment fields verbatim into an
-                    # `Annotated<T>`; the HTTP-service observer reads
-                    # the comment payload to update TTFT/ITL/OSL
-                    # histograms and then strips the annotation before
-                    # it reaches the client.
                     chunk_tokens = len(engine_response.get("token_ids") or [])
                     if chunk_tokens > 0:
                         cumulative_output_tokens += chunk_tokens
+                        metrics = {
+                            "input_tokens": input_tokens,
+                            "output_tokens": cumulative_output_tokens,
+                            "chunk_tokens": chunk_tokens,
+                        }
                         yield {
                             "_dynamo_annotated": True,
                             "event": "llm_metrics",
-                            "comment": [
-                                json.dumps(
-                                    {
-                                        "input_tokens": input_tokens,
-                                        "output_tokens": cumulative_output_tokens,
-                                        "chunk_tokens": chunk_tokens,
-                                    }
-                                )
-                            ],
+                            "comment": [json.dumps(metrics)],
                         }
             _nvtx.end_range(rng_stream)
         except Exception as e:

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -582,9 +582,7 @@ class VllmProcessor:
                 output_request_ids[output_idx] = child_request_id
                 registered_request_ids.append(child_request_id)
 
-        # Totals for the llm_metrics annotation emitted below — the
-        # Rust postprocessor that normally produces these is bypassed
-        # on the vllm chat processor path.
+        # llm_metrics totals; Rust postprocessor is bypassed on this path.
         input_tokens = len(tokens)
         cumulative_output_tokens = 0
 
@@ -622,6 +620,11 @@ class VllmProcessor:
                 if "token_ids" not in engine_response:
                     yield handle_engine_error(engine_response, request_id, logger)
                     break
+
+                # Count before any choice gate — tool/reasoning parsers may
+                # consume tokens without emitting a visible delta.
+                chunk_tokens = len(engine_response.get("token_ids") or [])
+                cumulative_output_tokens += chunk_tokens
 
                 output_idx = engine_response.get("index", 0) or 0
                 output_request_id = output_request_ids.get(output_idx)
@@ -666,25 +669,27 @@ class VllmProcessor:
                     pass
 
                 choices = []
-                if not vllm_out.request_outputs:
-                    continue
-                for output in vllm_out.request_outputs[0].outputs:
-                    post = post_processors.get(output.index)
-                    if post is None:
-                        yield {
-                            "error": {
-                                "message": (
-                                    f"Invalid postprocessor choice index {output.index} "
-                                    f"for request {request_id}"
-                                ),
-                                "type": "internal_error",
+                if vllm_out.request_outputs:
+                    for output in vllm_out.request_outputs[0].outputs:
+                        post = post_processors.get(output.index)
+                        if post is None:
+                            yield {
+                                "error": {
+                                    "message": (
+                                        f"Invalid postprocessor choice index {output.index} "
+                                        f"for request {request_id}"
+                                    ),
+                                    "type": "internal_error",
+                                }
                             }
-                        }
-                        break
-                    choice = post.process_output(output)
-                    if choice:
-                        choices.append(choice)
+                            break
+                        choice = post.process_output(output)
+                        if choice:
+                            choices.append(choice)
 
+                # One envelope per iteration carries both data and metrics so
+                # client cancellation can't drop the annotation between yields.
+                envelope: dict[str, Any] = {"_dynamo_annotated": True}
                 if choices:
                     dynamo_out = {
                         "id": request_id,
@@ -695,22 +700,17 @@ class VllmProcessor:
                     }
                     if usage := engine_response.get("completion_usage"):
                         dynamo_out["usage"] = usage
+                    envelope["data"] = dynamo_out
 
-                    yield dynamo_out
+                metrics = {
+                    "input_tokens": input_tokens,
+                    "output_tokens": cumulative_output_tokens,
+                    "chunk_tokens": chunk_tokens,
+                }
+                envelope["event"] = "llm_metrics"
+                envelope["comment"] = [json.dumps(metrics)]
 
-                    chunk_tokens = len(engine_response.get("token_ids") or [])
-                    if chunk_tokens > 0:
-                        cumulative_output_tokens += chunk_tokens
-                        metrics = {
-                            "input_tokens": input_tokens,
-                            "output_tokens": cumulative_output_tokens,
-                            "chunk_tokens": chunk_tokens,
-                        }
-                        yield {
-                            "_dynamo_annotated": True,
-                            "event": "llm_metrics",
-                            "comment": [json.dumps(metrics)],
-                        }
+                yield envelope
             _nvtx.end_range(rng_stream)
         except Exception as e:
             logger.exception("Error generating response for request %s", request_id)

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -362,7 +362,8 @@ where
                 .downcast::<PyDict>()
                 .ok()
                 .and_then(|d| d.get_item("_dynamo_annotated").ok().flatten())
-                .is_some();
+                .and_then(|v| v.is_truthy().ok())
+                .unwrap_or(false);
             if is_envelope {
                 depythonize::<Annotated<Resp>>(&bound)
             } else {

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -356,16 +356,8 @@ where
     let response = tokio::task::spawn_blocking(move || {
         Python::with_gil(|py| {
             let bound = item.into_bound(py);
-            // Python generators normally yield response data and we
-            // wrap it in `Annotated::from_data` below. Generators that
-            // need to emit a sidecar event on the stream (e.g. an
-            // LLMMetricAnnotation from the vllm chat processor so the
-            // HTTP-service metric observer can record TTFT/ITL) can
-            // yield a dict shaped like the wire Annotated<R> protocol
-            // and mark it with `_dynamo_annotated: True`. When the
-            // sentinel is present we deserialize the dict as an
-            // Annotated envelope so the `event` / `comment` / `data`
-            // fields land where downstream code expects them.
+            // Yields tagged with `_dynamo_annotated: True` are wire
+            // Annotated<R> envelopes; everything else is plain data.
             let is_envelope = bound
                 .downcast::<PyDict>()
                 .ok()

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -354,13 +354,33 @@ where
         })
     })?;
     let response = tokio::task::spawn_blocking(move || {
-        Python::with_gil(|py| depythonize::<Resp>(&item.into_bound(py)))
+        Python::with_gil(|py| {
+            let bound = item.into_bound(py);
+            // Python generators normally yield response data and we
+            // wrap it in `Annotated::from_data` below. Generators that
+            // need to emit a sidecar event on the stream (e.g. an
+            // LLMMetricAnnotation from the vllm chat processor so the
+            // HTTP-service metric observer can record TTFT/ITL) can
+            // yield a dict shaped like the wire Annotated<R> protocol
+            // and mark it with `_dynamo_annotated: True`. When the
+            // sentinel is present we deserialize the dict as an
+            // Annotated envelope so the `event` / `comment` / `data`
+            // fields land where downstream code expects them.
+            let is_envelope = bound
+                .downcast::<PyDict>()
+                .ok()
+                .and_then(|d| d.get_item("_dynamo_annotated").ok().flatten())
+                .is_some();
+            if is_envelope {
+                depythonize::<Annotated<Resp>>(&bound)
+            } else {
+                depythonize::<Resp>(&bound).map(Annotated::from_data)
+            }
+        })
     })
     .await
     .map_err(|e| ResponseProcessingError::Offload(e.to_string()))?
     .map_err(|e| ResponseProcessingError::Deserialize(e.to_string()))?;
-
-    let response = Annotated::from_data(response);
 
     Ok(response)
 }


### PR DESCRIPTION
## Problem

`dynamo_frontend_time_to_first_token_seconds` and `dynamo_frontend_inter_token_latency_seconds` get zero samples for any model served with `--dyn-chat-processor vllm`. Counters and request-lifecycle gauges remain accurate; only per-chunk histograms are affected.

## Root cause

The metric observer at `lib/llm/src/http/service/metrics.rs:1644` updates TTFT/ITL by reading an `LLMMetricAnnotation` attached to each response chunk. The default chat-processor path emits that annotation from the Rust postprocessor (`lib/llm/src/preprocessor.rs:1860-1933`).

`--dyn-chat-processor vllm` swaps the Rust postprocessor for `VllmProcessor` (Python) so vLLM's own tokenizer runs in-process. The Python implementation never emits the annotation, so `LLMMetricAnnotation::from_annotation(...)` returns `None` for every chunk and the histograms get no samples. Counters and gauges work because they're keyed off `create_inflight_guard`/`create_http_queue_guard` at HTTP entry/exit, not per-chunk metadata.

## Fix

**`lib/bindings/python/rust/engine.rs`** — `process_item` previously hard-wrapped every Python yield as `Annotated::from_data(...)`. It now peeks for a `_dynamo_annotated: True` sentinel on the yielded dict; when present, the dict is deserialized directly as `Annotated<Resp>` so `event`/`comment`/`data` flow through. Otherwise the existing path is unchanged. Backward-compatible.

**`components/src/dynamo/frontend/vllm_processor.py`** — `_generate_and_stream` tracks `input_tokens` and `cumulative_output_tokens`, and after each data yield emits an envelope with `event="llm_metrics"` and the metric payload in `comment`. The observer reads it, updates the histograms, and strips the annotation at `metrics.rs:1683` so it never reaches the response.

Covers both streaming and non-streaming — both consume `LLMMetricAnnotation` via equivalent observer functions (`process_response_using_event_converter_and_observe_metrics` vs `process_response_and_observe_metrics`).

## Out of scope

`cached_tokens`, tokenize/detokenize latencies, and `prefill`/`decode` worker_id attribution — not required for TTFT/ITL; can land as follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Introduced comprehensive token-level metrics tracking for streaming operations, now measuring and reporting input tokens, cumulative output tokens, and individual chunk token consumption to provide detailed usage analytics.

**Improvements**
- Upgraded response processing architecture to efficiently handle annotated response envelopes, enabling seamless integration of enhanced metrics data throughout the request lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->