### PR TITLE
fix(parser): route gpt-oss Harmony channels correctly

### DIFF
--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -7,7 +7,7 @@ use crate::ParserResult;
 use crate::ReasoningParser;
 
 use openai_harmony::StreamableParser;
-use openai_harmony::chat::TextContent;
+use openai_harmony::chat::{Content, Message, TextContent};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, chat::Role, load_harmony_encoding};
 
 ///// Static initialization of harmony encoder to not affect performance every time a parser is created
@@ -18,6 +18,15 @@ static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::
     OnceLock::new();
 static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
 const HARMONY_CALL_MARKER: &str = "<|call|>";
+const HARMONY_SPECIAL_TOKENS: &[&str] = &[
+    "<|start|>",
+    "<|end|>",
+    "<|return|>",
+    "<|channel|>",
+    "<|constrain|>",
+    "<|message|>",
+    "<|call|>",
+];
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
     GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
@@ -36,6 +45,9 @@ fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
 
 pub struct GptOssReasoningParser {
     parser: StreamableParser,
+    pending_text: String,
+    emitted_reasoning_text: bool,
+    insert_reasoning_separator: bool,
 }
 
 /// Implement Debug for GptOssReasoningParser separately because StreamableParser does not implement Debug
@@ -64,7 +76,12 @@ impl GptOssReasoningParser {
                 return Err(anyhow::anyhow!("Failed to load Harmony encoding: {e}"));
             }
         };
-        Ok(Self { parser })
+        Ok(Self {
+            parser,
+            pending_text: String::new(),
+            emitted_reasoning_text: false,
+            insert_reasoning_separator: false,
+        })
     }
 }
 
@@ -126,18 +143,70 @@ fn raw_input_text_for_tool_parser(
     text.to_string()
 }
 
+fn split_incomplete_harmony_suffix(text: &str) -> (&str, &str) {
+    let hold_len = HARMONY_SPECIAL_TOKENS
+        .iter()
+        .flat_map(|token| (1..token.len()).map(|idx| &token[..idx]))
+        .filter(|prefix| text.ends_with(*prefix))
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+
+    text.split_at(text.len() - hold_len)
+}
+
+fn append_separated(target: &mut String, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    if !target.is_empty() {
+        target.push('\n');
+    }
+    target.push_str(text);
+}
+
+fn append_text_content(target: &mut String, content: &[Content]) {
+    for item in content {
+        if let Content::Text(TextContent { text }) = item {
+            append_separated(target, text);
+        }
+    }
+}
+
+fn append_message_by_channel(reasoning_text: &mut String, normal_text: &mut String, msg: &Message) {
+    match msg.channel.as_deref() {
+        Some("analysis") => append_text_content(reasoning_text, &msg.content),
+        Some("final") | Some("commentary") => append_text_content(normal_text, &msg.content),
+        _ => {}
+    }
+}
+
+fn append_current_by_channel(
+    reasoning_text: &mut String,
+    normal_text: &mut String,
+    channel: Option<String>,
+    current: String,
+) {
+    match channel.as_deref() {
+        Some("analysis") => append_separated(reasoning_text, &current),
+        Some("final") | Some("commentary") => append_separated(normal_text, &current),
+        _ => {}
+    }
+}
+
 impl ReasoningParser for GptOssReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
+        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            let encoded_tokens = match encode_text_to_tokens(text) {
+            encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            &encoded_tokens.to_vec()
+            encoded_tokens.as_slice()
         } else {
             token_ids
         };
@@ -160,70 +229,29 @@ impl ReasoningParser for GptOssReasoningParser {
         let output_msgs = parser.messages();
         tracing::debug!("Parser has {} output messages", output_msgs.len());
 
-        match output_msgs.len() {
-            0 => {
-                tracing::debug!("No output messages, using current content");
-                let current = parser.current_content().unwrap_or_default();
-                tracing::debug!("Current content length: {}", current.len());
-                ParserResult {
-                    normal_text: String::new(),
-                    reasoning_text: current,
-                }
-            }
-            1 => {
-                tracing::debug!("Single output message detected");
-                let mut reasoning_text = String::new();
-                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                    output_msgs[0].content.first()
-                {
-                    reasoning_text.push_str(text);
-                    tracing::debug!("Extracted reasoning text length: {}", reasoning_text.len());
-                }
-                let current = parser.current_content().unwrap_or_default();
-                tracing::debug!("Current content length: {}", current.len());
-                ParserResult {
-                    normal_text: current,
-                    reasoning_text,
-                }
-            }
-            _ => {
-                tracing::debug!("Multiple output messages detected: {}", output_msgs.len());
-                let mut reasoning_text = String::new();
-                let mut normal_text = String::new();
+        let mut reasoning_text = String::new();
+        let mut normal_text = String::new();
+        for msg in output_msgs {
+            append_message_by_channel(&mut reasoning_text, &mut normal_text, msg);
+        }
 
-                // Loop until second last message
-                for (i, parse_msg) in output_msgs.iter().take(output_msgs.len() - 1).enumerate() {
-                    tracing::debug!("Processing reasoning message {}", i + 1);
-                    if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                        parse_msg.content.first()
-                    {
-                        reasoning_text.push_str(text);
-                        tracing::debug!("Added {} chars to reasoning text", text.len());
-                    }
-                }
+        let current = parser.current_content().unwrap_or_default();
+        append_current_by_channel(
+            &mut reasoning_text,
+            &mut normal_text,
+            parser.current_channel(),
+            current,
+        );
 
-                let last_msg = &output_msgs[output_msgs.len() - 1];
-                tracing::debug!("Processing final message");
+        tracing::debug!(
+            "Final result - normal_text: {} chars, reasoning_text: {} chars",
+            normal_text.len(),
+            reasoning_text.len()
+        );
 
-                // Handle the last message
-                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                    last_msg.content.first()
-                {
-                    normal_text.push_str(text);
-                    tracing::debug!("Added {} chars to normal text", text.len());
-                }
-
-                tracing::debug!(
-                    "Final result - normal_text: {} chars, reasoning_text: {} chars",
-                    normal_text.len(),
-                    reasoning_text.len()
-                );
-
-                ParserResult {
-                    normal_text,
-                    reasoning_text,
-                }
-            }
+        ParserResult {
+            normal_text,
+            reasoning_text,
         }
     }
 
@@ -233,16 +261,33 @@ impl ReasoningParser for GptOssReasoningParser {
         token_ids: &[u32],
     ) -> ParserResult {
         let caller_supplied_token_ids = !token_ids.is_empty();
+        let text_to_process;
+        let text = if caller_supplied_token_ids {
+            text
+        } else {
+            self.pending_text.push_str(text);
+            let combined = std::mem::take(&mut self.pending_text);
+            let (ready, pending) = split_incomplete_harmony_suffix(&combined);
+            self.pending_text.push_str(pending);
+            text_to_process = ready.to_string();
+            text_to_process.as_str()
+        };
+
+        if text.is_empty() && token_ids.is_empty() {
+            return ParserResult::default();
+        }
+
+        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            let encoded_tokens = match encode_text_to_tokens(text) {
+            encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            &encoded_tokens.to_vec()
+            encoded_tokens.as_slice()
         } else {
             token_ids
         };
@@ -258,21 +303,37 @@ impl ReasoningParser for GptOssReasoningParser {
                 token_ids.len(),
                 token_id
             );
+            let previous_channel = parser.current_channel();
             if let Err(e) = parser.process(*token_id) {
                 tracing::warn!("Harmony parse error for token_id {token_id}: {e}");
                 return ParserResult::default();
             }
+            let current_channel = parser.current_channel();
+
+            if previous_channel.as_deref() != Some("analysis")
+                && current_channel.as_deref() == Some("analysis")
+                && self.emitted_reasoning_text
+            {
+                self.insert_reasoning_separator = true;
+            }
 
             if let (Some(delta), Some(channel)) = (
                 parser.last_content_delta().unwrap_or_default(),
-                parser.current_channel(),
+                current_channel,
             ) {
                 // `last_content_delta` only exposes the newest token slice, so we forward
                 // `final`/`analysis` chunks immediately; commentary is reconstructed in the
                 // fallback path below because it needs the stripped metadata.
                 match channel.as_str() {
                     "final" => normal_delta.push_str(&delta),
-                    "analysis" => reasoning_delta.push_str(&delta),
+                    "analysis" => {
+                        if self.insert_reasoning_separator {
+                            reasoning_delta.push('\n');
+                            self.insert_reasoning_separator = false;
+                        }
+                        reasoning_delta.push_str(&delta);
+                        self.emitted_reasoning_text = true;
+                    }
                     "commentary" => {}
                     _ => {}
                 }
@@ -377,6 +438,23 @@ mod tests {
         );
     }
 
+    #[test] // REASONING.batch.4
+    fn test_gpt_oss_final_channel_without_analysis_is_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser.detect_and_parse_reasoning("<|channel|>final<|message|>answer", &[]);
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test] // REASONING.batch.6.a
+    fn test_gpt_oss_multiple_analysis_spans_join_before_final() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "first\nsecond");
+        assert_eq!(result.normal_text, "done");
+    }
+
     #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
@@ -399,6 +477,43 @@ mod tests {
             reasoning_text_incr
                 == "The user asks a simple factual question: capital of Brazil. The answer is Brasília. No additional explanation needed."
         );
+    }
+
+    #[test] // REASONING.stream.3.b
+    fn test_gpt_oss_reasoning_parser_streaming_split_end_marker() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis<|message|>thinking<|e",
+            "nd|><|start|>assistant<|channel|>final<|message|>answer",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "thinking");
+        assert_eq!(normal_text_incr, "answer");
+    }
+
+    #[test] // REASONING.stream.2.b
+    fn test_gpt_oss_reasoning_parser_streaming_multiple_analysis_spans() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis<|message|>first<|end|><|start|>assistant",
+            "<|channel|>analysis<|message|>second<|end|><|start|>assistant",
+            "<|channel|>final<|message|>done",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "first\nsecond");
+        assert_eq!(normal_text_incr, "done");
     }
 
     #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -404,6 +404,11 @@ impl ReasoningParser for GptOssReasoningParser {
         }
 
         if input_contains_call_marker(text, token_ids, caller_supplied_token_ids) {
+            // Streaming currently feeds the downstream Harmony tool parser through
+            // `normal_text`. This is an internal handoff, not visible-content
+            // semantics: directed commentary tool payloads must become tool calls,
+            // not assistant `content`. Batch parsing does not use this handoff and
+            // keeps directed commentary out of `normal_text`.
             let raw_input_text =
                 raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
             normal_delta.push_str(&raw_input_text);

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -195,6 +195,25 @@ fn append_current_by_channel(
 }
 
 impl ReasoningParser for GptOssReasoningParser {
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        let pending = std::mem::take(&mut self.pending_text);
+        if pending.is_empty() {
+            return ParserResult::default();
+        }
+
+        match self.parser.current_channel().as_deref() {
+            Some("analysis") => ParserResult {
+                normal_text: String::new(),
+                reasoning_text: pending,
+            },
+            Some("final") | Some("commentary") => ParserResult {
+                normal_text: pending,
+                reasoning_text: String::new(),
+            },
+            _ => ParserResult::default(),
+        }
+    }
+
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
         let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
@@ -495,6 +514,30 @@ mod tests {
         }
         assert_eq!(reasoning_text_incr, "thinking");
         assert_eq!(normal_text_incr, "answer");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_flushes_pending_suffix_on_finish() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser.parse_reasoning_streaming_incremental(
+            "<|channel|>analysis<|message|>thinking<|e",
+            &[],
+        );
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(result.reasoning_text, "thinking");
+        assert_eq!(finish.reasoning_text, "<|e");
+        assert_eq!(finish.normal_text, "");
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(finish.reasoning_text, "");
+        assert_eq!(finish.normal_text, "");
+
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser
+            .parse_reasoning_streaming_incremental("<|channel|>final<|message|>answer<|e", &[]);
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(result.normal_text, "answer");
+        assert_eq!(finish.normal_text, "<|e");
+        assert_eq!(finish.reasoning_text, "");
     }
 
     #[test] // REASONING.stream.2.b

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -46,6 +46,7 @@ fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
 pub struct GptOssReasoningParser {
     parser: StreamableParser,
     pending_text: String,
+    pending_tool_call_text: String,
     emitted_reasoning_text: bool,
     insert_reasoning_separator: bool,
     emitted_normal_text: bool,
@@ -81,6 +82,7 @@ impl GptOssReasoningParser {
         Ok(Self {
             parser,
             pending_text: String::new(),
+            pending_tool_call_text: String::new(),
             emitted_reasoning_text: false,
             insert_reasoning_separator: false,
             emitted_normal_text: false,
@@ -207,8 +209,13 @@ fn is_visible_normal_channel(channel: Option<&str>, recipient: Option<&str>) -> 
         || (matches!(channel, Some("commentary")) && recipient.is_none())
 }
 
+fn starts_directed_harmony_tool_call(text: &str) -> bool {
+    text.contains("<|channel|>commentary to=functions.")
+}
+
 impl ReasoningParser for GptOssReasoningParser {
     fn finish_reasoning_stream(&mut self) -> ParserResult {
+        self.pending_tool_call_text.clear();
         let pending = std::mem::take(&mut self.pending_text);
         if pending.is_empty() {
             return ParserResult::default();
@@ -403,15 +410,37 @@ impl ReasoningParser for GptOssReasoningParser {
             }
         }
 
-        if input_contains_call_marker(text, token_ids, caller_supplied_token_ids) {
+        let has_call_marker =
+            input_contains_call_marker(text, token_ids, caller_supplied_token_ids);
+        let raw_input_text = if has_call_marker
+            || !self.pending_tool_call_text.is_empty()
+            || starts_directed_harmony_tool_call(text)
+        {
+            Some(raw_input_text_for_tool_parser(
+                text,
+                token_ids,
+                caller_supplied_token_ids,
+            ))
+        } else {
+            None
+        };
+
+        if let Some(raw_input_text) = raw_input_text {
             // Streaming currently feeds the downstream Harmony tool parser through
             // `normal_text`. This is an internal handoff, not visible-content
             // semantics: directed commentary tool payloads must become tool calls,
             // not assistant `content`. Batch parsing does not use this handoff and
             // keeps directed commentary out of `normal_text`.
-            let raw_input_text =
-                raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
-            normal_delta.push_str(&raw_input_text);
+            if !self.pending_tool_call_text.is_empty() {
+                self.pending_tool_call_text.push_str(&raw_input_text);
+                if has_call_marker {
+                    normal_delta.push_str(&std::mem::take(&mut self.pending_tool_call_text));
+                }
+            } else if starts_directed_harmony_tool_call(&raw_input_text) && !has_call_marker {
+                self.pending_tool_call_text.push_str(&raw_input_text);
+            } else if has_call_marker {
+                normal_delta.push_str(&raw_input_text);
+            }
         }
 
         if !normal_delta.is_empty() || !reasoning_delta.is_empty() {
@@ -642,6 +671,27 @@ mod tests {
         }
         assert_eq!(reasoning_text_incr, "");
         assert_eq!(normal_text_incr, "I will check that.\nDone.");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_split_directed_commentary() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>commentary to=functions.get_",
+            "weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert_eq!(
+            normal_text_incr,
+            "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>"
+        );
     }
 
     #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -48,6 +48,8 @@ pub struct GptOssReasoningParser {
     pending_text: String,
     emitted_reasoning_text: bool,
     insert_reasoning_separator: bool,
+    emitted_normal_text: bool,
+    insert_normal_separator: bool,
 }
 
 /// Implement Debug for GptOssReasoningParser separately because StreamableParser does not implement Debug
@@ -81,6 +83,8 @@ impl GptOssReasoningParser {
             pending_text: String::new(),
             emitted_reasoning_text: false,
             insert_reasoning_separator: false,
+            emitted_normal_text: false,
+            insert_normal_separator: false,
         })
     }
 }
@@ -176,7 +180,10 @@ fn append_text_content(target: &mut String, content: &[Content]) {
 fn append_message_by_channel(reasoning_text: &mut String, normal_text: &mut String, msg: &Message) {
     match msg.channel.as_deref() {
         Some("analysis") => append_text_content(reasoning_text, &msg.content),
-        Some("final") | Some("commentary") => append_text_content(normal_text, &msg.content),
+        Some("final") => append_text_content(normal_text, &msg.content),
+        Some("commentary") if msg.recipient.is_none() => {
+            append_text_content(normal_text, &msg.content)
+        }
         _ => {}
     }
 }
@@ -189,9 +196,15 @@ fn append_current_by_channel(
 ) {
     match channel.as_deref() {
         Some("analysis") => append_separated(reasoning_text, &current),
-        Some("final") | Some("commentary") => append_separated(normal_text, &current),
+        Some("final") => append_separated(normal_text, &current),
+        Some("commentary") => append_separated(normal_text, &current),
         _ => {}
     }
+}
+
+fn is_visible_normal_channel(channel: Option<&str>, recipient: Option<&str>) -> bool {
+    matches!(channel, Some("final"))
+        || (matches!(channel, Some("commentary")) && recipient.is_none())
 }
 
 impl ReasoningParser for GptOssReasoningParser {
@@ -255,12 +268,16 @@ impl ReasoningParser for GptOssReasoningParser {
         }
 
         let current = parser.current_content().unwrap_or_default();
-        append_current_by_channel(
-            &mut reasoning_text,
-            &mut normal_text,
-            parser.current_channel(),
-            current,
-        );
+        let current_channel = parser.current_channel();
+        if current_channel.as_deref() != Some("commentary") || parser.current_recipient().is_none()
+        {
+            append_current_by_channel(
+                &mut reasoning_text,
+                &mut normal_text,
+                current_channel,
+                current,
+            );
+        }
 
         tracing::debug!(
             "Final result - normal_text: {} chars, reasoning_text: {} chars",
@@ -323,11 +340,13 @@ impl ReasoningParser for GptOssReasoningParser {
                 token_id
             );
             let previous_channel = parser.current_channel();
+            let previous_recipient = parser.current_recipient();
             if let Err(e) = parser.process(*token_id) {
                 tracing::warn!("Harmony parse error for token_id {token_id}: {e}");
                 return ParserResult::default();
             }
             let current_channel = parser.current_channel();
+            let current_recipient = parser.current_recipient();
 
             if previous_channel.as_deref() != Some("analysis")
                 && current_channel.as_deref() == Some("analysis")
@@ -336,15 +355,31 @@ impl ReasoningParser for GptOssReasoningParser {
                 self.insert_reasoning_separator = true;
             }
 
+            if is_visible_normal_channel(current_channel.as_deref(), current_recipient.as_deref())
+                && !is_visible_normal_channel(
+                    previous_channel.as_deref(),
+                    previous_recipient.as_deref(),
+                )
+                && self.emitted_normal_text
+            {
+                self.insert_normal_separator = true;
+            }
+
             if let (Some(delta), Some(channel)) = (
                 parser.last_content_delta().unwrap_or_default(),
                 current_channel,
             ) {
-                // `last_content_delta` only exposes the newest token slice, so we forward
-                // `final`/`analysis` chunks immediately; commentary is reconstructed in the
-                // fallback path below because it needs the stripped metadata.
+                // `last_content_delta` only exposes the newest token slice, so directed
+                // commentary still falls through to the raw handoff path for tool parsing.
                 match channel.as_str() {
-                    "final" => normal_delta.push_str(&delta),
+                    "final" => {
+                        if self.insert_normal_separator {
+                            normal_delta.push('\n');
+                            self.insert_normal_separator = false;
+                        }
+                        normal_delta.push_str(&delta);
+                        self.emitted_normal_text = true;
+                    }
                     "analysis" => {
                         if self.insert_reasoning_separator {
                             reasoning_delta.push('\n');
@@ -353,7 +388,16 @@ impl ReasoningParser for GptOssReasoningParser {
                         reasoning_delta.push_str(&delta);
                         self.emitted_reasoning_text = true;
                     }
-                    "commentary" => {}
+                    "commentary" => {
+                        if current_recipient.is_none() {
+                            if self.insert_normal_separator {
+                                normal_delta.push('\n');
+                                self.insert_normal_separator = false;
+                            }
+                            normal_delta.push_str(&delta);
+                            self.emitted_normal_text = true;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -474,6 +518,24 @@ mod tests {
         assert_eq!(result.normal_text, "done");
     }
 
+    #[test]
+    fn test_gpt_oss_recipient_commentary_is_not_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "think");
+        assert_eq!(result.normal_text, "It is sunny.");
+    }
+
+    #[test]
+    fn test_gpt_oss_recipientless_commentary_is_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant<|channel|>final<|message|>Done.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "I will check that.\nDone.");
+    }
+
     #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
@@ -557,6 +619,24 @@ mod tests {
         }
         assert_eq!(reasoning_text_incr, "first\nsecond");
         assert_eq!(normal_text_incr, "done");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_recipientless_commentary() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant",
+            "<|channel|>final<|message|>Done.",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert_eq!(normal_text_incr, "I will check that.\nDone.");
     }
 
     #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -38,11 +38,54 @@ cases:
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
-        normal_text: '{"city":"SF"}'
-      vllm:
-        reasoning_text: choose tool
         normal_text: ''
-        reason: vLLM gpt-oss reasoning keeps recipient commentary tool-call payload out of normal_text for the tool parser path.
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is visible normal text
+    ref: *upstream_ref
+    model_text: <|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant<|channel|>final<|message|>Done.
+    expected:
+      dynamo: &d_10
+        reasoning_text: ''
+        normal_text: |-
+          I will check that.
+          Done.
+      vllm: *d_10
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool call is not visible normal text
+    ref: *upstream_ref
+    model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+    expected:
+      dynamo: &d_11
+        reasoning_text: ''
+        normal_text: ''
+      vllm: *d_11
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool call stays in reasoning text
+    ref: *upstream_ref
+    model_text: <|channel|>analysis to=functions.search <|constrain|>json<|message|>{"q":"x"}<|call|>
+    expected:
+      dynamo: &d_12
+        reasoning_text: '{"q":"x"}'
+        normal_text: ''
+      vllm: *d_12
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.batch.3.f:
+    description: Harmony analysis, directed commentary tool call, then final answer
+    ref: *upstream_ref
+    model_text: <|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.
+    expected:
+      dynamo: &d_13
+        reasoning_text: think
+        normal_text: It is sunny.
+      vllm: *d_13
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.c:

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -58,16 +58,13 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.4:
     description: Final channel without prior analysis channel
-    dynamo_leak: true
     ref: *upstream_ref
     model_text: <|channel|>final<|message|>answer
     expected:
       dynamo: &d_4
-        reasoning_text: answer
-        normal_text: ''
-      vllm:
         reasoning_text: ''
         normal_text: answer
+      vllm: *d_4
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.5:
@@ -122,18 +119,15 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.6.a:
     description: Multiple Harmony analysis spans
-    dynamo_leak: true
     ref: *upstream_ref
     model_text: <|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done
     expected:
       dynamo: &d_9
-        reasoning_text: first
-        normal_text: second
-      vllm:
         reasoning_text: |-
           first
           second
         normal_text: done
+      vllm: *d_9
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.batch.2.d:

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -92,6 +92,51 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.4.a:
+    description: Recipientless Harmony commentary is visible normal text across chunks
+    ref: *upstream_ref
+    chunks:
+    - <|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant
+    - <|channel|>final<|message|>Done.
+    expected:
+      dynamo: &d_s6
+        reasoning_text: ''
+        normal_text: |-
+          I will check that.
+          Done.
+      vllm: *d_s6
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.4.b:
+    description: Directed Harmony commentary tool recipient split across chunks
+    ref: *upstream_ref
+    chunks:
+    - <|channel|>commentary to=functions.get_
+    - weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
+  REASONING.stream.4.c:
+    description: Two directed Harmony commentary tool calls in one stream
+    ref: *upstream_ref
+    chunks:
+    - <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant
+    - <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.1.b:
     description: Plain text without Harmony channel markers
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -117,7 +117,8 @@ cases:
       dynamo:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
-        reason: Dynamo's streaming reasoning parser uses `normal_text` as the internal handoff to the downstream Harmony tool-call parser. The full directed commentary envelope remains parseable as a tool call, so this is a reasoning-layer divergence from vLLM rather than a final response leak.
+        reason: >-
+          This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. If the reasoning parser removed the directed commentary envelope here, the downstream Harmony tool-call parser would never see the call. Matching vLLM's reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.
       vllm:
         reasoning_text: ''
         normal_text: ''
@@ -133,7 +134,8 @@ cases:
       dynamo:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
-        reason: Dynamo's streaming reasoning parser uses `normal_text` as the internal handoff to the downstream Harmony tool-call parser. The full directed commentary envelopes remain parseable as tool calls, so this is a reasoning-layer divergence from vLLM rather than a final response leak.
+        reason: >-
+          This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. If the reasoning parser removed the directed commentary envelopes here, the downstream Harmony tool-call parser would never see the calls. Matching vLLM's reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.
       vllm:
         reasoning_text: ''
         normal_text: ''

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -116,7 +116,8 @@ cases:
     expected:
       dynamo:
         reasoning_text: ''
-        normal_text: weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+        reason: Dynamo's streaming reasoning parser uses `normal_text` as the internal handoff to the downstream Harmony tool-call parser. The full directed commentary envelope remains parseable as a tool call, so this is a reasoning-layer divergence from vLLM rather than a final response leak.
       vllm:
         reasoning_text: ''
         normal_text: ''
@@ -132,6 +133,7 @@ cases:
       dynamo:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
+        reason: Dynamo's streaming reasoning parser uses `normal_text` as the internal handoff to the downstream Harmony tool-call parser. The full directed commentary envelopes remain parseable as tool calls, so this is a reasoning-layer divergence from vLLM rather than a final response leak.
       vllm:
         reasoning_text: ''
         normal_text: ''

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -118,7 +118,7 @@ cases:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
         reason: >-
-          This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. If the reasoning parser removed the directed commentary envelope here, the downstream Harmony tool-call parser would never see the call. Matching vLLM's reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.
+          This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. Confirmed that the `normal_text` handoff to the tool-call parser is processed properly: the downstream Harmony parser emits the tool call and leaves no final `normal_text` leak. If the reasoning parser removed the directed commentary envelope here, the downstream Harmony tool-call parser would never see the call. Matching vLLM's reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.
       vllm:
         reasoning_text: ''
         normal_text: ''
@@ -135,7 +135,7 @@ cases:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
         reason: >-
-          This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. If the reasoning parser removed the directed commentary envelopes here, the downstream Harmony tool-call parser would never see the calls. Matching vLLM's reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.
+          This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. Confirmed that the `normal_text` handoff to the tool-call parser is processed properly: the downstream Harmony parser emits the tool calls and leaves no final `normal_text` leak. If the reasoning parser removed the directed commentary envelopes here, the downstream Harmony tool-call parser would never see the calls. Matching vLLM's reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.
       vllm:
         reasoning_text: ''
         normal_text: ''

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -36,18 +36,18 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.2.b:
     description: Multiple Harmony analysis spans across chunks
-    dynamo_leak: true
     ref: *upstream_ref
     chunks:
-    - <|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>final<|message|>one
-    - <|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>two
+    - <|channel|>analysis<|message|>first<|end|><|start|>assistant
+    - <|channel|>analysis<|message|>second<|end|><|start|>assistant
+    - <|channel|>final<|message|>done
     expected:
-      dynamo:
-        reasoning_text: first
-        normal_text: one<|channel|>analysis<|message|>secondtwo
-      vllm:
-        reasoning_text: first
-        normal_text: one<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>two
+      dynamo: &d_s5
+        reasoning_text: |-
+          first
+          second
+        normal_text: done
+      vllm: *d_s5
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.3.a:
@@ -65,15 +65,14 @@ cases:
         unavailable: SGLang expectation not captured for Dynamo parser family 'gpt_oss'
   REASONING.stream.3.b:
     description: Harmony end marker split across chunks
-    dynamo_leak: true
     ref: *upstream_ref
     chunks:
     - <|channel|>analysis<|message|>thinking<|e
     - nd|><|start|>assistant<|channel|>final<|message|>answer
     expected:
       dynamo: &d_s3
-        reasoning_text: thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
-        normal_text: ''
+        reasoning_text: thinking
+        normal_text: answer
       vllm:
         unavailable: vLLM gpt-oss streaming parity for a split Harmony end token needs explicit token_chunks; text-only chunks are not faithful.
       sglang:

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -627,6 +627,7 @@ def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, 
     expected = case["expected"]
     dynamo = expected["dynamo"]
     dynamo_leak = _has_dynamo_leak(case, family)
+    dynamo_leak_reason = _dynamo_leak_reason(expected, family) if dynamo_leak else None
     markers = []
     unavailable = 0
     tooltip_parts = [case.get("description", "")]
@@ -644,10 +645,15 @@ def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, 
         if _canonical(spec) == _canonical(dynamo):
             tooltip_parts.append(f"{impl}: matches Dynamo")
             continue
-        suffix = "?" if dynamo_leak or not spec.get("reason") else ""
+        suffix = (
+            "?"
+            if (dynamo_leak and not dynamo_leak_reason)
+            or (not dynamo_leak and not spec.get("reason"))
+            else ""
+        )
         markers.append(f"{letter}{suffix}")
         reason = (
-            "research-needed" if dynamo_leak else spec.get("reason", "research-needed")
+            dynamo_leak_reason if dynamo_leak else spec.get("reason", "research-needed")
         )
         tooltip_parts.append(f"{impl}: diverges — {reason}")
 
@@ -1371,7 +1377,12 @@ def _tooltip_for(
             continue
         if _canonical(block) == _canonical(dyn):
             continue
-        if "reason" in block and not dynamo_leak:
+        dynamo_leak_reason = (
+            _dynamo_leak_reason(expected, family) if dynamo_leak else None
+        )
+        if dynamo_leak and dynamo_leak_reason:
+            parts.append(f"{name}: {dynamo_leak_reason}")
+        elif "reason" in block and not dynamo_leak:
             parts.append(f"{name}: {block['reason']}")
         elif "reasoning_text" in block or "normal_text" in block:
             parts.append(f"{name}: (research-needed — no `reason:` field yet)")

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -1365,6 +1365,7 @@ def _tooltip_for(
     parts: list[str] = []
     dynamo_leak = _has_dynamo_leak(case, family)
     expected = case.get("expected", {})
+    dynamo_leak_reason = _dynamo_leak_reason(expected, family) if dynamo_leak else None
     for impl in ("vllm", "sglang"):
         block = expected.get(impl)
         if not isinstance(block, dict) or block is dyn:
@@ -1377,11 +1378,10 @@ def _tooltip_for(
             continue
         if _canonical(block) == _canonical(dyn):
             continue
-        dynamo_leak_reason = (
-            _dynamo_leak_reason(expected, family) if dynamo_leak else None
-        )
-        if dynamo_leak and dynamo_leak_reason:
-            parts.append(f"{name}: {dynamo_leak_reason}")
+        if dynamo_leak_reason:
+            continue
+        if dynamo_leak:
+            parts.append(f"{name}: (research-needed — no `reason:` field yet)")
         elif "reason" in block and not dynamo_leak:
             parts.append(f"{name}: {block['reason']}")
         elif "reasoning_text" in block or "normal_text" in block:

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -93,11 +93,18 @@ def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> N
         r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.b — qwen3',
         html,
     )
+    split_end_cell = _cell_for(html, "REASONING.stream.3.b — gpt_oss")
     assert re.search(
-        r'<td class="cell leak[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">↯D</a>'
-        r'<div class="ttip"><div class="ttip-head">REASONING\.stream\.3\.b — gpt_oss',
-        html,
+        r'<td class="cell donly[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">D</a>',
+        split_end_cell,
     )
+    handoff_cell = _cell_for(html, "REASONING.stream.4.b — gpt_oss")
+    assert re.search(
+        r'<td class="cell leak[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">↯V</a>',
+        handoff_cell,
+    )
+    assert "↯ Dynamo reasoning leaks" in handoff_cell
+    assert "Divergent reasons" not in handoff_cell
     assert re.search(
         r'<td class="cell research[^"]*"[^>]*><a href="fixtures/kimi_k25/REASONING\.batch\.yaml">V\?</a>'
         r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.b — kimi_k25',
@@ -134,3 +141,12 @@ def _render_html_for(table: str, *extra_args: str) -> str:
         text=True,
     )
     return result.stdout
+
+
+def _cell_for(html: str, heading: str) -> str:
+    idx = html.find(heading)
+    assert idx != -1
+    start = html.rfind("<td", 0, idx)
+    end = html.find("</td>", idx)
+    assert start != -1 and end != -1
+    return html[start:end]


### PR DESCRIPTION
#### Overview:

This PR routes GPT-OSS Harmony reasoning, visible text, and tool-call handoff into the right Dynamo fields.

#### HTML diff:

```text
before 4e5148f0f7
  REASONING.stream.3.b: D
  REASONING.stream.4.b: ↯V?  divergent=True   leak=True   research-needed=True
  REASONING.stream.4.c: ↯V?  divergent=True   leak=True   research-needed=True

after ace4f8061a
  REASONING.stream.3.b: D
  REASONING.stream.4.b: ↯V   divergent=False  leak=True   research-needed=False
  REASONING.stream.4.c: ↯V   divergent=False  leak=True   research-needed=False
```

#### Details:

- **How is this fixed?** `GptOssReasoningParser` routes Harmony messages by channel/recipient and buffers split Harmony marker suffixes across streaming chunks.
- Directed streamed commentary remains Dynamo's internal `normal_text` handoff; confirmed the Harmony tool parser emits tool calls and leaves no final content leak.
- Table output now marks explained Dynamo handoff divergences as `↯V` without `?` and shows the reason once.

#### Verification:

`cargo test -p dynamo-parsers reasoning -- --nocapture`; `cargo test -p dynamo-llm test_gpt_oss_e2e_with_tool_calls_vllm -- --nocapture`; `python3 -m pytest -o filterwarnings= tests/parity/reasoning/test_parity_reasoning.py -q -k gpt_oss`; `python3 -m pytest -o filterwarnings= tests/parity/reasoning/test_reasoning_fixture_schema.py -q`; reasoning parity HTML regenerated.

#### Where should the reviewer start?

`lib/parsers/src/reasoning/gpt_oss_parser.rs`, then `tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml`

#### Related Issues:

Relates to DIS-2135

/coderabbit profile chill
