### PR TITLE
feat(examples/sglang): add Intel XPU deployment configs

### DIFF
--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -29,6 +29,17 @@ High-performance deployment with separated prefill and decode workers.
 - `SGLangPrefillWorker`: Specialized prefill-only worker (`--disaggregation-mode prefill`)
 - Communication via NIXL transfer backend (`--disaggregation-transfer-backend nixl`)
 
+### 4. **Deployments with Intel XPU (Optional)** (see [`xpu/`](./xpu/))
+Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynamic Resource Allocation (DRA).
+
+**Available Templates:**
+- `agg_xpu_dra.yaml`: Aggregated deployment with DRA
+- `disagg_xpu_dra.yaml`: Disaggregated deployment with DRA
+- `disagg_planner_xpu_dra.yaml`: Disaggregated + Planner with DRA
+- `disagg_xpu.yaml`: Disaggregated deployment using traditional device plugin (non-DRA)
+
+See the [XPU deployment README](./xpu/README.md) for detailed prerequisites and usage instructions.
+
 ## CRD Structure
 
 All templates use the **DynamoGraphDeployment** CRD:
@@ -88,6 +99,8 @@ Select the deployment pattern that matches your requirements:
 - Use `agg.yaml` for development/testing
 - Use `agg_router.yaml` for production with load balancing
 - Use `disagg.yaml` for maximum performance
+- Use `disagg_planner.yaml` for SLA-optimized performance
+- Use [XPU templates](./xpu/) for Intel XPU clusters with Kubernetes DRA
 
 ### 2. Customize Configuration
 Edit the template to match your environment:

--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -39,6 +39,7 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
 
 **Available Templates:**
 - `agg_xpu_dra.yaml`: Aggregated deployment with DRA
+- `agg_router_xpu_dra.yaml`: Aggregated deployment with the KV router and DRA
 - `disagg_xpu_dra.yaml`: Disaggregated deployment with DRA
 - `disagg_planner_xpu_dra.yaml`: Disaggregated + Planner with DRA
 - `disagg_xpu.yaml`: Disaggregated deployment using traditional device plugin (non-DRA)

--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -34,6 +34,17 @@ High-performance deployment with separated prefill and decode workers.
 - `SGLangPrefillWorker`: Specialized prefill-only worker (`--disaggregation-mode prefill`)
 - Communication via NIXL transfer backend (`--disaggregation-transfer-backend nixl`)
 
+### 4. **Deployments with Intel XPU (Optional)** (see [`xpu/`](./xpu/))
+Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynamic Resource Allocation (DRA).
+
+**Available Templates:**
+- `agg_xpu_dra.yaml`: Aggregated deployment with DRA
+- `disagg_xpu_dra.yaml`: Disaggregated deployment with DRA
+- `disagg_planner_xpu_dra.yaml`: Disaggregated + Planner with DRA
+- `disagg_xpu.yaml`: Disaggregated deployment using traditional device plugin (non-DRA)
+
+See the [XPU deployment README](./xpu/README.md) for detailed prerequisites and usage instructions.
+
 ## CRD Structure
 
 All templates use the **DynamoGraphDeployment** CRD:
@@ -101,6 +112,8 @@ Select the deployment pattern that matches your requirements:
 - Use `agg.yaml` for development/testing
 - Use `agg_router.yaml` for production with load balancing
 - Use `disagg.yaml` for maximum performance
+- Use `disagg_planner.yaml` for SLA-optimized performance
+- Use [XPU templates](./xpu/) for Intel XPU clusters with Kubernetes DRA
 
 ### 2. Customize Configuration
 Edit the template to match your environment:

--- a/examples/backends/sglang/deploy/README.md
+++ b/examples/backends/sglang/deploy/README.md
@@ -35,7 +35,7 @@ High-performance deployment with separated prefill and decode workers.
 - Communication via NIXL transfer backend (`--disaggregation-transfer-backend nixl`)
 
 ### 4. **Deployments with Intel XPU (Optional)** (see [`xpu/`](./xpu/))
-Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynamic Resource Allocation (DRA).
+Hardware-specific deployment templates for Intel GPUs using Kubernetes Dynamic Resource Allocation (DRA) or the Intel device plugin.
 
 **Available Templates:**
 - `agg_xpu_dra.yaml`: Aggregated deployment with DRA
@@ -114,7 +114,7 @@ Select the deployment pattern that matches your requirements:
 - Use `agg_router.yaml` for production with load balancing
 - Use `disagg.yaml` for maximum performance
 - Use `disagg_planner.yaml` for SLA-optimized performance
-- Use [XPU templates](./xpu/) for Intel XPU clusters with Kubernetes DRA
+- Use [XPU templates](./xpu/) for Intel GPU clusters
 
 ### 2. Customize Configuration
 Edit the template to match your environment:

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -12,6 +12,7 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
 | File | Pattern | Description |
 |------|---------|-------------|
 | `agg_xpu_dra.yaml` | Aggregated | Single worker with XPU target |
+| `agg_router_xpu_dra.yaml` | Aggregated + KV Router | 2 workers behind KV-aware router |
 | `disagg_xpu_dra.yaml` | Disaggregated | Prefill/decode separation with NixlConnector |
 | `disagg_planner_xpu_dra.yaml` | Disaggregated + Planner | Global Planner for throughput scaling |
 | `disagg_xpu.yaml` | Disaggregated (Device Plugin) | Traditional device plugin (gpu.intel.com/xe) |

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -1,0 +1,70 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Intel XPU Deployment Examples
+
+Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynamic Resource Allocation (DRA).
+
+## Available Templates
+
+| File | Pattern | Description |
+|------|---------|-------------|
+| `agg_xpu_dra.yaml` | Aggregated | Single worker with XPU target |
+| `disagg_xpu_dra.yaml` | Disaggregated | Prefill/decode separation with NixlConnector |
+| `disagg_planner_xpu_dra.yaml` | Disaggregated + Planner | Global Planner for throughput scaling |
+| `disagg_xpu.yaml` | Disaggregated (Device Plugin) | Traditional device plugin (gpu.intel.com/xe) |
+
+## Prerequisites
+
+1. **Kubernetes v1.34+** with DRA API v1 enabled
+2. **Intel GPU DRA Driver** installed with DeviceClass `gpu.intel.com`
+3. **Custom XPU runtime image** (build from source with `--device xpu`)
+4. **HuggingFace token secret**: `kubectl create secret generic hf-token-secret --from-literal=token=<your-token>`
+
+## Key Differences from NVIDIA Templates
+
+| Aspect | NVIDIA | Intel XPU |
+|--------|--------|-----------|
+| GPU Allocation | `resources.limits.gpu` | DRA `ResourceClaimTemplate` |
+| Device Target | Default (CUDA) | `--device xpu` flag |
+| CUDA Graph | Enabled | `--disable-cuda-graph` |
+| Grammar Backend | Default | `--grammar-backend none` |
+| DeviceClass | `nvidia.com` | `gpu.intel.com` |
+| Disagg KV Transfer | Default | `hostIPC: true`, `UCX_TLS=ze_ipc,...` |
+
+Note: Do not set `ZE_AFFINITY_MASK` with DRA - it conflicts and causes SIGSEGV.
+
+## Deploy
+
+```bash
+# Apply template (includes ResourceClaimTemplate)
+kubectl apply -f xpu/agg_xpu_dra.yaml -n $NAMESPACE
+
+# Verify GPU allocation
+kubectl get resourceclaim -n $NAMESPACE
+kubectl get resourceslices
+
+# Check deployment status
+kubectl get dynamographdeployment -n $NAMESPACE
+kubectl get pods -n $NAMESPACE
+```
+
+## Testing
+
+```bash
+# Port forward to frontend
+kubectl port-forward deployment/sglang-agg-xpu-dra-frontend 8000:8000 -n $NAMESPACE
+
+# Test inference
+curl localhost:8000/v1/models
+curl localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"Qwen/Qwen3-0.6B","prompt":"Hello","max_tokens":20}'
+```
+
+## Further Reading
+
+- [Main Deployment README](../README.md) - Overview of all deployment patterns
+- [Intel XPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes)

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -22,7 +22,7 @@ Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynam
 1. **Kubernetes v1.34+** with DRA API v1 enabled
 2. **Intel GPU DRA Driver** installed with DeviceClass `gpu.intel.com`
 3. **Custom XPU runtime image** (build from source with `--device xpu`)
-4. **HuggingFace token secret**: `kubectl create secret generic hf-token-secret --from-literal=token=<your-token>`
+4. **Hugging Face token secret**: `kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>`
 
 ## Key Differences from NVIDIA Templates
 

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -54,7 +54,7 @@ The files ending in `_dra.yaml` require:
 
 ### Device Plugin Template
 
-`disagg_xpu.yaml` requires the [Intel device plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes) and allocates `gpu.intel.com/xe`.
+`disagg_xpu.yaml` requires the [Intel device plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes) and allocates `gpu.intel.com/xe`. Its decode and prefill workers use the validated `ZE_AFFINITY_MASK` values `2` and `0`; update them if your node uses different Level Zero device numbering.
 
 ## Key Differences from NVIDIA Templates
 
@@ -67,7 +67,7 @@ The files ending in `_dra.yaml` require:
 | Disagg KV Transfer | Default | `hostIPC: true`, `UCX_TLS=ze_ipc,...` |
 
 > [!NOTE]
-> Do not hardcode `ZE_AFFINITY_MASK` in these Kubernetes manifests. DRA and the Intel device plugin select the allocated device.
+> Do not set `ZE_AFFINITY_MASK` in the DRA templates. DRA selects the allocated device. The device-plugin template retains topology-specific affinity values from the validated configuration.
 
 `agg_router_xpu_dra.yaml` starts two workers and requires two GPUs. `disagg_planner_xpu_dra.yaml` starts two decode workers and one prefill worker and requires three GPUs.
 

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -35,6 +35,8 @@ docker build -t docker.io/library/dynamo-planner:latest \
   -f container/dynamo-planner-cuda13.0-amd64-rendered.Dockerfile .
 ```
 
+The Planner template uses `optimization_target: sla` and requires Prometheus. Install `kube-prometheus-stack` as described in the [Dynamo Platform installation guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/pages/kubernetes/installation/install-dynamo.md). Planner uses `http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090` by default. If your Prometheus service uses a different address, set `PROMETHEUS_ENDPOINT` in the Planner container.
+
 The manifests use `imagePullPolicy: IfNotPresent`. Load these images on every eligible Kubernetes node, or push them to a registry and update the image references. If you build from a Dynamo version other than 1.4.0, update each `runtimeVersionOverride` to match.
 
 Create the Hugging Face token secret:

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -19,10 +19,42 @@ Hardware-specific deployment templates for Intel GPUs, with Kubernetes Dynamic R
 
 ## Prerequisites
 
-1. **Kubernetes v1.34 or later** with the DRA v1 API enabled
-2. **Intel GPU DRA driver** with the `gpu.intel.com` device class
-3. **Custom XPU runtime image** built from source with `--device xpu`
-4. **Hugging Face token secret** named `hf-token-secret`, with the token stored under the `HF_TOKEN` key
+Build the XPU runtime image from the current source:
+
+```bash
+python3 container/render.py --framework=sglang --device=xpu --target=runtime
+docker build -t docker.io/library/dynamo-sglang-xpu:latest \
+  -f container/sglang-runtime-xpu-amd64-rendered.Dockerfile .
+```
+
+For `disagg_planner_xpu_dra.yaml`, also build the Planner image:
+
+```bash
+python3 container/render.py --framework=dynamo --target=planner
+docker build -t docker.io/library/dynamo-planner:latest \
+  -f container/dynamo-planner-cuda13.0-amd64-rendered.Dockerfile .
+```
+
+The manifests use `imagePullPolicy: IfNotPresent`. Load these images on every eligible Kubernetes node, or push them to a registry and update the image references. If you build from a Dynamo version other than 1.4.0, update each `runtimeVersionOverride` to match.
+
+Create the Hugging Face token secret:
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="${HF_TOKEN}" \
+  -n "${NAMESPACE}"
+```
+
+### DRA Templates
+
+The files ending in `_dra.yaml` require:
+
+1. Kubernetes v1.34 or later with the DRA v1 API enabled
+2. The [Intel GPU resource driver](https://github.com/intel/intel-resource-drivers-for-kubernetes) with the `gpu.intel.com` device class
+
+### Device Plugin Template
+
+`disagg_xpu.yaml` requires the [Intel device plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes) and allocates `gpu.intel.com/xe`.
 
 ## Key Differences from NVIDIA Templates
 
@@ -31,35 +63,36 @@ Hardware-specific deployment templates for Intel GPUs, with Kubernetes Dynamic R
 | GPU Allocation | `nvidia.com/gpu` resource limit | DRA `ResourceClaimTemplate` or `gpu.intel.com/xe` resource limit |
 | Device Target | Default (CUDA) | `--device xpu` flag |
 | CUDA Graph | Enabled | `--disable-cuda-graph` |
-| Grammar Backend | Default | `--grammar-backend none` |
 | DeviceClass | `nvidia.com` | `gpu.intel.com` |
 | Disagg KV Transfer | Default | `hostIPC: true`, `UCX_TLS=ze_ipc,...` |
 
 > [!NOTE]
-> Do not set `ZE_AFFINITY_MASK` with DRA. It conflicts with DRA device allocation and can cause a segmentation fault.
+> Do not hardcode `ZE_AFFINITY_MASK` in these Kubernetes manifests. DRA and the Intel device plugin select the allocated device.
+
+`agg_router_xpu_dra.yaml` starts two workers and requires two GPUs. `disagg_planner_xpu_dra.yaml` starts two decode workers and one prefill worker and requires three GPUs.
+
+The Planner template includes bootstrap profile data for `Qwen/Qwen3-0.6B` because the current XPU SGLang build does not publish live forward pass metrics. Replace this data with measurements from your target XPU hardware before tuning production scaling.
 
 ## Deploy
 
 ```bash
-# Apply template (includes ResourceClaimTemplate)
-kubectl apply -f xpu/agg_xpu_dra.yaml -n ${NAMESPACE}
+kubectl apply \
+  -f examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml \
+  -n "${NAMESPACE}"
 
-# Verify GPU allocation
-kubectl get resourceclaim -n ${NAMESPACE}
+kubectl get resourceclaim -n "${NAMESPACE}"
 kubectl get resourceslices
 
-# Check deployment status
-kubectl get dynamographdeployment -n ${NAMESPACE}
-kubectl get pods -n ${NAMESPACE}
+kubectl get dynamographdeployment -n "${NAMESPACE}"
+kubectl get pods -n "${NAMESPACE}"
 ```
 
 ## Testing
 
 ```bash
-# Port forward to frontend
-kubectl port-forward deployment/sglang-agg-xpu-dra-frontend 8000:8000 -n ${NAMESPACE}
+kubectl port-forward deployment/sglang-agg-xpu-dra-frontend 8000:8000 \
+  -n "${NAMESPACE}"
 
-# Test inference
 curl localhost:8000/v1/models
 curl localhost:8000/v1/completions \
   -H "Content-Type: application/json" \
@@ -68,5 +101,4 @@ curl localhost:8000/v1/completions \
 
 ## Further Reading
 
-- [Main Deployment README](../README.md) - Overview of all deployment patterns
-- [Intel resource drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes)
+- [SGLang Kubernetes deployment configurations](../README.md)

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -5,58 +5,59 @@ SPDX-License-Identifier: Apache-2.0
 
 # Intel XPU Deployment Examples
 
-Hardware-specific deployment templates for Intel XPU GPUs using Kubernetes Dynamic Resource Allocation (DRA).
+Hardware-specific deployment templates for Intel GPUs, with Kubernetes Dynamic Resource Allocation (DRA) and device-plugin variants.
 
 ## Available Templates
 
 | File | Pattern | Description |
 |------|---------|-------------|
 | `agg_xpu_dra.yaml` | Aggregated | Single worker with XPU target |
-| `agg_router_xpu_dra.yaml` | Aggregated + KV Router | 2 workers behind KV-aware router |
-| `disagg_xpu_dra.yaml` | Disaggregated | Prefill/decode separation with NixlConnector |
-| `disagg_planner_xpu_dra.yaml` | Disaggregated + Planner | Global Planner for throughput scaling |
-| `disagg_xpu.yaml` | Disaggregated (Device Plugin) | Traditional device plugin (gpu.intel.com/xe) |
+| `agg_router_xpu_dra.yaml` | Aggregated + KV Router | Two workers behind the KV router |
+| `disagg_xpu_dra.yaml` | Disaggregated | Separate prefill and decode workers with NIXL |
+| `disagg_planner_xpu_dra.yaml` | Disaggregated + Planner | Dynamo Planner for throughput scaling |
+| `disagg_xpu.yaml` | Disaggregated (Device Plugin) | Device plugin resource `gpu.intel.com/xe` |
 
 ## Prerequisites
 
-1. **Kubernetes v1.34+** with DRA API v1 enabled
-2. **Intel GPU DRA Driver** installed with DeviceClass `gpu.intel.com`
-3. **Custom XPU runtime image** (build from source with `--device xpu`)
-4. **Hugging Face token secret**: `kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<your-token>`
+1. **Kubernetes v1.34 or later** with the DRA v1 API enabled
+2. **Intel GPU DRA driver** with the `gpu.intel.com` device class
+3. **Custom XPU runtime image** built from source with `--device xpu`
+4. **Hugging Face token secret** named `hf-token-secret`, with the token stored under the `HF_TOKEN` key
 
 ## Key Differences from NVIDIA Templates
 
 | Aspect | NVIDIA | Intel XPU |
 |--------|--------|-----------|
-| GPU Allocation | `resources.limits.gpu` | DRA `ResourceClaimTemplate` |
+| GPU Allocation | `nvidia.com/gpu` resource limit | DRA `ResourceClaimTemplate` or `gpu.intel.com/xe` resource limit |
 | Device Target | Default (CUDA) | `--device xpu` flag |
 | CUDA Graph | Enabled | `--disable-cuda-graph` |
 | Grammar Backend | Default | `--grammar-backend none` |
 | DeviceClass | `nvidia.com` | `gpu.intel.com` |
 | Disagg KV Transfer | Default | `hostIPC: true`, `UCX_TLS=ze_ipc,...` |
 
-Note: Do not set `ZE_AFFINITY_MASK` with DRA - it conflicts and causes SIGSEGV.
+> [!NOTE]
+> Do not set `ZE_AFFINITY_MASK` with DRA. It conflicts with DRA device allocation and can cause a segmentation fault.
 
 ## Deploy
 
 ```bash
 # Apply template (includes ResourceClaimTemplate)
-kubectl apply -f xpu/agg_xpu_dra.yaml -n $NAMESPACE
+kubectl apply -f xpu/agg_xpu_dra.yaml -n ${NAMESPACE}
 
 # Verify GPU allocation
-kubectl get resourceclaim -n $NAMESPACE
+kubectl get resourceclaim -n ${NAMESPACE}
 kubectl get resourceslices
 
 # Check deployment status
-kubectl get dynamographdeployment -n $NAMESPACE
-kubectl get pods -n $NAMESPACE
+kubectl get dynamographdeployment -n ${NAMESPACE}
+kubectl get pods -n ${NAMESPACE}
 ```
 
 ## Testing
 
 ```bash
 # Port forward to frontend
-kubectl port-forward deployment/sglang-agg-xpu-dra-frontend 8000:8000 -n $NAMESPACE
+kubectl port-forward deployment/sglang-agg-xpu-dra-frontend 8000:8000 -n ${NAMESPACE}
 
 # Test inference
 curl localhost:8000/v1/models
@@ -68,4 +69,4 @@ curl localhost:8000/v1/completions \
 ## Further Reading
 
 - [Main Deployment README](../README.md) - Overview of all deployment patterns
-- [Intel XPU Resource Driver](https://github.com/intel/intel-resource-drivers-for-kubernetes)
+- [Intel resource drivers for Kubernetes](https://github.com/intel/intel-resource-drivers-for-kubernetes)

--- a/examples/backends/sglang/deploy/xpu/README.md
+++ b/examples/backends/sglang/deploy/xpu/README.md
@@ -54,7 +54,7 @@ The files ending in `_dra.yaml` require:
 
 ### Device Plugin Template
 
-`disagg_xpu.yaml` requires the [Intel device plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes) and allocates `gpu.intel.com/xe`. Its decode and prefill workers use the validated `ZE_AFFINITY_MASK` values `2` and `0`; update them if your node uses different Level Zero device numbering.
+`disagg_xpu.yaml` requires the [Intel device plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes) and allocates `gpu.intel.com/xe`.
 
 ## Key Differences from NVIDIA Templates
 
@@ -67,7 +67,7 @@ The files ending in `_dra.yaml` require:
 | Disagg KV Transfer | Default | `hostIPC: true`, `UCX_TLS=ze_ipc,...` |
 
 > [!NOTE]
-> Do not set `ZE_AFFINITY_MASK` in the DRA templates. DRA selects the allocated device. The device-plugin template retains topology-specific affinity values from the validated configuration.
+> Do not hardcode `ZE_AFFINITY_MASK` in these examples. DRA or the Intel device plugin selects the allocated device.
 
 `agg_router_xpu_dra.yaml` starts two workers and requires two GPUs. `disagg_planner_xpu_dra.yaml` starts two decode workers and one prefill worker and requires three GPUs.
 

--- a/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
@@ -33,13 +33,13 @@ spec:
       envFromSecret: hf-token-secret
       componentType: frontend
       replicas: 1
+      envs:
+        - name: DYN_ROUTER_MODE
+          value: kv
       extraPodSpec:
         mainContainer:
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
-          env:
-            - name: DYN_ROUTER_MODE
-              value: kv
     decode:
       envFromSecret: hf-token-secret
       componentType: worker

--- a/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving with KV-aware router for Intel XPU.
+# 2 workers behind a KV router, each on a separate GPU.
+# Workers publish KV events via ZMQ for routing optimization.
+#
+# Prerequisites:
+# - Intel XPU GPU with DRA driver installed
+# - 2+ GPU devices available
+# - hf-token-secret created in target namespace
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-agg-router-xpu-dra
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DYN_ROUTER_MODE
+              value: kv
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 2
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44    # video group
+        #     - 991   # render group
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --enable-metrics
+            # KV events for router - endpoint differs per worker instance
+            # Dynamo will auto-assign unique ports for each replica
+            - --kv-events-config
+            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'

--- a/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
@@ -23,71 +23,77 @@ spec:
             deviceClassName: gpu.intel.com
             count: 1
 ---
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: sglang-agg-router-xpu-dra
 spec:
-  services:
-    Frontend:
-      envFromSecret: hf-token-secret
-      componentType: frontend
-      replicas: 1
-      envs:
-        - name: DYN_ROUTER_MODE
-          value: kv
-      extraPodSpec:
-        mainContainer:
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
-    decode:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      replicas: 2
-      resources:
-        requests:
-          custom:
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
+          name: main
+    replicas: 1
+    type: frontend
+  - name: decode
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --enable-metrics
+          # KV events for router - endpoint differs per worker instance.
+          # Dynamo auto-assigns unique ports for each replica.
+          - --kv-events-config
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          name: main
+          resources:
+            claims:
+            - name: gpu
+            requests:
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
         resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment.
         # securityContext:
         #   runAsUser: 1000
         #   runAsGroup: 1000
         #   supplementalGroups:
         #     - 44    # video group
         #     - 991   # render group
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
-          imagePullPolicy: IfNotPresent
-          resources:
-            claims:
-              - name: gpu
-          workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --enable-metrics
-            # KV events for router - endpoint differs per worker instance
-            # Dynamo will auto-assign unique ports for each replica
-            - --kv-events-config
-            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+    replicas: 2
+    type: worker

--- a/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_router_xpu_dra.yaml
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Aggregated serving with KV-aware router for Intel XPU.
-# 2 workers behind a KV router, each on a separate GPU.
+# Two workers behind a KV router, each on a separate GPU.
 # Workers publish KV events via ZMQ for routing optimization.
 #
 # Prerequisites:
 # - Intel XPU GPU with DRA driver installed
-# - 2+ GPU devices available
+# - Two or more GPU devices available
 # - hf-token-secret created in target namespace
 
 apiVersion: resource.k8s.io/v1
@@ -36,13 +36,11 @@ spec:
         - env:
           - name: DYN_ROUTER_MODE
             value: kv
-          envFrom:
-          - secretRef:
-              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
           name: main
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: frontend
   - name: decode
     podTemplate:
@@ -62,11 +60,6 @@ spec:
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
-          - --enable-metrics
-          # KV events for router - endpoint differs per worker instance.
-          # Dynamo auto-assigns unique ports for each replica.
           - --kv-events-config
           - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
           command:
@@ -88,12 +81,6 @@ spec:
         resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment.
-        # securityContext:
-        #   runAsUser: 1000
-        #   runAsGroup: 1000
-        #   supplementalGroups:
-        #     - 44    # video group
-        #     - 991   # render group
     replicas: 2
+    runtimeVersionOverride: 1.4.0
     type: worker

--- a/examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-agg-xpu-dra
+spec:
+  services:
+    Frontend:
+      envFromSecret: hf-token-secret
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            # Increase this value for larger models
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44    # video group
+        #     - 991   # render group
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none

--- a/examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml
@@ -14,64 +14,70 @@ spec:
             deviceClassName: gpu.intel.com
             count: 1
 ---
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: sglang-agg-xpu-dra
 spec:
-  services:
-    Frontend:
-      envFromSecret: hf-token-secret
-      componentType: frontend
-      replicas: 1
-      extraPodSpec:
-        mainContainer:
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - envFrom:
+          - secretRef:
+              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
-    decode:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      replicas: 1
-      resources:
-        requests:
-          custom:
-            # Increase this value for larger models
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
+          name: main
+    replicas: 1
+    type: frontend
+  - name: decode
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          name: main
+          resources:
+            claims:
+            - name: gpu
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
         resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment.
         # securityContext:
         #   runAsUser: 1000
         #   runAsGroup: 1000
         #   supplementalGroups:
         #     - 44    # video group
         #     - 991   # render group
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
-          imagePullPolicy: IfNotPresent
-          resources:
-            claims:
-              - name: gpu
-          workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
+    replicas: 1
+    type: worker

--- a/examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/agg_xpu_dra.yaml
@@ -24,13 +24,11 @@ spec:
     podTemplate:
       spec:
         containers:
-        - envFrom:
-          - secretRef:
-              name: hf-token-secret
-          image: docker.io/library/dynamo-sglang-xpu:latest
+        - image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
           name: main
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: frontend
   - name: decode
     podTemplate:
@@ -50,8 +48,6 @@ spec:
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           command:
           - python3
           - -m
@@ -72,12 +68,6 @@ spec:
         resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment.
-        # securityContext:
-        #   runAsUser: 1000
-        #   runAsGroup: 1000
-        #   supplementalGroups:
-        #     - 44    # video group
-        #     - 991   # render group
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: worker

--- a/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disaggregated + Planner deployment for Intel XPU.
+# WARNING: Requires 4+ GPU devices (2 prefill + 2 decode).
+# On a 3-GPU node, reduce replicas to 1 prefill + 2 decode (3 GPUs total).
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: planner-profile-data-xpu
+data:
+  prefill_raw_data.json: |
+    {
+      "prefill_isl":          [128, 256, 512, 1024, 2048],
+      "prefill_ttft":         [12,  18,  30,  55,   105],
+      "prefill_thpt_per_gpu": [9800, 8500, 6200, 3800, 2000]
+    }
+  decode_raw_data.json: |
+    {
+      "x_kv_usage":       [0.1, 0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.5, 0.5, 0.5, 0.5, 0.7, 0.7, 0.7, 0.7, 0.9, 0.9, 0.9, 0.9],
+      "y_context_length": [128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048, 128, 512, 1024, 2048],
+      "z_itl":            [5, 6, 7, 9, 6, 7, 8, 10, 7, 8, 10, 12, 8, 10, 12, 15, 10, 12, 15, 20],
+      "z_thpt_per_gpu":   [4500, 4000, 3500, 2800, 4200, 3700, 3200, 2500, 3800, 3300, 2800, 2200, 3400, 2900, 2400, 1800, 2800, 2400, 1900, 1400],
+      "max_kv_tokens": 32768
+    }
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg-planner-xpu-dra
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+    Planner:
+      envFromSecret: hf-token-secret
+      componentType: planner
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          # Use official dynamo-planner image (CPU-only)
+          # For Dynamo >= 1.1.0, planner is a separate image from worker runtime
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:nightly-2025-05-01
+          command:
+            - python3
+            - -m
+            - dynamo.planner
+          args:
+            - --config
+            - '{"environment": "kubernetes", "backend": "sglang", "throughput_adjustment_interval": 60, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 2}'
+          volumeMounts:
+            - name: planner-profile-data-xpu
+              mountPath: /workspace/profiling_results
+              readOnly: true
+        volumes:
+          - name: planner-profile-data-xpu
+            configMap:
+              name: planner-profile-data-xpu
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 2
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        hostIPC: true
+        hostPID: true
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44    # video group
+        #     - 991   # render group
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          env:
+            # XPU-specific environment variables for disaggregated KV transfer
+            # Note: Do not set ZE_AFFINITY_MASK when using DRA - let DRA allocate GPUs automatically
+            - name: UCX_TLS
+              value: "ze_copy,tcp,cma,sysv,posix,self"
+            - name: UCX_LOG_LEVEL
+              value: "info"
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --enable-metrics
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --disaggregation-mode
+            - decode
+            - --disaggregation-transfer-backend
+            - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
+    prefill:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        hostIPC: true
+        hostPID: true
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44    # video group
+        #     - 991   # render group
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          env:
+            # XPU-specific environment variables for disaggregated KV transfer
+            # Note: Do not set ZE_AFFINITY_MASK when using DRA - let DRA allocate GPUs automatically
+            - name: UCX_TLS
+              value: "ze_copy,tcp,cma,sysv,posix,self"
+            - name: UCX_LOG_LEVEL
+              value: "info"
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --enable-metrics
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --disaggregation-mode
+            - prefill
+            - --disaggregation-transfer-backend
+            - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "40000"

--- a/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -107,7 +107,7 @@ spec:
             # XPU-specific environment variables for disaggregated KV transfer
             # Note: Do not set ZE_AFFINITY_MASK when using DRA - let DRA allocate GPUs automatically
             - name: UCX_TLS
-              value: "ze_copy,tcp,cma,sysv,posix,self"
+              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
             - name: UCX_LOG_LEVEL
               value: "info"
           workingDir: /workspace/examples/backends/sglang
@@ -172,7 +172,7 @@ spec:
             # XPU-specific environment variables for disaggregated KV transfer
             # Note: Do not set ZE_AFFINITY_MASK when using DRA - let DRA allocate GPUs automatically
             - name: UCX_TLS
-              value: "ze_copy,tcp,cma,sysv,posix,self"
+              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
             - name: UCX_LOG_LEVEL
               value: "info"
           workingDir: /workspace/examples/backends/sglang

--- a/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Disaggregated + Planner deployment for Intel XPU.
-# WARNING: Requires 4+ GPU devices (2 prefill + 2 decode).
-# On a 3-GPU node, reduce replicas to 1 prefill + 2 decode (3 GPUs total).
+# Requires 3 GPU devices: 1 prefill replica and 2 decode replicas.
+# Increasing the replica count requires additional GPU capacity.
 
 apiVersion: v1
 kind: ConfigMap
@@ -66,7 +66,7 @@ spec:
             - dynamo.planner
           args:
             - --config
-            - '{"environment": "kubernetes", "backend": "sglang", "throughput_adjustment_interval": 60, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 2}'
+            - '{"environment": "kubernetes", "backend": "sglang", "throughput_adjustment_interval": 60, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 1}'
           volumeMounts:
             - name: planner-profile-data-xpu
               mountPath: /workspace/profiling_results

--- a/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -38,172 +38,180 @@ spec:
             deviceClassName: gpu.intel.com
             count: 1
 ---
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: sglang-disagg-planner-xpu-dra
 spec:
-  services:
-    Frontend:
-      componentType: frontend
-      replicas: 1
-      extraPodSpec:
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
-    Planner:
-      envFromSecret: hf-token-secret
-      componentType: planner
-      replicas: 1
-      extraPodSpec:
-        mainContainer:
-          # Use official dynamo-planner image (CPU-only)
-          # For Dynamo >= 1.1.0, planner is a separate image from worker runtime
+          name: main
+    replicas: 1
+    type: frontend
+  - name: Planner
+    podTemplate:
+      spec:
+        containers:
+        - args:
+          - --config
+          - '{"environment": "kubernetes", "backend": "sglang", "throughput_adjustment_interval": 60, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 1}'
+          command:
+          - python3
+          - -m
+          - dynamo.planner
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          # Use the official CPU-only Dynamo Planner image.
+          # For Dynamo 1.1.0 and later, Planner uses a separate image from the worker runtime.
           image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:nightly-2025-05-01
-          command:
-            - python3
-            - -m
-            - dynamo.planner
-          args:
-            - --config
-            - '{"environment": "kubernetes", "backend": "sglang", "throughput_adjustment_interval": 60, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 1}'
+          name: main
           volumeMounts:
-            - name: planner-profile-data-xpu
-              mountPath: /workspace/profiling_results
-              readOnly: true
+          - mountPath: /workspace/profiling_results
+            name: planner-profile-data-xpu
+            readOnly: true
         volumes:
-          - name: planner-profile-data-xpu
-            configMap:
-              name: planner-profile-data-xpu
-    decode:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: decode
-      replicas: 2
-      resources:
-        requests:
-          custom:
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
+        - configMap:
+            name: planner-profile-data-xpu
+          name: planner-profile-data-xpu
+    replicas: 1
+    type: planner
+  - name: decode
+    podTemplate:
+      spec:
         hostIPC: true
         hostPID: true
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --disaggregation-mode
+          - decode
+          - --disaggregation-transfer-backend
+          - nixl
+          - --disaggregation-bootstrap-port
+          - "12345"
+          - --host
+          - "0.0.0.0"
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          env:
+          # XPU-specific environment variables for disaggregated KV transfer.
+          # Do not set ZE_AFFINITY_MASK with DRA; let DRA allocate GPUs.
+          - name: UCX_TLS
+            value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          - name: UCX_LOG_LEVEL
+            value: "info"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          name: main
+          resources:
+            claims:
+            - name: gpu
+            requests:
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
         resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment.
         # securityContext:
         #   runAsUser: 1000
         #   runAsGroup: 1000
         #   supplementalGroups:
         #     - 44    # video group
         #     - 991   # render group
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
-          imagePullPolicy: IfNotPresent
-          resources:
-            claims:
-              - name: gpu
-          env:
-            # XPU-specific environment variables for disaggregated KV transfer
-            # Note: Do not set ZE_AFFINITY_MASK when using DRA - let DRA allocate GPUs automatically
-            - name: UCX_TLS
-              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
-            - name: UCX_LOG_LEVEL
-              value: "info"
-          workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --enable-metrics
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --disaggregation-mode
-            - decode
-            - --disaggregation-transfer-backend
-            - nixl
-            - --disaggregation-bootstrap-port
-            - "12345"
-            - --host
-            - "0.0.0.0"
-    prefill:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: prefill
-      replicas: 1
-      resources:
-        requests:
-          custom:
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
+    replicas: 2
+    type: decode
+  - name: prefill
+    podTemplate:
+      spec:
         hostIPC: true
         hostPID: true
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --disaggregation-mode
+          - prefill
+          - --disaggregation-transfer-backend
+          - nixl
+          - --disaggregation-bootstrap-port
+          - "12345"
+          - --host
+          - "0.0.0.0"
+          - --port
+          - "40000"
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          env:
+          # XPU-specific environment variables for disaggregated KV transfer.
+          # Do not set ZE_AFFINITY_MASK with DRA; let DRA allocate GPUs.
+          - name: UCX_TLS
+            value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          - name: UCX_LOG_LEVEL
+            value: "info"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          name: main
+          resources:
+            claims:
+            - name: gpu
+            requests:
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
         resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment.
         # securityContext:
         #   runAsUser: 1000
         #   runAsGroup: 1000
         #   supplementalGroups:
         #     - 44    # video group
         #     - 991   # render group
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
-          imagePullPolicy: IfNotPresent
-          resources:
-            claims:
-              - name: gpu
-          env:
-            # XPU-specific environment variables for disaggregated KV transfer
-            # Note: Do not set ZE_AFFINITY_MASK when using DRA - let DRA allocate GPUs automatically
-            - name: UCX_TLS
-              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
-            - name: UCX_LOG_LEVEL
-              value: "info"
-          workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --enable-metrics
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --disaggregation-mode
-            - prefill
-            - --disaggregation-transfer-backend
-            - nixl
-            - --disaggregation-bootstrap-port
-            - "12345"
-            - --host
-            - "0.0.0.0"
-            - --port
-            - "40000"
+    replicas: 1
+    type: prefill

--- a/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_planner_xpu_dra.yaml
@@ -52,6 +52,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: main
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: frontend
   - name: Planner
     podTemplate:
@@ -59,17 +60,24 @@ spec:
         containers:
         - args:
           - --config
-          - '{"environment": "kubernetes", "backend": "sglang", "throughput_adjustment_interval": 60, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu": 1, "decode_engine_num_gpu": 1}'
+          - '{"environment": "kubernetes", "backend": "sglang", "optimization_target": "sla",
+            "enable_throughput_scaling": true, "enable_load_scaling": true, "pre_deployment_sweeping_mode":
+            "thorough", "throughput_adjustment_interval_seconds": 60, "load_adjustment_interval_seconds":
+            5, "profile_results_dir": "/workspace/profiling_results", "prefill_engine_num_gpu":
+            1, "decode_engine_num_gpu": 1}'
           command:
           - python3
           - -m
           - dynamo.planner
+          env:
+          # Keep the optional query string non-empty until Planner accepts an unset value.
+          - name: PROMETHEUS_EXTRA_QUERY_PARAMS
+            value: "_="
           envFrom:
           - secretRef:
               name: hf-token-secret
-          # Use the official CPU-only Dynamo Planner image.
-          # For Dynamo 1.1.0 and later, Planner uses a separate image from the worker runtime.
-          image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:nightly-2025-05-01
+          image: docker.io/library/dynamo-planner:latest
+          imagePullPolicy: IfNotPresent
           name: main
           volumeMounts:
           - mountPath: /workspace/profiling_results
@@ -80,12 +88,12 @@ spec:
             name: planner-profile-data-xpu
           name: planner-profile-data-xpu
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: planner
   - name: decode
     podTemplate:
       spec:
         hostIPC: true
-        hostPID: true
         containers:
         - args:
           - --model-path
@@ -98,12 +106,9 @@ spec:
           - "1"
           - --trust-remote-code
           - --skip-tokenizer-init
-          - --enable-metrics
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           - --disaggregation-mode
           - decode
           - --disaggregation-transfer-backend
@@ -111,18 +116,14 @@ spec:
           - --disaggregation-bootstrap-port
           - "12345"
           - --host
-          - "0.0.0.0"
+          - 0.0.0.0
           command:
           - python3
           - -m
           - dynamo.sglang
           env:
-          # XPU-specific environment variables for disaggregated KV transfer.
-          # Do not set ZE_AFFINITY_MASK with DRA; let DRA allocate GPUs.
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
-          - name: UCX_LOG_LEVEL
-            value: "info"
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -132,26 +133,17 @@ spec:
           resources:
             claims:
             - name: gpu
-            requests:
-              ephemeral-storage: 2Gi
           workingDir: /workspace/examples/backends/sglang
         resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment.
-        # securityContext:
-        #   runAsUser: 1000
-        #   runAsGroup: 1000
-        #   supplementalGroups:
-        #     - 44    # video group
-        #     - 991   # render group
     replicas: 2
+    runtimeVersionOverride: 1.4.0
     type: decode
   - name: prefill
     podTemplate:
       spec:
         hostIPC: true
-        hostPID: true
         containers:
         - args:
           - --model-path
@@ -164,12 +156,9 @@ spec:
           - "1"
           - --trust-remote-code
           - --skip-tokenizer-init
-          - --enable-metrics
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           - --disaggregation-mode
           - prefill
           - --disaggregation-transfer-backend
@@ -177,20 +166,14 @@ spec:
           - --disaggregation-bootstrap-port
           - "12345"
           - --host
-          - "0.0.0.0"
-          - --port
-          - "40000"
+          - 0.0.0.0
           command:
           - python3
           - -m
           - dynamo.sglang
           env:
-          # XPU-specific environment variables for disaggregated KV transfer.
-          # Do not set ZE_AFFINITY_MASK with DRA; let DRA allocate GPUs.
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
-          - name: UCX_LOG_LEVEL
-            value: "info"
           envFrom:
           - secretRef:
               name: hf-token-secret
@@ -200,18 +183,10 @@ spec:
           resources:
             claims:
             - name: gpu
-            requests:
-              ephemeral-storage: 2Gi
           workingDir: /workspace/examples/backends/sglang
         resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment.
-        # securityContext:
-        #   runAsUser: 1000
-        #   runAsGroup: 1000
-        #   supplementalGroups:
-        #     - 44    # video group
-        #     - 991   # render group
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: prefill

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disaggregated serving on Intel XPU using traditional device plugin (gpu.intel.com/xe)
+# This does not require DRA and is more stable than DRA-based deployment.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg-xpu
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      extraPodSpec:
+        hostIPC: true
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              gpu.intel.com/xe: "1"
+          env:
+            # XPU-specific environment variables for disaggregated KV transfer
+            # ZE_AFFINITY_MASK selects specific tile on the GPU
+            # Adjust values based on your GPU topology (different tiles for prefill/decode)
+            - name: ZE_AFFINITY_MASK
+              value: "2"
+            # UCX transport layer configuration for XPU
+            - name: UCX_TLS
+              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --enable-metrics
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --disaggregation-mode
+            - decode
+            - --disaggregation-transfer-backend
+            - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
+    prefill:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      extraPodSpec:
+        hostIPC: true
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              gpu.intel.com/xe: "1"
+          env:
+            # XPU-specific environment variables for disaggregated KV transfer
+            # ZE_AFFINITY_MASK selects specific tile on the GPU
+            # Adjust values based on your GPU topology (different tiles for prefill/decode)
+            - name: ZE_AFFINITY_MASK
+              value: "0"
+            # UCX transport layer configuration for XPU
+            - name: UCX_TLS
+              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --enable-metrics
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --disaggregation-mode
+            - prefill
+            - --disaggregation-transfer-backend
+            - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "40000"

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Disaggregated serving on Intel XPU using traditional device plugin (gpu.intel.com/xe)
-# This does not require DRA and is more stable than DRA-based deployment.
+# Disaggregated serving on Intel XPU using the gpu.intel.com/xe device plugin.
 
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -18,6 +17,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: main
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: frontend
   - name: decode
     podTemplate:
@@ -35,12 +35,9 @@ spec:
           - "1"
           - --trust-remote-code
           - --skip-tokenizer-init
-          - --enable-metrics
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           - --disaggregation-mode
           - decode
           - --disaggregation-transfer-backend
@@ -48,18 +45,12 @@ spec:
           - --disaggregation-bootstrap-port
           - "12345"
           - --host
-          - "0.0.0.0"
+          - 0.0.0.0
           command:
           - python3
           - -m
           - dynamo.sglang
           env:
-          # XPU-specific environment variables for disaggregated KV transfer.
-          # ZE_AFFINITY_MASK selects a specific tile on the GPU.
-          # Adjust values for your GPU topology (different tiles for prefill and decode).
-          - name: ZE_AFFINITY_MASK
-            value: "2"
-          # UCX transport layer configuration for XPU.
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           envFrom:
@@ -73,6 +64,7 @@ spec:
               gpu.intel.com/xe: "1"
           workingDir: /workspace/examples/backends/sglang
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: decode
   - name: prefill
     podTemplate:
@@ -90,12 +82,9 @@ spec:
           - "1"
           - --trust-remote-code
           - --skip-tokenizer-init
-          - --enable-metrics
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           - --disaggregation-mode
           - prefill
           - --disaggregation-transfer-backend
@@ -103,20 +92,12 @@ spec:
           - --disaggregation-bootstrap-port
           - "12345"
           - --host
-          - "0.0.0.0"
-          - --port
-          - "40000"
+          - 0.0.0.0
           command:
           - python3
           - -m
           - dynamo.sglang
           env:
-          # XPU-specific environment variables for disaggregated KV transfer.
-          # ZE_AFFINITY_MASK selects a specific tile on the GPU.
-          # Adjust values for your GPU topology (different tiles for prefill and decode).
-          - name: ZE_AFFINITY_MASK
-            value: "0"
-          # UCX transport layer configuration for XPU.
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           envFrom:
@@ -130,4 +111,5 @@ spec:
               gpu.intel.com/xe: "1"
           workingDir: /workspace/examples/backends/sglang
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: prefill

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
@@ -51,6 +51,10 @@ spec:
           - -m
           - dynamo.sglang
           env:
+          # Select the decode device for the validated multi-device topology.
+          # Adjust this value to match the Level Zero numbering on your node.
+          - name: ZE_AFFINITY_MASK
+            value: "2"
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           envFrom:
@@ -98,6 +102,10 @@ spec:
           - -m
           - dynamo.sglang
           env:
+          # Select the prefill device for the validated multi-device topology.
+          # Adjust this value to match the Level Zero numbering on your node.
+          - name: ZE_AFFINITY_MASK
+            value: "0"
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           envFrom:

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
@@ -51,10 +51,6 @@ spec:
           - -m
           - dynamo.sglang
           env:
-          # Select the decode device for the validated multi-device topology.
-          # Adjust this value to match the Level Zero numbering on your node.
-          - name: ZE_AFFINITY_MASK
-            value: "2"
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           envFrom:
@@ -102,10 +98,6 @@ spec:
           - -m
           - dynamo.sglang
           env:
-          # Select the prefill device for the validated multi-device topology.
-          # Adjust this value to match the Level Zero numbering on your node.
-          - name: ZE_AFFINITY_MASK
-            value: "0"
           - name: UCX_TLS
             value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           envFrom:

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu.yaml
@@ -4,122 +4,130 @@
 # Disaggregated serving on Intel XPU using traditional device plugin (gpu.intel.com/xe)
 # This does not require DRA and is more stable than DRA-based deployment.
 
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: sglang-disagg-xpu
 spec:
-  services:
-    Frontend:
-      componentType: frontend
-      replicas: 1
-      extraPodSpec:
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
-    decode:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: decode
-      replicas: 1
-      extraPodSpec:
+          name: main
+    replicas: 1
+    type: frontend
+  - name: decode
+    podTemplate:
+      spec:
         hostIPC: true
-        mainContainer:
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --disaggregation-mode
+          - decode
+          - --disaggregation-transfer-backend
+          - nixl
+          - --disaggregation-bootstrap-port
+          - "12345"
+          - --host
+          - "0.0.0.0"
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          env:
+          # XPU-specific environment variables for disaggregated KV transfer.
+          # ZE_AFFINITY_MASK selects a specific tile on the GPU.
+          # Adjust values for your GPU topology (different tiles for prefill and decode).
+          - name: ZE_AFFINITY_MASK
+            value: "2"
+          # UCX transport layer configuration for XPU.
+          - name: UCX_TLS
+            value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
+          name: main
           resources:
             limits:
               gpu.intel.com/xe: "1"
-          env:
-            # XPU-specific environment variables for disaggregated KV transfer
-            # ZE_AFFINITY_MASK selects specific tile on the GPU
-            # Adjust values based on your GPU topology (different tiles for prefill/decode)
-            - name: ZE_AFFINITY_MASK
-              value: "2"
-            # UCX transport layer configuration for XPU
-            - name: UCX_TLS
-              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --enable-metrics
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --disaggregation-mode
-            - decode
-            - --disaggregation-transfer-backend
-            - nixl
-            - --disaggregation-bootstrap-port
-            - "12345"
-            - --host
-            - "0.0.0.0"
-    prefill:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: prefill
-      replicas: 1
-      extraPodSpec:
+    replicas: 1
+    type: decode
+  - name: prefill
+    podTemplate:
+      spec:
         hostIPC: true
-        mainContainer:
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --disaggregation-mode
+          - prefill
+          - --disaggregation-transfer-backend
+          - nixl
+          - --disaggregation-bootstrap-port
+          - "12345"
+          - --host
+          - "0.0.0.0"
+          - --port
+          - "40000"
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          env:
+          # XPU-specific environment variables for disaggregated KV transfer.
+          # ZE_AFFINITY_MASK selects a specific tile on the GPU.
+          # Adjust values for your GPU topology (different tiles for prefill and decode).
+          - name: ZE_AFFINITY_MASK
+            value: "0"
+          # UCX transport layer configuration for XPU.
+          - name: UCX_TLS
+            value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
+          name: main
           resources:
             limits:
               gpu.intel.com/xe: "1"
-          env:
-            # XPU-specific environment variables for disaggregated KV transfer
-            # ZE_AFFINITY_MASK selects specific tile on the GPU
-            # Adjust values based on your GPU topology (different tiles for prefill/decode)
-            - name: ZE_AFFINITY_MASK
-              value: "0"
-            # UCX transport layer configuration for XPU
-            - name: UCX_TLS
-              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
           workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --enable-metrics
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --disaggregation-mode
-            - prefill
-            - --disaggregation-transfer-backend
-            - nixl
-            - --disaggregation-bootstrap-port
-            - "12345"
-            - --host
-            - "0.0.0.0"
-            - --port
-            - "40000"
+    replicas: 1
+    type: prefill

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: gpu-template
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.intel.com
+            count: 1
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-disagg-xpu-dra
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+    decode:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        hostIPC: true
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44    # video group
+        #     - 991   # render group
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: UCX_TLS
+              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --enable-metrics
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --disaggregation-mode
+            - decode
+            - --disaggregation-transfer-backend
+            - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
+    prefill:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        hostIPC: true
+        resourceClaims:
+          - name: gpu
+            resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment
+        # securityContext:
+        #   runAsUser: 1000
+        #   runAsGroup: 1000
+        #   supplementalGroups:
+        #     - 44    # video group
+        #     - 991   # render group
+        mainContainer:
+          image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            claims:
+              - name: gpu
+          env:
+            - name: UCX_TLS
+              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          workingDir: /workspace/examples/backends/sglang
+          command:
+            - python3
+            - -m
+            - dynamo.sglang
+          args:
+            - --model-path
+            - Qwen/Qwen3-0.6B
+            - --served-model-name
+            - Qwen/Qwen3-0.6B
+            - --page-size
+            - "16"
+            - --tp
+            - "1"
+            - --trust-remote-code
+            - --skip-tokenizer-init
+            - --enable-metrics
+            - --device
+            - xpu
+            - --disable-cuda-graph
+            - --grammar-backend
+            - none
+            - --disaggregation-mode
+            - prefill
+            - --disaggregation-transfer-backend
+            - nixl
+            - --disaggregation-bootstrap-port
+            - "12345"
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "40000"

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml
@@ -28,6 +28,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: main
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: frontend
   - name: decode
     podTemplate:
@@ -45,12 +46,9 @@ spec:
           - "1"
           - --trust-remote-code
           - --skip-tokenizer-init
-          - --enable-metrics
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           - --disaggregation-mode
           - decode
           - --disaggregation-transfer-backend
@@ -58,7 +56,7 @@ spec:
           - --disaggregation-bootstrap-port
           - "12345"
           - --host
-          - "0.0.0.0"
+          - 0.0.0.0
           command:
           - python3
           - -m
@@ -75,20 +73,12 @@ spec:
           resources:
             claims:
             - name: gpu
-            requests:
-              ephemeral-storage: 2Gi
           workingDir: /workspace/examples/backends/sglang
         resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment.
-        # securityContext:
-        #   runAsUser: 1000
-        #   runAsGroup: 1000
-        #   supplementalGroups:
-        #     - 44    # video group
-        #     - 991   # render group
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: decode
   - name: prefill
     podTemplate:
@@ -106,12 +96,9 @@ spec:
           - "1"
           - --trust-remote-code
           - --skip-tokenizer-init
-          - --enable-metrics
           - --device
           - xpu
           - --disable-cuda-graph
-          - --grammar-backend
-          - none
           - --disaggregation-mode
           - prefill
           - --disaggregation-transfer-backend
@@ -119,9 +106,7 @@ spec:
           - --disaggregation-bootstrap-port
           - "12345"
           - --host
-          - "0.0.0.0"
-          - --port
-          - "40000"
+          - 0.0.0.0
           command:
           - python3
           - -m
@@ -138,18 +123,10 @@ spec:
           resources:
             claims:
             - name: gpu
-            requests:
-              ephemeral-storage: 2Gi
           workingDir: /workspace/examples/backends/sglang
         resourceClaims:
         - name: gpu
           resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment.
-        # securityContext:
-        #   runAsUser: 1000
-        #   runAsGroup: 1000
-        #   supplementalGroups:
-        #     - 44    # video group
-        #     - 991   # render group
     replicas: 1
+    runtimeVersionOverride: 1.4.0
     type: prefill

--- a/examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml
+++ b/examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml
@@ -14,138 +14,142 @@ spec:
             deviceClassName: gpu.intel.com
             count: 1
 ---
-apiVersion: nvidia.com/v1alpha1
+apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
   name: sglang-disagg-xpu-dra
 spec:
-  services:
-    Frontend:
-      componentType: frontend
-      replicas: 1
-      extraPodSpec:
-        mainContainer:
+  components:
+  - name: Frontend
+    podTemplate:
+      spec:
+        containers:
+        - image: docker.io/library/dynamo-sglang-xpu:latest
+          imagePullPolicy: IfNotPresent
+          name: main
+    replicas: 1
+    type: frontend
+  - name: decode
+    podTemplate:
+      spec:
+        hostIPC: true
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --disaggregation-mode
+          - decode
+          - --disaggregation-transfer-backend
+          - nixl
+          - --disaggregation-bootstrap-port
+          - "12345"
+          - --host
+          - "0.0.0.0"
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          env:
+          - name: UCX_TLS
+            value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
-    decode:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: decode
-      replicas: 1
-      resources:
-        requests:
-          custom:
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
-        hostIPC: true
+          name: main
+          resources:
+            claims:
+            - name: gpu
+            requests:
+              ephemeral-storage: 2Gi
+          workingDir: /workspace/examples/backends/sglang
         resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment.
         # securityContext:
         #   runAsUser: 1000
         #   runAsGroup: 1000
         #   supplementalGroups:
         #     - 44    # video group
         #     - 991   # render group
-        mainContainer:
+    replicas: 1
+    type: decode
+  - name: prefill
+    podTemplate:
+      spec:
+        hostIPC: true
+        containers:
+        - args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --served-model-name
+          - Qwen/Qwen3-0.6B
+          - --page-size
+          - "16"
+          - --tp
+          - "1"
+          - --trust-remote-code
+          - --skip-tokenizer-init
+          - --enable-metrics
+          - --device
+          - xpu
+          - --disable-cuda-graph
+          - --grammar-backend
+          - none
+          - --disaggregation-mode
+          - prefill
+          - --disaggregation-transfer-backend
+          - nixl
+          - --disaggregation-bootstrap-port
+          - "12345"
+          - --host
+          - "0.0.0.0"
+          - --port
+          - "40000"
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          env:
+          - name: UCX_TLS
+            value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
           image: docker.io/library/dynamo-sglang-xpu:latest
           imagePullPolicy: IfNotPresent
+          name: main
           resources:
             claims:
-              - name: gpu
-          env:
-            - name: UCX_TLS
-              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
+            - name: gpu
+            requests:
+              ephemeral-storage: 2Gi
           workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --enable-metrics
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --disaggregation-mode
-            - decode
-            - --disaggregation-transfer-backend
-            - nixl
-            - --disaggregation-bootstrap-port
-            - "12345"
-            - --host
-            - "0.0.0.0"
-    prefill:
-      envFromSecret: hf-token-secret
-      componentType: worker
-      subComponentType: prefill
-      replicas: 1
-      resources:
-        requests:
-          custom:
-            ephemeral-storage: "2Gi"
-      extraPodSpec:
-        hostIPC: true
         resourceClaims:
-          - name: gpu
-            resourceClaimTemplateName: gpu-template
-        # Uncomment if needed for your environment
+        - name: gpu
+          resourceClaimTemplateName: gpu-template
+        # Uncomment if needed for your environment.
         # securityContext:
         #   runAsUser: 1000
         #   runAsGroup: 1000
         #   supplementalGroups:
         #     - 44    # video group
         #     - 991   # render group
-        mainContainer:
-          image: docker.io/library/dynamo-sglang-xpu:latest
-          imagePullPolicy: IfNotPresent
-          resources:
-            claims:
-              - name: gpu
-          env:
-            - name: UCX_TLS
-              value: "ze_ipc,ze_copy,tcp,cma,sysv,posix,self"
-          workingDir: /workspace/examples/backends/sglang
-          command:
-            - python3
-            - -m
-            - dynamo.sglang
-          args:
-            - --model-path
-            - Qwen/Qwen3-0.6B
-            - --served-model-name
-            - Qwen/Qwen3-0.6B
-            - --page-size
-            - "16"
-            - --tp
-            - "1"
-            - --trust-remote-code
-            - --skip-tokenizer-init
-            - --enable-metrics
-            - --device
-            - xpu
-            - --disable-cuda-graph
-            - --grammar-backend
-            - none
-            - --disaggregation-mode
-            - prefill
-            - --disaggregation-transfer-backend
-            - nixl
-            - --disaggregation-bootstrap-port
-            - "12345"
-            - --host
-            - "0.0.0.0"
-            - --port
-            - "40000"
+    replicas: 1
+    type: prefill


### PR DESCRIPTION
#### Overview:

Add Kubernetes deployment templates for SGLang on Intel XPU GPUs using Dynamic Resource Allocation (DRA).

#### Details:

This PR adds XPU-specific deployment configurations for SGLang backend, aligning with the vLLM XPU configs structure from PR #9253.

**New files:**
- `deploy/xpu/agg_xpu_dra.yaml`: Aggregated deployment with single worker
- `deploy/xpu/disagg_xpu_dra.yaml`: Disaggregated deployment with DRA
- `deploy/xpu/disagg_planner_xpu_dra.yaml`: Disaggregated with Global Planner
- `deploy/xpu/disagg_xpu.yaml`: Traditional device plugin (gpu.intel.com/xe)
- `deploy/xpu/README.md`: XPU-specific deployment guide

**Key configurations for XPU disaggregated KV transfer:**
- `hostIPC: true` for ZE_IPC shared memory communication
- `UCX_TLS=ze_ipc,ze_copy,tcp,cma,sysv,posix,self` for UCX transport layer
- `ResourceClaimTemplate` for GPU allocation via Kubernetes DRA
- Note: Do not set `ZE_AFFINITY_MASK` with DRA - it conflicts and causes SIGSEGV

#### Where should the reviewer start?

- `examples/backends/sglang/deploy/xpu/README.md` - Overview and prerequisites
- `examples/backends/sglang/deploy/xpu/disagg_xpu_dra.yaml` - Core disaggregated config

#### Related Issues:

- Relates to PR #9253 (vLLM XPU deployment configs)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Intel XPU deployment documentation to the sglang backend examples.
  * Included new deployment templates and configuration examples for Intel XPU-based GPU serving on Kubernetes with both aggregated and disaggregated architectures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->