### PR TITLE
feat(mocker): add native Prometheus metrics

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -6,9 +6,11 @@
 //! The core mocker logic lives in the `dynamo-mocker` crate.
 //! This module provides the runtime-dependent engine wrapper.
 
+mod metrics;
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::backend::ExecutionContext;
 use crate::kv_router::publisher::{KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher};
@@ -27,6 +29,7 @@ use dynamo_mocker::scheduler::SchedulerHandle;
 use dynamo_mocker::services::bootstrap::{BootstrapServer, connect_to_prefill};
 use dynamo_mocker::services::zmq_events::ZmqKvEventSink;
 use dynamo_runtime::DistributedRuntime;
+use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::{
     component::Component,
@@ -42,6 +45,8 @@ use tokio::sync::{Notify, OnceCell, mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
+
+use self::metrics::NativeMockerMetrics;
 
 pub const MOCKER_COMPONENT: &str = "mocker";
 
@@ -80,6 +85,7 @@ pub struct MockEngine {
     unset_dp_rank_counter: AtomicU32,
     /// Bootstrap server for prefill workers in disaggregated mode
     bootstrap_server: Arc<OnceCell<Arc<BootstrapServer>>>,
+    native_metrics: Arc<NativeMockerMetrics>,
     /// Keep schedulers alive so their CancelGuards don't fire prematurely.
     _schedulers: OnceCell<Vec<Box<dyn SchedulerHandle>>>,
     /// Forward pass metrics publisher (kept alive for the engine lifetime).
@@ -130,6 +136,8 @@ impl AsyncEngine<SingleIn<serde_json::Value>, ManyOut<Annotated<serde_json::Valu
 impl MockEngine {
     /// Create a new MockEngine with the given parameters
     pub fn new(engine_args: MockEngineArgs) -> Self {
+        let native_metrics = NativeMockerMetrics::new(engine_args.engine_type, engine_args.dp_size)
+            .expect("mocker native metrics collectors should be valid");
         Self {
             active_requests: Arc::new(DashMap::new()),
             request_senders: OnceCell::new(),
@@ -137,6 +145,7 @@ impl MockEngine {
             engine_args,
             unset_dp_rank_counter: AtomicU32::new(0),
             bootstrap_server: Arc::new(OnceCell::new()),
+            native_metrics,
             _schedulers: OnceCell::new(),
             _fpm_publisher: OnceCell::new(),
         }
@@ -156,6 +165,8 @@ impl MockEngine {
         // child_token() is a child of endpoint_shutdown_token which is cancelled in Phase 1.
         // primary_token() is only cancelled in Phase 3, after waiting for inflight requests.
         let cancel_token = component.drt().primary_token();
+        self.native_metrics
+            .register(component.get_metrics_registry())?;
 
         // Simulate engine startup time if configured
         if let Some(startup_time_secs) = self.engine_args.startup_time {
@@ -211,8 +222,13 @@ impl MockEngine {
             .start_schedulers(kv_component, cancel_token.clone(), fpm_sinks)
             .await;
 
-        Self::start_metrics_publishing(&schedulers, component.clone(), cancel_token.clone())
-            .await?;
+        Self::start_metrics_publishing(
+            &schedulers,
+            component.clone(),
+            self.native_metrics.clone(),
+            cancel_token.clone(),
+        )
+        .await?;
 
         let _ = self._schedulers.set(schedulers);
 
@@ -417,6 +433,7 @@ impl MockEngine {
     async fn start_metrics_publishing(
         schedulers: &[Box<dyn SchedulerHandle>],
         component: Component,
+        native_metrics: Arc<NativeMockerMetrics>,
         cancel_token: CancellationToken,
     ) -> Result<()> {
         let metrics_publisher = Arc::new(WorkerMetricsPublisher::new()?);
@@ -427,6 +444,7 @@ impl MockEngine {
         for scheduler in schedulers.iter() {
             let mut metrics_rx = scheduler.metrics_receiver();
             let publisher = metrics_publisher.clone();
+            let native_metrics = native_metrics.clone();
             let cancel_token = cancel_token.clone();
 
             tokio::spawn(async move {
@@ -436,6 +454,7 @@ impl MockEngine {
                         Ok(_) = metrics_rx.changed() => {
                             // Get the latest metrics
                             let metrics = metrics_rx.borrow().clone();
+                            native_metrics.update_scheduler_snapshot(&metrics);
 
                             // Publish metrics using flat API
                             if let Err(e) = publisher.publish(
@@ -474,6 +493,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
         input: SingleIn<PreprocessedRequest>,
     ) -> Result<ManyOut<LLMEngineOutput>, Error> {
         let (request, ctx) = input.into_parts();
+        let request_start = Instant::now();
 
         let dp_rank = self.resolve_dp_rank(&request);
 
@@ -484,6 +504,22 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                 dp_rank, self.engine_args.dp_size
             )));
         }
+
+        let request_uuid = ctx.id().parse().unwrap_or(Uuid::new_v4());
+        let is_prefill = self.engine_args.is_prefill();
+        let max_output_tokens = if is_prefill {
+            1
+        } else {
+            request
+                .stop_conditions
+                .max_tokens
+                .ok_or_else(|| Error::msg("max_output_tokens must be specified for mocker"))?
+                as usize
+        };
+        let native_timing = self
+            .native_metrics
+            .request_timing(&request.model, dp_rank, is_prefill, request_start)
+            .await;
 
         // Bootstrap rendezvous for disaggregated serving
         // - Decode: send receiver metadata to prefill, then wait for prefill completion
@@ -500,19 +536,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
             .await
             .map_err(|e| Error::msg(format!("Bootstrap connection failed: {e}")))?;
         }
-
-        let request_uuid = ctx.id().parse().unwrap_or(Uuid::new_v4());
-
-        let is_prefill = self.engine_args.is_prefill();
-        let max_output_tokens = if is_prefill {
-            1
-        } else {
-            request
-                .stop_conditions
-                .max_tokens
-                .ok_or_else(|| Error::msg("max_output_tokens must be specified for mocker"))?
-                as usize
-        };
 
         // Convert PreprocessedRequest to DirectRequest for scheduler
         let direct_request = DirectRequest {
@@ -549,16 +572,26 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
         let active_requests = self.active_requests.clone();
         let async_context = ctx.context();
         let reasoning = self.engine_args.reasoning.clone();
+        let mut native_timing = native_timing;
 
         // Spawn a task to handle the complex async logic
         tokio::spawn(async move {
             if let Some((server, room_id, sender, direct_request)) = delayed_prefill_submission {
-                if let Err(e) = server.wait_for_decode_ready(room_id).await {
-                    let _ = stream_tx.send(LLMEngineOutput::error(format!(
-                        "Bootstrap wait for decode metadata failed: {e}"
-                    )));
-                    active_requests.remove(&request_uuid);
-                    return;
+                tokio::select! {
+                    result = server.wait_for_decode_ready(room_id) => {
+                        if let Err(e) = result {
+                            let _ = stream_tx.send(LLMEngineOutput::error(format!(
+                                "Bootstrap wait for decode metadata failed: {e}"
+                            )));
+                            active_requests.remove(&request_uuid);
+                            return;
+                        }
+                    }
+                    _ = async_context.stopped() => {
+                        let _ = stream_tx.send(LLMEngineOutput::cancelled());
+                        active_requests.remove(&request_uuid);
+                        return;
+                    }
                 }
 
                 if sender.send(direct_request).is_err() {
@@ -607,7 +640,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                         }
 
                         if signal.completed {
-                            let _ = stream_tx.send(output);
+                            if stream_tx.send(output).is_err() {
+                                tracing::error!("Output stream receiver closed.");
+                                break;
+                            }
+                            native_timing.record_tokens(1);
 
                             // Prefill-to-decode handoff delay is emitted by the shared mocker core.
                             if is_prefill
@@ -623,7 +660,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                                 server.complete_room(room_id);
                             }
 
-                            let _ = stream_tx.send(LLMEngineOutput::length());
+                            if stream_tx.send(LLMEngineOutput::length()).is_err() {
+                                tracing::error!("Output stream receiver closed.");
+                                break;
+                            }
+                            native_timing.record_normal_completion();
                             break;
                         }
 
@@ -631,6 +672,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             tracing::error!("Output stream receiver closed.");
                             break;
                         }
+                        native_timing.record_tokens(1);
                     }
 
                     _ = async_context.stopped() => {

--- a/lib/llm/src/mocker/metrics.rs
+++ b/lib/llm/src/mocker/metrics.rs
@@ -1,0 +1,900 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use anyhow::Result;
+use dynamo_mocker::common::protocols::EngineType;
+use dynamo_mocker::scheduler::MockerMetrics;
+use dynamo_runtime::MetricsRegistry;
+use prometheus::{
+    Gauge, GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts,
+};
+use tokio::sync::OnceCell;
+
+const VLLM_LABELS: &[&str] = &["model_name", "engine"];
+const SGLANG_SCHEDULER_LABELS: &[&str] = &[
+    "model_name",
+    "engine_type",
+    "tp_rank",
+    "pp_rank",
+    "moe_ep_rank",
+];
+const SGLANG_REQUEST_LABELS: &[&str] = &["model_name", "engine_type"];
+
+pub(crate) struct NativeMockerMetrics {
+    dp_size: u32,
+    collectors: NativeCollectors,
+    model_name: OnceCell<String>,
+    state: Mutex<NativeMockerMetricsState>,
+}
+
+#[derive(Default)]
+struct NativeMockerMetricsState {
+    registered: bool,
+    warned_model_mismatch: bool,
+    latest_snapshots: HashMap<u32, MockerMetrics>,
+    vllm_preemptions_seen: HashMap<u32, u64>,
+    handles: Option<NativeMetricHandles>,
+}
+
+enum NativeCollectors {
+    Vllm(VllmCollectors),
+    Sglang(SglangCollectors),
+}
+
+struct VllmCollectors {
+    num_requests_running: IntGaugeVec,
+    num_requests_waiting: IntGaugeVec,
+    kv_cache_usage_perc: GaugeVec,
+    gpu_cache_usage_perc: GaugeVec,
+    num_preemptions_total: IntCounterVec,
+    time_to_first_token_seconds: HistogramVec,
+    inter_token_latency_seconds: HistogramVec,
+    e2e_request_latency_seconds: HistogramVec,
+}
+
+struct SglangCollectors {
+    num_running_reqs: IntGaugeVec,
+    num_queue_reqs: IntGaugeVec,
+    cache_hit_rate: GaugeVec,
+    num_requests_total: IntCounterVec,
+    time_to_first_token_seconds: HistogramVec,
+    inter_token_latency_seconds: HistogramVec,
+    e2e_request_latency_seconds: HistogramVec,
+}
+
+enum NativeMetricHandles {
+    Vllm(HashMap<u32, VllmDpHandles>),
+    Sglang(SglangHandles),
+}
+
+struct VllmDpHandles {
+    num_requests_running: IntGauge,
+    num_requests_waiting: IntGauge,
+    kv_cache_usage_perc: Gauge,
+    gpu_cache_usage_perc: Gauge,
+    num_preemptions_total: IntCounter,
+    request_metrics: NativeRequestMetricHandles,
+}
+
+struct SglangHandles {
+    num_running_reqs: IntGauge,
+    num_queue_reqs: IntGauge,
+    cache_hit_rate: Gauge,
+    request_metrics: NativeRequestMetricHandles,
+}
+
+#[derive(Clone)]
+enum NativeRequestMetricHandles {
+    Vllm {
+        time_to_first_token_seconds: Histogram,
+        inter_token_latency_seconds: Histogram,
+        e2e_request_latency_seconds: Histogram,
+    },
+    Sglang {
+        num_requests_total: IntCounter,
+        time_to_first_token_seconds: Histogram,
+        inter_token_latency_seconds: Histogram,
+        e2e_request_latency_seconds: Histogram,
+    },
+}
+
+pub(crate) struct NativeRequestTiming {
+    handles: Option<NativeRequestMetricHandles>,
+    start: Instant,
+    last_token_at: Option<Instant>,
+}
+
+impl NativeMockerMetrics {
+    pub(crate) fn new(engine_type: EngineType, dp_size: u32) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            dp_size,
+            collectors: NativeCollectors::new(engine_type)?,
+            model_name: OnceCell::new(),
+            state: Mutex::new(NativeMockerMetricsState::default()),
+        }))
+    }
+
+    pub(crate) fn register(&self, registry: &MetricsRegistry) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("native mocker metrics lock poisoned");
+        if state.registered {
+            return Ok(());
+        }
+
+        self.collectors.register(registry)?;
+        state.registered = true;
+        Ok(())
+    }
+
+    pub(crate) fn update_scheduler_snapshot(&self, metrics: &MockerMetrics) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("native mocker metrics lock poisoned");
+        state
+            .latest_snapshots
+            .insert(metrics.dp_rank, metrics.clone());
+
+        if let Some(model_name) = self.model_name.get() {
+            self.bind_handles_locked(&mut state, model_name);
+        }
+        self.apply_snapshot_locked(&mut state, metrics);
+    }
+
+    pub(crate) async fn request_timing(
+        &self,
+        model_name: &str,
+        dp_rank: u32,
+        is_prefill: bool,
+        start: Instant,
+    ) -> NativeRequestTiming {
+        if is_prefill {
+            return NativeRequestTiming::disabled(start);
+        }
+
+        let Some(model_name) = self.ensure_model_name(model_name).await else {
+            return NativeRequestTiming::disabled(start);
+        };
+
+        let handles = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("native mocker metrics lock poisoned");
+            self.bind_handles_locked(&mut state, &model_name);
+            match state.handles.as_ref() {
+                Some(NativeMetricHandles::Vllm(handles)) => handles
+                    .get(&dp_rank)
+                    .map(|handles| handles.request_metrics.clone()),
+                Some(NativeMetricHandles::Sglang(handles)) => Some(handles.request_metrics.clone()),
+                None => None,
+            }
+        };
+
+        NativeRequestTiming::new(start, handles)
+    }
+
+    async fn ensure_model_name(&self, request_model_name: &str) -> Option<String> {
+        let request_model_name = request_model_name.trim();
+        if request_model_name.is_empty() {
+            return None;
+        }
+
+        let requested = request_model_name.to_string();
+        let model_name = self
+            .model_name
+            .get_or_try_init(|| async { Ok::<_, anyhow::Error>(requested.clone()) })
+            .await
+            .ok()?;
+
+        if model_name != request_model_name {
+            let mut state = self
+                .state
+                .lock()
+                .expect("native mocker metrics lock poisoned");
+            if !state.warned_model_mismatch {
+                tracing::warn!(
+                    first_model_name = %model_name,
+                    request_model_name,
+                    "mocker native metrics keep the first model_name label for this process"
+                );
+                state.warned_model_mismatch = true;
+            }
+        }
+
+        Some(model_name.clone())
+    }
+
+    fn bind_handles_locked(&self, state: &mut NativeMockerMetricsState, model_name: &str) {
+        if state.handles.is_some() {
+            return;
+        }
+
+        state.handles = match &self.collectors {
+            NativeCollectors::Vllm(collectors) => {
+                let mut handles = HashMap::with_capacity(self.dp_size as usize);
+                for dp_rank in 0..self.dp_size {
+                    let engine = dp_rank.to_string();
+                    let label_values = [model_name, engine.as_str()];
+                    handles.insert(
+                        dp_rank,
+                        VllmDpHandles {
+                            num_requests_running: collectors
+                                .num_requests_running
+                                .with_label_values(&label_values),
+                            num_requests_waiting: collectors
+                                .num_requests_waiting
+                                .with_label_values(&label_values),
+                            kv_cache_usage_perc: collectors
+                                .kv_cache_usage_perc
+                                .with_label_values(&label_values),
+                            gpu_cache_usage_perc: collectors
+                                .gpu_cache_usage_perc
+                                .with_label_values(&label_values),
+                            num_preemptions_total: collectors
+                                .num_preemptions_total
+                                .with_label_values(&label_values),
+                            request_metrics: NativeRequestMetricHandles::Vllm {
+                                time_to_first_token_seconds: collectors
+                                    .time_to_first_token_seconds
+                                    .with_label_values(&label_values),
+                                inter_token_latency_seconds: collectors
+                                    .inter_token_latency_seconds
+                                    .with_label_values(&label_values),
+                                e2e_request_latency_seconds: collectors
+                                    .e2e_request_latency_seconds
+                                    .with_label_values(&label_values),
+                            },
+                        },
+                    );
+                }
+                Some(NativeMetricHandles::Vllm(handles))
+            }
+            NativeCollectors::Sglang(collectors) => {
+                let scheduler_label_values = [model_name, "sglang", "0", "0", "0"];
+                let request_label_values = [model_name, "sglang"];
+                Some(NativeMetricHandles::Sglang(SglangHandles {
+                    num_running_reqs: collectors
+                        .num_running_reqs
+                        .with_label_values(&scheduler_label_values),
+                    num_queue_reqs: collectors
+                        .num_queue_reqs
+                        .with_label_values(&scheduler_label_values),
+                    cache_hit_rate: collectors
+                        .cache_hit_rate
+                        .with_label_values(&scheduler_label_values),
+                    request_metrics: NativeRequestMetricHandles::Sglang {
+                        num_requests_total: collectors
+                            .num_requests_total
+                            .with_label_values(&request_label_values),
+                        time_to_first_token_seconds: collectors
+                            .time_to_first_token_seconds
+                            .with_label_values(&request_label_values),
+                        inter_token_latency_seconds: collectors
+                            .inter_token_latency_seconds
+                            .with_label_values(&request_label_values),
+                        e2e_request_latency_seconds: collectors
+                            .e2e_request_latency_seconds
+                            .with_label_values(&request_label_values),
+                    },
+                }))
+            }
+        };
+
+        let snapshots = state.latest_snapshots.values().cloned().collect::<Vec<_>>();
+        for snapshot in snapshots {
+            self.apply_snapshot_locked(state, &snapshot);
+        }
+    }
+
+    fn apply_snapshot_locked(&self, state: &mut NativeMockerMetricsState, metrics: &MockerMetrics) {
+        match state.handles.as_ref() {
+            Some(NativeMetricHandles::Vllm(handles)) => {
+                let Some(handles) = handles.get(&metrics.dp_rank) else {
+                    return;
+                };
+                handles
+                    .num_requests_running
+                    .set(clamp_u64_to_i64(metrics.running_requests));
+                handles
+                    .num_requests_waiting
+                    .set(clamp_u64_to_i64(metrics.waiting_requests));
+                handles
+                    .kv_cache_usage_perc
+                    .set(metrics.gpu_cache_usage_perc);
+                handles
+                    .gpu_cache_usage_perc
+                    .set(metrics.gpu_cache_usage_perc);
+
+                let last_seen = state
+                    .vllm_preemptions_seen
+                    .entry(metrics.dp_rank)
+                    .or_insert(0);
+                if metrics.vllm_preemptions_total > *last_seen {
+                    handles
+                        .num_preemptions_total
+                        .inc_by(metrics.vllm_preemptions_total - *last_seen);
+                    *last_seen = metrics.vllm_preemptions_total;
+                }
+            }
+            Some(NativeMetricHandles::Sglang(handles)) => {
+                let running = state
+                    .latest_snapshots
+                    .values()
+                    .map(|snapshot| snapshot.running_requests)
+                    .sum::<u64>();
+                let queued = state
+                    .latest_snapshots
+                    .values()
+                    .map(|snapshot| snapshot.waiting_requests)
+                    .sum::<u64>();
+                let cache_hits = state
+                    .latest_snapshots
+                    .values()
+                    .map(|snapshot| snapshot.sglang_cache_hit_tokens)
+                    .sum::<u64>();
+                let cache_total = state
+                    .latest_snapshots
+                    .values()
+                    .map(|snapshot| snapshot.sglang_cache_total_tokens)
+                    .sum::<u64>();
+
+                handles.num_running_reqs.set(clamp_u64_to_i64(running));
+                handles.num_queue_reqs.set(clamp_u64_to_i64(queued));
+                handles.cache_hit_rate.set(if cache_total == 0 {
+                    0.0
+                } else {
+                    cache_hits as f64 / cache_total as f64
+                });
+            }
+            None => {}
+        }
+    }
+}
+
+impl NativeCollectors {
+    fn new(engine_type: EngineType) -> Result<Self> {
+        match engine_type {
+            EngineType::Vllm => Ok(Self::Vllm(VllmCollectors::new()?)),
+            EngineType::Sglang => Ok(Self::Sglang(SglangCollectors::new()?)),
+        }
+    }
+
+    fn register(&self, registry: &MetricsRegistry) -> Result<()> {
+        match self {
+            Self::Vllm(collectors) => collectors.register(registry),
+            Self::Sglang(collectors) => collectors.register(registry),
+        }
+    }
+}
+
+impl VllmCollectors {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            num_requests_running: IntGaugeVec::new(
+                Opts::new(
+                    "vllm:num_requests_running",
+                    "Number of requests currently running on GPU.",
+                ),
+                VLLM_LABELS,
+            )?,
+            num_requests_waiting: IntGaugeVec::new(
+                Opts::new(
+                    "vllm:num_requests_waiting",
+                    "Number of requests waiting to be processed.",
+                ),
+                VLLM_LABELS,
+            )?,
+            kv_cache_usage_perc: GaugeVec::new(
+                Opts::new(
+                    "vllm:kv_cache_usage_perc",
+                    "KV-cache usage as a fraction of available cache blocks.",
+                ),
+                VLLM_LABELS,
+            )?,
+            gpu_cache_usage_perc: GaugeVec::new(
+                Opts::new(
+                    "vllm:gpu_cache_usage_perc",
+                    "Compatibility alias for KV-cache usage as a fraction of available cache blocks.",
+                ),
+                VLLM_LABELS,
+            )?,
+            num_preemptions_total: IntCounterVec::new(
+                Opts::new(
+                    "vllm:num_preemptions_total",
+                    "Cumulative number of request preemptions.",
+                ),
+                VLLM_LABELS,
+            )?,
+            time_to_first_token_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "vllm:time_to_first_token_seconds",
+                    "Histogram of time to first token in seconds.",
+                )
+                .buckets(vllm_ttft_buckets()),
+                VLLM_LABELS,
+            )?,
+            inter_token_latency_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "vllm:inter_token_latency_seconds",
+                    "Histogram of inter-token latency in seconds.",
+                )
+                .buckets(vllm_itl_buckets()),
+                VLLM_LABELS,
+            )?,
+            e2e_request_latency_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "vllm:e2e_request_latency_seconds",
+                    "Histogram of e2e request latency in seconds.",
+                )
+                .buckets(vllm_e2e_buckets()),
+                VLLM_LABELS,
+            )?,
+        })
+    }
+
+    fn register(&self, registry: &MetricsRegistry) -> Result<()> {
+        registry.add_metric(Box::new(self.num_requests_running.clone()))?;
+        registry.add_metric(Box::new(self.num_requests_waiting.clone()))?;
+        registry.add_metric(Box::new(self.kv_cache_usage_perc.clone()))?;
+        registry.add_metric(Box::new(self.gpu_cache_usage_perc.clone()))?;
+        registry.add_metric(Box::new(self.num_preemptions_total.clone()))?;
+        registry.add_metric(Box::new(self.time_to_first_token_seconds.clone()))?;
+        registry.add_metric(Box::new(self.inter_token_latency_seconds.clone()))?;
+        registry.add_metric(Box::new(self.e2e_request_latency_seconds.clone()))?;
+        Ok(())
+    }
+}
+
+impl SglangCollectors {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            num_running_reqs: IntGaugeVec::new(
+                Opts::new("sglang:num_running_reqs", "The number of running requests."),
+                SGLANG_SCHEDULER_LABELS,
+            )?,
+            num_queue_reqs: IntGaugeVec::new(
+                Opts::new("sglang:num_queue_reqs", "The number of queued requests."),
+                SGLANG_SCHEDULER_LABELS,
+            )?,
+            cache_hit_rate: GaugeVec::new(
+                Opts::new("sglang:cache_hit_rate", "Cache hit rate."),
+                SGLANG_SCHEDULER_LABELS,
+            )?,
+            num_requests_total: IntCounterVec::new(
+                Opts::new("sglang:num_requests_total", "Number of requests processed."),
+                SGLANG_REQUEST_LABELS,
+            )?,
+            time_to_first_token_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "sglang:time_to_first_token_seconds",
+                    "Histogram of time to first token in seconds.",
+                )
+                .buckets(sglang_ttft_buckets()),
+                SGLANG_REQUEST_LABELS,
+            )?,
+            inter_token_latency_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "sglang:inter_token_latency_seconds",
+                    "Histogram of inter-token latency in seconds.",
+                )
+                .buckets(sglang_itl_buckets()),
+                SGLANG_REQUEST_LABELS,
+            )?,
+            e2e_request_latency_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "sglang:e2e_request_latency_seconds",
+                    "Histogram of End-to-end request latency in seconds",
+                )
+                .buckets(sglang_e2e_buckets()),
+                SGLANG_REQUEST_LABELS,
+            )?,
+        })
+    }
+
+    fn register(&self, registry: &MetricsRegistry) -> Result<()> {
+        registry.add_metric(Box::new(self.num_running_reqs.clone()))?;
+        registry.add_metric(Box::new(self.num_queue_reqs.clone()))?;
+        registry.add_metric(Box::new(self.cache_hit_rate.clone()))?;
+        registry.add_metric(Box::new(self.num_requests_total.clone()))?;
+        registry.add_metric(Box::new(self.time_to_first_token_seconds.clone()))?;
+        registry.add_metric(Box::new(self.inter_token_latency_seconds.clone()))?;
+        registry.add_metric(Box::new(self.e2e_request_latency_seconds.clone()))?;
+        Ok(())
+    }
+}
+
+impl NativeRequestTiming {
+    fn new(start: Instant, handles: Option<NativeRequestMetricHandles>) -> Self {
+        Self {
+            handles,
+            start,
+            last_token_at: None,
+        }
+    }
+
+    fn disabled(start: Instant) -> Self {
+        Self::new(start, None)
+    }
+
+    pub(crate) fn record_tokens(&mut self, token_count: usize) {
+        if token_count == 0 {
+            return;
+        }
+        let Some(handles) = &self.handles else {
+            return;
+        };
+
+        let now = Instant::now();
+        let Some(last_token_at) = self.last_token_at.replace(now) else {
+            handles.observe_ttft(now.duration_since(self.start).as_secs_f64());
+            return;
+        };
+
+        let per_token_interval =
+            now.duration_since(last_token_at).as_secs_f64() / token_count as f64;
+        for _ in 0..token_count {
+            handles.observe_itl(per_token_interval);
+        }
+    }
+
+    pub(crate) fn record_normal_completion(&self) {
+        let Some(handles) = &self.handles else {
+            return;
+        };
+
+        handles.observe_e2e(self.start.elapsed().as_secs_f64());
+        handles.inc_completed_requests();
+    }
+}
+
+impl NativeRequestMetricHandles {
+    fn observe_ttft(&self, value: f64) {
+        match self {
+            Self::Vllm {
+                time_to_first_token_seconds,
+                ..
+            }
+            | Self::Sglang {
+                time_to_first_token_seconds,
+                ..
+            } => time_to_first_token_seconds.observe(value),
+        }
+    }
+
+    fn observe_itl(&self, value: f64) {
+        match self {
+            Self::Vllm {
+                inter_token_latency_seconds,
+                ..
+            }
+            | Self::Sglang {
+                inter_token_latency_seconds,
+                ..
+            } => inter_token_latency_seconds.observe(value),
+        }
+    }
+
+    fn observe_e2e(&self, value: f64) {
+        match self {
+            Self::Vllm {
+                e2e_request_latency_seconds,
+                ..
+            }
+            | Self::Sglang {
+                e2e_request_latency_seconds,
+                ..
+            } => e2e_request_latency_seconds.observe(value),
+        }
+    }
+
+    fn inc_completed_requests(&self) {
+        if let Self::Sglang {
+            num_requests_total, ..
+        } = self
+        {
+            num_requests_total.inc();
+        }
+    }
+}
+
+fn clamp_u64_to_i64(value: u64) -> i64 {
+    value.min(i64::MAX as u64) as i64
+}
+
+fn vllm_ttft_buckets() -> Vec<f64> {
+    vec![
+        0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+        20.0, 40.0, 80.0, 160.0, 640.0, 2560.0,
+    ]
+}
+
+fn vllm_itl_buckets() -> Vec<f64> {
+    vec![
+        0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+        20.0, 40.0, 80.0,
+    ]
+}
+
+fn vllm_e2e_buckets() -> Vec<f64> {
+    vec![
+        0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0, 120.0,
+        240.0, 480.0, 960.0, 1920.0, 7680.0,
+    ]
+}
+
+fn sglang_ttft_buckets() -> Vec<f64> {
+    vec![
+        0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 20.0, 40.0, 60.0, 80.0, 100.0,
+        200.0, 400.0,
+    ]
+}
+
+fn sglang_itl_buckets() -> Vec<f64> {
+    vec![
+        0.002, 0.004, 0.006, 0.008, 0.010, 0.015, 0.020, 0.025, 0.030, 0.035, 0.040, 0.060, 0.080,
+        0.100, 0.200, 0.400, 0.600, 0.800, 1.000, 2.000, 4.000, 6.000, 8.000,
+    ]
+}
+
+fn sglang_e2e_buckets() -> Vec<f64> {
+    vec![
+        0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 20.0, 40.0, 60.0, 80.0, 100.0,
+        200.0, 400.0, 600.0, 1200.0, 1800.0, 2400.0,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::time::{Duration, Instant};
+
+    use dynamo_mocker::common::protocols::EngineType;
+    use dynamo_mocker::scheduler::MockerMetrics;
+    use dynamo_runtime::MetricsRegistry;
+    use prometheus::proto::{Metric, MetricFamily, MetricType};
+
+    use super::NativeMockerMetrics;
+
+    fn gather_family(registry: &MetricsRegistry, name: &str) -> MetricFamily {
+        registry
+            .get_prometheus_registry()
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("missing metric family {name}"))
+    }
+
+    fn metric_labels(metric: &Metric) -> HashSet<String> {
+        metric
+            .get_label()
+            .iter()
+            .map(|label| label.name().to_string())
+            .collect()
+    }
+
+    fn metric_with_label<'a>(
+        family: &'a MetricFamily,
+        label_name: &str,
+        label_value: &str,
+    ) -> &'a Metric {
+        family
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == label_name && label.value() == label_value)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing metric in {} with {label_name}={label_value}",
+                    family.name()
+                )
+            })
+    }
+
+    fn histogram_count(registry: &MetricsRegistry, name: &str) -> u64 {
+        gather_family(registry, name)
+            .get_metric()
+            .iter()
+            .map(|metric| metric.histogram.as_ref().unwrap().sample_count())
+            .sum()
+    }
+
+    fn counter_value(registry: &MetricsRegistry, name: &str) -> f64 {
+        gather_family(registry, name)
+            .get_metric()
+            .iter()
+            .map(|metric| metric.counter.as_ref().unwrap().value())
+            .sum()
+    }
+
+    #[tokio::test]
+    async fn vllm_scrape_contract_uses_native_names_and_engine_labels() {
+        let registry = MetricsRegistry::new();
+        let metrics = NativeMockerMetrics::new(EngineType::Vllm, 2).unwrap();
+        metrics.register(&registry).unwrap();
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 3, 10, 2, 4, 5, 0, 0));
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(1, 4, 10, 7, 8, 1, 0, 0));
+
+        let mut timing = metrics
+            .request_timing("llama", 0, false, Instant::now())
+            .await;
+        timing.record_tokens(1);
+        timing.record_normal_completion();
+
+        let running = gather_family(&registry, "vllm:num_requests_running");
+        assert_eq!(running.get_field_type(), MetricType::GAUGE);
+        let engine0 = metric_with_label(&running, "engine", "0");
+        let engine1 = metric_with_label(&running, "engine", "1");
+        assert_eq!(
+            metric_labels(engine0),
+            HashSet::from(["model_name".to_string(), "engine".to_string()])
+        );
+        assert_eq!(engine0.gauge.as_ref().unwrap().value(), 2.0);
+        assert_eq!(engine1.gauge.as_ref().unwrap().value(), 7.0);
+
+        assert_eq!(
+            gather_family(&registry, "vllm:kv_cache_usage_perc").get_field_type(),
+            MetricType::GAUGE
+        );
+        assert_eq!(
+            gather_family(&registry, "vllm:gpu_cache_usage_perc").get_field_type(),
+            MetricType::GAUGE
+        );
+        assert_eq!(
+            gather_family(&registry, "vllm:num_preemptions_total").get_field_type(),
+            MetricType::COUNTER
+        );
+        assert_eq!(
+            gather_family(&registry, "vllm:time_to_first_token_seconds").get_field_type(),
+            MetricType::HISTOGRAM
+        );
+
+        let text = registry.prometheus_expfmt_combined().unwrap();
+        assert!(!text.contains("dynamo_component_vllm"));
+        assert!(!text.contains("vllm_kv_cache_usage_perc"));
+    }
+
+    #[tokio::test]
+    async fn vllm_preemption_counter_is_monotonic_across_snapshots() {
+        let registry = MetricsRegistry::new();
+        let metrics = NativeMockerMetrics::new(EngineType::Vllm, 1).unwrap();
+        metrics.register(&registry).unwrap();
+        let _ = metrics
+            .request_timing("llama", 0, false, Instant::now())
+            .await;
+
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 3, 0, 0));
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 3, 0, 0));
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 2, 0, 0));
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 5, 0, 0));
+
+        assert_eq!(counter_value(&registry, "vllm:num_preemptions_total"), 5.0);
+    }
+
+    #[tokio::test]
+    async fn sglang_scrape_contract_uses_scheduler_and_request_label_sets() {
+        let registry = MetricsRegistry::new();
+        let metrics = NativeMockerMetrics::new(EngineType::Sglang, 2).unwrap();
+        metrics.register(&registry).unwrap();
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 2, 10, 1, 3, 0, 2, 4));
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(1, 2, 10, 4, 5, 0, 1, 2));
+
+        let mut timing = metrics
+            .request_timing("llama", 0, false, Instant::now())
+            .await;
+        timing.record_tokens(1);
+        timing.record_normal_completion();
+
+        let running = gather_family(&registry, "sglang:num_running_reqs");
+        assert_eq!(running.get_field_type(), MetricType::GAUGE);
+        let running_metric = running.get_metric().first().unwrap();
+        assert_eq!(running_metric.gauge.as_ref().unwrap().value(), 5.0);
+        assert_eq!(
+            metric_labels(running_metric),
+            HashSet::from([
+                "model_name".to_string(),
+                "engine_type".to_string(),
+                "tp_rank".to_string(),
+                "pp_rank".to_string(),
+                "moe_ep_rank".to_string(),
+            ])
+        );
+
+        let queue = gather_family(&registry, "sglang:num_queue_reqs");
+        assert_eq!(
+            queue
+                .get_metric()
+                .first()
+                .unwrap()
+                .gauge
+                .as_ref()
+                .unwrap()
+                .value(),
+            8.0
+        );
+        let cache_hit_rate = gather_family(&registry, "sglang:cache_hit_rate");
+        assert_eq!(
+            cache_hit_rate
+                .get_metric()
+                .first()
+                .unwrap()
+                .gauge
+                .as_ref()
+                .unwrap()
+                .value(),
+            0.5
+        );
+
+        let requests = gather_family(&registry, "sglang:num_requests_total");
+        assert_eq!(requests.get_field_type(), MetricType::COUNTER);
+        let request_metric = requests.get_metric().first().unwrap();
+        assert_eq!(
+            metric_labels(request_metric),
+            HashSet::from(["model_name".to_string(), "engine_type".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn request_timing_records_successful_token_lifecycle_only() {
+        let registry = MetricsRegistry::new();
+        let metrics = NativeMockerMetrics::new(EngineType::Sglang, 1).unwrap();
+        metrics.register(&registry).unwrap();
+
+        let mut timing = metrics
+            .request_timing(
+                "llama",
+                0,
+                false,
+                Instant::now() - Duration::from_millis(10),
+            )
+            .await;
+        timing.record_tokens(1);
+        assert_eq!(
+            histogram_count(&registry, "sglang:time_to_first_token_seconds"),
+            1
+        );
+        assert_eq!(
+            histogram_count(&registry, "sglang:inter_token_latency_seconds"),
+            0
+        );
+        assert_eq!(
+            histogram_count(&registry, "sglang:e2e_request_latency_seconds"),
+            0
+        );
+        assert_eq!(counter_value(&registry, "sglang:num_requests_total"), 0.0);
+
+        timing.record_tokens(1);
+        timing.record_normal_completion();
+        assert_eq!(
+            histogram_count(&registry, "sglang:inter_token_latency_seconds"),
+            1
+        );
+        assert_eq!(
+            histogram_count(&registry, "sglang:e2e_request_latency_seconds"),
+            1
+        );
+        assert_eq!(counter_value(&registry, "sglang:num_requests_total"), 1.0);
+
+        let mut prefill_timing = metrics
+            .request_timing("llama", 0, true, Instant::now() - Duration::from_millis(10))
+            .await;
+        prefill_timing.record_tokens(1);
+        prefill_timing.record_normal_completion();
+        assert_eq!(
+            histogram_count(&registry, "sglang:e2e_request_latency_seconds"),
+            1
+        );
+        assert_eq!(counter_value(&registry, "sglang:num_requests_total"), 1.0);
+    }
+}

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -125,7 +125,7 @@ pub(crate) struct EnginePassResult {
     pub(crate) completed_requests: usize,
     pub(crate) output_signals: Vec<OutputSignal>,
     pub(crate) admissions: Vec<AdmissionEvent>,
-    pub(crate) active_decode_blocks: u64,
+    pub(crate) mocker_metrics: MockerMetrics,
     /// Controls when replay/live schedulers should expose this pass's buffered
     /// KV events to the real router or publisher sink.
     pub(crate) router_event_visibility: RouterEventVisibility,

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -17,12 +17,13 @@ use super::policy::apply_schedule_policy;
 use super::prefill::get_new_batch_prefill;
 use super::request::{SglangRequest, direct_to_sglang};
 use crate::scheduler::{
-    CapturedRouterEventBuffer, EnginePassResult, RouterEventVisibility, build_fpm_snapshot,
-    capture_router_event_sink,
+    CapturedRouterEventBuffer, EnginePassResult, MockerMetrics, RouterEventVisibility,
+    build_fpm_snapshot, capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
     pub(super) config: SglangConfig,
+    dp_rank: u32,
     pub(super) waiting: VecDeque<SglangRequest>,
     pub(super) running: Vec<SglangRequest>,
     pub(super) new_token_ratio: f64,
@@ -65,6 +66,7 @@ impl SglangCore {
 
         Self {
             config,
+            dp_rank,
             waiting: VecDeque::new(),
             running: Vec::new(),
             new_token_ratio: SglangConfig::from_args(&args).init_new_token_ratio,
@@ -190,6 +192,14 @@ impl SglangCore {
             .max(self.config.min_new_token_ratio);
 
         // Build FPM snapshot now that all state has settled.
+        let sglang_cache_hit_tokens = prefill_fpm
+            .iter()
+            .map(|item| item.prefix_tokens as u64)
+            .sum::<u64>();
+        let sglang_cache_total_tokens = prefill_fpm
+            .iter()
+            .map(|item| (item.prefix_tokens + item.tokens_computed) as u64)
+            .sum::<u64>();
         let fpm = build_fpm_snapshot(
             prefill_fpm.iter().map(|p| {
                 (
@@ -211,6 +221,7 @@ impl SglangCore {
         );
 
         debug_assert_sglang_scheduler_state(&self.waiting, &self.running, self.config.block_size);
+        let active_decode_blocks = self.active_kv_blocks();
         EnginePassResult {
             end_ms: decode.end_ms,
             completed_requests: decode
@@ -220,7 +231,16 @@ impl SglangCore {
                 .count(),
             output_signals: decode.output_signals,
             admissions: admit.admissions,
-            active_decode_blocks: self.active_kv_blocks(),
+            mocker_metrics: MockerMetrics::from_parts(
+                self.dp_rank,
+                active_decode_blocks,
+                self.config.total_kv_tokens.div_ceil(self.config.block_size) as u64,
+                self.running.len() as u64,
+                self.waiting.len() as u64,
+                0,
+                sglang_cache_hit_tokens,
+                sglang_cache_total_tokens,
+            ),
             router_event_visibility: RouterEventVisibility::PassEnd,
             kv_events: self
                 .kv_event_buffer

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -134,15 +134,11 @@ impl SglangScheduler {
                     publish_deferred_kv_events(&kv_event_publishers, deferred_kv_events.drain());
                     publish_deferred_fpm(&fpm_publisher, deferred_fpm.drain());
                 }
-                let active_decode_blocks = pass.active_decode_blocks;
+                let metrics = pass.mocker_metrics.clone();
                 flush_output_signals(&output_tx, pass.output_signals);
                 publish_deferred_kv_events(&kv_event_publishers, deferred_kv_events.drain());
                 publish_deferred_fpm(&fpm_publisher, deferred_fpm.drain());
-                let _ = metrics_tx.send(MockerMetrics::new(
-                    dp_rank,
-                    active_decode_blocks,
-                    total_blocks,
-                ));
+                let _ = metrics_tx.send(metrics);
             }
         });
 

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -526,7 +526,7 @@ mod core_behavior {
 
         let pass = core.execute_pass_internal(None, 0.0);
         assert_eq!(pass.completed_requests, 0);
-        assert_eq!(pass.active_decode_blocks, 2);
+        assert_eq!(pass.mocker_metrics.active_decode_blocks, 2);
     }
 
     #[test]
@@ -1013,6 +1013,39 @@ mod forward_pass_metrics {
         assert!(
             fpm2.sum_decode_kv_tokens > 0,
             "decode requests should have KV context"
+        );
+    }
+
+    #[test]
+    fn test_mocker_metrics_reports_prefix_cache_reuse() {
+        let mut core = SglangCore::new(fpm_args());
+
+        core.receive(DirectRequest {
+            tokens: (0..8).collect(),
+            max_output_tokens: 2,
+            uuid: Some(Uuid::from_u128(1)),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass1 = core.execute_pass(&mut collector, 0.0);
+        assert_eq!(pass1.mocker_metrics.sglang_cache_hit_tokens, 0);
+        assert_eq!(pass1.mocker_metrics.sglang_cache_total_tokens, 8);
+
+        core.receive(DirectRequest {
+            tokens: (0..8).collect(),
+            max_output_tokens: 1,
+            uuid: Some(Uuid::from_u128(2)),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+
+        let pass2 = core.execute_pass(&mut collector, pass1.end_ms);
+        assert!(pass2.mocker_metrics.sglang_cache_hit_tokens > 0);
+        assert!(
+            pass2.mocker_metrics.sglang_cache_hit_tokens
+                <= pass2.mocker_metrics.sglang_cache_total_tokens
         );
     }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -270,7 +270,7 @@ impl VllmCore {
         let (buffer, sink) = capture_router_event_sink(worker_id);
         Self::new_internal(
             args,
-            0,
+            worker_id as u32,
             Some(buffer),
             KvEventPublishers::new(Some(sink), None),
         )

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -28,7 +28,7 @@ use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
 use crate::replay::TraceCollector;
 use crate::scheduler::{
     AdmissionEvent, CapturedRouterEventBuffer, EnginePassResult, ForwardPassSnapshot,
-    RouterEventVisibility, build_fpm_snapshot, capture_router_event_sink,
+    MockerMetrics, RouterEventVisibility, build_fpm_snapshot, capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,6 +52,7 @@ pub(crate) struct SchedulerState {
     pub(crate) running: VecDeque<Uuid>,
     running_members: FxHashSet<Uuid>,
     pub(crate) requests: FxHashMap<Uuid, VllmRequestState>,
+    pub(crate) preemptions_total: u64,
 }
 
 struct PreemptedRequest {
@@ -192,6 +193,7 @@ impl SchedulerState {
         request.status = RequestStatus::Preempted;
         request.num_computed_tokens = 0;
         request.num_preemptions += 1;
+        self.preemptions_total += 1;
         let signals = request.sequence.reset_with_signal();
         debug_assert_vllm_request_invariants(uuid, request);
         #[cfg(debug_assertions)]
@@ -242,6 +244,7 @@ enum SwapInAdmissionAttempt {
 
 pub(crate) struct VllmCore {
     args: MockEngineArgs,
+    dp_rank: u32,
     pub(super) state: SchedulerState,
     pub(super) kv_manager: KvManager,
     kv_event_buffer: Option<CapturedRouterEventBuffer>,
@@ -296,6 +299,7 @@ impl VllmCore {
                 dp_rank,
             ),
             args,
+            dp_rank,
             state: SchedulerState::default(),
             kv_event_buffer,
             #[cfg(feature = "kvbm-offload")]
@@ -353,6 +357,19 @@ impl VllmCore {
 
     pub(crate) fn num_requests(&self) -> usize {
         self.state.requests.len()
+    }
+
+    pub(super) fn mocker_metrics(&self) -> MockerMetrics {
+        MockerMetrics::from_parts(
+            self.dp_rank,
+            self.kv_manager.num_active_blocks() as u64,
+            self.args.num_gpu_blocks as u64,
+            self.state.running_members.len() as u64,
+            self.state.waiting_members.len() as u64,
+            self.state.preemptions_total,
+            0,
+            0,
+        )
     }
 
     pub(crate) fn execute_pass(
@@ -712,14 +729,13 @@ impl VllmCore {
         }
 
         let fpm = self.compute_fpm(&scheduled, (end_ms - now_ms) / 1000.0);
-
         debug_assert_vllm_scheduler_state(&self.state);
         EnginePassResult {
             end_ms,
             completed_requests: requests_before.saturating_sub(self.state.requests.len()),
             output_signals,
             admissions,
-            active_decode_blocks: self.kv_manager.num_active_blocks() as u64,
+            mocker_metrics: self.mocker_metrics(),
             router_event_visibility: RouterEventVisibility::PassStart,
             kv_events: self
                 .kv_event_buffer

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -24,6 +24,11 @@ pub struct MockerMetrics {
     pub active_decode_blocks: u64,
     pub total_blocks: u64,
     pub gpu_cache_usage_perc: f64,
+    pub running_requests: u64,
+    pub waiting_requests: u64,
+    pub vllm_preemptions_total: u64,
+    pub sglang_cache_hit_tokens: u64,
+    pub sglang_cache_total_tokens: u64,
 }
 
 impl MockerMetrics {
@@ -31,6 +36,20 @@ impl MockerMetrics {
         dp_rank: dynamo_kv_router::protocols::DpRank,
         active_decode_blocks: u64,
         total_blocks: u64,
+    ) -> Self {
+        Self::from_parts(dp_rank, active_decode_blocks, total_blocks, 0, 0, 0, 0, 0)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        dp_rank: dynamo_kv_router::protocols::DpRank,
+        active_decode_blocks: u64,
+        total_blocks: u64,
+        running_requests: u64,
+        waiting_requests: u64,
+        vllm_preemptions_total: u64,
+        sglang_cache_hit_tokens: u64,
+        sglang_cache_total_tokens: u64,
     ) -> Self {
         let gpu_cache_usage_perc = if total_blocks == 0 {
             0.0
@@ -42,6 +61,11 @@ impl MockerMetrics {
             active_decode_blocks,
             total_blocks,
             gpu_cache_usage_perc,
+            running_requests,
+            waiting_requests,
+            vllm_preemptions_total,
+            sglang_cache_hit_tokens,
+            sglang_cache_total_tokens,
         }
     }
 }
@@ -163,11 +187,7 @@ impl Scheduler {
                 flush_output_signals(&mut core, &output_tx, pass.output_signals);
                 publish_deferred_kv_events(&kv_event_publishers, deferred_kv_events.drain());
                 publish_deferred_fpm(&fpm_publisher, deferred_fpm.drain());
-                let _ = metrics_tx.send(MockerMetrics::new(
-                    dp_rank,
-                    core.kv_manager.num_active_blocks() as u64,
-                    total_blocks,
-                ));
+                let _ = metrics_tx.send(core.mocker_metrics());
             }
         });
 

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -111,6 +111,8 @@ mod core_behavior {
             "first request should emit immediately"
         );
         assert_eq!(core.state.waiting.len(), 0);
+        assert_eq!(pass.mocker_metrics.running_requests, 2);
+        assert_eq!(pass.mocker_metrics.waiting_requests, 0);
         assert_eq!(
             core.state.running.iter().copied().collect::<Vec<_>>(),
             vec![r1, r2]
@@ -326,13 +328,16 @@ mod core_behavior {
         }
 
         let mut collector = crate::replay::TraceCollector::default();
-        core.execute_pass(&mut collector, 0.0);
-        core.execute_pass(&mut collector, 1.0);
+        let pass1 = core.execute_pass(&mut collector, 0.0);
+        let pass2 = core.execute_pass(&mut collector, 1.0);
         let request = core.state.requests.get(&r2).unwrap();
         assert_eq!(request.status, RequestStatus::Preempted);
         assert_eq!(request.num_computed_tokens, 0);
         assert_eq!(request.num_preemptions, 1);
         assert_eq!(core.state.waiting.front().copied(), Some(r2));
+        assert_eq!(pass1.mocker_metrics.vllm_preemptions_total, 0);
+        assert_eq!(pass2.mocker_metrics.vllm_preemptions_total, 1);
+        assert_eq!(pass2.mocker_metrics.waiting_requests, 1);
     }
 
     #[test]


### PR DESCRIPTION
Adds native vLLM/SGLang-style Prometheus metrics for live mocker while keeping FPM and replay paths unchanged.

Closes https://github.com/ai-dynamo/dynamo/issues/8752
Related: https://github.com/volcano-sh/kthena/issues/1129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Prometheus metrics for LLM inference with request timing (time-to-first-token, inter-token latency, end-to-end latency)
  * Added engine-level metrics: cache hit rates, request queue status, preemption counter tracking
  * Improved error handling and logging for output streaming operations

* **Tests**
  * Added comprehensive metrics validation tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->