### PR TITLE
Reject remote G2 promoted-primary leases

### DIFF
--- a/components/src/dynamo/trtllm/args.py
+++ b/components/src/dynamo/trtllm/args.py
@@ -25,7 +25,7 @@ DEFAULT_PREFILL_COMPONENT = "prefill"
 DEFAULT_ENCODE_COMPONENT = "tensorrt_llm_encode"
 DEFAULT_DIFFUSION_COMPONENT = "diffusion"
 DEFAULT_ENDPOINT_NAME = "generate"
-VALID_TRTLLM_CONNECTORS = {"none", "kvbm"}
+VALID_TRTLLM_CONNECTORS = {"none", "kvbm", "remote_g2"}
 
 
 class Config(DynamoRuntimeConfig, DynamoTrtllmConfig):

--- a/components/src/dynamo/trtllm/kv_p2p/__init__.py
+++ b/components/src/dynamo/trtllm/kv_p2p/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/components/src/dynamo/trtllm/kv_p2p/_engine_internals.py
+++ b/components/src/dynamo/trtllm/kv_p2p/_engine_internals.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Engine-internal accessors for remote-G2 source-side setup.
+
+Helpers shared between the event-driven (alpha) and direct-query (beta)
+source-side implementations. They reach into the TRT-LLM engine to
+locate the C++ kv_cache_manager wrapper, the secondary pool's base
+pointer, and the per-block byte size; both setup flavors need these.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def kv_cache_manager(engine: Any) -> Optional[Any]:
+    """Reach the C++ kv_cache_manager wrapper from the dynamo engine.
+
+    Returns None when not reachable (older TRT-LLM, ENCODE worker, etc.);
+    caller should treat that as "remote-G2 not enabled here".
+    """
+    llm = getattr(engine, "llm", None)
+    if llm is None:
+        return None
+    executor = getattr(llm, "_executor", None)
+    if executor is None:
+        return None
+    py_executor = getattr(executor, "engine", None)
+    if py_executor is None:
+        return None
+    return getattr(py_executor, "kv_cache_manager", None)
+
+
+def secondary_pool_base_ptr(kv: Any) -> int:
+    """Return the secondary KV cache pool's base host address, or 0
+    when it is not available (no host pool allocated, exposure binding
+    missing, etc.).
+    """
+    try:
+        return int(kv.get_secondary_pool_data(0).data_ptr())
+    except Exception:
+        return 0
+
+
+def derive_block_size_bytes(kv: Any) -> Optional[int]:
+    """Compute per-block byte size by dividing the secondary pool's total
+    bytes by the C++-reported secondary block capacity.
+
+    Avoids layout assumptions about the pool tensor's dimension order.
+    Uses KvCacheIterationStats.secondary_max_num_blocks (capacity, not
+    free/used) which is set at pool allocation and constant for the
+    worker's lifetime.
+    """
+    try:
+        pool = kv.get_secondary_pool_data(0)
+    except Exception:
+        return None
+    if pool is None or pool.numel() == 0:
+        return None
+
+    try:
+        iter_stats = kv.get_iteration_stats()
+    except Exception:
+        return None
+    if not iter_stats:
+        return None
+
+    # iter_stats is dict[window_size, KvCacheIterationStats]. The connector
+    # operates under the single-window-block-manager constraint, so we take
+    # the first (and only) entry.
+    stats = next(iter(iter_stats.values()))
+    num_secondary = int(getattr(stats, "secondary_max_num_blocks", 0) or 0)
+    if num_secondary <= 0:
+        return None
+
+    total_bytes = pool.element_size() * pool.numel()
+    return total_bytes // num_secondary

--- a/components/src/dynamo/trtllm/kv_p2p/_engine_internals.py
+++ b/components/src/dynamo/trtllm/kv_p2p/_engine_internals.py
@@ -20,7 +20,10 @@ def kv_cache_manager(engine: Any) -> Optional[Any]:
     Returns None when not reachable (older TRT-LLM, ENCODE worker, etc.);
     caller should treat that as "remote-G2 not enabled here".
     """
-    llm = getattr(engine, "llm", None)
+    # `TensorRTLLMEngine` (dynamo wrapper) stores the underlying TRT-LLM
+    # `LLM` instance as `_llm` (underscored). Fall through to a `llm`
+    # attribute if a future wrapper exposes it as a property.
+    llm = getattr(engine, "_llm", None) or getattr(engine, "llm", None)
     if llm is None:
         return None
     executor = getattr(llm, "_executor", None)

--- a/components/src/dynamo/trtllm/kv_p2p/_handle.py
+++ b/components/src/dynamo/trtllm/kv_p2p/_handle.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-side handle returned from remote-G2 setup helpers.
+
+Holds the SourceG2DescriptorRegistry used for lease/TTL/refcount
+bookkeeping. Setup flavors (alpha event-driven, beta direct-query) both
+return one of these; setup-flavor-specific state (e.g. the alpha event
+adapter) is kept alive externally and does not appear on the handle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tensorrt_llm._torch.pyexecutor.connectors.remote_g2 import (
+    SourceG2DescriptorRegistry,
+)
+
+
+@dataclass
+class RemoteG2SourceHandle:
+    registry: SourceG2DescriptorRegistry

--- a/components/src/dynamo/trtllm/kv_p2p/source_rpc_server.py
+++ b/components/src/dynamo/trtllm/kv_p2p/source_rpc_server.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-side RPC server living in the dynamo worker parent process.
+
+The actual SourceG2DescriptorRegistry runs inside the engine subprocess
+(spawned by TRT-LLM via OpenMPI). It exposes a ZMQ REP loop over a Unix
+domain socket at ``/tmp/dynamo_remote_g2_ipc_<dynamo_pid>.sock``.
+
+This module bridges that local socket to dynamo's network-discoverable
+runtime endpoints. Two endpoints are registered:
+
+* ``<namespace>.<component>.remote-g2-resolve`` — forwards resolve_and_lease
+* ``<namespace>.<component>.remote-g2-release`` — forwards release_lease
+
+Each endpoint handler is an async generator (dynamo's standard endpoint
+shape). It uses ``loop.run_in_executor`` to call into the blocking ZMQ
+REQ wrapper without blocking the event loop.
+
+The ZMQ REQ wrapper holds a single ``zmq.REQ`` socket guarded by a
+``threading.Lock``, since REQ/REP is strict lockstep (you cannot have
+two in-flight requests on one socket). For POC throughput this is fine
+— the registry's own critical section serializes calls anyway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import pickle
+import threading
+import time
+from typing import Any, AsyncIterator, Optional
+
+
+class _ZmqReqWrapper:
+    """Thread-safe ZMQ REQ client to the engine-subprocess REP service.
+
+    REQ/REP requires strict send-then-recv lockstep on a single socket.
+    The lock serializes concurrent callers; only one RPC is in flight
+    at a time. That matches the registry's own ``self._lock``, so we're
+    not introducing extra contention.
+    """
+
+    def __init__(self, socket_path: str, timeout_ms: int = 5000) -> None:
+        import zmq
+
+        self._socket_path = socket_path
+        self._ctx = zmq.Context.instance()
+        self._socket = self._ctx.socket(zmq.REQ)
+        self._socket.RCVTIMEO = timeout_ms
+        self._socket.SNDTIMEO = timeout_ms
+        # `connect()` is lazy — actual connection happens on first send.
+        self._socket.connect(f"ipc://{socket_path}")
+        self._lock = threading.Lock()
+
+    def request(self, method: str, payload: dict) -> dict:
+        """Synchronously round-trip a single RPC. Returns the response dict.
+
+        Always grabs the lock. Wire format mirrors what the REP loop in
+        the engine subprocess expects: pickle-encoded
+        ``{"method": ..., "payload": ...}`` request, pickle-encoded
+        ``{"ok": bool, "result"|"error": ...}`` response.
+        """
+        with self._lock:
+            self._socket.send(pickle.dumps({"method": method, "payload": payload}))
+            raw = self._socket.recv()
+        return pickle.loads(raw)
+
+
+def _make_resolve_handler(req_wrapper: _ZmqReqWrapper):
+    """Build the async-generator handler for the remote-g2-resolve endpoint."""
+
+    async def handler(request: dict, context: Any = None) -> AsyncIterator[dict]:
+        plan = (request or {}).get("plan")
+        if plan is None:
+            yield {"ok": False, "error": "missing 'plan' in request"}
+            return
+        loop = asyncio.get_running_loop()
+        try:
+            response = await loop.run_in_executor(
+                None, req_wrapper.request, "resolve_and_lease", {"plan": plan}
+            )
+        except Exception as exc:
+            logging.exception("remote_g2: resolve_and_lease RPC raised")
+            yield {"ok": False, "error": repr(exc)}
+            return
+        yield response
+
+    return handler
+
+
+def _make_release_handler(req_wrapper: _ZmqReqWrapper):
+    """Build the async-generator handler for the remote-g2-release endpoint."""
+
+    async def handler(request: dict, context: Any = None) -> AsyncIterator[dict]:
+        lease_id = (request or {}).get("lease_id")
+        reason = (request or {}).get("reason", "ack")
+        if lease_id is None:
+            yield {"ok": False, "error": "missing 'lease_id' in request"}
+            return
+        loop = asyncio.get_running_loop()
+        try:
+            response = await loop.run_in_executor(
+                None,
+                req_wrapper.request,
+                "release_lease",
+                {"lease_id": lease_id, "reason": reason},
+            )
+        except Exception as exc:
+            logging.exception("remote_g2: release_lease RPC raised")
+            yield {"ok": False, "error": repr(exc)}
+            return
+        yield response
+
+    return handler
+
+
+def _ipc_socket_path() -> str:
+    """The Unix-domain-socket path the engine subprocess's REP service
+    binds to. Keyed by the dynamo parent's PID so multiple workers on
+    one host don't collide."""
+    return f"/tmp/dynamo_remote_g2_ipc_{os.getpid()}.sock"
+
+
+def _wait_for_socket(path: str, timeout_s: float = 30.0) -> bool:
+    """Poll for the REP socket file to appear. The engine subprocess
+    binds it during register_kv_caches, which happens late in engine
+    init. By the time get_llm_engine returns, it should be up — but
+    a short poll catches the case where this setup races ahead of the
+    subprocess."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.25)
+    return False
+
+
+async def setup_source_rpc_endpoints(
+    runtime: Any,
+    namespace: str,
+    component: str,
+) -> Optional[_ZmqReqWrapper]:
+    """Register the two source-side dynamo runtime endpoints and spawn
+    their serving tasks. Returns the ``_ZmqReqWrapper`` so the caller
+    can hold it alive (the socket closes when the wrapper is GCed).
+
+    Returns ``None`` if the engine subprocess's ZMQ REP socket never
+    appears (e.g. remote-G2 wasn't actually bootstrapped).
+    """
+    socket_path = _ipc_socket_path()
+    if not _wait_for_socket(socket_path):
+        logging.warning(
+            "remote_g2: ZMQ REP socket %s never appeared; source RPC endpoints not registered",
+            socket_path,
+        )
+        return None
+
+    req_wrapper = _ZmqReqWrapper(socket_path)
+
+    resolve_ep = runtime.endpoint(f"{namespace}.{component}.remote-g2-resolve")
+    release_ep = runtime.endpoint(f"{namespace}.{component}.remote-g2-release")
+
+    # serve_endpoint may return either a coroutine or a Future depending on
+    # the dynamo runtime version. asyncio.ensure_future accepts both and
+    # returns a Task/Future we can hold on to without blocking here.
+    _resolve_task = asyncio.ensure_future(
+        resolve_ep.serve_endpoint(_make_resolve_handler(req_wrapper))
+    )
+    _release_task = asyncio.ensure_future(
+        release_ep.serve_endpoint(_make_release_handler(req_wrapper))
+    )
+
+    logging.warning(
+        "remote_g2: source RPC endpoints registered "
+        "(resolve=%s.%s.remote-g2-resolve release=%s.%s.remote-g2-release ipc=%s)",
+        namespace,
+        component,
+        namespace,
+        component,
+        socket_path,
+    )
+    return req_wrapper

--- a/components/src/dynamo/trtllm/kv_p2p/source_rpc_server.py
+++ b/components/src/dynamo/trtllm/kv_p2p/source_rpc_server.py
@@ -117,6 +117,44 @@ def _make_release_handler(req_wrapper: _ZmqReqWrapper):
     return handler
 
 
+def _make_metadata_handler(req_wrapper: _ZmqReqWrapper):
+    """Build the async-generator handler for the remote-g2-metadata endpoint.
+
+    Unary RPC. Returns the source NIXL agent's identity (remote_name,
+    agent_desc bytes, connection_info, source_generation) so target
+    workers can call load_remote_agent_by_connection before issuing
+    READs.
+
+    When the caller's request includes ``peer_name`` +
+    ``peer_connection_info``, those are forwarded to the engine
+    subprocess's REP loop, which calls
+    ``source_agent.load_remote_agent_by_connection(peer_name, peer_conn)``
+    before returning. This implements the bidirectional NIXL handshake.
+    """
+
+    async def handler(request: dict, context: Any = None) -> AsyncIterator[dict]:
+        req = request or {}
+        payload: dict = {}
+        peer_name = req.get("peer_name")
+        peer_conn = req.get("peer_connection_info")
+        if peer_name:
+            payload["peer_name"] = peer_name
+        if peer_conn:
+            payload["peer_connection_info"] = peer_conn
+        loop = asyncio.get_running_loop()
+        try:
+            response = await loop.run_in_executor(
+                None, req_wrapper.request, "get_metadata", payload
+            )
+        except Exception as exc:
+            logging.exception("remote_g2: get_metadata RPC raised")
+            yield {"ok": False, "error": repr(exc)}
+            return
+        yield response
+
+    return handler
+
+
 def _ipc_socket_path() -> str:
     """The Unix-domain-socket path the engine subprocess's REP service
     binds to. Keyed by the dynamo parent's PID so multiple workers on
@@ -162,6 +200,7 @@ async def setup_source_rpc_endpoints(
 
     resolve_ep = runtime.endpoint(f"{namespace}.{component}.remote-g2-resolve")
     release_ep = runtime.endpoint(f"{namespace}.{component}.remote-g2-release")
+    metadata_ep = runtime.endpoint(f"{namespace}.{component}.remote-g2-metadata")
 
     # serve_endpoint may return either a coroutine or a Future depending on
     # the dynamo runtime version. asyncio.ensure_future accepts both and
@@ -172,10 +211,16 @@ async def setup_source_rpc_endpoints(
     _release_task = asyncio.ensure_future(
         release_ep.serve_endpoint(_make_release_handler(req_wrapper))
     )
+    _metadata_task = asyncio.ensure_future(
+        metadata_ep.serve_endpoint(_make_metadata_handler(req_wrapper))
+    )
 
     logging.warning(
         "remote_g2: source RPC endpoints registered "
-        "(resolve=%s.%s.remote-g2-resolve release=%s.%s.remote-g2-release ipc=%s)",
+        "(resolve=%s.%s.remote-g2-resolve release=%s.%s.remote-g2-release "
+        "metadata=%s.%s.remote-g2-metadata ipc=%s)",
+        namespace,
+        component,
         namespace,
         component,
         namespace,

--- a/components/src/dynamo/trtllm/kv_p2p/target_rpc_client.py
+++ b/components/src/dynamo/trtllm/kv_p2p/target_rpc_client.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Target-side RPC client living in the dynamo worker parent process.
+
+When the target worker's connector wants to resolve a remote-G2 plan,
+it calls this client which routes to the chosen source worker via
+``client.direct(payload, instance_id=source_worker_id)`` against the
+source's ``remote-g2-resolve`` endpoint.
+
+This module only contains the **parent-side async client wrapper**.
+How that wrapper is reached from the engine-subprocess connector (which
+is in a different process and can't share Python objects with the
+parent) is a Stage 3 concern — that's where the engine→parent IPC
+bridge lives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+
+class _TargetRpcClient:
+    """Wraps the dynamo runtime client for making remote-G2 RPC calls.
+
+    Holds a lazily-initialized dynamo client per endpoint. Calls are
+    async and route via ``client.direct(payload, instance_id=...)`` so
+    they reach the specific source worker the plan names.
+    """
+
+    def __init__(self, runtime: Any, namespace: str, component: str) -> None:
+        self._runtime = runtime
+        self._namespace = namespace
+        self._component = component
+        # Lazy-init: clients are constructed on first use of each endpoint.
+        self._resolve_client: Optional[Any] = None
+        self._release_client: Optional[Any] = None
+        self._client_init_lock = asyncio.Lock()
+
+    async def _prime_discovery(self, client: Any, endpoint_name: str) -> None:
+        """Wait until dynamo discovery surfaces at least one instance for
+        the freshly-built client. ``client.instance_ids()`` is a sync
+        cache read; immediately after ``ep.client()`` returns, the cache
+        is typically empty even though etcd already has the instances
+        registered. Without this prime, the first ``direct()`` call
+        raises ``instance_id=X not found for endpoint ...``."""
+        try:
+            await asyncio.wait_for(client.wait_for_instances(), timeout=10.0)
+        except asyncio.TimeoutError:
+            logging.warning(
+                "remote_g2: %s discovery prime timed out — no instances visible",
+                endpoint_name,
+            )
+
+    async def _resolve_endpoint_client(self) -> Any:
+        if self._resolve_client is None:
+            async with self._client_init_lock:
+                if self._resolve_client is None:
+                    ep = self._runtime.endpoint(
+                        f"{self._namespace}.{self._component}.remote-g2-resolve"
+                    )
+                    client = await ep.client()
+                    await self._prime_discovery(client, "remote-g2-resolve")
+                    self._resolve_client = client
+        return self._resolve_client
+
+    async def _release_endpoint_client(self) -> Any:
+        if self._release_client is None:
+            async with self._client_init_lock:
+                if self._release_client is None:
+                    ep = self._runtime.endpoint(
+                        f"{self._namespace}.{self._component}.remote-g2-release"
+                    )
+                    client = await ep.client()
+                    await self._prime_discovery(client, "remote-g2-release")
+                    self._release_client = client
+        return self._release_client
+
+    async def resolve_and_lease(
+        self, plan: dict, source_worker_id: int
+    ) -> Optional[dict]:
+        """Call the source worker's resolve endpoint. Returns the response
+        dict (whose ``ok`` field indicates success). Returns ``None`` on
+        transport-level failure (caller should treat as plan rejected and
+        fall back to local recompute).
+        """
+        try:
+            client = await self._resolve_endpoint_client()
+        except Exception:
+            logging.exception(
+                "remote_g2: failed to obtain resolve endpoint client"
+            )
+            return None
+
+        payload = {"plan": plan}
+        try:
+            # PROBE: enumerate which instance_ids dynamo discovery sees
+            # for this endpoint so we can compare against the plan's
+            # source_worker_id.
+            try:
+                ids = list(client.instance_ids())
+            except Exception:
+                ids = ["<query_failed>"]
+            logging.warning(
+                "PROBE rpc_chain target_client_direct instance_id=%s endpoint=remote-g2-resolve known_ids=%s",
+                source_worker_id,
+                ids,
+            )
+            # client.direct(...) returns a Future that resolves to the
+            # response stream — await it to get the async iterator.
+            stream = await client.direct(payload, instance_id=source_worker_id)
+            async for response in stream:
+                # Unary RPC — the source endpoint yields exactly once.
+                # Dynamo wraps yielded values in an `Annotated` object
+                # (Rust-side container, not picklable). Unwrap to the
+                # plain dict the source endpoint actually yielded.
+                # Unwrap dynamo's Annotated wrapper. `.data` is a method
+                # on the Rust-side object, not an attribute — call it to
+                # get the plain Python dict the source endpoint yielded.
+                if hasattr(response, "data") and callable(response.data):
+                    response = response.data()
+                return response
+        except Exception:
+            logging.exception(
+                "remote_g2: resolve_and_lease RPC to source_worker_id=%s failed",
+                source_worker_id,
+            )
+            return None
+        # Empty stream — endpoint closed without yielding anything.
+        return None
+
+    async def release_lease(
+        self, lease_id: str, source_worker_id: int, reason: str = "ack"
+    ) -> Optional[dict]:
+        """Call the source worker's release endpoint. Same semantics as
+        ``resolve_and_lease`` — ``None`` on transport failure."""
+        try:
+            client = await self._release_endpoint_client()
+        except Exception:
+            logging.exception(
+                "remote_g2: failed to obtain release endpoint client"
+            )
+            return None
+
+        payload = {"lease_id": lease_id, "reason": reason}
+        try:
+            stream = await client.direct(payload, instance_id=source_worker_id)
+            async for response in stream:
+                # Unwrap dynamo's Annotated wrapper. `.data` is a method
+                # on the Rust-side object, not an attribute — call it to
+                # get the plain Python dict the source endpoint yielded.
+                if hasattr(response, "data") and callable(response.data):
+                    response = response.data()
+                return response
+        except Exception:
+            logging.exception(
+                "remote_g2: release_lease RPC to source_worker_id=%s failed",
+                source_worker_id,
+            )
+            return None
+        return None
+
+
+def build_target_rpc_client(
+    runtime: Any, namespace: str, component: str
+) -> _TargetRpcClient:
+    """Construct the target-side RPC client. Cheap — no network I/O at
+    construction; the per-endpoint dynamo clients are lazy-initialized
+    on first call.
+    """
+    return _TargetRpcClient(runtime, namespace, component)

--- a/components/src/dynamo/trtllm/kv_p2p/target_rpc_client.py
+++ b/components/src/dynamo/trtllm/kv_p2p/target_rpc_client.py
@@ -37,6 +37,7 @@ class _TargetRpcClient:
         # Lazy-init: clients are constructed on first use of each endpoint.
         self._resolve_client: Optional[Any] = None
         self._release_client: Optional[Any] = None
+        self._metadata_client: Optional[Any] = None
         self._client_init_lock = asyncio.Lock()
 
     async def _prime_discovery(self, client: Any, endpoint_name: str) -> None:
@@ -77,6 +78,72 @@ class _TargetRpcClient:
                     await self._prime_discovery(client, "remote-g2-release")
                     self._release_client = client
         return self._release_client
+
+    async def _metadata_endpoint_client(self) -> Any:
+        if self._metadata_client is None:
+            async with self._client_init_lock:
+                if self._metadata_client is None:
+                    ep = self._runtime.endpoint(
+                        f"{self._namespace}.{self._component}.remote-g2-metadata"
+                    )
+                    client = await ep.client()
+                    await self._prime_discovery(client, "remote-g2-metadata")
+                    self._metadata_client = client
+        return self._metadata_client
+
+    async def get_source_metadata(
+        self,
+        source_worker_id: int,
+        peer_name: str = "",
+        peer_connection_info: str = "",
+    ) -> Optional[dict]:
+        """Fetch the source worker's NIXL agent identity for transfer setup.
+
+        When ``peer_name`` + ``peer_connection_info`` are provided, the
+        source side will pre-load us as a NIXL peer (bidirectional
+        handshake) before returning its metadata. UCX needs both peers
+        to know each other's connection info for the subsequent
+        createXferReq's rkey lookup to work.
+
+        Returns the inner result dict (with ``remote_name``, ``agent_desc``,
+        ``source_generation``, ``source_worker_id``, ``source_dp_rank``) on
+        success, or ``None`` on transport/RPC failure.
+        """
+        try:
+            client = await self._metadata_endpoint_client()
+        except Exception:
+            logging.exception(
+                "remote_g2: failed to obtain metadata endpoint client"
+            )
+            return None
+
+        payload: dict = {}
+        if peer_name:
+            payload["peer_name"] = peer_name
+        if peer_connection_info:
+            payload["peer_connection_info"] = peer_connection_info
+        try:
+            stream = await client.direct(payload, instance_id=source_worker_id)
+            async for response in stream:
+                if hasattr(response, "data") and callable(response.data):
+                    response = response.data()
+                if not isinstance(response, dict):
+                    return None
+                if not response.get("ok"):
+                    logging.warning(
+                        "remote_g2: get_source_metadata returned not-ok: %s",
+                        response.get("error"),
+                    )
+                    return None
+                inner = response.get("result")
+                return inner if isinstance(inner, dict) else None
+        except Exception:
+            logging.exception(
+                "remote_g2: get_source_metadata RPC to source_worker_id=%s failed",
+                source_worker_id,
+            )
+            return None
+        return None
 
     async def resolve_and_lease(
         self, plan: dict, source_worker_id: int

--- a/components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py
+++ b/components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py
@@ -37,6 +37,9 @@ from typing import Any, Optional
 
 from .target_rpc_client import _TargetRpcClient
 
+REMOTE_G2_STATUS_PROMOTED_PRIMARY = "promoted_primary"
+REMOTE_G2_RELEASE_REASON_PROMOTED_PRIMARY = "promoted_primary"
+
 
 class _LeaseSourceMap:
     """Thread-safe ``lease_id → source_worker_id`` map.
@@ -61,6 +64,45 @@ class _LeaseSourceMap:
 
 def _ipc_socket_path() -> str:
     return f"/tmp/dynamo_remote_g2_target_{os.getpid()}.sock"
+
+
+def _per_block_status_value(entry: Any) -> Optional[str]:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        status = entry.get("status")
+        return str(status) if status is not None else None
+    return None
+
+
+def _has_promoted_primary_status(per_block_status: Any) -> bool:
+    if not isinstance(per_block_status, list):
+        return False
+    for entry in per_block_status:
+        if _per_block_status_value(entry) == REMOTE_G2_STATUS_PROMOTED_PRIMARY:
+            return True
+    return False
+
+
+def _release_promoted_primary_lease(
+    client: _TargetRpcClient,
+    lease_id: str,
+    source_worker_id: int,
+    loop: asyncio.AbstractEventLoop,
+    timeout_s: float,
+) -> None:
+    coro = client.release_lease(
+        lease_id,
+        source_worker_id,
+        REMOTE_G2_RELEASE_REASON_PROMOTED_PRIMARY,
+    )
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        future.result(timeout=timeout_s)
+    except Exception:
+        logging.exception(
+            "remote_g2: failed to release lease after promoted-primary resolve"
+        )
 
 
 def _dispatch_resolve(
@@ -102,8 +144,6 @@ def _dispatch_resolve(
         return {"ok": False, "error": f"non_dict_response:{type(response).__name__}"}
     inner = response.get("result") if isinstance(response.get("result"), dict) else {}
     lease_id = inner.get("lease_id")
-    if lease_id:
-        lease_map.put(str(lease_id), source_worker_id)
     # PROBE: dump the resolved descriptors so we can verify the source-side
     # registry actually returned matching blocks. Trim each descriptor for log readability.
     descs = inner.get("descriptors") or []
@@ -121,6 +161,22 @@ def _dispatch_resolve(
                                 "pool_id", "byte_offset", "byte_length")}
          for d in descs[:3]],
     )
+    if _has_promoted_primary_status(pbs):
+        if lease_id:
+            _release_promoted_primary_lease(
+                client, str(lease_id), source_worker_id, loop, timeout_s
+            )
+        logging.info(
+            "remote_g2: resolve found promoted-primary block; rejecting plan "
+            "so target falls back"
+        )
+        return {
+            "ok": False,
+            "error": REMOTE_G2_STATUS_PROMOTED_PRIMARY,
+            "result": inner,
+        }
+    if lease_id:
+        lease_map.put(str(lease_id), source_worker_id)
     return response
 
 

--- a/components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py
+++ b/components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py
@@ -124,6 +124,49 @@ def _dispatch_resolve(
     return response
 
 
+def _dispatch_metadata(
+    client: _TargetRpcClient,
+    payload: dict,
+    loop: asyncio.AbstractEventLoop,
+    timeout_s: float,
+) -> dict:
+    """Forward a get_metadata call from the engine subprocess via the
+    target parent's dynamo client to the source worker's
+    remote-g2-metadata endpoint. Returns the standard
+    ``{"ok": True, "result": <flat_dict>}`` envelope the engine
+    subprocess's _TargetReqWrapper expects.
+
+    Note: ``agent_desc`` is raw bytes; both pickle and dynamo NATS
+    transports carry it transparently."""
+    source_worker_id = payload.get("source_worker_id")
+    if source_worker_id is None:
+        return {"ok": False, "error": "missing source_worker_id"}
+    try:
+        source_worker_id = int(source_worker_id)
+    except (TypeError, ValueError):
+        return {"ok": False, "error": f"invalid source_worker_id: {source_worker_id!r}"}
+
+    # Pass through peer_name + peer_connection_info to enable the
+    # bidirectional NIXL handshake.
+    peer_name = payload.get("peer_name", "")
+    peer_conn = payload.get("peer_connection_info", "")
+    coro = client.get_source_metadata(
+        source_worker_id,
+        peer_name=str(peer_name) if peer_name else "",
+        peer_connection_info=str(peer_conn) if peer_conn else "",
+    )
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        response = future.result(timeout=timeout_s)
+    except Exception as exc:
+        logging.exception("remote_g2: target REP metadata dispatch raised")
+        return {"ok": False, "error": repr(exc)}
+
+    if response is None:
+        return {"ok": False, "error": "transport_failure"}
+    return {"ok": True, "result": response}
+
+
 def _dispatch_release(
     client: _TargetRpcClient,
     payload: dict,
@@ -223,6 +266,10 @@ def setup_target_rpc_local(
                 elif method == "release":
                     response = _dispatch_release(
                         client, payload, loop, lease_map, timeout_s
+                    )
+                elif method == "metadata":
+                    response = _dispatch_metadata(
+                        client, payload, loop, timeout_s
                     )
                 else:
                     response = {

--- a/components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py
+++ b/components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Target-side local IPC bridge: parent ZMQ REP loop that translates
+requests from the target engine subprocess into dynamo client.direct(...)
+calls on the source worker.
+
+This is the mirror of source_rpc_server.py:
+* source side: parent REQ ──network──► source-engine-subprocess REP
+* target side: target-engine-subprocess REQ ──ipc──► parent REP ──network──► source
+
+The parent REP socket binds at
+``/tmp/dynamo_remote_g2_target_<dynamo_pid>.sock``. The engine subprocess
+walks its /proc parent chain to find the dynamo parent's PID and
+connects to the same path. Wire format mirrors source side: pickle
+``{"method": ..., "payload": ...}`` request, pickle
+``{"ok": bool, "result": dict | None, "error": str | None}`` response.
+
+Lease lifecycle: the connector's ``release_lease(lease_id, reason)``
+signature does not carry source_worker_id, so this bridge maintains a
+``lease_id → source_worker_id`` mapping populated from successful
+resolve responses. Release calls look up the mapping; if the lease is
+unknown (e.g. parent restarted between resolve and release) the call
+is silently dropped — the source-side lease will time out via its TTL
+mechanism.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import pickle
+import threading
+import time
+from typing import Any, Optional
+
+from .target_rpc_client import _TargetRpcClient
+
+
+class _LeaseSourceMap:
+    """Thread-safe ``lease_id → source_worker_id`` map.
+
+    Populated on successful resolve, consulted on release. Bounded only
+    by total active leases — entries should be removed by the connector
+    via release_lease. POC-level: no eviction policy.
+    """
+
+    def __init__(self) -> None:
+        self._map: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def put(self, lease_id: str, source_worker_id: int) -> None:
+        with self._lock:
+            self._map[lease_id] = source_worker_id
+
+    def pop(self, lease_id: str) -> Optional[int]:
+        with self._lock:
+            return self._map.pop(lease_id, None)
+
+
+def _ipc_socket_path() -> str:
+    return f"/tmp/dynamo_remote_g2_target_{os.getpid()}.sock"
+
+
+def _dispatch_resolve(
+    client: _TargetRpcClient,
+    payload: dict,
+    loop: asyncio.AbstractEventLoop,
+    lease_map: _LeaseSourceMap,
+    timeout_s: float,
+) -> dict:
+    """Run the async resolve coroutine on the parent's loop and wait.
+
+    Returns the standard ``{"ok": ..., "result": ..., "error": ...}`` shape.
+    """
+    plan = payload.get("plan")
+    source_worker_id = payload.get("source_worker_id")
+    if plan is None or source_worker_id is None:
+        return {"ok": False, "error": "missing plan or source_worker_id"}
+
+    try:
+        source_worker_id = int(source_worker_id)
+    except (TypeError, ValueError):
+        return {"ok": False, "error": f"invalid source_worker_id: {source_worker_id!r}"}
+
+    coro = client.resolve_and_lease(plan, source_worker_id)
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        response = future.result(timeout=timeout_s)
+    except Exception as exc:
+        logging.exception("remote_g2: target REP resolve dispatch raised")
+        return {"ok": False, "error": repr(exc)}
+
+    if response is None:
+        return {"ok": False, "error": "transport_failure"}
+    # The source endpoint already yields the wire-shape envelope
+    # ``{"ok": True, "result": <flat_dict>}``. Pass it through verbatim —
+    # the engine subprocess's _make_resolve_callable expects exactly that
+    # outer shape and reads `.result` for the flat dict.
+    if not isinstance(response, dict):
+        return {"ok": False, "error": f"non_dict_response:{type(response).__name__}"}
+    inner = response.get("result") if isinstance(response.get("result"), dict) else {}
+    lease_id = inner.get("lease_id")
+    if lease_id:
+        lease_map.put(str(lease_id), source_worker_id)
+    # PROBE: dump the resolved descriptors so we can verify the source-side
+    # registry actually returned matching blocks. Trim each descriptor for log readability.
+    descs = inner.get("descriptors") or []
+    pbs = inner.get("per_block_status") or []
+    logging.warning(
+        "PROBE rpc_chain resolve_response lease_id=%s num_tokens=%s reason=%s source_generation=%s "
+        "descriptors_count=%d per_block_status_count=%d  descriptors_head=%s",
+        lease_id,
+        inner.get("num_tokens"),
+        inner.get("reason"),
+        inner.get("source_generation"),
+        len(descs),
+        len(pbs),
+        [{k: d.get(k) for k in ("block_hash", "descriptor_generation",
+                                "pool_id", "byte_offset", "byte_length")}
+         for d in descs[:3]],
+    )
+    return response
+
+
+def _dispatch_release(
+    client: _TargetRpcClient,
+    payload: dict,
+    loop: asyncio.AbstractEventLoop,
+    lease_map: _LeaseSourceMap,
+    timeout_s: float,
+) -> dict:
+    lease_id = payload.get("lease_id")
+    if lease_id is None:
+        return {"ok": False, "error": "missing lease_id"}
+    lease_id = str(lease_id)
+    reason = str(payload.get("reason", "ack"))
+    source = lease_map.pop(lease_id)
+    if source is None:
+        # Lease unknown — silently treat as ok. Source-side TTL will
+        # garbage-collect orphaned leases.
+        return {"ok": True, "result": False}
+
+    coro = client.release_lease(lease_id, source, reason)
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        response = future.result(timeout=timeout_s)
+    except Exception as exc:
+        logging.exception("remote_g2: target REP release dispatch raised")
+        return {"ok": False, "error": repr(exc)}
+
+    if response is None:
+        return {"ok": False, "error": "transport_failure"}
+    completed = bool(response.get("result")) if isinstance(response, dict) else False
+    return {"ok": True, "result": completed}
+
+
+def setup_target_rpc_local(
+    runtime: Any,
+    namespace: str,
+    component: str,
+    *,
+    timeout_s: float = 30.0,
+) -> Optional[dict]:
+    """Bind the parent's ZMQ REP socket and start the dispatch loop.
+
+    Returns a handle dict (kept alive by the caller) on success, or
+    ``None`` on bind failure. The dispatch loop runs in a daemon thread;
+    it uses ``asyncio.run_coroutine_threadsafe`` to dispatch into the
+    parent's running event loop, where the dynamo client lives.
+    """
+    import zmq
+
+    from .target_rpc_client import build_target_rpc_client
+
+    socket_path = _ipc_socket_path()
+    try:
+        os.unlink(socket_path)
+    except FileNotFoundError:
+        pass
+
+    ctx = zmq.Context.instance()
+    try:
+        rep = ctx.socket(zmq.REP)
+        rep.bind(f"ipc://{socket_path}")
+    except Exception:
+        logging.exception(
+            "remote_g2: target REP bind failed at %s", socket_path
+        )
+        return None
+
+    client = build_target_rpc_client(runtime, namespace, component)
+    lease_map = _LeaseSourceMap()
+    loop = asyncio.get_event_loop()
+
+    def _loop_body() -> None:
+        while True:
+            try:
+                raw = rep.recv()
+            except Exception as e:
+                logging.error(
+                    "remote_g2: target REP recv failed; exiting loop: type=%s repr=%s",
+                    type(e).__name__,
+                    repr(e),
+                )
+                return
+            try:
+                req = pickle.loads(raw)
+                method = req.get("method") if isinstance(req, dict) else None
+                payload = (req.get("payload") or {}) if isinstance(req, dict) else {}
+                logging.warning(
+                    "PROBE rpc_chain target_rep_recv pid=%d method=%s "
+                    "payload_keys=%s",
+                    os.getpid(),
+                    method,
+                    list(payload.keys()) if isinstance(payload, dict) else None,
+                )
+                if method == "resolve":
+                    response = _dispatch_resolve(
+                        client, payload, loop, lease_map, timeout_s
+                    )
+                elif method == "release":
+                    response = _dispatch_release(
+                        client, payload, loop, lease_map, timeout_s
+                    )
+                else:
+                    response = {
+                        "ok": False,
+                        "error": f"unknown method: {method!r}",
+                    }
+            except Exception as exc:
+                logging.exception("remote_g2: target REP dispatch raised")
+                response = {"ok": False, "error": repr(exc)}
+            try:
+                payload_bytes = pickle.dumps(response)
+            except Exception as e:
+                logging.error(
+                    "remote_g2: target REP pickle.dumps failed: type=%s repr=%s response_type=%s response_repr=%s",
+                    type(e).__name__,
+                    repr(e),
+                    type(response).__name__,
+                    repr(response)[:300],
+                )
+                # Send a synthetic error so the REQ side can unblock.
+                payload_bytes = pickle.dumps(
+                    {"ok": False, "error": f"pickle_failed:{type(e).__name__}"}
+                )
+            try:
+                rep.send(payload_bytes)
+            except Exception as e:
+                logging.error(
+                    "remote_g2: target REP send failed: type=%s repr=%s bytes_len=%d",
+                    type(e).__name__,
+                    repr(e),
+                    len(payload_bytes),
+                )
+
+    thread = threading.Thread(
+        target=_loop_body, name="remote_g2_target_rep", daemon=True
+    )
+    thread.start()
+
+    logging.warning(
+        "remote_g2: target REP bound at %s (namespace=%s component=%s)",
+        socket_path,
+        namespace,
+        component,
+    )
+
+    return {
+        "socket_path": socket_path,
+        "client": client,
+        "lease_map": lease_map,
+        "thread": thread,
+        "rep": rep,
+    }

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -107,6 +107,20 @@ def _to_signed_i64(value: int | None) -> int | None:
     return value
 
 
+# Mapping between TRT-LLM's KV cache level integers and the storage_tier
+# strings accepted by dynamo.llm.KvEventPublisher. TRT-LLM uses cache_level=0
+# for the primary (GPU) pool and 1 for the secondary (host) pool; the router
+# protocol uses "device" / "host_pinned" respectively.
+_CACHE_LEVEL_TO_TIER = {
+    0: "device",
+    1: "host_pinned",
+}
+
+
+def _cache_level_to_tier(cache_level: int) -> str:
+    return _CACHE_LEVEL_TO_TIER.get(int(cache_level), "device")
+
+
 class ZmqKvEventPublisher:
     """
     Pure Python ZMQ PUBLISHER for TensorRT-LLM KV events.
@@ -429,6 +443,15 @@ class Publisher:
         # A set to store the block hash of partial block (i.e. block containing less than kv_block_size tokens) hashes.
         # It is used to prevent sending remove event to kv router since partial blocks are not stored.
         self.partial_block_hashes: set[int] = set()
+        # Per-block metadata cache (block_hash -> dict) so that `updated`
+        # events (which only carry a hash + tier transition) can be turned
+        # back into a tier-tagged store event for the router. Cleared on
+        # `removed` events. Capacity is bounded by the engine's KV pool
+        # plus secondary pool, so this dict cannot grow unbounded in steady
+        # state -- but we still cap it defensively to avoid leaks if the
+        # remove side ever drifts.
+        self._block_metadata: Dict[int, dict] = {}
+        self._block_metadata_max = 1 << 20  # ~1M block hashes (~80 MB)
         self.error_queue: Queue = Queue()
         self._stop_event = threading.Event()
         # Track the last engine event_id to assert consecutive event IDs from the engine
@@ -805,10 +828,12 @@ class Publisher:
             # request handling under load).
             self.processing_initial_created_events = False
             parent_hash = _to_signed_i64(data["parent_hash"])
-            token_ids: list[int] = []
-            num_block_tokens: list[int] = []
-            block_hashes: list[int] = []
-            block_mm_infos: list[dict | None] = []
+            # Group blocks by cache_level (0 = primary GPU, 1 = secondary
+            # host pool) so we can emit one BlockStored event per tier with
+            # the correct storage_tier tag for the router's tiered indexer.
+            # In steady state a single `stored` event almost always has
+            # uniform cache_level, but we don't rely on that.
+            per_tier: dict[int, dict] = {}
             kv_block_size = self.kv_block_size
             partial_block_hashes = self.partial_block_hashes
             for block in data["blocks"]:
@@ -828,11 +853,24 @@ class Publisher:
                 if token_num_in_block < kv_block_size:
                     partial_block_hashes.add(block_hash)
                     break
-                num_block_tokens.append(token_num_in_block)
-                block_hashes.append(block_hash)
-                token_ids.extend(int(t["token_id"]) for t in block_tokens)
+
+                cache_level = int(block.get("cache_level", 0))
+                bucket = per_tier.setdefault(
+                    cache_level,
+                    {
+                        "token_ids": [],
+                        "num_block_tokens": [],
+                        "block_hashes": [],
+                        "block_mm_infos": [],
+                    },
+                )
+                bucket["num_block_tokens"].append(token_num_in_block)
+                bucket["block_hashes"].append(block_hash)
+                token_id_list = [int(t["token_id"]) for t in block_tokens]
+                bucket["token_ids"].extend(token_id_list)
 
                 mm_keys = block.get("mm_keys")
+                mm_info: dict | None = None
                 if mm_keys:
                     mm_hashes = [
                         int(mk["hash"][:16], 16)
@@ -840,17 +878,27 @@ class Publisher:
                         if mk.get("type") == "mm_key" and mk.get("hash")
                     ]
                     if mm_hashes:
-                        block_mm_infos.append(
-                            {
-                                "mm_objects": [
-                                    {"mm_hash": h, "offsets": []} for h in mm_hashes
-                                ]
-                            }
-                        )
-                    else:
-                        block_mm_infos.append(None)
-                else:
-                    block_mm_infos.append(None)
+                        mm_info = {
+                            "mm_objects": [
+                                {"mm_hash": h, "offsets": []} for h in mm_hashes
+                            ]
+                        }
+                bucket["block_mm_infos"].append(mm_info)
+
+                # Cache per-block metadata so a subsequent `updated` event
+                # (cache_level transition) can re-emit a BlockStored event at
+                # the new tier without seeing the original token IDs again.
+                if len(self._block_metadata) >= self._block_metadata_max:
+                    # Defensive cap; drop an arbitrary entry. In steady
+                    # state remove events keep this map bounded.
+                    self._block_metadata.pop(next(iter(self._block_metadata)))
+                self._block_metadata[block_hash] = {
+                    "token_ids": token_id_list,
+                    "num_block_tokens": token_num_in_block,
+                    "parent_hash": parent_hash,
+                    "block_mm_info": mm_info,
+                    "cache_level": cache_level,
+                }
 
             lora_name = data.get("lora_name")
 
@@ -858,43 +906,83 @@ class Publisher:
             # Default to 0 for backwards compatibility with older TRT-LLM versions
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
-            logging.debug(
-                f"publish stored event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, token_ids: {token_ids}, num_block_tokens: {num_block_tokens}, block_hashes: {block_hashes}, lora_name: {lora_name}, parent_hash: {parent_hash}"
-            )
-            # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
-            # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
-            if self.zmq_kv_event_publisher:
-                # Consolidator enabled: publish to ZMQ only
-                self.zmq_kv_event_publisher.publish_stored(
-                    token_ids,
-                    num_block_tokens,
-                    block_hashes,
-                    parent_hash,
-                    block_mm_infos,
-                    attention_dp_rank,
-                    lora_name,
+            for cache_level, bucket in per_tier.items():
+                tier_tag = _cache_level_to_tier(cache_level)
+                logging.debug(
+                    f"publish stored event: engine_event_id: {event_id}, "
+                    f"attention_dp_rank: {attention_dp_rank}, "
+                    f"tier: {tier_tag}, "
+                    f"token_ids: {bucket['token_ids']}, "
+                    f"num_block_tokens: {bucket['num_block_tokens']}, "
+                    f"block_hashes: {bucket['block_hashes']}, "
+                    f"lora_name: {lora_name}, parent_hash: {parent_hash}"
                 )
-            elif self.kv_event_publishers:
-                # No consolidator: publish to NATS (router subscribes directly)
-                # Route to correct publisher based on attention_dp_rank
-                publisher = self.kv_event_publishers.get(attention_dp_rank)
-                if publisher:
-                    publisher.publish_stored(
-                        token_ids,
-                        num_block_tokens,
-                        block_hashes,
-                        parent_hash,
-                        block_mm_infos,
-                        lora_name=lora_name,
-                    )
-                else:
-                    logging.warning(
-                        f"No publisher for attention_dp_rank={attention_dp_rank}, "
-                        f"available ranks: {list(self.kv_event_publishers.keys())}"
-                    )
+                self._dispatch_stored(
+                    token_ids=bucket["token_ids"],
+                    num_block_tokens=bucket["num_block_tokens"],
+                    block_hashes=bucket["block_hashes"],
+                    parent_hash=parent_hash,
+                    block_mm_infos=bucket["block_mm_infos"],
+                    lora_name=lora_name,
+                    attention_dp_rank=attention_dp_rank,
+                    storage_tier=tier_tag,
+                )
+        elif data["type"] == "updated":
+            # cacheLevel transition: a block migrated between primary GPU
+            # and secondary host pool. We translate this into a Remove at
+            # the old tier + a Store at the new tier so the router's
+            # tiered prefix index stays in sync. Without this, all blocks
+            # stay tagged "device" forever and the remote-G2 planner
+            # (which looks for `host_pinned` hits on non-target workers)
+            # never fires.
+            self.processing_initial_created_events = False
+            block_hash = _to_signed_i64(data.get("block_hash"))
+            cache_level_diff = data.get("cache_level")
+            attention_dp_rank = event.get("attention_dp_rank", 0)
+            if (
+                block_hash is None
+                or cache_level_diff is None
+                or "old_value" not in cache_level_diff
+                or "new_value" not in cache_level_diff
+            ):
+                return  # no tier transition payload -> nothing to do
+            old_level = int(cache_level_diff["old_value"])
+            new_level = int(cache_level_diff["new_value"])
+            if old_level == new_level:
+                return
+            meta = self._block_metadata.get(block_hash)
+            if meta is None:
+                # We never saw the original BlockStored (e.g. event predates
+                # this Python process or the metadata cache evicted it).
+                # Without token_ids we can't reconstruct the radix-tree
+                # entry at the new tier; log and skip rather than corrupt
+                # the index with a tier-less remove.
+                logging.debug(
+                    f"updated event for unknown block_hash {block_hash}; skipping tier transition"
+                )
+                return
+            # Step 1: remove at the OLD tier.
+            self._dispatch_removed(
+                block_hashes=[block_hash],
+                attention_dp_rank=attention_dp_rank,
+                storage_tier=_cache_level_to_tier(old_level),
+            )
+            # Step 2: re-store at the NEW tier.
+            self._dispatch_stored(
+                token_ids=meta["token_ids"],
+                num_block_tokens=[meta["num_block_tokens"]],
+                block_hashes=[block_hash],
+                parent_hash=meta["parent_hash"],
+                block_mm_infos=[meta["block_mm_info"]],
+                lora_name=None,  # lora_name is event-scoped, not block-scoped
+                attention_dp_rank=attention_dp_rank,
+                storage_tier=_cache_level_to_tier(new_level),
+            )
+            meta["cache_level"] = new_level
         elif data["type"] == "removed":
             self.processing_initial_created_events = False
             removed_block_hashes: list[int] = []
+            removed_by_tier: dict[str, list[int]] = {}
             for block_hash in data["block_hashes"]:
                 block_hash = _to_signed_i64(block_hash)
                 if block_hash is None:
@@ -906,33 +994,116 @@ class Publisher:
                     self.partial_block_hashes.remove(block_hash)
                     continue
                 removed_block_hashes.append(block_hash)
+                # Look up the last known cache_level so we can target the
+                # remove at the right tier. Falls back to device for
+                # blocks we've never tracked (preserves prior behavior).
+                meta = self._block_metadata.pop(block_hash, None)
+                tier_tag = _cache_level_to_tier(
+                    meta["cache_level"] if meta is not None else 0
+                )
+                removed_by_tier.setdefault(tier_tag, []).append(block_hash)
 
             # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
             logging.debug(
-                f"publish removed event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, block_hashes: {removed_block_hashes}"
+                f"publish removed event: engine_event_id: {event_id}, "
+                f"attention_dp_rank: {attention_dp_rank}, "
+                f"block_hashes: {removed_block_hashes}, "
+                f"by_tier: {dict((t, len(h)) for t, h in removed_by_tier.items())}"
             )
-            # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
-            # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
-            if self.zmq_kv_event_publisher:
-                # Consolidator enabled: publish to ZMQ only
-                self.zmq_kv_event_publisher.publish_removed(
-                    removed_block_hashes, attention_dp_rank
+            for tier_tag, hashes in removed_by_tier.items():
+                self._dispatch_removed(
+                    block_hashes=hashes,
+                    attention_dp_rank=attention_dp_rank,
+                    storage_tier=tier_tag,
                 )
-            elif self.kv_event_publishers:
-                # No consolidator: publish to NATS (router subscribes directly)
-                # Route to correct publisher based on attention_dp_rank
-                publisher = self.kv_event_publishers.get(attention_dp_rank)
-                if publisher:
-                    publisher.publish_removed(removed_block_hashes)
-                else:
-                    logging.warning(
-                        f"No publisher for attention_dp_rank={attention_dp_rank}, "
-                        f"available ranks: {list(self.kv_event_publishers.keys())}"
-                    )
         elif data["type"] == "created" and self.processing_initial_created_events:
             self.update_max_window_size(event)
+
+    def _dispatch_stored(
+        self,
+        token_ids: list[int],
+        num_block_tokens: list[int],
+        block_hashes: list[int],
+        parent_hash: Optional[int],
+        block_mm_infos: list[dict | None],
+        lora_name: Optional[str],
+        attention_dp_rank: int,
+        storage_tier: str,
+    ) -> None:
+        """Route a BlockStored event to ZMQ (consolidator) or NATS (direct).
+
+        `storage_tier` is "device", "host_pinned", "disk", or "external".
+        Only the NATS direct path is tier-aware today; the ZMQ path remains
+        on the vLLM-compatible schema (always device) until the consolidator
+        learns to carry the tier field.
+        """
+        if not block_hashes:
+            return
+        if self.zmq_kv_event_publisher:
+            if storage_tier != "device":
+                logging.warning(
+                    "Dropping non-device BlockStored event under ZMQ "
+                    "consolidator path (schema does not yet carry tier). "
+                    f"tier={storage_tier} hashes={block_hashes}"
+                )
+                return
+            self.zmq_kv_event_publisher.publish_stored(
+                token_ids,
+                num_block_tokens,
+                block_hashes,
+                parent_hash,
+                block_mm_infos,
+                attention_dp_rank,
+                lora_name,
+            )
+        elif self.kv_event_publishers:
+            publisher = self.kv_event_publishers.get(attention_dp_rank)
+            if publisher is None:
+                logging.warning(
+                    f"No publisher for attention_dp_rank={attention_dp_rank}, "
+                    f"available ranks: {list(self.kv_event_publishers.keys())}"
+                )
+                return
+            publisher.publish_stored(
+                token_ids,
+                num_block_tokens,
+                block_hashes,
+                parent_hash,
+                block_mm_infos,
+                lora_name=lora_name,
+                storage_tier=storage_tier,
+            )
+
+    def _dispatch_removed(
+        self,
+        block_hashes: list[int],
+        attention_dp_rank: int,
+        storage_tier: str,
+    ) -> None:
+        if not block_hashes:
+            return
+        if self.zmq_kv_event_publisher:
+            if storage_tier != "device":
+                logging.warning(
+                    "Dropping non-device BlockRemoved event under ZMQ "
+                    "consolidator path (schema does not yet carry tier). "
+                    f"tier={storage_tier} hashes={block_hashes}"
+                )
+                return
+            self.zmq_kv_event_publisher.publish_removed(
+                block_hashes, attention_dp_rank
+            )
+        elif self.kv_event_publishers:
+            publisher = self.kv_event_publishers.get(attention_dp_rank)
+            if publisher is None:
+                logging.warning(
+                    f"No publisher for attention_dp_rank={attention_dp_rank}, "
+                    f"available ranks: {list(self.kv_event_publishers.keys())}"
+                )
+                return
+            publisher.publish_removed(block_hashes, storage_tier=storage_tier)
 
     def start(self) -> None:
         # Each ManagedThread owns its own asyncio loop now, so we no longer

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -828,6 +828,15 @@ class Publisher:
             # request handling under load).
             self.processing_initial_created_events = False
             parent_hash = _to_signed_i64(data["parent_hash"])
+            # Track each block's actual chain parent for the metadata cache.
+            # The event-level `parent_hash` is the FIRST block's parent and
+            # stays unchanged for the per-tier dispatch below; `chain_parent`
+            # walks forward block-by-block so each block's metadata records
+            # the right parent for a later tier-transition `updated` event.
+            # Without this, every block past the first in a multi-block event
+            # gets cached with parent_hash=event_parent, which breaks the
+            # router's lower-tier chain walk on eviction.
+            chain_parent = parent_hash
             # Group blocks by cache_level (0 = primary GPU, 1 = secondary
             # host pool) so we can emit one BlockStored event per tier with
             # the correct storage_tier tag for the router's tiered indexer.
@@ -895,10 +904,14 @@ class Publisher:
                 self._block_metadata[block_hash] = {
                     "token_ids": token_id_list,
                     "num_block_tokens": token_num_in_block,
-                    "parent_hash": parent_hash,
+                    "parent_hash": chain_parent,
                     "block_mm_info": mm_info,
                     "cache_level": cache_level,
                 }
+                # Advance the chain so the next block in this event records
+                # the right parent in its metadata (this block becomes that
+                # block's parent in the prefix tree).
+                chain_parent = block_hash
 
             lora_name = data.get("lora_name")
 
@@ -1041,6 +1054,11 @@ class Publisher:
         """
         if not block_hashes:
             return
+        import logging as _lg
+        _lg.getLogger(__name__).warning(
+            'PROBE dispatch_stored: tier=%s parent=%s hashes=%s ntok=%s',
+            storage_tier, parent_hash, block_hashes, num_block_tokens,
+        )
         if self.zmq_kv_event_publisher:
             if storage_tier != "device":
                 logging.warning(
@@ -1084,6 +1102,11 @@ class Publisher:
     ) -> None:
         if not block_hashes:
             return
+        import logging as _lg
+        _lg.getLogger(__name__).warning(
+            'PROBE dispatch_removed: tier=%s hashes=%s',
+            storage_tier, block_hashes,
+        )
         if self.zmq_kv_event_publisher:
             if storage_tier != "device":
                 logging.warning(

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -24,6 +24,10 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Optional, Protocol, Union
 
 import torch
+from tensorrt_llm._torch.pyexecutor.connectors.remote_g2 import (
+    REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY,
+    target_remote_g2_plan_store,
+)
 from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.executor.utils import RequestError
@@ -1100,6 +1104,10 @@ class HandlerBase(BaseGenerativeHandler):
 
         # Priority is a float in [0.0, 1.0]; health checks use 1.0. Default is 0.5.
         priority = request.get("priority", DEFAULT_REQUEST_PRIORITY)
+        trtllm_request_id = None
+        remote_g2_plan = (request.get("extra_args") or {}).get(
+            REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY
+        )
 
         try:
             # NEW: Updated engine call to include multimodal data
@@ -1111,7 +1119,9 @@ class HandlerBase(BaseGenerativeHandler):
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
                 priority=priority,
+                remote_g2_plan=remote_g2_plan,
             )
+            trtllm_request_id = getattr(generation_result, "request_id", None)
 
             # In disagg decode mode, wrap abort() to defer until first token
             # (KV transfer complete).
@@ -1321,6 +1331,9 @@ class HandlerBase(BaseGenerativeHandler):
 
             # Initiate graceful shutdown
             await self._initiate_shutdown(e)
+        finally:
+            if trtllm_request_id is not None:
+                target_remote_g2_plan_store().discard(trtllm_request_id)
 
     @staticmethod
     def _override_sampling_params(sampling_params, request: dict) -> SamplingParams:

--- a/components/src/dynamo/trtllm/tests/test_remote_g2_target_rpc_local.py
+++ b/components/src/dynamo/trtllm/tests/test_remote_g2_target_rpc_local.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import threading
+from contextlib import contextmanager
+
+from dynamo.trtllm.kv_p2p import target_rpc_local
+
+
+class _FakeTargetRpcClient:
+    def __init__(self, resolve_response):
+        self.resolve_response = resolve_response
+        self.released = []
+
+    async def resolve_and_lease(self, plan, source_worker_id):
+        return self.resolve_response
+
+    async def release_lease(self, lease_id, source_worker_id, reason="ack"):
+        self.released.append((lease_id, source_worker_id, reason))
+        return {"ok": True, "result": True}
+
+
+@contextmanager
+def _running_loop():
+    loop = asyncio.new_event_loop()
+
+    def run():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    try:
+        yield loop
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+
+def test_promoted_primary_status_is_detected_from_dict_entries():
+    assert target_rpc_local._has_promoted_primary_status(
+        [
+            {"block_hash": 1, "status": "resolved_secondary"},
+            {"block_hash": 2, "status": "promoted_primary"},
+        ]
+    )
+
+
+def test_promoted_primary_status_is_detected_from_string_entries():
+    assert target_rpc_local._has_promoted_primary_status(
+        ["resolved_secondary", "promoted_primary"]
+    )
+
+
+def test_dispatch_resolve_rejects_promoted_primary_and_releases_lease():
+    client = _FakeTargetRpcClient(
+        {
+            "ok": True,
+            "result": {
+                "lease_id": "lease-1",
+                "descriptors": [{"block_hash": 10}],
+                "per_block_status": [
+                    {"block_hash": 10, "status": "resolved_secondary"},
+                    {"block_hash": 11, "status": "promoted_primary"},
+                ],
+            },
+        }
+    )
+    lease_map = target_rpc_local._LeaseSourceMap()
+
+    with _running_loop() as loop:
+        response = target_rpc_local._dispatch_resolve(
+            client,
+            {"plan": {"plan_id": "p1"}, "source_worker_id": 7},
+            loop,
+            lease_map,
+            timeout_s=5,
+        )
+
+    assert response["ok"] is False
+    assert response["error"] == "promoted_primary"
+    assert client.released == [("lease-1", 7, "promoted_primary")]
+    assert lease_map.pop("lease-1") is None
+
+
+def test_dispatch_resolve_tracks_lease_for_secondary_only_response():
+    client = _FakeTargetRpcClient(
+        {
+            "ok": True,
+            "result": {
+                "lease_id": "lease-2",
+                "descriptors": [{"block_hash": 10}],
+                "per_block_status": [
+                    {"block_hash": 10, "status": "resolved_secondary"},
+                ],
+            },
+        }
+    )
+    lease_map = target_rpc_local._LeaseSourceMap()
+
+    with _running_loop() as loop:
+        response = target_rpc_local._dispatch_resolve(
+            client,
+            {"plan": {"plan_id": "p2"}, "source_worker_id": 8},
+            loop,
+            lease_map,
+            timeout_s=5,
+        )
+
+    assert response["ok"] is True
+    assert client.released == []
+    assert lease_map.pop("lease-2") == 8

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -504,6 +504,22 @@ async def init_llm_worker(
             worker_id_path,
         )
 
+    # Bind the target-side REP socket BEFORE engine subprocess startup.
+    # The engine subprocess calls maybe_start_remote_g2_target_client
+    # inside register_kv_caches and polls for this socket; if we bind
+    # later (e.g. inside get_publisher) the engine times out before the
+    # socket appears. The bind itself is synchronous and only needs the
+    # dynamo runtime, so it's safe here.
+    _remote_g2_target_handle = None
+    if config.has_connector("remote_g2"):
+        from dynamo.trtllm.kv_p2p.target_rpc_local import (
+            setup_target_rpc_local,
+        )
+
+        _remote_g2_target_handle = setup_target_rpc_local(
+            runtime, config.namespace, config.component
+        )
+
     async with get_llm_engine(
         engine_args,
         config.disaggregation_mode,
@@ -736,10 +752,26 @@ async def init_llm_worker(
             ) as publisher:
                 handler_config.publisher = publisher
 
-                # remote-G2 source registry is now bootstrapped inside the
-                # engine subprocess (in RemoteG2KvCacheConnectorWorker.
-                # register_kv_caches), reading DYNAMO_REMOTE_G2_WORKER_ID
-                # from env vars set above.
+                # remote-G2 source registry is bootstrapped inside the
+                # engine subprocess (in PyExecutor, via
+                # maybe_start_remote_g2_service). It exposes a ZMQ REP
+                # socket; here we register dynamo runtime endpoints that
+                # forward to it, so other workers can reach this source
+                # via client.direct(...).
+                _remote_g2_rpc_handle = None
+                if config.has_connector("remote_g2"):
+                    from dynamo.trtllm.kv_p2p.source_rpc_server import (
+                        setup_source_rpc_endpoints,
+                    )
+
+                    # Source REP socket is bound by the engine subprocess;
+                    # the parent's REQ side waits for it to appear. The
+                    # target REP bind was already done before get_llm_engine
+                    # (see _remote_g2_target_handle above) — we keep that
+                    # reference alive but don't re-bind here.
+                    _remote_g2_rpc_handle = await setup_source_rpc_endpoints(
+                        runtime, config.namespace, config.component
+                    )
 
                 handler = RequestHandlerFactory().get_request_handler(handler_config)
                 if config.load_format == "gms":

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -470,6 +470,40 @@ async def init_llm_worker(
         component_name=config.component,
     )
 
+    # Create the endpoint BEFORE the engine. The engine subprocess inherits
+    # this process's env vars at spawn time, so remote-G2 needs the worker
+    # instance_id (== endpoint.connection_id()) available in env vars before
+    # get_llm_engine runs. The dynamo TRT-LLM connector reads these env vars
+    # inside register_kv_caches to identify the source worker the registry
+    # belongs to.
+    endpoint = runtime.endpoint(
+        f"{config.namespace}.{config.component}.{config.endpoint}"
+    )
+    if config.has_connector("remote_g2"):
+        worker_id = str(endpoint.connection_id())
+        os.environ["DYNAMO_REMOTE_G2_WORKER_ID"] = worker_id
+        os.environ["DYNAMO_REMOTE_G2_DP_RANK"] = "0"
+        # OpenMPI's orted strips arbitrary env vars when spawning ranks,
+        # so the engine subprocess won't see DYNAMO_REMOTE_G2_WORKER_ID
+        # via the env var path. Write a sidecar file keyed by this
+        # process's PID; the engine subprocess walks up its parent chain
+        # (engine → orted → dynamo worker) to find this PID and read the
+        # file.
+        # TODO production: replace with a proper TRT-LLM-aware mechanism.
+        worker_id_path = f"/tmp/dynamo_remote_g2_worker_{os.getpid()}.txt"
+        try:
+            with open(worker_id_path, "w") as f:
+                f.write(worker_id)
+        except Exception:
+            logging.exception("remote_g2: failed to write worker_id sidecar file")
+        logging.warning(
+            "PROBE remote_g2 dynamo-side env vars set: "
+            "DYNAMO_REMOTE_G2_WORKER_ID=%s DYNAMO_REMOTE_G2_DP_RANK=0 "
+            "sidecar=%s",
+            worker_id,
+            worker_id_path,
+        )
+
     async with get_llm_engine(
         engine_args,
         config.disaggregation_mode,
@@ -479,10 +513,6 @@ async def init_llm_worker(
         # The callback uses this to poll active request count during shutdown.
         if engine_holder is not None:
             engine_holder.append(engine)
-
-        endpoint = runtime.endpoint(
-            f"{config.namespace}.{config.component}.{config.endpoint}"
-        )
 
         if shutdown_endpoints is not None:
             shutdown_endpoints[:] = [endpoint]
@@ -705,6 +735,12 @@ async def init_llm_worker(
                 metrics_collector=metrics_collector,
             ) as publisher:
                 handler_config.publisher = publisher
+
+                # remote-G2 source registry is now bootstrapped inside the
+                # engine subprocess (in RemoteG2KvCacheConnectorWorker.
+                # register_kv_caches), reading DYNAMO_REMOTE_G2_WORKER_ID
+                # from env vars set above.
+
                 handler = RequestHandlerFactory().get_request_handler(handler_config)
                 if config.load_format == "gms":
                     _register_memory_routes(runtime, handler)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -87,6 +87,12 @@ def build_kv_connector_config(config: Config):
                 connector_scheduler_class="DynamoKVBMConnectorLeader",
                 connector_worker_class="DynamoKVBMConnectorWorker",
             )
+        elif config.connector[0] == "remote_g2":
+            return KvCacheConnectorConfig(
+                connector_module="tensorrt_llm._torch.pyexecutor.connectors.remote_g2_connector",
+                connector_scheduler_class="RemoteG2KvCacheConnectorScheduler",
+                connector_worker_class="RemoteG2KvCacheConnectorWorker",
+            )
         elif config.connector[0] == "none":
             return None
         else:

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -35,6 +35,21 @@ fn depythonize_block_mm_infos(obj: &Bound<'_, PyAny>) -> PyResult<Vec<Option<Blo
     depythonize(obj).map_err(to_pyerr)
 }
 
+fn parse_storage_tier(tier: Option<&str>) -> PyResult<Option<StorageTier>> {
+    let Some(tier) = tier else {
+        return Ok(None);
+    };
+    match tier.to_ascii_lowercase().as_str() {
+        "device" | "gpu" => Ok(Some(StorageTier::Device)),
+        "host_pinned" | "host" | "cpu_pinned" => Ok(Some(StorageTier::HostPinned)),
+        "disk" | "nvme" => Ok(Some(StorageTier::Disk)),
+        "external" | "remote" => Ok(Some(StorageTier::External)),
+        other => Err(to_pyerr(anyhow::anyhow!(
+            "unknown storage_tier {other:?}; expected one of: device, host_pinned, disk, external"
+        ))),
+    }
+}
+
 #[cfg(feature = "kv-indexer")]
 #[derive(Parser)]
 #[command(
@@ -276,7 +291,7 @@ impl KvEventPublisher {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, parent_hash=None, block_mm_infos=None, lora_name=None, is_eagle=None))]
+    #[pyo3(signature = (token_ids, num_block_tokens, block_hashes, parent_hash=None, block_mm_infos=None, lora_name=None, is_eagle=None, storage_tier=None))]
     fn publish_stored(
         &self,
         py: Python,
@@ -287,6 +302,7 @@ impl KvEventPublisher {
         block_mm_infos: Option<Bound<PyAny>>,
         lora_name: Option<String>,
         is_eagle: Option<bool>,
+        storage_tier: Option<&str>,
     ) -> PyResult<()> {
         let kv_block_size = self.kv_block_size as u32;
         let dp_rank = self.dp_rank;
@@ -299,6 +315,8 @@ impl KvEventPublisher {
             .as_ref()
             .map(depythonize_block_mm_infos)
             .transpose()?;
+
+        let tier = parse_storage_tier(storage_tier)?;
 
         py.allow_threads(|| {
             let block_hashes_u64: Vec<u64> = block_hashes.iter().map(|&h| h as u64).collect();
@@ -321,16 +339,28 @@ impl KvEventPublisher {
                 dp_rank,
             };
 
-            inner.publish(event).map_err(to_pyerr)
+            match tier {
+                Some(tier) => inner.publish_with_storage_tier(event, tier),
+                None => inner.publish(event),
+            }
+            .map_err(to_pyerr)
         })
     }
 
-    fn publish_removed(&self, py: Python, block_hashes: Vec<i64>) -> PyResult<()> {
+    #[pyo3(signature = (block_hashes, storage_tier=None))]
+    fn publish_removed(
+        &self,
+        py: Python,
+        block_hashes: Vec<i64>,
+        storage_tier: Option<&str>,
+    ) -> PyResult<()> {
         let dp_rank = self.dp_rank;
         let inner = self.inner.clone();
 
         // Use shared monotonic event_id counter from the inner publisher
         let event_id = inner.next_event_id();
+
+        let tier = parse_storage_tier(storage_tier)?;
 
         py.allow_threads(|| {
             let block_hashes: Vec<ExternalSequenceBlockHash> = block_hashes
@@ -343,7 +373,11 @@ impl KvEventPublisher {
                 dp_rank,
             };
 
-            inner.publish(event).map_err(to_pyerr)
+            match tier {
+                Some(tier) => inner.publish_with_storage_tier(event, tier),
+                None => inner.publish(event),
+            }
+            .map_err(to_pyerr)
         })
     }
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -791,6 +791,7 @@ class KvEventPublisher:
         block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
         lora_name: Optional[str] = None,
         is_eagle: Optional[bool] = None,
+        storage_tier: Optional[str] = None,
     ) -> None:
         """
         Publish a KV stored event.
@@ -808,10 +809,18 @@ class KvEventPublisher:
             lora_name: Optional LoRA adapter name for adapter-aware block hashing.
             is_eagle: Optional Eagle mode flag. When true, stored blocks are
                 reconstructed using overlapping `kv_block_size + 1` token windows.
+            storage_tier: Optional storage tier tag for the event. One of
+                "device", "host_pinned", "disk", "external". Defaults to "device"
+                when omitted. Used by routers that maintain per-tier prefix indexes
+                (e.g. for remote-G2 cross-instance reuse plan generation).
         """
         ...
 
-    def publish_removed(self, block_hashes: List[int]) -> None:
+    def publish_removed(
+        self,
+        block_hashes: List[int],
+        storage_tier: Optional[str] = None,
+    ) -> None:
         """
         Publish a KV removed event.
 

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -333,6 +333,43 @@ impl LowerTierIndexer {
             .unwrap_or_default()
     }
 
+    /// Walk the edge chain owned by `worker` starting from `parent_hash`,
+    /// returning each step's child block hash in plan order. Stops at the
+    /// first edge missing from the index or not owned by `worker`, so the
+    /// returned chain may be shorter than `tokens_hashes`.
+    ///
+    /// Used by the remote-G2 planner after it picks a source worker, to
+    /// extract the chain of TRT-LLM-side `block_hash` values the source
+    /// will need for `find_block_by_hash`. Best-effort: between successive
+    /// edge lookups, other threads may insert or remove edges. Callers
+    /// should treat the returned chain length as authoritative for the
+    /// current view and shrink or reject their plan accordingly.
+    pub fn chain_block_hashes_for_worker(
+        &self,
+        worker: WorkerWithDpRank,
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        tokens_hashes: &[LocalBlockHash],
+    ) -> Vec<ExternalSequenceBlockHash> {
+        let mut chain = Vec::with_capacity(tokens_hashes.len());
+        let mut current_parent = parent_hash;
+        for &tokens_hash in tokens_hashes {
+            let key = TransitionKey {
+                parent_hash: current_parent,
+                local_hash: tokens_hash,
+            };
+            let Some(edge) = self.edges.get(&key) else {
+                break;
+            };
+            if !edge.contains(&worker) {
+                break;
+            }
+            let child_hash = edge.child_hash();
+            chain.push(child_hash);
+            current_parent = Some(child_hash);
+        }
+        chain
+    }
+
     /// Reconstruct store events from the per-worker block index. Each block
     /// becomes a single-block `Stored` event with the correct parent hash,
     /// suitable for replaying into a fresh indexer to recreate the same state.
@@ -877,6 +914,47 @@ mod tests {
 
         let hits = index.query_contiguous_hits(&local_hashes(&[11, 12, 13]), &continuations);
         assert_eq!(hits.get(&WorkerWithDpRank::new(7, 0)), Some(&3));
+    }
+
+    #[test]
+    fn chain_block_hashes_returns_external_hashes_for_full_match() {
+        // chain walk on a fully-owned 3-block chain returns the
+        // external (TRT-LLM splitmix) block_hash at each step in order.
+        let mut index = TestLowerTierIndex::new();
+        index
+            .apply_event(store_event(7, 0, 0, None, &[11, 12, 13], &[101, 102, 103]))
+            .unwrap();
+
+        let chain = index.index.chain_block_hashes_for_worker(
+            WorkerWithDpRank::new(7, 0),
+            None,
+            &local_hashes(&[11, 12, 13]),
+        );
+
+        assert_eq!(
+            chain,
+            vec![
+                ExternalSequenceBlockHash(101),
+                ExternalSequenceBlockHash(102),
+                ExternalSequenceBlockHash(103),
+            ],
+        );
+    }
+
+    #[test]
+    fn chain_block_hashes_returns_empty_when_worker_not_owner() {
+        // worker 8 does not own these edges; chain comes back empty.
+        let mut index = TestLowerTierIndex::new();
+        index
+            .apply_event(store_event(7, 0, 0, None, &[11, 12, 13], &[101, 102, 103]))
+            .unwrap();
+
+        let chain = index.index.chain_block_hashes_for_worker(
+            WorkerWithDpRank::new(8, 0),
+            None,
+            &local_hashes(&[11, 12, 13]),
+        );
+        assert!(chain.is_empty());
     }
 
     #[test]

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod cleanup;
 pub mod indexer;
 pub mod protocols;
 pub mod recovery;
+pub mod remote_g2_plan;
 pub mod scheduling;
 pub mod sequences;
 pub mod zmq_wire;

--- a/lib/kv-router/src/remote_g2_plan.rs
+++ b/lib/kv-router/src/remote_g2_plan.rs
@@ -21,6 +21,11 @@ pub struct RemoteKvReusePlan {
     pub source_dp_rank: DpRank,
     pub source_tier: StorageTier,
     pub block_hashes: Vec<LocalBlockHash>,
+    /// Position in the request's prefix where `block_hashes[0]` lives.
+    /// Equals the source worker's device-tier match count at plan time.
+    /// The target's connector uses this to verify alignment with its own
+    /// `num_computed_tokens` before attaching descriptors.
+    pub start_block_index: u32,
     pub planned_prefix_blocks: u32,
     pub block_size_tokens: u32,
     pub created_at_ms: u64,
@@ -140,13 +145,34 @@ pub fn select_remote_g2_reuse_plan(
         };
     };
 
-    let planned_prefix_blocks = hits.min(input.block_hashes.len()) as u32;
+    // The indexer returns `hits` as a chained continuation count: the
+    // HostPinned chain for this source extends from the position where its
+    // Device chain ended, not from position 0. Without offsetting, the plan
+    // would reference request.block_hashes[..hits] (positions 0..hits), but
+    // the actual HostPinned matches on the source cover positions
+    // [device_match, device_match + hits). The wrong hashes would land in
+    // the plan, the source's resolve_for_request would fail to find them,
+    // and the plan would be silently useless.
+    let device_match = input
+        .tiered_matches
+        .device
+        .overlap_scores
+        .scores
+        .get(&source)
+        .copied()
+        .unwrap_or(0) as usize;
+
+    let request_blocks = input.block_hashes.len();
+    let start = device_match.min(request_blocks);
+    let available_after_device = request_blocks.saturating_sub(start);
+    let planned_prefix_blocks = (hits as usize).min(available_after_device) as u32;
     if planned_prefix_blocks == 0 {
         return RemoteKvReuseDecision::NoPlan {
             reason: RemoteKvReuseNoPlanReason::NoContiguousPrefix,
             stats,
         };
     }
+    let end = start + planned_prefix_blocks as usize;
 
     RemoteKvReuseDecision::Plan {
         plan: RemoteKvReusePlan {
@@ -160,7 +186,8 @@ pub fn select_remote_g2_reuse_plan(
             source_worker_id: source.worker_id,
             source_dp_rank: source.dp_rank,
             source_tier: StorageTier::HostPinned,
-            block_hashes: input.block_hashes[..planned_prefix_blocks as usize].to_vec(),
+            block_hashes: input.block_hashes[start..end].to_vec(),
+            start_block_index: start as u32,
             planned_prefix_blocks,
             block_size_tokens: input.block_size_tokens,
             created_at_ms: input.created_at_ms,
@@ -190,6 +217,7 @@ mod tests {
             source_dp_rank: 1,
             source_tier: StorageTier::HostPinned,
             block_hashes: vec![LocalBlockHash(11), LocalBlockHash(22)],
+            start_block_index: 0,
             planned_prefix_blocks: 2,
             block_size_tokens: 16,
             created_at_ms: 1000,
@@ -385,6 +413,49 @@ mod tests {
                 assert_eq!(reason, RemoteKvReuseNoPlanReason::NoContiguousPrefix);
             }
             other => panic!("expected no plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_start_block_index_is_zero_when_source_has_no_device_match() {
+        // Source A has 0 device-tier matches and 3 HostPinned hits → plan
+        // covers request positions [0, 3) and start_block_index == 0.
+        let hashes = block_hashes(5);
+        let target = WorkerWithDpRank::new(9, 0);
+        let source = WorkerWithDpRank::new(7, 0);
+        let matches = tiered_matches(&[], &[(source, 3)]);
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::Plan { plan, .. } => {
+                assert_eq!(plan.start_block_index, 0);
+                assert_eq!(plan.planned_prefix_blocks, 3);
+                assert_eq!(plan.block_hashes, hashes[..3].to_vec());
+            }
+            other => panic!("expected plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_start_block_index_equals_source_device_match() {
+        // Source A has 2 device-tier matches and 2 HostPinned hits chained
+        // past them → plan covers request positions [2, 4) and
+        // start_block_index == 2 (skip past A's device chain).
+        let hashes = block_hashes(6);
+        let target = WorkerWithDpRank::new(9, 0);
+        let source = WorkerWithDpRank::new(7, 0);
+        let matches = tiered_matches(&[(source, 2)], &[(source, 2)]);
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::Plan { plan, .. } => {
+                assert_eq!(plan.start_block_index, 2);
+                assert_eq!(plan.planned_prefix_blocks, 2);
+                assert_eq!(plan.block_hashes, hashes[2..4].to_vec());
+            }
+            other => panic!("expected plan, got {other:?}"),
         }
     }
 }

--- a/lib/kv-router/src/remote_g2_plan.rs
+++ b/lib/kv-router/src/remote_g2_plan.rs
@@ -1,0 +1,390 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::indexer::TieredMatchDetails;
+use crate::protocols::{DpRank, LocalBlockHash, StorageTier, WorkerId, WorkerWithDpRank};
+
+pub const REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY: &str = "remote_kv_reuse_plan";
+pub const REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY: &str =
+    "remote_kv_reuse_no_plan_reason";
+pub const REMOTE_KV_REUSE_PLAN_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteKvReusePlan {
+    pub plan_id: String,
+    pub request_id: String,
+    pub target_worker_id: WorkerId,
+    pub target_dp_rank: DpRank,
+    pub source_worker_id: WorkerId,
+    pub source_dp_rank: DpRank,
+    pub source_tier: StorageTier,
+    pub block_hashes: Vec<LocalBlockHash>,
+    pub planned_prefix_blocks: u32,
+    pub block_size_tokens: u32,
+    pub created_at_ms: u64,
+    pub expires_at_ms: u64,
+    pub plan_version: u32,
+}
+
+// Compatibility identity is intentionally deferred in v1; source resolve remains authoritative.
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteKvReuseNoPlanReason {
+    Disabled,
+    NoRemoteG2Candidate,
+    NoContiguousPrefix,
+    SourceIsTarget,
+    IncompatibleBlockSize,
+    PlanExpired,
+    SerializationFailed,
+}
+
+impl RemoteKvReuseNoPlanReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::NoRemoteG2Candidate => "no_remote_g2_candidate",
+            Self::NoContiguousPrefix => "no_contiguous_prefix",
+            Self::SourceIsTarget => "source_is_target",
+            Self::IncompatibleBlockSize => "incompatible_block_size",
+            Self::PlanExpired => "plan_expired",
+            Self::SerializationFailed => "serialization_failed",
+        }
+    }
+}
+
+pub struct RemoteKvReuseSelectionInput<'a> {
+    pub request_id: &'a str,
+    pub target: WorkerWithDpRank,
+    pub block_hashes: &'a [LocalBlockHash],
+    pub block_size_tokens: u32,
+    pub tiered_matches: &'a TieredMatchDetails,
+    pub created_at_ms: u64,
+    pub expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RemoteKvReuseSelectionStats {
+    pub rejected_g1_candidates: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteKvReuseDecision {
+    Plan {
+        plan: RemoteKvReusePlan,
+        stats: RemoteKvReuseSelectionStats,
+    },
+    NoPlan {
+        reason: RemoteKvReuseNoPlanReason,
+        stats: RemoteKvReuseSelectionStats,
+    },
+}
+
+pub fn select_remote_g2_reuse_plan(
+    input: RemoteKvReuseSelectionInput<'_>,
+) -> RemoteKvReuseDecision {
+    let stats = RemoteKvReuseSelectionStats {
+        rejected_g1_candidates: input
+            .tiered_matches
+            .device
+            .overlap_scores
+            .scores
+            .values()
+            .filter(|&&overlap| overlap > 0)
+            .count() as u32,
+    };
+
+    let Some(host_pinned_matches) = input
+        .tiered_matches
+        .lower_tier
+        .get(&StorageTier::HostPinned)
+    else {
+        return RemoteKvReuseDecision::NoPlan {
+            reason: RemoteKvReuseNoPlanReason::NoRemoteG2Candidate,
+            stats,
+        };
+    };
+
+    let mut saw_remote_candidate = false;
+    let mut best: Option<(WorkerWithDpRank, usize)> = None;
+    for (&worker, &hits) in &host_pinned_matches.hits {
+        if worker == input.target {
+            continue;
+        }
+        saw_remote_candidate = true;
+        if hits == 0 {
+            continue;
+        }
+        match best {
+            None => best = Some((worker, hits)),
+            Some((best_worker, best_hits))
+                if hits > best_hits || (hits == best_hits && worker < best_worker) =>
+            {
+                best = Some((worker, hits));
+            }
+            Some(_) => {}
+        }
+    }
+
+    let Some((source, hits)) = best else {
+        return RemoteKvReuseDecision::NoPlan {
+            reason: if saw_remote_candidate {
+                RemoteKvReuseNoPlanReason::NoContiguousPrefix
+            } else {
+                RemoteKvReuseNoPlanReason::NoRemoteG2Candidate
+            },
+            stats,
+        };
+    };
+
+    let planned_prefix_blocks = hits.min(input.block_hashes.len()) as u32;
+    if planned_prefix_blocks == 0 {
+        return RemoteKvReuseDecision::NoPlan {
+            reason: RemoteKvReuseNoPlanReason::NoContiguousPrefix,
+            stats,
+        };
+    }
+
+    RemoteKvReuseDecision::Plan {
+        plan: RemoteKvReusePlan {
+            plan_id: format!(
+                "remote-g2:{}:{}:{}:{}",
+                input.request_id, source.worker_id, source.dp_rank, input.created_at_ms
+            ),
+            request_id: input.request_id.to_string(),
+            target_worker_id: input.target.worker_id,
+            target_dp_rank: input.target.dp_rank,
+            source_worker_id: source.worker_id,
+            source_dp_rank: source.dp_rank,
+            source_tier: StorageTier::HostPinned,
+            block_hashes: input.block_hashes[..planned_prefix_blocks as usize].to_vec(),
+            planned_prefix_blocks,
+            block_size_tokens: input.block_size_tokens,
+            created_at_ms: input.created_at_ms,
+            expires_at_ms: input.expires_at_ms,
+            plan_version: REMOTE_KV_REUSE_PLAN_VERSION,
+        },
+        stats,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
+    use crate::protocols::{LocalBlockHash, OverlapScores, StorageTier, WorkerWithDpRank};
+    use crate::remote_g2_plan::{
+        REMOTE_KV_REUSE_PLAN_VERSION, RemoteKvReuseDecision, RemoteKvReuseNoPlanReason,
+        RemoteKvReusePlan, RemoteKvReuseSelectionInput, select_remote_g2_reuse_plan,
+    };
+
+    fn test_plan() -> RemoteKvReusePlan {
+        RemoteKvReusePlan {
+            plan_id: "plan-1".to_string(),
+            request_id: "request-1".to_string(),
+            target_worker_id: 9,
+            target_dp_rank: 0,
+            source_worker_id: 7,
+            source_dp_rank: 1,
+            source_tier: StorageTier::HostPinned,
+            block_hashes: vec![LocalBlockHash(11), LocalBlockHash(22)],
+            planned_prefix_blocks: 2,
+            block_size_tokens: 16,
+            created_at_ms: 1000,
+            expires_at_ms: 2000,
+            plan_version: REMOTE_KV_REUSE_PLAN_VERSION,
+        }
+    }
+
+    fn block_hashes(count: u64) -> Vec<LocalBlockHash> {
+        (0..count).map(LocalBlockHash).collect()
+    }
+
+    fn tiered_matches(
+        device_hits: &[(WorkerWithDpRank, u32)],
+        host_pinned_hits: &[(WorkerWithDpRank, usize)],
+    ) -> TieredMatchDetails {
+        let mut device = MatchDetails {
+            overlap_scores: OverlapScores::new(),
+            ..Default::default()
+        };
+        device
+            .overlap_scores
+            .scores
+            .extend(device_hits.iter().copied());
+
+        let mut lower_tier = std::collections::HashMap::new();
+        let mut host_pinned = LowerTierMatchDetails::default();
+        host_pinned.hits.extend(host_pinned_hits.iter().copied());
+        lower_tier.insert(StorageTier::HostPinned, host_pinned);
+
+        TieredMatchDetails { device, lower_tier }
+    }
+
+    fn selection_input<'a>(
+        target: WorkerWithDpRank,
+        block_hashes: &'a [LocalBlockHash],
+        tiered_matches: &'a TieredMatchDetails,
+    ) -> RemoteKvReuseSelectionInput<'a> {
+        RemoteKvReuseSelectionInput {
+            request_id: "request-1",
+            target,
+            block_hashes,
+            block_size_tokens: 16,
+            tiered_matches,
+            created_at_ms: 1000,
+            expires_at_ms: 2000,
+        }
+    }
+
+    #[test]
+    fn remote_kv_reuse_plan_round_trips_json() {
+        let plan = test_plan();
+        let json = serde_json::to_string(&plan).unwrap();
+        let decoded: RemoteKvReusePlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, plan);
+    }
+
+    #[test]
+    fn remote_kv_reuse_plan_serialization_has_no_forbidden_router_truth() {
+        let json = serde_json::to_string(&test_plan()).unwrap();
+        for forbidden in [
+            "virtual_address",
+            "physical_address",
+            "nixl_descriptor",
+            "descriptor",
+            "target_g1_block_id",
+            "source_block_id",
+            "block_ptr",
+            "handle",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "serialized plan contains forbidden router truth: {forbidden}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_plan_reason_is_low_cardinality_snake_case() {
+        let json = serde_json::to_string(&RemoteKvReuseNoPlanReason::NoRemoteG2Candidate).unwrap();
+        assert_eq!(json, "\"no_remote_g2_candidate\"");
+    }
+
+    #[test]
+    fn selects_longest_remote_g2_prefix() {
+        let hashes = block_hashes(5);
+        let target = WorkerWithDpRank::new(9, 0);
+        let matches = tiered_matches(
+            &[],
+            &[
+                (WorkerWithDpRank::new(7, 0), 2),
+                (WorkerWithDpRank::new(8, 0), 4),
+            ],
+        );
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::Plan { plan, .. } => {
+                assert_eq!(plan.source_worker_id, 8);
+                assert_eq!(plan.source_dp_rank, 0);
+                assert_eq!(plan.planned_prefix_blocks, 4);
+                assert_eq!(plan.block_hashes, hashes[..4].to_vec());
+            }
+            other => panic!("expected plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remote_g2_tie_break_is_stable_by_worker_then_rank() {
+        let hashes = block_hashes(4);
+        let target = WorkerWithDpRank::new(9, 0);
+        let matches = tiered_matches(
+            &[],
+            &[
+                (WorkerWithDpRank::new(8, 1), 3),
+                (WorkerWithDpRank::new(7, 3), 3),
+                (WorkerWithDpRank::new(7, 1), 3),
+            ],
+        );
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::Plan { plan, .. } => {
+                assert_eq!(plan.source_worker_id, 7);
+                assert_eq!(plan.source_dp_rank, 1);
+                assert_eq!(plan.planned_prefix_blocks, 3);
+            }
+            other => panic!("expected plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remote_g1_device_hits_are_rejected_not_selected() {
+        let hashes = block_hashes(2);
+        let target = WorkerWithDpRank::new(9, 0);
+        let matches = TieredMatchDetails {
+            device: {
+                let mut device = MatchDetails {
+                    overlap_scores: OverlapScores::new(),
+                    ..Default::default()
+                };
+                device
+                    .overlap_scores
+                    .scores
+                    .insert(WorkerWithDpRank::new(7, 0), 2);
+                device
+            },
+            lower_tier: Default::default(),
+        };
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::NoPlan { reason, stats } => {
+                assert_eq!(reason, RemoteKvReuseNoPlanReason::NoRemoteG2Candidate);
+                assert!(stats.rejected_g1_candidates > 0);
+            }
+            other => panic!("expected no plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn source_selection_does_not_change_target() {
+        let hashes = block_hashes(3);
+        let target = WorkerWithDpRank::new(42, 2);
+        let matches = tiered_matches(&[], &[(WorkerWithDpRank::new(7, 0), 3)]);
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::Plan { plan, .. } => {
+                assert_eq!(plan.target_worker_id, 42);
+                assert_eq!(plan.target_dp_rank, 2);
+                assert_eq!(plan.source_worker_id, 7);
+                assert_eq!(plan.source_dp_rank, 0);
+            }
+            other => panic!("expected plan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn zero_host_pinned_hits_return_no_contiguous_prefix() {
+        let hashes = block_hashes(2);
+        let target = WorkerWithDpRank::new(9, 0);
+        let matches = tiered_matches(&[], &[(WorkerWithDpRank::new(7, 0), 0)]);
+
+        let decision = select_remote_g2_reuse_plan(selection_input(target, &hashes, &matches));
+
+        match decision {
+            RemoteKvReuseDecision::NoPlan { reason, .. } => {
+                assert_eq!(reason, RemoteKvReuseNoPlanReason::NoContiguousPrefix);
+            }
+            other => panic!("expected no plan, got {other:?}"),
+        }
+    }
+}

--- a/lib/kv-router/src/remote_g2_plan.rs
+++ b/lib/kv-router/src/remote_g2_plan.rs
@@ -31,6 +31,15 @@ pub struct RemoteKvReusePlan {
     pub created_at_ms: u64,
     pub expires_at_ms: u64,
     pub plan_version: u32,
+    /// Parallel to `block_hashes`, carrying each block's source-side
+    /// KV-cache-manager hash (TRT-LLM splitmix). The TRT-LLM source side
+    /// uses these values to look up blocks via `find_block_by_hash`;
+    /// `block_hashes` (XXH3 tokens hash) remains the plan's identity.
+    /// Empty when the producer has not been updated to populate the new
+    /// field — TRT-LLM's source falls back to using `block_hashes` for
+    /// the lookup (legacy behavior).
+    #[serde(default)]
+    pub kv_block_hashes: Vec<u64>,
 }
 
 // Compatibility identity is intentionally deferred in v1; source resolve remains authoritative.
@@ -193,6 +202,10 @@ pub fn select_remote_g2_reuse_plan(
             created_at_ms: input.created_at_ms,
             expires_at_ms: input.expires_at_ms,
             plan_version: REMOTE_KV_REUSE_PLAN_VERSION,
+            // Caller fills this in post-selection by walking the indexer for
+            // the chosen source. Left empty here so the planner stays a pure
+            // function of `tiered_matches` and does not depend on the indexer.
+            kv_block_hashes: Vec::new(),
         },
         stats,
     }
@@ -223,6 +236,7 @@ mod tests {
             created_at_ms: 1000,
             expires_at_ms: 2000,
             plan_version: REMOTE_KV_REUSE_PLAN_VERSION,
+            kv_block_hashes: vec![],
         }
     }
 
@@ -273,6 +287,45 @@ mod tests {
         let json = serde_json::to_string(&plan).unwrap();
         let decoded: RemoteKvReusePlan = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, plan);
+    }
+
+    #[test]
+    fn remote_kv_reuse_plan_round_trips_kv_block_hashes() {
+        // Populated kv_block_hashes must appear in the JSON and survive
+        // a serialize → deserialize round trip with the exact same values.
+        let mut plan = test_plan();
+        plan.kv_block_hashes = vec![
+            0xAAAA_AAAA_AAAA_AAAA,
+            0xBBBB_BBBB_BBBB_BBBB,
+            0xCCCC_CCCC_CCCC_CCCC,
+        ];
+        let json = serde_json::to_string(&plan).unwrap();
+        assert!(
+            json.contains("\"kv_block_hashes\""),
+            "serialized plan missing kv_block_hashes field: {json}"
+        );
+        // Big values must serialize as integers, not stringified
+        assert!(json.contains("12297829382473034410"));
+        let decoded: RemoteKvReusePlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.kv_block_hashes, plan.kv_block_hashes);
+    }
+
+    #[test]
+    fn remote_kv_reuse_plan_accepts_legacy_payload_without_kv_block_hashes() {
+        // A producer that has not been updated to populate kv_block_hashes
+        // emits the field-less JSON; it must still deserialize, with the
+        // new field defaulting to empty.
+        let plan = test_plan();
+        let json = serde_json::to_string(&plan).unwrap();
+        // Strip the kv_block_hashes field from the JSON to simulate a
+        // legacy producer.
+        let legacy = json.replace(",\"kv_block_hashes\":[]", "");
+        assert!(
+            !legacy.contains("kv_block_hashes"),
+            "legacy payload should not contain kv_block_hashes"
+        );
+        let decoded: RemoteKvReusePlan = serde_json::from_str(&legacy).unwrap();
+        assert!(decoded.kv_block_hashes.is_empty());
     }
 
     #[test]

--- a/lib/kv-router/src/zmq_wire/convert.rs
+++ b/lib/kv-router/src/zmq_wire/convert.rs
@@ -152,6 +152,17 @@ pub fn create_stored_block_from_parts(
         kv_block_size,
         mm_extra_info
     );
+    // PROBE: emit both hashes at WARN so the worker log can be cross-referenced
+    // against the planner output. The planner emits plans containing tokens_hash
+    // values (LocalBlockHash, XXH3 seed=1337), while publisher.py's PROBE log
+    // captures the upstream block_hash (TRT-LLM external). Both spaces matter:
+    // - tokens_hash is what the indexer keys on and what the planner emits.
+    // - block_hash is what the source descriptor registry would key on (for NIXL).
+    tracing::warn!(
+        "PROBE create_stored_block: block_hash={} tokens_hash={}",
+        block_hash,
+        tokens_hash.0,
+    );
     KvCacheStoredBlockData {
         block_hash: ExternalSequenceBlockHash::from(block_hash),
         tokens_hash,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -618,7 +618,7 @@ where
             .instrument(tracing::info_span!("kv_router.schedule"))
             .await?;
         let created_at_ms = unix_epoch_ms();
-        let remote_kv_reuse = if remote_g2_reuse_enabled() {
+        let mut remote_kv_reuse = if remote_g2_reuse_enabled() {
             select_remote_g2_reuse_plan(RemoteKvReuseSelectionInput {
                 request_id: context_id.unwrap_or_default(),
                 target: response.best_worker,
@@ -634,6 +634,69 @@ where
                 stats: RemoteKvReuseSelectionStats::default(),
             }
         };
+
+        // Post-selection: extract the chosen source's host-pinned chain of
+        // TRT-LLM-side block_hashes and populate the plan. The chain may
+        // come back shorter than `planned_prefix_blocks` if eviction races
+        // with our walk; in that case shrink the plan to the chain length,
+        // or demote to NoPlan if the chain is empty entirely.
+        if let RemoteKvReuseDecision::Plan {
+            plan,
+            stats: plan_stats,
+        } = &mut remote_kv_reuse
+        {
+            let source = dynamo_kv_router::protocols::WorkerWithDpRank::new(
+                plan.source_worker_id,
+                plan.source_dp_rank,
+            );
+            let start = plan.start_block_index as usize;
+            let end = start + plan.planned_prefix_blocks as usize;
+            // Starting parent_hash for the host-pinned chain: None when the
+            // source had no device-tier matches (start == 0), otherwise the
+            // device tier's last matched block_hash for this source.
+            let parent_hash = if start == 0 {
+                None
+            } else {
+                tiered_matches
+                    .device
+                    .last_matched_hashes
+                    .get(&source)
+                    .copied()
+            };
+
+            let chain = self.indexer.chain_block_hashes_for_host_pinned(
+                source,
+                parent_hash,
+                &block_hashes[start..end],
+            );
+
+            // PROBE: emit at WARN so worker-side block_hash logs can be
+            // cross-referenced against planner output. Investigation-only
+            // until the hash plumbing is validated end-to-end.
+            tracing::warn!(
+                plan_id = %plan.plan_id,
+                source_worker_id = source.worker_id,
+                source_dp_rank = source.dp_rank,
+                requested_block_hashes = ?plan.block_hashes,
+                chain_kv_block_hashes = ?chain,
+                "PROBE remote_g2_plan kv_block_hash chain"
+            );
+
+            if chain.is_empty() {
+                let stats_copy = *plan_stats;
+                remote_kv_reuse = RemoteKvReuseDecision::NoPlan {
+                    reason: RemoteKvReuseNoPlanReason::NoContiguousPrefix,
+                    stats: stats_copy,
+                };
+            } else {
+                if chain.len() < end - start {
+                    let new_len = chain.len();
+                    plan.planned_prefix_blocks = new_len as u32;
+                    plan.block_hashes.truncate(new_len);
+                }
+                plan.kv_block_hashes = chain.into_iter().map(|h| h.0).collect();
+            }
+        }
         let total_elapsed = start.elapsed();
 
         if let Some(m) = metrics::RoutingOverheadMetrics::get() {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -3,8 +3,9 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    env,
     sync::Arc,
-    time::Instant,
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Result;
@@ -17,6 +18,10 @@ use dynamo_kv_router::{
         BlockExtraInfo, BlockHashOptions, DpRank, LocalBlockHash, PrefillLoadHint, RouterEvent,
         RouterRequest, RouterResponse, TokensWithHashes, WorkerId, WorkerWithDpRank,
         compute_block_hash_for_seq,
+    },
+    remote_g2_plan::{
+        RemoteKvReuseDecision, RemoteKvReuseNoPlanReason, RemoteKvReuseSelectionInput,
+        RemoteKvReuseSelectionStats, select_remote_g2_reuse_plan,
     },
     scheduling::TierOverlapBlocks,
 };
@@ -65,6 +70,7 @@ use crate::{
         sequence::{SequenceError, SequenceRequest},
     },
     local_model::runtime_config::ModelRuntimeConfig,
+    protocols::common::preprocessor::PreprocessedRequest,
 };
 
 // [gluo TODO] shouldn't need to be public
@@ -105,10 +111,49 @@ struct CacheHitEstimates {
     cached_tokens: HashMap<WorkerWithDpRank, usize>,
 }
 
-#[derive(Debug, Clone, Copy)]
+const REMOTE_KV_REUSE_PLAN_TTL_MS: u64 = 30_000;
+const REMOTE_G2_REUSE_ENABLED_ENV: &str = "DYN_REMOTE_G2_REUSE_ENABLED";
+
+#[derive(Debug, Clone)]
 pub(crate) struct BestMatchDetails {
     pub worker: WorkerWithDpRank,
     pub cache_hit: WorkerCacheHitEstimate,
+    pub remote_kv_reuse: RemoteKvReuseDecision,
+}
+
+fn unix_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+        .unwrap_or_default()
+}
+
+fn remote_g2_reuse_enabled() -> bool {
+    env::var(REMOTE_G2_REUSE_ENABLED_ENV)
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+        })
+        .unwrap_or(true)
+}
+
+pub(crate) fn attach_remote_kv_reuse_decision(
+    request: &mut PreprocessedRequest,
+    decision: &RemoteKvReuseDecision,
+) -> serde_json::Result<()> {
+    match decision {
+        RemoteKvReuseDecision::Plan { plan, .. } => {
+            if request.attach_remote_kv_reuse_plan(plan).is_ok() {
+                return Ok(());
+            }
+            request.attach_remote_kv_reuse_no_plan_reason(
+                RemoteKvReuseNoPlanReason::SerializationFailed,
+            )
+        }
+        RemoteKvReuseDecision::NoPlan { reason, .. } => {
+            request.attach_remote_kv_reuse_no_plan_reason(reason.clone())
+        }
+    }
 }
 
 fn cache_hit_weight_for_tier(
@@ -500,7 +545,7 @@ where
             if let Some(ref shared_cache) = self.shared_cache {
                 let indexer_fut = self
                     .indexer
-                    .find_matches_by_tier(block_hashes)
+                    .find_matches_by_tier(block_hashes.clone())
                     .instrument(tracing::info_span!("kv_router.find_matches"));
                 let shared_fut = shared_cache
                     .check_blocks(tokens, self.block_size)
@@ -536,7 +581,7 @@ where
                 let t = Instant::now();
                 let tiered = self
                     .indexer
-                    .find_matches_by_tier(block_hashes)
+                    .find_matches_by_tier(block_hashes.clone())
                     .instrument(tracing::info_span!("kv_router.find_matches"))
                     .await?;
                 (tiered, None, t.elapsed(), None)
@@ -572,6 +617,23 @@ where
             )
             .instrument(tracing::info_span!("kv_router.schedule"))
             .await?;
+        let created_at_ms = unix_epoch_ms();
+        let remote_kv_reuse = if remote_g2_reuse_enabled() {
+            select_remote_g2_reuse_plan(RemoteKvReuseSelectionInput {
+                request_id: context_id.unwrap_or_default(),
+                target: response.best_worker,
+                block_hashes: &block_hashes,
+                block_size_tokens: self.block_size,
+                tiered_matches: &tiered_matches,
+                created_at_ms,
+                expires_at_ms: created_at_ms.saturating_add(REMOTE_KV_REUSE_PLAN_TTL_MS),
+            })
+        } else {
+            RemoteKvReuseDecision::NoPlan {
+                reason: RemoteKvReuseNoPlanReason::Disabled,
+                stats: RemoteKvReuseSelectionStats::default(),
+            }
+        };
         let total_elapsed = start.elapsed();
 
         if let Some(m) = metrics::RoutingOverheadMetrics::get() {
@@ -597,6 +659,10 @@ where
             m.shared_cache_beyond_blocks.observe(beyond as f64);
         }
 
+        if let Some(m) = metrics::RouterRequestMetrics::get() {
+            m.observe_remote_g2_decision(&remote_kv_reuse, self.block_size);
+        }
+
         #[cfg(feature = "bench")]
         tracing::info!(
             isl_tokens,
@@ -614,6 +680,7 @@ where
                 effective_overlap_blocks: response.effective_overlap_blocks,
                 cached_tokens: response.cached_tokens,
             },
+            remote_kv_reuse,
         })
     }
 
@@ -935,7 +1002,12 @@ mod tests {
     use async_trait::async_trait;
     use dynamo_kv_router::{
         indexer::{LowerTierMatchDetails, MatchDetails},
-        protocols::{OverlapScores, StorageTier},
+        protocols::{LocalBlockHash, OverlapScores, StorageTier},
+        remote_g2_plan::{
+            REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY, REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY,
+            REMOTE_KV_REUSE_PLAN_VERSION, RemoteKvReuseNoPlanReason, RemoteKvReusePlan,
+            RemoteKvReuseSelectionStats,
+        },
     };
     use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
     use tokio::sync::watch;
@@ -1154,5 +1226,88 @@ mod tests {
 
         assert_eq!(worker, WorkerWithDpRank::from_worker_id(0));
         assert_eq!(overlap, 0);
+    }
+
+    fn remote_g2_test_request() -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("test".to_string())
+            .token_ids(vec![1, 2, 3, 4])
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default())
+            .build()
+            .unwrap()
+    }
+
+    fn remote_g2_test_plan() -> RemoteKvReusePlan {
+        RemoteKvReusePlan {
+            plan_id: "plan-1".to_string(),
+            request_id: "request-1".to_string(),
+            target_worker_id: 42,
+            target_dp_rank: 2,
+            source_worker_id: 7,
+            source_dp_rank: 0,
+            source_tier: StorageTier::HostPinned,
+            block_hashes: vec![LocalBlockHash(11), LocalBlockHash(22)],
+            planned_prefix_blocks: 2,
+            block_size_tokens: 16,
+            created_at_ms: 1000,
+            expires_at_ms: 2000,
+            plan_version: REMOTE_KV_REUSE_PLAN_VERSION,
+        }
+    }
+
+    #[test]
+    fn router_attaches_remote_g2_plan_after_target_selection() {
+        let mut request = remote_g2_test_request();
+        let decision = RemoteKvReuseDecision::Plan {
+            plan: remote_g2_test_plan(),
+            stats: RemoteKvReuseSelectionStats {
+                rejected_g1_candidates: 1,
+            },
+        };
+
+        attach_remote_kv_reuse_decision(&mut request, &decision).unwrap();
+
+        let extra_args = request.extra_args.unwrap();
+        let plan = &extra_args[REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY];
+        assert_eq!(plan["target_worker_id"], 42);
+        assert_eq!(plan["target_dp_rank"], 2);
+        assert_eq!(plan["source_worker_id"], 7);
+        assert_eq!(plan["source_dp_rank"], 0);
+        assert_eq!(plan["source_tier"], "host_pinned");
+    }
+
+    #[test]
+    fn router_no_plan_has_reason_without_forbidden_fields() {
+        let mut request = remote_g2_test_request();
+        let decision = RemoteKvReuseDecision::NoPlan {
+            reason: RemoteKvReuseNoPlanReason::NoRemoteG2Candidate,
+            stats: RemoteKvReuseSelectionStats {
+                rejected_g1_candidates: 1,
+            },
+        };
+
+        attach_remote_kv_reuse_decision(&mut request, &decision).unwrap();
+
+        let extra_args = request.extra_args.unwrap();
+        assert_eq!(
+            extra_args[REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY],
+            "no_remote_g2_candidate"
+        );
+        let serialized = serde_json::to_string(&extra_args).unwrap();
+        for forbidden in [
+            "virtual_address",
+            "physical_address",
+            "nixl_descriptor",
+            "descriptor",
+            "source_block_id",
+            "target_g1_block_id",
+            "prompt text",
+            "11",
+            "22",
+        ] {
+            assert!(!serialized.contains(forbidden));
+        }
     }
 }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -1249,6 +1249,7 @@ mod tests {
             source_dp_rank: 0,
             source_tier: StorageTier::HostPinned,
             block_hashes: vec![LocalBlockHash(11), LocalBlockHash(22)],
+            start_block_index: 0,
             planned_prefix_blocks: 2,
             block_size_tokens: 16,
             created_at_ms: 1000,

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -13,8 +13,8 @@ use dynamo_kv_router::{
         MatchDetails, ThreadPoolIndexer, query_lower_tiers,
     },
     protocols::{
-        DpRank, LocalBlockHash, OverlapScores, RouterEvent, TokensWithHashes, WorkerId,
-        WorkerWithDpRank,
+        DpRank, ExternalSequenceBlockHash, LocalBlockHash, OverlapScores, RouterEvent,
+        StorageTier, TokensWithHashes, WorkerId, WorkerWithDpRank,
     },
 };
 
@@ -203,6 +203,41 @@ impl Indexer {
             }
             Self::None => Ok(TieredMatchDetails::default()),
         }
+    }
+
+    /// Walk the host-pinned chain for `source` starting from `parent_hash`,
+    /// returning each step's TRT-LLM-side block_hash. Used by the remote-G2
+    /// planner to populate `RemoteKvReusePlan.kv_block_hashes` for the
+    /// selected source worker.
+    ///
+    /// Returns an empty Vec when:
+    /// - the indexer is `None` or `Remote` (host-pinned indexer not locally
+    ///   reachable),
+    /// - no host-pinned events have been seen yet (lazy tier is unallocated),
+    /// - the source's chain breaks before the first step (eviction race or
+    ///   worker not an owner of the first edge).
+    ///
+    /// Empty result causes `kv_block_hashes` to stay empty, in which case
+    /// the TRT-LLM source side falls back to using `block_hashes` for the
+    /// resolve lookup (legacy behavior).
+    pub fn chain_block_hashes_for_host_pinned(
+        &self,
+        source: WorkerWithDpRank,
+        parent_hash: Option<ExternalSequenceBlockHash>,
+        tokens_hashes: &[LocalBlockHash],
+    ) -> Vec<ExternalSequenceBlockHash> {
+        let lower_tier = match self {
+            Self::KvIndexer { lower_tier, .. } | Self::Concurrent { lower_tier, .. } => {
+                lower_tier
+            }
+            Self::Remote(_) | Self::None => return Vec::new(),
+        };
+        let Some(indexer) = lower_tier.get(StorageTier::HostPinned) else {
+            return Vec::new();
+        };
+        indexer
+            .backend()
+            .chain_block_hashes_for_worker(source, parent_hash, tokens_hashes)
     }
 
     pub(crate) async fn record_hashed_routing_decision(

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -60,6 +60,7 @@ use dynamo_runtime::traits::DistributedRuntimeProvider;
 use prometheus::{HistogramOpts, IntCounter, IntCounterVec, IntGaugeVec, Opts};
 
 use crate::http::service::metrics::generate_log_buckets;
+use dynamo_kv_router::remote_g2_plan::RemoteKvReuseDecision;
 
 /// Buckets for CPU-bound compute phases (block hashing, sequence hashing).
 fn compute_overhead_buckets() -> Vec<f64> {
@@ -512,6 +513,10 @@ pub struct RouterRequestMetrics {
     pub kv_transfer_estimated_latency_seconds: prometheus::Histogram,
     pub shared_cache_hit_rate: prometheus::Histogram,
     pub shared_cache_beyond_blocks: prometheus::Histogram,
+    pub remote_g2_plans_total: prometheus::IntCounter,
+    pub remote_g2_planned_tokens: prometheus::IntCounter,
+    pub remote_g2_rejected_g1_candidates_total: prometheus::IntCounter,
+    pub remote_g2_no_plan_total: IntCounterVec,
 }
 
 static ROUTER_REQUEST_METRICS: OnceLock<Arc<RouterRequestMetrics>> = OnceLock::new();
@@ -607,6 +612,35 @@ impl RouterRequestMetrics {
                         Some(prometheus::exponential_buckets(1.0, 2.0, 12).unwrap()),
                     )
                     .expect("failed to create router_shared_cache_beyond_blocks");
+                let remote_g2_plans_total = metrics
+                    .create_intcounter(
+                        &router_metric("remote_g2_plans_total"),
+                        "Total remote G2 reuse plans attached by the router",
+                        extra_labels,
+                    )
+                    .expect("failed to create router_remote_g2_plans_total");
+                let remote_g2_planned_tokens = metrics
+                    .create_intcounter(
+                        &router_metric("remote_g2_planned_tokens"),
+                        "Total prompt tokens covered by router-planned remote G2 reuse",
+                        extra_labels,
+                    )
+                    .expect("failed to create router_remote_g2_planned_tokens");
+                let remote_g2_rejected_g1_candidates_total = metrics
+                    .create_intcounter(
+                        &router_metric("remote_g2_rejected_g1_candidates_total"),
+                        "Total device-tier candidates rejected as v1 remote G2 sources",
+                        extra_labels,
+                    )
+                    .expect("failed to create router_remote_g2_rejected_g1_candidates_total");
+                let remote_g2_no_plan_total = metrics
+                    .create_intcountervec(
+                        &router_metric("remote_g2_no_plan_total"),
+                        "Total remote G2 no-plan decisions by low-cardinality reason",
+                        &["reason"],
+                        extra_labels,
+                    )
+                    .expect("failed to create router_remote_g2_no_plan_total");
                 Arc::new(Self {
                     requests_total,
                     time_to_first_token_seconds,
@@ -617,9 +651,38 @@ impl RouterRequestMetrics {
                     kv_transfer_estimated_latency_seconds,
                     shared_cache_hit_rate,
                     shared_cache_beyond_blocks,
+                    remote_g2_plans_total,
+                    remote_g2_planned_tokens,
+                    remote_g2_rejected_g1_candidates_total,
+                    remote_g2_no_plan_total,
                 })
             })
             .clone()
+    }
+
+    pub fn observe_remote_g2_decision(&self, decision: &RemoteKvReuseDecision, block_size: u32) {
+        match decision {
+            RemoteKvReuseDecision::Plan { plan, stats } => {
+                self.remote_g2_plans_total.inc();
+                let block_size_tokens = if plan.block_size_tokens == 0 {
+                    block_size
+                } else {
+                    plan.block_size_tokens
+                };
+                self.remote_g2_planned_tokens.inc_by(
+                    u64::from(plan.planned_prefix_blocks) * u64::from(block_size_tokens),
+                );
+                self.remote_g2_rejected_g1_candidates_total
+                    .inc_by(u64::from(stats.rejected_g1_candidates));
+            }
+            RemoteKvReuseDecision::NoPlan { reason, stats } => {
+                self.remote_g2_no_plan_total
+                    .with_label_values(&[reason.as_str()])
+                    .inc();
+                self.remote_g2_rejected_g1_candidates_total
+                    .inc_by(u64::from(stats.rejected_g1_candidates));
+            }
+        }
     }
 }
 
@@ -853,6 +916,42 @@ dynamo_frontend_router_queue_pending_requests{worker_type=\"decode\"} 5
             Duration::from_millis(1),
         );
         // Reaching here without panic confirms saturating_sub works
+    }
+
+    #[test]
+    fn remote_g2_metrics_use_low_cardinality_reason_label() {
+        let registry = prometheus::Registry::new();
+        let remote_g2_no_plan_total = IntCounterVec::new(
+            Opts::new(
+                "remote_g2_no_plan_total",
+                "Total remote G2 no-plan decisions by low-cardinality reason",
+            ),
+            &["reason"],
+        )
+        .unwrap();
+        registry
+            .register(Box::new(remote_g2_no_plan_total.clone()))
+            .unwrap();
+
+        remote_g2_no_plan_total
+            .with_label_values(&["no_remote_g2_candidate"])
+            .inc();
+
+        let output = gather_pef(&registry);
+        assert!(output.contains("remote_g2_no_plan_total{reason=\"no_remote_g2_candidate\"} 1"));
+        for forbidden in [
+            "virtual_address",
+            "physical_address",
+            "nixl_descriptor",
+            "descriptor",
+            "source_block_id",
+            "target_g1_block_id",
+            "prompt text",
+            "11",
+            "22",
+        ] {
+            assert!(!output.contains(forbidden));
+        }
     }
 
     #[test]

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -4,7 +4,10 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_kv_router::protocols::{TokensWithHashes, WorkerWithDpRank};
+use dynamo_kv_router::{
+    protocols::{TokensWithHashes, WorkerWithDpRank},
+    remote_g2_plan::RemoteKvReuseDecision,
+};
 use dynamo_runtime::{
     dynamo_nvtx_range,
     metrics::frontend_perf::{STAGE_DISPATCH, STAGE_ROUTE, StageGuard},
@@ -20,7 +23,7 @@ use tracing::Instrument;
 
 use crate::{
     kv_router::{
-        KvRouter,
+        KvRouter, attach_remote_kv_reuse_decision,
         agent_controller::{AgentController, SessionCloseAction},
         metrics::RouterRequestMetrics,
         sticky_sessions::{InMemoryAffinityStore, StickySessionRouter},
@@ -52,6 +55,7 @@ struct WorkerSelection {
     /// Whether the scheduler is tracking this request (add_request or
     /// find_best_match_details with update_states=true was called).
     scheduler_tracked: bool,
+    remote_kv_reuse: Option<RemoteKvReuseDecision>,
 }
 
 /// Drop guard that manages the full lifecycle of a routed request:
@@ -324,6 +328,7 @@ impl KvPushRouter {
             let effective_overlap_blocks = selection.cache_hit.effective_overlap_blocks;
             let cached_tokens = selection.cache_hit.cached_tokens;
             let overlap_amount = selection.cache_hit.rounded_overlap_blocks();
+            let remote_kv_reuse = Some(selection.remote_kv_reuse);
 
             if !is_query_only {
                 let total_blocks = routing_token_ids
@@ -353,6 +358,7 @@ impl KvPushRouter {
                 effective_overlap_blocks,
                 cached_tokens,
                 scheduler_tracked: !is_query_only,
+                remote_kv_reuse,
             });
         };
 
@@ -380,6 +386,7 @@ impl KvPushRouter {
             let effective_overlap_blocks = selection.cache_hit.effective_overlap_blocks;
             let cached_tokens = selection.cache_hit.cached_tokens;
             let overlap_amount = selection.cache_hit.rounded_overlap_blocks();
+            let remote_kv_reuse = Some(selection.remote_kv_reuse);
 
             return Ok(WorkerSelection {
                 instance_id: best_worker.worker_id,
@@ -388,6 +395,7 @@ impl KvPushRouter {
                 effective_overlap_blocks,
                 cached_tokens,
                 scheduler_tracked: true,
+                remote_kv_reuse,
             });
         }
 
@@ -460,6 +468,7 @@ impl KvPushRouter {
             effective_overlap_blocks,
             cached_tokens,
             scheduler_tracked: !is_query_only && resolved_dp_rank.is_some(),
+            remote_kv_reuse: None,
         })
     }
 }
@@ -536,6 +545,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             effective_overlap_blocks,
             cached_tokens,
             scheduler_tracked,
+            remote_kv_reuse,
         } = selection;
 
         // In approximate mode (use_kv_events=false), record the routing decision
@@ -609,6 +619,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             let response = Annotated::from_data(output);
             let stream = stream::iter(vec![response]);
             return Ok(ResponseStream::new(Box::pin(stream), stream_context));
+        }
+
+        if let Some(decision) = remote_kv_reuse.as_ref()
+            && let Err(error) = attach_remote_kv_reuse_decision(&mut request, decision)
+        {
+            tracing::warn!(
+                request_id = %context_id,
+                error = %error,
+                "Failed to attach remote G2 reuse metadata"
+            );
         }
 
         // End route stage — worker has been selected and routing metrics recorded.

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1578,7 +1578,6 @@ impl OpenAIPreprocessor {
                             choice.delta.refusal = None;
                             choice.delta.reasoning_content = None;
                             choice.finish_reason = None;
-                            choice.stop_reason = None;
                             choice.logprobs = None;
                             true
                         } else {

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -372,6 +372,7 @@ mod tests {
             source_dp_rank: 0,
             source_tier: StorageTier::HostPinned,
             block_hashes: vec![LocalBlockHash(11), LocalBlockHash(22)],
+            start_block_index: 0,
             planned_prefix_blocks: 2,
             block_size_tokens: 16,
             created_at_ms: 1000,

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -8,6 +8,10 @@ use derive_builder::Builder;
 use dynamo_kv_router::{
     config::RouterConfigOverride,
     protocols::{BlockExtraInfo, WorkerId},
+    remote_g2_plan::{
+        REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY, REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY,
+        RemoteKvReuseNoPlanReason, RemoteKvReusePlan,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -254,6 +258,46 @@ impl PreprocessedRequest {
         }
         (tokens, Some(mm.block_mm_infos.as_slice()))
     }
+
+    // TODO: replace extra_args transport with a typed routed request field after v1 hardening.
+    pub fn attach_remote_kv_reuse_plan(
+        &mut self,
+        plan: &RemoteKvReusePlan,
+    ) -> serde_json::Result<()> {
+        let plan_value = serde_json::to_value(plan)?;
+        let mut map = extra_args_object(self.extra_args.take());
+        map.remove(REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY);
+        map.insert(
+            REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY.to_string(),
+            plan_value,
+        );
+        self.extra_args = Some(serde_json::Value::Object(map));
+        Ok(())
+    }
+
+    pub fn attach_remote_kv_reuse_no_plan_reason(
+        &mut self,
+        reason: RemoteKvReuseNoPlanReason,
+    ) -> serde_json::Result<()> {
+        let reason_value = serde_json::to_value(reason)?;
+        let mut map = extra_args_object(self.extra_args.take());
+        map.remove(REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY);
+        map.insert(
+            REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY.to_string(),
+            reason_value,
+        );
+        self.extra_args = Some(serde_json::Value::Object(map));
+        Ok(())
+    }
+}
+
+fn extra_args_object(
+    extra_args: Option<serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    match extra_args {
+        Some(serde_json::Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    }
 }
 
 /// [`PreprocessedEmbeddingRequest`] is the internal representation of an embedding request
@@ -290,5 +334,93 @@ impl PreprocessedEmbeddingRequest {
 impl PreprocessedEmbeddingRequest {
     pub fn builder() -> PreprocessedEmbeddingRequestBuilder {
         PreprocessedEmbeddingRequestBuilder::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dynamo_kv_router::{
+        protocols::{LocalBlockHash, StorageTier},
+        remote_g2_plan::{
+            REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY, REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY,
+            REMOTE_KV_REUSE_PLAN_VERSION, RemoteKvReuseNoPlanReason, RemoteKvReusePlan,
+        },
+    };
+    use serde_json::json;
+
+    use super::PreprocessedRequest;
+
+    fn test_request() -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("test".to_string())
+            .token_ids(vec![1, 2, 3, 4])
+            .stop_conditions(Default::default())
+            .sampling_options(Default::default())
+            .output_options(Default::default())
+            .extra_args(Some(json!({ "existing_key": "existing_value" })))
+            .build()
+            .unwrap()
+    }
+
+    fn test_plan() -> RemoteKvReusePlan {
+        RemoteKvReusePlan {
+            plan_id: "plan-1".to_string(),
+            request_id: "request-1".to_string(),
+            target_worker_id: 42,
+            target_dp_rank: 2,
+            source_worker_id: 7,
+            source_dp_rank: 0,
+            source_tier: StorageTier::HostPinned,
+            block_hashes: vec![LocalBlockHash(11), LocalBlockHash(22)],
+            planned_prefix_blocks: 2,
+            block_size_tokens: 16,
+            created_at_ms: 1000,
+            expires_at_ms: 2000,
+            plan_version: REMOTE_KV_REUSE_PLAN_VERSION,
+        }
+    }
+
+    #[test]
+    fn extra_args_preserves_existing_keys_when_attaching_remote_plan() {
+        let mut request = test_request();
+        request.attach_remote_kv_reuse_plan(&test_plan()).unwrap();
+
+        let extra_args = request.extra_args.unwrap();
+        assert_eq!(extra_args["existing_key"], "existing_value");
+        assert_eq!(
+            extra_args[REMOTE_KV_REUSE_PLAN_EXTRA_ARGS_KEY]["source_tier"],
+            "host_pinned"
+        );
+    }
+
+    #[test]
+    fn extra_args_no_plan_reason_is_structured_only() {
+        let mut request = test_request();
+        request
+            .attach_remote_kv_reuse_no_plan_reason(
+                RemoteKvReuseNoPlanReason::NoRemoteG2Candidate,
+            )
+            .unwrap();
+
+        let extra_args = request.extra_args.unwrap();
+        assert_eq!(extra_args["existing_key"], "existing_value");
+        assert_eq!(
+            extra_args[REMOTE_KV_REUSE_NO_PLAN_REASON_EXTRA_ARGS_KEY],
+            "no_remote_g2_candidate"
+        );
+        let serialized = serde_json::to_string(&extra_args).unwrap();
+        for forbidden in [
+            "virtual_address",
+            "physical_address",
+            "nixl_descriptor",
+            "descriptor",
+            "source_block_id",
+            "target_g1_block_id",
+            "prompt text",
+            "11",
+            "22",
+        ] {
+            assert!(!serialized.contains(forbidden));
+        }
     }
 }

--- a/lib/llm/tests/remote_g2_no_kvbm_boundary.rs
+++ b/lib/llm/tests/remote_g2_no_kvbm_boundary.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+#[test]
+fn remote_g2_router_contract_does_not_use_forbidden_kvbm_boundary() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let files = [
+        manifest_dir.join("../kv-router/src/remote_g2_plan.rs"),
+        manifest_dir.join("src/kv_router.rs"),
+        manifest_dir.join("src/protocols/common/preprocessor.rs"),
+    ];
+    let forbidden = [
+        "dynamo_kvbm",
+        "kvbm::",
+        "kvbm-",
+        "velo",
+        "TransferManager",
+        "kvbm_connector",
+        "KVBMConnector",
+    ];
+
+    for file in files {
+        let contents =
+            std::fs::read_to_string(&file).unwrap_or_else(|err| panic!("read {file:?}: {err}"));
+        for &needle in &forbidden {
+            assert!(
+                !contents.contains(needle),
+                "{file:?} contains forbidden v1 remote G2 dependency marker {needle:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
#### Overview:

This PR updates remote G2 target-side resolve handling so plans that include a promoted-primary block are rejected and fall back instead of being tracked as usable remote leases.

#### Details:

- Added explicit promoted-primary status and release reason constants for remote G2 resolve handling.
- Added helper logic to detect `promoted_primary` in `per_block_status` entries represented as either strings or dictionaries.
- Updated target-side resolve dispatch to release the source lease immediately when a promoted-primary block is detected, then return a failed resolve response so the target can fall back.
- Preserved normal lease tracking for successful secondary-only resolve responses.
- Added unit coverage for promoted-primary status detection, promoted-primary lease release behavior, and normal secondary-only lease tracking.

#### Where should the reviewer start?

- `components/src/dynamo/trtllm/kv_p2p/target_rpc_local.py`
- `components/src/dynamo/trtllm/tests/test_remote_g2_target_rpc_local.py`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->