### PR TITLE
chore(kv-router): clean up worker selection routing

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -42,7 +42,6 @@ pub use dynamo_kv_router::protocols;
 pub use dynamo_kv_router::scheduling;
 pub use dynamo_kv_router::selector;
 
-pub mod agent_controller;
 pub mod indexer;
 pub mod metrics;
 pub mod prefill_router;
@@ -53,14 +52,13 @@ pub mod scheduler;
 mod scheduler_inputs;
 pub mod sequence;
 pub mod shared_cache;
-pub mod sticky_sessions;
+pub mod sticky;
 
-pub use agent_controller::AgentController;
 pub use indexer::{Indexer, ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub use prefill_router::PrefillRouter;
 pub use push_router::{DirectRoutingRouter, KvPushRouter};
 pub use scheduler_inputs::{OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore};
-pub use sticky_sessions::StickySessionRouter;
+pub use sticky::{SessionLifecycleController, StickySessionRouter};
 
 use route_lookup::{TieredLookupResult, query_tiered_matches, split_retained_block_hashes};
 use scheduler_inputs::{

--- a/lib/llm/src/kv_router/prefill_router/inner.rs
+++ b/lib/llm/src/kv_router/prefill_router/inner.rs
@@ -62,9 +62,9 @@ impl InnerPrefillRouter {
         request: &PreprocessedRequest,
     ) -> Option<WorkerWithDpRank> {
         match self {
-            InnerPrefillRouter::KvRouter(router) => {
-                router.sticky_worker_for_phase(request, RequestPhase::Prefill)
-            }
+            InnerPrefillRouter::KvRouter(router) => router
+                .sticky
+                .worker_for_phase(request, RequestPhase::Prefill),
             InnerPrefillRouter::SimpleRouter(_) => None,
         }
     }
@@ -108,7 +108,9 @@ impl InnerPrefillRouter {
 
     pub(super) fn refresh_sticky_prefill_worker(&self, request: &PreprocessedRequest) {
         if let InnerPrefillRouter::KvRouter(router) = self {
-            router.refresh_sticky_worker_for_phase(request, RequestPhase::Prefill);
+            router
+                .sticky
+                .refresh_worker_for_phase(request, RequestPhase::Prefill);
         }
     }
 }

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 use dynamo_kv_router::{
@@ -27,9 +26,11 @@ use tracing::Instrument;
 use crate::{
     kv_router::{
         KvRouter,
-        agent_controller::{AgentController, SessionCloseAction, SessionLifecycleOutcome},
         metrics::RouterRequestMetrics,
-        sticky_sessions::{AffinityKind, InMemoryAffinityStore, StickySessionRouter},
+        sticky::{
+            coordinator::{StickySessionCoordinator, sticky_allowed_for_phase},
+            lifecycle::SessionCloseAction,
+        },
     },
     preprocessor::PreprocessedRequest,
     protocols::common::{
@@ -43,9 +44,7 @@ pub struct KvPushRouter {
     inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     pub chooser: Arc<KvRouter>,
     /// Sticky session routing. Lazily activated when requests carry session_control.
-    sticky_sessions: Arc<StickySessionRouter>,
-    /// Session lifecycle RPCs (open/close). Client is lazy (OnceCell).
-    agent_controller: Arc<AgentController>,
+    pub(super) sticky: Arc<StickySessionCoordinator>,
 }
 
 /// Result of worker selection containing instance ID, dp_rank, and overlap amount.
@@ -266,31 +265,13 @@ impl KvPushRouter {
         // and the standalone router create KvPushRouter, so this covers both.
         RouterRequestMetrics::from_component(chooser.client().endpoint.component());
 
-        // Agent controller manages session lifecycle RPCs (open/close).
-        // Always created; the event-plane client inside is lazy (OnceCell)
-        // so there is zero cost until a request actually carries session_control.
         let component = chooser.client().endpoint.component().clone();
-        let agent_controller = Arc::new(AgentController::new(component));
-
-        // Sticky sessions share expiry handling with the agent controller so
-        // router-side reap also closes the worker session.
-        let on_expire = {
-            let controller = agent_controller.clone();
-            Arc::new(move |session_id: String, worker_id: u64| {
-                controller
-                    .clone()
-                    .close_expired_session(session_id, worker_id);
-            }) as Arc<dyn Fn(String, u64) + Send + Sync>
-        };
-        let sticky_sessions = Arc::new(StickySessionRouter::new(
-            InMemoryAffinityStore::new_with_on_expire(Some(on_expire)),
-        ));
+        let sticky = Arc::new(StickySessionCoordinator::new(component));
 
         KvPushRouter {
             inner,
             chooser,
-            sticky_sessions,
-            agent_controller,
+            sticky,
         }
     }
 
@@ -574,37 +555,6 @@ impl KvPushRouter {
         })
     }
 
-    pub(crate) fn sticky_worker_for_phase(
-        &self,
-        request: &PreprocessedRequest,
-        phase: RequestPhase,
-    ) -> Option<WorkerWithDpRank> {
-        let session_id = sticky_session_id_for_phase(request, phase)?;
-        self.sticky_sessions.peek_session(session_id)
-    }
-
-    pub(crate) fn refresh_sticky_worker_for_phase(
-        &self,
-        request: &PreprocessedRequest,
-        phase: RequestPhase,
-    ) {
-        let Some(session_id) = sticky_session_id_for_phase(request, phase) else {
-            return;
-        };
-        let Some(sc) = request
-            .routing
-            .as_ref()
-            .and_then(|routing| routing.session_control.as_ref())
-        else {
-            return;
-        };
-        if sc.action.is_some() {
-            return;
-        }
-
-        self.sticky_sessions.resolve_session(session_id);
-    }
-
     fn sticky_worker_ineligibility_for_phase(
         &self,
         request: &PreprocessedRequest,
@@ -643,7 +593,7 @@ impl KvPushRouter {
             return false;
         };
 
-        let Some(session_id) = sticky_session_id_for_phase(request, phase) else {
+        let Some((session_id, _binding)) = self.sticky.unbind_for_phase(request, phase) else {
             return false;
         };
         tracing::warn!(
@@ -654,7 +604,6 @@ impl KvPushRouter {
             reason = %reason,
             "Sticky worker is no longer eligible; removing session affinity"
         );
-        let _ = self.sticky_sessions.unbind(session_id);
         true
     }
 
@@ -719,7 +668,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
         let should_record = !is_query_only && self.chooser.indexer().records_routing_decisions();
         let block_size = self.chooser.block_size() as usize;
-        let sticky_worker = match self.sticky_worker_for_phase(&request, phase) {
+        let sticky_worker = match self.sticky.worker_for_phase(&request, phase) {
             Some(worker)
                 if self.unbind_ineligible_sticky_worker_for_phase(
                     &context_id,
@@ -746,7 +695,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         {
             Ok(selection) => {
                 if sticky_worker.is_some() && !is_query_only {
-                    self.refresh_sticky_worker_for_phase(&request, phase);
+                    self.sticky.refresh_worker_for_phase(&request, phase);
                 }
                 selection
             }
@@ -879,37 +828,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let track_output_blocks = self.chooser.kv_router_config().router_track_output_blocks;
         let tracker = request.tracker.clone();
 
-        // Session lifecycle RPCs via agent controller.
+        // Session lifecycle RPCs.
         // Fails fast if session_control.open is requested but the client can't be created.
-        let route_outcome = self
-            .agent_controller
-            .on_routed(
-                &request,
-                instance_id,
-                &context_id,
-                Some(&*self.sticky_sessions),
-            )
-            .await?;
-        if let Some(kind) = affinity_kind_for_lifecycle(route_outcome.lifecycle)
-            && let Some(sc) = request
-                .routing
-                .as_ref()
-                .and_then(|r| r.session_control.as_ref())
-        {
-            let worker = WorkerWithDpRank::new(instance_id, dp_rank);
-            let ttl = Duration::from_secs(sc.timeout);
-            match kind {
-                AffinityKind::RouterOnly => {
-                    self.sticky_sessions
-                        .bind_router_only(&sc.session_id, worker, ttl);
-                }
-                AffinityKind::EngineBacked => {
-                    // Bind/rebind only after the worker accepted open_session.
-                    self.sticky_sessions
-                        .bind_engine_session(&sc.session_id, worker, ttl);
-                }
-            }
-        }
+        let worker = WorkerWithDpRank::new(instance_id, dp_rank);
+        let route_outcome = self.sticky.on_routed(&request, worker, &context_id).await?;
         let deferred_close = route_outcome.deferred_close;
 
         let (mut backend_input, context) = request.into_parts();
@@ -1035,51 +957,6 @@ fn pinned_worker_hint(
     }
 }
 
-fn sticky_allowed_for_phase(phase: RequestPhase, routing: Option<&RoutingHints>) -> bool {
-    let Some(routing) = routing else {
-        return false;
-    };
-    if routing.session_control.is_none() {
-        return false;
-    }
-
-    match phase {
-        RequestPhase::Prefill => {
-            routing.prefill_worker_id.is_none()
-                && routing.prefill_dp_rank.is_none()
-                && routing.backend_instance_id.is_none()
-        }
-        RequestPhase::Decode => {
-            routing.decode_worker_id.is_none()
-                && routing.dp_rank.is_none()
-                && routing.backend_instance_id.is_none()
-        }
-        RequestPhase::Aggregated => {
-            routing.backend_instance_id.is_none() && routing.dp_rank.is_none()
-        }
-    }
-}
-
-fn affinity_kind_for_lifecycle(lifecycle: SessionLifecycleOutcome) -> Option<AffinityKind> {
-    match lifecycle {
-        SessionLifecycleOutcome::OpenSucceeded => Some(AffinityKind::EngineBacked),
-        SessionLifecycleOutcome::BindRequested => Some(AffinityKind::RouterOnly),
-        _ => None,
-    }
-}
-
-fn sticky_session_id_for_phase(request: &PreprocessedRequest, phase: RequestPhase) -> Option<&str> {
-    let routing = request.routing.as_ref()?;
-    if !sticky_allowed_for_phase(phase, Some(routing)) {
-        return None;
-    }
-
-    routing
-        .session_control
-        .as_ref()
-        .map(|sc| sc.session_id.as_str())
-}
-
 /// A direct routing wrapper for `RouterMode::Direct`.
 ///
 /// This wraps a `PushRouter` and reads worker IDs from each request's routing hints,
@@ -1127,19 +1004,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
 #[cfg(test)]
 mod tests {
-    use super::{affinity_kind_for_lifecycle, pinned_worker_hint, sticky_allowed_for_phase};
-    use crate::kv_router::agent_controller::SessionLifecycleOutcome;
-    use crate::kv_router::sticky_sessions::AffinityKind;
+    use super::pinned_worker_hint;
     use crate::protocols::common::{preprocessor::RoutingHints, timing::RequestPhase};
-    use crate::protocols::openai::nvext::SessionControl;
-
-    fn session_control() -> SessionControl {
-        SessionControl {
-            session_id: "sess-1".to_string(),
-            action: None,
-            timeout: 300,
-        }
-    }
 
     #[test]
     fn pinned_worker_hint_prefill_uses_prefill_worker_before_backend() {
@@ -1178,111 +1044,5 @@ mod tests {
 
         let hint = pinned_worker_hint(RequestPhase::Aggregated, Some(&routing));
         assert_eq!(hint, Some((9, Some(7))));
-    }
-
-    #[test]
-    fn sticky_is_noop_without_session_control() {
-        let routing = RoutingHints::default();
-        assert!(!sticky_allowed_for_phase(
-            RequestPhase::Aggregated,
-            Some(&routing)
-        ));
-    }
-
-    #[test]
-    fn sticky_allowed_when_only_session_control_is_present() {
-        let routing = RoutingHints {
-            session_control: Some(session_control()),
-            ..Default::default()
-        };
-        assert!(sticky_allowed_for_phase(
-            RequestPhase::Aggregated,
-            Some(&routing)
-        ));
-        assert!(sticky_allowed_for_phase(
-            RequestPhase::Prefill,
-            Some(&routing)
-        ));
-        assert!(sticky_allowed_for_phase(
-            RequestPhase::Decode,
-            Some(&routing)
-        ));
-    }
-
-    #[test]
-    fn sticky_skips_phase_specific_explicit_pins() {
-        let prefill = RoutingHints {
-            session_control: Some(session_control()),
-            prefill_worker_id: Some(1),
-            ..Default::default()
-        };
-        assert!(!sticky_allowed_for_phase(
-            RequestPhase::Prefill,
-            Some(&prefill)
-        ));
-
-        let prefill_rank = RoutingHints {
-            session_control: Some(session_control()),
-            prefill_dp_rank: Some(2),
-            ..Default::default()
-        };
-        assert!(!sticky_allowed_for_phase(
-            RequestPhase::Prefill,
-            Some(&prefill_rank)
-        ));
-
-        let decode = RoutingHints {
-            session_control: Some(session_control()),
-            decode_worker_id: Some(3),
-            ..Default::default()
-        };
-        assert!(!sticky_allowed_for_phase(
-            RequestPhase::Decode,
-            Some(&decode)
-        ));
-
-        let decode_rank = RoutingHints {
-            session_control: Some(session_control()),
-            dp_rank: Some(4),
-            ..Default::default()
-        };
-        assert!(!sticky_allowed_for_phase(
-            RequestPhase::Decode,
-            Some(&decode_rank)
-        ));
-
-        let aggregated = RoutingHints {
-            session_control: Some(session_control()),
-            backend_instance_id: Some(5),
-            ..Default::default()
-        };
-        assert!(!sticky_allowed_for_phase(
-            RequestPhase::Aggregated,
-            Some(&aggregated)
-        ));
-    }
-
-    #[test]
-    fn open_lifecycle_binds_engine_backed_affinity() {
-        assert_eq!(
-            affinity_kind_for_lifecycle(SessionLifecycleOutcome::OpenSucceeded),
-            Some(AffinityKind::EngineBacked)
-        );
-    }
-
-    #[test]
-    fn bind_lifecycle_binds_router_only_affinity() {
-        assert_eq!(
-            affinity_kind_for_lifecycle(SessionLifecycleOutcome::BindRequested),
-            Some(AffinityKind::RouterOnly)
-        );
-    }
-
-    #[test]
-    fn no_action_lifecycle_does_not_create_affinity() {
-        assert_eq!(
-            affinity_kind_for_lifecycle(SessionLifecycleOutcome::NoAction),
-            None
-        );
     }
 }

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use anyhow::Result;
 use dynamo_kv_router::{
+    RouterConfigOverride,
     indexer::RoutingDecisionHashes,
-    protocols::{RoutingConstraints, TokensWithHashes, WorkerConfigLike, WorkerWithDpRank},
+    protocols::{BlockExtraInfo, RoutingConstraints, TokensWithHashes, WorkerId, WorkerWithDpRank},
     scheduling::{WorkerEligibilityError, validate_worker_eligibility},
 };
 use dynamo_runtime::{
@@ -25,7 +26,7 @@ use tracing::Instrument;
 
 use crate::{
     kv_router::{
-        KvRouter,
+        FindBestMatchOutcome, KvRouter,
         metrics::RouterRequestMetrics,
         sticky::{
             coordinator::{StickySessionCoordinator, sticky_allowed_for_phase},
@@ -33,10 +34,13 @@ use crate::{
         },
     },
     preprocessor::PreprocessedRequest,
-    protocols::common::{
-        llm_backend::LLMEngineOutput,
-        preprocessor::RoutingHints,
-        timing::{RequestPhase, RequestTracker},
+    protocols::{
+        TokenIdType,
+        common::{
+            llm_backend::LLMEngineOutput,
+            preprocessor::RoutingHints,
+            timing::{RequestPhase, RequestTracker},
+        },
     },
 };
 
@@ -57,6 +61,55 @@ struct WorkerSelection {
     routing_hashes: Option<RoutingDecisionHashes>,
     /// Whether the scheduler is tracking this request (add_request or
     /// find_best_match_details with update_states=true was called).
+    scheduler_tracked: bool,
+}
+
+// NOTE: In KV router mode, worker selection is DP-rank precise. A pinned
+// worker without a concrete dp_rank is invalid unless the worker owns exactly
+// one rank and can be resolved unambiguously. Rank 0 is a real rank, not an
+// unset sentinel. Do not coerce unresolved ranks to 0.
+fn resolve_pinned_worker_rank(
+    worker_id: WorkerId,
+    requested_dp_rank: Option<u32>,
+    unique_dp_rank: Option<u32>,
+) -> Result<WorkerWithDpRank, Error> {
+    let Some(dp_rank) = requested_dp_rank.or(unique_dp_rank) else {
+        return Err(anyhow::anyhow!(
+            "Pinned worker {worker_id} requires an explicit dp_rank because it has multiple or unknown DP ranks"
+        ));
+    };
+
+    Ok(WorkerWithDpRank::new(worker_id, dp_rank))
+}
+
+#[derive(Clone, Copy)]
+struct RoutingRequestParts<'a> {
+    token_ids: &'a [TokenIdType],
+    block_mm_infos: Option<&'a [Option<BlockExtraInfo>]>,
+}
+
+impl<'a> RoutingRequestParts<'a> {
+    fn new(request: &'a PreprocessedRequest) -> Self {
+        let (token_ids, block_mm_infos) = request.block_mm_routing_info();
+        Self {
+            token_ids,
+            block_mm_infos,
+        }
+    }
+}
+
+struct BestMatchArgs<'a> {
+    context_id: &'a str,
+    routing_parts: RoutingRequestParts<'a>,
+    router_config_override: Option<&'a RouterConfigOverride>,
+    update_states: bool,
+    return_routing_hashes: bool,
+    lora_name: Option<String>,
+    priority_jump: f64,
+    expected_output_tokens: Option<u32>,
+    pinned_worker: Option<WorkerWithDpRank>,
+    allowed_worker_ids: Option<HashSet<WorkerId>>,
+    routing_constraints: RoutingConstraints,
     scheduler_tracked: bool,
 }
 
@@ -275,16 +328,65 @@ impl KvPushRouter {
         }
     }
 
+    async fn select_best_match(&self, args: BestMatchArgs<'_>) -> Result<WorkerSelection, Error> {
+        let outcome = self
+            .chooser
+            .find_best_match_details(
+                Some(args.context_id),
+                args.routing_parts.token_ids,
+                args.routing_parts.block_mm_infos,
+                args.router_config_override,
+                args.update_states,
+                args.return_routing_hashes,
+                args.lora_name,
+                args.priority_jump,
+                args.expected_output_tokens,
+                args.pinned_worker,
+                args.allowed_worker_ids,
+                args.routing_constraints,
+            )
+            .await?;
+
+        match outcome {
+            FindBestMatchOutcome::Routed {
+                worker,
+                overlap_blocks,
+                effective_overlap_blocks,
+                cached_tokens,
+                routing_hashes,
+            } => Ok(WorkerSelection {
+                instance_id: worker.worker_id,
+                dp_rank: worker.dp_rank,
+                overlap_amount: overlap_blocks,
+                effective_overlap_blocks,
+                cached_tokens,
+                routing_hashes,
+                scheduler_tracked: args.scheduler_tracked,
+            }),
+            FindBestMatchOutcome::Backpressure {
+                reason,
+                queued_isl_tokens,
+                max_queued_isl_tokens,
+            } => Err(DynamoError::builder()
+                .error_type(DynamoErrorType::ResourceExhausted)
+                .message(format!(
+                    "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
+                ))
+                .build()
+                .into()),
+        }
+    }
+
     /// Select a worker for the request, either using an exact phase-specific pin
     /// or by finding the best KV overlap match.
     async fn select_worker(
         &self,
         context_id: &str,
         request: &PreprocessedRequest,
+        routing_parts: RoutingRequestParts<'_>,
         phase: RequestPhase,
         is_query_only: bool,
         sticky_worker: Option<WorkerWithDpRank>,
-        return_routing_hashes: bool,
     ) -> Result<WorkerSelection, Error> {
         let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
         let routing = request.routing.as_ref();
@@ -292,267 +394,99 @@ impl KvPushRouter {
         let priority_jump = routing.and_then(|r| r.priority_jump).unwrap_or(0.0);
         let expected_output_tokens = routing.and_then(|r| r.expected_output_tokens);
         let allowed_worker_ids = routing.and_then(|r| r.allowed_worker_ids.clone());
+        let return_routing_hashes =
+            !is_query_only && self.chooser.indexer().records_routing_decisions();
         let routing_constraints = routing
             .and_then(|r| r.routing_constraints.clone())
             .unwrap_or_default();
-        let (routing_token_ids, block_mm_infos) = request.block_mm_routing_info();
         let sticky_pin = sticky_worker.map(|worker| (worker.worker_id, Some(worker.dp_rank)));
         let Some((pinned_worker_id, requested_dp_rank)) =
             pinned_worker_hint(phase, routing).or(sticky_pin)
         else {
             let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
-            let outcome = self
-                .chooser
-                .find_best_match_details(
-                    Some(context_id),
-                    routing_token_ids,
-                    block_mm_infos,
-                    request.router_config_override.as_ref(),
-                    !is_query_only,
+            let selection = self
+                .select_best_match(BestMatchArgs {
+                    context_id,
+                    routing_parts,
+                    router_config_override: request.router_config_override.as_ref(),
+                    update_states: !is_query_only,
                     return_routing_hashes,
                     lora_name,
                     priority_jump,
                     expected_output_tokens,
-                    None,
+                    pinned_worker: None,
                     allowed_worker_ids,
-                    routing_constraints.clone(),
-                )
+                    routing_constraints: routing_constraints.clone(),
+                    scheduler_tracked: !is_query_only,
+                })
                 .await?;
-            let (
-                best_worker,
-                effective_overlap_blocks,
-                cached_tokens,
-                overlap_amount,
-                routing_hashes,
-            ) = match outcome {
-                crate::kv_router::FindBestMatchOutcome::Routed {
-                    worker,
-                    overlap_blocks,
-                    effective_overlap_blocks,
-                    cached_tokens,
-                    routing_hashes,
-                } => (
-                    worker,
-                    effective_overlap_blocks,
-                    cached_tokens,
-                    overlap_blocks,
-                    routing_hashes,
-                ),
-                crate::kv_router::FindBestMatchOutcome::Backpressure {
-                    reason,
-                    queued_isl_tokens,
-                    max_queued_isl_tokens,
-                } => {
-                    // TODO(#8189): classify queue-depth
-                    // saturation distinctly from generic resource exhaustion
-                    // (operator-facing 429 vs 503) once the shared rejection
-                    // layer lands.
-                    return Err(DynamoError::builder()
-                        .error_type(DynamoErrorType::ResourceExhausted)
-                        .message(format!(
-                            "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
-                        ))
-                        .build()
-                        .into());
-                }
-            };
 
             if !is_query_only {
-                let total_blocks = routing_token_ids
+                let total_blocks = routing_parts
+                    .token_ids
                     .len()
                     .div_ceil(self.chooser.block_size() as usize);
                 // tests/utils/router_logs.py parses the structured fields on this event.
                 tracing::debug!(
                     request_id = %context_id,
-                    worker_id = best_worker.worker_id,
-                    dp_rank = best_worker.dp_rank,
-                    overlap_blocks = overlap_amount,
+                    worker_id = selection.instance_id,
+                    dp_rank = selection.dp_rank,
+                    overlap_blocks = selection.overlap_amount,
                     total_blocks = total_blocks,
                     "[ROUTING] Best: worker_{} dp_rank={} with {}/{} blocks overlap",
-                    best_worker.worker_id,
-                    best_worker.dp_rank,
-                    overlap_amount,
+                    selection.instance_id,
+                    selection.dp_rank,
+                    selection.overlap_amount,
                     total_blocks,
                 );
             }
 
-            return Ok(WorkerSelection {
-                instance_id: best_worker.worker_id,
-                dp_rank: best_worker.dp_rank,
-                overlap_amount,
-                effective_overlap_blocks,
-                cached_tokens,
-                routing_hashes,
-                scheduler_tracked: !is_query_only,
-            });
+            return Ok(selection);
         };
 
-        let resolved_pinned_worker: Option<WorkerWithDpRank> = requested_dp_rank
-            .or_else(|| self.chooser.unique_dp_rank_for_worker(pinned_worker_id))
-            .map(|dp_rank| WorkerWithDpRank::new(pinned_worker_id, dp_rank));
-
-        if !is_query_only && let Some(pinned_worker) = resolved_pinned_worker {
-            let outcome = self
-                .chooser
-                .find_best_match_details(
-                    Some(context_id),
-                    routing_token_ids,
-                    block_mm_infos,
-                    request.router_config_override.as_ref(),
-                    true,
-                    return_routing_hashes,
-                    lora_name.clone(),
-                    priority_jump,
-                    expected_output_tokens,
-                    Some(pinned_worker),
-                    allowed_worker_ids,
-                    routing_constraints.clone(),
-                )
-                .await?;
-            let (
-                best_worker,
-                effective_overlap_blocks,
-                cached_tokens,
-                overlap_amount,
-                routing_hashes,
-            ) = match outcome {
-                crate::kv_router::FindBestMatchOutcome::Routed {
-                    worker,
-                    overlap_blocks,
-                    effective_overlap_blocks,
-                    cached_tokens,
-                    routing_hashes,
-                } => (
-                    worker,
-                    effective_overlap_blocks,
-                    cached_tokens,
-                    overlap_blocks,
-                    routing_hashes,
-                ),
-                crate::kv_router::FindBestMatchOutcome::Backpressure {
-                    reason,
-                    queued_isl_tokens,
-                    max_queued_isl_tokens,
-                } => {
-                    // TODO(#8189): same classification
-                    // refinement applies on the pinned-worker path.
-                    return Err(DynamoError::builder()
-                        .error_type(DynamoErrorType::ResourceExhausted)
-                        .message(format!(
-                            "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
-                        ))
-                        .build()
-                        .into());
-                }
-            };
-
-            return Ok(WorkerSelection {
-                instance_id: best_worker.worker_id,
-                dp_rank: best_worker.dp_rank,
-                overlap_amount,
-                effective_overlap_blocks,
-                cached_tokens,
-                routing_hashes,
-                scheduler_tracked: true,
-            });
+        let pinned_worker = resolve_pinned_worker_rank(
+            pinned_worker_id,
+            requested_dp_rank,
+            self.chooser.unique_dp_rank_for_worker(pinned_worker_id),
+        )?;
+        {
+            let configs = self.chooser.workers_with_configs.borrow();
+            if let Err(error) = validate_worker_eligibility(
+                &configs,
+                pinned_worker,
+                allowed_worker_ids.as_ref(),
+                &routing_constraints,
+            ) {
+                return Err(anyhow::anyhow!(
+                    "Pinned worker {} dp_rank {} is not eligible: {error}",
+                    pinned_worker.worker_id,
+                    pinned_worker.dp_rank
+                ));
+            }
         }
 
-        // Fallback: pinned worker hint was present but dp_rank could not be
-        // resolved (or this is a query-only request that skipped the scheduler
-        // path above).  Estimate cache hit directly and, when possible, register
-        // the request with the scheduler for bookkeeping.
-        let resolved_dp_rank: Option<u32> = resolved_pinned_worker.map(|w| w.dp_rank);
-
         tracing::debug!(
-            worker_id = pinned_worker_id,
-            dp_rank = ?resolved_dp_rank,
+            worker_id = pinned_worker.worker_id,
+            dp_rank = pinned_worker.dp_rank,
             ?phase,
             "Routing to specified worker"
         );
 
-        if routing_constraints.has_hard_constraints() {
-            let configs = self.chooser.workers_with_configs.borrow();
-            match configs.get(&pinned_worker_id) {
-                Some(config)
-                    if !routing_constraints.is_compatible_with_worker_taints(config.taints()) =>
-                {
-                    return Err(anyhow::anyhow!(
-                        "Pinned worker {} does not satisfy required taints {:?}; worker taints: {:?}",
-                        pinned_worker_id,
-                        routing_constraints.required_taints,
-                        config.taints()
-                    ));
-                }
-                None => {
-                    return Err(anyhow::anyhow!(
-                        "Pinned worker {} could not be validated against required taints {:?} because worker config was unavailable",
-                        pinned_worker_id,
-                        routing_constraints.required_taints
-                    ));
-                }
-                _ => {}
-            }
-        }
-
-        // Build a WorkerWithDpRank; use 0 as a fallback dp_rank when it
-        // couldn't be resolved -- this is only used for the cache-hit
-        // estimate query and won't affect scheduler state.
-        let effective_dp_rank = resolved_dp_rank.unwrap_or(0);
-        let worker = WorkerWithDpRank::new(pinned_worker_id, effective_dp_rank);
-        let (cache_hit, routing_hashes) = self
-            .chooser
-            .get_cache_hit_estimate_with_hashes(
-                routing_token_ids,
-                block_mm_infos,
-                worker,
-                lora_name.as_deref(),
-                return_routing_hashes,
-            )
-            .await?;
-        let effective_overlap_blocks = cache_hit.effective_overlap_blocks;
-        let cached_tokens = cache_hit.cached_tokens;
-        let overlap_blocks = cache_hit.rounded_overlap_blocks();
-
-        if !is_query_only {
-            if let Some(_dp_rank) = resolved_dp_rank {
-                self.chooser
-                    .add_request(
-                        context_id.to_string(),
-                        routing_token_ids,
-                        block_mm_infos,
-                        cached_tokens,
-                        expected_output_tokens,
-                        worker,
-                        lora_name,
-                        request.router_config_override.as_ref(),
-                    )
-                    .await;
-            } else {
-                tracing::debug!(
-                    request_id = %context_id,
-                    worker_id = pinned_worker_id,
-                    ?phase,
-                    "Routing to specified worker without resolved dp_rank; skipping scheduler bookkeeping"
-                );
-            }
-        } else {
-            tracing::debug!(
-                request_id = %context_id,
-                worker_id = pinned_worker_id,
-                dp_rank = ?resolved_dp_rank,
-                "Skipping add_request - query-only request"
-            );
-        }
-
-        Ok(WorkerSelection {
-            instance_id: pinned_worker_id,
-            dp_rank: effective_dp_rank,
-            overlap_amount: overlap_blocks,
-            effective_overlap_blocks,
-            cached_tokens,
-            routing_hashes,
-            scheduler_tracked: !is_query_only && resolved_dp_rank.is_some(),
+        self.select_best_match(BestMatchArgs {
+            context_id,
+            routing_parts,
+            router_config_override: request.router_config_override.as_ref(),
+            update_states: !is_query_only,
+            return_routing_hashes,
+            lora_name,
+            priority_jump,
+            expected_output_tokens,
+            pinned_worker: Some(pinned_worker),
+            allowed_worker_ids,
+            routing_constraints,
+            scheduler_tracked: !is_query_only,
         })
+        .await
     }
 
     fn sticky_worker_ineligibility_for_phase(
@@ -614,8 +548,16 @@ impl KvPushRouter {
         phase: RequestPhase,
         worker: WorkerWithDpRank,
     ) -> Result<WorkerWithDpRank, Error> {
+        let routing_parts = RoutingRequestParts::new(request);
         let selection = self
-            .select_worker(context_id, request, phase, true, Some(worker), false)
+            .select_worker(
+                context_id,
+                request,
+                routing_parts,
+                phase,
+                true,
+                Some(worker),
+            )
             .await?;
         Ok(WorkerWithDpRank::new(
             selection.instance_id,
@@ -637,8 +579,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
     ///
     /// 2. **If a phase-specific worker or `backend_instance_id` is set in the request**:
     ///    - Query-only requests return that worker selection without state updates
-    ///    - Execution requests route through the scheduler as an exact pin when dp_rank is resolved
-    ///    - If dp_rank cannot be resolved, falls back to direct routing without scheduler bookkeeping
+    ///    - Requests route through the scheduler as an exact pin when dp_rank is resolved
+    ///    - If dp_rank cannot be resolved, the request is rejected instead of treating rank 0 as a sentinel
     ///
     /// 3. **If neither are set (default behavior)**:
     ///    - Finds the best worker based on KV cache overlap
@@ -668,6 +610,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
         let should_record = !is_query_only && self.chooser.indexer().records_routing_decisions();
         let block_size = self.chooser.block_size() as usize;
+        let routing_parts = RoutingRequestParts::new(&request);
         let sticky_worker = match self.sticky.worker_for_phase(&request, phase) {
             Some(worker)
                 if self.unbind_ineligible_sticky_worker_for_phase(
@@ -685,10 +628,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             .select_worker(
                 &context_id,
                 &request,
+                routing_parts,
                 phase,
                 is_query_only,
                 sticky_worker,
-                should_record,
             )
             .instrument(tracing::info_span!("kv_router.select_worker"))
             .await
@@ -719,10 +662,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 self.select_worker(
                     &context_id,
                     &request,
+                    routing_parts,
                     phase,
                     is_query_only,
                     None,
-                    should_record,
                 )
                 .instrument(tracing::info_span!("kv_router.select_worker_fallback"))
                 .await?
@@ -747,11 +690,12 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                     .await
             } else {
                 let lora_name = request.routing.as_ref().and_then(|r| r.lora_name.clone());
-                let (routing_token_ids, block_mm_infos) = request.block_mm_routing_info();
-                let mut tokens_with_hashes =
-                    TokensWithHashes::new(routing_token_ids.to_vec(), self.chooser.block_size())
-                        .with_is_eagle(self.chooser.is_eagle());
-                if let Some(infos) = block_mm_infos {
+                let mut tokens_with_hashes = TokensWithHashes::new(
+                    routing_parts.token_ids.to_vec(),
+                    self.chooser.block_size(),
+                )
+                .with_is_eagle(self.chooser.is_eagle());
+                if let Some(infos) = routing_parts.block_mm_infos {
                     tokens_with_hashes = tokens_with_hashes.with_mm_infos(infos.to_vec());
                 }
                 if let Some(lora_name) = lora_name {
@@ -776,10 +720,9 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let request_metrics =
             RouterRequestMetrics::from_component(self.chooser.client().endpoint.component());
         if let Some(ref tracker) = request.tracker {
-            let (routing_token_ids, _) = request.block_mm_routing_info();
-            let isl_blocks = routing_token_ids.len().div_ceil(block_size);
+            let isl_blocks = routing_parts.token_ids.len().div_ceil(block_size);
             tracker.record_kv_hit(effective_overlap_blocks, isl_blocks);
-            tracker.record_isl(routing_token_ids.len(), Some(cached_tokens));
+            tracker.record_isl(routing_parts.token_ids.len(), Some(cached_tokens));
             tracker.record_worker(instance_id, Some(dp_rank), self.chooser.worker_type());
             tracker.record_router_queue_depth(self.chooser.pending_count());
             if let Some(hit_rate) = tracker.kv_hit_rate() {
@@ -1004,8 +947,30 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
 #[cfg(test)]
 mod tests {
-    use super::pinned_worker_hint;
+    use super::{pinned_worker_hint, resolve_pinned_worker_rank};
     use crate::protocols::common::{preprocessor::RoutingHints, timing::RequestPhase};
+
+    #[test]
+    fn resolve_pinned_worker_rank_uses_explicit_rank_including_zero() {
+        let worker = resolve_pinned_worker_rank(7, Some(0), Some(3)).unwrap();
+        assert_eq!(worker.worker_id, 7);
+        assert_eq!(worker.dp_rank, 0);
+    }
+
+    #[test]
+    fn resolve_pinned_worker_rank_uses_unique_rank_when_unset() {
+        let worker = resolve_pinned_worker_rank(7, None, Some(3)).unwrap();
+        assert_eq!(worker.worker_id, 7);
+        assert_eq!(worker.dp_rank, 3);
+    }
+
+    #[test]
+    fn resolve_pinned_worker_rank_rejects_unresolved_rank() {
+        let error = resolve_pinned_worker_rank(7, None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("requires an explicit dp_rank"));
+    }
 
     #[test]
     fn pinned_worker_hint_prefill_uses_prefill_worker_before_backend() {

--- a/lib/llm/src/kv_router/scheduler_inputs.rs
+++ b/lib/llm/src/kv_router/scheduler_inputs.rs
@@ -19,7 +19,6 @@ use super::{
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct WorkerCacheHitEstimate {
     pub effective_overlap_blocks: f64,
-    pub cached_tokens: usize,
 }
 
 impl WorkerCacheHitEstimate {
@@ -128,11 +127,6 @@ pub(super) fn cache_hit_for_worker(
             .get(&worker)
             .copied()
             .unwrap_or(0.0),
-        cached_tokens: cache_hit_estimates
-            .cached_tokens
-            .get(&worker)
-            .copied()
-            .unwrap_or(0),
     }
 }
 

--- a/lib/llm/src/kv_router/sticky/coordinator.rs
+++ b/lib/llm/src/kv_router/sticky/coordinator.rs
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Coordination layer for sticky routing and backend session lifecycle.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use dynamo_kv_router::protocols::WorkerWithDpRank;
+use dynamo_runtime::component::Component;
+
+use crate::{
+    preprocessor::PreprocessedRequest,
+    protocols::{
+        common::{preprocessor::RoutingHints, timing::RequestPhase},
+        openai::nvext::SessionAction,
+    },
+};
+
+use super::{
+    lifecycle::{SessionCloseAction, SessionLifecycleController},
+    router::{AffinityBinding, AffinityKind, InMemoryAffinityStore, StickySessionRouter},
+};
+
+pub struct SessionRoutingResult {
+    pub deferred_close: Option<SessionCloseAction>,
+}
+
+pub struct StickySessionCoordinator {
+    router: Arc<StickySessionRouter>,
+    lifecycle: Arc<SessionLifecycleController>,
+}
+
+impl StickySessionCoordinator {
+    pub fn new(component: Component) -> Self {
+        let lifecycle = Arc::new(SessionLifecycleController::new(component));
+        let on_expire = {
+            let lifecycle = lifecycle.clone();
+            Arc::new(move |session_id: String, worker_id: u64| {
+                lifecycle
+                    .clone()
+                    .close_expired_session(session_id, worker_id);
+            }) as Arc<dyn Fn(String, u64) + Send + Sync>
+        };
+        let router = Arc::new(StickySessionRouter::new(
+            InMemoryAffinityStore::new_with_on_expire(Some(on_expire)),
+        ));
+
+        StickySessionCoordinator { router, lifecycle }
+    }
+
+    pub fn worker_for_phase(
+        &self,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+    ) -> Option<WorkerWithDpRank> {
+        let session_id = sticky_session_id_for_phase(request, phase)?;
+        self.router.peek_session(session_id)
+    }
+
+    pub fn refresh_worker_for_phase(&self, request: &PreprocessedRequest, phase: RequestPhase) {
+        let Some(session_id) = sticky_session_id_for_phase(request, phase) else {
+            return;
+        };
+        let Some(sc) = request
+            .routing
+            .as_ref()
+            .and_then(|routing| routing.session_control.as_ref())
+        else {
+            return;
+        };
+        if sc.action.is_some() {
+            return;
+        }
+
+        self.router.resolve_session(session_id);
+    }
+
+    pub fn unbind_for_phase<'a>(
+        &self,
+        request: &'a PreprocessedRequest,
+        phase: RequestPhase,
+    ) -> Option<(&'a str, Option<AffinityBinding>)> {
+        let session_id = sticky_session_id_for_phase(request, phase)?;
+        Some((session_id, self.router.unbind(session_id)))
+    }
+
+    pub async fn on_routed(
+        &self,
+        request: &PreprocessedRequest,
+        worker: WorkerWithDpRank,
+        context_id: &str,
+    ) -> Result<SessionRoutingResult> {
+        let sc = request
+            .routing
+            .as_ref()
+            .and_then(|r| r.session_control.as_ref());
+
+        let Some(sc) = sc else {
+            return Ok(SessionRoutingResult {
+                deferred_close: None,
+            });
+        };
+        let Some(action) = sc.action.as_ref() else {
+            return Ok(SessionRoutingResult {
+                deferred_close: None,
+            });
+        };
+
+        match action {
+            SessionAction::Open => {
+                let opened = self
+                    .lifecycle
+                    .open_session(&sc.session_id, sc.timeout, worker.worker_id, context_id)
+                    .await?;
+                if opened {
+                    self.bind_with_kind(sc, worker, AffinityKind::EngineBacked);
+                }
+                Ok(SessionRoutingResult {
+                    deferred_close: None,
+                })
+            }
+            SessionAction::Bind => {
+                self.bind_with_kind(sc, worker, AffinityKind::RouterOnly);
+                Ok(SessionRoutingResult {
+                    deferred_close: None,
+                })
+            }
+            SessionAction::Close => {
+                let should_close_worker_session = self
+                    .router
+                    .unbind(&sc.session_id)
+                    .map(|binding| binding.kind == AffinityKind::EngineBacked)
+                    .unwrap_or(true);
+                let deferred_close = if should_close_worker_session {
+                    self.lifecycle
+                        .deferred_close(sc.session_id.clone(), worker.worker_id)
+                        .await
+                } else {
+                    None
+                };
+                Ok(SessionRoutingResult { deferred_close })
+            }
+        }
+    }
+
+    fn bind_with_kind(
+        &self,
+        sc: &crate::protocols::openai::nvext::SessionControl,
+        worker: WorkerWithDpRank,
+        kind: AffinityKind,
+    ) {
+        let ttl = Duration::from_secs(sc.timeout);
+        match kind {
+            AffinityKind::RouterOnly => self.router.bind_router_only(&sc.session_id, worker, ttl),
+            AffinityKind::EngineBacked => {
+                self.router.bind_engine_session(&sc.session_id, worker, ttl)
+            }
+        }
+    }
+}
+
+pub(crate) fn sticky_allowed_for_phase(
+    phase: RequestPhase,
+    routing: Option<&RoutingHints>,
+) -> bool {
+    let Some(routing) = routing else {
+        return false;
+    };
+    if routing.session_control.is_none() {
+        return false;
+    }
+
+    match phase {
+        RequestPhase::Prefill => {
+            routing.prefill_worker_id.is_none()
+                && routing.prefill_dp_rank.is_none()
+                && routing.backend_instance_id.is_none()
+        }
+        RequestPhase::Decode => {
+            routing.decode_worker_id.is_none()
+                && routing.dp_rank.is_none()
+                && routing.backend_instance_id.is_none()
+        }
+        RequestPhase::Aggregated => {
+            routing.backend_instance_id.is_none() && routing.dp_rank.is_none()
+        }
+    }
+}
+
+fn sticky_session_id_for_phase(request: &PreprocessedRequest, phase: RequestPhase) -> Option<&str> {
+    let routing = request.routing.as_ref()?;
+    if !sticky_allowed_for_phase(phase, Some(routing)) {
+        return None;
+    }
+
+    routing
+        .session_control
+        .as_ref()
+        .map(|sc| sc.session_id.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sticky_allowed_for_phase;
+    use crate::protocols::common::{preprocessor::RoutingHints, timing::RequestPhase};
+    use crate::protocols::openai::nvext::SessionControl;
+
+    fn session_control() -> SessionControl {
+        SessionControl {
+            session_id: "sess-1".to_string(),
+            action: None,
+            timeout: 300,
+        }
+    }
+
+    #[test]
+    fn sticky_is_noop_without_session_control() {
+        let routing = RoutingHints::default();
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Aggregated,
+            Some(&routing)
+        ));
+    }
+
+    #[test]
+    fn sticky_allowed_when_only_session_control_is_present() {
+        let routing = RoutingHints {
+            session_control: Some(session_control()),
+            ..Default::default()
+        };
+        assert!(sticky_allowed_for_phase(
+            RequestPhase::Aggregated,
+            Some(&routing)
+        ));
+        assert!(sticky_allowed_for_phase(
+            RequestPhase::Prefill,
+            Some(&routing)
+        ));
+        assert!(sticky_allowed_for_phase(
+            RequestPhase::Decode,
+            Some(&routing)
+        ));
+    }
+
+    #[test]
+    fn sticky_skips_phase_specific_explicit_pins() {
+        let prefill = RoutingHints {
+            session_control: Some(session_control()),
+            prefill_worker_id: Some(1),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Prefill,
+            Some(&prefill)
+        ));
+
+        let prefill_rank = RoutingHints {
+            session_control: Some(session_control()),
+            prefill_dp_rank: Some(2),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Prefill,
+            Some(&prefill_rank)
+        ));
+
+        let decode = RoutingHints {
+            session_control: Some(session_control()),
+            decode_worker_id: Some(3),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Decode,
+            Some(&decode)
+        ));
+
+        let decode_rank = RoutingHints {
+            session_control: Some(session_control()),
+            dp_rank: Some(4),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Decode,
+            Some(&decode_rank)
+        ));
+
+        let aggregated = RoutingHints {
+            session_control: Some(session_control()),
+            backend_instance_id: Some(5),
+            ..Default::default()
+        };
+        assert!(!sticky_allowed_for_phase(
+            RequestPhase::Aggregated,
+            Some(&aggregated)
+        ));
+    }
+}

--- a/lib/llm/src/kv_router/sticky/lifecycle.rs
+++ b/lib/llm/src/kv_router/sticky/lifecycle.rs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Session lifecycle controller for subagent KV isolation.
+//! Session lifecycle controller for backend KV sessions.
 //!
 //! Manages open/close RPCs to workers via the event plane. Session affinity
 //! (routing the same session to the same worker) is handled separately by
-//! [`super::sticky_sessions::StickySessionRouter`].
+//! [`super::router::StickySessionRouter`].
 //!
 //! The controller:
 //! - Lazily initializes a session_control event plane client
@@ -23,10 +23,6 @@ use dynamo_runtime::{
 };
 use futures::StreamExt;
 use tokio::sync::OnceCell;
-
-use crate::protocols::openai::nvext::SessionAction;
-
-use super::sticky_sessions::{AffinityKind, StickySessionRouter};
 
 /// Untyped event plane client for session_control endpoint.
 pub type EventPlaneClient = PushRouter<serde_json::Value, Annotated<serde_json::Value>>;
@@ -69,35 +65,19 @@ impl SessionCloseAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SessionLifecycleOutcome {
-    NoSessionControl,
-    NoAction,
-    OpenSucceeded,
-    BindRequested,
-    NoSessionControlEndpoint,
-    CloseRequested,
-}
-
-pub struct AgentRouteOutcome {
-    pub lifecycle: SessionLifecycleOutcome,
-    pub deferred_close: Option<SessionCloseAction>,
-}
-
 /// Session lifecycle controller.
 ///
-/// Owns a lazy event plane client for the `session_control` endpoint
-/// and coordinates with [`StickySessionRouter`] for affinity management.
-pub struct AgentController {
+/// Owns a lazy event plane client for the `session_control` endpoint.
+pub struct SessionLifecycleController {
     /// `None` means we checked and no worker exposes session_control.
     session_control: OnceCell<Option<EventPlaneClient>>,
     component: Component,
 }
 
-impl AgentController {
+impl SessionLifecycleController {
     pub fn new(component: Component) -> Self {
-        tracing::debug!("AgentController initialized");
-        AgentController {
+        tracing::debug!("SessionLifecycleController initialized");
+        SessionLifecycleController {
             session_control: OnceCell::new(),
             component,
         }
@@ -129,112 +109,57 @@ impl AgentController {
         });
     }
 
-    /// Called after worker selection. Fires open_session if needed and returns
-    /// a deferred close action for RequestGuard::finish().
-    pub async fn on_routed(
+    /// Open a backend session on a selected worker before generation starts.
+    pub async fn open_session(
         &self,
-        request: &crate::preprocessor::PreprocessedRequest,
+        session_id: &str,
+        timeout_secs: u64,
         instance_id: u64,
         context_id: &str,
-        sticky: Option<&StickySessionRouter>,
-    ) -> Result<AgentRouteOutcome> {
-        let sc = request
-            .routing
-            .as_ref()
-            .and_then(|r| r.session_control.as_ref());
-
-        let Some(sc) = sc else {
-            return Ok(AgentRouteOutcome {
-                lifecycle: SessionLifecycleOutcome::NoSessionControl,
-                deferred_close: None,
-            });
+    ) -> Result<bool> {
+        let Some(client) = self.get_session_control_client().await else {
+            return Ok(false);
         };
+        let worker_timeout_secs = timeout_secs.saturating_add(SESSION_TIMEOUT_FALLBACK_BUFFER_SECS);
 
-        let Some(action) = sc.action.as_ref() else {
-            // No action -- just session_id for sticky routing (handled by StickySessionRouter)
-            return Ok(AgentRouteOutcome {
-                lifecycle: SessionLifecycleOutcome::NoAction,
-                deferred_close: None,
-            });
-        };
+        // Open session synchronously -- the session must exist on the worker
+        // before the first generate request arrives.
+        let request = serde_json::json!({
+            "action": "open_session",
+            "session_id": session_id,
+            "timeout": worker_timeout_secs,
+            "capacity_of_str_len": DEFAULT_SESSION_CAPACITY,
+        });
+        let resp = send_session_request(
+            &client,
+            request,
+            instance_id,
+            session_id,
+            context_id,
+            "open_session",
+        )
+        .await;
 
-        match action {
-            SessionAction::Open => {
-                let Some(client) = self.get_session_control_client().await else {
-                    // No session_control endpoint available -- skip session
-                    // lifecycle and let the request proceed without isolation.
-                    return Ok(AgentRouteOutcome {
-                        lifecycle: SessionLifecycleOutcome::NoSessionControlEndpoint,
-                        deferred_close: None,
-                    });
-                };
-                let worker_timeout_secs = sc
-                    .timeout
-                    .saturating_add(SESSION_TIMEOUT_FALLBACK_BUFFER_SECS);
+        let resp =
+            resp.ok_or_else(|| anyhow!("open_session RPC failed for session {session_id}"))?;
+        ensure_session_open_succeeded(&resp, session_id)?;
 
-                // Open session synchronously -- the session must exist on the
-                // worker before the first generate request arrives, otherwise
-                // SGLang rejects it with "session does not exist".
-                let request = serde_json::json!({
-                    "action": "open_session",
-                    "session_id": sc.session_id,
-                    "timeout": worker_timeout_secs,
-                    "capacity_of_str_len": DEFAULT_SESSION_CAPACITY,
-                });
-                let resp = send_session_request(
-                    &client,
-                    request,
-                    instance_id,
-                    &sc.session_id,
-                    context_id,
-                    "open_session",
-                )
-                .await;
+        Ok(true)
+    }
 
-                let resp = resp.ok_or_else(|| {
-                    anyhow!("open_session RPC failed for session {}", sc.session_id)
-                })?;
-                ensure_session_open_succeeded(&resp, &sc.session_id)?;
-
-                // Affinity is bound at the routing layer after worker selection;
-                // this controller only owns the open/close RPC lifecycle.
-
-                Ok(AgentRouteOutcome {
-                    lifecycle: SessionLifecycleOutcome::OpenSucceeded,
-                    deferred_close: None,
-                })
-            }
-            SessionAction::Bind => Ok(AgentRouteOutcome {
-                lifecycle: SessionLifecycleOutcome::BindRequested,
-                deferred_close: None,
-            }),
-            SessionAction::Close => {
-                // Remove affinity immediately
-                let should_close_worker_session = sticky
-                    .map(|sticky| match sticky.unbind(&sc.session_id) {
-                        Some(binding) => binding.kind == AffinityKind::EngineBacked,
-                        None => true,
-                    })
-                    .unwrap_or(true);
-
-                // Defer close to after generation completes
-                let deferred_close = if should_close_worker_session {
-                    self.get_session_control_client()
-                        .await
-                        .map(|client| SessionCloseAction {
-                            session_id: sc.session_id.clone(),
-                            client,
-                            instance_id,
-                        })
-                } else {
-                    None
-                };
-                Ok(AgentRouteOutcome {
-                    lifecycle: SessionLifecycleOutcome::CloseRequested,
-                    deferred_close,
-                })
-            }
-        }
+    /// Build a deferred close action for RequestGuard::finish().
+    pub async fn deferred_close(
+        &self,
+        session_id: String,
+        instance_id: u64,
+    ) -> Option<SessionCloseAction> {
+        self.get_session_control_client()
+            .await
+            .map(|client| SessionCloseAction {
+                session_id,
+                client,
+                instance_id,
+            })
     }
 
     async fn get_session_control_client(&self) -> Option<EventPlaneClient> {

--- a/lib/llm/src/kv_router/sticky/mod.rs
+++ b/lib/llm/src/kv_router/sticky/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod coordinator;
+pub mod lifecycle;
+pub mod router;
+
+pub use coordinator::StickySessionCoordinator;
+pub use lifecycle::SessionLifecycleController;
+pub use router::StickySessionRouter;

--- a/lib/llm/src/kv_router/sticky/router.rs
+++ b/lib/llm/src/kv_router/sticky/router.rs
@@ -20,8 +20,6 @@ use std::time::{Duration, Instant};
 use dashmap::DashMap;
 use dynamo_kv_router::protocols::WorkerWithDpRank;
 
-use crate::preprocessor::PreprocessedRequest;
-
 /// Interval between sweeps of the background reaper that removes expired entries.
 const REAPER_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -208,8 +206,7 @@ impl AffinityStore for InMemoryAffinityStore {
 
 /// Routes requests to workers based on session affinity.
 ///
-/// Wraps an [`AffinityStore`] and provides request-level helpers
-/// that extract session IDs from [`PreprocessedRequest`] routing hints.
+/// Wraps an [`AffinityStore`] and provides session-id-level affinity helpers.
 pub struct StickySessionRouter {
     store: Box<dyn AffinityStore>,
 }
@@ -222,29 +219,6 @@ impl StickySessionRouter {
         }
     }
 
-    /// Resolve a request's session to a pinned `(worker, dp_rank)`.
-    ///
-    /// Looks up `session_control.session_id` from the request's routing hints.
-    /// Returns `None` if no session control is present or the session is unknown/expired.
-    pub fn resolve(&self, request: &PreprocessedRequest) -> Option<WorkerWithDpRank> {
-        let routing = request.routing.as_ref()?;
-        let session_id = routing
-            .session_control
-            .as_ref()
-            .map(|sc| sc.session_id.as_str())?;
-        self.store.get(session_id)
-    }
-
-    /// Resolve a request's session without refreshing the sticky TTL.
-    pub fn peek(&self, request: &PreprocessedRequest) -> Option<WorkerWithDpRank> {
-        let routing = request.routing.as_ref()?;
-        let session_id = routing
-            .session_control
-            .as_ref()
-            .map(|sc| sc.session_id.as_str())?;
-        self.store.peek(session_id)
-    }
-
     /// Resolve a session id directly and refresh its sticky TTL.
     pub fn resolve_session(&self, session_id: &str) -> Option<WorkerWithDpRank> {
         self.store.get(session_id)
@@ -253,11 +227,6 @@ impl StickySessionRouter {
     /// Resolve a session id directly without refreshing its sticky TTL.
     pub fn peek_session(&self, session_id: &str) -> Option<WorkerWithDpRank> {
         self.store.peek(session_id)
-    }
-
-    /// Bind an engine-backed session to a `(worker, dp_rank)` with the given TTL.
-    pub fn bind(&self, session_id: &str, worker: WorkerWithDpRank, ttl: Duration) {
-        self.bind_engine_session(session_id, worker, ttl);
     }
 
     /// Bind a router-only session to a `(worker, dp_rank)` with the given TTL.
@@ -300,31 +269,9 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
-    use crate::protocols::common::preprocessor::{PreprocessedRequest, RoutingHints};
-    use crate::protocols::openai::nvext::SessionControl;
 
     fn worker(worker_id: u64, dp_rank: u32) -> WorkerWithDpRank {
         WorkerWithDpRank::new(worker_id, dp_rank)
-    }
-
-    fn make_request(session_id: Option<&str>) -> PreprocessedRequest {
-        let routing = session_id.map(|id| RoutingHints {
-            session_control: Some(SessionControl {
-                session_id: id.to_owned(),
-                action: None,
-                timeout: 300,
-            }),
-            ..Default::default()
-        });
-        PreprocessedRequest::builder()
-            .model("test".to_string())
-            .token_ids(vec![1, 2, 3])
-            .stop_conditions(Default::default())
-            .sampling_options(Default::default())
-            .output_options(Default::default())
-            .routing(routing)
-            .build()
-            .unwrap()
     }
 
     #[test]
@@ -334,19 +281,7 @@ mod tests {
             on_expire: None,
         };
         let router = StickySessionRouter::new(store);
-        let req = make_request(Some("unknown-session"));
-        assert!(router.resolve(&req).is_none());
-    }
-
-    #[test]
-    fn resolve_returns_none_when_no_session_id() {
-        let store = InMemoryAffinityStore {
-            map: Arc::new(DashMap::new()),
-            on_expire: None,
-        };
-        let router = StickySessionRouter::new(store);
-        let req = make_request(None);
-        assert!(router.resolve(&req).is_none());
+        assert!(router.resolve_session("unknown-session").is_none());
     }
 
     #[test]
@@ -356,10 +291,9 @@ mod tests {
             on_expire: None,
         };
         let router = StickySessionRouter::new(store);
-        router.bind("sess-1", worker(42, 3), Duration::from_secs(300));
+        router.bind_engine_session("sess-1", worker(42, 3), Duration::from_secs(300));
 
-        let req = make_request(Some("sess-1"));
-        assert_eq!(router.resolve(&req), Some(worker(42, 3)));
+        assert_eq!(router.resolve_session("sess-1"), Some(worker(42, 3)));
     }
 
     #[test]
@@ -382,8 +316,7 @@ mod tests {
         };
         let router = StickySessionRouter::new(store);
 
-        let req = make_request(Some("sess-peek"));
-        assert_eq!(router.peek(&req), Some(worker(7, 2)));
+        assert_eq!(router.peek_session("sess-peek"), Some(worker(7, 2)));
 
         let entry = map.get("sess-peek").unwrap();
         assert_eq!(entry.expires_at, expires_at);
@@ -397,11 +330,10 @@ mod tests {
             on_expire: None,
         };
         let router = StickySessionRouter::new(store);
-        router.bind("sess-1", worker(1, 0), Duration::from_secs(10));
+        router.bind_engine_session("sess-1", worker(1, 0), Duration::from_secs(10));
         router.bind_router_only("sess-1", worker(2, 3), Duration::from_secs(90));
 
-        let req = make_request(Some("sess-1"));
-        assert_eq!(router.peek(&req), Some(worker(2, 3)));
+        assert_eq!(router.peek_session("sess-1"), Some(worker(2, 3)));
 
         let entry = map.get("sess-1").unwrap();
         assert_eq!(entry.worker, worker(2, 3));
@@ -417,7 +349,7 @@ mod tests {
             on_expire: None,
         };
         let router = StickySessionRouter::new(store);
-        router.bind("sess-1", worker(42, 1), Duration::from_secs(300));
+        router.bind_engine_session("sess-1", worker(42, 1), Duration::from_secs(300));
         assert_eq!(
             router.unbind("sess-1"),
             Some(AffinityBinding {
@@ -426,8 +358,7 @@ mod tests {
             })
         );
 
-        let req = make_request(Some("sess-1"));
-        assert!(router.resolve(&req).is_none());
+        assert!(router.resolve_session("sess-1").is_none());
     }
 
     #[test]
@@ -448,8 +379,7 @@ mod tests {
         );
         let router = StickySessionRouter::new(store);
 
-        let req = make_request(Some("sess-expired"));
-        assert!(router.resolve(&req).is_none());
+        assert!(router.resolve_session("sess-expired").is_none());
         // Entry should be cleaned up
         assert!(router.store.peek("sess-expired").is_none());
     }
@@ -474,8 +404,7 @@ mod tests {
         };
         let router = StickySessionRouter::new(store);
 
-        let req = make_request(Some("sess-refresh"));
-        assert_eq!(router.resolve(&req), Some(worker(7, 2)));
+        assert_eq!(router.resolve_session("sess-refresh"), Some(worker(7, 2)));
 
         // After resolve, expires_at should be refreshed to now + ttl (60s),
         // so it should be at least 50s from now (not the original 5s).
@@ -514,8 +443,7 @@ mod tests {
         );
         let router = StickySessionRouter::new(store);
 
-        let req = make_request(Some("sess-expired"));
-        assert!(router.resolve(&req).is_none());
+        assert!(router.resolve_session("sess-expired").is_none());
         assert_eq!(
             expired_sessions.lock().unwrap().as_slice(),
             &[("sess-expired".to_string(), 99)]
@@ -549,8 +477,7 @@ mod tests {
         );
         let router = StickySessionRouter::new(store);
 
-        let req = make_request(Some("sess-router-only"));
-        assert!(router.resolve(&req).is_none());
+        assert!(router.resolve_session("sess-router-only").is_none());
         assert!(expired_sessions.lock().unwrap().is_empty());
     }
 


### PR DESCRIPTION
Refactors KV-router sticky session handling into a coordinator module and clearer sticky lifecycle/router boundaries. This keeps behavior unchanged while removing the old agent-oriented naming.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked sticky session routing into a coordinator + lifecycle controller for clearer session management.
  * Simplified and unified sticky-worker selection and binding pathways.
  * Cleaned up scheduler inputs by removing obsolete cached-token field.

* **Behavior**
  * Stricter handling of pinned-worker selection to reject ambiguous pins instead of falling back.
  * Session open/close and deferred-close handling improved for more reliable lifecycle control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->