### PR TITLE
fix: use batch vLLM tool parsing for non-streaming chat

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -353,7 +353,9 @@ class StreamingPostProcessor:
         if extracted.tools_called:
             for i, tool_call in enumerate(extracted.tool_calls):
                 self._add_tool_call_from_extracted(i, tool_call)
-            return self._compose_delta_message(saved_reasoning, None)
+            return self._compose_delta_message(
+                saved_reasoning, extracted.content or None
+            )
 
         return self._compose_delta_message(saved_reasoning, extracted.content or None)
 

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -225,11 +225,13 @@ class StreamingPostProcessor:
         tool_parser: ToolParser | None,
         reasoning_parser_class: type[ReasoningParser] | None,
         chat_template_kwargs: dict[str, Any],
+        stream_response: bool = True,
     ) -> None:
         self.tokenizer = tokenizer
         self.request_for_sampling = request_for_sampling
         self.sampling_params = sampling_params
         self.tool_parser = tool_parser
+        self.stream_response = stream_response
         # See https://github.com/ai-dynamo/dynamo/issues/8636 —
         # when the chat template runs with enable_thinking=False,
         # the reasoning open/close tags live in the prompt and the generated
@@ -270,6 +272,14 @@ class StreamingPostProcessor:
         # this correctly, so we accumulate text here and fall back to the
         # non-streaming extract_tool_calls() once the buffer is complete.
         self._tool_text_buffer: str | None = None
+
+    def _should_buffer_for_non_streaming_tool_parse(self) -> bool:
+        return (
+            not self.stream_response
+            and self.tool_parser is not None
+            and self.reasoning_parser is None
+            and self.request_for_sampling.tool_choice != "none"
+        )
 
     @staticmethod
     def _merge_tool_call(
@@ -420,7 +430,37 @@ class StreamingPostProcessor:
             "logprobs": output.logprobs,
         }
 
+    def _process_non_streaming_tool_output(self, output: Any) -> dict[str, Any] | None:
+        delta_token_ids = list(output.token_ids or [])
+        delta_text = output.text or ""
+        current_text = self.previous_text + delta_text
+        current_token_ids = self.previous_token_ids + delta_token_ids
+
+        self.previous_text = current_text
+        self.previous_token_ids = current_token_ids
+        if not output.finish_reason:
+            return None
+
+        delta_message = self._extract_tool_calls_from_text(current_text)
+        if delta_message is None:
+            if self.in_progress_tool_calls:
+                return self._emit_tool_calls_choice(output)
+            return self._build_choice(output, {})
+
+        delta: dict[str, Any] = {"role": "assistant"}
+        if delta_message.content:
+            delta["content"] = delta_message.content
+        if self.in_progress_tool_calls:
+            delta["tool_calls"] = self._dump_in_progress_tool_calls()
+            self.in_progress_tool_calls.clear()
+        if len(delta) == 1:
+            delta = {}
+        return self._build_choice(output, delta)
+
     def process_output(self, output: Any) -> dict[str, Any] | None:
+        if self._should_buffer_for_non_streaming_tool_parse():
+            return self._process_non_streaming_tool_output(output)
+
         delta_token_ids = list(output.token_ids or [])
         # vLLM output_processor already applies stop-token/stop-string trimming
         # to text. Re-detokenizing from token_ids can reintroduce stop markers.

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -277,7 +277,6 @@ class StreamingPostProcessor:
         return (
             not self.stream_response
             and self.tool_parser is not None
-            and self.reasoning_parser is None
             and self.request_for_sampling.tool_choice != "none"
         )
 
@@ -443,7 +442,20 @@ class StreamingPostProcessor:
         if not output.finish_reason:
             return None
 
-        delta_message = self._extract_tool_calls_from_text(current_text)
+        saved_reasoning = None
+        content = current_text
+        if self.reasoning_parser:
+            saved_reasoning, content = self.reasoning_parser.extract_reasoning(
+                current_text,
+                request=self.request_for_sampling,
+            )
+            if not self.request_for_sampling.include_reasoning:
+                saved_reasoning = None
+
+        delta_message = self._extract_tool_calls_from_text(
+            content or "",
+            saved_reasoning=saved_reasoning,
+        )
         if delta_message is None:
             if self.in_progress_tool_calls:
                 return self._emit_tool_calls_choice(output)
@@ -452,6 +464,8 @@ class StreamingPostProcessor:
         delta: dict[str, Any] = {"role": "assistant"}
         if delta_message.content:
             delta["content"] = delta_message.content
+        if delta_message.reasoning:
+            delta["reasoning_content"] = delta_message.reasoning
         if self.in_progress_tool_calls:
             delta["tool_calls"] = self._dump_in_progress_tool_calls()
             self.in_progress_tool_calls.clear()

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -499,6 +499,7 @@ class VllmProcessor:
                     tool_parser=tool_parser,
                     reasoning_parser_class=self.reasoning_parser_class,
                     chat_template_kwargs=chat_template_kwargs,
+                    stream_response=bool(request.get("stream", False)),
                 )
 
             # StreamingPostProcessor keeps delta/tool/reasoning parser state, so

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -570,10 +570,11 @@ class TestVllmRendererApi:
         )
 
     def test_reasoning_parser_method_signatures(self):
-        """Verify ReasoningParser has extract_reasoning_streaming and
-        is_reasoning_end_streaming.
+        """Verify ReasoningParser has extract_reasoning_streaming,
+        is_reasoning_end_streaming, and extract_reasoning.
 
-        prepost.py calls both during streaming post-processing to separate
+        prepost.py calls the streaming pair during streaming post-processing
+        and extract_reasoning on the non-streaming finalize path to separate
         reasoning tokens from content tokens.
         """
         assert hasattr(ReasoningParser, "extract_reasoning_streaming"), (
@@ -607,4 +608,16 @@ class TestVllmRendererApi:
         assert end_params == ["self", "input_ids", "delta_ids"], (
             "ReasoningParser.is_reasoning_end_streaming signature changed; "
             f"expected ['self', 'input_ids', 'delta_ids'], got {end_params}"
+        )
+
+        assert hasattr(ReasoningParser, "extract_reasoning"), (
+            "ReasoningParser no longer has 'extract_reasoning'; "
+            "update StreamingPostProcessor in "
+            "components/src/dynamo/frontend/prepost.py"
+        )
+        batch_sig = inspect.signature(ReasoningParser.extract_reasoning)
+        batch_params = list(batch_sig.parameters)
+        assert batch_params == ["self", "model_output", "request"], (
+            "ReasoningParser.extract_reasoning signature changed; "
+            f"expected ['self', 'model_output', 'request'], got {batch_params}"
         )

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -1567,6 +1567,56 @@ def test_qwen3_coder_non_streaming_preserves_content_before_tool_call(
 
 
 @pytest.mark.vllm
+def test_qwen3_coder_non_streaming_batches_reasoning_before_tool_parse(
+    tokenizer, qwen3_coder_request_for_sampling, sampling_params
+):
+    outputs = [
+        CompletionOutput(
+            index=0,
+            text=(
+                "<think>Need the weather.</think>\n"
+                "<function=get_weather>\n"
+                "<parameter=location>\n"
+                "NYC\n"
+                "</parameter>\n"
+                "</function>"
+            ),
+            token_ids=[1001],
+            cumulative_logprob=None,
+            logprobs=None,
+            finish_reason="stop",
+        )
+    ]
+
+    proc = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=qwen3_coder_request_for_sampling,
+        sampling_params=sampling_params,
+        prompt_token_ids=PROMPT_TOKEN_IDS,
+        tool_parser=Qwen3CoderToolParser(
+            tokenizer, qwen3_coder_request_for_sampling.tools
+        ),
+        reasoning_parser_class=Qwen3ReasoningParser,
+        chat_template_kwargs={"reasoning_effort": None},
+        stream_response=False,
+    )
+
+    results = _collect_results(proc, outputs)
+    assert len(results) == 1
+    assert results[0]["delta"]["reasoning_content"] == "Need the weather."
+
+    all_content = "".join(r.get("delta", {}).get("content", "") for r in results)
+    assert "<function=get_weather>" not in all_content
+    assert "</function>" not in all_content
+
+    tool_calls = _collect_tool_calls(results)
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {"location": "NYC"}
+    assert results[0]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.vllm
 def test_stream_interval_1(processor):
     """stream_interval=1: one token per chunk. Baseline that works."""
     results = _collect_results(processor, OUTPUTS_INTERVAL_1)

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -23,6 +23,7 @@ if HAS_VLLM:
     from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
     from vllm.sampling_params import SamplingParams
     from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+    from vllm.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
 
     from dynamo.frontend.prepost import StreamingPostProcessor
 else:
@@ -1305,6 +1306,45 @@ def request_for_sampling():
 
 
 @pytest.fixture
+def qwen3_coder_request_for_sampling():
+    return ChatCompletionRequest.model_construct(
+        messages=[{"content": "What is the weather in NYC?", "role": "user"}],
+        model="Qwen/Qwen3-Coder",
+        tools=[
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(
+                    name="get_weather",
+                    description="Get weather for a location",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "City name",
+                            }
+                        },
+                        "required": ["location"],
+                    },
+                ),
+            )
+        ],
+        tool_choice="auto",
+        include_reasoning=True,
+        stream=False,
+        n=1,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        temperature=None,
+        top_p=None,
+        skip_special_tokens=False,
+        chat_template_kwargs=None,
+        reasoning_effort=None,
+        parallel_tool_calls=True,
+    )
+
+
+@pytest.fixture
 def sampling_params():
     return SamplingParams(
         n=1,
@@ -1405,6 +1445,81 @@ def _collect_tool_calls(results):
 # ---------------------------------------------------------------------------
 # Test
 # ---------------------------------------------------------------------------
+@pytest.mark.vllm
+def test_qwen3_coder_non_streaming_uses_batch_tool_parse(
+    tokenizer, qwen3_coder_request_for_sampling, sampling_params
+):
+    """Dynamo internally streams, but non-streaming clients should match vLLM batch parsing."""
+    outputs = [
+        CompletionOutput(
+            index=0,
+            text=(
+                "<function=get_weather>\n"
+                "<parameter=location>\n"
+                "NYC\n"
+                "</parameter>\n"
+            ),
+            token_ids=[1001],
+            cumulative_logprob=None,
+            logprobs=None,
+        ),
+        CompletionOutput(
+            index=0,
+            text="</function>\n</function>\n</function>",
+            token_ids=[1002],
+            cumulative_logprob=None,
+            logprobs=None,
+            finish_reason="length",
+        ),
+    ]
+
+    streaming_proc = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=qwen3_coder_request_for_sampling,
+        sampling_params=sampling_params,
+        prompt_token_ids=PROMPT_TOKEN_IDS,
+        tool_parser=Qwen3CoderToolParser(
+            tokenizer, qwen3_coder_request_for_sampling.tools
+        ),
+        reasoning_parser_class=None,
+        chat_template_kwargs={"reasoning_effort": None},
+        stream_response=True,
+    )
+    streaming_results = _collect_results(streaming_proc, outputs)
+    streaming_content = "".join(
+        r.get("delta", {}).get("content", "") for r in streaming_results
+    )
+    assert "<function=get_weather>" in streaming_content
+    assert _collect_tool_calls(streaming_results) == []
+
+    non_streaming_proc = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=qwen3_coder_request_for_sampling,
+        sampling_params=sampling_params,
+        prompt_token_ids=PROMPT_TOKEN_IDS,
+        tool_parser=Qwen3CoderToolParser(
+            tokenizer, qwen3_coder_request_for_sampling.tools
+        ),
+        reasoning_parser_class=None,
+        chat_template_kwargs={"reasoning_effort": None},
+        stream_response=False,
+    )
+    non_streaming_results = _collect_results(non_streaming_proc, outputs)
+    assert len(non_streaming_results) == 1
+
+    all_content = "".join(
+        r.get("delta", {}).get("content", "") for r in non_streaming_results
+    )
+    assert "<function=get_weather>" not in all_content
+    assert "</function>" not in all_content
+
+    tool_calls = _collect_tool_calls(non_streaming_results)
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {"location": "NYC"}
+    assert non_streaming_results[0]["finish_reason"] == "length"
+
+
 @pytest.mark.vllm
 def test_stream_interval_1(processor):
     """stream_interval=1: one token per chunk. Baseline that works."""

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -1521,6 +1521,52 @@ def test_qwen3_coder_non_streaming_uses_batch_tool_parse(
 
 
 @pytest.mark.vllm
+def test_qwen3_coder_non_streaming_preserves_content_before_tool_call(
+    tokenizer, qwen3_coder_request_for_sampling, sampling_params
+):
+    outputs = [
+        CompletionOutput(
+            index=0,
+            text=(
+                "I can check that.\n"
+                "<function=get_weather>\n"
+                "<parameter=location>\n"
+                "NYC\n"
+                "</parameter>\n"
+                "</function>"
+            ),
+            token_ids=[1001],
+            cumulative_logprob=None,
+            logprobs=None,
+            finish_reason="stop",
+        )
+    ]
+
+    proc = StreamingPostProcessor(
+        tokenizer=tokenizer,
+        request_for_sampling=qwen3_coder_request_for_sampling,
+        sampling_params=sampling_params,
+        prompt_token_ids=PROMPT_TOKEN_IDS,
+        tool_parser=Qwen3CoderToolParser(
+            tokenizer, qwen3_coder_request_for_sampling.tools
+        ),
+        reasoning_parser_class=None,
+        chat_template_kwargs={"reasoning_effort": None},
+        stream_response=False,
+    )
+
+    results = _collect_results(proc, outputs)
+    assert len(results) == 1
+    assert results[0]["delta"]["content"] == "I can check that.\n"
+
+    tool_calls = _collect_tool_calls(results)
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["name"] == "get_weather"
+    assert json.loads(tool_calls[0]["function"]["arguments"]) == {"location": "NYC"}
+    assert results[0]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.vllm
 def test_stream_interval_1(processor):
     """stream_interval=1: one token per chunk. Baseline that works."""
     results = _collect_results(processor, OUTPUTS_INTERVAL_1)


### PR DESCRIPTION
#### Overview:

This PR makes Dynamo's vLLM chat processor use vLLM's batch tool parser for non-streaming chat responses.

#### Details:

- **How is this fixed?** `StreamingPostProcessor` now receives the client `stream` mode; for non-streaming requests without a reasoning parser, it buffers generated text until finish and calls vLLM's `extract_tool_calls()` instead of the streaming parser.
- Streaming responses keep the existing vLLM streaming parser path, so token-by-token behavior is unchanged.
- The new Qwen3-Coder regression test covers the bare `<function=...>` case where vLLM streaming leaks content but vLLM batch parsing recovers the tool call.
- Concrete failure mode: Dynamo internally streams engine output for both `stream=true` and `stream=false`, so `--dyn-chat-processor vllm` previously used vLLM streaming parser behavior even for non-streaming clients.

#### Verification:

In the vLLM devcontainer: `python3 -m pytest tests/frontend/test_prepost.py -q` passed; `python3 -m pytest components/src/dynamo/frontend/tests/test_vllm_processor_unit.py -q` passed.

#### Where should the reviewer start?

`components/src/dynamo/frontend/prepost.py`, then `tests/frontend/test_prepost.py`

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool call parsing in the Qwen3-Coder model.
  * Improved tool call handling to adapt based on streaming mode configuration.

* **Tests**
  * Added test coverage for tool call parsing with Qwen3-Coder in non-streaming mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->