### PR TITLE
fix(trtllm): skip NIXL initialization in aggregated mode (#9501)

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -436,8 +436,31 @@ async def init_llm_worker(
         default_sampling_params.detokenize = False
 
     connector = None
-    logging.info("Initializing NIXL Connect.")
-    connector = nixl_connect.Connector()
+    needs_nixl = config.disaggregation_mode != DisaggregationMode.AGGREGATED or (
+        config.modality == Modality.MULTIMODAL
+        and (
+            config.frontend_decoding
+            or config.disaggregation_mode == DisaggregationMode.ENCODE
+            or (
+                config.disaggregation_mode == DisaggregationMode.PREFILL
+                and bool(config.encode_endpoint)
+            )
+        )
+    )
+    if needs_nixl:
+        try:
+            logging.info("Initializing NIXL Connect.")
+            connector = nixl_connect.Connector()
+            await connector._create_connection()
+        except Exception:
+            logging.warning(
+                "Failed to initialize NIXL Connect; "
+                "KV-cache transfer will be unavailable.",
+                exc_info=True,
+            )
+            connector = None
+    else:
+        logging.info("Skipping NIXL Connect initialization (aggregated mode).")
 
     dump_config(
         config.dump_config_to, {"engine_args": engine_args, "dynamo_args": config}


### PR DESCRIPTION
## Summary
- Cherry-pick of #9501 to `release/1.2.0`.
- Skips `nixl_connect.Connector()` creation in AGGREGATED mode (never used for KV-cache transfer in single-node deployments) and wraps disaggregated-mode NIXL init in try/except with an eager `_create_connection()` probe so failures (e.g. no IB/RDMA hardware) surface at init with a warning instead of crashing on first request.
- Fixes #4734.

## Original PR
- Main PR: #9501
- Merge commit: `870eb9fc4890cd68f239302ba9209040920ff34c`

## Cherry-pick notes
- Clean cherry-pick — no conflicts. Single file (`components/src/dynamo/trtllm/workers/llm_worker.py`), +25/-2, identical to upstream.

## Test plan
- [ ] CI passes on `release/1.2.0`
- [ ] PREFILL mode + `UCX_TLS=rc,dc` (no IB): warning logged, `connector=None`, worker continues (verified upstream)
- [ ] AGGREGATED mode: no `Connector()` created (verified upstream)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->