### PR TITLE
fix(gms): prune unreferenced torch allocations

### DIFF
--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -547,32 +547,36 @@ class GMSClientMemoryManager:
 
         assert self._granted_lock_type is not None
 
-        allocations_by_slot = {
-            int(info.layout_slot): info for info in self.list_handles()
-        }
+        committed_allocations = sorted(
+            self.list_handles(),
+            key=lambda info: int(info.layout_slot),
+        )
+        local_mappings = sorted(
+            self._mappings.items(), key=lambda item: item[1].layout_slot
+        )
+        if len(committed_allocations) != len(local_mappings):
+            raise StaleMemoryLayoutError(
+                "Layout allocation count changed: "
+                f"{len(local_mappings)} vs {len(committed_allocations)}"
+            )
 
         remapped_count = 0
         total_bytes = 0
         remapped_vas: list[int] = []
-        for va, mapping in sorted(
-            self._mappings.items(), key=lambda item: item[1].layout_slot
+        for rank, ((va, mapping), alloc_info) in enumerate(
+            zip(local_mappings, committed_allocations)
         ):
             if mapping.handle != 0:
                 continue
 
-            alloc_info = allocations_by_slot.get(mapping.layout_slot)
-            if alloc_info is None:
-                raise StaleMemoryLayoutError(
-                    f"Layout slot {mapping.layout_slot} is missing from the committed layout"
-                )
             if int(alloc_info.aligned_size) != mapping.aligned_size:
                 raise StaleMemoryLayoutError(
-                    f"Layout slot {mapping.layout_slot} size changed: "
+                    f"Layout rank {rank} size changed: "
                     f"{mapping.aligned_size} vs {int(alloc_info.aligned_size)}"
                 )
             if str(alloc_info.tag) != mapping.tag:
                 raise StaleMemoryLayoutError(
-                    f"Layout slot {mapping.layout_slot} tag changed: "
+                    f"Layout rank {rank} tag changed: "
                     f"{mapping.tag} vs {alloc_info.tag}"
                 )
 

--- a/lib/gpu_memory_service/client/torch/allocator.py
+++ b/lib/gpu_memory_service/client/torch/allocator.py
@@ -266,6 +266,64 @@ def get_gms_client_memory_managers() -> tuple["GMSClientMemoryManager", ...]:
     return tuple(state.manager for state in _tag_states.values())
 
 
+def prune_allocations(
+    manager: "GMSClientMemoryManager",
+    *,
+    referenced_allocation_ids: set[str],
+    synchronize: bool = True,
+) -> None:
+    """Free GMS allocations that are not in an explicit torch keep-set.
+
+    Callers provide the allocation IDs that remain valid; this helper does not
+    infer liveness from Python GC.  Weight loaders call it after registering
+    module tensors, treating other allocations as load-time scratch/cache that
+    PyTorch's caching allocator may leave behind because ``empty_cache()`` is a
+    no-op while live GMS mempool mappings exist.
+
+    Args:
+        manager: GMS manager whose local mappings should be pruned.
+        referenced_allocation_ids: Allocation IDs that must remain mapped and
+            committed.
+        synchronize: Synchronize CUDA before freeing unreferenced mappings.  The
+            default avoids freeing a block while prior GPU work may still be
+            using it.  Callers that have already synchronized can pass
+            ``False``.
+
+    """
+    if manager.granted_lock_type != GrantedLockType.RW or manager.is_unmapped:
+        return
+
+    if not any(mapping.handle != 0 for mapping in manager.mappings.values()):
+        return
+
+    if synchronize:
+        import torch
+
+        torch.cuda.synchronize(manager.device)
+
+    keep = {str(allocation_id) for allocation_id in referenced_allocation_ids}
+
+    pruned_allocations = 0
+    pruned_bytes = 0
+    for va, mapping in list(manager.mappings.items()):
+        if str(mapping.allocation_id) in keep:
+            continue
+        if mapping.handle == 0:
+            continue
+        pruned_allocations += 1
+        pruned_bytes += int(mapping.aligned_size)
+        manager.destroy_mapping(va)
+
+    if pruned_allocations:
+        logger.info(
+            "[GMS] Pruned %d unreferenced allocations (%.2f GiB); "
+            "kept %d registered allocations",
+            pruned_allocations,
+            pruned_bytes / (1 << 30),
+            len(keep),
+        )
+
+
 def evict_gms_client_memory_manager(manager: "GMSClientMemoryManager") -> None:
     for tag, state in list(_tag_states.items()):
         if state.manager is manager:

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -120,13 +120,17 @@ def _resolve_module_attr(
 def register_module_tensors(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
-) -> None:
+) -> set[str]:
     """Register all model tensors into the GMS metadata store.
 
     Args:
         gms_client_memory_manager: GMS client memory manager in write mode.
         model: PyTorch model to register.
+
+    Returns:
+        Allocation IDs referenced by registered tensors.
     """
+    referenced_allocation_ids: set[str] = set()
     for name, tensor, tensor_type in _iter_module_tensors(model):
         ptr = int(tensor.data_ptr())
 
@@ -141,6 +145,7 @@ def register_module_tensors(
                     offset_bytes=offset,
                     value=meta.to_bytes(),
                 )
+                referenced_allocation_ids.add(mapping.allocation_id)
                 break
         else:
             # No mapping matched - tensor pointer not in any GMS allocation
@@ -151,6 +156,7 @@ def register_module_tensors(
             logger.debug(
                 "[GMS] Skipping %s %r - not in GMS allocations", tensor_type, name
             )
+    return referenced_allocation_ids
 
 
 def materialize_module_from_gms(

--- a/lib/gpu_memory_service/integrations/common/__init__.py
+++ b/lib/gpu_memory_service/integrations/common/__init__.py
@@ -5,6 +5,7 @@
 
 from gpu_memory_service.integrations.common.patches import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
+    GMSWriteFinalizeResult,
     GMS_TAGS,
     finalize_gms_write,
     setup_meta_tensor_workaround,
@@ -12,6 +13,7 @@ from gpu_memory_service.integrations.common.utils import (
 
 __all__ = [
     "GMS_TAGS",
+    "GMSWriteFinalizeResult",
     "patch_empty_cache",
     "setup_meta_tensor_workaround",
     "finalize_gms_write",

--- a/lib/gpu_memory_service/integrations/common/__init__.py
+++ b/lib/gpu_memory_service/integrations/common/__init__.py
@@ -5,8 +5,8 @@
 
 from gpu_memory_service.integrations.common.patches import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
-    GMSCommittedMemoryStats,
     GMS_TAGS,
+    GMSCommittedMemoryStats,
     finalize_gms_write,
     setup_meta_tensor_workaround,
 )

--- a/lib/gpu_memory_service/integrations/common/__init__.py
+++ b/lib/gpu_memory_service/integrations/common/__init__.py
@@ -5,7 +5,7 @@
 
 from gpu_memory_service.integrations.common.patches import patch_empty_cache
 from gpu_memory_service.integrations.common.utils import (
-    GMSWriteFinalizeResult,
+    GMSCommittedMemoryStats,
     GMS_TAGS,
     finalize_gms_write,
     setup_meta_tensor_workaround,
@@ -13,7 +13,7 @@ from gpu_memory_service.integrations.common.utils import (
 
 __all__ = [
     "GMS_TAGS",
-    "GMSWriteFinalizeResult",
+    "GMSCommittedMemoryStats",
     "patch_empty_cache",
     "setup_meta_tensor_workaround",
     "finalize_gms_write",

--- a/lib/gpu_memory_service/integrations/common/patches.py
+++ b/lib/gpu_memory_service/integrations/common/patches.py
@@ -32,11 +32,12 @@ def patch_empty_cache() -> None:
     _original_empty_cache = torch.cuda.empty_cache
 
     def safe_empty_cache() -> None:
+        managers = get_gms_client_memory_managers()
         # Allow empty_cache when all managers are unmapped (sleep/checkpoint)
         # or when there are no active VMM mappings with live handles.
         has_live_mappings = any(
             any(m.handle != 0 for m in manager.mappings.values())
-            for manager in get_gms_client_memory_managers()
+            for manager in managers
         )
         if has_live_mappings:
             logger.debug(

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import torch
+from gpu_memory_service.client.torch.allocator import prune_allocations
 from gpu_memory_service.client.torch.module import register_module_tensors
 from gpu_memory_service.common.locks import RequestedLockType
 
@@ -82,8 +83,16 @@ def finalize_gms_write(
     Returns:
         Total bytes committed.
     """
-    register_module_tensors(allocator, model)
+    referenced_allocation_ids = register_module_tensors(allocator, model)
+    before_prune_bytes = allocator.total_bytes
+    before_prune_count = len(allocator.mappings)
+    prune_allocations(
+        allocator,
+        referenced_allocation_ids=referenced_allocation_ids,
+    )
     total_bytes = allocator.total_bytes
+    pruned_bytes = before_prune_bytes - total_bytes
+    pruned_count = before_prune_count - len(allocator.mappings)
 
     # Synchronize before commit — caller's writes must be visible
     torch.cuda.synchronize()
@@ -94,9 +103,12 @@ def finalize_gms_write(
     allocator.remap_all_vas()
 
     logger.info(
-        "[GMS] Committed %.2f GiB, switched to read mode with %d mappings",
+        "[GMS] Committed %.2f GiB, switched to read mode with %d mappings "
+        "(pruned %d allocations / %.2f GiB before commit)",
         total_bytes / (1 << 30),
         len(allocator._mappings),
+        pruned_count,
+        pruned_bytes / (1 << 30),
     )
 
     return int(total_bytes)

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 import torch
@@ -19,6 +19,26 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 GMS_TAGS = ("weights", "kv_cache")
+
+
+@dataclass(frozen=True)
+class GMSWriteFinalizeResult:
+    """Result of finalizing a GMS write-mode model load.
+
+    ``committed_bytes`` is the actual pruned GMS layout published to readers.
+    ``pruned_bytes`` is the amount of transient loader memory removed before
+    commit. Backend memory profilers can add it back to their non-KV accounting
+    if pruning already appears as a free-memory delta, avoiding double-crediting
+    the same reclaimed memory as KV cache headroom.
+    """
+
+    committed_bytes: int
+    pruned_bytes: int
+
+    @property
+    def accounting_bytes(self) -> int:
+        """Bytes to charge as non-KV model memory in backend profilers."""
+        return self.committed_bytes + self.pruned_bytes
 
 
 def get_gms_lock_mode(extra_config: dict):
@@ -70,8 +90,11 @@ def setup_meta_tensor_workaround() -> None:
 
 
 def finalize_gms_write(
-    allocator: "GMSClientMemoryManager", model: torch.nn.Module
-) -> int:
+    allocator: "GMSClientMemoryManager",
+    model: torch.nn.Module,
+    *,
+    return_result: bool = False,
+) -> int | GMSWriteFinalizeResult:
     """Finalize GMS write mode: register tensors, commit, reconnect in read mode.
 
     Flow: register tensors -> sync -> unmap + commit -> connect(RO) -> remap
@@ -81,7 +104,8 @@ def finalize_gms_write(
         model: The loaded model with weights to register.
 
     Returns:
-        Total bytes committed.
+        By default, total bytes committed.  When ``return_result=True``, returns
+        committed bytes plus the number of pruned bytes.
     """
     referenced_allocation_ids = register_module_tensors(allocator, model)
     before_prune_bytes = allocator.total_bytes
@@ -111,4 +135,8 @@ def finalize_gms_write(
         pruned_bytes / (1 << 30),
     )
 
-    return int(total_bytes)
+    result = GMSWriteFinalizeResult(
+        committed_bytes=int(total_bytes),
+        pruned_bytes=int(pruned_bytes),
+    )
+    return result if return_result else result.committed_bytes

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -22,23 +22,9 @@ GMS_TAGS = ("weights", "kv_cache")
 
 
 @dataclass(frozen=True)
-class GMSWriteFinalizeResult:
-    """Result of finalizing a GMS write-mode model load.
-
-    ``committed_bytes`` is the actual pruned GMS layout published to readers.
-    ``pruned_bytes`` is the amount of transient loader memory removed before
-    commit. Backend memory profilers can add it back to their non-KV accounting
-    if pruning already appears as a free-memory delta, avoiding double-crediting
-    the same reclaimed memory as KV cache headroom.
-    """
-
+class GMSCommittedMemoryStats:
     committed_bytes: int
     pruned_bytes: int
-
-    @property
-    def accounting_bytes(self) -> int:
-        """Bytes to charge as non-KV model memory in backend profilers."""
-        return self.committed_bytes + self.pruned_bytes
 
 
 def get_gms_lock_mode(extra_config: dict):
@@ -92,9 +78,7 @@ def setup_meta_tensor_workaround() -> None:
 def finalize_gms_write(
     allocator: "GMSClientMemoryManager",
     model: torch.nn.Module,
-    *,
-    return_result: bool = False,
-) -> int | GMSWriteFinalizeResult:
+) -> GMSCommittedMemoryStats:
     """Finalize GMS write mode: register tensors, commit, reconnect in read mode.
 
     Flow: register tensors -> sync -> unmap + commit -> connect(RO) -> remap
@@ -104,8 +88,7 @@ def finalize_gms_write(
         model: The loaded model with weights to register.
 
     Returns:
-        By default, total bytes committed.  When ``return_result=True``, returns
-        committed bytes plus the number of pruned bytes.
+        Committed/pruned byte stats.
     """
     referenced_allocation_ids = register_module_tensors(allocator, model)
     before_prune_bytes = allocator.total_bytes
@@ -135,8 +118,7 @@ def finalize_gms_write(
         pruned_bytes / (1 << 30),
     )
 
-    result = GMSWriteFinalizeResult(
+    return GMSCommittedMemoryStats(
         committed_bytes=int(total_bytes),
         pruned_bytes=int(pruned_bytes),
     )
-    return result if return_result else result.committed_bytes

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -93,6 +93,10 @@ def finalize_gms_write(
     referenced_allocation_ids = register_module_tensors(allocator, model)
     before_prune_bytes = allocator.total_bytes
     before_prune_count = len(allocator.mappings)
+
+    # prune_allocations synchronizes allocator.device before destroying
+    # unreferenced mappings. allocator.commit() performs the publish-barrier
+    # sync before committing the remaining registered weights.
     prune_allocations(
         allocator,
         referenced_allocation_ids=referenced_allocation_ids,
@@ -100,9 +104,6 @@ def finalize_gms_write(
     total_bytes = allocator.total_bytes
     pruned_bytes = before_prune_bytes - total_bytes
     pruned_count = before_prune_count - len(allocator.mappings)
-
-    # Synchronize before commit — caller's writes must be visible
-    torch.cuda.synchronize()
 
     allocator.commit()
 
@@ -113,7 +114,7 @@ def finalize_gms_write(
         "[GMS] Committed %.2f GiB, switched to read mode with %d mappings "
         "(pruned %d allocations / %.2f GiB before commit)",
         total_bytes / (1 << 30),
-        len(allocator._mappings),
+        len(allocator.mappings),
         pruned_count,
         pruned_bytes / (1 << 30),
     )

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -71,6 +71,7 @@ class GMSMemorySaverImpl:
     ):
         self._device = torch.device("cuda", device_index)
         self.imported_weights_bytes = 0
+        self.preloaded_weights_bytes = 0
         self.ro_connect_timeout_ms = ro_connect_timeout_ms
         requested_mode = mode or RequestedLockType.RW_OR_RO
         self.allocators = {
@@ -188,6 +189,6 @@ class GMSMemorySaverImpl:
             # Read-only import mode never republishes weights.
             return
 
-        self.imported_weights_bytes = finalize_gms_write(
-            self.allocators["weights"], model
-        ).committed_bytes
+        stats = finalize_gms_write(self.allocators["weights"], model)
+        self.imported_weights_bytes = stats.committed_bytes
+        self.preloaded_weights_bytes = 0

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -190,4 +190,4 @@ class GMSMemorySaverImpl:
 
         self.imported_weights_bytes = finalize_gms_write(
             self.allocators["weights"], model
-        )
+        ).committed_bytes

--- a/lib/gpu_memory_service/integrations/sglang/model_loader.py
+++ b/lib/gpu_memory_service/integrations/sglang/model_loader.py
@@ -106,6 +106,7 @@ class GMSModelLoader:
 
         materialize_module_from_gms(allocator, model, device_index=device_index)
         impl.imported_weights_bytes = allocator.total_bytes
+        impl.preloaded_weights_bytes = allocator.total_bytes
 
         logger.info(
             "[GMS] READ mode: imported %.2f GiB from metadata",

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -140,12 +140,14 @@ def patch_torch_memory_saver() -> None:
 
 
 def patch_model_runner() -> None:
-    """Patch SGLang's ModelRunner to fix memory accounting with pre-loaded weights.
+    """Patch SGLang's ModelRunner to size KV cache with GMS-resident weights.
 
-    SGLang 0.5.9 passes a startup free-memory snapshot as total_gpu_memory into
-    init_memory_pool(). In GMS read mode, imported weights can already occupy GPU
-    memory, so that snapshot is lower than physical device capacity and the KV cache
-    overhead term is under-reserved.
+    SGLang's KV sizing formula reserves dynamic headroom from a free-memory
+    snapshot taken before its own model load. In GMS read mode, the committed
+    weight handles already exist in the GMS server before that snapshot, so the
+    snapshot is lower by those weights. Add just those preloaded weight bytes
+    back to the baseline. Do not adjust write mode: weights are loaded after
+    the snapshot there, so upstream's formula already subtracts them correctly.
     """
     global _model_runner_patched
 
@@ -172,41 +174,64 @@ def patch_model_runner() -> None:
     )
 
     def patched_init_memory_pool(self, *args, **kwargs):
-        """Patch init_memory_pool for SGLang versions that use total_gpu_memory.
-
-        SGLang's KV cache formula uses total_gpu_memory as the baseline:
-        rest_memory = available - total*(1-mem_fraction).
-        Replace that baseline with physical device capacity when GMS imported
-        weights are already resident. Newer SGLang versions changed this API, so
-        only rewrite the old total_gpu_memory parameter shape.
-        """
+        """Patch memory baseline for SGLang old/new init_memory_pool signatures."""
         impl = get_gms_memory_saver_impl()
-        if impl is not None and impl.imported_weights_bytes > 0:
-            total_memory_gib = torch.cuda.get_device_properties(
-                torch.cuda.current_device()
-            ).total_memory / (1 << 30)
-            if memory_arg_name == "total_gpu_memory":
-                if args:
-                    old_value = args[0]
-                    args = (total_memory_gib,) + args[1:]
-                elif memory_arg_name in kwargs:
-                    old_value = kwargs[memory_arg_name]
-                    kwargs = dict(kwargs)
-                    kwargs[memory_arg_name] = total_memory_gib
-                else:
-                    old_value = None
-                logger.info(
-                    "[GMS] Adjusted total_gpu_memory: %s -> %.2f GiB",
-                    (
-                        f"{old_value:.2f} GiB"
-                        if isinstance(old_value, (int, float))
-                        else "<missing>"
-                    ),
-                    total_memory_gib,
+        preloaded_weights_gib = 0.0
+        if impl is not None:
+            preloaded_weights_gib = impl.preloaded_weights_bytes / (1 << 30)
+
+        if preloaded_weights_gib > 0 and memory_arg_name in (
+            "pre_model_load_memory",
+            "total_gpu_memory",
+        ):
+            if args:
+                old_value = args[0]
+                new_value = (
+                    old_value + preloaded_weights_gib
+                    if isinstance(old_value, (int, float))
+                    else old_value
                 )
-            elif memory_arg_name is not None:
+                args = (new_value,) + args[1:]
+            elif memory_arg_name in kwargs:
+                old_value = kwargs[memory_arg_name]
+                new_value = (
+                    old_value + preloaded_weights_gib
+                    if isinstance(old_value, (int, float))
+                    else old_value
+                )
+                kwargs = dict(kwargs)
+                kwargs[memory_arg_name] = new_value
+            else:
+                old_value = None
+                new_value = None
+
+            if isinstance(old_value, (int, float)) and isinstance(
+                new_value, (int, float)
+            ):
                 logger.info(
-                    "[GMS] Leaving %s unchanged in patched init_memory_pool",
+                    "[GMS] Adjusted %s for preloaded weights: "
+                    "%.2f GiB + %.2f GiB = %.2f GiB",
+                    memory_arg_name,
+                    old_value,
+                    preloaded_weights_gib,
+                    new_value,
+                )
+            else:
+                logger.info(
+                    "[GMS] Could not adjust %s for preloaded weights; value=%r",
+                    memory_arg_name,
+                    old_value,
+                )
+        elif impl is not None and impl.imported_weights_bytes > 0:
+            if preloaded_weights_gib > 0:
+                logger.info(
+                    "[GMS] Leaving %s unchanged; unsupported SGLang "
+                    "init_memory_pool signature for preloaded weights",
+                    memory_arg_name,
+                )
+            else:
+                logger.info(
+                    "[GMS] Leaving %s unchanged; weights were loaded by this process",
                     memory_arg_name,
                 )
 

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -165,7 +165,9 @@ def _load_rw(
         _move_untracked_params(model, gms_client, target_device)
         torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    _last_imported_weights_bytes = finalize_gms_write(
+        gms_client, model
+    ).committed_bytes
 
     logger.info(
         "[GMS] TRT-LLM RW: published %.2f GiB",

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -165,9 +165,7 @@ def _load_rw(
         _move_untracked_params(model, gms_client, target_device)
         torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(
-        gms_client, model
-    ).committed_bytes
+    _last_imported_weights_bytes = finalize_gms_write(gms_client, model).committed_bytes
 
     logger.info(
         "[GMS] TRT-LLM RW: published %.2f GiB",

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -50,11 +50,17 @@ logger = logging.getLogger(__name__)
 
 # Track imported weights for memory accounting
 _last_imported_weights_bytes: int = 0
+_last_weight_accounting_bytes: int = 0
 
 
 def get_imported_weights_bytes() -> int:
     """Return bytes of weights imported in the last load_model call."""
     return _last_imported_weights_bytes
+
+
+def get_weight_accounting_bytes() -> int:
+    """Return non-KV model bytes to charge to vLLM memory accounting."""
+    return _last_weight_accounting_bytes or _last_imported_weights_bytes
 
 
 # =============================================================================
@@ -166,7 +172,7 @@ def _load_read_mode(
     When MX is active, registers materialized tensors with NIXL so this
     node is discoverable as a P2P source (e.g. for shadow engine failover).
     """
-    global _last_imported_weights_bytes
+    global _last_imported_weights_bytes, _last_weight_accounting_bytes
 
     try:
         model = _create_meta_model(vllm_config, model_config)
@@ -179,6 +185,7 @@ def _load_read_mode(
             publish_metadata(mx_ctx)
 
         _last_imported_weights_bytes = gms_client.total_bytes
+        _last_weight_accounting_bytes = _last_imported_weights_bytes
         logger.info(
             "[GMS] Read mode: imported %.2f GiB",
             _last_imported_weights_bytes / (1 << 30),
@@ -205,7 +212,7 @@ def _load_write_mode(
     detection (RDMA P2P -> ModelStreamer -> GDS -> disk) with fallback.
     The chain also handles NIXL registration and metadata publishing.
     """
-    global _last_imported_weights_bytes
+    global _last_imported_weights_bytes, _last_weight_accounting_bytes
 
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
@@ -232,11 +239,14 @@ def _load_write_mode(
 
             torch.cuda.empty_cache()
 
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model)
+    finalize_result = finalize_gms_write(gms_client, model, return_result=True)
+    _last_imported_weights_bytes = finalize_result.committed_bytes
+    _last_weight_accounting_bytes = finalize_result.accounting_bytes
 
     logger.info(
-        "[GMS] Write mode: published %.2f GiB",
+        "[GMS] Write mode: published %.2f GiB (accounting %.2f GiB)",
         _last_imported_weights_bytes / (1 << 30),
+        _last_weight_accounting_bytes / (1 << 30),
     )
     return model.eval()
 

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -48,9 +48,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Track imported weights for memory accounting
+# Track imported weights plus the vLLM-local model_memory_usage adjustment.
 _last_imported_weights_bytes: int = 0
-_last_weight_memory_charge_bytes: int = 0
+_last_model_memory_usage_offset_bytes: int = 0
 
 
 def get_imported_weights_bytes() -> int:
@@ -58,9 +58,9 @@ def get_imported_weights_bytes() -> int:
     return _last_imported_weights_bytes
 
 
-def get_weight_memory_charge_bytes() -> int:
-    """Return non-KV model bytes to charge to vLLM memory accounting."""
-    return _last_weight_memory_charge_bytes or _last_imported_weights_bytes
+def get_model_memory_usage_offset_bytes() -> int:
+    """Return the offset to add to imported bytes for vLLM model_memory_usage."""
+    return _last_model_memory_usage_offset_bytes
 
 
 # =============================================================================
@@ -172,7 +172,7 @@ def _load_read_mode(
     When MX is active, registers materialized tensors with NIXL so this
     node is discoverable as a P2P source (e.g. for shadow engine failover).
     """
-    global _last_imported_weights_bytes, _last_weight_memory_charge_bytes
+    global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
     try:
         model = _create_meta_model(vllm_config, model_config)
@@ -185,7 +185,7 @@ def _load_read_mode(
             publish_metadata(mx_ctx)
 
         _last_imported_weights_bytes = gms_client.total_bytes
-        _last_weight_memory_charge_bytes = _last_imported_weights_bytes
+        _last_model_memory_usage_offset_bytes = 0
         logger.info(
             "[GMS] Read mode: imported %.2f GiB",
             _last_imported_weights_bytes / (1 << 30),
@@ -212,7 +212,7 @@ def _load_write_mode(
     detection (RDMA P2P -> ModelStreamer -> GDS -> disk) with fallback.
     The chain also handles NIXL registration and metadata publishing.
     """
-    global _last_imported_weights_bytes, _last_weight_memory_charge_bytes
+    global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
@@ -241,14 +241,13 @@ def _load_write_mode(
 
     finalize_result = finalize_gms_write(gms_client, model)
     _last_imported_weights_bytes = finalize_result.committed_bytes
-    _last_weight_memory_charge_bytes = (
-        finalize_result.committed_bytes + finalize_result.pruned_bytes
-    )
+    _last_model_memory_usage_offset_bytes = finalize_result.pruned_bytes
 
     logger.info(
-        "[GMS] Write mode: published %.2f GiB (vLLM memory charge %.2f GiB)",
+        "[GMS] Write mode: published %.2f GiB "
+        "(vLLM memory offset %.2f GiB)",
         _last_imported_weights_bytes / (1 << 30),
-        _last_weight_memory_charge_bytes / (1 << 30),
+        _last_model_memory_usage_offset_bytes / (1 << 30),
     )
     return model.eval()
 

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 # Track imported weights for memory accounting
 _last_imported_weights_bytes: int = 0
-_last_weight_accounting_bytes: int = 0
+_last_weight_memory_charge_bytes: int = 0
 
 
 def get_imported_weights_bytes() -> int:
@@ -58,9 +58,9 @@ def get_imported_weights_bytes() -> int:
     return _last_imported_weights_bytes
 
 
-def get_weight_accounting_bytes() -> int:
+def get_weight_memory_charge_bytes() -> int:
     """Return non-KV model bytes to charge to vLLM memory accounting."""
-    return _last_weight_accounting_bytes or _last_imported_weights_bytes
+    return _last_weight_memory_charge_bytes or _last_imported_weights_bytes
 
 
 # =============================================================================
@@ -172,7 +172,7 @@ def _load_read_mode(
     When MX is active, registers materialized tensors with NIXL so this
     node is discoverable as a P2P source (e.g. for shadow engine failover).
     """
-    global _last_imported_weights_bytes, _last_weight_accounting_bytes
+    global _last_imported_weights_bytes, _last_weight_memory_charge_bytes
 
     try:
         model = _create_meta_model(vllm_config, model_config)
@@ -185,7 +185,7 @@ def _load_read_mode(
             publish_metadata(mx_ctx)
 
         _last_imported_weights_bytes = gms_client.total_bytes
-        _last_weight_accounting_bytes = _last_imported_weights_bytes
+        _last_weight_memory_charge_bytes = _last_imported_weights_bytes
         logger.info(
             "[GMS] Read mode: imported %.2f GiB",
             _last_imported_weights_bytes / (1 << 30),
@@ -212,7 +212,7 @@ def _load_write_mode(
     detection (RDMA P2P -> ModelStreamer -> GDS -> disk) with fallback.
     The chain also handles NIXL registration and metadata publishing.
     """
-    global _last_imported_weights_bytes, _last_weight_accounting_bytes
+    global _last_imported_weights_bytes, _last_weight_memory_charge_bytes
 
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
@@ -239,14 +239,16 @@ def _load_write_mode(
 
             torch.cuda.empty_cache()
 
-    finalize_result = finalize_gms_write(gms_client, model, return_result=True)
+    finalize_result = finalize_gms_write(gms_client, model)
     _last_imported_weights_bytes = finalize_result.committed_bytes
-    _last_weight_accounting_bytes = finalize_result.accounting_bytes
+    _last_weight_memory_charge_bytes = (
+        finalize_result.committed_bytes + finalize_result.pruned_bytes
+    )
 
     logger.info(
-        "[GMS] Write mode: published %.2f GiB (accounting %.2f GiB)",
+        "[GMS] Write mode: published %.2f GiB (vLLM memory charge %.2f GiB)",
         _last_imported_weights_bytes / (1 << 30),
-        _last_weight_accounting_bytes / (1 << 30),
+        _last_weight_memory_charge_bytes / (1 << 30),
     )
     return model.eval()
 

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -244,8 +244,7 @@ def _load_write_mode(
     _last_model_memory_usage_offset_bytes = finalize_result.pruned_bytes
 
     logger.info(
-        "[GMS] Write mode: published %.2f GiB "
-        "(vLLM memory offset %.2f GiB)",
+        "[GMS] Write mode: published %.2f GiB " "(vLLM memory offset %.2f GiB)",
         _last_imported_weights_bytes / (1 << 30),
         _last_model_memory_usage_offset_bytes / (1 << 30),
     )

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -239,21 +239,17 @@ class GMSWorker(Worker):
         # Correct memory accounting for GMS-imported weights
         try:
             from gpu_memory_service.integrations.vllm.model_loader import (
-                get_imported_weights_bytes,
+                get_weight_accounting_bytes,
             )
 
-            imported_bytes = int(get_imported_weights_bytes())
-            if (
-                imported_bytes > 0
-                and hasattr(self, "model_runner")
-                and self.model_runner is not None
-            ):
+            accounting_bytes = int(get_weight_accounting_bytes())
+            if accounting_bytes > 0 and self.model_runner is not None:
                 old_usage = getattr(self.model_runner, "model_memory_usage", 0)
-                self.model_runner.model_memory_usage = imported_bytes
+                self.model_runner.model_memory_usage = accounting_bytes
                 logger.info(
                     "[GMS] Corrected model_memory_usage: %.2f GiB -> %.2f GiB",
                     old_usage / (1 << 30),
-                    imported_bytes / (1 << 30),
+                    accounting_bytes / (1 << 30),
                 )
         except Exception as e:
             logger.debug("[GMS] Could not correct memory accounting: %s", e)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -174,8 +174,7 @@ class GMSWorker(Worker):
         cudagraph_memory_estimate = 0
         if (
             current_platform.is_cuda()
-            and self.vllm_config.compilation_config.cudagraph_mode
-            != CUDAGraphMode.NONE
+            and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
             cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
         cudagraph_memory_estimate_applied = (
@@ -270,8 +269,7 @@ class GMSWorker(Worker):
             )
 
             model_memory_usage_bytes = int(
-                get_imported_weights_bytes()
-                + get_model_memory_usage_offset_bytes()
+                get_imported_weights_bytes() + get_model_memory_usage_offset_bytes()
             )
             if model_memory_usage_bytes > 0 and self.model_runner is not None:
                 old_usage = getattr(self.model_runner, "model_memory_usage", 0)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -239,17 +239,17 @@ class GMSWorker(Worker):
         # Correct memory accounting for GMS-imported weights
         try:
             from gpu_memory_service.integrations.vllm.model_loader import (
-                get_weight_accounting_bytes,
+                get_weight_memory_charge_bytes,
             )
 
-            accounting_bytes = int(get_weight_accounting_bytes())
-            if accounting_bytes > 0 and self.model_runner is not None:
+            weight_memory_charge_bytes = int(get_weight_memory_charge_bytes())
+            if weight_memory_charge_bytes > 0 and self.model_runner is not None:
                 old_usage = getattr(self.model_runner, "model_memory_usage", 0)
-                self.model_runner.model_memory_usage = accounting_bytes
+                self.model_runner.model_memory_usage = weight_memory_charge_bytes
                 logger.info(
                     "[GMS] Corrected model_memory_usage: %.2f GiB -> %.2f GiB",
                     old_usage / (1 << 30),
-                    accounting_bytes / (1 << 30),
+                    weight_memory_charge_bytes / (1 << 30),
                 )
         except Exception as e:
             logger.debug("[GMS] Could not correct memory accounting: %s", e)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -162,10 +162,28 @@ class GMSWorker(Worker):
         if not is_scratch_kv_enabled():
             return super().determine_available_memory()
 
+        import vllm.envs as envs
+        from vllm.config import CUDAGraphMode
+        from vllm.platforms import current_platform
+
         torch.cuda.reset_peak_memory_stats()
         self.model_runner.profile_run()
         torch.cuda.synchronize()
         torch_peak = torch.cuda.max_memory_allocated()
+
+        cudagraph_memory_estimate = 0
+        if (
+            current_platform.is_cuda()
+            and self.vllm_config.compilation_config.cudagraph_mode
+            != CUDAGraphMode.NONE
+        ):
+            cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
+        cudagraph_memory_estimate_applied = (
+            cudagraph_memory_estimate
+            if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
+            else 0
+        )
+        self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
         # GMS weights mapped via cuMemMap are invisible to PyTorch's memory
         # stats on RO engines. Add them explicitly. On RW engines, torch_peak
@@ -176,18 +194,26 @@ class GMSWorker(Worker):
         else:
             non_kv_cache_memory = torch_peak
 
-        projected_available = self.requested_memory - non_kv_cache_memory
+        projected_available = (
+            self.requested_memory
+            - non_kv_cache_memory
+            - cudagraph_memory_estimate_applied
+        )
+        self.available_kv_cache_memory_bytes = int(projected_available)
 
         msg = (
             "[GMS] projected available memory "
             "%.2f GiB (requested=%.2f GiB, non_kv=%.2f GiB, "
-            "torch_peak=%.2f GiB, weights=%.2f GiB)"
+            "torch_peak=%.2f GiB, weights=%.2f GiB, "
+            "cudagraph_estimate=%.2f GiB, cudagraph_applied=%.2f GiB)"
             % (
                 projected_available / (1 << 30),
                 self.requested_memory / (1 << 30),
                 non_kv_cache_memory / (1 << 30),
                 torch_peak / (1 << 30),
                 weights_memory / (1 << 30),
+                cudagraph_memory_estimate / (1 << 30),
+                cudagraph_memory_estimate_applied / (1 << 30),
             )
         )
         logger.info(msg)
@@ -239,17 +265,21 @@ class GMSWorker(Worker):
         # Correct memory accounting for GMS-imported weights
         try:
             from gpu_memory_service.integrations.vllm.model_loader import (
-                get_weight_memory_charge_bytes,
+                get_imported_weights_bytes,
+                get_model_memory_usage_offset_bytes,
             )
 
-            weight_memory_charge_bytes = int(get_weight_memory_charge_bytes())
-            if weight_memory_charge_bytes > 0 and self.model_runner is not None:
+            model_memory_usage_bytes = int(
+                get_imported_weights_bytes()
+                + get_model_memory_usage_offset_bytes()
+            )
+            if model_memory_usage_bytes > 0 and self.model_runner is not None:
                 old_usage = getattr(self.model_runner, "model_memory_usage", 0)
-                self.model_runner.model_memory_usage = weight_memory_charge_bytes
+                self.model_runner.model_memory_usage = model_memory_usage_bytes
                 logger.info(
                     "[GMS] Corrected model_memory_usage: %.2f GiB -> %.2f GiB",
                     old_usage / (1 << 30),
-                    weight_memory_charge_bytes / (1 << 30),
+                    model_memory_usage_bytes / (1 << 30),
                 )
         except Exception as e:
             logger.debug("[GMS] Could not correct memory accounting: %s", e)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -268,16 +268,27 @@ class GMSWorker(Worker):
                 get_model_memory_usage_offset_bytes,
             )
 
+            imported_weights_bytes = get_imported_weights_bytes()
+            memory_usage_offset_bytes = get_model_memory_usage_offset_bytes()
+            # The offset is not committed/restored GMS weight state. It is the
+            # load-time allocation footprint pruned before commit. vLLM uses
+            # model_memory_usage for KV-cache sizing, not only as a literal
+            # live-weight counter; reporting committed GMS bytes only can
+            # overestimate safe KV capacity and allocate an oversized cache.
             model_memory_usage_bytes = int(
-                get_imported_weights_bytes() + get_model_memory_usage_offset_bytes()
+                imported_weights_bytes + memory_usage_offset_bytes
             )
             if model_memory_usage_bytes > 0 and self.model_runner is not None:
                 old_usage = getattr(self.model_runner, "model_memory_usage", 0)
                 self.model_runner.model_memory_usage = model_memory_usage_bytes
                 logger.info(
-                    "[GMS] Corrected model_memory_usage: %.2f GiB -> %.2f GiB",
+                    "[GMS] Corrected vLLM model_memory_usage for KV sizing: "
+                    "%.2f GiB -> %.2f GiB "
+                    "(weights %.2f GiB + offset %.2f GiB)",
                     old_usage / (1 << 30),
                     model_memory_usage_bytes / (1 << 30),
+                    imported_weights_bytes / (1 << 30),
+                    memory_usage_offset_bytes / (1 << 30),
                 )
         except Exception as e:
             logger.debug("[GMS] Could not correct memory accounting: %s", e)

--- a/lib/gpu_memory_service/server/gms.py
+++ b/lib/gpu_memory_service/server/gms.py
@@ -179,9 +179,7 @@ class GMS:
             sorted(allocations, key=lambda info: info.layout_slot)
         ):
             allocation_ranks_by_id[info.allocation_id] = rank
-            h.update(
-                f"{rank}:{info.size}:{info.aligned_size}:{info.tag}".encode()
-            )
+            h.update(f"{rank}:{info.size}:{info.aligned_size}:{info.tag}".encode())
 
         for key in sorted(self._metadata):
             entry = self._metadata[key]

--- a/lib/gpu_memory_service/server/gms.py
+++ b/lib/gpu_memory_service/server/gms.py
@@ -174,17 +174,19 @@ class GMS:
 
     def _compute_memory_layout_hash(self, allocations: list[AllocationInfo]) -> str:
         h = hashlib.sha256()
-        allocation_slots_by_id: dict[str, int] = {}
-        for info in sorted(allocations, key=lambda info: info.layout_slot):
-            allocation_slots_by_id[info.allocation_id] = info.layout_slot
+        allocation_ranks_by_id: dict[str, int] = {}
+        for rank, info in enumerate(
+            sorted(allocations, key=lambda info: info.layout_slot)
+        ):
+            allocation_ranks_by_id[info.allocation_id] = rank
             h.update(
-                f"{info.layout_slot}:{info.size}:{info.aligned_size}:{info.tag}".encode()
+                f"{rank}:{info.size}:{info.aligned_size}:{info.tag}".encode()
             )
 
         for key in sorted(self._metadata):
             entry = self._metadata[key]
-            layout_slot = allocation_slots_by_id[entry.allocation_id]
-            h.update(f"{key}:{layout_slot}:{entry.offset_bytes}:".encode())
+            rank = allocation_ranks_by_id[entry.allocation_id]
+            h.update(f"{key}:{rank}:{entry.offset_bytes}:".encode())
             h.update(entry.value)
         return h.hexdigest()
 

--- a/lib/gpu_memory_service/tests/test_runtime_flows.py
+++ b/lib/gpu_memory_service/tests/test_runtime_flows.py
@@ -713,6 +713,38 @@ def test_destroy_mapping_frees_allocation_and_metadata(running_gms):
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_prune_allocations_frees_unreferenced_mappings(running_gms):
+    _, socket_path = running_gms
+
+    from gpu_memory_service.client.torch.allocator import prune_allocations
+
+    writer = GMSClientMemoryManager(socket_path, device=0)
+    try:
+        writer.connect(RequestedLockType.RW)
+        keep_va = writer.create_mapping(size=4096, tag="weights")
+        prune_va = writer.create_mapping(size=8192, tag="weights")
+
+        keep_allocation_id = writer.mappings[keep_va].allocation_id
+        prune_allocation_id = writer.mappings[prune_va].allocation_id
+
+        prune_allocations(
+            writer,
+            referenced_allocation_ids={keep_allocation_id},
+            synchronize=False,
+        )
+
+        assert keep_va in writer.mappings
+        assert prune_va not in writer.mappings
+        assert [info.allocation_id for info in writer.list_handles()] == [
+            keep_allocation_id
+        ]
+        with pytest.raises(RuntimeError, match="Unknown allocation"):
+            writer.get_handle_info(prune_allocation_id)
+    finally:
+        writer.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
 def test_remap_all_vas_succeeds_when_committed_layout_is_unchanged(
     running_gms,
 ):

--- a/lib/gpu_memory_service/tests/test_runtime_flows.py
+++ b/lib/gpu_memory_service/tests/test_runtime_flows.py
@@ -851,6 +851,80 @@ def test_remap_all_vas_accepts_new_layout_with_same_structural_layout(
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_remap_all_vas_accepts_restored_layout_after_pruned_slot_gap(
+    running_gms,
+):
+    """Pruned layouts may have sparse source slots but compact restore slots."""
+
+    _, socket_path = running_gms
+
+    from gpu_memory_service.client.torch.allocator import prune_allocations
+
+    first_writer = GMSClientMemoryManager(socket_path, device=0)
+    reader = GMSClientMemoryManager(socket_path, device=0)
+    second_writer = GMSClientMemoryManager(socket_path, device=0)
+    try:
+        first_writer.connect(RequestedLockType.RW)
+        kept_a_va = first_writer.create_mapping(size=4096, tag="weights")
+        pruned_va = first_writer.create_mapping(size=8192, tag="weights")
+        kept_b_va = first_writer.create_mapping(
+            size=first_writer.granularity + 4096,
+            tag="weights",
+        )
+
+        kept_a = first_writer.mappings[kept_a_va]
+        kept_b = first_writer.mappings[kept_b_va]
+        assert first_writer.mappings[pruned_va].layout_slot == 1
+        assert kept_b.layout_slot == 2
+
+        prune_allocations(
+            first_writer,
+            referenced_allocation_ids={kept_a.allocation_id, kept_b.allocation_id},
+            synchronize=False,
+        )
+        first_writer.metadata_put("tensor.0", kept_a.allocation_id, 0, b"a")
+        first_writer.metadata_put("tensor.1", kept_b.allocation_id, 0, b"b")
+        assert first_writer.commit()
+
+        reader.connect(RequestedLockType.RO)
+        source_hash = reader.get_memory_layout_hash()
+        assert source_hash
+        imported_a_va = reader.create_mapping(allocation_id=kept_a.allocation_id)
+        imported_b_va = reader.create_mapping(allocation_id=kept_b.allocation_id)
+        reader.unmap_all_vas()
+        reader.abort()
+
+        second_writer.connect(RequestedLockType.RW)
+        restored_a_va = second_writer.create_mapping(size=kept_a.size, tag=kept_a.tag)
+        restored_b_va = second_writer.create_mapping(size=kept_b.size, tag=kept_b.tag)
+        restored_a = second_writer.mappings[restored_a_va]
+        restored_b = second_writer.mappings[restored_b_va]
+        assert restored_a.layout_slot == 0
+        assert restored_b.layout_slot == 1
+        second_writer.metadata_put("tensor.0", restored_a.allocation_id, 0, b"a")
+        second_writer.metadata_put("tensor.1", restored_b.allocation_id, 0, b"b")
+        assert second_writer.commit()
+
+        verifier = _GMSClientSession(socket_path, RequestedLockType.RO, None)
+        try:
+            assert verifier.get_memory_layout_hash() == source_hash
+        finally:
+            verifier.close()
+
+        reader.connect(RequestedLockType.RO)
+        reader.remap_all_vas()
+
+        assert reader.mappings[imported_a_va].allocation_id == restored_a.allocation_id
+        assert reader.mappings[imported_b_va].allocation_id == restored_b.allocation_id
+        assert reader.metadata_get("tensor.0") == (restored_a.allocation_id, 0, b"a")
+        assert reader.metadata_get("tensor.1") == (restored_b.allocation_id, 0, b"b")
+    finally:
+        second_writer.close()
+        reader.close()
+        first_writer.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
 def test_reallocate_all_handles_reuses_preserved_vas_in_new_layout(
     running_gms,
 ):

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -201,6 +201,63 @@ def test_gms_tensor_matches_plain_torch_ops(running_gms):
     reader.close()
 
 
+def test_finalize_gms_write_prunes_unreferenced_allocations(running_gms):
+    from gpu_memory_service.integrations.common.utils import finalize_gms_write
+
+    socket_path = running_gms
+    torch.manual_seed(11)
+    baseline = _TinyModule().cuda()
+    gms_model = _TinyModule().cuda()
+    gms_model.load_state_dict(baseline.state_dict())
+    inputs = torch.randn(3, 8, device="cuda", dtype=torch.float32)
+    expected = baseline(inputs).detach().clone()
+
+    writer = GMSClientMemoryManager(socket_path, device=0)
+    writer.connect(RequestedLockType.RW)
+
+    baseline_weight = cast(torch.Tensor, baseline.linear.weight)
+    baseline_scale = cast(torch.Tensor, baseline.scale)
+    baseline_extra = cast(torch.Tensor, baseline.extra)
+
+    _, gms_weight = _make_gms_tensor(writer, baseline_weight, tag="weights")
+    gms_model.linear.weight = torch.nn.Parameter(
+        gms_weight, requires_grad=baseline_weight.requires_grad
+    )
+    _, gms_scale = _make_gms_tensor(writer, baseline_scale, tag="weights")
+    gms_model._buffers["scale"] = gms_scale
+    _, gms_extra = _make_gms_tensor(writer, baseline_extra, tag="weights")
+    gms_model.extra = gms_extra
+
+    unreferenced_va = writer.create_mapping(size=1024 * 1024, tag="weights")
+    unreferenced_allocation_id = writer.mappings[unreferenced_va].allocation_id
+
+    committed_bytes = finalize_gms_write(writer, gms_model)
+    assert committed_bytes == sum(m.aligned_size for m in writer.mappings.values())
+    assert all(
+        mapping.allocation_id != unreferenced_allocation_id
+        for mapping in writer.mappings.values()
+    )
+
+    del gms_weight
+    del gms_scale
+    del gms_extra
+    del gms_model
+    writer.close()
+
+    reader = GMSClientMemoryManager(socket_path, device=0)
+    reader.connect(RequestedLockType.RO)
+    try:
+        handles = reader.list_handles()
+        assert len(handles) == 3
+        assert all(info.allocation_id != unreferenced_allocation_id for info in handles)
+
+        materialized = _TinyModule().cuda()
+        materialize_module_from_gms(reader, materialized, device_index=0)
+        _assert_exact_tensor_equal(expected, materialized(inputs))
+    finally:
+        reader.close()
+
+
 def test_live_gms_tensor_survives_unmap_and_remap(running_gms):
     socket_path = running_gms
     baseline = torch.arange(64, device="cuda", dtype=torch.float32).reshape(8, 8)

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -231,7 +231,7 @@ def test_finalize_gms_write_prunes_unreferenced_allocations(running_gms):
     unreferenced_va = writer.create_mapping(size=1024 * 1024, tag="weights")
     unreferenced_allocation_id = writer.mappings[unreferenced_va].allocation_id
 
-    committed_bytes = finalize_gms_write(writer, gms_model)
+    committed_bytes = finalize_gms_write(writer, gms_model).committed_bytes
     assert committed_bytes == sum(m.aligned_size for m in writer.mappings.values())
     assert all(
         mapping.allocation_id != unreferenced_allocation_id


### PR DESCRIPTION
## Summary

Prune GMS allocations that are not referenced by registered torch module tensors before committing the writer layout.

This addresses the GPT-OSS-120B checkpoint shape observed in the benchmark artifact:

- `3435` GMS allocations in `manifest.json`
- only `283` allocations referenced by tensor metadata
- `3152` unreferenced allocations accounting for ~`65 GiB`, dominated by `3091 x 20 MiB` blocks

The important distinction is:

- normal RO GMS model load maps only metadata-registered tensors;
- snapshot save/restore currently walks every committed GMS handle.

So the extra unregistered handles do not matter much for a fresh RO model load, but they do bloat snapshot artifacts and restore allocation/transfer work.

## Changes

- Adds internal torch allocator helper `prune_allocations()`.
- `register_module_tensors()` now returns allocation IDs referenced by registered tensors.
- `finalize_gms_write()` now:
  1. registers module tensors,
  2. prunes all non-referenced GMS mappings/handles,
  3. computes committed bytes,
  4. commits and reconnects/remaps as before.
- Adds mocked runtime coverage for freeing unreferenced mappings.
- Adds GPU integration coverage for finalize/prune behavior; this requires a CUDA-capable test environment.

## What this does not do

This intentionally does **not** walk Python GC to infer live torch tensors, and it does **not** prune from the `torch.cuda.empty_cache()` monkey patch.

Python GC is not a sound ownership oracle for PyTorch CUDA storage: tensors/storage can be held by C++ runtime/autograd/backend structures or allocator caches that are not visible as Python GC roots. The prune is therefore only explicit and post-registration: keep allocations backing registered module tensors, and treat the rest of the `weights` GMS mempool as load-time scratch/cache before commit.

## Validation

Ran locally:

```bash
python -m py_compile \
  lib/gpu_memory_service/client/torch/__init__.py \
  lib/gpu_memory_service/client/torch/allocator.py \
  lib/gpu_memory_service/client/torch/module.py \
  lib/gpu_memory_service/integrations/common/patches.py \
  lib/gpu_memory_service/integrations/common/utils.py \
  lib/gpu_memory_service/tests/test_runtime_flows.py \
  lib/gpu_memory_service/tests/test_torch_integration.py

git diff --check

PYTHONPATH=lib /tmp/gms-bulk-pytest/bin/python -m pytest \
  lib/gpu_memory_service/tests/test_runtime_flows.py::test_prune_allocations_frees_unreferenced_mappings \
  lib/gpu_memory_service/tests/test_runtime_flows.py::test_destroy_mapping_frees_allocation_and_metadata -q
```

Result:

```text
2 passed
```

The GPU torch integration test is added but was not runnable in my local venv because the full CUDA/GMS torch deps are unavailable there. Next validation should be an image build + GPT-OSS-120B checkpoint/restore e2e on the nscale node.

## Notes / risk

This assumes all committed, restore-required weight allocations are represented by registered module tensors. That matches the current GMS model-loading contract, but the first cluster validation should verify:

- post-prune checkpoint manifest allocation count/bytes,
- successful restore,
- coherent post-restore inference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic pruning of unreferenced GPU memory allocations.
  * Added CUDA graph memory profiling to improve available memory estimation.
  * Introduced memory usage offset tracking for better memory accounting.

* **Improvements**
  * Enhanced memory statistics reporting with committed and pruned byte tracking.
  * Optimized memory pool sizing calculations for improved accuracy.
  * Improved CUDA memory validation and synchronization efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->