### PR TITLE
fix(runtime): let runtime pick explicit event plane

### DIFF
--- a/components/src/dynamo/common/utils/runtime.py
+++ b/components/src/dynamo/common/utils/runtime.py
@@ -12,7 +12,6 @@ Provides:
 """
 
 import asyncio
-import os
 import warnings
 from typing import Optional, Tuple
 
@@ -75,19 +74,12 @@ def create_runtime(
 
     loop = asyncio.get_running_loop()
 
-    # Scope DYN_EVENT_PLANE to this call so an explicit event_plane doesn't leak
-    # process-wide and silently override later create_runtime(event_plane=None)
-    # calls that rely on the Rust-side auto-detect.
-    previous_event_plane = os.environ.get("DYN_EVENT_PLANE")
-    try:
-        if event_plane:
-            os.environ["DYN_EVENT_PLANE"] = event_plane
-        runtime = DistributedRuntime(loop, discovery_backend, request_plane)
-    finally:
-        if previous_event_plane is None:
-            os.environ.pop("DYN_EVENT_PLANE", None)
-        else:
-            os.environ["DYN_EVENT_PLANE"] = previous_event_plane
+    runtime = DistributedRuntime(
+        loop,
+        discovery_backend,
+        request_plane,
+        event_plane=event_plane,
+    )
 
     return runtime, loop
 

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -94,7 +94,7 @@ For MoE models, AIC requires `aic_tp_size * aic_attention_dp_size == aic_moe_tp_
 |-------------|---------|---------|-------------|
 | `--discovery-backend` | `DYN_DISCOVERY_BACKEND` | `etcd` | Service discovery: `kubernetes`, `etcd`, `file`, `mem` |
 | `--request-plane` | `DYN_REQUEST_PLANE` | `tcp` | Request distribution: `tcp` (fastest), `nats` |
-| `--event-plane` | `DYN_EVENT_PLANE` | `nats` | Event publishing: `nats`, `zmq` |
+| `--event-plane` | `DYN_EVENT_PLANE` | auto | Event publishing: `nats`, `zmq`; defaults to `zmq` for `file`/`mem` discovery and `nats` for `etcd`/`kubernetes` |
 
 ## KServe gRPC
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_llm::local_model::LocalModel;
+use dynamo_runtime::discovery::EventTransportKind;
 use dynamo_runtime::distributed::{DiscoveryBackend, DistributedConfig, RequestPlaneMode};
 use dynamo_runtime::storage::kv;
 use futures::StreamExt;
@@ -239,6 +240,20 @@ fn kv_indexer_to_pyerr(err: anyhow::Error) -> PyErr {
     }
 
     to_pyerr(err)
+}
+
+fn resolve_event_transport_kind(
+    discovery_backend: &DiscoveryBackend,
+    event_plane: Option<&str>,
+) -> PyResult<EventTransportKind> {
+    match event_plane {
+        Some("nats") => Ok(EventTransportKind::Nats),
+        Some("zmq") => Ok(EventTransportKind::Zmq),
+        Some("") | None => Ok(discovery_backend.resolve_event_transport_kind()),
+        Some(other) => Err(PyValueError::new_err(format!(
+            "Invalid event_plane value '{other}'. Valid values: 'nats', 'zmq'"
+        ))),
+    }
 }
 
 #[pyfunction(name = "run_kv_indexer")]
@@ -690,12 +705,13 @@ impl From<llm_rs::worker_type::WorkerType> for WorkerType {
 #[pymethods]
 impl DistributedRuntime {
     #[new]
-    #[pyo3(signature = (event_loop, discovery_backend, request_plane, enable_nats=None))]
+    #[pyo3(signature = (event_loop, discovery_backend, request_plane, enable_nats=None, *, event_plane=None))]
     fn new(
         event_loop: PyObject,
         discovery_backend: String,
         request_plane: String,
         enable_nats: Option<bool>,
+        event_plane: Option<String>,
     ) -> PyResult<Self> {
         if enable_nats.is_some() {
             Python::with_gil(|py| {
@@ -719,6 +735,9 @@ impl DistributedRuntime {
             }
         };
         let request_plane: RequestPlaneMode = request_plane.parse().map_err(to_pyerr)?;
+        let explicit_event_plane = event_plane.as_deref().filter(|value| !value.is_empty());
+        let event_transport_kind =
+            resolve_event_transport_kind(&discovery_backend_config, event_plane.as_deref())?;
 
         // Try to get existing runtime first, create new Worker only if needed
         // This allows multiple DistributedRuntime instances to share the same tokio runtime
@@ -748,14 +767,13 @@ impl DistributedRuntime {
             });
         }
 
-        let event_transport_kind = discovery_backend_config.resolve_event_transport_kind();
-
         let nats_enabled = request_plane.is_nats()
-            || std::env::var(config::environment_names::nats::NATS_SERVER).is_ok()
             || matches!(
                 event_transport_kind,
                 dynamo_runtime::discovery::EventTransportKind::Nats
-            );
+            )
+            || (explicit_event_plane.is_none()
+                && std::env::var(config::environment_names::nats::NATS_SERVER).is_ok());
 
         let runtime_config = DistributedConfig {
             discovery_backend: discovery_backend_config,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -123,6 +123,9 @@ class DistributedRuntime:
         event_loop: Any,
         discovery_backend: str,
         request_plane: str,
+        enable_nats: Optional[bool] = None,
+        *,
+        event_plane: Optional[str] = None,
     ) -> "DistributedRuntime":
         """
         Create a new DistributedRuntime.
@@ -131,6 +134,8 @@ class DistributedRuntime:
             event_loop: The asyncio event loop
             discovery_backend: Discovery backend ("kubernetes", "etcd", "file", or "mem")
             request_plane: Request plane transport ("tcp" or "nats")
+            enable_nats: Deprecated; NATS enablement is inferred from runtime config
+            event_plane: Event plane transport ("nats" or "zmq")
         """
         ...
 

--- a/lib/bindings/python/tests/test_deprecated_enable_nats.py
+++ b/lib/bindings/python/tests/test_deprecated_enable_nats.py
@@ -45,6 +45,14 @@ def test_enable_nats_parameter_in_signature():
     assert param.default is None
 
 
+def test_event_plane_parameter_in_signature():
+    """DistributedRuntime.__init__ should accept explicit event-plane selection."""
+    sig = inspect.signature(DistributedRuntime)
+    assert "event_plane" in sig.parameters
+    param = sig.parameters["event_plane"]
+    assert param.default is None
+
+
 @pytest.mark.forked
 def test_enable_nats_emits_deprecation_warning(discovery_backend, request_plane):
     """Passing enable_nats should emit a DeprecationWarning but otherwise work.
@@ -93,6 +101,37 @@ def test_no_warning_without_enable_nats(discovery_backend, request_plane):
             assert len(deprecation_warnings) == 0
         finally:
             runtime.shutdown()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.forked
+def test_event_plane_zmq_ignores_ambient_nats(monkeypatch):
+    """Explicit ZMQ event plane should not connect to ambient NATS in file/TCP mode."""
+
+    async def _run():
+        monkeypatch.setenv("NATS_SERVER", "nats://127.0.0.1:9")
+        runtime = DistributedRuntime(
+            asyncio.get_running_loop(),
+            "file",
+            "tcp",
+            event_plane="zmq",
+        )
+        runtime.shutdown()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.forked
+def test_invalid_event_plane_errors():
+    async def _run():
+        with pytest.raises(Exception, match="Invalid event_plane value"):
+            DistributedRuntime(
+                asyncio.get_running_loop(),
+                "file",
+                "tcp",
+                event_plane="invalid",
+            )
 
     asyncio.run(_run())
 

--- a/lib/bindings/python/tests/test_deprecated_enable_nats.py
+++ b/lib/bindings/python/tests/test_deprecated_enable_nats.py
@@ -125,7 +125,7 @@ def test_event_plane_zmq_ignores_ambient_nats(monkeypatch):
 @pytest.mark.forked
 def test_invalid_event_plane_errors():
     async def _run():
-        with pytest.raises(Exception, match="Invalid event_plane value"):
+        with pytest.raises(ValueError, match="Invalid event_plane value"):
             DistributedRuntime(
                 asyncio.get_running_loop(),
                 "file",

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -117,7 +117,7 @@ pub async fn start_subscriber(
     kv_router_config: &KvRouterConfig,
     indexer: Indexer,
 ) -> Result<()> {
-    let transport_kind = EventTransportKind::from_env_or_default();
+    let transport_kind = component.drt().default_event_transport_kind();
 
     // Start subscriber - durable_kv_events flag determines the mode:
     // - durable_kv_events=false (default): Use NATS Core / generic event plane (requires workers to have local_indexer enabled)
@@ -127,9 +127,9 @@ pub async fn start_subscriber(
             "--durable-kv-events is deprecated and will be removed in a future release. \
              The event-plane subscriber (local_indexer mode) is now the recommended path."
         );
-        if transport_kind == EventTransportKind::Zmq {
-            tracing::warn!(
-                "--durable-kv-events requires NATS, but ZMQ event plane is configured; falling back to JetStream anyway"
+        if transport_kind != EventTransportKind::Nats {
+            anyhow::bail!(
+                "--durable-kv-events requires NATS event plane, but runtime is configured for {transport_kind:?}"
             );
         }
         tracing::info!("Using JetStream subscription (--durable-kv-events enabled)");

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1549,11 +1549,14 @@ def _test_router_indexers_sync(
             durable_kv_events=durable_kv_events,
             router_event_threads=router_event_threads,
         )
+        event_plane = "nats" if durable_kv_events else None
 
         # If standalone indexer mode, launch workers one-by-one and register.
         # We need to create a temporary endpoint just to discover worker IDs.
         if standalone_indexer_url:
-            tmp_runtime = get_runtime(store_backend, request_plane)
+            tmp_runtime = get_runtime(
+                store_backend, request_plane, event_plane=event_plane
+            )
             tmp_endpoint = tmp_runtime.endpoint(
                 f"{engine_workers.namespace}.{engine_workers.component_name}.generate"
             )
@@ -1649,7 +1652,7 @@ def _test_router_indexers_sync(
 
         # Create first runtime and endpoint for router 1
         logger.info("Creating first KV router with its own runtime")
-        runtime1 = get_runtime(store_backend, request_plane)
+        runtime1 = get_runtime(store_backend, request_plane, event_plane=event_plane)
         endpoint1 = runtime1.endpoint(
             f"{engine_workers.namespace}.{engine_workers.component_name}.generate"
         )
@@ -1758,7 +1761,7 @@ def _test_router_indexers_sync(
 
         # Create second runtime and endpoint for router 2
         logger.info("Creating second KV router with its own runtime")
-        runtime2 = get_runtime(store_backend, request_plane)
+        runtime2 = get_runtime(store_backend, request_plane, event_plane=event_plane)
         endpoint2 = runtime2.endpoint(
             f"{engine_workers.namespace}.{engine_workers.component_name}.generate"
         )

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -442,12 +442,17 @@ async def send_request_with_retry(url: str, payload: dict, max_retries: int = 8)
     return False
 
 
-def get_runtime(store_backend="etcd", request_plane="tcp"):
+def get_runtime(
+    store_backend: str = "etcd",
+    request_plane: str = "tcp",
+    event_plane: Optional[str] = None,
+):
     """Create a DistributedRuntime instance for testing.
 
     Args:
         store_backend: Storage backend to use ("etcd" or "file"). Defaults to "etcd".
         request_plane: How frontend talks to backend ("tcp", "nats"). Defaults to "tcp".
+        event_plane: How KV events are transported ("nats" or "zmq"). Defaults to runtime behavior.
     """
     try:
         # Try to get running loop (works in async context)
@@ -456,7 +461,9 @@ def get_runtime(store_backend="etcd", request_plane="tcp"):
         # No running loop, create a new one (sync context)
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-    return DistributedRuntime(loop, store_backend, request_plane)
+    return DistributedRuntime(
+        loop, store_backend, request_plane, event_plane=event_plane
+    )
 
 
 async def check_nats_consumers(namespace: str, expected_count: Optional[int] = None):


### PR DESCRIPTION
Add an explicit Python DistributedRuntime event_plane parameter so runtime event transport selection can avoid ambient NATS when callers request ZMQ.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `event_plane` keyword parameter to `DistributedRuntime` to configure event transport selection between "nats" or "zmq" options.

* **Deprecations**
  * Marked `enable_nats` parameter as deprecated; use `event_plane` instead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->