### PR TITLE
fix(parser): document DeepSeek V3 reasoning parity

### DIFF
--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -134,6 +134,7 @@ cases:
   REASONING.batch.6.a:
     description: Multiple reasoning spans are concatenated by Dynamo
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     model_text: <think>first</think> middle <think>second</think> done
     expected:
       dynamo:
@@ -142,5 +143,6 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -24,6 +24,7 @@ cases:
   REASONING.stream.2.a:
     description: Single reasoning block across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thin
     - king</think>
@@ -35,11 +36,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo strips reasoning delimiters even when the block is streamed across chunks; vLLM leaks the start delimiter.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.2.b:
     description: Multiple reasoning spans across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>first</think>
     - ' middle '
@@ -51,11 +54,13 @@ cases:
       vllm:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts each complete reasoning span across chunks; vLLM leaves the later complete span in normal_text.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <th
     - ink>thinking</think>answer
@@ -66,11 +71,13 @@ cases:
       vllm:
         reasoning_text: <think>thinking
         normal_text: answer
+        reason: Dynamo buffers a split start delimiter and strips it; vLLM leaks the reconstructed delimiter.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.3.b:
     description: End marker split across chunks
     ref: *upstream_ref
+    spec_ref: 'lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo'
     chunks:
     - <think>thinking</th
     - ink>answer
@@ -81,6 +88,7 @@ cases:
       vllm:
         reasoning_text: <think>thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers a split end delimiter and resumes normal_text after it; vLLM keeps the delimiter and answer in reasoning_text.
       sglang:
         unavailable: SGLang expectation not captured for Dynamo parser family 'deepseek_v3'
   REASONING.stream.3.c:


### PR DESCRIPTION
#### Overview:

This PR documents the remaining DeepSeek V3 / V3.1 / V3.2 reasoning parity divergences.

There is no Dynamo parser code change. These models share the `deepseek_v3` reasoning fixture family and the `DeepseekR1` force-reasoning parser implementation. Dynamo already follows the reasoning split contract by stripping reasoning delimiters, buffering split markers, and extracting complete reasoning spans without leaking protocol markers into `normal_text`.

#### Details:

This PR adds `reason:` and `spec_ref:` entries for the remaining vLLM divergences in:

```text
REASONING.batch.6.a
REASONING.stream.2.a
REASONING.stream.2.b
REASONING.stream.3.a
REASONING.stream.3.b
```

For `REASONING.batch.6.a` and `REASONING.stream.2.b`, Dynamo extracts each complete reasoning span and concatenates the reasoning text. vLLM only extracts the first span and leaves the later complete `<think>...</think>` span in `normal_text`.

For `REASONING.stream.2.a`, `3.a`, and `3.b`, Dynamo strips or buffers split reasoning delimiters correctly. vLLM leaks `<think>` / `</think>` markers into `reasoning_text`, and in the split end-marker case also keeps the answer text in `reasoning_text`.

Before:

```text
DeepSeek V3 / V3.1 / V3.2 stream cells: V? V? V? V?
DeepSeek V3 / V3.1 / V3.2 batch.6.a: V?
```

After:

```text
DeepSeek V3 / V3.1 / V3.2 stream cells: V V V V
DeepSeek V3 / V3.1 / V3.2 batch.6.a: V
```

#### Where should the reviewer start?

- `tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml`
- `tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml`

#### Related Issues:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reasoning mode test fixtures with specification references and behavioral documentation clarifications for parsing validation across different implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->