### PR TITLE
fix(kv-router): keep monitoring workers when skip_initial_worker_wait is set

### DIFF
--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -1305,4 +1305,74 @@ mod tests {
 
         cancel_token.cancel();
     }
+
+    // Regression tests for ai-dynamo/dynamo#8534.
+    #[tokio::test]
+    async fn test_new_worker_discovered_when_monitoring_enabled() {
+        let mut workers = HashMap::new();
+        workers.insert(
+            1,
+            SimpleWorkerConfig {
+                max_num_batched_tokens: Some(64),
+                ..Default::default()
+            },
+        );
+        let (_scheduler, slots, cfg_tx, cancel_token) =
+            make_scheduler(workers.clone(), None, true, None);
+
+        workers.insert(
+            2,
+            SimpleWorkerConfig {
+                max_num_batched_tokens: Some(64),
+                ..Default::default()
+            },
+        );
+        cfg_tx.send(workers).unwrap();
+
+        tokio::time::timeout(Duration::from_millis(500), async {
+            while !slots
+                .active_tokens(Instant::now())
+                .keys()
+                .any(|w| w.worker_id == 2)
+            {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("scheduler did not pick up new worker");
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_new_worker_not_discovered_when_monitoring_disabled() {
+        let mut workers = HashMap::new();
+        workers.insert(
+            1,
+            SimpleWorkerConfig {
+                max_num_batched_tokens: Some(64),
+                ..Default::default()
+            },
+        );
+        let (_scheduler, slots, cfg_tx, cancel_token) =
+            make_scheduler(workers.clone(), None, false, None);
+
+        workers.insert(
+            2,
+            SimpleWorkerConfig {
+                max_num_batched_tokens: Some(64),
+                ..Default::default()
+            },
+        );
+        cfg_tx.send(workers).unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert!(
+            !slots
+                .active_tokens(Instant::now())
+                .keys()
+                .any(|w| w.worker_id == 2)
+        );
+        cancel_token.cancel();
+    }
 }

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -82,10 +82,9 @@ where
         .await
         .map_err(|e| KvSchedulerError::InitFailed(e.to_string()))?;
 
-        let watch_worker_configs = !kv_router_config.skip_initial_worker_wait;
-        if !watch_worker_configs {
-            tracing::info!("skipping discovery-based worker monitoring");
-        }
+        // Always watch: skip_initial_worker_wait only gates boot-time
+        // blocking, not runtime discovery. See ai-dynamo/dynamo#8534.
+        let watch_worker_configs = true;
 
         let policy = RouterSchedulingPolicy::new(kv_router_config.router_queue_policy);
         tracing::info!(


### PR DESCRIPTION
#### Status

⚠️ **WIP / discussion-only.** Opening this for review and CI signal. The fix has only been exercised via Rust unit tests; the end-to-end EPP reproduction (kind cluster, real EPP pod + decode workers added after startup) has **not** been confirmed yet, and #8534 itself is not yet reproduced on a live cluster on my side. Please treat this as a proposed direction rather than a verified fix.

#### Overview:

EPP's `create_routers` sets `kv_router_config.skip_initial_worker_wait = true` so the router can construct before any decode worker has registered. Inside `KvScheduler::start`, the same flag was also being used to gate the runtime config monitor task, which meant the EPP router never picked up decode workers that joined after startup — traffic stayed pinned to whatever workers existed at init, and only restarting the EPP pod recovered correct routing.

This PR decouples the two concerns. `skip_initial_worker_wait` keeps its original meaning (don't block in `KvRouter::new` waiting for workers). Runtime-config monitoring is always on.

#### Details:

- `lib/llm/src/kv_router/scheduler.rs`: stop deriving `watch_worker_configs` from `!skip_initial_worker_wait` and unconditionally enable the monitor task. Drop the now-unreachable "skipping discovery-based worker monitoring" log.
- `lib/kv-router/src/scheduling/local.rs`: add two regression tests against `LocalScheduler`'s `monitor_worker_configs` parameter — one confirms late-joining workers are reflected in the slot table when monitoring is on; the other locks down the low-level invariant that monitoring=off freezes the slot table (the underlying property the EPP bug used to land on).

No public API or config surface change. `skip_initial_worker_wait` continues to gate boot-time waiting in `KvRouter::new` (`lib/llm/src/kv_router.rs:488`).

#### Where should the reviewer start?

`lib/llm/src/kv_router/scheduler.rs` — the one-line behavior change and the comment explaining why. Then `lib/kv-router/src/scheduling/local.rs` for the regression tests.

#### Verification

- `cargo test -p dynamo-kv-router -p dynamo-llm --lib` — 1739 passed, 5 ignored.
- `cargo build -p libdynamo_llm` (C FFI used by EPP) — clean.
- ❌ Live EPP / kind end-to-end reproduction: **not yet done.** Help wanted from anyone who can stand the failing scenario up.

#### Related Issues:

- Relates to GitHub issue: #8534