### PR TITLE
chore(ci): rename NVSkills request workflow to match upstream policy

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
 
-name: NVSkills CI
+name: Request NVSkills CI
 
 on:
   issue_comment:


### PR DESCRIPTION
## Summary

Rename the wrapper workflow from `.github/workflows/nvskills-ci.yml` to `.github/workflows/request-nvskills-ci.yml` so it matches the path NVIDIA/nvskills-ci's onboarded-repositories policy expects:

```json
"allowed_request_workflow_paths": [".github/workflows/request-nvskills-ci.yml"]
```

Also updates the in-workflow `name:` from `NVSkills CI` to `Request NVSkills CI`, aligning with the upstream template at [`NVIDIA/nvskills-ci/templates/team-request-workflow.yml`](https://github.com/NVIDIA/nvskills-ci/blob/main/templates/team-request-workflow.yml) and disambiguating from the destination repo's own `NVSkills CI` workflow.

## Why

PR #9998 landed the wrapper as `nvskills-ci.yml`. When triggered with `/nvskills-ci` on a PR, the downstream NVIDIA/nvskills-ci validator currently rejects the dispatch:

```
Request rejected: Request workflow path '.github/workflows/nvskills-ci.yml' is not allowed
```

Verified on NVIDIA/nvskills-ci run [`26494086764`](https://github.com/NVIDIA/nvskills-ci/actions/runs/26494086764) triggered from PR #10017. After this rename, the path matches the policy and signing requests will proceed to validation.

## Test plan

- [ ] CI green
- [ ] After merge, \`/nvskills-ci\` on PR #10017 (or any future skill-touching PR) advances past the path-validation step at NVIDIA/nvskills-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow display name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->