### PR TITLE
fix(parser): document Nemotron Nano reasoning parity

### DIFF
--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -122,6 +122,7 @@ cases:
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:
@@ -130,5 +131,6 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -22,6 +22,7 @@ cases:
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thin
     - king</think>
@@ -33,11 +34,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo strips reasoning delimiters even when the block is streamed across chunks; vLLM leaks the start delimiter.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -49,11 +52,13 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span across chunks; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -64,11 +69,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo buffers a split start delimiter and strips it; vLLM leaks the reconstructed delimiter.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.3.b:
     description: End marker split across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -79,6 +86,7 @@ cases:
       vllm:
         reasoning_text: <think>thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_r1'
   REASONING.stream.3.c:

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -70,7 +70,7 @@ cases:
   REASONING.batch.2.d:
     description: Normal text around reasoning
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: before <think>thinking</think> after
     expected:
       dynamo:
@@ -147,7 +147,7 @@ cases:
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo: &d_9

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -22,7 +22,7 @@ cases:
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thin
     - king</think>answer
@@ -39,7 +39,7 @@ cases:
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -57,7 +57,7 @@ cases:
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -74,7 +74,7 @@ cases:
   REASONING.stream.3.b:
     description: End marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thinking</th
     - ink>answer

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -56,7 +56,7 @@ cases:
   REASONING.batch.2.d:
     description: Gemma normal text around reasoning
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: |-
       Hello. <|channel>thought
       rumination<channel|> Goodbye.
@@ -95,7 +95,7 @@ cases:
   REASONING.batch.5:
     description: Open thought channel without close treats suffix as reasoning
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: |-
       intro <|channel>thought
       partial
@@ -154,7 +154,7 @@ cases:
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: |-
       <|channel>thought
       first<channel|> middle <|channel>thought

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -22,7 +22,7 @@ cases:
   REASONING.stream.2.a:
     description: Gemma thought channel across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - |
       <|channel>thought
@@ -48,7 +48,7 @@ cases:
   REASONING.stream.2.b:
     description: Multiple Gemma thought channels across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - |-
       <|channel>thought
@@ -70,7 +70,7 @@ cases:
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <|chan
     - |-
@@ -91,7 +91,7 @@ cases:
   REASONING.stream.3.b:
     description: End marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.vllm.ai/en/v0.21.0/api/vllm/reasoning/gemma4_reasoning_parser/; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - |-
       <|channel>thought

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -10,7 +10,7 @@ cases:
   REASONING.batch.1.b:
     description: Plain text without reasoning markers
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -62,7 +62,7 @@ cases:
   REASONING.batch.2.d:
     description: Normal text around reasoning
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: before <think>thinking</think> after
     expected:
       dynamo:
@@ -139,7 +139,7 @@ cases:
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -22,7 +22,7 @@ cases:
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thin
     - king</think>
@@ -40,7 +40,7 @@ cases:
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -58,7 +58,7 @@ cases:
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -75,7 +75,7 @@ cases:
   REASONING.stream.3.b:
     description: End marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -92,7 +92,7 @@ cases:
   REASONING.stream.3.c:
     description: Partial start-marker prefix later becomes normal text
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - plain <th
     - esis answer
@@ -109,7 +109,7 @@ cases:
   REASONING.stream.1.b:
     description: Plain text without reasoning markers
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - plain
     - ' answer'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -10,7 +10,7 @@ cases:
   REASONING.batch.1.b:
     description: Plain text without reasoning markers
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -72,7 +72,7 @@ cases:
   REASONING.batch.2.d:
     description: Normal text around reasoning
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: before <think>thinking</think> after
     expected:
       dynamo: &d_11
@@ -149,7 +149,7 @@ cases:
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo: &d_9

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -34,7 +34,7 @@ cases:
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -54,7 +54,7 @@ cases:
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -70,7 +70,7 @@ cases:
   REASONING.stream.3.b:
     description: End marker split across chunks
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -89,7 +89,7 @@ cases:
   REASONING.stream.3.c:
     description: Partial start-marker prefix later becomes normal text
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - plain <th
     - esis answer
@@ -105,7 +105,7 @@ cases:
   REASONING.stream.1.b:
     description: Plain text never enters reasoning mode
     ref: *upstream_ref
-    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning'
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://qwen.readthedocs.io/en/stable/inference/transformers.html#parsing-thinking-content; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - plain
     - ' answer'


### PR DESCRIPTION
#### Overview:

This PR documents the remaining Nemotron Nano `REASONING.batch.*` and `REASONING.stream.*` parity divergences.

There is no Dynamo parser code change. Nemotron Nano uses the DeepSeek R1 force-reasoning parser path, and Dynamo is already following the no-leak / reasoning-split contract for these cases.

This PR also updates stale reasoning `spec_ref` URLs that still pointed at the old Agents docs route.

#### Details:

For Nemotron Nano, the remaining divergences are vLLM differences where Dynamo strips or buffers reasoning delimiters correctly, while vLLM leaves `<think>` / `</think>` markers in the wrong output field or leaves a later complete reasoning span in `normal_text`.

The documented cases are:

```text
REASONING.batch.6.a
REASONING.stream.2.a
REASONING.stream.2.b
REASONING.stream.3.a
REASONING.stream.3.b
```

Dynamo behavior remains unchanged. The fixtures now explain why Dynamo is the alignment target for these cells.


This PR Also replaced the stale docs URL:

```text
https://docs.nvidia.com/dynamo/dev/user-guides/agents/reasoning
```

with the current route:

```text
https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo
```

#### Where should the reviewer start?

- `tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml`
- `tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml`

The other fixture changes are URL-only `spec_ref` updates.

#### Related Issues:

- Relates to #9583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated documentation references in reasoning model test fixtures across multiple suites (DeepSeek R1/V4, Gemma4, Nemotron Deci, Qwen3).
  * Added test metadata and reasoning commentary for select reasoning parsing test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->