### PR TITLE
docs: fix PR template so 'closes #xxx' auto-links the issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@
 
 #### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
 
-- closes GitHub issue: #xxx
+- closes #xxx


### PR DESCRIPTION
## Summary
- The PR template's related-issues line read `closes GitHub issue: #xxx`, which is not a valid GitHub auto-close pattern. As a result, linked issues never closed automatically on merge.
- Change to `closes #xxx` so GitHub recognizes the keyword+reference and auto-links / auto-closes the issue.

## Test plan
- [ ] Open a new PR after merge and confirm the template defaults to `- closes #xxx` and that filling in a real issue number creates the auto-link in the sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified pull request template formatting for linking related issues to use more concise syntax.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->