### PR TITLE
feat(planner): expose SLA target metrics to Prometheus

### DIFF
--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -167,6 +167,8 @@ class NativePlannerBase:
                 )
             except Exception as e:
                 logger.error(f"Failed to start Prometheus metrics server: {e}")
+            self.prometheus_metrics.sla_target_ttft_ms.set(config.ttft_ms)
+            self.prometheus_metrics.sla_target_itl_ms.set(config.itl_ms)
 
         # Worker info (resolved during _async_init)
         self.prefill_worker_info = WorkerInfo()

--- a/components/src/dynamo/planner/monitoring/planner_metrics.py
+++ b/components/src/dynamo/planner/monitoring/planner_metrics.py
@@ -104,6 +104,16 @@ class PlannerPrometheusMetrics:
             "Cumulative GPU hours consumed",
         )
 
+        # -- SLA targets (static: set once at planner startup) ------------
+        self.sla_target_ttft_ms = Gauge(
+            f"{PREFIX}_sla_target_ttft_ms",
+            "Configured SLA target for time to first token (ms)",
+        )
+        self.sla_target_itl_ms = Gauge(
+            f"{PREFIX}_sla_target_itl_ms",
+            "Configured SLA target for inter-token latency (ms)",
+        )
+
         # -- Diagnostics: estimated latencies -----------------------------
         self.estimated_ttft_ms = Gauge(
             f"{PREFIX}_estimated_ttft_ms",

--- a/components/src/dynamo/planner/tests/unit/test_metric_publication.py
+++ b/components/src/dynamo/planner/tests/unit/test_metric_publication.py
@@ -17,7 +17,7 @@ Covers:
 """
 
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -29,6 +29,7 @@ from dynamo.planner.core.types import (
     TickInput,
     WorkerCounts,
 )
+from dynamo.planner.monitoring.planner_metrics import PREFIX, PlannerPrometheusMetrics
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -86,6 +87,7 @@ def _make_planner(prometheus_enabled: bool = True) -> NativePlannerBase:
 
 
 def _tick_input(now_s: float, num_p: int = 2, num_d: int = 3) -> TickInput:
+    """Build a TickInput with the given wall-clock time and worker counts."""
     return TickInput(
         now_s=now_s,
         worker_counts=WorkerCounts(ready_num_prefill=num_p, ready_num_decode=num_d),
@@ -100,6 +102,7 @@ class TestPublishInventoryAndGpuHours:
     whether the throughput-scaling path is enabled."""
 
     def test_replica_gauges_set_on_first_call(self):
+        """Prefill and decode replica gauges are written with current counts."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -109,6 +112,7 @@ class TestPublishInventoryAndGpuHours:
         pm.num_decode_replicas.set.assert_called_once_with(3)
 
     def test_first_call_contributes_zero_gpu_hours(self):
+        """First tick has no prior timestamp so the gpu_hours delta is zero."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -119,6 +123,7 @@ class TestPublishInventoryAndGpuHours:
         pm.gpu_hours.set.assert_called_once_with(0.0)
 
     def test_cumulative_gpu_hours_uses_wall_clock_delta(self):
+        """gpu_hours accumulates using wall-clock delta between ticks."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -132,6 +137,7 @@ class TestPublishInventoryAndGpuHours:
         pm.gpu_hours.set.assert_called_with(pytest.approx(0.8))
 
     def test_accumulates_across_multiple_ticks(self):
+        """gpu_hours increases monotonically across successive ticks."""
         planner = _make_planner()
         # Two 5-second ticks with 1 prefill + 1 decode worker each on single GPUs.
         planner.config.prefill_engine_num_gpu = 1
@@ -151,6 +157,7 @@ class TestPublishInventoryAndGpuHours:
         assert planner._cumulative_gpu_hours == pytest.approx(20.0 / 3600.0)
 
     def test_prometheus_disabled_still_accumulates_gpu_hours(self):
+        """gpu_hours accumulates internally even when Prometheus export is off."""
         # Prometheus export off, but the HTML recorder / live dashboard
         # still consumes _cumulative_gpu_hours, so accumulation must
         # continue. Only the gauge publishes should be skipped.
@@ -169,6 +176,7 @@ class TestPublishInventoryAndGpuHours:
         pm.gpu_hours.set.assert_not_called()
 
     def test_handles_none_worker_counts(self):
+        """No gauge writes when worker_counts is None (states not yet available)."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -186,6 +194,7 @@ class TestPublishInventoryAndGpuHours:
 def _diag(
     load_reason: str | None = None, throughput_reason: str | None = None
 ) -> TickDiagnostics:
+    """Build a TickDiagnostics with optional load/throughput decision reasons."""
     return TickDiagnostics(
         load_decision_reason=load_reason,
         throughput_decision_reason=throughput_reason,
@@ -193,6 +202,7 @@ def _diag(
 
 
 def _tick(run_load: bool, run_throughput: bool) -> ScheduledTick:
+    """Build a ScheduledTick with the given load/throughput scaling flags."""
     return ScheduledTick(
         at_s=0.0,
         run_load_scaling=run_load,
@@ -209,6 +219,7 @@ class TestReportDiagnosticsEnumGating:
     throughput Enum (and vice versa)."""
 
     def test_load_only_tick_does_not_touch_throughput_enum(self):
+        """A load-only tick writes the load Enum but leaves the throughput Enum untouched."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -247,6 +258,7 @@ class TestReportDiagnosticsEnumGating:
         )
 
     def test_throughput_only_tick_does_not_touch_load_enum(self):
+        """A throughput-only tick writes the throughput Enum but leaves the load Enum untouched."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -259,6 +271,7 @@ class TestReportDiagnosticsEnumGating:
         pm.load_scaling_decision.state.assert_not_called()
 
     def test_combined_tick_publishes_both(self):
+        """A tick with both paths enabled writes both Enum gauges."""
         planner = _make_planner()
         pm = planner.prometheus_metrics
 
@@ -271,6 +284,7 @@ class TestReportDiagnosticsEnumGating:
         pm.throughput_scaling_decision.state.assert_called_once_with("set_lower_bound")
 
     def test_run_tick_with_no_reason_still_writes_unset(self):
+        """A scaling path that ran without populating a reason writes 'unset'."""
         # Defensive: if a scaling path ran but didn't populate a reason,
         # explicitly write "unset" so stale state from a prior tick
         # doesn't linger.
@@ -283,6 +297,7 @@ class TestReportDiagnosticsEnumGating:
         pm.throughput_scaling_decision.state.assert_not_called()
 
     def test_skipped_when_prometheus_disabled(self):
+        """No Enum writes when prometheus_port=0."""
         planner = _make_planner(prometheus_enabled=False)
         pm = planner.prometheus_metrics
 
@@ -383,13 +398,6 @@ class TestPlannerPrometheusMetricsHasSlaTargetGauges:
 
     def test_metrics_object_has_sla_target_gauge_attributes(self):
         """Instance attributes sla_target_ttft_ms and sla_target_itl_ms must exist."""
-        from unittest.mock import MagicMock
-
-        from dynamo.planner.monitoring.planner_metrics import (
-            PREFIX,
-            PlannerPrometheusMetrics,
-        )
-
         with patch(
             "dynamo.planner.monitoring.planner_metrics.Gauge"
         ) as mock_gauge, patch("dynamo.planner.monitoring.planner_metrics.Enum"):

--- a/components/src/dynamo/planner/tests/unit/test_metric_publication.py
+++ b/components/src/dynamo/planner/tests/unit/test_metric_publication.py
@@ -10,6 +10,10 @@ Covers:
 - ``_report_diagnostics``: scaling-decision Enum gauges must only be
   written for the scaling path that actually ran this tick, so
   load-only ticks don't wipe the throughput Enum (and vice versa).
+- SLA target gauges (``sla_target_ttft_ms``, ``sla_target_itl_ms``):
+  must be written once at planner startup with the configured SLA
+  values so Grafana dashboards can compare observed/estimated latency
+  against the operator-defined target.
 """
 
 import os
@@ -289,3 +293,120 @@ class TestReportDiagnosticsEnumGating:
 
         pm.load_scaling_decision.state.assert_not_called()
         pm.throughput_scaling_decision.state.assert_not_called()
+
+
+# ── SLA target gauges: published once at __init__ ───────────────────
+
+
+def _make_planner_with_port(
+    ttft_ms: float = 500.0,
+    itl_ms: float = 50.0,
+    prometheus_enabled: bool = True,
+) -> NativePlannerBase:
+    """Build a NativePlannerBase with prometheus_port set at config time.
+
+    Unlike ``_make_planner``, this helper sets ``metric_reporting_prometheus_port``
+    in the PlannerConfig itself (not post-init) so that __init__-time Prometheus
+    publication — such as the one-shot SLA target gauge writes — is exercised.
+    ``start_http_server`` is still patched to avoid binding a real port.
+    """
+    port = 9091 if prometheus_enabled else 0
+    with patch(
+        "dynamo.planner.core.base.PlannerPrometheusMetrics"
+    ) as mock_metrics, patch("dynamo.planner.core.base.start_http_server"), patch(
+        "dynamo.planner.connectors.kubernetes.KubernetesAPI"
+    ), patch.dict(
+        os.environ, {"DYN_PARENT_DGD_K8S_NAME": "test-graph"}
+    ):
+        mock_metrics.return_value = Mock()
+        config = PlannerConfig.model_construct(
+            throughput_adjustment_interval_seconds=60,
+            prefill_engine_num_gpu=2,
+            decode_engine_num_gpu=4,
+            min_endpoint=1,
+            max_gpu_budget=-1,
+            ttft_ms=ttft_ms,
+            itl_ms=itl_ms,
+            backend="vllm",
+            no_operation=True,
+            metric_pulling_prometheus_endpoint="http://localhost:9090",
+            metric_reporting_prometheus_port=port,
+            load_predictor="constant",
+            environment="kubernetes",
+            namespace="test-namespace",
+            mode="disagg",
+            enable_load_scaling=True,
+            enable_throughput_scaling=True,
+            load_adjustment_interval_seconds=5,
+            max_num_fpm_samples=50,
+            fpm_sample_bucket_size=16,
+            load_scaling_down_sensitivity=80,
+            load_metric_samples=10,
+            load_min_observations=5,
+        )
+        planner = NativePlannerBase(None, config)
+    return planner
+
+
+class TestSlaTargetGaugesInit:
+    """sla_target_ttft_ms and sla_target_itl_ms must be published once
+    during NativePlannerBase.__init__ with the values from PlannerConfig."""
+
+    def test_sla_targets_set_at_init_with_default_config_values(self):
+        """Default config (ttft_ms=500, itl_ms=50) is pushed to Prometheus on startup."""
+        planner = _make_planner_with_port()
+        pm = planner.prometheus_metrics
+
+        pm.sla_target_ttft_ms.set.assert_called_once_with(500.0)
+        pm.sla_target_itl_ms.set.assert_called_once_with(50.0)
+
+    def test_sla_targets_not_set_when_prometheus_disabled(self):
+        """No gauge writes when prometheus_port=0 (Prometheus export disabled)."""
+        planner = _make_planner_with_port(prometheus_enabled=False)
+        pm = planner.prometheus_metrics
+
+        pm.sla_target_ttft_ms.set.assert_not_called()
+        pm.sla_target_itl_ms.set.assert_not_called()
+
+    def test_sla_targets_reflect_custom_config_values(self):
+        """Non-default SLA targets from PlannerConfig are passed through unchanged."""
+        planner = _make_planner_with_port(ttft_ms=1500.0, itl_ms=75.0)
+        pm = planner.prometheus_metrics
+
+        pm.sla_target_ttft_ms.set.assert_called_once_with(1500.0)
+        pm.sla_target_itl_ms.set.assert_called_once_with(75.0)
+
+
+class TestPlannerPrometheusMetricsHasSlaTargetGauges:
+    """PlannerPrometheusMetrics must declare sla_target_ttft_ms and
+    sla_target_itl_ms as Gauge attributes with the correct metric names."""
+
+    def test_metrics_object_has_sla_target_gauge_attributes(self):
+        """Instance attributes sla_target_ttft_ms and sla_target_itl_ms must exist."""
+        from unittest.mock import MagicMock
+
+        from dynamo.planner.monitoring.planner_metrics import (
+            PREFIX,
+            PlannerPrometheusMetrics,
+        )
+
+        with patch(
+            "dynamo.planner.monitoring.planner_metrics.Gauge"
+        ) as mock_gauge, patch("dynamo.planner.monitoring.planner_metrics.Enum"):
+            mock_gauge.return_value = MagicMock()
+            metrics = PlannerPrometheusMetrics()
+
+        assert hasattr(
+            metrics, "sla_target_ttft_ms"
+        ), "PlannerPrometheusMetrics is missing sla_target_ttft_ms attribute"
+        assert hasattr(
+            metrics, "sla_target_itl_ms"
+        ), "PlannerPrometheusMetrics is missing sla_target_itl_ms attribute"
+
+        registered_names = [call.args[0] for call in mock_gauge.call_args_list]
+        assert (
+            f"{PREFIX}_sla_target_ttft_ms" in registered_names
+        ), f"Expected Gauge name '{PREFIX}_sla_target_ttft_ms' not registered"
+        assert (
+            f"{PREFIX}_sla_target_itl_ms" in registered_names
+        ), f"Expected Gauge name '{PREFIX}_sla_target_itl_ms' not registered"


### PR DESCRIPTION
Add sla_target_ttft_ms and sla_target_itl_ms Gauges to
  PlannerPrometheusMetrics so that the configured SLA target values
  are visible alongside observed_ttft_ms / estimated_ttft_ms in
  Grafana dashboards.

  - planner_metrics.py: declare two new Gauge attributes
  - core/base.py: set gauges once at __init__ when Prometheus is enabled
  - test_metric_publication.py: add TestSlaTargetGaugesInit and TestPlannerPrometheusMetricsHasSlaTargetGauges test classes

#### Overview:

 The Dynamo planner already publishes four Prometheus metrics that reflect
  runtime behaviour:

  - `dynamo_planner_observed_ttft_ms` — measured time to first token
  - `dynamo_planner_observed_itl_ms` — measured inter-token latency
  - `dynamo_planner_estimated_ttft_ms` — regression-model estimate of TTFT
  - `dynamo_planner_estimated_itl_ms` — regression-model estimate of ITL

  However, the configured SLA target values (`ttft_ms` / `itl_ms` from
  `PlannerConfig`) were never exposed to Prometheus, making it impossible to
  visualise how close the system is to its SLA boundary in Grafana — you could
  see observed/estimated latency but had no reference line to compare against.

  This PR adds two new static Gauges that publish the operator-configured SLA
  targets once at planner startup, so dashboards and alert rules can directly
  compare observed/estimated latency against the intended SLA target.

#### Details:

  - **`monitoring/planner_metrics.py`**: declare `sla_target_ttft_ms` and
    grouped with the existing observed/estimated latency metrics.
  - **`core/base.py`**: set both gauges once inside `NativePlannerBase.__init__`
    when `prometheus_port != 0`, using `config.ttft_ms` and `config.itl_ms`.
    Both `ttft_ms` and `ttft` config aliases are handled transparently by
    Pydantic `AliasChoices` before this point.
  - **`tests/unit/test_metric_publication.py`**: add two new test classes —
    `TestSlaTargetGaugesInit` (verifies correct values are published at init,
    and skipped when Prometheus is disabled) and
    `TestPlannerPrometheusMetricsHasSlaTargetGauges` (verifies the Gauge
    attributes and metric names are declared on the class).

  Example PromQL to compare all three values side by side:
  ```promql
  dynamo_planner_sla_target_ttft_ms
  dynamo_planner_observed_ttft_ms
  dynamo_planner_estimated_ttft_ms
  ```
#### Where should the reviewer start?

  - monitoring/planner_metrics.py — new Gauge declarations (alongside
  existing observed_* and estimated_* latency metrics)
  - core/base.py lines ~160–170 — the two .set() calls added inside the
  if self.prometheus_port != 0 block
  - tests/unit/test_metric_publication.py — TestSlaTargetGaugesInit and
  TestPlannerPrometheusMetricsHasSlaTargetGauges at the bottom of the file

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

  - Relates to #9537 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish SLA target metrics for time-to-first-token and inter-token latency so dashboards can compare observed vs configured targets.

* **Tests**
  * Added tests covering one-time publication, registration, default/custom values, and behavior when Prometheus export is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->