### PR TITLE
docs: fix broken skill links, convert cross-docs refs to relative paths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ the navigation in `docs/index.yml`, and running `fern check` to validate.
 
 | Skill | Description |
 |-------|-------------|
-| [dynamo-docs](https://github.com/ai-dynamo/dynamo/blob/main/.agents/skills/dynamo-docs/SKILL.md) | Add, update, move, or remove a docs page |
+| [dynamo-docs](https://github.com/ai-dynamo/dynamo/blob/main/.agents/contributor-skills/dynamo-docs/SKILL.md) | Add, update, move, or remove a docs page |
 
 ---
 

--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -85,7 +85,7 @@ kubectl create secret generic hf-token-secret \
 
 ### Step 1.3: Install Dynamo Platform
 
-Follow the [Dynamo Kubernetes Installation Guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/kubernetes/installation-guide.md) to install the platform in `dynamo-bench`.
+Follow the [Dynamo Kubernetes Installation Guide](../kubernetes/installation-guide.md) to install the platform in `dynamo-bench`.
 
 > **Note:** Namespace-restricted mode (`namespaceRestriction.enabled=true`) is deprecated and will be removed in a future release. Use cluster-wide mode for new deployments.
 

--- a/docs/digest/agentic-inference/agentic-inference.md
+++ b/docs/digest/agentic-inference/agentic-inference.md
@@ -51,7 +51,7 @@ Agent harnesses are increasingly adopting `v1/responses` and `v1/messages` over 
 </tr>
 </table>
 
-We have also invested in day-0 tool call and reasoning parsing support for various open-source models. If you find that a model is not supported, please [open an issue](https://github.com/ai-dynamo/dynamo/issues) or use the [tool-call-parser-generator](https://github.com/ai-dynamo/dynamo/blob/main/.agents/skills/tool-parser-generator/SKILL.md) skill to generate it with your harness of choice.
+We have also invested in day-0 tool call and reasoning parsing support for various open-source models. If you find that a model is not supported, please [open an issue](https://github.com/ai-dynamo/dynamo/issues) or use the [tool-call-parser-generator](https://github.com/ai-dynamo/dynamo/blob/main/.agents/contributor-skills/tool-parser-generator/SKILL.md) skill to generate it with your harness of choice.
 
 ### Agent Hints: The Harness-Orchestrator Interface
 

--- a/docs/features/multimodal/README.md
+++ b/docs/features/multimodal/README.md
@@ -42,9 +42,9 @@ Dynamo provides support for improving latency and throughput for vision-and-lang
 
 | Stack | Image | Video | Audio |
 |-------|-------|-------|-------|
-| **[vLLM](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md)** | ✅ | 🧪  | 🧪 |
-| **[TRT-LLM](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md)** | ✅ | ❌ | ❌ |
-| **[SGLang](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md)** | ✅ | 🧪 | ❌ |
+| **[vLLM](multimodal-vllm.md)** | ✅ | 🧪  | 🧪 |
+| **[TRT-LLM](multimodal-trtllm.md)** | ✅ | ❌ | ❌ |
+| **[SGLang](multimodal-sglang.md)** | ✅ | 🧪 | ❌ |
 
 **Status:** ✅ Supported | 🧪 Experimental | ❌ Not supported
 
@@ -79,6 +79,6 @@ Reference implementations for deploying multimodal models:
 
 Detailed deployment guides, configuration, and examples for each backend:
 
-- **[vLLM Multimodal](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md)**
-- **[TensorRT-LLM Multimodal](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md)**
-- **[SGLang Multimodal](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md)**
+- **[vLLM Multimodal](multimodal-vllm.md)**
+- **[TensorRT-LLM Multimodal](multimodal-trtllm.md)**
+- **[SGLang Multimodal](multimodal-sglang.md)**

--- a/docs/features/multimodal/embedding-cache.md
+++ b/docs/features/multimodal/embedding-cache.md
@@ -8,7 +8,7 @@ subtitle: Cache vision encoder embeddings to skip re-encoding repeated images
 ## Overview
 
 The embedding cache is a CPU-side LRU cache that stores vision encoder outputs. When the same image appears in multiple requests, the cached embedding is reused instead of running the vision encoder again. This reduces GPU load on the encoder and lowers latency for repeated images.
-> Note: This feature can also be referred to as **encoder cache**. Embedding cache is separate from KV cache, which reuses attention key/value state after prefill to skip prefill and go straight to decode. For KV cache reuse and routing, see [Multimodal KV Routing](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-kv-routing.md).
+> Note: This feature can also be referred to as **encoder cache**. Embedding cache is separate from KV cache, which reuses attention key/value state after prefill to skip prefill and go straight to decode. For KV cache reuse and routing, see [Multimodal KV Routing](multimodal-kv-routing.md).
 ## When to Use
 
 Use the embedding cache when your workload includes repeated images across requests. Common scenarios:
@@ -65,4 +65,4 @@ cd $DYNAMO_HOME/examples/backends/trtllm
 
 Set the capacity based on your expected working set of unique images. A larger cache holds more embeddings but consumes more host memory.
 
-See the backend-specific documentation ([vLLM](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md#embedding-cache), [TRT-LLM](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md#embedding-cache)) for more details.
+See the backend-specific documentation ([vLLM](multimodal-vllm.md#embedding-cache), [TRT-LLM](multimodal-trtllm.md#embedding-cache)) for more details.

--- a/docs/features/multimodal/encoder-disaggregation.md
+++ b/docs/features/multimodal/encoder-disaggregation.md
@@ -91,4 +91,4 @@ cd $DYNAMO_HOME/examples/backends/sglang
 ./launch/multimodal_disagg.sh
 ```
 
-See the backend-specific documentation ([vLLM](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md), [TRT-LLM](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md), [SGLang](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md)) for full configuration details and component flags.
+See the backend-specific documentation ([vLLM](multimodal-vllm.md), [TRT-LLM](multimodal-trtllm.md), [SGLang](multimodal-sglang.md)) for full configuration details and component flags.

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -11,7 +11,7 @@ Multimodal KV routing extends Dynamo's KV-aware router to account for image cont
 
 Repeated requests containing the same image are routed to the worker that already has the corresponding KV cache blocks, maximizing prefix cache reuse.
 
-> Note: KV cache is separate from embedding cache (also called encoder cache), which reuses vision encoder outputs (image→embeddings) to avoid re-running the encoder. For encoder-side reuse see [Embedding Cache](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/embedding-cache.md).
+> Note: KV cache is separate from embedding cache (also called encoder cache), which reuses vision encoder outputs (image→embeddings) to avoid re-running the encoder. For encoder-side reuse see [Embedding Cache](embedding-cache.md).
 
 ## When to Use
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -123,10 +123,10 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 
 {/* Multimodal */}
 [mm]: ../user-guides/multimodal
-[mm-vllm]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md
-[mm-trtllm]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md
-[mm-sglang]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md
-[mm-kv-routing]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-kv-routing.md
+[mm-vllm]: ../features/multimodal/multimodal-vllm.md
+[mm-trtllm]: ../features/multimodal/multimodal-trtllm.md
+[mm-sglang]: ../features/multimodal/multimodal-sglang.md
+[mm-kv-routing]: ../features/multimodal/multimodal-kv-routing.md
 
 {/* Feature-specific */}
 [lora]: ../kubernetes-deployment/deployment-guide/managing-models-with-dynamo-model


### PR DESCRIPTION
## Summary

Two changes — one urgent, one cleanup:

1. **Fix two 404s blocking lychee on every PR.** After #10017 flipped the canonical skill dir, the docs still referenced `.agents/skills/{dynamo-docs,tool-parser-generator}/SKILL.md`, but those skills actually live under `.agents/contributor-skills/`. Both paths corrected.
2. **Convert 18 cross-docs references** (docs/ → docs/) from `blob/main` URLs to relative paths. Both source and target live inside the Fern build, so the relative form renders correctly on docs.nvidia.com/dynamo and removes the `main` mutability concern from the rendered docs site.

## What this does NOT touch

The other 153 `blob/main` references in docs/ (which point at `examples/`, `lib/`, `components/`, etc.) are intentionally left alone. Three reasons:

- Fern's published site only ships `docs/`, so relative paths to non-docs files would 404 on docs.nvidia.com.
- The Fern release workflow (`.github/workflows/fern-docs.yml`, lines 428–448) literally `sed`s `blob/main` → `blob/vX.Y.Z` per release to version-pin source links. Relative paths would silently break that mechanism.
- `tree/main/<dir>` URLs render directory listings on GitHub; relative paths to directories don't render anywhere.

## Test plan

- [ ] `lychee` no longer reports 404 on `.agents/skills/dynamo-docs/SKILL.md` or `.agents/skills/tool-parser-generator/SKILL.md` (verified locally — both targets resolve at `.agents/contributor-skills/<x>/SKILL.md`).
- [ ] Fern docs preview renders the multimodal README, embedding-cache, encoder-disaggregation, multimodal-kv-routing, kv-router-ab-testing, and feature-matrix pages with the 18 converted links working as in-site navigation.
- [ ] `Docs link check` workflow goes green on this PR (was failing across all open PRs due to issue #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links across multimodal features, benchmark guides, and contributor skill references to improve internal navigation
  * Enhanced references for KV routing, embedding cache, and encoder disaggregation documentation
  * Clarified the distinction between embedding cache (encoder cache) and KV cache functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->