### PR TITLE
Add SGLang metadata upload support

### DIFF
--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -45,6 +45,7 @@ class GenerateRequest(TypedDict, total=False):
     output_options: dict[str, Any]
     prefill_result: dict[str, Any]
     bootstrap_info: dict[str, Any]
+    extra_args: dict[str, Any]
 
 
 class GenerateChunk(TypedDict, total=False):
@@ -62,6 +63,7 @@ class GenerateChunk(TypedDict, total=False):
     finish_reason: str
     completion_usage: dict[str, int]
     disaggregated_params: dict[str, Any]
+    engine_data: dict[str, Any]
 
 
 @dataclass

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -21,6 +21,7 @@ from dynamo._internal import ModelDeploymentCard
 from dynamo.frontend.frontend_args import FrontendConfig
 from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
 from dynamo.llm.exceptions import InvalidArgument, Unknown
+from dynamo.sglang.metadata_upload import metadata_upload_requested
 
 from .sglang_prepost import (
     SglangStreamingPostProcessor,
@@ -249,6 +250,15 @@ def _build_dynamo_preproc(
     mm_data = extract_mm_urls(request.get("messages", []))
     if mm_data:
         preproc["multi_modal_data"] = mm_data
+
+    nvext = request.get("nvext")
+    if isinstance(nvext, dict):
+        nvext_passthrough: dict[str, Any] = {}
+        for key in ("metadata_upload", "extra_fields"):
+            if key in nvext:
+                nvext_passthrough[key] = nvext[key]
+        if nvext_passthrough:
+            preproc["extra_args"] = {"nvext": nvext_passthrough}
 
     return preproc
 
@@ -512,6 +522,7 @@ class SglangProcessor:
 
                 if usage := engine_response.get("completion_usage"):
                     pending_usage = usage
+                engine_data = engine_response.get("engine_data")
 
                 pending_token_ids.extend(new_ids)
 
@@ -544,10 +555,18 @@ class SglangProcessor:
                         }
                         if pending_usage:
                             dynamo_out["usage"] = pending_usage
+                        response_nvext: dict[str, Any] = {}
                         if stop_reason is not None and nvext_extra_field_requested(
                             request, "stop_reason"
                         ):
-                            dynamo_out["nvext"] = {"stop_reason": stop_reason}
+                            response_nvext["stop_reason"] = stop_reason
+                        if engine_data is not None and (
+                            nvext_extra_field_requested(request, "engine_data")
+                            or metadata_upload_requested(request)
+                        ):
+                            response_nvext["engine_data"] = engine_data
+                        if response_nvext:
+                            dynamo_out["nvext"] = response_nvext
 
                         yield dynamo_out
 

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -249,6 +249,31 @@ class TestBuildDynamoPreproc:  # FRONTEND.7 — worker subprocess preproc constr
         )
         assert result["output_options"]["logprobs"] is None
 
+    def test_metadata_upload_nvext_is_forwarded_to_backend(self):
+        result = _build_dynamo_preproc(
+            {
+                "model": "test",
+                "nvext": {
+                    "metadata_upload": {
+                        "s3_url": "s3://bucket/root",
+                        "s3_path": "rollouts",
+                        "request_id": "rollout-7",
+                    },
+                    "extra_fields": ["engine_data"],
+                },
+            },
+            [1],
+            "test",
+            None,
+        )
+
+        assert result["extra_args"]["nvext"]["metadata_upload"] == {
+            "s3_url": "s3://bucket/root",
+            "s3_path": "rollouts",
+            "request_id": "rollout-7",
+        }
+        assert result["extra_args"]["nvext"]["extra_fields"] == ["engine_data"]
+
     def test_model_name_and_token_ids(self):
         """Model name and token_ids are set correctly."""
         result = _build_dynamo_preproc(

--- a/components/src/dynamo/sglang/metadata_upload.py
+++ b/components/src/dynamo/sglang/metadata_upload.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dynamo._core import Context
+
+_SAFE_PATH_COMPONENT_RE = re.compile(r"[^A-Za-z0-9._=-]+")
+
+
+def _as_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _first_str(raw: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = _as_str(raw.get(key))
+        if value is not None:
+            return value.strip()
+    return None
+
+
+def _request_scopes(request: dict[str, Any]):
+    yield request
+    nvext = request.get("nvext")
+    if isinstance(nvext, dict):
+        yield nvext
+
+    extra_args = request.get("extra_args")
+    if isinstance(extra_args, dict):
+        yield extra_args
+
+        extra_nvext = extra_args.get("nvext")
+        if isinstance(extra_nvext, dict):
+            yield extra_nvext
+
+
+def _find_upload_config(request: dict[str, Any]) -> dict[str, Any] | None:
+    for scope in _request_scopes(request):
+        candidate = scope.get("metadata_upload")
+        if isinstance(candidate, dict):
+            return candidate
+    return None
+
+
+def _find_request_id(request: dict[str, Any]) -> str | None:
+    for scope in _request_scopes(request):
+        request_id = _first_str(scope, "request_id", "x_request_id", "id")
+        if request_id is not None:
+            return request_id
+    return None
+
+
+def _sanitize_path_component(value: str, default: str = "unknown") -> str:
+    sanitized = _SAFE_PATH_COMPONENT_RE.sub("_", value.strip())
+    sanitized = sanitized.strip("._-/")
+    return sanitized[:160] or default
+
+
+def _join_storage_path(*parts: str | None) -> str:
+    cleaned = [part.strip("/") for part in parts if part and part.strip("/")]
+    return "/".join(cleaned)
+
+
+def _sanitize_storage_prefix(value: str) -> str:
+    return "/".join(
+        _sanitize_path_component(part)
+        for part in value.split("/")
+        if part.strip() and part.strip() not in (".", "..")
+    )
+
+
+def _context_request_id(context: "Context") -> str | None:
+    try:
+        headers = context.trace_headers()
+    except Exception:
+        headers = None
+
+    if isinstance(headers, dict):
+        for key in ("x-request-id", "request-id"):
+            value = _as_str(headers.get(key))
+            if value is not None:
+                return value
+
+    try:
+        return _as_str(context.id())
+    except Exception:
+        return None
+
+
+async def _upload_bytes(fs_url: str, storage_path: str, data: bytes) -> str:
+    try:
+        from dynamo.common.storage import get_fs, upload_to_fs
+    except ImportError as exc:
+        raise RuntimeError(
+            "SGLang metadata upload requires fsspec support. "
+            "Install fsspec and the backend extra, for example `fsspec[s3]` for S3."
+        ) from exc
+
+    return await upload_to_fs(get_fs(fs_url), storage_path, data)
+
+
+def _serialize_zstd_json(payload: dict[str, Any]) -> bytes:
+    try:
+        import zstandard as zstd
+    except ImportError as exc:
+        raise RuntimeError(
+            "SGLang metadata upload requires zstandard. "
+            "Install ai-dynamo[sglang] or add the zstandard package."
+        ) from exc
+
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+    try:
+        return zstd.ZstdCompressor().compress(raw)
+    finally:
+        del raw
+
+
+@dataclass(frozen=True)
+class MetadataUploadConfig:
+    fs_url: str
+    base_path: str = ""
+    request_id: str | None = None
+
+    @classmethod
+    def from_request(cls, request: dict[str, Any]) -> MetadataUploadConfig | None:
+        raw = _find_upload_config(request)
+        if raw is None:
+            return None
+        if raw.get("enabled") is False:
+            return None
+
+        fs_url = _first_str(raw, "s3_url", "fs_url", "url")
+        if fs_url is None:
+            return None
+
+        return cls(
+            fs_url=fs_url,
+            base_path=_sanitize_storage_prefix(
+                _first_str(raw, "s3_path", "path", "prefix") or ""
+            ),
+            request_id=_first_str(raw, "request_id", "x_request_id", "id")
+            or _find_request_id(request),
+        )
+
+    def uploader_for_context(self, context: "Context") -> MetadataUploader:
+        request_id = self.request_id or _context_request_id(context) or "unknown"
+        try:
+            context_id = _as_str(context.id())
+        except Exception:
+            context_id = None
+        return MetadataUploader(
+            fs_url=self.fs_url,
+            base_path=self.base_path,
+            request_id=_sanitize_path_component(request_id),
+            context_id=context_id,
+        )
+
+
+@dataclass
+class ChoiceMetadata:
+    choice_index: int
+    sglang_request_id: str | None = None
+    log_probs: list[float] = field(default_factory=list)
+    top_logprobs: list[list[dict[str, Any]]] = field(default_factory=list)
+    routed_experts: Any = None
+
+    def add_logprobs(
+        self,
+        log_probs: list[float] | None,
+        top_logprobs: list[list[dict[str, Any]]] | None,
+    ) -> None:
+        if log_probs:
+            self.log_probs.extend(log_probs)
+        if top_logprobs:
+            self.top_logprobs.extend(top_logprobs)
+
+    def has_payload(self) -> bool:
+        return bool(
+            self.log_probs or self.top_logprobs or self.routed_experts is not None
+        )
+
+    def release_payload(self) -> None:
+        self.log_probs.clear()
+        self.top_logprobs.clear()
+        self.routed_experts = None
+
+    def to_payload(self, request_id: str, context_id: str | None) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        if self.log_probs:
+            metadata["log_probs"] = self.log_probs
+        if self.top_logprobs:
+            metadata["top_logprobs"] = self.top_logprobs
+        if self.routed_experts is not None:
+            metadata["routed_experts"] = self.routed_experts
+
+        return {
+            "schema_version": 1,
+            "request_id": request_id,
+            "context_id": context_id,
+            "choice_index": self.choice_index,
+            "sglang_request_id": self.sglang_request_id,
+            "metadata": metadata,
+        }
+
+
+@dataclass(frozen=True)
+class MetadataUploader:
+    fs_url: str
+    base_path: str
+    request_id: str
+    context_id: str | None = None
+
+    def storage_path_for_choice(self, choice_index: int) -> str:
+        choice_name = f"choice_{choice_index}.json.zst"
+        return _join_storage_path(self.base_path, self.request_id, choice_name)
+
+    async def upload_choice(self, choice: ChoiceMetadata) -> dict[str, Any] | None:
+        if not choice.has_payload():
+            return None
+
+        storage_path = self.storage_path_for_choice(choice.choice_index)
+        payload = choice.to_payload(self.request_id, self.context_id)
+        data = await asyncio.to_thread(_serialize_zstd_json, payload)
+        try:
+            url = await _upload_bytes(self.fs_url, storage_path, data)
+        finally:
+            del data
+            del payload
+        return {
+            "url": url,
+            "path": storage_path,
+            "request_id": self.request_id,
+            "choice_index": choice.choice_index,
+            "compression": "zstd",
+        }
+
+
+def metadata_upload_requested(request: dict[str, Any]) -> bool:
+    raw = _find_upload_config(request)
+    return (
+        raw is not None
+        and raw.get("enabled") is not False
+        and _first_str(raw, "s3_url", "fs_url", "url") is not None
+    )

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -18,6 +18,11 @@ from dynamo.sglang._compat import filter_supported_async_generate_kwargs
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+from dynamo.sglang.metadata_upload import (
+    ChoiceMetadata,
+    MetadataUploadConfig,
+    MetadataUploader,
+)
 
 # Escape hatch: set to "1" (or any truthy value) to allow top_logprobs_num >= 1.
 # Default-off because SGLang's tokenizer manager detokenizes top-k tokens
@@ -64,11 +69,21 @@ def _extract_media_urls(mm_data: Dict[str, Any], media_key: str) -> list[str] | 
 def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
     nvext = request.get("nvext")
     if not isinstance(nvext, dict):
+        extra_args = request.get("extra_args")
+        if isinstance(extra_args, dict):
+            nvext = extra_args.get("nvext")
+    if not isinstance(nvext, dict):
         return False
     extra_fields = nvext.get("extra_fields")
     if not isinstance(extra_fields, list):
         return False
     return field in extra_fields
+
+
+def _release_large_meta_info_refs(meta_info: dict[str, Any]) -> None:
+    meta_info.pop("output_token_logprobs", None)
+    meta_info.pop("output_top_logprobs", None)
+    meta_info.pop("routed_experts", None)
 
 
 def _user_stop_token_ids(request: Dict[str, Any]) -> set[int]:
@@ -433,6 +448,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         input_param = self._get_input_param(request)
         priority = (request.get("routing") or {}).get("priority")
         logprob_kwargs = self._build_logprob_kwargs(request)
+        metadata_upload_config = MetadataUploadConfig.from_request(request)
+        metadata_uploader = (
+            metadata_upload_config.uploader_for_context(context)
+            if metadata_upload_config is not None
+            else None
+        )
 
         output_options = request.get("output_options", {})
         return_tokens_as_token_ids = bool(
@@ -489,6 +510,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    metadata_uploader=metadata_uploader,
                 ):
                     yield out
             else:
@@ -497,6 +519,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     request=request,
                     user_stop_token_ids=user_stop_token_ids,
+                    metadata_uploader=metadata_uploader,
                 ):
                     yield out
         else:
@@ -546,6 +569,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    metadata_uploader=metadata_uploader,
                 ):
                     yield out
             else:
@@ -554,6 +578,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     request=request,
                     user_stop_token_ids=user_stop_token_ids,
+                    metadata_uploader=metadata_uploader,
                 ):
                     yield out
 
@@ -563,6 +588,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         context: Context,
         return_tokens_as_token_ids: bool = False,
         user_stop_token_ids: set[int] | None = None,
+        metadata_uploader: MetadataUploader | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
 
@@ -583,11 +609,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # With n>1, chunks for different choices are interleaved, so track the
         # cumulative-logprob cursor per choice index instead of globally.
         output_logprobs_per_choice: dict[int, int] = {}
+        metadata_per_choice: dict[int, ChoiceMetadata] | None = (
+            {} if metadata_uploader is not None else None
+        )
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
+                meta_info = res.get("meta_info", {})
                 # Extract SGLang request ID from the first response and set the future
                 if not request_id_future.done():
-                    meta_info = res.get("meta_info", {})
                     sglang_request_id = meta_info.get("id")
                     if sglang_request_id:
                         request_id_future.set_result(sglang_request_id)
@@ -600,8 +629,17 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # SGLang omits index for non-n/legacy chunks; treat those as
                 # choice 0 while preserving explicit indices for n>1.
                 output_idx = res.get("index") or 0
+                choice_metadata = None
+                if metadata_per_choice is not None:
+                    choice_metadata = metadata_per_choice.setdefault(
+                        output_idx, ChoiceMetadata(choice_index=output_idx)
+                    )
+                    sglang_request_id = meta_info.get("id")
+                    if isinstance(sglang_request_id, str):
+                        choice_metadata.sglang_request_id = sglang_request_id
+
                 out: dict[str, Any] = {"index": output_idx}
-                finish_reason = res["meta_info"]["finish_reason"]
+                finish_reason = meta_info["finish_reason"]
                 if finish_reason:
                     out["finish_reason"] = normalize_finish_reason(
                         finish_reason["type"]
@@ -630,24 +668,31 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     top_logprobs,
                     next_logprobs_total,
                 ) = self._extract_logprobs(
-                    res["meta_info"],
+                    meta_info,
                     output_logprobs_per_choice.get(output_idx, 0),
                     return_tokens_as_token_ids=return_tokens_as_token_ids,
                 )
                 output_logprobs_per_choice[output_idx] = next_logprobs_total
-                if log_probs is not None:
+                if choice_metadata is not None:
+                    choice_metadata.add_logprobs(log_probs, top_logprobs)
+                elif log_probs is not None:
                     out["log_probs"] = log_probs
-                if top_logprobs is not None:
+                if choice_metadata is None and top_logprobs is not None:
                     out["top_logprobs"] = top_logprobs
 
-                routed_experts = res["meta_info"].get("routed_experts")
+                routed_experts = meta_info.get("routed_experts")
                 if routed_experts is not None:
-                    # sglang >= 0.5.11 base64-encodes routed_experts upstream.
-                    out["disaggregated_params"] = {"routed_experts": routed_experts}
+                    if choice_metadata is not None:
+                        choice_metadata.routed_experts = routed_experts
+                    else:
+                        # sglang >= 0.5.11 base64-encodes routed_experts upstream.
+                        out["disaggregated_params"] = {
+                            "routed_experts": routed_experts
+                        }
                 if finish_reason:
-                    input_tokens = res["meta_info"]["prompt_tokens"]
-                    completion_tokens = res["meta_info"]["completion_tokens"]
-                    cached_tokens = res["meta_info"]["cached_tokens"]
+                    input_tokens = meta_info["prompt_tokens"]
+                    completion_tokens = meta_info["completion_tokens"]
+                    cached_tokens = meta_info["cached_tokens"]
                     prefill_prompt_tokens_details = None
                     if cached_tokens is not None and cached_tokens > 0:
                         prefill_prompt_tokens_details = {"cached_tokens": cached_tokens}
@@ -657,6 +702,30 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         "total_tokens": input_tokens + completion_tokens,
                         "prompt_tokens_details": prefill_prompt_tokens_details,
                     }
+                    if (
+                        metadata_uploader is not None
+                        and metadata_per_choice is not None
+                        and choice_metadata is not None
+                    ):
+                        try:
+                            metadata_ref = await metadata_uploader.upload_choice(
+                                choice_metadata
+                            )
+                        finally:
+                            choice_metadata.release_payload()
+                            metadata_per_choice.pop(output_idx, None)
+                            output_logprobs_per_choice.pop(output_idx, None)
+                            _release_large_meta_info_refs(meta_info)
+                            log_probs = None
+                            top_logprobs = None
+                            routed_experts = None
+                        if metadata_ref is not None:
+                            out["engine_data"] = {"sglang_metadata": metadata_ref}
+                if metadata_uploader is not None:
+                    _release_large_meta_info_refs(meta_info)
+                    log_probs = None
+                    top_logprobs = None
+                    routed_experts = None
                 if not context.is_stopped():
                     yield out
 
@@ -666,6 +735,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         context: Context,
         request: Dict[str, Any] | None = None,
         user_stop_token_ids: set[int] | None = None,
+        metadata_uploader: MetadataUploader | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process text-based stream output in OpenAI format.
 
@@ -684,11 +754,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
+        metadata_per_choice: dict[int, ChoiceMetadata] | None = (
+            {} if metadata_uploader is not None else None
+        )
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
+                meta_info = res.get("meta_info", {})
                 # Extract SGLang request ID from the first response and set the future
                 if not request_id_future.done():
-                    meta_info = res.get("meta_info", {})
                     sglang_request_id = meta_info.get("id")
                     if sglang_request_id:
                         request_id_future.set_result(sglang_request_id)
@@ -701,9 +774,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
                 # Same defaulting as token mode: non-n chunks are choice 0.
                 index = res.get("index") or 0
+                choice_metadata = None
+                if metadata_per_choice is not None:
+                    choice_metadata = metadata_per_choice.setdefault(
+                        index, ChoiceMetadata(choice_index=index)
+                    )
+                    sglang_request_id = meta_info.get("id")
+                    if isinstance(sglang_request_id, str):
+                        choice_metadata.sglang_request_id = sglang_request_id
+
                 text = res.get("text", "")
 
-                finish_reason = res["meta_info"]["finish_reason"]
+                finish_reason = meta_info["finish_reason"]
                 finish_reason_type = (
                     normalize_finish_reason(finish_reason["type"])
                     if finish_reason
@@ -723,7 +805,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 )
 
                 response = {
-                    "id": res["meta_info"]["id"],
+                    "id": meta_info["id"],
                     "created": int(time.time()),
                     "choices": [choice_data],
                     "model": self.config.server_args.served_model_name,
@@ -734,10 +816,35 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     request, "stop_reason"
                 ):
                     response_nvext["stop_reason"] = stop_reason
-                routed_experts = res["meta_info"].get("routed_experts")
+                routed_experts = meta_info.get("routed_experts")
                 if routed_experts is not None:
-                    # sglang >= 0.5.11 base64-encodes routed_experts upstream.
-                    response_nvext["routed_experts"] = routed_experts
+                    if choice_metadata is not None:
+                        choice_metadata.routed_experts = routed_experts
+                    else:
+                        # sglang >= 0.5.11 base64-encodes routed_experts upstream.
+                        response_nvext["routed_experts"] = routed_experts
+                if (
+                    finish_reason
+                    and metadata_uploader is not None
+                    and metadata_per_choice is not None
+                    and choice_metadata is not None
+                ):
+                    try:
+                        metadata_ref = await metadata_uploader.upload_choice(
+                            choice_metadata
+                        )
+                    finally:
+                        choice_metadata.release_payload()
+                        metadata_per_choice.pop(index, None)
+                        _release_large_meta_info_refs(meta_info)
+                        routed_experts = None
+                    if metadata_ref is not None:
+                        response_nvext["engine_data"] = {
+                            "sglang_metadata": metadata_ref
+                        }
+                if metadata_uploader is not None:
+                    _release_large_meta_info_refs(meta_info)
+                    routed_experts = None
                 if response_nvext:
                     response["nvext"] = response_nvext
                 if not context.is_stopped():

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -14,6 +14,10 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     _openai_stop_sampling_params,
     _user_stop_token_ids,
 )
+from dynamo.sglang.metadata_upload import (
+    MetadataUploadConfig,
+    MetadataUploader,
+)
 from dynamo.sglang.request_handlers.multimodal.worker_handler import StreamProcessor
 
 pytestmark = [
@@ -23,6 +27,12 @@ pytestmark = [
     pytest.mark.profiled_vram_gib(0),
     pytest.mark.pre_merge,
 ]
+
+
+def _read_zstd_json(path):
+    import zstandard as zstd
+
+    return json.loads(zstd.ZstdDecompressor().decompress(path.read_bytes()))
 
 
 def test_extract_media_urls_supports_string_and_wire_items():
@@ -227,6 +237,27 @@ def test_extract_logprobs_formats_top_tokens_as_token_ids():
     assert total == 1
 
 
+def test_metadata_upload_config_parses_extra_args_nvext():
+    config = MetadataUploadConfig.from_request(
+        {
+            "extra_args": {
+                "request_id": "rollout-extra",
+                "nvext": {
+                    "metadata_upload": {
+                        "s3_url": "s3://bucket/root",
+                        "s3_path": "rollouts",
+                    }
+                }
+            }
+        }
+    )
+
+    assert config is not None
+    assert config.fs_url == "s3://bucket/root"
+    assert config.base_path == "rollouts"
+    assert config.request_id == "rollout-extra"
+
+
 @pytest.mark.asyncio
 async def test_process_token_stream_tracks_logprobs_per_choice_index():
     handler = _new_decode_handler()
@@ -274,6 +305,75 @@ async def test_process_token_stream_tracks_logprobs_per_choice_index():
     assert [chunk["index"] for chunk in chunks] == [0, 1, 0]
     assert [chunk["token_ids"] for chunk in chunks] == [[101], [201], [102]]
     assert [chunk["log_probs"] for chunk in chunks] == [[-0.1], [-0.2], [-0.3]]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_uploads_large_metadata(tmp_path):
+    handler = _new_decode_handler()
+    recorded = {}
+
+    class RecordingUploader(MetadataUploader):
+        async def upload_choice(self, choice):
+            recorded["choice"] = choice
+            return await super().upload_choice(choice)
+
+    uploader = RecordingUploader(
+        fs_url=tmp_path.as_uri(),
+        base_path="metadata",
+        request_id="rollout-7",
+        context_id="ctx-1",
+    )
+    meta_info = {
+        "id": "sglang-1",
+        "finish_reason": {"type": "stop"},
+        "output_token_logprobs": [(-0.1, 101, "a")],
+        "output_top_logprobs": [[(-0.1, 101, "a"), (-0.2, 102, "b")]],
+        "routed_experts": "base64-experts",
+        "prompt_tokens": 2,
+        "completion_tokens": 1,
+        "cached_tokens": 0,
+    }
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101],
+                        "meta_info": meta_info,
+                    }
+                ]
+            ),
+            _Context(),
+            metadata_uploader=uploader,
+        )
+    )
+
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert "log_probs" not in chunk
+    assert "top_logprobs" not in chunk
+    assert "disaggregated_params" not in chunk
+    metadata_ref = chunk["engine_data"]["sglang_metadata"]
+    assert metadata_ref["path"] == "metadata/rollout-7/choice_0.json.zst"
+    assert metadata_ref["compression"] == "zstd"
+
+    payload = _read_zstd_json(tmp_path / metadata_ref["path"])
+    assert payload["request_id"] == "rollout-7"
+    assert payload["context_id"] == "ctx-1"
+    assert payload["choice_index"] == 0
+    assert payload["sglang_request_id"] == "sglang-1"
+    assert payload["metadata"]["log_probs"] == [-0.1]
+    assert payload["metadata"]["top_logprobs"][0][1]["token_id"] == 102
+    assert payload["metadata"]["routed_experts"] == "base64-experts"
+    assert "output_token_logprobs" not in meta_info
+    assert "output_top_logprobs" not in meta_info
+    assert "routed_experts" not in meta_info
+
+    assert recorded["choice"].log_probs == []
+    assert recorded["choice"].top_logprobs == []
+    assert recorded["choice"].routed_experts is None
 
 
 @pytest.mark.asyncio
@@ -371,6 +471,46 @@ async def test_process_text_stream_stop_reason_requires_nvext_extra_field():
 
     assert "stop_reason" not in chunks[0]["choices"][0]
     assert "nvext" not in chunks[0]
+
+
+@pytest.mark.asyncio
+async def test_process_text_stream_uploads_routed_experts(tmp_path):
+    handler = _new_decode_handler(use_sglang_tokenizer=True)
+    uploader = MetadataUploader(
+        fs_url=tmp_path.as_uri(),
+        base_path="metadata",
+        request_id="rollout-8",
+        context_id="ctx-2",
+    )
+    meta_info = {
+        "id": "sglang-2",
+        "finish_reason": {"type": "stop"},
+        "routed_experts": "base64-experts",
+    }
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello",
+                        "meta_info": meta_info,
+                    }
+                ]
+            ),
+            _Context(),
+            metadata_uploader=uploader,
+        )
+    )
+
+    assert "routed_experts" not in chunks[0]["nvext"]
+    metadata_ref = chunks[0]["nvext"]["engine_data"]["sglang_metadata"]
+    assert metadata_ref["compression"] == "zstd"
+    payload = _read_zstd_json(tmp_path / metadata_ref["path"])
+    assert payload["request_id"] == "rollout-8"
+    assert payload["metadata"]["routed_experts"] == "base64-experts"
+    assert "routed_experts" not in meta_info
 
 
 @pytest.mark.asyncio

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -271,6 +271,12 @@ impl OpenAIPreprocessor {
             if let Some(ref salt) = nvext.cache_salt {
                 nvext_passthrough.insert("cache_salt".to_string(), serde_json::json!(salt));
             }
+            if let Some(ref metadata_upload) = nvext.metadata_upload {
+                nvext_passthrough.insert(
+                    "metadata_upload".to_string(),
+                    serde_json::json!(metadata_upload),
+                );
+            }
             if nvext.token_data.is_some() {
                 nvext_passthrough.insert("token_in".to_string(), serde_json::Value::Bool(true));
             }
@@ -2994,7 +3000,13 @@ mod tests {
             "bad_words_token_ids": [[12, 13]],
             "nvext": {
                 "cache_salt": "step_7",
-                "extra_fields": ["completion_token_ids"]
+                "extra_fields": ["completion_token_ids"],
+                "metadata_upload": {
+                    "enabled": true,
+                    "s3_url": "s3://bucket/root",
+                    "s3_path": "rollouts",
+                    "request_id": "rollout-7"
+                }
             }
         }))
         .unwrap();
@@ -3005,6 +3017,15 @@ mod tests {
         assert_eq!(
             extra_args["nvext"]["extra_fields"],
             serde_json::json!(["completion_token_ids"])
+        );
+        assert_eq!(
+            extra_args["nvext"]["metadata_upload"],
+            serde_json::json!({
+                "enabled": true,
+                "s3_url": "s3://bucket/root",
+                "s3_path": "rollouts",
+                "request_id": "rollout-7"
+            })
         );
         assert_eq!(extra_args["sampling_options"]["detokenize"], false);
         assert_eq!(

--- a/lib/llm/src/protocols/openai/nvext.rs
+++ b/lib/llm/src/protocols/openai/nvext.rs
@@ -232,6 +232,13 @@ impl NvExtResponseFieldSelection {
                 }
             }
         }
+        if ext
+            .metadata_upload
+            .as_ref()
+            .is_some_and(|upload| upload.enabled != Some(false))
+        {
+            selection.engine_data = true;
+        }
         if ext.has_query_instance_id_annotation() {
             selection.worker_id = true;
             selection.token_ids = true;
@@ -389,6 +396,28 @@ pub struct RoutingConstraintsSchema {
     pub preferred_taints: std::collections::HashMap<String, f32>,
 }
 
+/// Destination for large backend metadata uploaded out of band.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct MetadataUpload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s3_url: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fs_url: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s3_path: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
 /// NVIDIA LLM extensions to the OpenAI API
 #[derive(ToSchema, Serialize, Deserialize, Builder, Validate, Debug, Clone)]
 #[validate(schema(function = "validate_nv_ext"))]
@@ -455,6 +484,11 @@ pub struct NvExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub extra_fields: Option<Vec<String>>,
+
+    /// Upload large backend metadata and return a reference in `nvext.engine_data`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub metadata_upload: Option<MetadataUpload>,
 
     /// Targeted prefill worker ID for disaggregated serving (GAIE Stage 2)
     /// When set, the request will be routed to this specific prefill worker.
@@ -642,6 +676,7 @@ mod tests {
         assert_eq!(nv_ext.max_thinking_tokens, None);
         assert_eq!(nv_ext.cache_salt, None);
         assert_eq!(nv_ext.extra_fields, None);
+        assert_eq!(nv_ext.metadata_upload, None);
         assert_eq!(nv_ext.prefill_worker_id, None);
         assert_eq!(nv_ext.decode_worker_id, None);
         assert_eq!(nv_ext.agent_hints, None);
@@ -802,6 +837,32 @@ mod tests {
         assert!(!selection.timing);
         assert!(!selection.token_ids);
         assert!(selection.routed_experts);
+    }
+
+    #[test]
+    fn test_metadata_upload_selects_engine_data_unless_disabled() {
+        let nvext: NvExt = serde_json::from_value(serde_json::json!({
+            "metadata_upload": {
+                "s3_url": "s3://bucket/root",
+                "s3_path": "rollouts",
+                "request_id": "rollout-123"
+            }
+        }))
+        .unwrap();
+
+        let upload = nvext.metadata_upload.as_ref().unwrap();
+        assert_eq!(upload.s3_url.as_deref(), Some("s3://bucket/root"));
+        assert!(NvExtResponseFieldSelection::from_nvext(Some(&nvext)).engine_data);
+
+        let disabled: NvExt = serde_json::from_value(serde_json::json!({
+            "metadata_upload": {
+                "enabled": false,
+                "s3_url": "s3://bucket/root"
+            }
+        }))
+        .unwrap();
+
+        assert!(!NvExtResponseFieldSelection::from_nvext(Some(&disabled)).engine_data);
     }
 
     #[test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ sglang = [
     "accelerate>=0.17.0",
     "nixl[cu12]>=1.0.0,<1.1.0",
     "cupy-cuda12x>=13.0.0",
+    "zstandard>=0.23.0,<1.0",
 ]
 
 mocker = [


### PR DESCRIPTION
## Summary

Adds an opt-in SGLang metadata upload path for large RL-serving metadata such as routed expert captures and top-logprobs. When a request includes `nvext.metadata_upload`, the SGLang worker accumulates the large metadata out of band and uploads one final compressed object when the choice finishes. Incremental chunks continue streaming normally and do not upload per-token objects.

The response returns the uploaded object reference in `nvext.engine_data.sglang_metadata`.

## Request shape

```json
{
  "nvext": {
    "metadata_upload": {
      "s3_url": "s3://bucket/root",
      "s3_path": "rollouts/run-123",
      "request_id": "trajectory-456"
    }
  }
}
```

`metadata_upload.s3_url` is the storage root. `s3_path` is an optional prefix below that root. `request_id` scopes the object path; if omitted, the worker falls back to request/context identifiers.

Uploaded objects use:

```text
<s3_path>/<request_id>/choice_<index>.json.zst
```

The metadata reference includes `url`, `path`, `request_id`, `choice_index`, and `compression: "zstd"`.

## Payload

The decompressed JSON contains:

- `schema_version`
- `request_id`
- `context_id`
- `choice_index`
- `sglang_request_id`
- `metadata.log_probs`, when present
- `metadata.top_logprobs`, when present
- `metadata.routed_experts`, when present

This intentionally does not duplicate normal frontend token output, sampling config, model metadata, or timing telemetry.

## Implementation notes

- Upload happens only on final choice completion, not for every incremental response.
- Large SGLang `meta_info` fields are removed from the chunk once captured for upload.
- Accumulated choice payloads and serialized/compressed byte buffers are cleared after upload, including failure paths.
- Uses the existing `dynamo.common.storage` fsspec helper, so S3-compatible storage follows the same configuration path as other media storage.
- Adds `zstandard` to the SGLang optional dependency set for default `.json.zst` uploads.

## Validation

- Graham-style review pass run after implementation; follow-up fixes applied:
  - reused common storage helper instead of duplicating fsspec setup
  - made upload guards explicit in the stream handlers
  - avoided silently dropping Rust nvext metadata serialization
- `python -m py_compile components/src/dynamo/sglang/metadata_upload.py components/src/dynamo/sglang/request_handlers/llm/decode_handler.py components/src/dynamo/sglang/tests/test_sglang_decode_handler.py components/src/dynamo/frontend/sglang_processor.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py`
- `env PYTHONPATH=components/src /tmp/dynamo-sglang-e2e/bin/python -m pytest components/src/dynamo/sglang/tests/test_sglang_decode_handler.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py::TestBuildDynamoPreproc::test_metadata_upload_nvext_is_forwarded_to_backend -q`
- `cargo test -p dynamo-llm metadata_upload --no-default-features`
- `cargo test -p dynamo-llm test_backend_extra_args_preserves_nvext_and_sampling_extensions --no-default-features`
