### PR TITLE
feat(self-host): native preprocessor consumes resolved slug_dir (gh-8749)

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -623,8 +623,12 @@ class SglangEngineFactory:
             )
         loop = asyncio.get_running_loop()
 
-        # download_config already populated mdc.local_dir(); no refetch.
         local_dir = mdc.local_dir()
+        if not os.path.isdir(local_dir):
+            raise RuntimeError(
+                f"MDC local_dir {local_dir!r} not populated for model {mdc.name()!r}; "
+                f"download_config must run before the engine factory."
+            )
 
         logger.info("Loading SGLang tokenizer from %s", local_dir)
         tokenizer = _load_tokenizer(local_dir, self.trust_remote_code)

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -19,7 +19,7 @@ from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
 from dynamo._internal import ModelDeploymentCard
 from dynamo.frontend.frontend_args import FrontendConfig
-from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
+from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine
 from dynamo.llm.exceptions import InvalidArgument, Unknown
 
 from .sglang_prepost import (
@@ -623,12 +623,11 @@ class SglangEngineFactory:
             )
         loop = asyncio.get_running_loop()
 
-        # TODO(gh-8749): consume mdc.model_info.path()'s parent (slug_dir)
-        # instead of re-running fetch_model. The MDC cache already has
-        # blake3-verified copies; this path duplicates the download.
-        source_path = mdc.source_path()
-        if not os.path.exists(source_path):
-            source_path = await fetch_model(source_path, ignore_weights=True)
+        # download_config has already resolved every MDC file into
+        # mdc.local_dir() with blake3-verified copies (and harvested
+        # extra siblings — preprocessor_config.json, special_tokens_map.json,
+        # …). Point native-preprocessor mode at that dir directly.
+        source_path = mdc.local_dir()
 
         logger.info("Loading SGLang tokenizer from %s", source_path)
         tokenizer = _load_tokenizer(source_path, self.trust_remote_code)

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -623,14 +623,11 @@ class SglangEngineFactory:
             )
         loop = asyncio.get_running_loop()
 
-        # download_config has already resolved every MDC file into
-        # mdc.local_dir() with blake3-verified copies (and harvested
-        # extra siblings — preprocessor_config.json, special_tokens_map.json,
-        # …). Point native-preprocessor mode at that dir directly.
-        source_path = mdc.local_dir()
+        # download_config already populated mdc.local_dir(); no refetch.
+        local_dir = mdc.local_dir()
 
-        logger.info("Loading SGLang tokenizer from %s", source_path)
-        tokenizer = _load_tokenizer(source_path, self.trust_remote_code)
+        logger.info("Loading SGLang tokenizer from %s", local_dir)
+        tokenizer = _load_tokenizer(local_dir, self.trust_remote_code)
 
         eos_token_id = getattr(tokenizer, "eos_token_id", None)
 
@@ -661,13 +658,13 @@ class SglangEngineFactory:
             logger.info(
                 "Creating SGLang preprocess worker pool with %d workers for %s",
                 preprocess_workers,
-                source_path,
+                local_dir,
             )
             preprocess_pool = ProcessPoolExecutor(
                 max_workers=preprocess_workers,
                 initializer=_init_worker,
                 initargs=(
-                    source_path,
+                    local_dir,
                     tool_call_parser_name,
                     reasoning_parser_name,
                     self.config.exclude_tools_when_tool_choice_none,

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -771,8 +771,12 @@ class EngineFactory:
             )
         loop = asyncio.get_running_loop()
 
-        # download_config already populated mdc.local_dir(); no refetch.
         local_dir = mdc.local_dir()
+        if not os.path.isdir(local_dir):
+            raise RuntimeError(
+                f"MDC local_dir {local_dir!r} not populated for model {mdc.name()!r}; "
+                f"download_config must run before the engine factory."
+            )
 
         tokenizer_mode = getattr(self.flags, "tokenizer_mode", None) or "auto"
         config_format = getattr(self.flags, "config_format", None) or "auto"

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -771,11 +771,8 @@ class EngineFactory:
             )
         loop = asyncio.get_running_loop()
 
-        # download_config has already resolved every MDC file into
-        # mdc.local_dir() with blake3-verified copies (and harvested
-        # extra siblings — preprocessor_config.json, special_tokens_map.json,
-        # …). Point native-preprocessor mode at that dir directly.
-        source_path = mdc.local_dir()
+        # download_config already populated mdc.local_dir(); no refetch.
+        local_dir = mdc.local_dir()
 
         tokenizer_mode = getattr(self.flags, "tokenizer_mode", None) or "auto"
         config_format = getattr(self.flags, "config_format", None) or "auto"
@@ -784,7 +781,7 @@ class EngineFactory:
         enable_auto_tool_choice = getattr(self.flags, "enable_auto_tool_choice", False)
 
         model_config = ModelConfig(
-            model=source_path,
+            model=local_dir,
             tokenizer_mode=tokenizer_mode,
             config_format=config_format,
             trust_remote_code=trust_remote_code,
@@ -819,7 +816,7 @@ class EngineFactory:
         # vLLM's renderer skips its AutoProcessor fallback when tools are present,
         # so tool calls crash unless tokenizer.chat_template is set; load from disk.
         if tokenizer.chat_template is None:
-            tokenizer.chat_template = resolve_chat_template(source_path)
+            tokenizer.chat_template = resolve_chat_template(local_dir)
 
         # --chat-template overrides; load_chat_template accepts either a file path
         # or an inline Jinja template string.

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -36,7 +36,7 @@ from dynamo.common.multimodal.mm_kwargs_transfer import (
 from dynamo.common.multimodal.routing_utils import build_mm_routing_info_from_features
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.frontend.frontend_args import FrontendConfig
-from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
+from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine
 
 from .prepost import StreamingPostProcessor, preprocess_chat_request
 from .utils import (
@@ -771,12 +771,11 @@ class EngineFactory:
             )
         loop = asyncio.get_running_loop()
 
-        # TODO(gh-8749): consume mdc.model_info.path()'s parent (slug_dir)
-        # instead of re-running fetch_model. The MDC cache already has
-        # blake3-verified copies; this path duplicates the download.
-        source_path = mdc.source_path()
-        if not os.path.exists(source_path):
-            source_path = await fetch_model(source_path, ignore_weights=True)
+        # download_config has already resolved every MDC file into
+        # mdc.local_dir() with blake3-verified copies (and harvested
+        # extra siblings — preprocessor_config.json, special_tokens_map.json,
+        # …). Point native-preprocessor mode at that dir directly.
+        source_path = mdc.local_dir()
 
         tokenizer_mode = getattr(self.flags, "tokenizer_mode", None) or "auto"
         config_format = getattr(self.flags, "config_format", None) or "auto"

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -38,9 +38,13 @@ impl ModelDeploymentCard {
 
     /// Resolved metadata directory (post-`download_config`).
     fn local_dir(&self) -> PyResult<String> {
-        self.inner.local_dir().into_os_string().into_string().map_err(|os| {
-            PyValueError::new_err(format!("MDC local_dir contains non-UTF-8 bytes: {os:?}"))
-        })
+        self.inner
+            .local_dir()
+            .into_os_string()
+            .into_string()
+            .map_err(|os| {
+                PyValueError::new_err(format!("MDC local_dir contains non-UTF-8 bytes: {os:?}"))
+            })
     }
 
     fn name(&self) -> &str {

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use llm_rs::model_card::ModelDeploymentCard as RsModelDeploymentCard;
+use pyo3::exceptions::PyValueError;
 
 #[pyclass]
 #[derive(Clone)]
@@ -35,12 +36,17 @@ impl ModelDeploymentCard {
         self.inner.source_path()
     }
 
-    /// On-disk directory where the frontend's `download_config` pipeline
-    /// has resolved every typed file + harvested extra_file. Use this in
-    /// engine factories instead of re-running `fetch_model` against the
-    /// worker URI — the cache already has blake3-verified copies.
-    fn local_dir(&self) -> String {
-        self.inner.local_dir().to_string_lossy().into_owned()
+    /// Resolved metadata directory (post-`download_config`).
+    fn local_dir(&self) -> PyResult<String> {
+        self.inner
+            .local_dir()
+            .into_os_string()
+            .into_string()
+            .map_err(|os| {
+                PyValueError::new_err(format!(
+                    "MDC local_dir contains non-UTF-8 bytes: {os:?}"
+                ))
+            })
     }
 
     fn name(&self) -> &str {

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -35,6 +35,14 @@ impl ModelDeploymentCard {
         self.inner.source_path()
     }
 
+    /// On-disk directory where the frontend's `download_config` pipeline
+    /// has resolved every typed file + harvested extra_file. Use this in
+    /// engine factories instead of re-running `fetch_model` against the
+    /// worker URI — the cache already has blake3-verified copies.
+    fn local_dir(&self) -> String {
+        self.inner.local_dir().to_string_lossy().into_owned()
+    }
+
     fn name(&self) -> &str {
         self.inner.name()
     }

--- a/lib/bindings/python/rust/llm/model_card.rs
+++ b/lib/bindings/python/rust/llm/model_card.rs
@@ -38,15 +38,9 @@ impl ModelDeploymentCard {
 
     /// Resolved metadata directory (post-`download_config`).
     fn local_dir(&self) -> PyResult<String> {
-        self.inner
-            .local_dir()
-            .into_os_string()
-            .into_string()
-            .map_err(|os| {
-                PyValueError::new_err(format!(
-                    "MDC local_dir contains non-UTF-8 bytes: {os:?}"
-                ))
-            })
+        self.inner.local_dir().into_os_string().into_string().map_err(|os| {
+            PyValueError::new_err(format!("MDC local_dir contains non-UTF-8 bytes: {os:?}"))
+        })
     }
 
     fn name(&self) -> &str {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -713,6 +713,10 @@ class ModelDeploymentCard:
         ValueError if the path contains non-UTF-8 bytes."""
         ...
 
+    def name(self) -> str:
+        """Return the model name."""
+        ...
+
     def runtime_config(self) -> Any:
         """Return the runtime configuration as a dict."""
         ...

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -708,6 +708,12 @@ class ModelDeploymentCard:
         """Return the source path of this deployment card."""
         ...
 
+    def local_dir(self) -> str:
+        """Return the on-disk directory where this card's resolved metadata files
+        live (post-`download_config`). Use this in engine factories instead of
+        re-running `fetch_model` on the worker URI."""
+        ...
+
     def runtime_config(self) -> Any:
         """Return the runtime configuration as a dict."""
         ...

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -709,9 +709,8 @@ class ModelDeploymentCard:
         ...
 
     def local_dir(self) -> str:
-        """Return the on-disk directory where this card's resolved metadata files
-        live (post-`download_config`). Use this in engine factories instead of
-        re-running `fetch_model` on the worker URI."""
+        """Resolved metadata directory (post-`download_config`). Raises
+        ValueError if the path contains non-UTF-8 bytes."""
         ...
 
     def runtime_config(self) -> Any:

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -837,6 +837,20 @@ impl ModelDeploymentCard {
         Ok(serde_json::to_string(self)?)
     }
 
+    /// On-disk directory where this MDC's resolved metadata files
+    /// live. After `download_config` runs, this dir contains symlinks
+    /// to every typed file + harvested extra_file, ready for
+    /// `from_pretrained(local_dir)` consumers (native preprocessors,
+    /// tokenizer loaders). Pure path computation — does not create
+    /// the directory; callers needing it created should go through
+    /// the resolve pipeline.
+    pub fn local_dir(&self) -> PathBuf {
+        mdc_cache_root()
+            .join("by-slug")
+            .join(self.slug.to_string())
+            .join(self.mdcsum())
+    }
+
     pub fn mdcsum(&self) -> &str {
         self.checksum
             .get_or_init(|| {
@@ -2234,6 +2248,21 @@ mod tests {
             got,
             url::Url::from_file_path(&local_cfg).unwrap().to_string()
         );
+    }
+
+    #[test]
+    fn local_dir_matches_resolve_pipeline_path() {
+        // local_dir must compute the same path that resolve_metadata_files
+        // writes into, so vllm/sglang factories can use it directly
+        // instead of re-running fetch_model.
+        let card = super::ModelDeploymentCard::with_name_only("Qwen/Qwen3-0.6B");
+        let dir = card.local_dir();
+
+        let expected = super::mdc_cache_root()
+            .join("by-slug")
+            .join(card.slug().to_string())
+            .join(card.mdcsum());
+        assert_eq!(dir, expected);
     }
 
     /// Rung 4: when worker path is missing and `--model-path` doesn't

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -224,13 +224,20 @@ fn mdc_blobs_dir() -> anyhow::Result<PathBuf> {
     Ok(dir)
 }
 
-fn mdc_slug_dir(slug: &Slug, mdcsum: &str) -> anyhow::Result<PathBuf> {
-    let dir = mdc_cache_root()
+/// Per-MDC cache directory: `<root>/by-slug/<slug>/<mdcsum>/`.
+/// Pure path computation; use [`mdc_local_dir`] when you need the
+/// directory created.
+fn mdc_local_path(slug: &Slug, mdcsum: &str) -> PathBuf {
+    mdc_cache_root()
         .join("by-slug")
         .join(slug.to_string())
-        .join(mdcsum);
+        .join(mdcsum)
+}
+
+fn mdc_local_dir(slug: &Slug, mdcsum: &str) -> anyhow::Result<PathBuf> {
+    let dir = mdc_local_path(slug, mdcsum);
     std::fs::create_dir_all(&dir)
-        .with_context(|| format!("creating MDC slug dir {}", dir.display()))?;
+        .with_context(|| format!("creating MDC local dir {}", dir.display()))?;
     Ok(dir)
 }
 
@@ -350,9 +357,9 @@ fn file_uri_parent(uri: &str) -> Option<PathBuf> {
     parent.is_dir().then(|| parent.to_path_buf())
 }
 
-/// Symlink non-weight files from `snapshot_dir` into `slug_dir`. Picks up
+/// Symlink non-weight files from `snapshot_dir` into `local_dir`. Picks up
 /// `preprocessor_config.json` and other sibling files that
-/// `from_pretrained(slug_dir)` consumers need.
+/// `from_pretrained(local_dir)` consumers need.
 ///
 /// Names in `typed_filenames` are owned by the resolve loop's typed-slot
 /// pass — never overwritten. Every other harvested sibling is re-linked
@@ -361,7 +368,7 @@ fn file_uri_parent(uri: &str) -> Option<PathBuf> {
 /// cover harvested files).
 fn harvest_siblings(
     snapshot_dir: &Path,
-    slug_dir: &Path,
+    local_dir: &Path,
     typed_filenames: &std::collections::HashSet<String>,
 ) -> anyhow::Result<()> {
     let entries = match std::fs::read_dir(snapshot_dir) {
@@ -388,7 +395,7 @@ fn harvest_siblings(
         if typed_filenames.contains(&name) {
             continue;
         }
-        let dst = slug_dir.join(&name);
+        let dst = local_dir.join(&name);
         // Resolve through the canonical target so a downstream
         // `canonicalize` lands on a stable blob path rather than
         // chasing snapshot-dir symlinks. `symlink_force` is idempotent
@@ -399,7 +406,7 @@ fn harvest_siblings(
         tracing::debug!(
             file = %name,
             target = %target.display(),
-            "harvested sibling into slug_dir",
+            "harvested sibling into local_dir",
         );
     }
     Ok(())
@@ -837,18 +844,12 @@ impl ModelDeploymentCard {
         Ok(serde_json::to_string(self)?)
     }
 
-    /// On-disk directory where this MDC's resolved metadata files
-    /// live. After `download_config` runs, this dir contains symlinks
-    /// to every typed file + harvested extra_file, ready for
-    /// `from_pretrained(local_dir)` consumers (native preprocessors,
-    /// tokenizer loaders). Pure path computation — does not create
-    /// the directory; callers needing it created should go through
-    /// the resolve pipeline.
+    /// Per-MDC resolve directory. After `download_config` runs, every
+    /// typed slot + harvested sibling is symlinked here for
+    /// `from_pretrained(local_dir)` consumers. Pure path — does not
+    /// create the directory; the resolve pipeline owns that.
     pub fn local_dir(&self) -> PathBuf {
-        mdc_cache_root()
-            .join("by-slug")
-            .join(self.slug.to_string())
-            .join(self.mdcsum())
+        mdc_local_path(&self.slug, self.mdcsum())
     }
 
     pub fn mdcsum(&self) -> &str {
@@ -884,7 +885,7 @@ impl ModelDeploymentCard {
                 // (a) workers with identical siblings produce the same
                 // mdcsum regardless of `read_dir` order, and (b) the same
                 // bytes under different filenames don't collide — otherwise
-                // the frontend cache could serve a slug_dir missing siblings.
+                // the frontend cache could serve a local_dir missing siblings.
                 let mut extras: Vec<(&str, &str)> = self
                     .extra_files
                     .iter()
@@ -1243,7 +1244,7 @@ impl ModelDeploymentCard {
         let source = self.source_path().to_string();
         let mdcsum = self.mdcsum().to_string();
         let blobs = mdc_blobs_dir()?;
-        let slug_dir = mdc_slug_dir(&self.slug, &mdcsum)?;
+        let local_dir = mdc_local_dir(&self.slug, &mdcsum)?;
 
         let entries: Vec<(String, CheckedFile)> = self
             .iter_metadata_files()
@@ -1285,7 +1286,7 @@ impl ModelDeploymentCard {
             let blob = blobs.join(blake3_hex);
             tracing::debug!(filename = %filename, uri = %uri, blake3 = %blake3_hex, "resolving");
             resolve_uri(&client, uri, expected, &blob, &hf_snapshots).await?;
-            symlink_force(&blob, &slug_dir.join(&filename))?;
+            symlink_force(&blob, &local_dir.join(&filename))?;
         }
         tracing::debug!(
             display_name = %self.display_name,
@@ -1309,13 +1310,13 @@ impl ModelDeploymentCard {
             }
         }
         for snap in &snapshot_dirs {
-            harvest_siblings(snap, &slug_dir, &typed_filenames)?;
+            harvest_siblings(snap, &local_dir, &typed_filenames)?;
         }
 
         // Pass 3: rewrite cf.path to the cache symlink so downstream
         // tokenizer/config loaders read from a verified location.
         for (cf, _) in self.iter_metadata_files_mut() {
-            cf.update_dir(&slug_dir);
+            cf.update_dir(&local_dir);
         }
         Ok(())
     }
@@ -1963,7 +1964,7 @@ fn check_valid_local_repo_path(path: impl AsRef<Path>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::HFConfig;
+    use super::{HFConfig, ModelDeploymentCard};
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
 
@@ -2166,7 +2167,7 @@ mod tests {
 
             // Sibling harvest: TinyLlama_v1.1 fixture ships
             // `special_tokens_map.json` and `tokenizer.model` outside the
-            // typed slots — both must land in slug_dir for
+            // typed slots — both must land in local_dir for
             // `from_pretrained()` to see a complete model dir.
             assert!(snap.join("special_tokens_map.json").exists());
             assert!(snap.join("tokenizer.model").exists());
@@ -2194,7 +2195,7 @@ mod tests {
 
     /// Two MDCs with `extra_files` that share bytes but differ in basename
     /// must produce distinct mdcsums — otherwise the frontend cache would
-    /// alias them and a slug_dir built from one worker's harvest would be
+    /// alias them and a local_dir built from one worker's harvest would be
     /// reused for another worker that needs a differently-named sibling.
     #[test]
     fn mdcsum_extras_distinguish_basename_at_equal_checksum() {
@@ -2251,18 +2252,15 @@ mod tests {
     }
 
     #[test]
-    fn local_dir_matches_resolve_pipeline_path() {
-        // local_dir must compute the same path that resolve_metadata_files
-        // writes into, so vllm/sglang factories can use it directly
-        // instead of re-running fetch_model.
-        let card = super::ModelDeploymentCard::with_name_only("Qwen/Qwen3-0.6B");
-        let dir = card.local_dir();
-
-        let expected = super::mdc_cache_root()
-            .join("by-slug")
-            .join(card.slug().to_string())
-            .join(card.mdcsum());
-        assert_eq!(dir, expected);
+    fn local_dir_computes_expected_path() {
+        // Sentinel for cache-layout drift: the public `local_dir()` must
+        // stay in lockstep with `mdc_local_path`. Resolve-pipeline
+        // integration is covered by the vllm/sglang serve tests.
+        let card = ModelDeploymentCard::with_name_only("Qwen/Qwen3-0.6B");
+        assert_eq!(
+            card.local_dir(),
+            super::mdc_local_path(card.slug(), card.mdcsum())
+        );
     }
 
     /// Rung 4: when worker path is missing and `--model-path` doesn't
@@ -2377,7 +2375,7 @@ mod tests {
         let snap = tempfile::tempdir()?;
         let slug = tempfile::tempdir()?;
 
-        // Typed slot: blob in the dynamo cache; slug_dir links to it.
+        // Typed slot: blob in the dynamo cache; local_dir links to it.
         let typed_blob = blob_dir.path().join("config-blob");
         std::fs::write(&typed_blob, b"typed-slot-content")?;
         super::symlink_force(&typed_blob, &slug.path().join("config.json"))?;


### PR DESCRIPTION
#### Overview

vllm and sglang engine factories stop re-running `fetch_model` against the worker URI when initializing native preprocessor mode, and instead consume the already-resolved `slug_dir` that `download_config` populates on the frontend. This eliminates a redundant HF download on every model registration and is the natural follow-on to #9707 — the frontend now has every typed file plus harvested sibling (preprocessor_config.json, special_tokens_map.json, …) blake3-verified under `~/.cache/dynamo/mdc/by-slug/<slug>/<mdcsum>/`, so the native preprocessor just needs to be pointed at that directory.

#### Why now

#9610 + #9707 closed the multimodal-completeness gap by harvesting non-typed siblings on both the HF and self-host paths. The TODOs in `vllm_processor.py` and `sglang_processor.py` flagged the redundant `fetch_model` as the next thing to remove once that landed. This is the smallest remaining piece in the gh-8749 stack before the `DYN_SELF_HOST_METADATA` default-ON flip (#8754 capstone); it's also a prerequisite for that flip to be a no-op in latency terms.

#### Details

- `ModelDeploymentCard::local_dir() -> PathBuf` — pure path computation, returns the same path that `mdc_slug_dir(slug, mdcsum)` produces. No fs side effect (the resolve pipeline owns directory creation).
- Python binding `ModelDeploymentCard.local_dir() -> str` plus `.pyi` stub.
- vllm and sglang factories replace the `source_path = mdc.source_path(); if not exists: fetch_model(source_path, ignore_weights=True)` block with `source_path = mdc.local_dir()`. The unused `fetch_model` import is dropped in both.
- TensorBased models skip `download_config` and would have an empty `slug_dir`, but both factories already gate on `model_type.supports_chat()` at the top, which excludes them — no extra guard needed.

#### Test

Rust unit test (`model_card::tests::local_dir_matches_resolve_pipeline_path`) asserts the path produced by `local_dir()` matches what `resolve_metadata_files` writes into. The existing `tests/frontend/test_self_host_metadata.py` covers the worker HTTP route end; the factory consumer path is exercised by the real vllm/sglang serve tests in CI (`tests/serve/test_vllm.py`, `tests/serve/test_sglang.py`).

#### Out of scope

- Default-ON flip of `DYN_SELF_HOST_METADATA` — still gated on auto-detach-cleanup landing.
- Auto-detach-cleanup itself — separate follow-up; the `MetadataArtifactRegistry` needs a secondary `(endpoint, lora_slug) -> Vec<(slug, suffix)>` index so the static `detach_from_endpoint` helper can clean up without holding a `LocalModel` handle.
- Multimodal positive e2e covering a Qwen-VL through the full self-host path — separate PR.

#### Related

- gh-8749 — self-hosted metadata stack
- #9707 — worker advertises non-typed metadata siblings (merged 2026-05-27 as squash 53aa9b777f)
- #9610 — frontend HF-sibling harvest
- #8855, #9057 — earlier merges in the same stack
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `local_dir()` method to access the local directory containing cached model files, enabling direct access to resolved metadata without requiring runtime fetch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->