### PR TITLE
feat(container): libfabric2.5.1 for EFA and TRTLLM

### DIFF
--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -36,13 +36,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
     rm -rf /tmp/efa && \
-    # Disable the EFA installer's aws-ofi-nccl plugin: it crashes TRT-LLM at engine init.
-    # The plugin is installed at /opt/amazon/ofi-nccl (no `aws-` prefix), but ld.so picks
-    # it up via /etc/ld.so.conf.d/aws-ofi-nccl.conf (which DOES carry the `aws-` prefix).
-    # Remove both, and also the cuda-dl-base location /opt/amazon/aws-ofi-nccl if present,
-    # before re-running ldconfig.
-    rm -rf /opt/amazon/aws-ofi-nccl /opt/amazon/ofi-nccl \
-           /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
+    rm -rf /opt/amazon/aws-ofi-nccl /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
     ldconfig
 
 ENV EFA_VERSION="${EFA_VERSION}"
@@ -61,11 +55,11 @@ RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric
     if [ -n "$EFA_LIBFABRIC_VER" ] && [ -n "$REF_VER" ] && \
        [ "$(printf '%s\n' "$EFA_LIBFABRIC_VER" "$REF_VER" | sort -V | head -n1)" = "$EFA_LIBFABRIC_VER" ] && \
        [ "$EFA_LIBFABRIC_VER" != "$REF_VER" ]; then \
-        cp -Pf /tmp/libfabric_build/lib/libfabric.so* /opt/amazon/efa/lib/ && \
-        if [ -d /opt/amazon/efa/lib64 ]; then \
-            cp -Pf /tmp/libfabric_build/lib/libfabric.so* /opt/amazon/efa/lib64/; \
-        fi && \
-        cp -f /tmp/libfabric_build/bin/fi_info /opt/amazon/efa/bin/fi_info && \
+        rm -rf /opt/amazon/efa && \
+        cp -Pfr /tmp/libfabric_build /opt/amazon/efa && \
+        sed -i 's|^prefix=.*|prefix=/opt/amazon/efa|' /opt/amazon/efa/lib/pkgconfig/libfabric.pc && \
+        echo "/opt/amazon/efa/lib" > /etc/ld.so.conf.d/000_efa.conf && \
+        rm -f /etc/ld.so.conf.d/efa.conf && \
         ldconfig && \
         echo "[aws] libfabric overlay: ${REF_VER} (overwrites EFA stock ${EFA_LIBFABRIC_RAW})"; \
     else \
@@ -84,18 +78,15 @@ RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric
 # Dynamo-built NIXL 0.10.1 plugins). LIBFABRIC goes through libfabric directly
 # (not UCX), so it is unaffected by the UCX 1.20.0 hang that LD_PRELOAD works
 # around — and LIBFABRIC is the recommended backend for EFA.
-RUN set -e && \
-    arch_libdir=$(find /opt/nvidia/nvda_nixl/lib -maxdepth 1 -type d -name '*-linux-gnu' | head -1) && \
-    [ -n "$arch_libdir" ] || { echo "ERROR: no arch-specific NIXL plugin dir under /opt/nvidia/nvda_nixl/lib" >&2; exit 1; } && \
-    venv_lf=$(find /opt/dynamo/venv -path '*.nixl_cu13.mesonpy.libs/plugins/libplugin_LIBFABRIC.so' | head -1) && \
-    [ -n "$venv_lf" ] || { echo "ERROR: no libplugin_LIBFABRIC.so under /opt/dynamo/venv" >&2; exit 1; } && \
-    cp -Pf "$venv_lf" "$arch_libdir/plugins/" && \
-    ln -sfT "$arch_libdir/plugins" /opt/nvidia/nvda_nixl/plugins && \
-    [ -f /opt/nvidia/nvda_nixl/plugins/libplugin_LIBFABRIC.so ] || { echo "ERROR: LIBFABRIC plugin not visible via /opt/nvidia/nvda_nixl/plugins" >&2; ls -la /opt/nvidia/nvda_nixl/plugins/ >&2; exit 1; } && \
-    echo "[aws] NIXL plugins consolidated under /opt/nvidia/nvda_nixl/plugins -> $arch_libdir/plugins"
+RUN --mount=from=wheel_builder,source=/opt/nvidia/nvda_nixl,target=/tmp/nvda_nixl \
+    rm -rf /opt/nvidia/nvda_nixl && \
+    cp -Pfr /tmp/nvda_nixl /opt/nvidia/nvda_nixl && \
+    export LD_PRELOAD=/opt/nvidia/nvda_nixl/lib64/libnixl.so && \
+    export NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins && \
+    ldconfig
 
-ENV LD_PRELOAD=""
-ENV NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/plugins
+ENV LD_PRELOAD=/opt/nvidia/nvda_nixl/lib64/libnixl.so
+ENV NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
 {% endif %}
 
 {% if target == "runtime" %}


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

This PR fixes issues with PR #9727 

#### Details:

<!-- Describe the changes made in this PR. -->

* Use EFA installer aws-ofi-nccl instead of TRTLLM container image aws-ofi-nccl
* Use NIXL libraries from wheel builder step to be used with EFA

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced AWS EFA container template with improved libfabric overlay handling for cases when bundled versions are outdated, including refined path management and optimized dynamic linker configuration
  * Simplified NIXL plugin setup and framework integration to improve container initialization, deployment reliability, and compatibility across different environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->