### PR TITLE
chore(planner): switch to using v1beta1 DGD API

### DIFF
--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -20,7 +20,11 @@ from typing import Optional
 
 from dynamo.planner.config.defaults import SubComponentType, TargetReplica
 from dynamo.planner.connectors.base import PlannerConnector
-from dynamo.planner.connectors.kubernetes_api import KubernetesAPI
+from dynamo.planner.connectors.kubernetes_api import (
+    DYNAMO_WORKER_METADATA_API_VERSION,
+    NVIDIA_API_GROUP,
+    KubernetesAPI,
+)
 from dynamo.planner.connectors.mdc import (
     MdcEntry,
     is_model_card,
@@ -36,7 +40,9 @@ from dynamo.planner.errors import (
     UserProvidedModelNameMismatchError,
 )
 from dynamo.planner.monitoring.dgd_services import (
-    get_service_from_sub_component_type_or_name,
+    get_component_type,
+    get_component_from_type_or_name,
+    get_components_by_name,
 )
 from dynamo.planner.monitoring.worker_info import (
     WorkerInfo,
@@ -106,7 +112,7 @@ class KubernetesConnector(PlannerConnector):
 
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
-        service = get_service_from_sub_component_type_or_name(
+        service = get_component_from_type_or_name(
             deployment, sub_component_type
         )
         self.kube_api.update_graph_replicas(
@@ -126,7 +132,7 @@ class KubernetesConnector(PlannerConnector):
 
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
-        service = get_service_from_sub_component_type_or_name(
+        service = get_component_from_type_or_name(
             deployment, sub_component_type
         )
         if service.number_replicas() > 0:
@@ -148,12 +154,12 @@ class KubernetesConnector(PlannerConnector):
         require_decode: bool = True,
     ):
         """
-        Verify that the deployment contains services with subComponentType prefill and decode and the model name exists.
-        Will fallback to worker service names for backwards compatibility. (TODO: deprecate)
+        Verify that the deployment contains prefill/decode components and the model name exists.
+        Allows explicit component-name overrides when the caller provides them.
 
         Raises:
             DynamoGraphDeploymentNotFoundError: If the deployment is not found
-            DeploymentValidationError: If the deployment does not contain services with subComponentType prefill and decode
+            DeploymentValidationError: If the deployment does not contain required prefill/decode components
         """
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
@@ -161,7 +167,7 @@ class KubernetesConnector(PlannerConnector):
 
         if require_prefill:
             try:
-                get_service_from_sub_component_type_or_name(
+                get_component_from_type_or_name(
                     deployment,
                     SubComponentType.PREFILL,
                     component_name=prefill_component_name,
@@ -171,7 +177,7 @@ class KubernetesConnector(PlannerConnector):
 
         if require_decode:
             try:
-                get_service_from_sub_component_type_or_name(
+                get_component_from_type_or_name(
                     deployment,
                     SubComponentType.DECODE,
                     component_name=decode_component_name,
@@ -210,13 +216,13 @@ class KubernetesConnector(PlannerConnector):
             prefill_model_name = None
             decode_model_name = None
             if require_prefill:
-                prefill_service = get_service_from_sub_component_type_or_name(
+                prefill_service = get_component_from_type_or_name(
                     deployment,
                     SubComponentType.PREFILL,
                 )
                 prefill_model_name = prefill_service.get_model_name()
             if require_decode:
-                decode_service = get_service_from_sub_component_type_or_name(
+                decode_service = get_component_from_type_or_name(
                     deployment,
                     SubComponentType.DECODE,
                 )
@@ -264,12 +270,12 @@ class KubernetesConnector(PlannerConnector):
         require_prefill: bool = True,
         require_decode: bool = True,
     ) -> tuple[int, int]:
-        """Get the GPU counts for prefill and decode services from the deployment.
+        """Get the GPU counts for prefill and decode components from the deployment.
 
         Args:
             deployment: Optional deployment dict, fetched if not provided
-            require_prefill: Whether to require prefill service
-            require_decode: Whether to require decode service
+            require_prefill: Whether to require a prefill component
+            require_decode: Whether to require a decode component
 
         Returns:
             Tuple of (prefill_gpu_count, decode_gpu_count)
@@ -286,7 +292,7 @@ class KubernetesConnector(PlannerConnector):
 
         if require_prefill:
             try:
-                prefill_service = get_service_from_sub_component_type_or_name(
+                prefill_service = get_component_from_type_or_name(
                     deployment,
                     SubComponentType.PREFILL,
                 )
@@ -296,7 +302,7 @@ class KubernetesConnector(PlannerConnector):
 
         if require_decode:
             try:
-                decode_service = get_service_from_sub_component_type_or_name(
+                decode_service = get_component_from_type_or_name(
                     deployment,
                     SubComponentType.DECODE,
                 )
@@ -310,21 +316,23 @@ class KubernetesConnector(PlannerConnector):
         return prefill_gpu_count, decode_gpu_count
 
     def get_frontend_metrics_url(self, port: int = 8000) -> Optional[str]:
-        """Auto-discover the Frontend service's metrics URL from the DGD.
+        """Auto-discover the frontend component's metrics URL from the DGD.
 
-        Iterates spec.services to find the service with componentType "frontend",
+        Iterates DGD components to find the component with type "frontend",
         then constructs the in-cluster URL using the operator's naming convention:
-        http://{dgd_name}-{service_key_lowercase}:{port}/metrics
+        http://{dgd_name}-{component_name_lowercase}:{port}/metrics
 
         Returns:
-            The metrics URL string, or None if no frontend service is found.
+            The metrics URL string, or None if no frontend component is found.
         """
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
-        services = deployment.get("spec", {}).get("services", {})
+        components = get_components_by_name(deployment)
 
-        for service_key, service_spec in services.items():
-            if service_spec.get("componentType", "") == "frontend":
-                service_name = f"{self.graph_deployment_name}-{service_key.lower()}"
+        for component_name, component_spec in components.items():
+            if get_component_type(component_spec) == "frontend":
+                service_name = (
+                    f"{self.graph_deployment_name}-{component_name.lower()}"
+                )
                 url = f"http://{service_name}:{port}/metrics"
                 logger.info(f"Auto-discovered frontend metrics URL: {url}")
                 return url
@@ -335,7 +343,7 @@ class KubernetesConnector(PlannerConnector):
         """Wait for the deployment to be ready.
 
         Args:
-            include_planner: If False, skip the planner service when checking
+            include_planner: If False, skip the planner component when checking
                 readiness. This lets the planner read MDC from worker pods
                 without waiting for itself to be marked ready in the DGD.
         """
@@ -355,8 +363,8 @@ class KubernetesConnector(PlannerConnector):
 
         try:
             result = self.kube_api.custom_api.list_namespaced_custom_object(
-                group="nvidia.com",
-                version="v1alpha1",
+                group=NVIDIA_API_GROUP,
+                version=DYNAMO_WORKER_METADATA_API_VERSION,
                 namespace=self.kube_api.current_namespace,
                 plural="dynamoworkermetadatas",
             )
@@ -409,7 +417,7 @@ class KubernetesConnector(PlannerConnector):
     ) -> tuple[Optional[str], str]:
         """Return (dgd_service_name, component_name_for_filter).
 
-        ``dgd_service_name`` is the DGD ``spec.services`` dict key (typically
+        ``dgd_service_name`` is the stable DGD component name (typically
         PascalCase, e.g. ``"VllmPrefillWorker"``) and is used for Kubernetes
         operations like patching replica counts.
 
@@ -424,15 +432,15 @@ class KubernetesConnector(PlannerConnector):
            :func:`build_worker_info_from_defaults` (e.g. ``"prefill"`` /
            ``"backend"``).
 
-        Note: the DGD services dict key (``service.name``) must NOT be used
-        here -- it is typically PascalCase (``"VllmPrefillWorker"``) and
+        Note: the DGD component name (``service.name``) must NOT be used for
+        filtering -- it is typically PascalCase (``"VllmPrefillWorker"``) and
         would never match the lowercase value the worker writes to MDC.
         """
         defaults = build_worker_info_from_defaults(backend, sub_component_type)
         expected_component = defaults.component_name or ""
         try:
             deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
-            service = get_service_from_sub_component_type_or_name(
+            service = get_component_from_type_or_name(
                 deployment, sub_component_type
             )
             user_component = service.get_component_name_from_endpoint_arg()
@@ -463,7 +471,7 @@ class KubernetesConnector(PlannerConnector):
                 deployment = self.kube_api.get_graph_deployment(
                     self.graph_deployment_name
                 )
-                service = get_service_from_sub_component_type_or_name(
+                service = get_component_from_type_or_name(
                     deployment, sub_component_type
                 )
                 return service.get_model_name()
@@ -521,7 +529,7 @@ class KubernetesConnector(PlannerConnector):
 
         Returns:
             tuple[int, int, bool]: (prefill_count, decode_count, is_stable)
-            - is_stable: False if any service is in a rollout (scaling should be skipped)
+            - is_stable: False if any component is in a rollout (scaling should be skipped)
         """
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
@@ -530,7 +538,7 @@ class KubernetesConnector(PlannerConnector):
         all_stable = True
 
         if prefill_component_name:
-            service = get_service_from_sub_component_type_or_name(
+            service = get_component_from_type_or_name(
                 deployment,
                 SubComponentType.PREFILL,
                 component_name=prefill_component_name,
@@ -543,7 +551,7 @@ class KubernetesConnector(PlannerConnector):
             prefill_count = ready_replicas
 
         if decode_component_name:
-            service = get_service_from_sub_component_type_or_name(
+            service = get_component_from_type_or_name(
                 deployment,
                 SubComponentType.DECODE,
                 component_name=decode_component_name,
@@ -573,7 +581,7 @@ class KubernetesConnector(PlannerConnector):
             return
 
         for target_replica in target_replicas:
-            service = get_service_from_sub_component_type_or_name(
+            service = get_component_from_type_or_name(
                 deployment,
                 target_replica.sub_component_type,
                 component_name=target_replica.component_name,

--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -40,8 +40,8 @@ from dynamo.planner.errors import (
     UserProvidedModelNameMismatchError,
 )
 from dynamo.planner.monitoring.dgd_services import (
-    get_component_type,
     get_component_from_type_or_name,
+    get_component_type,
     get_components_by_name,
 )
 from dynamo.planner.monitoring.worker_info import (
@@ -112,9 +112,7 @@ class KubernetesConnector(PlannerConnector):
 
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
-        service = get_component_from_type_or_name(
-            deployment, sub_component_type
-        )
+        service = get_component_from_type_or_name(deployment, sub_component_type)
         self.kube_api.update_graph_replicas(
             self.graph_deployment_name,
             service.name,
@@ -132,9 +130,7 @@ class KubernetesConnector(PlannerConnector):
 
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
 
-        service = get_component_from_type_or_name(
-            deployment, sub_component_type
-        )
+        service = get_component_from_type_or_name(deployment, sub_component_type)
         if service.number_replicas() > 0:
             self.kube_api.update_graph_replicas(
                 self.graph_deployment_name,
@@ -330,9 +326,7 @@ class KubernetesConnector(PlannerConnector):
 
         for component_name, component_spec in components.items():
             if get_component_type(component_spec) == "frontend":
-                service_name = (
-                    f"{self.graph_deployment_name}-{component_name.lower()}"
-                )
+                service_name = f"{self.graph_deployment_name}-{component_name.lower()}"
                 url = f"http://{service_name}:{port}/metrics"
                 logger.info(f"Auto-discovered frontend metrics URL: {url}")
                 return url
@@ -440,9 +434,7 @@ class KubernetesConnector(PlannerConnector):
         expected_component = defaults.component_name or ""
         try:
             deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
-            service = get_component_from_type_or_name(
-                deployment, sub_component_type
-            )
+            service = get_component_from_type_or_name(deployment, sub_component_type)
             user_component = service.get_component_name_from_endpoint_arg()
             if user_component:
                 expected_component = user_component

--- a/components/src/dynamo/planner/connectors/kubernetes_api.py
+++ b/components/src/dynamo/planner/connectors/kubernetes_api.py
@@ -21,10 +21,22 @@ from kubernetes import client, config
 from kubernetes.config.config_exception import ConfigException
 
 from dynamo.planner.errors import DynamoGraphDeploymentNotFoundError
+from dynamo.planner.monitoring.dgd_services import (
+    Service,
+    get_component_type,
+    get_components_by_name,
+)
 from dynamo.runtime.logging import configure_dynamo_logging
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
+
+NVIDIA_API_GROUP = "nvidia.com"
+DYNAMO_API_VERSION = "v1beta1"
+DYNAMO_WORKER_METADATA_API_VERSION = "v1alpha1"
+DGD_PLURAL = "dynamographdeployments"
+DGDSA_PLURAL = "dynamographdeploymentscalingadapters"
+JSON_PATCH_CONTENT_TYPE = "application/json-patch+json"
 
 
 def get_current_k8s_namespace() -> str:
@@ -51,20 +63,20 @@ class KubernetesAPI:
     def _get_graph_deployment_from_name(self, graph_deployment_name: str) -> dict:
         """Get the graph deployment from the dynamo graph deployment name"""
         return self.custom_api.get_namespaced_custom_object(
-            group="nvidia.com",
-            version="v1alpha1",
+            group=NVIDIA_API_GROUP,
+            version=DYNAMO_API_VERSION,
             namespace=self.current_namespace,
-            plural="dynamographdeployments",
+            plural=DGD_PLURAL,
             name=graph_deployment_name,
         )
 
     def list_graph_deployments(self) -> list[dict]:
         """List all DynamoGraphDeployments in the current namespace."""
         result = self.custom_api.list_namespaced_custom_object(
-            group="nvidia.com",
-            version="v1alpha1",
+            group=NVIDIA_API_GROUP,
+            version=DYNAMO_API_VERSION,
             namespace=self.current_namespace,
-            plural="dynamographdeployments",
+            plural=DGD_PLURAL,
         )
         return result.get("items", [])
 
@@ -92,12 +104,12 @@ class KubernetesAPI:
         self, graph_deployment_name: str, service_name: str, replicas: int
     ) -> None:
         """
-        Update replicas for a service using Scale subresource when DGDSA exists.
-        Falls back to DGD patch for backward compatibility with older operators.
+        Update replicas for a component using Scale subresource when DGDSA exists.
+        Falls back to a direct DGD patch when the component does not have a DGDSA.
 
         Args:
             graph_deployment_name: Name of the DynamoGraphDeployment
-            service_name: Name of the service in DGD.spec.services
+            service_name: Name of the component in DGD.spec.components
             replicas: Desired number of replicas
         """
         # DGDSA naming convention: <dgd-name>-<lowercase-service-name>
@@ -106,10 +118,10 @@ class KubernetesAPI:
         try:
             # Try to scale via DGDSA Scale subresource
             self.custom_api.patch_namespaced_custom_object_scale(
-                group="nvidia.com",
-                version="v1alpha1",
+                group=NVIDIA_API_GROUP,
+                version=DYNAMO_API_VERSION,
                 namespace=self.current_namespace,
-                plural="dynamographdeploymentscalingadapters",
+                plural=DGDSA_PLURAL,
                 name=adapter_name,
                 body={"spec": {"replicas": replicas}},
             )
@@ -117,7 +129,7 @@ class KubernetesAPI:
 
         except client.ApiException as e:
             if e.status == 404:
-                # DGDSA doesn't exist - fall back to DGD patch (old operator)
+                # DGDSA doesn't exist - fall back to a direct DGD patch.
                 logger.info(
                     f"DGDSA {adapter_name} not found, falling back to DGD update"
                 )
@@ -128,25 +140,101 @@ class KubernetesAPI:
     def _update_dgd_replicas(
         self, graph_deployment_name: str, service_name: str, replicas: int
     ) -> None:
-        """Update replicas directly in DGD (fallback for old operators)"""
-        patch = {"spec": {"services": {service_name: {"replicas": replicas}}}}
-        self.custom_api.patch_namespaced_custom_object(
-            group="nvidia.com",
-            version="v1alpha1",
-            namespace=self.current_namespace,
-            plural="dynamographdeployments",
-            name=graph_deployment_name,
-            body=patch,
+        """Update replicas directly in DGD when no DGDSA is available."""
+        deployment = self.get_graph_deployment(graph_deployment_name)
+        components = self._dgd_components(deployment, graph_deployment_name)
+        self._patch_component_replicas(
+            graph_deployment_name, components, service_name, replicas
         )
         logger.info(
-            f"Updated DGD {graph_deployment_name} service {service_name} to {replicas} replicas"
+            f"Updated DGD {graph_deployment_name} component {service_name} to {replicas} replicas"
+        )
+
+    @staticmethod
+    def _dgd_components(deployment: dict, graph_deployment_name: str) -> list[dict]:
+        components = deployment.get("spec", {}).get("components")
+        if components is None:
+            raise KeyError(
+                f"DGD {graph_deployment_name!r} has no v1beta1 spec.components"
+            )
+        if not isinstance(components, list):
+            raise TypeError(
+                f"DGD {graph_deployment_name!r} spec.components must be a list"
+            )
+        return components
+
+    def _patch_component_replicas(
+        self,
+        graph_deployment_name: str,
+        components: list[dict],
+        component_name: str,
+        replicas: int,
+    ) -> None:
+        index = self._find_component_index(
+            graph_deployment_name, components, component_name
+        )
+        patch = self._component_replicas_json_patch(index, component_name, replicas)
+        self._patch_dgd_with_json_patch(graph_deployment_name, patch)
+
+    @staticmethod
+    def _find_component_index(
+        graph_deployment_name: str, components: list[dict], component_name: str
+    ) -> int:
+        for index, component in enumerate(components):
+            if component.get("name") == component_name:
+                return index
+        raise KeyError(
+            f"component {component_name!r} not found in DGD {graph_deployment_name!r}"
+        )
+
+    @staticmethod
+    def _component_replicas_json_patch(
+        index: int, component_name: str, replicas: int
+    ) -> list[dict]:
+        return [
+            {
+                "op": "test",
+                "path": f"/spec/components/{index}/name",
+                "value": component_name,
+            },
+            {
+                "op": "add",
+                "path": f"/spec/components/{index}/replicas",
+                "value": replicas,
+            },
+        ]
+
+    def _patch_dgd_with_json_patch(
+        self, graph_deployment_name: str, patch: list[dict]
+    ) -> None:
+        """Patch a v1beta1 DGD with RFC 6902 JSON Patch operations."""
+        self.custom_api.api_client.call_api(
+            "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}",
+            "PATCH",
+            {
+                "group": NVIDIA_API_GROUP,
+                "version": DYNAMO_API_VERSION,
+                "namespace": self.current_namespace,
+                "plural": DGD_PLURAL,
+                "name": graph_deployment_name,
+            },
+            [],
+            {
+                "Accept": "application/json",
+                "Content-Type": JSON_PATCH_CONTENT_TYPE,
+            },
+            body=patch,
+            response_type="object",
+            auth_settings=["BearerToken"],
+            _return_http_data_only=True,
+            collection_formats={},
         )
 
     def update_graph_replicas(
         self, graph_deployment_name: str, component_name: str, replicas: int
     ) -> None:
         """
-        Update replicas for a service. Now uses DGDSA when available.
+        Update replicas for a component. Now uses DGDSA when available.
 
         Deprecated: Use update_service_replicas() instead for clarity.
         This method is kept for backward compatibility.
@@ -167,7 +255,7 @@ class KubernetesAPI:
         self, deployment: dict, service_name: str
     ) -> tuple[int, bool]:
         """
-        Get the actual ready replica count for a service from DGD status.
+        Get the actual ready replica count for a component from DGD status.
 
         Returns:
             tuple[int, bool]: (replica_count, is_stable)
@@ -175,21 +263,20 @@ class KubernetesAPI:
             - is_stable: no rollout is in progress (desired == updated == ready/available)
         """
         # Get desired replicas from spec
-        service_spec = (
-            deployment.get("spec", {}).get("services", {}).get(service_name, {})
-        )
-        desired_replicas = service_spec.get("replicas", 0)
+        service_spec = get_components_by_name(deployment).get(service_name, {})
+        desired_replicas = Service(
+            name=service_name, service=service_spec
+        ).number_replicas()
 
         # Get status fields
-        service_status = (
-            deployment.get("status", {}).get("services", {}).get(service_name, {})
-        )
+        status = deployment.get("status", {})
+        service_status = status.get("components", {}).get(service_name, {})
         available = service_status.get("availableReplicas")
         ready = service_status.get("readyReplicas", 0)
         updated = service_status.get("updatedReplicas", 0)
 
         # availableReplicas takes precedence over readyReplicas for the count
-        # refer to ServiceReplicaStatus type (https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/api/v1alpha1/dynamographdeployment_types.go#L157)
+        # refer to ComponentReplicaStatus in deploy/operator/api/v1beta1/common.go
         if available is not None:
             traffic_serving_replicas = available
         else:
@@ -212,8 +299,8 @@ class KubernetesAPI:
 
         Args:
             graph_deployment_name: Name of the DGD to wait for.
-            include_planner: If False, skip services with componentType "planner"
-                and check per-service readiness instead of the global DGD Ready
+            include_planner: If False, skip components with type "planner"
+                and check per-component readiness instead of the global DGD Ready
                 condition. This avoids a circular wait when the planner itself
                 is one of the services in the DGD.
             max_attempts: Maximum polling iterations.
@@ -238,23 +325,23 @@ class KubernetesAPI:
                     f"message: {ready_condition.get('message') if ready_condition else 'no condition found'})"
                 )
             else:
-                services = graph_deployment.get("spec", {}).get("services", {})
+                components = get_components_by_name(graph_deployment)
                 not_ready: list[str] = []
-                for svc_name, svc_spec in services.items():
-                    if svc_spec.get("componentType", "") == "planner":
+                for component_name, component_spec in components.items():
+                    if get_component_type(component_spec) == "planner":
                         continue
                     _, is_stable = self.get_service_replica_status(
-                        graph_deployment, svc_name
+                        graph_deployment, component_name
                     )
                     if not is_stable:
-                        not_ready.append(svc_name)
+                        not_ready.append(component_name)
 
                 if not not_ready:
                     return
 
                 logger.info(
                     f"[Attempt {attempt + 1}/{max_attempts}] "
-                    f"Waiting for services (excluding planner): "
+                    f"Waiting for components (excluding planner): "
                     f"not ready: {not_ready}"
                 )
 

--- a/components/src/dynamo/planner/errors.py
+++ b/components/src/dynamo/planner/errors.py
@@ -69,10 +69,10 @@ class DynamoGraphDeploymentNotFoundError(PlannerError):
 
 
 class ComponentError(PlannerError):
-    """Base class for subComponent configuration issues.
+    """Base class for component type configuration issues.
 
     This serves as a parent class for all exceptions related to
-    subComponentType configuration problems in DynamoGraphDeployments.
+    component type configuration problems in DynamoGraphDeployments.
     """
 
     pass
@@ -138,16 +138,19 @@ class BackendFrameworkInvalidError(PlannerError):
 
 
 class SubComponentNotFoundError(ComponentError):
-    """Raised when a required subComponentType is not found in the deployment.
+    """Raised when a required component role is not found in the deployment.
 
-    This occurs when the DynamoGraphDeployment doesn't contain any service
-    with the requested subComponentType (e.g., 'prefill', 'decode').
+    This occurs when the DynamoGraphDeployment doesn't contain any component
+    with the requested role (e.g., 'prefill', 'decode').
     """
 
     def __init__(self, sub_component_type: str):
         self.sub_component_type = sub_component_type
 
-        message = f"DynamoGraphDeployment must contain a service with subComponentType '{sub_component_type}'"
+        message = (
+            f"DynamoGraphDeployment must contain a component with "
+            f"type '{sub_component_type}'"
+        )
 
         super().__init__(message)
 
@@ -158,10 +161,10 @@ class SubComponentNotFoundError(ComponentError):
 
 
 class DuplicateSubComponentError(ComponentError):
-    """Raised when multiple services have the same subComponentType.
+    """Raised when multiple components have the same planner role.
 
-    This occurs when the DynamoGraphDeployment contains more than one service
-    with the same subComponentType, which violates the expected uniqueness constraint.
+    This occurs when the DynamoGraphDeployment contains more than one component
+    with the same role, which violates the expected uniqueness constraint.
     """
 
     def __init__(self, sub_component_type: str, service_names: List[str]):
@@ -169,8 +172,8 @@ class DuplicateSubComponentError(ComponentError):
         self.service_names = service_names
 
         message = (
-            f"DynamoGraphDeployment must contain only one service with "
-            f"subComponentType '{sub_component_type}', but found multiple: "
+            f"DynamoGraphDeployment must contain only one component with "
+            f"type '{sub_component_type}', but found multiple: "
             f"{', '.join(sorted(service_names))}"
         )
 

--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -27,6 +27,10 @@ from dynamo.runtime.logging import configure_dynamo_logging
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
+MAIN_CONTAINER_NAME = "main"
+V1BETA1_COMPONENT_TYPES = {"prefill", "decode"}
+GPU_RESOURCE_KEY = "nvidia.com/gpu"
+
 
 def break_arguments(args: list[str] | None) -> list[str]:
     ans: list[str] = []
@@ -43,6 +47,46 @@ def break_arguments(args: list[str] | None) -> list[str]:
     return ans
 
 
+def _main_container_from_pod_template(component: dict) -> dict:
+    containers = (
+        component.get("podTemplate", {})
+        .get("spec", {})
+        .get("containers", [])
+        or []
+    )
+    for container in containers:
+        if container.get("name") == MAIN_CONTAINER_NAME:
+            return container
+    return {}
+
+
+def get_main_container(component: dict) -> dict:
+    """Return the planner-relevant v1beta1 main container."""
+    return _main_container_from_pod_template(component)
+
+
+def get_components_by_name(deployment: dict) -> dict[str, dict]:
+    """Return v1beta1 DGD components keyed by logical name.
+
+    v1beta1 exposes components as ``spec.components[]`` with ``name`` and
+    ``type``. The planner consumes this map so the rest of the code does not
+    have to work with list traversal.
+    """
+    components = deployment.get("spec", {}).get("components") or []
+    return {component["name"]: component for component in components}
+
+
+def get_component_type(component: dict) -> str:
+    return component.get("type", "")
+
+
+def get_planner_component_role(component: dict) -> str:
+    component_type = get_component_type(component)
+    if component_type in V1BETA1_COMPONENT_TYPES:
+        return component_type
+    return ""
+
+
 class Service(BaseModel):
     name: str
     service: dict
@@ -51,11 +95,7 @@ class Service(BaseModel):
         return self.service.get("replicas", 0)
 
     def get_model_name(self) -> Optional[str]:
-        args = (
-            self.service.get("extraPodSpec", {})
-            .get("mainContainer", {})
-            .get("args", [])
-        )
+        args = get_main_container(self.service).get("args", [])
 
         args = break_arguments(args)
         if (
@@ -83,11 +123,7 @@ class Service(BaseModel):
         the backend default. Returns ``None`` if ``--endpoint`` is not
         present or malformed.
         """
-        args = (
-            self.service.get("extraPodSpec", {})
-            .get("mainContainer", {})
-            .get("args", [])
-        )
+        args = get_main_container(self.service).get("args", [])
         args = break_arguments(args)
         if "--endpoint" not in args:
             return None
@@ -101,46 +137,45 @@ class Service(BaseModel):
             return None
 
     def get_gpu_count(self) -> int:
-        """Get the GPU count from the service's resource specification.
+        """Get the GPU count from the component's resource specification.
 
-        GPU count is read from spec.services.[ServiceName].resources.limits.gpu,
-        falling back to requests.gpu if limits is not specified.
+        GPU count is read from the v1beta1 main container resources
+        (``nvidia.com/gpu``).
 
         Returns:
-            The number of GPUs configured for this service
+            The number of GPUs configured for this component
 
         Raises:
             ValueError: If GPU count is not specified or invalid
         """
-        resources = self.service.get("resources", {})
+        resources = get_main_container(self.service).get("resources", {})
         limits = resources.get("limits", {})
         requests = resources.get("requests", {})
 
         # Prefer limits, fall back to requests. For GPUs, Kubernetes device plugins
         # typically treat requests and limits as equivalent since GPUs are
         # non-compressible and allocated exclusively (no fractional sharing).
-        gpu_str = limits.get("gpu") or requests.get("gpu")
+        gpu_str = limits.get(GPU_RESOURCE_KEY) or requests.get(GPU_RESOURCE_KEY)
 
         if gpu_str is None:
             raise ValueError(
-                f"No GPU count specified for service '{self.name}'. "
-                f"Please set resources.limits.gpu or resources.requests.gpu in the DGD."
+                f"No GPU count specified for component '{self.name}'. "
+                f"Please set main container resources.limits.{GPU_RESOURCE_KEY} "
+                f"or resources.requests.{GPU_RESOURCE_KEY} in the DGD."
             )
 
         try:
             return int(gpu_str)
         except (ValueError, TypeError):
             raise ValueError(
-                f"Invalid GPU count '{gpu_str}' for service '{self.name}'. "
+                f"Invalid GPU count '{gpu_str}' for component '{self.name}'. "
                 f"GPU count must be an integer."
             )
 
 
-# TODO: still supporting framework component names for backwards compatibility
-# Should be deprecated in favor of service subComponentType
-def get_service_from_sub_component_type_or_name(
+def get_component_from_type_or_name(
     deployment: dict,
-    sub_component_type: SubComponentType,
+    component_type: SubComponentType,
     component_name: Optional[str] = None,
 ) -> Service:
     """
@@ -149,39 +184,31 @@ def get_service_from_sub_component_type_or_name(
     Returns: Service object
 
     Raises:
-        SubComponentNotFoundError: If no service with the specified subComponentType is found
-        DuplicateSubComponentError: If multiple services with the same subComponentType are found
+        SubComponentNotFoundError: If no component with the specified role is found
+        DuplicateSubComponentError: If multiple components have the same role
     """
-    services = deployment.get("spec", {}).get("services", {})
+    components = get_components_by_name(deployment)
 
-    # Collect all available subComponentTypes for better error messages
-    available_types = []
-    matching_services = []
+    matching_components = []
 
-    for curr_name, curr_service in services.items():
-        service_sub_type = curr_service.get("subComponentType", "")
-        if service_sub_type:
-            available_types.append(service_sub_type)
-
-        if service_sub_type == sub_component_type.value:
-            matching_services.append((curr_name, curr_service))
+    for curr_name, curr_component in components.items():
+        component_role = get_planner_component_role(curr_component)
+        if component_role == component_type.value:
+            matching_components.append((curr_name, curr_component))
 
     # Check for duplicates
-    if len(matching_services) > 1:
-        service_names = [name for name, _ in matching_services]
-        raise DuplicateSubComponentError(sub_component_type.value, service_names)
+    if len(matching_components) > 1:
+        component_names = [name for name, _ in matching_components]
+        raise DuplicateSubComponentError(component_type.value, component_names)
 
-    # If no service found with subCompontType and fallback component_name is not provided or not found,
-    # or if the fallback component has a non-empty subComponentType, raise error
-    if not matching_services and (
-        not component_name
-        or component_name not in services
-        or services[component_name].get("subComponentType", "") != ""
-    ):
-        raise SubComponentNotFoundError(sub_component_type.value)
-    # If fallback component_name is provided and exists within services, add to matching_services
-    elif not matching_services and component_name in services:
-        matching_services.append((component_name, services[component_name]))
+    if not matching_components and component_name in components:
+        component = components[component_name]
+        explicit_type = get_component_type(component)
+        if explicit_type and explicit_type != component_type.value:
+            raise SubComponentNotFoundError(component_type.value)
+        matching_components.append((component_name, component))
+    elif not matching_components:
+        raise SubComponentNotFoundError(component_type.value)
 
-    name, service = matching_services[0]
-    return Service(name=name, service=service)
+    name, component = matching_components[0]
+    return Service(name=name, service=component)

--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -49,10 +49,7 @@ def break_arguments(args: list[str] | None) -> list[str]:
 
 def _main_container_from_pod_template(component: dict) -> dict:
     containers = (
-        component.get("podTemplate", {})
-        .get("spec", {})
-        .get("containers", [])
-        or []
+        component.get("podTemplate", {}).get("spec", {}).get("containers", []) or []
     )
     for container in containers:
         if container.get("name") == MAIN_CONTAINER_NAME:
@@ -166,11 +163,11 @@ class Service(BaseModel):
 
         try:
             return int(gpu_str)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as err:
             raise ValueError(
                 f"Invalid GPU count '{gpu_str}' for component '{self.name}'. "
                 f"GPU count must be an integer."
-            )
+            ) from err
 
 
 def get_component_from_type_or_name(

--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 MAIN_CONTAINER_NAME = "main"
 V1BETA1_COMPONENT_TYPES = {"prefill", "decode"}
+V1BETA1_GENERIC_WORKER_COMPONENT_TYPE = "worker"
 GPU_RESOURCE_KEY = "nvidia.com/gpu"
 
 
@@ -82,6 +83,17 @@ def get_planner_component_role(component: dict) -> str:
     if component_type in V1BETA1_COMPONENT_TYPES:
         return component_type
     return ""
+
+
+def _can_use_explicit_component_name(
+    component: dict, component_type: SubComponentType
+) -> bool:
+    explicit_type = get_component_type(component)
+    return explicit_type in (
+        "",
+        V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+        component_type.value,
+    )
 
 
 class Service(BaseModel):
@@ -200,8 +212,7 @@ def get_component_from_type_or_name(
 
     if not matching_components and component_name in components:
         component = components[component_name]
-        explicit_type = get_component_type(component)
-        if explicit_type and explicit_type != component_type.value:
+        if not _can_use_explicit_component_name(component, component_type):
             raise SubComponentNotFoundError(component_type.value)
         matching_components.append((component_name, component))
     elif not matching_components:

--- a/components/src/dynamo/planner/tests/unit/test_kube.py
+++ b/components/src/dynamo/planner/tests/unit/test_kube.py
@@ -89,7 +89,7 @@ def test_get_graph_deployment_from_name(k8s_api, mock_custom_api):
     assert result == mock_deployment
     mock_custom_api.get_namespaced_custom_object.assert_called_once_with(
         group="nvidia.com",
-        version="v1alpha1",
+        version="v1beta1",
         namespace=k8s_api.current_namespace,
         plural="dynamographdeployments",
         name="test-deployment",
@@ -105,7 +105,7 @@ def test_update_service_replicas_uses_dgdsa_scale(k8s_api, mock_custom_api):
     # Should use Scale subresource with lowercase adapter name
     mock_custom_api.patch_namespaced_custom_object_scale.assert_called_once_with(
         group="nvidia.com",
-        version="v1alpha1",
+        version="v1beta1",
         namespace=k8s_api.current_namespace,
         plural="dynamographdeploymentscalingadapters",
         name="test-deployment-frontend",  # lowercase service name
@@ -121,6 +121,15 @@ def test_update_service_replicas_fallback_to_dgd(k8s_api, mock_custom_api):
     mock_custom_api.patch_namespaced_custom_object_scale.side_effect = (
         client.ApiException(status=404)
     )
+    mock_custom_api.get_namespaced_custom_object.return_value = {
+        "metadata": {"name": "test-deployment"},
+        "spec": {
+            "components": [
+                {"name": "test-component", "type": "decode", "replicas": 0},
+                {"name": "other-component", "type": "prefill", "replicas": 2},
+            ]
+        },
+    }
     mock_custom_api.patch_namespaced_custom_object.return_value = None
 
     k8s_api.update_service_replicas("test-deployment", "test-component", 1)
@@ -128,14 +137,39 @@ def test_update_service_replicas_fallback_to_dgd(k8s_api, mock_custom_api):
     # Should have tried DGDSA first
     mock_custom_api.patch_namespaced_custom_object_scale.assert_called_once()
 
-    # Should fall back to DGD patch
-    mock_custom_api.patch_namespaced_custom_object.assert_called_once_with(
-        group="nvidia.com",
-        version="v1alpha1",
-        namespace=k8s_api.current_namespace,
-        plural="dynamographdeployments",
-        name="test-deployment",
-        body={"spec": {"services": {"test-component": {"replicas": 1}}}},
+    # Should fall back to a narrow DGD JSON Patch.
+    mock_custom_api.patch_namespaced_custom_object.assert_not_called()
+    mock_custom_api.api_client.call_api.assert_called_once_with(
+        "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}",
+        "PATCH",
+        {
+            "group": "nvidia.com",
+            "version": "v1beta1",
+            "namespace": k8s_api.current_namespace,
+            "plural": "dynamographdeployments",
+            "name": "test-deployment",
+        },
+        [],
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json-patch+json",
+        },
+        body=[
+            {
+                "op": "test",
+                "path": "/spec/components/0/name",
+                "value": "test-component",
+            },
+            {
+                "op": "add",
+                "path": "/spec/components/0/replicas",
+                "value": 1,
+            },
+        ],
+        response_type="object",
+        auth_settings=["BearerToken"],
+        _return_http_data_only=True,
+        collection_formats={},
     )
 
 
@@ -163,7 +197,7 @@ def test_update_graph_replicas_calls_update_service_replicas(k8s_api, mock_custo
     # Should delegate to update_service_replicas which uses Scale API
     mock_custom_api.patch_namespaced_custom_object_scale.assert_called_once_with(
         group="nvidia.com",
-        version="v1alpha1",
+        version="v1beta1",
         namespace=k8s_api.current_namespace,
         plural="dynamographdeploymentscalingadapters",
         name="test-deployment-test-component",
@@ -173,17 +207,50 @@ def test_update_graph_replicas_calls_update_service_replicas(k8s_api, mock_custo
 
 def test_update_dgd_replicas_directly(k8s_api, mock_custom_api):
     """Test the internal _update_dgd_replicas method"""
+    mock_custom_api.get_namespaced_custom_object.return_value = {
+        "metadata": {"name": "test-deployment"},
+        "spec": {
+            "components": [
+                {"name": "test-component", "type": "prefill", "replicas": 0},
+            ]
+        },
+    }
     mock_custom_api.patch_namespaced_custom_object.return_value = None
 
     k8s_api._update_dgd_replicas("test-deployment", "test-component", 1)
 
-    mock_custom_api.patch_namespaced_custom_object.assert_called_once_with(
-        group="nvidia.com",
-        version="v1alpha1",
-        namespace=k8s_api.current_namespace,
-        plural="dynamographdeployments",
-        name="test-deployment",
-        body={"spec": {"services": {"test-component": {"replicas": 1}}}},
+    mock_custom_api.patch_namespaced_custom_object.assert_not_called()
+    mock_custom_api.api_client.call_api.assert_called_once_with(
+        "/apis/{group}/{version}/namespaces/{namespace}/{plural}/{name}",
+        "PATCH",
+        {
+            "group": "nvidia.com",
+            "version": "v1beta1",
+            "namespace": k8s_api.current_namespace,
+            "plural": "dynamographdeployments",
+            "name": "test-deployment",
+        },
+        [],
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json-patch+json",
+        },
+        body=[
+            {
+                "op": "test",
+                "path": "/spec/components/0/name",
+                "value": "test-component",
+            },
+            {
+                "op": "add",
+                "path": "/spec/components/0/replicas",
+                "value": 1,
+            },
+        ],
+        response_type="object",
+        auth_settings=["BearerToken"],
+        _return_http_data_only=True,
+        collection_formats={},
     )
 
 
@@ -374,9 +441,38 @@ def test_get_service_replica_status_stable_with_available_replicas(
 ):
     """Test stable case with availableReplicas present (takes precedence over readyReplicas)"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"prefill-worker": {"replicas": 2}}},
+        "spec": {"components": [{"name": "prefill-worker", "replicas": 2}]},
         "status": {
-            "services": {
+            "components": {
+                "prefill-worker": {
+                    "availableReplicas": 2,
+                    "readyReplicas": 2,
+                    "updatedReplicas": 2,
+                }
+            }
+        },
+    }
+
+    count, is_stable = k8s_api.get_service_replica_status(deployment, "prefill-worker")
+
+    assert count == 2
+    assert is_stable is True
+
+
+def test_get_service_replica_status_v1beta_components(k8s_api, mock_custom_api):
+    """Test stable case using v1beta1 spec.components/status.components."""
+    deployment: Dict[str, Any] = {
+        "spec": {
+            "components": [
+                {
+                    "name": "prefill-worker",
+                    "type": "prefill",
+                    "replicas": 2,
+                }
+            ]
+        },
+        "status": {
+            "components": {
                 "prefill-worker": {
                     "availableReplicas": 2,
                     "readyReplicas": 2,
@@ -397,9 +493,9 @@ def test_get_service_replica_status_stable_with_ready_replicas_fallback(
 ):
     """Test stable case falling back to readyReplicas when availableReplicas is not present"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"decode-worker": {"replicas": 4}}},
+        "spec": {"components": [{"name": "decode-worker", "replicas": 4}]},
         "status": {
-            "services": {
+            "components": {
                 "decode-worker": {
                     "readyReplicas": 4,
                     "updatedReplicas": 4,
@@ -417,9 +513,9 @@ def test_get_service_replica_status_stable_with_ready_replicas_fallback(
 def test_get_service_replica_status_scale_up_in_progress(k8s_api, mock_custom_api):
     """Test scale-up in progress: desired=4, updated=2, ready=2"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"prefill-worker": {"replicas": 4}}},
+        "spec": {"components": [{"name": "prefill-worker", "replicas": 4}]},
         "status": {
-            "services": {
+            "components": {
                 "prefill-worker": {
                     "availableReplicas": 2,
                     "readyReplicas": 2,
@@ -438,9 +534,9 @@ def test_get_service_replica_status_scale_up_in_progress(k8s_api, mock_custom_ap
 def test_get_service_replica_status_scale_down_in_progress(k8s_api, mock_custom_api):
     """Test scale-down in progress: desired=2, updated=4, ready=4"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"decode-worker": {"replicas": 2}}},
+        "spec": {"components": [{"name": "decode-worker", "replicas": 2}]},
         "status": {
-            "services": {
+            "components": {
                 "decode-worker": {
                     "availableReplicas": 4,
                     "readyReplicas": 4,
@@ -459,9 +555,9 @@ def test_get_service_replica_status_scale_down_in_progress(k8s_api, mock_custom_
 def test_get_service_replica_status_rollout_in_progress(k8s_api, mock_custom_api):
     """Test rollout in progress: desired=4, updated=2, ready=4 (old replicas still running)"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"prefill-worker": {"replicas": 4}}},
+        "spec": {"components": [{"name": "prefill-worker", "replicas": 4}]},
         "status": {
-            "services": {
+            "components": {
                 "prefill-worker": {
                     "availableReplicas": 4,
                     "readyReplicas": 4,
@@ -480,8 +576,8 @@ def test_get_service_replica_status_rollout_in_progress(k8s_api, mock_custom_api
 def test_get_service_replica_status_missing_status_fields(k8s_api, mock_custom_api):
     """Test handling when status fields are missing"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"prefill-worker": {"replicas": 2}}},
-        "status": {"services": {}},
+        "spec": {"components": [{"name": "prefill-worker", "replicas": 2}]},
+        "status": {"components": {}},
     }
 
     count, is_stable = k8s_api.get_service_replica_status(deployment, "prefill-worker")
@@ -506,9 +602,9 @@ def test_get_service_replica_status_empty_deployment(k8s_api, mock_custom_api):
 def test_get_service_replica_status_available_replicas_zero(k8s_api, mock_custom_api):
     """Test when availableReplicas is explicitly 0 (should use 0, not fall back to ready)"""
     deployment: Dict[str, Any] = {
-        "spec": {"services": {"prefill-worker": {"replicas": 0}}},
+        "spec": {"components": [{"name": "prefill-worker", "replicas": 0}]},
         "status": {
-            "services": {
+            "components": {
                 "prefill-worker": {
                     "availableReplicas": 0,
                     "readyReplicas": 2,  # Should be ignored

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -236,9 +236,7 @@ def test_get_service_name_from_v1beta_component_type(kubernetes_connector):
     assert service.name == "VllmPrefillWorker"
     assert service.number_replicas() == 2
 
-    service = get_component_from_type_or_name(
-        deployment, SubComponentType.DECODE
-    )
+    service = get_component_from_type_or_name(deployment, SubComponentType.DECODE)
     assert service.name == "VllmDecodeWorker"
     assert service.number_replicas() == 3
 
@@ -246,9 +244,7 @@ def test_get_service_name_from_v1beta_component_type(kubernetes_connector):
 def test_get_service_name_from_sub_component_type_not_found(kubernetes_connector):
     deployment = _deployment(_component("test-component-decode", "decode", replicas=3))
     with pytest.raises(SubComponentNotFoundError) as exc_info:
-        get_component_from_type_or_name(
-            deployment, SubComponentType.PREFILL
-        )
+        get_component_from_type_or_name(deployment, SubComponentType.PREFILL)
 
     with pytest.raises(SubComponentNotFoundError) as exc_info:
         get_component_from_type_or_name(
@@ -1143,7 +1139,9 @@ def test_resolve_dgd_service_trtllm_decode_uses_backend_name(
     kubernetes_connector, mock_kube_api
 ):
     """TRT-LLM decode: MDC carries "backend" (matches vLLM/SGLang); filter must match."""
-    mock_deployment = _deployment(_component("TRTLLMDecodeWorker", "decode", replicas=1))
+    mock_deployment = _deployment(
+        _component("TRTLLMDecodeWorker", "decode", replicas=1)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     _, expected_component = kubernetes_connector._resolve_dgd_service(

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -31,7 +31,7 @@ from dynamo.planner.errors import (
 )
 from dynamo.planner.monitoring.dgd_services import (
     Service,
-    get_service_from_sub_component_type_or_name,
+    get_component_from_type_or_name,
 )
 
 pytestmark = [
@@ -68,6 +68,35 @@ def kubernetes_connector(mock_kube_api_class, monkeypatch):
     with patch.dict(os.environ, {"DYN_PARENT_DGD_K8S_NAME": "test-graph"}):
         connector = KubernetesConnector("test-dynamo-namespace")
         return connector
+
+
+def _main_container(args=None, gpu=None):
+    container = {"name": "main"}
+    if args is not None:
+        container["args"] = args
+    if gpu is not None:
+        container["resources"] = {"limits": {"nvidia.com/gpu": str(gpu)}}
+    return container
+
+
+def _component(name, component_type=None, replicas=None, args=None, gpu=None):
+    component = {"name": name}
+    if component_type is not None:
+        component["type"] = component_type
+    if replicas is not None:
+        component["replicas"] = replicas
+    if args is not None or gpu is not None:
+        component["podTemplate"] = {
+            "spec": {"containers": [_main_container(args=args, gpu=gpu)]}
+        }
+    return component
+
+
+def _deployment(*components):
+    return {
+        "metadata": {"name": "test-graph"},
+        "spec": {"components": list(components)},
+    }
 
 
 def test_kubernetes_connector_no_env_var():
@@ -156,56 +185,73 @@ def test_get_worker_runtime_namespace_with_legacy_v1_and_v2_hash(
 
 
 def test_get_service_name_from_sub_component_type(kubernetes_connector):
-    deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "test-component-prefill": {
-                    "replicas": 2,
-                    "subComponentType": "prefill",
-                },
-                "test-component-decode": {"replicas": 3, "subComponentType": "decode"},
-            }
-        },
-    }
+    deployment = _deployment(
+        _component("test-component-prefill", "prefill", replicas=2),
+        _component("test-component-decode", "decode", replicas=3),
+    )
 
-    service = get_service_from_sub_component_type_or_name(
+    service = get_component_from_type_or_name(
         deployment, SubComponentType.PREFILL
     )
     assert service.name == "test-component-prefill"
     assert service.number_replicas() == 2
 
     # should still work if the component_name is provided
-    service = get_service_from_sub_component_type_or_name(
+    service = get_component_from_type_or_name(
         deployment, SubComponentType.PREFILL, "test-component-prefill"
     )
     assert service.name == "test-component-prefill"
     assert service.number_replicas() == 2
 
-    # should respect subComponentType first
-    service = get_service_from_sub_component_type_or_name(
+    # should respect component type first
+    service = get_component_from_type_or_name(
         deployment, SubComponentType.DECODE, "test-component-prefill"
     )
     assert service.name == "test-component-decode"
     assert service.number_replicas() == 3
 
 
-def test_get_service_name_from_sub_component_type_not_found(kubernetes_connector):
+def test_get_service_name_from_v1beta_component_type(kubernetes_connector):
     deployment = {
         "metadata": {"name": "test-graph"},
         "spec": {
-            "services": {
-                "test-component-decode": {"replicas": 3, "subComponentType": "decode"},
-            }
+            "components": [
+                {
+                    "name": "VllmPrefillWorker",
+                    "replicas": 2,
+                    "type": "prefill",
+                },
+                {
+                    "name": "VllmDecodeWorker",
+                    "replicas": 3,
+                    "type": "decode",
+                },
+            ]
         },
     }
+
+    service = get_component_from_type_or_name(
+        deployment, SubComponentType.PREFILL
+    )
+    assert service.name == "VllmPrefillWorker"
+    assert service.number_replicas() == 2
+
+    service = get_component_from_type_or_name(
+        deployment, SubComponentType.DECODE
+    )
+    assert service.name == "VllmDecodeWorker"
+    assert service.number_replicas() == 3
+
+
+def test_get_service_name_from_sub_component_type_not_found(kubernetes_connector):
+    deployment = _deployment(_component("test-component-decode", "decode", replicas=3))
     with pytest.raises(SubComponentNotFoundError) as exc_info:
-        get_service_from_sub_component_type_or_name(
+        get_component_from_type_or_name(
             deployment, SubComponentType.PREFILL
         )
 
     with pytest.raises(SubComponentNotFoundError) as exc_info:
-        get_service_from_sub_component_type_or_name(
+        get_component_from_type_or_name(
             deployment, SubComponentType.PREFILL, "test-component-decode"
         )
 
@@ -214,25 +260,15 @@ def test_get_service_name_from_sub_component_type_not_found(kubernetes_connector
 
 
 def test_get_service_name_from_sub_component_type_duplicate(kubernetes_connector):
-    deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "test-component-prefill": {
-                    "replicas": 2,
-                    "subComponentType": "prefill",
-                },
-                "test-component-prefill-2": {
-                    "replicas": 3,
-                    "subComponentType": "prefill",
-                },
-            }
-        },
-    }
+    deployment = _deployment(
+        _component("test-component-prefill", "prefill", replicas=2),
+        _component("test-component-prefill-2", "prefill", replicas=3),
+    )
 
     with pytest.raises(DuplicateSubComponentError) as exc_info:
-        # even though "test-component-prefill" is provided, subComponentType duplicates should result in an error
-        get_service_from_sub_component_type_or_name(
+        # even though "test-component-prefill" is provided, duplicate component
+        # types should result in an error
+        get_component_from_type_or_name(
             deployment, SubComponentType.PREFILL, "test-component-prefill"
         )
 
@@ -245,17 +281,12 @@ def test_get_service_name_from_sub_component_type_duplicate(kubernetes_connector
 
 
 def test_get_service_name_from_sub_component_type_or_name(kubernetes_connector):
-    deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "test-component-prefill": {"replicas": 2},
-                "test-component-decode": {"replicas": 3},
-            }
-        },
-    }
+    deployment = _deployment(
+        _component("test-component-prefill", replicas=2),
+        _component("test-component-decode", replicas=3),
+    )
 
-    service = get_service_from_sub_component_type_or_name(
+    service = get_component_from_type_or_name(
         deployment, SubComponentType.PREFILL, "test-component-prefill"
     )
     assert service.name == "test-component-prefill"
@@ -267,17 +298,9 @@ async def test_add_component_increases_replicas(kubernetes_connector, mock_kube_
     # Arrange
     sub_component_type = SubComponentType.PREFILL
     component_name = "test-component"
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                component_name: {
-                    "replicas": 1,
-                    "subComponentType": sub_component_type.value,
-                }
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(component_name, sub_component_type.value, replicas=1)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.update_graph_replicas.return_value = None
     mock_kube_api.wait_for_graph_deployment_ready.return_value = None
@@ -300,12 +323,7 @@ async def test_add_component_with_no_replicas_specified(
     # Arrange
     sub_component_type = SubComponentType.PREFILL
     component_name = "test-component"
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {component_name: {"subComponentType": sub_component_type.value}}
-        },
-    }
+    mock_deployment = _deployment(_component(component_name, sub_component_type.value))
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -336,7 +354,7 @@ async def test_add_component_component_not_found(kubernetes_connector, mock_kube
     # Arrange
     mock_deployment = {
         "metadata": {"name": "test-graph"},
-        "spec": {"services": {"test-component": {"subComponentType": "decode"}}},
+        "spec": {"components": [_component("test-component", "decode")]},
     }
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
@@ -356,17 +374,9 @@ async def test_remove_component_decreases_replicas(kubernetes_connector, mock_ku
     # Arrange
     component_name = "test-component"
     sub_component_type = SubComponentType.PREFILL
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "test-component": {
-                    "replicas": 2,
-                    "subComponentType": sub_component_type.value,
-                }
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("test-component", sub_component_type.value, replicas=2)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -384,17 +394,9 @@ async def test_remove_component_with_zero_replicas(kubernetes_connector, mock_ku
     # Arrange
     component_name = "test-component"
     sub_component_type = SubComponentType.PREFILL
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                component_name: {
-                    "replicas": 0,
-                    "subComponentType": sub_component_type.value,
-                }
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(component_name, sub_component_type.value, replicas=0)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -412,17 +414,9 @@ async def test_remove_component_component_not_found(
     # Arrange
     component_name = "test-component"
     sub_component_type = SubComponentType.PREFILL
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                component_name: {
-                    "replicas": 0,
-                    "subComponentType": sub_component_type.value,
-                }
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(component_name, sub_component_type.value, replicas=0)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -448,15 +442,10 @@ async def test_set_component_replicas(kubernetes_connector, mock_kube_api):
             desired_replicas=2,
         ),
     ]
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {"replicas": 1},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component("component2", replicas=1),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.is_deployment_ready.return_value = True
     mock_kube_api.wait_for_graph_deployment_ready.return_value = None
@@ -485,15 +474,10 @@ async def test_set_component_replicas_component_not_found(
         TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3),
         TargetReplica(sub_component_type=SubComponentType.DECODE, desired_replicas=2),
     ]
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {"replicas": 1},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component("component2", replicas=1),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.is_deployment_ready.return_value = True
     mock_kube_api.update_graph_replicas.return_value = None
@@ -516,15 +500,10 @@ async def test_set_component_replicas_component_already_at_desired_replicas(
         TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3),
         TargetReplica(sub_component_type=SubComponentType.DECODE, desired_replicas=2),
     ]
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {"replicas": 2, "subComponentType": "decode"},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component("component2", "decode", replicas=2),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.is_deployment_ready.return_value = True
     mock_kube_api.update_graph_replicas.return_value = None
@@ -581,15 +560,10 @@ async def test_set_component_replicas_deployment_not_ready(
         TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3),
         TargetReplica(sub_component_type=SubComponentType.DECODE, desired_replicas=2),
     ]
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {"replicas": 2, "subComponentType": "decode"},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component("component2", "decode", replicas=2),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.is_deployment_ready.return_value = False
 
@@ -605,23 +579,15 @@ async def test_set_component_replicas_deployment_not_ready(
 @pytest.mark.asyncio
 async def test_validate_deployment_true(kubernetes_connector, mock_kube_api):
     # Arrange
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": ["--served-model-name", "prefill-model"]
-                        }
-                    },
-                },
-                "component2": {"replicas": 2, "subComponentType": "decode"},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(
+            "component1",
+            "prefill",
+            replicas=1,
+            args=["--served-model-name", "prefill-model"],
+        ),
+        _component("component2", "decode", replicas=2),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -631,15 +597,10 @@ async def test_validate_deployment_true(kubernetes_connector, mock_kube_api):
 @pytest.mark.asyncio
 async def test_validate_deployment_fail(kubernetes_connector, mock_kube_api):
     # Arrange
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {"replicas": 2, "subComponentType": "prefill"},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component("component2", "prefill", replicas=2),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -655,15 +616,10 @@ async def test_validate_deployment_fail(kubernetes_connector, mock_kube_api):
 
 def test_get_model_name_both_none_raises_error(kubernetes_connector, mock_kube_api):
     # Arrange
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {"replicas": 2, "subComponentType": "decode"},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component("component2", "decode", replicas=2),
+    )
 
     with pytest.raises(ModelNameNotFoundError):
         kubernetes_connector.get_model_name(mock_deployment)
@@ -671,21 +627,15 @@ def test_get_model_name_both_none_raises_error(kubernetes_connector, mock_kube_a
 
 def test_get_model_name_prefill_none_decode_valid_returns_decode(kubernetes_connector):
     # Arrange
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {"replicas": 1, "subComponentType": "prefill"},
-                "component2": {
-                    "replicas": 2,
-                    "subComponentType": "decode",
-                    "extraPodSpec": {
-                        "mainContainer": {"args": ["--served-model-name", "test-model"]}
-                    },
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("component1", "prefill", replicas=1),
+        _component(
+            "component2",
+            "decode",
+            replicas=2,
+            args=["--served-model-name", "test-model"],
+        ),
+    )
     # Act
     result = kubernetes_connector.get_model_name(mock_deployment)
 
@@ -694,31 +644,20 @@ def test_get_model_name_prefill_none_decode_valid_returns_decode(kubernetes_conn
 
 
 def test_get_model_name_mismatch_raises_error(kubernetes_connector, mock_kube_api):
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": ["--served-model-name", "prefill-model"]
-                        }
-                    },
-                },
-                "component2": {
-                    "replicas": 2,
-                    "subComponentType": "decode",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": ["--served-model-name", "decode-model"]
-                        }
-                    },
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(
+            "component1",
+            "prefill",
+            replicas=1,
+            args=["--served-model-name", "prefill-model"],
+        ),
+        _component(
+            "component2",
+            "decode",
+            replicas=2,
+            args=["--served-model-name", "decode-model"],
+        ),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act & Assert
@@ -732,31 +671,20 @@ def test_get_model_name_mismatch_raises_error(kubernetes_connector, mock_kube_ap
 
 def test_get_model_name_agree_returns_model_name(kubernetes_connector, mock_kube_api):
     # Arrange
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "component1": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": ["--served-model-name", "agreed-model"]
-                        }
-                    },
-                },
-                "component2": {
-                    "replicas": 2,
-                    "subComponentType": "decode",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": ["--served-model-name", "agreed-model"]
-                        }
-                    },
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(
+            "component1",
+            "prefill",
+            replicas=1,
+            args=["--served-model-name", "agreed-model"],
+        ),
+        _component(
+            "component2",
+            "decode",
+            replicas=2,
+            args=["--served-model-name", "agreed-model"],
+        ),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     # Act
@@ -768,38 +696,53 @@ def test_get_model_name_agree_returns_model_name(kubernetes_connector, mock_kube
 
 # Tests for Service.get_gpu_count()
 def test_service_get_gpu_count_valid():
-    """Test that get_gpu_count returns correct GPU count from resources.limits.gpu"""
+    """Test that get_gpu_count returns GPU count from main container limits."""
     service = Service(
         name="test-service",
-        service={
-            "replicas": 1,
-            "resources": {"limits": {"gpu": "4"}},
-        },
+        service=_component("test-service", replicas=1, gpu=4),
     )
     assert service.get_gpu_count() == 4
 
 
 def test_service_get_gpu_count_from_requests_fallback():
-    """Test that get_gpu_count falls back to requests.gpu when limits.gpu is missing"""
+    """Test that get_gpu_count falls back to main container requests."""
     service = Service(
         name="test-service",
         service={
             "replicas": 1,
-            "resources": {"requests": {"gpu": "2"}},
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {"requests": {"nvidia.com/gpu": "2"}},
+                        }
+                    ]
+                }
+            },
         },
     )
     assert service.get_gpu_count() == 2
 
 
 def test_service_get_gpu_count_limits_preferred_over_requests():
-    """Test that limits.gpu is preferred over requests.gpu when both are present"""
+    """Test that limits are preferred over requests when both are present."""
     service = Service(
         name="test-service",
         service={
             "replicas": 1,
-            "resources": {
-                "limits": {"gpu": "4"},
-                "requests": {"gpu": "2"},
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {
+                                "limits": {"nvidia.com/gpu": "4"},
+                                "requests": {"nvidia.com/gpu": "2"},
+                            },
+                        }
+                    ]
+                }
             },
         },
     )
@@ -812,7 +755,16 @@ def test_service_get_gpu_count_integer_value():
         name="test-service",
         service={
             "replicas": 1,
-            "resources": {"limits": {"gpu": 2}},
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {"limits": {"nvidia.com/gpu": 2}},
+                        }
+                    ]
+                }
+            },
         },
     )
     assert service.get_gpu_count() == 2
@@ -836,7 +788,16 @@ def test_service_get_gpu_count_invalid_raises_error():
         name="test-service",
         service={
             "replicas": 1,
-            "resources": {"limits": {"gpu": "invalid"}},
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "resources": {"limits": {"nvidia.com/gpu": "invalid"}},
+                        }
+                    ]
+                }
+            },
         },
     )
     with pytest.raises(ValueError) as exc_info:
@@ -844,26 +805,62 @@ def test_service_get_gpu_count_invalid_raises_error():
     assert "Invalid GPU count" in str(exc_info.value)
 
 
+def test_service_reads_v1beta_pod_template_main_container():
+    service = Service(
+        name="VllmPrefillWorker",
+        service={
+            "podTemplate": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "sidecar",
+                            "args": ["--ignored"],
+                        },
+                        {
+                            "name": "main",
+                            "args": [
+                                "--endpoint",
+                                "ns.custom-prefill.generate",
+                                "--model",
+                                "Qwen/Qwen3-8B",
+                            ],
+                            "resources": {
+                                "limits": {
+                                    "nvidia.com/gpu": "2",
+                                }
+                            },
+                        },
+                    ]
+                }
+            }
+        },
+    )
+
+    assert service.get_model_name() == "Qwen/Qwen3-8B"
+    assert service.get_component_name_from_endpoint_arg() == "custom-prefill"
+    assert service.get_gpu_count() == 2
+
+
 # Tests for KubernetesConnector.get_gpu_counts()
 def test_get_gpu_counts_both_services(kubernetes_connector, mock_kube_api):
     """Test get_gpu_counts returns correct counts for both prefill and decode"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "prefill-worker": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "resources": {"limits": {"gpu": "2"}},
-                },
-                "decode-worker": {
-                    "replicas": 1,
-                    "subComponentType": "decode",
-                    "resources": {"limits": {"gpu": "4"}},
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("prefill-worker", "prefill", replicas=1, gpu=2),
+        _component("decode-worker", "decode", replicas=1, gpu=4),
+    )
+    mock_kube_api.get_graph_deployment.return_value = mock_deployment
+
+    prefill_gpu, decode_gpu = kubernetes_connector.get_gpu_counts()
+
+    assert prefill_gpu == 2
+    assert decode_gpu == 4
+
+
+def test_get_gpu_counts_v1beta_components(kubernetes_connector, mock_kube_api):
+    mock_deployment = _deployment(
+        _component("prefill-worker", "prefill", replicas=1, gpu=2),
+        _component("decode-worker", "decode", replicas=1, gpu=4),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     prefill_gpu, decode_gpu = kubernetes_connector.get_gpu_counts()
@@ -874,18 +871,9 @@ def test_get_gpu_counts_both_services(kubernetes_connector, mock_kube_api):
 
 def test_get_gpu_counts_prefill_only(kubernetes_connector, mock_kube_api):
     """Test get_gpu_counts with require_decode=False"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "prefill-worker": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "resources": {"limits": {"gpu": "2"}},
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("prefill-worker", "prefill", replicas=1, gpu=2)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     prefill_gpu, decode_gpu = kubernetes_connector.get_gpu_counts(
@@ -898,18 +886,9 @@ def test_get_gpu_counts_prefill_only(kubernetes_connector, mock_kube_api):
 
 def test_get_gpu_counts_decode_only(kubernetes_connector, mock_kube_api):
     """Test get_gpu_counts with require_prefill=False"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "decode-worker": {
-                    "replicas": 1,
-                    "subComponentType": "decode",
-                    "resources": {"limits": {"gpu": "4"}},
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("decode-worker", "decode", replicas=1, gpu=4)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     prefill_gpu, decode_gpu = kubernetes_connector.get_gpu_counts(
@@ -922,23 +901,10 @@ def test_get_gpu_counts_decode_only(kubernetes_connector, mock_kube_api):
 
 def test_get_gpu_counts_missing_gpu_raises_error(kubernetes_connector, mock_kube_api):
     """Test get_gpu_counts raises DeploymentValidationError when GPU count missing"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "prefill-worker": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    # No resources.limits.gpu
-                },
-                "decode-worker": {
-                    "replicas": 1,
-                    "subComponentType": "decode",
-                    "resources": {"limits": {"gpu": "4"}},
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("prefill-worker", "prefill", replicas=1),
+        _component("decode-worker", "decode", replicas=1, gpu=4),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     with pytest.raises(DeploymentValidationError) as exc_info:
@@ -951,19 +917,9 @@ def test_get_gpu_counts_service_not_found_raises_error(
     kubernetes_connector, mock_kube_api
 ):
     """Test get_gpu_counts raises DeploymentValidationError when service not found"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "prefill-worker": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "resources": {"limits": {"gpu": "2"}},
-                },
-                # No decode service
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("prefill-worker", "prefill", replicas=1, gpu=2)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     with pytest.raises(DeploymentValidationError) as exc_info:
@@ -977,15 +933,10 @@ def test_get_gpu_counts_service_not_found_raises_error(
 
 def test_get_actual_worker_counts_stable(kubernetes_connector, mock_kube_api):
     """Test get_actual_worker_counts when both services are stable"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "prefill-component": {},
-                "decode-component": {},
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("prefill-component"),
+        _component("decode-component"),
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.get_service_replica_status.side_effect = [(2, True), (4, True)]
 
@@ -1010,10 +961,10 @@ def test_get_actual_worker_counts_prefill_rollout_in_progress(
     mock_deployment = {
         "metadata": {"name": "test-graph"},
         "spec": {
-            "services": {
-                "prefill-component": {},
-                "decode-component": {},
-            }
+            "components": [
+                _component("prefill-component"),
+                _component("decode-component"),
+            ]
         },
     }
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
@@ -1035,17 +986,9 @@ def test_get_actual_worker_counts_prefill_rollout_in_progress(
 
 def test_get_actual_worker_counts_prefill_only(kubernetes_connector, mock_kube_api):
     """Test get_actual_worker_counts with only prefill component"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "prefill-component": {
-                    "replicas": 2,
-                    "subComponentType": "prefill",
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component("prefill-component", "prefill", replicas=2)
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.get_service_replica_status.return_value = (2, True)
 
@@ -1065,17 +1008,7 @@ def test_get_actual_worker_counts_prefill_only(kubernetes_connector, mock_kube_a
 
 def test_get_actual_worker_counts_decode_only(kubernetes_connector, mock_kube_api):
     """Test get_actual_worker_counts with only decode component"""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "decode-component": {
-                    "replicas": 4,
-                    "subComponentType": "decode",
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(_component("decode-component", "decode", replicas=4))
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
     mock_kube_api.get_service_replica_status.return_value = (4, True)
 
@@ -1097,8 +1030,8 @@ def test_get_actual_worker_counts_no_components(kubernetes_connector, mock_kube_
     """Test get_actual_worker_counts with no components specified"""
     mock_deployment = {
         "metadata": {"name": "test-graph"},
-        "spec": {"services": {}},
-        "status": {"services": {}},
+        "spec": {"components": []},
+        "status": {"components": {}},
     }
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
@@ -1120,10 +1053,10 @@ def test_get_actual_worker_counts_no_components(kubernetes_connector, mock_kube_
 #
 # Regression: the filter that compares an MDC entry's ``component`` field
 # against ``expected_component`` must use the lowercase backend-default
-# name (what the Rust runtime writes to MDC), NOT the DGD ``spec.services``
-# dict key. The DGD key is typically PascalCase (``VllmPrefillWorker``)
+# name (what the Rust runtime writes to MDC), NOT the DGD component name.
+# The DGD component name is typically PascalCase (``VllmPrefillWorker``)
 # while MDC carries the Endpoint name (``prefill`` / ``backend``);
-# returning the DGD key for the filter would cause every real-world MDC
+# returning the DGD component name for the filter would cause every real-world MDC
 # entry to be skipped, leaving WorkerInfo without ``context_length`` and
 # silently breaking easy-mode load scaling.
 
@@ -1131,16 +1064,50 @@ def test_get_actual_worker_counts_no_components(kubernetes_connector, mock_kube_
 def test_resolve_dgd_service_prefill_uses_backend_default_for_filter(
     kubernetes_connector, mock_kube_api
 ):
-    """vLLM prefill: filter name = "prefill" (MDC side), not DGD services key."""
+    """vLLM prefill: filter name = "prefill" (MDC side), not DGD component name."""
+    mock_deployment = _deployment(
+        _component("VllmPrefillWorker", "prefill", replicas=1)
+    )
+    mock_kube_api.get_graph_deployment.return_value = mock_deployment
+
+    dgd_service_name, expected_component = kubernetes_connector._resolve_dgd_service(
+        SubComponentType.PREFILL, backend="vllm"
+    )
+
+    # k8s operations (e.g. replica patch) still target the PascalCase DGD component.
+    assert dgd_service_name == "VllmPrefillWorker"
+    # The filter side must match what the Rust runtime writes to MDC.
+    assert expected_component == "prefill"
+
+
+def test_resolve_dgd_service_v1beta_endpoint_override(
+    kubernetes_connector, mock_kube_api
+):
     mock_deployment = {
         "metadata": {"name": "test-graph"},
         "spec": {
-            "services": {
-                "VllmPrefillWorker": {
+            "components": [
+                {
+                    "name": "VllmPrefillWorker",
                     "replicas": 1,
-                    "subComponentType": "prefill",
+                    "type": "prefill",
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "main",
+                                    "args": [
+                                        "--endpoint",
+                                        "my-ns.my-custom-prefill.generate",
+                                        "--model",
+                                        "Qwen/Qwen3-8B",
+                                    ],
+                                }
+                            ]
+                        }
+                    },
                 },
-            }
+            ]
         },
     }
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
@@ -1149,27 +1116,15 @@ def test_resolve_dgd_service_prefill_uses_backend_default_for_filter(
         SubComponentType.PREFILL, backend="vllm"
     )
 
-    # k8s operations (e.g. replica patch) still target the PascalCase DGD key.
     assert dgd_service_name == "VllmPrefillWorker"
-    # The filter side must match what the Rust runtime writes to MDC.
-    assert expected_component == "prefill"
+    assert expected_component == "my-custom-prefill"
 
 
 def test_resolve_dgd_service_decode_uses_backend_default_for_filter(
     kubernetes_connector, mock_kube_api
 ):
     """vLLM decode: MDC carries "backend", NOT "decode"; filter must match that."""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "VllmDecodeWorker": {
-                    "replicas": 1,
-                    "subComponentType": "decode",
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(_component("VllmDecodeWorker", "decode", replicas=1))
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     dgd_service_name, expected_component = kubernetes_connector._resolve_dgd_service(
@@ -1188,17 +1143,7 @@ def test_resolve_dgd_service_trtllm_decode_uses_backend_name(
     kubernetes_connector, mock_kube_api
 ):
     """TRT-LLM decode: MDC carries "backend" (matches vLLM/SGLang); filter must match."""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "TRTLLMDecodeWorker": {
-                    "replicas": 1,
-                    "subComponentType": "decode",
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(_component("TRTLLMDecodeWorker", "decode", replicas=1))
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     _, expected_component = kubernetes_connector._resolve_dgd_service(
@@ -1228,34 +1173,26 @@ def test_resolve_dgd_service_respects_user_endpoint_override(
     kubernetes_connector, mock_kube_api
 ):
     """If the DGD passes --endpoint ns.comp.ep, the MDC filter must use 'comp'."""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "VllmPrefillWorker": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": [
-                                "--endpoint",
-                                "my-ns.my-custom-prefill.generate",
-                                "--model",
-                                "Qwen/Qwen3-8B",
-                            ]
-                        }
-                    },
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(
+            "VllmPrefillWorker",
+            "prefill",
+            replicas=1,
+            args=[
+                "--endpoint",
+                "my-ns.my-custom-prefill.generate",
+                "--model",
+                "Qwen/Qwen3-8B",
+            ],
+        )
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     dgd_service_name, expected_component = kubernetes_connector._resolve_dgd_service(
         SubComponentType.PREFILL, backend="vllm"
     )
 
-    # k8s operations still target the DGD services key.
+    # k8s operations still target the DGD component name.
     assert dgd_service_name == "VllmPrefillWorker"
     # Filter must match what the worker will actually write to MDC, which
     # comes from the user's --endpoint override, not the backend default.
@@ -1266,25 +1203,17 @@ def test_resolve_dgd_service_endpoint_override_with_dyn_prefix(
     kubernetes_connector, mock_kube_api
 ):
     """parse_endpoint accepts 'dyn://' prefix; the extracted component must strip it."""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "VllmDecodeWorker": {
-                    "replicas": 1,
-                    "subComponentType": "decode",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": [
-                                "--endpoint",
-                                "dyn://ns.user-decode.generate",
-                            ]
-                        }
-                    },
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(
+            "VllmDecodeWorker",
+            "decode",
+            replicas=1,
+            args=[
+                "--endpoint",
+                "dyn://ns.user-decode.generate",
+            ],
+        )
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     _, expected_component = kubernetes_connector._resolve_dgd_service(
@@ -1298,22 +1227,14 @@ def test_resolve_dgd_service_malformed_endpoint_falls_back_to_default(
     kubernetes_connector, mock_kube_api
 ):
     """Malformed --endpoint (wrong number of parts) falls back to backend default."""
-    mock_deployment = {
-        "metadata": {"name": "test-graph"},
-        "spec": {
-            "services": {
-                "VllmPrefillWorker": {
-                    "replicas": 1,
-                    "subComponentType": "prefill",
-                    "extraPodSpec": {
-                        "mainContainer": {
-                            "args": ["--endpoint", "only-two.parts"],
-                        }
-                    },
-                },
-            }
-        },
-    }
+    mock_deployment = _deployment(
+        _component(
+            "VllmPrefillWorker",
+            "prefill",
+            replicas=1,
+            args=["--endpoint", "only-two.parts"],
+        )
+    )
     mock_kube_api.get_graph_deployment.return_value = mock_deployment
 
     _, expected_component = kubernetes_connector._resolve_dgd_service(
@@ -1326,18 +1247,15 @@ def test_resolve_dgd_service_malformed_endpoint_falls_back_to_default(
 def test_service_get_component_name_from_endpoint_arg_present():
     service = Service(
         name="VllmPrefillWorker",
-        service={
-            "extraPodSpec": {
-                "mainContainer": {
-                    "args": [
-                        "--endpoint",
-                        "ns.custom-comp.generate",
-                        "--other",
-                        "flag",
-                    ]
-                }
-            }
-        },
+        service=_component(
+            "VllmPrefillWorker",
+            args=[
+                "--endpoint",
+                "ns.custom-comp.generate",
+                "--other",
+                "flag",
+            ],
+        ),
     )
     assert service.get_component_name_from_endpoint_arg() == "custom-comp"
 
@@ -1345,13 +1263,10 @@ def test_service_get_component_name_from_endpoint_arg_present():
 def test_service_get_component_name_from_endpoint_arg_absent():
     service = Service(
         name="VllmPrefillWorker",
-        service={
-            "extraPodSpec": {
-                "mainContainer": {
-                    "args": ["--model", "Qwen/Qwen3-8B"],
-                }
-            }
-        },
+        service=_component(
+            "VllmPrefillWorker",
+            args=["--model", "Qwen/Qwen3-8B"],
+        ),
     )
     assert service.get_component_name_from_endpoint_arg() is None
 
@@ -1360,6 +1275,6 @@ def test_service_get_component_name_from_endpoint_arg_missing_value():
     """--endpoint with no following arg should return None, not raise IndexError."""
     service = Service(
         name="VllmPrefillWorker",
-        service={"extraPodSpec": {"mainContainer": {"args": ["--endpoint"]}}},
+        service=_component("VllmPrefillWorker", args=["--endpoint"]),
     )
     assert service.get_component_name_from_endpoint_arg() is None

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -190,9 +190,7 @@ def test_get_service_name_from_sub_component_type(kubernetes_connector):
         _component("test-component-decode", "decode", replicas=3),
     )
 
-    service = get_component_from_type_or_name(
-        deployment, SubComponentType.PREFILL
-    )
+    service = get_component_from_type_or_name(deployment, SubComponentType.PREFILL)
     assert service.name == "test-component-prefill"
     assert service.number_replicas() == 2
 
@@ -230,9 +228,7 @@ def test_get_service_name_from_v1beta_component_type(kubernetes_connector):
         },
     }
 
-    service = get_component_from_type_or_name(
-        deployment, SubComponentType.PREFILL
-    )
+    service = get_component_from_type_or_name(deployment, SubComponentType.PREFILL)
     assert service.name == "VllmPrefillWorker"
     assert service.number_replicas() == 2
 
@@ -548,6 +544,7 @@ async def test_set_component_replicas_empty_target_replicas(
         await kubernetes_connector.set_component_replicas(target_replicas)
 
 
+@pytest.mark.asyncio
 async def test_set_component_replicas_deployment_not_ready(
     kubernetes_connector, mock_kube_api
 ):
@@ -840,19 +837,6 @@ def test_service_reads_v1beta_pod_template_main_container():
 # Tests for KubernetesConnector.get_gpu_counts()
 def test_get_gpu_counts_both_services(kubernetes_connector, mock_kube_api):
     """Test get_gpu_counts returns correct counts for both prefill and decode"""
-    mock_deployment = _deployment(
-        _component("prefill-worker", "prefill", replicas=1, gpu=2),
-        _component("decode-worker", "decode", replicas=1, gpu=4),
-    )
-    mock_kube_api.get_graph_deployment.return_value = mock_deployment
-
-    prefill_gpu, decode_gpu = kubernetes_connector.get_gpu_counts()
-
-    assert prefill_gpu == 2
-    assert decode_gpu == 4
-
-
-def test_get_gpu_counts_v1beta_components(kubernetes_connector, mock_kube_api):
     mock_deployment = _deployment(
         _component("prefill-worker", "prefill", replicas=1, gpu=2),
         _component("decode-worker", "decode", replicas=1, gpu=4),

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -237,6 +237,17 @@ def test_get_service_name_from_v1beta_component_type(kubernetes_connector):
     assert service.number_replicas() == 3
 
 
+def test_get_service_name_from_v1beta_worker_type_by_name(kubernetes_connector):
+    deployment = _deployment(_component("worker", "worker", replicas=2))
+
+    service = get_component_from_type_or_name(
+        deployment, SubComponentType.PREFILL, "worker"
+    )
+
+    assert service.name == "worker"
+    assert service.number_replicas() == 2
+
+
 def test_get_service_name_from_sub_component_type_not_found(kubernetes_connector):
     deployment = _deployment(_component("test-component-decode", "decode", replicas=3))
     with pytest.raises(SubComponentNotFoundError) as exc_info:


### PR DESCRIPTION
**Summary**

- Move planner DGD/DGDSA Kubernetes calls from v1alpha1 to v1beta1.
- Replace DGD parsing from spec.services / status.services with spec.components[] / status.components.
- Read component role from v1beta1 type, pod args/resources from podTemplate.spec.containers[name=main], and GPU count from nvidia.com/gpu.
- Update direct DGD replica fallback to JSON Patch /spec/components/<idx>/replicas with a guarding test op on component name.
- Remove legacy alpha-shaped planner fallback paths and update unit fixtures to v1beta1 component shape.

**Compatibility Notes**

- DynamoWorkerMetadata remains v1alpha1 intentionally because that CRD is still served only as v1alpha1.
- Existing planner API names like SubComponentType / sub_component_type remain for now as compatibility naming debt; they no longer map to the old DGD subComponentType field.
- Planner no longer accepts alpha-shaped DGD spec.services / status.services.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component detection and replica status tracking for Kubernetes deployments
  * Enhanced GPU count discovery from container resources
  * Refined worker metadata retrieval and model-name extraction

* **Documentation**
  * Updated error messages to reflect component-based configuration terminology

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->