### PR TITLE
fix(examples): enable block_reuse + cuda_graph in qwen2-vl-7b agg config (#9942)

### DIFF
--- a/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/agg.yaml
+++ b/examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/agg.yaml
@@ -23,10 +23,22 @@ enable_chunked_prefill: true
 
 kv_cache_config:
   free_gpu_memory_fraction: 0.3
-  enable_block_reuse: false
+  # Enable prefix-block reuse to match `trtllm-serve`'s default. Without this,
+  # repeated multimodal requests re-prefill the visual tokens every time and
+  # TTFT is dominated by vision-encoder + LLM-prefill cost on every request.
+  # See https://github.com/ai-dynamo/dynamo/issues/5086 for the measured impact.
+  enable_block_reuse: true
 
 cache_transceiver_config:
   backend: DEFAULT
+
+# Capture CUDA graphs for steady-state prefill/decode kernels. Required to
+# amortize per-launch overhead; without this, enabling `enable_block_reuse`
+# alone is pathological (cache-management work pays on every cold launch and
+# never recoups).
+cuda_graph_config:
+  max_batch_size: 8
+
 # NOTE: pytorch_backend_config section flattened since: https://github.com/NVIDIA/TensorRT-LLM/pull/4603
 # NOTE: overlap_scheduler enabled by default since this commit and changed
 # config field from 'enable_overlap_scheduler' to 'disable_overlap_scheduler':


### PR DESCRIPTION
## Summary
- Cherry-pick of #9942 to `release/1.2.0`.
- Aligns the qwen2-vl-7b-instruct aggregated engine config with `trtllm-serve`'s defaults: enables `kv_cache_config.enable_block_reuse: true` and adds `cuda_graph_config: { max_batch_size: 8 }`.
- Closes the +682 ms TTFT gap vs `trtllm-serve` on the same H100x4 / TP=4 workload (measured 5778 ms → 5590 ms, slightly faster than upstream).
- Fixes #5086.

## Original PR
- Main PR: #9942
- Merge commit: `936d64f4e9acad327fe88b7158e1515cf9eaacb0`

## Cherry-pick notes
- Clean cherry-pick — no conflicts. Single file (`examples/backends/trtllm/engine_configs/qwen2-vl-7b-instruct/agg.yaml`), +13/-1, identical to upstream.

## Test plan
- [ ] CI passes on `release/1.2.0`
- [ ] TTFT measurement on H100x4 / TP=4 with the reporter's payload reproduces the closed gap (verified upstream)

## Caveats
- The `enable_block_reuse` ↔ `cuda_graph_config` interaction (block_reuse alone causes a 1.6× slowdown without CUDA graphs) is worth a separate look as a Dynamo bug. Out of scope for this cherry-pick; this is a docs/example fix.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->