### PR TITLE
feat: add InternLM tool parser parity

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -944,20 +944,117 @@ impl JailedStream {
         first_marker.map(|pos| &content[..pos])
     }
 
+    fn first_parser_tool_call_marker_pos(&self, content: &str) -> Option<usize> {
+        self.first_parser_tool_call_marker(content)
+            .map(|(pos, _)| pos)
+    }
+
+    fn first_parser_tool_call_marker(&self, content: &str) -> Option<(usize, usize)> {
+        let parser_name = self.tool_call_parser.as_deref()?;
+        let config = get_tool_parser_map().get(parser_name)?;
+
+        config
+            .parser_config
+            .tool_call_start_tokens()
+            .iter()
+            .filter(|marker| !marker.is_empty())
+            .filter_map(|marker| content.find(marker).map(|pos| (pos, marker.len())))
+            .min_by_key(|(pos, _)| *pos)
+    }
+
+    fn suppress_parser_markers_on_parse_failure(&self) -> bool {
+        let Some(parser_name) = self.tool_call_parser.as_deref() else {
+            return false;
+        };
+        let Some(config) = get_tool_parser_map().get(parser_name) else {
+            return false;
+        };
+
+        match &config.parser_config {
+            ParserConfig::Json(config) | ParserConfig::Harmony(config) => {
+                config.suppress_marker_tokens_on_parse_failure
+            }
+            _ => false,
+        }
+    }
+
+    fn should_use_json_aware_end_marker_fallback(&self, accumulated_content: &str) -> bool {
+        if self.tool_call_parser.as_deref() != Some("internlm") {
+            return false;
+        }
+
+        let Some((marker_pos, marker_len)) =
+            self.first_parser_tool_call_marker(accumulated_content)
+        else {
+            return false;
+        };
+
+        accumulated_content[marker_pos + marker_len..]
+            .trim_start()
+            .starts_with(['{', '['])
+    }
+
+    fn find_end_marker_outside_json_string(
+        &self,
+        accumulated_content: &str,
+    ) -> Option<(usize, String)> {
+        let (_, marker_len) = self.first_parser_tool_call_marker(accumulated_content)?;
+        let marker_pos = self.first_parser_tool_call_marker_pos(accumulated_content)?;
+        let scan_start = marker_pos + marker_len;
+        let mut in_string = false;
+        let mut escape = false;
+
+        for (offset, ch) in accumulated_content[scan_start..].char_indices() {
+            let pos = scan_start + offset;
+            if !in_string {
+                for seq in self.jail_end_sequences.iter().filter(|seq| !seq.is_empty()) {
+                    if accumulated_content[pos..].starts_with(seq) {
+                        return Some((pos + seq.len(), seq.clone()));
+                    }
+                }
+            }
+
+            if escape {
+                escape = false;
+                continue;
+            }
+            if in_string {
+                match ch {
+                    '\\' => escape = true,
+                    '"' => in_string = false,
+                    _ => {}
+                }
+            } else if ch == '"' {
+                in_string = true;
+            }
+        }
+
+        None
+    }
+
+    fn end_marker_info(&self, accumulated_content: &str) -> Option<(usize, String)> {
+        if self.jail_end_sequences.is_empty() {
+            return None;
+        }
+
+        if self.should_use_json_aware_end_marker_fallback(accumulated_content) {
+            return self.find_end_marker_outside_json_string(accumulated_content);
+        }
+
+        self.jail_end_sequences.iter().find_map(|seq| {
+            accumulated_content
+                .find(seq)
+                .map(|pos| (pos + seq.len(), seq.clone()))
+        })
+    }
+
     /// Check if accumulated content should end jail
     async fn should_end_jail(&self, accumulated_content: &str) -> (bool, usize) {
         match &self.jail_mode {
             JailMode::MarkerBased => {
-                // Path 1: End sequence detected via naive string search.
-                let end_marker_info = if !self.jail_end_sequences.is_empty() {
-                    self.jail_end_sequences.iter().find_map(|seq| {
-                        accumulated_content
-                            .find(seq)
-                            .map(|pos| (pos + seq.len(), seq.clone()))
-                    })
-                } else {
-                    None
-                };
+                // Path 1: End sequence fallback. InternLM uses JSON wrappers,
+                // so ignore marker-looking text while inside JSON strings.
+                let end_marker_info = self.end_marker_info(accumulated_content);
 
                 // Path 2: Complete tool call(s) can be parsed (early exit)
                 let early_exit = self.should_exit_jail_early(accumulated_content).await;
@@ -1150,6 +1247,17 @@ impl JailedStream {
                                 .unwrap_or("")
                         } else if normal_text.as_deref() == Some("") {
                             ""
+                        } else if self.suppress_parser_markers_on_parse_failure()
+                            && normal_text.as_deref() == Some(accumulated_content)
+                            && let Some(parser_marker_pos) =
+                                self.first_parser_tool_call_marker_pos(accumulated_content)
+                            && let Some(prefix) =
+                                self.prefix_before_first_tool_call_marker(accumulated_content)
+                            && prefix.len() <= parser_marker_pos
+                        {
+                            // Only opt-in parsers suppress marker-looking text here. Legacy parser
+                            // families intentionally preserve malformed wrapped content as text.
+                            prefix
                         } else if is_harmony_parser(self.tool_call_parser.as_deref())
                             && contains_harmony_protocol(accumulated_content)
                         {
@@ -1997,6 +2105,35 @@ mod tests {
             "Missing get_time tool call. Got: {:?}",
             names
         );
+    }
+
+    #[tokio::test]
+    async fn test_internlm_stream_keeps_end_marker_inside_argument_string() {
+        let jail = JailedStream::builder().tool_call_parser("internlm").build();
+
+        let chunks = vec![
+            text_chunk(
+                r#"<|action_start|><|plugin|>{"name":"get_weather","parameters":{"location":"NYC <|action_end|>"#,
+            ),
+            text_chunk(r#" still inside string"}}<|action_end|>"#),
+        ];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+        let tool_calls = collect_tool_calls(&responses);
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "Expected one InternLM tool call, got {:?}",
+            tool_calls
+        );
+        assert_eq!(tool_calls[0].0, "get_weather");
+
+        let args: serde_json::Value = serde_json::from_str(&tool_calls[0].1).unwrap();
+        assert_eq!(args["location"], "NYC <|action_end|> still inside string");
+        assert_eq!(collect_text_content(&responses), "");
     }
 
     #[tokio::test]

--- a/lib/parsers/README.md
+++ b/lib/parsers/README.md
@@ -94,6 +94,8 @@ Reasoning parsers:
 
 ## Adding a new parser
 
+Workspace agents should use the `dyn-create-parser` skill for this workflow. This README keeps the repo-local checklist and file paths available for humans and agents that do not have the skill loaded.
+
 1. **Pick the family** from the cheat sheet above. If an existing config-driven
    family fits, add a `ToolCallConfig::<your_model>()` constructor in
    `tool_calling/config.rs`, register it in `tool_calling/parsers.rs`. Done —
@@ -107,11 +109,9 @@ Reasoning parsers:
    grammar truly diverges (append-think, Harmony channels). Most new models
    use plain `<think>...</think>` and can share.
 
-4. **Write tests.** Minimum viable set is in [`TOOLCALLING_CASES.md`](./TOOLCALLING_CASES.md) (`TOOLCALLING.*`
-   taxonomy). At minimum: `TOOLCALLING.1`/`TOOLCALLING.2`/`TOOLCALLING.3` for correctness,
-   `TOOLCALLING.5` for truncation behavior, `TOOLCALLING.8`/`TOOLCALLING.9` for streaming
-   with reasoning, and `TOOLCALLING.13` for interleaved text. `N/A` categories
-   should be explicitly called out in a comment rather than silently skipped.
+4. **Write parity fixtures.** Day-0 model imports should try every column/case in [`TOOLCALLING_CASES.md`](./TOOLCALLING_CASES.md), not only the minimum happy path. Add real fixtures where the grammar can express the case, and add explicit `N/A`, `unavailable`, or reasoned expected entries when the case does not apply or a peer parser cannot run. Avoid leaving `—` cells as silent TODOs; if a column stays blank, call out the blocker in the PR.
+
+5. **Log recovery.** If Dynamo intentionally recovers from malformed wrapper syntax, missing end markers, orphan markers, truncation, resync after bad JSON, or marker suppression, emit a structured `tracing::warn!` with a stable `why` field and small counts such as `skipped_bytes`, `recovered_bytes`, or `repaired_bytes`. Do not dump raw model text or full arguments into logs.
 
 ## Related docs
 

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -13,6 +13,11 @@ pub struct JsonParserConfig {
     pub tool_call_start_tokens: Vec<String>,
     /// End token for individual tool calls (e.g., `</TOOLCALL>`)
     pub tool_call_end_tokens: Vec<String>,
+    /// Marker tokens that belong to the family grammar but are not complete
+    /// tool-call start tokens by themselves. If parsing fails, these markers
+    /// should still be suppressed rather than leaked as normal text.
+    #[serde(default)]
+    pub tool_call_sentinel_tokens: Vec<String>,
     /// Separator tokens between function name and arguments
     /// (e.g., "<｜tool▁sep｜>" for DeepSeek v3.1)
     /// Used by some models to separate function name from arguments
@@ -64,6 +69,29 @@ pub struct JsonParserConfig {
     /// trailing marker as leaked text on the next chunk.
     #[serde(default)]
     pub strip_markup_on_recovery: bool,
+
+    /// Allow recovery from a valid raw JSON call followed only by orphan end
+    /// tokens. This is opt-in because most grammars require an opening marker.
+    #[serde(default)]
+    pub recover_orphan_end_token: bool,
+
+    /// Treat `{"name": ...}` as an empty-argument tool call when the tool
+    /// schema allows no required arguments. This is opt-in because most
+    /// established parser families require an explicit arguments object.
+    #[serde(default)]
+    pub allow_name_only_tool_calls: bool,
+
+    /// Use JSON-aware wrapper extraction that can skip malformed wrappers and
+    /// resynchronize at the next start marker. This is opt-in because older
+    /// parser families have recorded behavior for malformed framed content.
+    #[serde(default)]
+    pub recover_malformed_wrappers: bool,
+
+    /// Suppress family marker tokens when parsing fails instead of returning
+    /// them as normal text. This should be enabled only when the family grammar
+    /// is known and marker leaks are never useful user-visible content.
+    #[serde(default)]
+    pub suppress_marker_tokens_on_parse_failure: bool,
 }
 
 impl Default for JsonParserConfig {
@@ -71,6 +99,7 @@ impl Default for JsonParserConfig {
         Self {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string(), "<|python_tag|>".to_string()],
             tool_call_end_tokens: vec!["</TOOLCALL>".to_string(), "".to_string()],
+            tool_call_sentinel_tokens: vec![],
             tool_call_separator_tokens: vec![],
             function_name_keys: vec!["name".to_string()],
             arguments_keys: vec!["arguments".to_string(), "parameters".to_string()],
@@ -78,6 +107,10 @@ impl Default for JsonParserConfig {
             bare_json_mode: false,
             allow_eof_recovery: false,
             strip_markup_on_recovery: false,
+            recover_orphan_end_token: false,
+            allow_name_only_tool_calls: false,
+            recover_malformed_wrappers: false,
+            suppress_marker_tokens_on_parse_failure: false,
         }
     }
 }
@@ -447,6 +480,29 @@ impl ToolCallConfig {
         }
     }
 
+    pub fn internlm() -> Self {
+        Self {
+            parser_config: ParserConfig::Json(JsonParserConfig {
+                tool_call_start_tokens: vec![
+                    "<|action_start|><|plugin|>".to_string(),
+                    "<|action_start|>".to_string(),
+                ],
+                tool_call_end_tokens: vec!["<|action_end|>".to_string()],
+                tool_call_sentinel_tokens: vec![
+                    "<|action_start|>".to_string(),
+                    "<|plugin|>".to_string(),
+                    "<|action_end|>".to_string(),
+                ],
+                recover_orphan_end_token: true,
+                allow_name_only_tool_calls: true,
+                recover_malformed_wrappers: true,
+                suppress_marker_tokens_on_parse_failure: true,
+                ..Default::default()
+            }),
+            structural_tag_builder: None,
+        }
+    }
+
     pub fn phi4() -> Self {
         Self {
             parser_config: ParserConfig::Json(JsonParserConfig {
@@ -693,6 +749,19 @@ mod tests {
         assert_eq!(cfg.block_start, "<｜DSML｜function_calls>");
         assert_eq!(cfg.block_end, "</｜DSML｜function_calls>");
         assert_eq!(cfg.invoke_start_prefix, "<｜DSML｜invoke name=");
+    }
+
+    #[test]
+    fn json_config_deserializes_without_sentinel_tokens() {
+        let legacy = serde_json::json!({
+            "tool_call_start_tokens": ["<tool_call>"],
+            "tool_call_end_tokens": ["</tool_call>"],
+            "tool_call_separator_tokens": [],
+            "function_name_keys": ["name"],
+            "arguments_keys": ["arguments"],
+        });
+        let cfg: JsonParserConfig = serde_json::from_value(legacy).unwrap();
+        assert!(cfg.tool_call_sentinel_tokens.is_empty());
     }
 
     #[test]

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::RegexBuilder;
-use serde_json::value::RawValue;
+use serde_json::{Value, value::RawValue};
 use uuid::Uuid;
 
 use super::super::ToolDefinition;
@@ -31,9 +31,87 @@ pub struct CalledFunctionArguments {
     pub arguments: Box<RawValue>,
 }
 
-// Extract the contents between start and end tokens using regex parsing.
-// Returns a JSON array string if there are multiple matches, otherwise returns the last match directly.
-fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) -> Option<String> {
+#[derive(Debug, serde::Deserialize)]
+pub struct CalledFunctionNameOnly {
+    pub name: String,
+}
+
+fn tool_allows_empty_arguments(name: &str, tools: Option<&[ToolDefinition]>) -> bool {
+    let Some(tools) = tools else {
+        return false;
+    };
+    tools
+        .iter()
+        .any(|tool| tool.name == name && schema_allows_empty_arguments(tool.parameters.as_ref()))
+}
+
+fn schema_allows_empty_arguments(schema: Option<&Value>) -> bool {
+    let Some(schema) = schema else {
+        return true;
+    };
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|required| required.is_empty())
+        .unwrap_or(true)
+}
+
+fn contains_marker_token(text: &str, config: &JsonParserConfig) -> bool {
+    config
+        .tool_call_start_tokens
+        .iter()
+        .chain(config.tool_call_end_tokens.iter())
+        .chain(config.tool_call_sentinel_tokens.iter())
+        .any(|token| !token.is_empty() && text.contains(token))
+}
+
+fn strip_marker_tokens(input: &str, config: &JsonParserConfig) -> String {
+    let mut stripped = input.to_string();
+    for token in config
+        .tool_call_start_tokens
+        .iter()
+        .chain(config.tool_call_end_tokens.iter())
+        .chain(config.tool_call_sentinel_tokens.iter())
+        .filter(|token| !token.is_empty())
+    {
+        stripped = stripped.replace(token, "");
+    }
+    stripped.trim().to_string()
+}
+
+fn strip_trailing_end_tokens(input: &str, end_tokens: &[String]) -> Option<String> {
+    let mut trimmed = input.trim_end();
+    let mut changed = false;
+
+    loop {
+        let mut matched = false;
+        for token in end_tokens.iter().filter(|token| !token.is_empty()) {
+            if let Some(prefix) = trimmed.strip_suffix(token.as_str()) {
+                trimmed = prefix.trim_end();
+                changed = true;
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            break;
+        }
+    }
+
+    if changed && (trimmed.starts_with('{') || trimmed.starts_with('[')) {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+// Legacy extraction for established JSON parser families. Keep this behavior
+// stable unless a family opts into JSON-aware wrapper recovery.
+fn extract_tool_call_content_regex(
+    input: &str,
+    start_token: &str,
+    end_token: &str,
+) -> Option<String> {
     let escaped_start = regex::escape(start_token);
     let escaped_end = regex::escape(end_token);
     let pattern = format!(r"{}(.*?){}", escaped_start, escaped_end);
@@ -43,25 +121,245 @@ fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) ->
         .build()
     {
         Ok(regex) => {
-            // Get all matches and take the last one for now. TODO: Handle multiple tool calls
             let matches: Vec<_> = regex
                 .captures_iter(input)
                 .filter_map(|captures| captures.get(1))
                 .map(|m| m.as_str().trim().to_string())
                 .collect();
-            if !matches.is_empty() {
-                // If only one match, return it directly, otherwise return as a JSON array string
-                if matches.len() == 1 {
-                    // Return the last match directly
-                    return Some(matches.last().unwrap().clone());
-                } else {
-                    // Join the matches into a JSON array string
-                    return Some(format!("[{}]", matches.join(",")));
-                }
+            if matches.is_empty() {
+                None
+            } else if matches.len() == 1 {
+                matches.last().cloned()
+            } else {
+                Some(format!("[{}]", matches.join(",")))
             }
-            None
         }
         Err(_) => None,
+    }
+}
+
+// Extract complete JSON values after each start token. This deliberately uses a
+// JSON parser instead of a `start(.*?)end` regex so marker-looking text inside a
+// JSON string is treated as data, and so a malformed wrapper can be skipped
+// before resynchronizing on a later valid wrapper.
+fn extract_tool_call_content_with_recovery(
+    input: &str,
+    start_tokens: &[String],
+    end_token: &str,
+    allow_eof_recovery: bool,
+) -> Option<String> {
+    let mut cursor = 0;
+    let mut values: Vec<String> = Vec::new();
+    let mut saw_start = false;
+    let mut saw_closed_wrapper = false;
+    let mut saw_unclosed_wrapper = false;
+
+    while let Some((start_pos, start_token)) = find_next_start_token(input, cursor, start_tokens) {
+        saw_start = true;
+        let body_pos = start_pos + start_token.len();
+        let body = &input[body_pos..];
+        let trimmed_body = body.trim_start();
+        let leading_ws = body.len() - trimmed_body.len();
+        let json_pos = body_pos + leading_ws;
+
+        if !(trimmed_body.starts_with('{') || trimmed_body.starts_with('[')) {
+            match next_wrapper_boundary(input, body_pos, start_tokens, end_token) {
+                WrapperBoundary::End(pos) => {
+                    tracing::warn!(
+                        why = "non_json_wrapper_body",
+                        skipped_bytes = pos.saturating_sub(body_pos),
+                        "JSON tool-call recovery: skipped malformed marker wrapper whose body did not start with JSON."
+                    );
+                    saw_closed_wrapper = true;
+                    cursor = pos + end_token.len();
+                }
+                WrapperBoundary::Start(pos) => {
+                    tracing::warn!(
+                        why = "non_json_wrapper_body_resync",
+                        skipped_bytes = pos.saturating_sub(body_pos),
+                        "JSON tool-call recovery: skipped malformed marker wrapper and resynchronized at the next start token."
+                    );
+                    saw_unclosed_wrapper = true;
+                    cursor = pos;
+                }
+                WrapperBoundary::None => {
+                    if allow_eof_recovery {
+                        tracing::warn!(
+                            why = "non_json_wrapper_body_no_boundary",
+                            skipped_bytes = body.len(),
+                            "JSON tool-call recovery: suppressed malformed marker wrapper with no later boundary."
+                        );
+                    }
+                    saw_unclosed_wrapper = true;
+                    break;
+                }
+            }
+            continue;
+        }
+
+        let mut stream =
+            serde_json::Deserializer::from_str(trimmed_body).into_iter::<Box<RawValue>>();
+        match stream.next() {
+            Some(Ok(raw)) => {
+                let raw_json = raw.get();
+                let after_raw = &trimmed_body[raw_json.len()..];
+                let after_raw_trimmed = after_raw.trim_start();
+                let raw_trailing_ws = after_raw.len() - after_raw_trimmed.len();
+                if after_raw_trimmed.starts_with(end_token) {
+                    values.push(raw_json.to_string());
+                    cursor = json_pos + raw_json.len() + raw_trailing_ws + end_token.len();
+                    saw_closed_wrapper = true;
+                } else if allow_eof_recovery && after_raw_trimmed.trim().is_empty() {
+                    tracing::warn!(
+                        why = "missing_end_token",
+                        recovered_bytes = raw_json.len(),
+                        "JSON tool-call recovery: accepted complete JSON at EOF because end token was missing."
+                    );
+                    values.push(raw_json.to_string());
+                    break;
+                } else {
+                    match next_wrapper_boundary(input, body_pos, start_tokens, end_token) {
+                        WrapperBoundary::End(pos) => {
+                            tracing::warn!(
+                                why = "invalid_trailing_wrapper_bytes",
+                                skipped_bytes = pos.saturating_sub(body_pos),
+                                "JSON tool-call recovery: skipped marker wrapper with bytes after the JSON body before the end token."
+                            );
+                            saw_closed_wrapper = true;
+                            cursor = pos + end_token.len();
+                        }
+                        WrapperBoundary::Start(pos) => {
+                            tracing::warn!(
+                                why = "invalid_trailing_wrapper_bytes_resync",
+                                skipped_bytes = pos.saturating_sub(body_pos),
+                                "JSON tool-call recovery: skipped marker wrapper with invalid trailing bytes and resynchronized at the next start token."
+                            );
+                            saw_unclosed_wrapper = true;
+                            cursor = pos;
+                        }
+                        WrapperBoundary::None => {
+                            if allow_eof_recovery {
+                                tracing::warn!(
+                                    why = "invalid_trailing_wrapper_bytes_no_boundary",
+                                    skipped_bytes = body.len(),
+                                    "JSON tool-call recovery: suppressed marker wrapper with invalid trailing bytes and no later boundary."
+                                );
+                            }
+                            saw_unclosed_wrapper = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            _ => {
+                let boundary = next_wrapper_boundary(input, body_pos, start_tokens, end_token);
+                if allow_eof_recovery {
+                    let repair_candidate = match boundary {
+                        WrapperBoundary::End(end_pos) => Some(input[json_pos..end_pos].trim()),
+                        WrapperBoundary::None => Some(trimmed_body),
+                        WrapperBoundary::Start(_) => None,
+                    };
+                    if let Some(candidate) = repair_candidate
+                        && let Some(repaired) = try_repair_truncated_json(candidate)
+                        && serde_json::from_str::<Box<RawValue>>(&repaired).is_ok()
+                    {
+                        tracing::warn!(
+                            why = "truncated_json_repaired",
+                            original_bytes = candidate.len(),
+                            repaired_bytes = repaired.len(),
+                            "JSON tool-call recovery: repaired truncated JSON before parsing tool call."
+                        );
+                        values.push(repaired);
+                        if let WrapperBoundary::End(end_pos) = boundary {
+                            saw_closed_wrapper = true;
+                            cursor = end_pos + end_token.len();
+                            continue;
+                        }
+                        break;
+                    }
+                }
+                match boundary {
+                    WrapperBoundary::End(pos) => {
+                        tracing::warn!(
+                            why = "malformed_json_wrapper",
+                            skipped_bytes = pos.saturating_sub(body_pos),
+                            "JSON tool-call recovery: skipped marker wrapper whose JSON body could not be parsed or repaired."
+                        );
+                        saw_closed_wrapper = true;
+                        cursor = pos + end_token.len();
+                    }
+                    WrapperBoundary::Start(pos) => {
+                        tracing::warn!(
+                            why = "malformed_json_wrapper_resync",
+                            skipped_bytes = pos.saturating_sub(body_pos),
+                            "JSON tool-call recovery: skipped malformed JSON wrapper and resynchronized at the next start token."
+                        );
+                        saw_unclosed_wrapper = true;
+                        cursor = pos;
+                    }
+                    WrapperBoundary::None => {
+                        if allow_eof_recovery {
+                            tracing::warn!(
+                                why = "malformed_json_wrapper_no_boundary",
+                                skipped_bytes = body.len(),
+                                "JSON tool-call recovery: suppressed malformed JSON wrapper with no later boundary."
+                            );
+                        }
+                        saw_unclosed_wrapper = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if values.len() == 1 {
+        Some(values.remove(0))
+    } else if !values.is_empty() {
+        Some(format!("[{}]", values.join(",")))
+    } else if saw_closed_wrapper || (saw_start && !saw_unclosed_wrapper) {
+        Some(String::new())
+    } else {
+        None
+    }
+}
+
+enum WrapperBoundary {
+    End(usize),
+    Start(usize),
+    None,
+}
+
+fn find_next_start_token<'a>(
+    input: &str,
+    search_from: usize,
+    start_tokens: &'a [String],
+) -> Option<(usize, &'a str)> {
+    start_tokens
+        .iter()
+        .filter(|token| !token.is_empty())
+        .filter_map(|token| {
+            input[search_from..]
+                .find(token)
+                .map(|pos| (search_from + pos, token.as_str()))
+        })
+        .min_by_key(|(pos, token)| (*pos, std::cmp::Reverse(token.len())))
+}
+
+fn next_wrapper_boundary(
+    input: &str,
+    search_from: usize,
+    start_tokens: &[String],
+    end_token: &str,
+) -> WrapperBoundary {
+    let tail = &input[search_from..];
+    let next_start = find_next_start_token(input, search_from, start_tokens).map(|(pos, _)| pos);
+    let next_end = tail.find(end_token).map(|pos| search_from + pos);
+    match (next_start, next_end) {
+        (Some(start), Some(end)) if start < end => WrapperBoundary::Start(start),
+        (_, Some(end)) => WrapperBoundary::End(end),
+        (Some(start), None) => WrapperBoundary::Start(start),
+        (None, None) => WrapperBoundary::None,
     }
 }
 
@@ -225,6 +523,12 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
     String::new()
 }
 
+fn try_parse_normal_text_from_tokens(input: &str, start_tokens: &[String]) -> String {
+    find_next_start_token(input, 0, start_tokens)
+        .map(|(idx, _)| input[..idx].trim().to_string())
+        .unwrap_or_default()
+}
+
 /// Attempts to parse a tool call from a raw LLM message string into a unified [`ToolCallResponse`] format.
 ///
 /// This is a flexible helper that handles a variety of potential formats emitted by LLMs for function/tool calls,
@@ -282,13 +586,27 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
 /// than re-serializing a parsed `HashMap` / `Value`, which keeps them
 /// byte-identical to what the model emitted (required for KV-cache append-only
 /// prefix matching across multi-step tool use).
-fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
+fn parse_calls(
+    payload: &str,
+    allow_name_only: bool,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
     let mk = |name: String, args: &RawValue| ToolCallResponse {
         id: format!("call-{}", Uuid::new_v4()),
         tp: ToolCallType::Function,
         function: CalledFunction {
             name,
             arguments: args.get().to_string(),
+        },
+    };
+    // Name-only call (`{"name": ...}` with no args) — opt-in via
+    // `allow_name_only` and only when the tool schema permits empty arguments.
+    let mk_empty = |name: String| ToolCallResponse {
+        id: format!("call-{}", Uuid::new_v4()),
+        tp: ToolCallType::Function,
+        function: CalledFunction {
+            name,
+            arguments: "{}".to_string(),
         },
     };
 
@@ -302,6 +620,11 @@ fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
                 serde_json::from_str::<CalledFunctionParameters>(item_str)
             {
                 calls.push(mk(func_params.name, &func_params.parameters));
+            } else if allow_name_only
+                && let Ok(func_name) = serde_json::from_str::<CalledFunctionNameOnly>(item_str)
+                && tool_allows_empty_arguments(&func_name.name, tools)
+            {
+                calls.push(mk_empty(func_name.name));
             }
             // Skip malformed entries silently.
         }
@@ -312,6 +635,12 @@ fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
     }
     if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(payload) {
         return Ok(Some(vec![mk(single.name, &single.arguments)]));
+    }
+    if allow_name_only
+        && let Ok(single) = serde_json::from_str::<CalledFunctionNameOnly>(payload)
+        && tool_allows_empty_arguments(&single.name, tools)
+    {
+        return Ok(Some(vec![mk_empty(single.name)]));
     }
     Ok(None)
 }
@@ -344,6 +673,7 @@ pub fn try_tool_call_parse_basic_json(
     let mut json = trimmed.to_string();
     let mut normal_text = trimmed.to_string();
     let mut found_start_token_with_no_valid_json = false;
+    let mut extracted_marker_wrapped_content = false;
 
     // First, check if ANY start token exists in the input. `bare_json_mode`
     // short-circuits this to false so we always take the no-marker branch.
@@ -351,6 +681,7 @@ pub fn try_tool_call_parse_basic_json(
         && tool_call_start_tokens
             .iter()
             .any(|token| !token.is_empty() && normal_text.contains(token));
+    let has_marker_token = !config.bare_json_mode && contains_marker_token(trimmed, config);
 
     if !has_start_token {
         // No start tokens found, try to extract JSON directly. Everything that starts with { or [ is considered a potential JSON.
@@ -358,8 +689,36 @@ pub fn try_tool_call_parse_basic_json(
             let extracted_normal = normal_text[..idx].trim().to_string();
             let extracted_json = normal_text[idx..].trim().to_string();
             if !extracted_json.is_empty() {
-                normal_text = extracted_normal;
-                json = extracted_json;
+                normal_text = if config.suppress_marker_tokens_on_parse_failure && has_marker_token
+                {
+                    let stripped_normal = strip_marker_tokens(&extracted_normal, config);
+                    if stripped_normal != extracted_normal {
+                        tracing::warn!(
+                            why = "marker_prefix_before_recovered_raw_json",
+                            "JSON tool-call recovery: stripped marker tokens before recovered raw JSON."
+                        );
+                    }
+                    stripped_normal
+                } else {
+                    extracted_normal
+                };
+                json = if config.recover_orphan_end_token && has_marker_token {
+                    if let Some(stripped) =
+                        strip_trailing_end_tokens(&extracted_json, tool_call_end_tokens)
+                    {
+                        tracing::warn!(
+                            why = "orphan_end_token",
+                            original_bytes = extracted_json.len(),
+                            stripped_bytes = extracted_json.len().saturating_sub(stripped.len()),
+                            "JSON tool-call recovery: stripped trailing orphan end token before parsing raw JSON."
+                        );
+                        stripped
+                    } else {
+                        extracted_json
+                    }
+                } else {
+                    extracted_json
+                };
             }
         }
     } else {
@@ -367,7 +726,11 @@ pub fn try_tool_call_parse_basic_json(
         // Try all combinations of start and end tokens
         'outer: for start_token in tool_call_start_tokens.iter() {
             for end_token in tool_call_end_tokens.iter() {
-                let new_normal_text = try_parse_normal_text(&normal_text, start_token);
+                let new_normal_text = if config.recover_malformed_wrappers {
+                    try_parse_normal_text_from_tokens(&normal_text, tool_call_start_tokens)
+                } else {
+                    try_parse_normal_text(&normal_text, start_token)
+                };
 
                 // Process based on token types
                 match (start_token.is_empty(), end_token.is_empty()) {
@@ -389,22 +752,40 @@ pub fn try_tool_call_parse_basic_json(
                             json = content;
                             // For single token case, use the normal text we extracted earlier
                             normal_text = new_normal_text;
+                            extracted_marker_wrapped_content = true;
 
                             break 'outer; // Found content, exit early
                         }
                     }
                     (false, false) => {
                         // Start and end token case
-                        let mut result = extract_tool_call_content(&json, start_token, end_token);
+                        let mut result = if config.recover_malformed_wrappers {
+                            extract_tool_call_content_with_recovery(
+                                &json,
+                                tool_call_start_tokens,
+                                end_token,
+                                config.allow_eof_recovery,
+                            )
+                        } else {
+                            extract_tool_call_content_regex(&json, start_token, end_token)
+                        };
                         // EOF recovery: only when explicitly opted in (finalize
                         // path). Streaming jails leave `allow_eof_recovery=false`
                         // so the parser doesn't claim a complete call before
                         // the end-token has actually arrived.
                         if result.is_none()
                             && config.allow_eof_recovery
-                            && json.contains(start_token.as_str())
+                            && let Some((_, eof_start_token)) =
+                                find_next_start_token(&json, 0, tool_call_start_tokens)
                         {
-                            result = extract_tool_call_content_eof_recovery(&json, start_token);
+                            result = extract_tool_call_content_eof_recovery(&json, eof_start_token);
+                            if let Some(content) = result.as_ref() {
+                                tracing::warn!(
+                                    why = "missing_end_token_eof_fallback",
+                                    recovered_bytes = content.len(),
+                                    "JSON tool-call recovery: treated EOF as the end token after wrapper extraction failed."
+                                );
+                            }
                         }
                         if let Some(content) = result {
                             // Check if we found a start token but got empty JSON back
@@ -415,6 +796,7 @@ pub fn try_tool_call_parse_basic_json(
 
                             json = content;
                             normal_text = new_normal_text;
+                            extracted_marker_wrapped_content = true;
 
                             break 'outer; // Found content, exit early
                         }
@@ -431,10 +813,11 @@ pub fn try_tool_call_parse_basic_json(
     // Anonymous function to attempt deserialization into a known representation.
     //
     // Try the three canonical JSON shapes (single object with `parameters` or
-    // `arguments`, or an array of either). A recognized shape returns here —
+    // `arguments`, or an array of either) plus the opt-in name-only shape
+    // (`{"name": ...}` with no args). A recognized shape returns here —
     // including an empty array, which is a valid empty result and must not fall
     // through to truncation recovery.
-    if let Some(calls) = parse_calls(json)? {
+    if let Some(calls) = parse_calls(json, config.allow_name_only_tool_calls, _tools)? {
         return Ok((calls, Some(normal_text)));
     }
 
@@ -444,15 +827,28 @@ pub fn try_tool_call_parse_basic_json(
     // call while the model is still emitting JSON tokens.
     if config.allow_eof_recovery
         && let Some(repaired) = try_repair_truncated_json(json)
-        && let Some(calls) = parse_calls(repaired.as_str())?
+        && let Some(calls) =
+            parse_calls(repaired.as_str(), config.allow_name_only_tool_calls, _tools)?
         && !calls.is_empty()
     {
+        tracing::warn!(
+            why = "truncated_json_repaired_parse_retry",
+            original_bytes = json.len(),
+            "JSON tool-call recovery: repaired truncated JSON after the initial parse failed."
+        );
         return Ok((calls, Some(normal_text)));
     }
 
     // If we found a start token but no valid JSON, return empty content
     // to avoid leaking the token and invalid JSON content
     if found_start_token_with_no_valid_json {
+        if config.suppress_marker_tokens_on_parse_failure {
+            tracing::warn!(
+                why = "marker_wrapped_content_unparseable",
+                "JSON tool-call recovery: suppressed marker-wrapped content that did not parse as a supported tool-call shape."
+            );
+            return Ok((vec![], Some(normal_text)));
+        }
         return Ok((vec![], Some(String::new())));
     }
 
@@ -521,7 +917,8 @@ pub fn try_tool_call_parse_basic_json(
             }
             let payload = payload.trim();
 
-            let calls = parse_calls(payload)?.unwrap_or_default();
+            let calls = parse_calls(payload, config.allow_name_only_tool_calls, _tools)?
+                .unwrap_or_default();
 
             if !calls.is_empty() {
                 tracing::warn!(
@@ -540,7 +937,21 @@ pub fn try_tool_call_parse_basic_json(
         }
     }
 
-    Ok((vec![], Some(trimmed.to_string())))
+    if config.suppress_marker_tokens_on_parse_failure && extracted_marker_wrapped_content {
+        tracing::warn!(
+            why = "marker_wrapped_content_unparseable",
+            "JSON tool-call recovery: suppressed marker-wrapped content that did not parse as a supported tool-call shape."
+        );
+        Ok((vec![], Some(normal_text)))
+    } else if config.suppress_marker_tokens_on_parse_failure && has_marker_token {
+        tracing::warn!(
+            why = "marker_token_without_parse",
+            "JSON tool-call recovery: suppressed tool marker tokens that did not produce a valid tool call."
+        );
+        Ok((vec![], Some(String::new())))
+    } else {
+        Ok((vec![], Some(trimmed.to_string())))
+    }
 }
 
 pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig) -> bool {
@@ -607,6 +1018,68 @@ mod repair_tests {
             "repaired must parse: {:?}",
             repaired
         );
+    }
+}
+
+#[cfg(test)]
+mod wrapper_recovery_tests {
+    use super::*;
+
+    fn internlm_recovery_config() -> JsonParserConfig {
+        JsonParserConfig {
+            tool_call_start_tokens: vec![
+                "<|action_start|><|plugin|>".to_string(),
+                "<|action_start|>".to_string(),
+            ],
+            tool_call_end_tokens: vec!["<|action_end|>".to_string()],
+            tool_call_sentinel_tokens: vec![
+                "<|action_start|>".to_string(),
+                "<|plugin|>".to_string(),
+                "<|action_end|>".to_string(),
+            ],
+            recover_malformed_wrappers: true,
+            recover_orphan_end_token: true,
+            suppress_marker_tokens_on_parse_failure: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_recovery_scans_mixed_internlm_start_tokens() {
+        let config = internlm_recovery_config();
+        let input = concat!(
+            "prefix ",
+            r#"<|action_start|><|plugin|>{"name":"get_weather","parameters":{"city":"NYC"}}<|action_end|>"#,
+            r#"<|action_start|>{"name":"current_time","parameters":{"timezone":"UTC"}}<|action_end|>"#
+        );
+
+        let (calls, normal_text) = try_tool_call_parse_basic_json(input, &config, None).unwrap();
+        assert_eq!(normal_text.as_deref(), Some("prefix"));
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "current_time");
+
+        let first_args: serde_json::Value =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let second_args: serde_json::Value =
+            serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(first_args["city"], "NYC");
+        assert_eq!(second_args["timezone"], "UTC");
+    }
+
+    #[test]
+    fn test_internlm_recovery_strips_sentinel_only_prefix() {
+        let config = internlm_recovery_config();
+        let input =
+            r#"<|plugin|>{"name":"get_weather","parameters":{"location":"NYC"}}<|action_end|>"#;
+
+        let (calls, normal_text) = try_tool_call_parse_basic_json(input, &config, None).unwrap();
+        assert_eq!(normal_text.as_deref(), Some(""));
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["location"], "NYC");
     }
 }
 

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -130,13 +130,107 @@ pub fn find_tool_call_end_position_json(
                 chunk.len()
             }
         }
+        "internlm" => find_internlm_tool_call_end_position(chunk, config).unwrap_or(chunk.len()),
         _ => chunk.len(),
     }
+}
+
+fn find_internlm_tool_call_end_position(chunk: &str, config: &JsonParserConfig) -> Option<usize> {
+    let end_token = config
+        .tool_call_end_tokens
+        .iter()
+        .find(|token| !token.is_empty())?
+        .as_str();
+    let mut start_tokens: Vec<&str> = config
+        .tool_call_start_tokens
+        .iter()
+        .map(String::as_str)
+        .filter(|token| !token.is_empty())
+        .collect();
+    start_tokens.sort_by_key(|token| std::cmp::Reverse(token.len()));
+
+    let mut cursor = 0;
+    let mut last_complete_end = None;
+
+    loop {
+        let Some((start_pos, start_token)) = find_next_internlm_start(chunk, cursor, &start_tokens)
+        else {
+            return last_complete_end;
+        };
+
+        if last_complete_end.is_some() && !chunk[cursor..start_pos].chars().all(char::is_whitespace)
+        {
+            return last_complete_end;
+        }
+
+        let body_pos = start_pos + start_token.len();
+        let Some(end_pos) = find_internlm_wrapper_end(chunk, body_pos, end_token) else {
+            if last_complete_end.is_some() {
+                return last_complete_end;
+            }
+            cursor = body_pos;
+            continue;
+        };
+
+        last_complete_end = Some(end_pos);
+        cursor = end_pos;
+    }
+}
+
+fn find_next_internlm_start<'a>(
+    chunk: &str,
+    search_from: usize,
+    start_tokens: &'a [&'a str],
+) -> Option<(usize, &'a str)> {
+    start_tokens
+        .iter()
+        .filter_map(|token| {
+            chunk[search_from..]
+                .find(token)
+                .map(|pos| (search_from + pos, *token))
+        })
+        .min_by_key(|(pos, token)| (*pos, std::cmp::Reverse(token.len())))
+}
+
+fn find_internlm_wrapper_end(chunk: &str, body_pos: usize, end_token: &str) -> Option<usize> {
+    let body = &chunk[body_pos..];
+    let trimmed_body = body.trim_start();
+    let leading_ws = body.len() - trimmed_body.len();
+    let json_pos = body_pos + leading_ws;
+
+    if trimmed_body.starts_with('{') || trimmed_body.starts_with('[') {
+        let mut stream = serde_json::Deserializer::from_str(trimmed_body)
+            .into_iter::<Box<serde_json::value::RawValue>>();
+        if let Some(Ok(raw)) = stream.next() {
+            let raw_json = raw.get();
+            let after_raw = &trimmed_body[raw_json.len()..];
+            let after_raw_trimmed = after_raw.trim_start();
+            let raw_trailing_ws = after_raw.len() - after_raw_trimmed.len();
+            if after_raw_trimmed.starts_with(end_token) {
+                return Some(json_pos + raw_json.len() + raw_trailing_ws + end_token.len());
+            }
+        }
+        return None;
+    }
+
+    body.find(end_token)
+        .map(|pos| body_pos + pos + end_token.len())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn internlm_config() -> JsonParserConfig {
+        JsonParserConfig {
+            tool_call_start_tokens: vec![
+                "<|action_start|><|plugin|>".to_string(),
+                "<|action_start|>".to_string(),
+            ],
+            tool_call_end_tokens: vec!["<|action_end|>".to_string()],
+            ..Default::default()
+        }
+    }
 
     /// Regression test for issue #6822: parallel tool calls in a single chunk must
     /// all be captured by find_tool_call_end_position_json so that the jail passes the
@@ -230,6 +324,79 @@ mod tests {
         assert!(
             incomplete[pos_inc..].starts_with("<｜tool▁call▁begin｜>"),
             "incomplete trailing call must remain unconsumed"
+        );
+    }
+
+    #[test]
+    fn test_find_tool_call_end_position_internlm_stops_before_incomplete_next_action() {
+        let config = internlm_config();
+        let complete =
+            r#"<|action_start|><|plugin|>{"name":"first","parameters":{}}<|action_end|>"#;
+        let input = format!("{complete}<|action_start|><|plugin|>{{\"name\":\"second\"");
+
+        let pos = find_tool_call_end_position_json(&input, "internlm", &config);
+        assert_eq!(pos, complete.len());
+        assert_eq!(
+            &input[pos..],
+            r#"<|action_start|><|plugin|>{"name":"second""#
+        );
+    }
+
+    #[test]
+    fn test_find_tool_call_end_position_internlm_captures_consecutive_actions() {
+        let config = internlm_config();
+        let actions = concat!(
+            r#"<|action_start|><|plugin|>{"name":"first","parameters":{"x":1}}<|action_end|>"#,
+            r#"  <|action_start|>{"name":"second","parameters":{"y":2}}<|action_end|>"#
+        );
+        let input = format!("{actions} trailing");
+
+        let pos = find_tool_call_end_position_json(&input, "internlm", &config);
+        assert_eq!(pos, actions.len());
+        assert_eq!(&input[pos..], " trailing");
+    }
+
+    #[test]
+    fn test_find_tool_call_end_position_internlm_ignores_end_marker_inside_json_string() {
+        let config = internlm_config();
+        let action = r#"<|action_start|><|plugin|>{"name":"run_query","parameters":{"sql":"SELECT '<|action_end|>' as marker"}}<|action_end|>"#;
+        let input = format!("{action} done");
+
+        let pos = find_tool_call_end_position_json(&input, "internlm", &config);
+        assert_eq!(pos, action.len());
+        assert_eq!(&input[pos..], " done");
+    }
+
+    #[test]
+    fn test_find_tool_call_end_position_internlm_ignores_end_marker_inside_incomplete_json_string()
+    {
+        let config = internlm_config();
+        let complete =
+            r#"<|action_start|><|plugin|>{"name":"first","parameters":{}}<|action_end|>"#;
+        let input = format!(
+            "{complete}<|action_start|><|plugin|>{{\"name\":\"second\",\"parameters\":{{\"text\":\"partial <|action_end|>"
+        );
+
+        let pos = find_tool_call_end_position_json(&input, "internlm", &config);
+        assert_eq!(pos, complete.len());
+        assert_eq!(
+            &input[pos..],
+            r#"<|action_start|><|plugin|>{"name":"second","parameters":{"text":"partial <|action_end|>"#
+        );
+    }
+
+    #[test]
+    fn test_find_tool_call_end_position_internlm_resyncs_after_malformed_json_wrapper() {
+        let config = internlm_config();
+        let malformed = r#"<|action_start|><|plugin|>{"name":"broken"<|action_end|>"#;
+        let valid = r#"<|action_start|><|plugin|>{"name":"first","parameters":{}}<|action_end|>"#;
+        let input = format!("{malformed}{valid}<|action_start|><|plugin|>{{\"name\":\"second\"");
+
+        let pos = find_tool_call_end_position_json(&input, "internlm", &config);
+        assert_eq!(pos, malformed.len() + valid.len());
+        assert_eq!(
+            &input[pos..],
+            r#"<|action_start|><|plugin|>{"name":"second""#
         );
     }
 

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -40,6 +40,7 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("nemotron_deci", ToolCallConfig::nemotron_deci());
         map.insert("llama3_json", ToolCallConfig::llama3_json());
         map.insert("mistral", ToolCallConfig::mistral());
+        map.insert("internlm", ToolCallConfig::internlm());
         map.insert("phi4", ToolCallConfig::phi4());
         map.insert("pythonic", ToolCallConfig::pythonic());
         map.insert("harmony", ToolCallConfig::harmony());
@@ -323,6 +324,7 @@ mod tests {
             "harmony",
             "nemotron_deci",
             "mistral",
+            "internlm",
             "phi4",
             "default",
             "pythonic",
@@ -1171,6 +1173,51 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
     }
 
     #[tokio::test]
+    async fn test_legacy_json_parser_preserves_malformed_marker_wrapped_text() {
+        let input = r#"<tool_call>not json</tool_call>"#;
+
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+        assert_eq!(content, Some(input.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_legacy_json_parser_rejects_name_only_tool_call() {
+        let input = r#"<tool_call>{"name": "get_time"}</tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "get_time".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {},
+            })),
+            strict: None,
+        }];
+
+        let (result, content) = detect_and_parse_tool_call(input, Some("hermes"), Some(&tools))
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+        assert_eq!(content, Some(input.to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_legacy_single_token_parser_drops_prefix_on_parse_failure() {
+        let input = r#"I'll fetch both cities now.
+functools[{"name": "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}"#;
+
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::phi4(), None)
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+        assert_eq!(content, Some(String::new()));
+    }
+
+    #[tokio::test]
     #[ignore]
     async fn test_internlm_internlm2_5_7b_chat_simple() {
         let input = r#"San Francisco's weather is known for its mild climate with plenty of fog, especially along the coast. Here's an overview of the weather in Fahrenheit:
@@ -1183,6 +1230,156 @@ Remember, San Francisco weather can be quite unpredictable, particularly with it
             .unwrap();
         assert_eq!(content, Some(input.to_string()));
         assert!(result.is_empty()); // This model doesn't produce tool calls
+    }
+
+    #[tokio::test]
+    async fn test_internlm_parameterless_action_defaults_to_empty_arguments() {
+        let input = r#"<|action_start|><|plugin|>{"name": "refresh"}<|action_end|>"#;
+        let tools = vec![ToolDefinition {
+            name: "refresh".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {},
+            })),
+            strict: None,
+        }];
+
+        let (result, content) =
+            try_tool_call_parse(input, &ToolCallConfig::internlm(), Some(&tools))
+                .await
+                .unwrap();
+
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "refresh");
+        assert_eq!(args, serde_json::json!({}));
+    }
+
+    #[tokio::test]
+    async fn test_internlm_malformed_action_does_not_leak_markers() {
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            })),
+            strict: None,
+        }];
+        let cases = [
+            r#"<|action_start|><|plugin|>not json<|action_end|>"#,
+            r#"<|action_start|><|plugin|>{"parameters": {"location": "NYC"}}<|action_end|>"#,
+        ];
+
+        for input in cases {
+            let (result, content) =
+                try_tool_call_parse(input, &ToolCallConfig::internlm(), Some(&tools))
+                    .await
+                    .unwrap();
+
+            assert!(result.is_empty(), "unexpected call for {input:?}");
+            assert_eq!(
+                content,
+                Some("".to_string()),
+                "leaked content for {input:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_internlm_recovers_action_missing_plugin_marker() {
+        let input = r#"<|action_start|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>"#;
+
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::internlm(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args, serde_json::json!({"location": "NYC"}));
+    }
+
+    #[tokio::test]
+    async fn test_internlm_recovers_action_with_orphan_end_marker() {
+        let input = r#"{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>"#;
+
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::internlm(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args, serde_json::json!({"location": "NYC"}));
+    }
+
+    #[tokio::test]
+    async fn test_internlm_recovers_valid_action_after_malformed_prefix() {
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            })),
+            strict: None,
+        }];
+        let input = r#"<|action_start|><|plugin|>not json<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>"#;
+
+        let (result, content) =
+            try_tool_call_parse(input, &ToolCallConfig::internlm(), Some(&tools))
+                .await
+                .unwrap();
+
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args, serde_json::json!({"location": "NYC"}));
+    }
+
+    #[tokio::test]
+    async fn test_internlm_multiple_action_blocks() {
+        let input = r#"<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "LA"}}<|action_end|>"#;
+
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::internlm(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 2);
+        let (name_0, args_0) = extract_name_and_args(result[0].clone());
+        let (name_1, args_1) = extract_name_and_args(result[1].clone());
+        assert_eq!(name_0, "get_weather");
+        assert_eq!(args_0, serde_json::json!({"location": "NYC"}));
+        assert_eq!(name_1, "get_weather");
+        assert_eq!(args_1, serde_json::json!({"location": "LA"}));
+    }
+
+    #[tokio::test]
+    async fn test_internlm_marker_text_inside_argument_is_data() {
+        let input = r#"<|action_start|><|plugin|>{"name": "run_query", "parameters": {"sql": "SELECT '<|action_start|><|plugin|>not a call<|action_end|>' as marker"}}<|action_end|>"#;
+
+        let (result, content) = try_tool_call_parse(input, &ToolCallConfig::internlm(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(content, Some("".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "run_query");
+        assert_eq!(
+            args,
+            serde_json::json!({"sql": "SELECT '<|action_start|><|plugin|>not a call<|action_end|>' as marker"})
+        );
     }
 
     #[tokio::test]

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -919,23 +919,20 @@ real value-add is the cross-implementation half (vLLM and SGLang).
 
 ## Adding a new parser family
 
+Workspace agents should use the `dyn-create-parser` skill for this workflow. This section is the parity-fixture checklist that the skill points back to.
+
 1. Add the family name to Dynamo's parser registry (Rust side).
-2. Author a fixture YAML at
-   `tests/parity/toolcalling/fixtures/<family>/TOOLCALLING.batch.yaml` covering
-   the `TOOLCALLING.batch.<n>` cases that apply (mirror an existing
-   family's case shape — see `fixtures/kimi_k2/TOOLCALLING.batch.yaml`).
-   Each case minimally needs `description`, `ref`, `model_text`,
-   and `tools`. Author by hand or copy-edit from an upstream test.
-   AI can draft case shells, but humans must review them against
-   `TOOLCALLING_CASES.md` and the model format before merging.
-3. Run `python3 -m tests.parity.toolcalling.capture_toolcalling_outputs --impl dynamo --merge`
+2. Author a fixture YAML at `tests/parity/toolcalling/fixtures/<family>/TOOLCALLING.batch.yaml` and try to cover every table column/case from `lib/parsers/TOOLCALLING_CASES.md`, not just the cases that look likely to pass. Mirror an existing family's case shape — see `fixtures/kimi_k2/TOOLCALLING.batch.yaml`. Each case minimally needs `description`, `ref`, `model_text`, and `tools`. Author by hand or copy-edit from an upstream test. AI can draft case shells, but humans must review them against `TOOLCALLING_CASES.md` and the model format before merging.
+3. For cases that do not apply, cannot be expressed by the model grammar, or cannot be captured in a peer engine yet, add explicit `n/a`, `unavailable`, or reasoned expected entries. Do not leave `—` cells as silent TODOs unless the PR calls out the blocker.
+4. If a case depends on Dynamo recovering from malformed wrapper syntax, missing end markers, orphan markers, truncation, resync after bad JSON, or marker suppression, the parser code should emit a structured `tracing::warn!` with a stable `why` field. The fixture captures the API contract; the log makes the recovery visible in production.
+5. Run `python3 -m tests.parity.toolcalling.capture_toolcalling_outputs --impl dynamo --merge`
    to fill in each case's `expected.dynamo` by running Dynamo against
    `model_text` + `tools`. Cases that already have `expected.dynamo`
    are left alone.
-4. Add the family's vLLM and SGLang dispatch entries to
+6. Add the family's vLLM and SGLang dispatch entries to
    `_FAMILY_TO_VLLM_KEY` (`vllm.py`) and
    `_FAMILY_TO_SGLANG_DETECTOR` (`sglang.py`).
-5. Populate vLLM and SGLang outputs for the new family by running
+7. Populate vLLM and SGLang outputs for the new family by running
    `python3 -m tests.parity.toolcalling.capture_toolcalling_outputs --impl <vllm|sglang> --merge`
    inside each engine's container. The merge writes anchor refs to
    dynamo for matching engines, concrete `{calls, normal_text}` for
@@ -946,4 +943,4 @@ real value-add is the cross-implementation half (vLLM and SGLang).
    rather than the full volatile message. Add a `reason:` field to
    intentional divergences so they show as `V`/`S` not `V?`/`S?` in the
    table.
-6. Regenerate the table: `python3 tests/parity/generate_parity_table.py toolcalling --html > tests/parity/toolcalling/PARITY.html`.
+8. Regenerate the table: `python3 tests/parity/generate_parity_table.py toolcalling --html > tests/parity/toolcalling/PARITY.html`.

--- a/tests/parity/markup.py
+++ b/tests/parity/markup.py
@@ -67,6 +67,19 @@ _HARMONY_SEGMENT_CLASS = {
     "call": "tt-h-call",
 }
 
+_INTERNLM_ACTION_OPEN = "action_start"
+_INTERNLM_ACTION_CLOSE = "action_end"
+_INTERNLM_ACTION_PLUGIN = "plugin"
+_INTERNLM_ACTION_PAIR = "__internlm_action"
+_FIXED_COLOR_CLASSES = {
+    _INTERNLM_ACTION_PAIR: "tt-c0",
+    _INTERNLM_ACTION_PLUGIN: "tt-c0",
+}
+
+
+def _stable_color_class_for(name: str) -> str:
+    return _FIXED_COLOR_CLASSES.get(name) or _singleton_class_for(name)
+
 
 def _colorize_harmony(text: str) -> str:
     """Color Harmony's linear token segments as `<|token|>related-text`.
@@ -136,6 +149,12 @@ def _tag_kind_and_name(inner: str) -> tuple[str | None, str, str | None]:
     ends_pipe = inner[-1:] in _PIPES
     if starts_pipe and ends_pipe and len(inner) >= 2:
         middle = inner[1:-1]
+        if middle == _INTERNLM_ACTION_OPEN:
+            return ("open", _INTERNLM_ACTION_PAIR, _INTERNLM_ACTION_PAIR)
+        if middle == _INTERNLM_ACTION_CLOSE:
+            return ("close", _INTERNLM_ACTION_PAIR, _INTERNLM_ACTION_PAIR)
+        if middle == _INTERNLM_ACTION_PLUGIN:
+            return ("singleton", _INTERNLM_ACTION_PLUGIN, None)
         stripped = _strip_suffix(middle, _BEGIN_SUFFIXES)
         if stripped is not None:
             return ("open", stripped, None)
@@ -171,7 +190,7 @@ def _colorize_xml(text: str) -> str:
     their orphan-ness without poisoning the surrounding pairs.
     """
     pieces: list[str] = []
-    stack: list[tuple[str, int]] = []
+    stack: list[tuple[str, int, str | None]] = []
     last = 0
     for m in _TAG_RE.finditer(text):
         if m.start() > last:
@@ -182,7 +201,7 @@ def _colorize_xml(text: str) -> str:
         if kind is None:
             pieces.append(f'<span class="tt-orphan">{esc}</span>')
         elif kind == "singleton":
-            cls = _singleton_class_for(pair_id)
+            cls = _stable_color_class_for(pair_id)
             pieces.append(f'<span class="{cls}">{esc}</span>')
         elif kind == "close":
             match_at = -1
@@ -191,18 +210,20 @@ def _colorize_xml(text: str) -> str:
                     match_at = i
                     break
             if match_at >= 0:
-                for _, unmatched_idx in stack[match_at + 1 :]:
+                for _, unmatched_idx, _ in stack[match_at + 1 :]:
                     pieces[
                         unmatched_idx
                     ] = f'<span class="tt-orphan">{pieces[unmatched_idx]}</span>'
                 open_idx = stack[match_at][1]
-                # Per-instance color: every matched pair gets a fresh palette
-                # index, so two `<tool_call>...</tool_call>` (or two
-                # `<|start|>...<|call|>`) blocks in the same input render as
-                # different colors. (color_override unused on the paired
-                # path — kept on the singleton-flavor branch only.)
-                _ = color_override
-                cls = _next_color_class()
+                stable_pair = color_override or stack[match_at][2]
+                # Most pairs get per-instance colors so adjacent tool-call
+                # blocks remain easy to distinguish. Family-specific marker
+                # pairs can opt into stable colors across tooltip sections.
+                cls = (
+                    _stable_color_class_for(stable_pair)
+                    if stable_pair
+                    else _next_color_class()
+                )
                 pieces[open_idx] = f'<span class="{cls}">{pieces[open_idx]}</span>'
                 pieces.append(f'<span class="{cls}">{esc}</span>')
                 del stack[match_at:]
@@ -210,9 +231,9 @@ def _colorize_xml(text: str) -> str:
                 pieces.append(f'<span class="tt-orphan">{esc}</span>')
         else:
             pieces.append(esc)
-            stack.append((pair_id, len(pieces) - 1))
+            stack.append((pair_id, len(pieces) - 1, color_override))
         last = m.end()
-    for _, idx in stack:
+    for _, idx, _ in stack:
         pieces[idx] = f'<span class="tt-orphan">{pieces[idx]}</span>'
     if last < len(text):
         pieces.append(html_lib.escape(text[last:]))
@@ -221,16 +242,16 @@ def _colorize_xml(text: str) -> str:
 
 def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
     intervals: list[dict[str, Any]] = []
-    stack: list[tuple[str, int]] = []
+    stack: list[tuple[str, int, str | None]] = []
     for match in _TAG_RE.finditer(text):
         idx = len(intervals)
         tok = match.group(0)
-        kind, pair_id, _color_override = _tag_kind_and_name(tok[1:-1])
+        kind, pair_id, color_override = _tag_kind_and_name(tok[1:-1])
         intervals.append({"start": match.start(), "end": match.end(), "class": None})
         if kind is None:
             intervals[idx]["class"] = "tt-orphan"
         elif kind == "singleton":
-            intervals[idx]["class"] = _singleton_class_for(pair_id)
+            intervals[idx]["class"] = _stable_color_class_for(pair_id)
         elif kind == "close":
             match_at = -1
             for i in range(len(stack) - 1, -1, -1):
@@ -238,17 +259,22 @@ def _xml_token_intervals(text: str) -> list[dict[str, Any]]:
                     match_at = i
                     break
             if match_at >= 0:
-                for _, unmatched_idx in stack[match_at + 1 :]:
+                for _, unmatched_idx, _ in stack[match_at + 1 :]:
                     intervals[unmatched_idx]["class"] = "tt-orphan"
-                cls = _next_color_class()
+                stable_pair = color_override or stack[match_at][2]
+                cls = (
+                    _stable_color_class_for(stable_pair)
+                    if stable_pair
+                    else _next_color_class()
+                )
                 intervals[stack[match_at][1]]["class"] = cls
                 intervals[idx]["class"] = cls
                 del stack[match_at:]
             else:
                 intervals[idx]["class"] = "tt-orphan"
         else:
-            stack.append((pair_id, idx))
-    for _, idx in stack:
+            stack.append((pair_id, idx, color_override))
+    for _, idx, _ in stack:
         intervals[idx]["class"] = "tt-orphan"
     return intervals
 

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -24,9 +24,9 @@ td.cell { text-align: center; min-width: 24px; font-weight: 400; }
 td.cell.ok         { color: #0a7d2c; }
 td.cell.donly      { color: #8b949e; }
 td.cell.documented { color: #555; }
-td.cell.research   { color: #b00; }
-td.cell.leak       { color: #b00; }
-td.cell.err        { color: #b00; }
+td.cell.research   { color: #b00;    font-weight: bold; }
+td.cell.leak       { color: #b00;    font-weight: bold; }
+td.cell.err        { color: #222; }
 td.cell.na         { color: #aeb6bf; }
 td.cell.missing    { color: #8a6d3b; }
 td.cell a { color: inherit; text-decoration: none; display: block; }
@@ -251,7 +251,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   (e.g. V?, S? — diverges with no <code>reason:</code> yet) ·
   <span style="color:#b00">↯</span> Dynamo leaks tool call markup into <code>normal_text</code>
   (<code>expected.dynamo.reason:</code> carries the explanation) ·
-  <span style="color:#b00">!</span> expected-error suffix
+  <span style="color:#222">!</span> expected-error suffix
   (e.g. V!, S! — engine crashes by design) ·
   <span style="color:#aaa">n/a</span> not applicable ·
   <span style="color:#8a6d3b">—</span> missing fixture coverage ·
@@ -294,7 +294,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   (have <code>reason:</code>) ·
   <span style="color:#b00">{{ panel.stats.research }} research-needed</span>
   (no <code>reason:</code> yet) ·
-  <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
+  <span style="color:#222">{{ panel.stats.errors }} expected-errors</span>.
 </p>
 {% if panel.glossary_groups %}
 <div class="details-only">

--- a/tests/parity/toolcalling/fixtures/internlm/TOOLCALLING.batch.yaml
+++ b/tests/parity/toolcalling/fixtures/internlm/TOOLCALLING.batch.yaml
@@ -1,0 +1,807 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: internlm
+model_label: InternLM
+mode: batch
+cases:
+  TOOLCALLING.batch.1:
+    description: Single tool call with parameters (happy path)
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.2.a:
+    description: Two adjacent action/plugin calls
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "LA"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so multiple action wrappers raise ValueError instead of extracting every valid call.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.2.b:
+    description: Adjacent action/plugin calls with no prose separator
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "Boston"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so adjacent action wrappers raise ValueError instead of extracting both calls.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.2.c:
+    description: Multiple action/plugin calls with surrounding narration
+    model_text: 'Both: <|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "LA"}}<|action_end|> Done.'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'Both:'
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so multiple action wrappers raise ValueError instead of extracting both calls.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.2.d:
+    description: Multi-call ID / index distinctness is not part of the InternLM2 action/plugin grammar
+    reason: The InternLM action/plugin JSON body has name and parameters fields, but no model-emitted call ID or index to preserve.
+  TOOLCALLING.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools: *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
+      vllm:
+        calls: []
+        normal_text: Hello, how can I help you today?
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.4.a:
+    description: Generic malformed body inside action/plugin wrapper
+    model_text: <|action_start|><|plugin|>not json<|action_end|>
+    tools: *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: vLLM's Internlm2ToolParser calls json.loads on the action body and lets JSONDecodeError escape instead of treating malformed marker-wrapped content as no call.
+        error: 'JSONDecodeError: Expecting value'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.4.b:
+    description: Invalid JSON syntax inside action/plugin wrapper
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC",}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: vLLM's Internlm2ToolParser calls json.loads on the action body and lets JSONDecodeError escape instead of treating invalid marker-wrapped JSON as no call.
+        error: 'JSONDecodeError: Expecting property name enclosed in double quotes'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.4.c:
+    description: Missing required name key inside action/plugin object
+    model_text: '<|action_start|><|plugin|>{"parameters": {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: vLLM's Internlm2ToolParser assumes action_dict["name"] exists and lets KeyError escape when the JSON object is missing the required name key.
+        error: 'KeyError: ''name'''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.4.d:
+    description: Malformed wrapper missing the plugin marker
+    model_text: '<|action_start|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: vLLM preserves malformed InternLM marker text in normal_text when the plugin marker is missing; Dynamo suppresses
+          the malformed wrapper and recovers the JSON tool body.
+        calls: []
+        normal_text: '<|action_start|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.4.e:
+    description: Malformed prefix followed by a valid action/plugin object
+    model_text: '<|action_start|><|plugin|>not json<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters":
+      {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so multiple action blocks raise ValueError instead of recovering or suppressing malformed content.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.4.f:
+    description: Tool-name XML tag case is not part of the InternLM2 action/plugin grammar
+    reason: InternLM2 uses a JSON object after <|action_start|><|plugin|>. It does not encode the tool name as an XML-style
+      tag.
+  TOOLCALLING.batch.5.a:
+    description: Missing closing action_end marker after complete action/plugin JSON
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.5.b:
+    description: Orphan closing action_end marker without action/plugin opener
+    model_text: '{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: vLLM preserves an orphan InternLM action_end marker in normal_text; Dynamo strips the orphan marker and recovers
+          the JSON tool body.
+        calls: []
+        normal_text: '{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.5.c:
+    description: Truncated mid-call body
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NY'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''
+      vllm:
+        reason: vLLM calls json.loads on the truncated action body and lets JSONDecodeError escape instead of suppressing the incomplete tool-call block.
+        error: 'JSONDecodeError: Unterminated string'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.5.d:
+    description: Multiple action/plugin calls with the final action_end marker missing
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "LA"}}'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so multiple action wrappers raise ValueError before it can recover the missing final end marker.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.5.e:
+    description: Multiple action/plugin calls with the trailing call truncated mid-argument
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NY'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so multiple action wrappers raise ValueError before it can recover the truncated trailing call.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.6.a:
+    description: Canonical empty parameters object
+    model_text: '<|action_start|><|plugin|>{"name": "refresh", "parameters": {}}<|action_end|>'
+    tools: &id002
+    - name: refresh
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      dynamo:
+        calls:
+        - name: refresh
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: refresh
+          arguments: {}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.6.b:
+    description: Empty parameters object with whitespace and newlines
+    model_text: |-
+      <|action_start|><|plugin|>{
+        "name": "refresh",
+        "parameters": {
+        }
+      }<|action_end|>
+    tools: *id002
+    expected:
+      dynamo:
+        calls:
+        - name: refresh
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: refresh
+          arguments: {}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.6.c:
+    description: Missing parameters / arguments key for parameterless tool
+    model_text: '<|action_start|><|plugin|>{"name": "refresh"}<|action_end|>'
+    tools: *id002
+    expected:
+      dynamo:
+        calls:
+        - name: refresh
+          arguments: {}
+        normal_text: ''
+      vllm:
+        calls:
+        - name: refresh
+          arguments: {}
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.7.a:
+    description: Standard scalar and container argument types
+    model_text: '<|action_start|><|plugin|>{"name": "test_function", "parameters": {"string_field": "hello", "int_field":
+      42, "float_field": 3.14, "bool_field": true, "null_field": null, "array_field": ["a", "b"], "object_field": {"nested":
+      "value"}}}<|action_end|>'
+    tools: &id003
+    - name: test_function
+      parameters:
+        type: object
+        properties:
+          string_field:
+            type: string
+          int_field:
+            type: integer
+          float_field:
+            type: number
+          bool_field:
+            type: boolean
+          null_field:
+            type: string
+          array_field:
+            type: array
+            items:
+              type: string
+          object_field:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: test_function
+          arguments:
+            string_field: hello
+            int_field: 42
+            float_field: 3.14
+            bool_field: true
+            null_field: null
+            array_field:
+            - a
+            - b
+            object_field:
+              nested: value
+        normal_text: ''
+      vllm:
+        calls:
+        - name: test_function
+          arguments:
+            string_field: hello
+            int_field: 42
+            float_field: 3.14
+            bool_field: true
+            null_field: null
+            array_field:
+            - a
+            - b
+            object_field:
+              nested: value
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.7.b:
+    description: Escaped and special string values
+    model_text: '<|action_start|><|plugin|>{"name": "test_function", "parameters": {"quoted": "He said \"hello\"", "path":
+      "C:\\Users\\file.txt", "newline": "line1\nline2", "html": "<b>bold</b>"}}<|action_end|>'
+    tools: *id003
+    expected:
+      dynamo:
+        calls:
+        - name: test_function
+          arguments:
+            quoted: He said "hello"
+            path: C:\Users\file.txt
+            newline: |-
+              line1
+              line2
+            html: <b>bold</b>
+        normal_text: ''
+      vllm:
+        calls:
+        - name: test_function
+          arguments:
+            quoted: He said "hello"
+            path: C:\Users\file.txt
+            newline: |-
+              line1
+              line2
+            html: <b>bold</b>
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.7.c:
+    description: Schema mismatch preserves string value
+    model_text: '<|action_start|><|plugin|>{"name": "set_temperature", "parameters": {"celsius": "20"}}<|action_end|>'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
+      vllm:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.7.d:
+    description: Multiple arguments with nested object and array values
+    model_text: '<|action_start|><|plugin|>{"name": "book_trip", "parameters": {"city": "Tokyo", "days": 3, "options": {"hotel":
+      true, "tags": ["business", "wifi"]}}}<|action_end|>'
+    tools:
+    - name: book_trip
+      parameters:
+        type: object
+        properties:
+          city:
+            type: string
+          days:
+            type: integer
+          options:
+            type: object
+    expected:
+      dynamo:
+        calls:
+        - name: book_trip
+          arguments:
+            city: Tokyo
+            days: 3
+            options:
+              hotel: true
+              tags:
+              - business
+              - wifi
+        normal_text: ''
+      vllm:
+        calls:
+        - name: book_trip
+          arguments:
+            city: Tokyo
+            days: 3
+            options:
+              hotel: true
+              tags:
+              - business
+              - wifi
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.7.e:
+    description: Larger nested payload with null and empty containers
+    model_text: '<|action_start|><|plugin|>{"name": "submit_payload", "parameters": {"items": [{"id": 1, "meta": {"tags":
+      [], "note": null}}, {"id": 2, "meta": {"tags": ["x"], "note": "ok"}}], "empty_object": {}, "empty_array": []}}<|action_end|>'
+    tools:
+    - name: submit_payload
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          empty_object:
+            type: object
+          empty_array:
+            type: array
+    expected:
+      dynamo:
+        calls:
+        - name: submit_payload
+          arguments:
+            items:
+            - id: 1
+              meta:
+                tags: []
+                note: null
+            - id: 2
+              meta:
+                tags:
+                - x
+                note: ok
+            empty_object: {}
+            empty_array: []
+        normal_text: ''
+      vllm:
+        calls:
+        - name: submit_payload
+          arguments:
+            items:
+            - id: 1
+              meta:
+                tags: []
+                note: null
+            - id: 2
+              meta:
+                tags:
+                - x
+                note: ok
+            empty_object: {}
+            empty_array: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.7.f:
+    description: Numeric precision edge
+    model_text: '<|action_start|><|plugin|>{"name": "record_number", "parameters": {"value": 9007199254740993}}<|action_end|>'
+    tools:
+    - name: record_number
+      parameters:
+        type: object
+        properties:
+          value:
+            type: integer
+    expected:
+      dynamo:
+        calls:
+        - name: record_number
+          arguments:
+            value: 9007199254740993
+        normal_text: ''
+      vllm:
+        calls:
+        - name: record_number
+          arguments:
+            value: 9007199254740993
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.8.a:
+    description: Text before tool call
+    model_text: 'Let me check.<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me check.
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me check.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.8.b:
+    description: Text after tool call
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>Done.'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.8.c:
+    description: Text before and after tool call
+    model_text: 'Let me check.<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>Done.'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me check.
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me check.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.8.d:
+    description: Narration between multiple action/plugin calls
+    model_text: 'I will check the weather. <|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|> Then check LA weather. <|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "LA"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so narration between multiple action wrappers raises ValueError instead of extracting both calls.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.9.a:
+    description: Empty model text
+    model_text: ''
+    tools: *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.9.b:
+    description: Blank / whitespace-only model text
+    model_text: '   '
+    tools: *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.10:
+    description: Duplicate action/plugin calls
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so duplicate action wrappers raise ValueError instead of preserving both calls.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.13.a:
+    description: Unknown-only action/plugin call
+    model_text: '<|action_start|><|plugin|>{"name": "unknown_tool", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: unknown_tool
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.13.c:
+    description: Mixed known and unknown action/plugin calls
+    model_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_start|><|plugin|>{"name": "unknown_tool", "parameters": {"location": "LA"}}<|action_end|>'
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: unknown_tool
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so mixed known and unknown action wrappers raise ValueError instead of extracting both calls.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.30.a:
+    description: Call separator character inside an argument string is not part of the InternLM2 action/plugin grammar
+    reason: InternLM2 uses one JSON object rather than a delimiter-separated multi-call grammar, so there is no call separator
+      for this family.
+  TOOLCALLING.batch.30.b:
+    description: JSON structural delimiters inside one argument string value
+    model_text: '<|action_start|><|plugin|>{"name": "run_query", "parameters": {"sql": "SELECT value WHERE note has brace
+      } and bracket ]"}}<|action_end|>'
+    tools: &id004
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      vllm:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.30.c:
+    description: Action/plugin marker text inside one argument string value
+    model_text: '<|action_start|><|plugin|>{"name": "run_query", "parameters": {"sql": "SELECT ''<|action_start|><|plugin|>not
+      a call<|action_end|>'' as marker"}}<|action_end|>'
+    tools: *id004
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT '<|action_start|><|plugin|>not a call<|action_end|>' as marker
+        normal_text: ''
+      vllm:
+        reason: vLLM splits on the marker string inside the argument value and raises ValueError instead of treating marker-looking text inside JSON strings as data.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.batch.31.a:
+    description: Multi-call separator character case is not part of the InternLM2 action/plugin grammar
+    reason: InternLM action/plugin calls are separated by structural markers, not by a call separator character. TOOLCALLING.batch.31.b covers the applicable multi-call structural-marker case.
+  TOOLCALLING.batch.31.b:
+    description: Multiple action/plugin calls with JSON structural delimiters inside one argument string
+    model_text: '<|action_start|><|plugin|>{"name": "run_query", "parameters": {"sql": "SELECT value WHERE note has brace } and bracket ]"}}<|action_end|><|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT value WHERE note has brace } and bracket ]
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: vLLM's batch InternLM parser splits on "<|action_start|><|plugin|>" expecting one action block, so multiple wrappers raise ValueError even when marker-looking structural characters are only JSON string data.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'

--- a/tests/parity/toolcalling/fixtures/internlm/TOOLCALLING.stream.1.yaml
+++ b/tests/parity/toolcalling/fixtures/internlm/TOOLCALLING.stream.1.yaml
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: internlm
+model_label: InternLM
+mode: stream
+cases:
+  TOOLCALLING.stream.1.a:
+    description: Complete tool-call payload delivered in one content chunk
+    chunks:
+    - delta_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    - delta_text: ''
+      finish_reason: tool_calls
+    tools: &id001
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+        reason: vLLM Internlm2ToolParser emits the tool name first, then logs ValueError while trying to stream arguments
+          from the same completed JSON payload. The returned call keeps empty arguments.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.stream.1.b:
+    description: Complete tool call split across parser-significant boundaries
+    chunks:
+    - delta_text: <|action_start|><|plugin|>
+    - delta_text: '{"name": "get_weather", '
+    - delta_text: '"parameters": {"location": "NYC"}}'
+    - delta_text: <|action_end|>
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+        reason: vLLM Internlm2ToolParser emits the tool name first, then logs ValueError when the later delta text does not
+          appear in json.dumps(parameters). The returned call keeps empty arguments.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.stream.2:
+    description: Multiple streaming action/plugin calls
+    chunks:
+    - delta_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>'
+    - delta_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "LA"}}<|action_end|>'
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      vllm:
+        reason: vLLM's streaming InternLM parser splits the accumulated text on "<|action_start|><|plugin|>" expecting one action block, so multiple action wrappers raise ValueError instead of extracting both calls.
+        error: 'ValueError: too many values to unpack'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.stream.3:
+    description: Start marker split across chunks
+    chunks:
+    - delta_text: <|action
+    - delta_text: '_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}'
+    - delta_text: <|action_end|>
+      finish_reason: tool_calls
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: <|action
+        reason: vLLM flushes the partial start marker as normal content before the full <|action_start|><|plugin|> marker
+          is available, so the later chunks no longer reconstruct a call.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.stream.4.a:
+    description: Stream ends after complete JSON but before action_end marker
+    chunks:
+    - delta_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NYC"}}'
+      finish_reason: length
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+        reason: vLLM can emit the tool name from the complete JSON object before action_end arrives, but its streaming argument-delta
+          path does not emit the parameters.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.stream.4.b:
+    description: Stream ends mid-call body
+    chunks:
+    - delta_text: '<|action_start|><|plugin|>{"name": "get_weather", "parameters": {"location": "NY'
+      finish_reason: length
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+        reason: vLLM can emit the tool name from the partial JSON object, but the truncated argument string is not emitted
+          through its streaming argument-delta path.
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'
+  TOOLCALLING.stream.4.c:
+    description: Inner JSON body without required action/plugin wrapper plus orphan close markers
+    chunks:
+    - delta_text: '{"name": "get_weather", "parameters": {"location": "NYC"}}'
+    - delta_text: <|action_end|><|action_end|>
+      finish_reason: stop
+    tools: *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        reason: vLLM preserves orphan InternLM action_end markers in normal_text; Dynamo strips the orphan markers and recovers
+          the JSON tool body.
+        calls: []
+        normal_text: '{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|><|action_end|>'
+      sglang:
+        unavailable: SGLang has no detector for family='internlm'

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -589,7 +589,8 @@ _TOOL_CALL_MARKUP_RE = re.compile(
     r"</?tool_call|</?tool_calls|<\|tool_call|<\|tool_calls|"
     r"<\|(?:channel|message|call|python_tag)\|>|"
     r"</?TOOLCALL|TOOL_CALLS|<｜(?:DSML｜)?(?:tool|tool▁call|tool▁calls)|"
-    r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value"
+    r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value|"
+    r"<\|action_(?:start|end)\|>|<\|plugin\|>"
 )
 
 
@@ -816,7 +817,10 @@ def _format_output_block_html(block, family: str | None = None) -> str:
     if block.get("unavailable"):
         return html_lib.escape(f"unavailable: {block['unavailable']}")
     if "error" in block:
-        return html_lib.escape(f"error matching {block['error']!r}")
+        lines = [f"expected error: {block['error']}"]
+        if block.get("reason"):
+            lines.append(f"reason: {block['reason']}")
+        return html_lib.escape("\n".join(lines))
     nt = block.get("normal_text", "") or ""
     calls = block.get("calls") or []
     if calls:
@@ -915,7 +919,8 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
     Each non-matching, non-unavailable peer contributes one line:
       vllm: <reason>                        # `reason:` field present
       vllm: UNKNOWN — divergent ...         # divergent, no reason
-      vllm: expected error matching '...'   # `error:` field present
+      vllm: expected error: ...             # `error:` field present
+      vllm: <reason> (expected error: ...)  # `error:` plus `reason:`
     """
     parts: list[str] = []
     n_dyn = {
@@ -930,7 +935,12 @@ def _tooltip_for(case: dict, dyn: dict) -> str:
             continue
         name = _IMPL_DISPLAY.get(impl, impl)
         if "error" in block:
-            parts.append(f"{name}: expected error matching {block['error']!r}")
+            if block.get("reason"):
+                parts.append(
+                    f"{name}: {block['reason']} (expected error: {block['error']})"
+                )
+            else:
+                parts.append(f"{name}: expected error: {block['error']}")
             continue
         # Don't rely on PyYAML preserving anchor identity (the `block is dyn`
         # check above is the fast path; value equality is the safety net).

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.parity.markup import colorize_markup, colorize_stream_deltas
+
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.pre_merge,
@@ -50,6 +52,8 @@ def test_generate_parser_parity_table_html() -> None:
     assert "<html" in html.lower()
     assert "<table" in html.lower()
     assert "Dynamo Tool Calling Parser - Parity Table" in html
+    assert "td.cell.err        { color: #222; }" in html
+    assert '<span style="color:#222">!</span> expected-error suffix' in html
     assert re.search(
         r'data-col-toggle="model"[^>]+data-default-visible="true"[^>]+aria-pressed="true"',
         html,
@@ -189,6 +193,19 @@ def test_generate_combined_parity_table_html() -> None:
 
 
 @pytest.mark.timeout(60)
+def test_toolcalling_html_shows_reason_for_expected_vllm_python_error() -> None:
+    html = _render_html("--mode", "batch")
+
+    assert "TOOLCALLING.batch.4.c — internlm" in html
+    assert "expected error: KeyError: &#x27;name&#x27;" in html
+    assert (
+        "vLLM&#x27;s Internlm2ToolParser assumes action_dict[&quot;name&quot;] exists"
+        in html
+    )
+    assert "(expected error: KeyError: &#x27;name&#x27;)" in html
+
+
+@pytest.mark.timeout(60)
 def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> None:
     html = _render_html_for("reasoning")
 
@@ -231,6 +248,56 @@ def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> N
         r'<div class="ttip"><div class="ttip-head">REASONING\.batch\.3\.a — minimax_append_think',
         html,
     )
+
+
+def test_internlm_action_markers_are_colorized_as_tool_call_markup() -> None:
+    html = colorize_markup(
+        '<|action_start|><|plugin|>{"name": "refresh"}<|action_end|>',
+        "internlm",
+    )
+    second_html = colorize_markup(
+        '<|action_start|><|plugin|>{"parameters": {"location": "NYC"}}<|action_end|>',
+        "internlm",
+    )
+
+    assert "tt-orphan" not in html
+    start = re.search(r'<span class="(tt-c\d+)">&lt;\|action_start\|&gt;</span>', html)
+    end = re.search(r'<span class="(tt-c\d+)">&lt;\|action_end\|&gt;</span>', html)
+    plugin = re.search(r'<span class="(tt-c\d+)">&lt;\|plugin\|&gt;</span>', html)
+    second_start = re.search(
+        r'<span class="(tt-c\d+)">&lt;\|action_start\|&gt;</span>',
+        second_html,
+    )
+    second_plugin = re.search(
+        r'<span class="(tt-c\d+)">&lt;\|plugin\|&gt;</span>',
+        second_html,
+    )
+    assert start is not None
+    assert end is not None
+    assert plugin is not None
+    assert second_start is not None
+    assert second_plugin is not None
+    assert start.group(1) == end.group(1)
+    assert start.group(1) == plugin.group(1)
+    assert start.group(1) == second_start.group(1)
+    assert plugin.group(1) == second_plugin.group(1)
+
+
+def test_internlm_split_action_marker_is_colorized_across_stream_chunks() -> None:
+    chunks = [
+        {"delta_text": "<|action"},
+        {"delta_text": '_start|><|plugin|>{"name": "refresh"}'},
+        {"delta_text": "<|action_end|>"},
+    ]
+
+    rendered = colorize_stream_deltas(chunks, "internlm")
+
+    assert "tt-orphan" not in "".join(rendered)
+    first = re.search(r'<span class="(tt-c\d+)">&lt;\|action</span>', rendered[0])
+    second = re.search(r'<span class="(tt-c\d+)">_start\|&gt;</span>', rendered[1])
+    assert first is not None
+    assert second is not None
+    assert first.group(1) == second.group(1)
 
 
 def _render_html(*extra_args: str) -> str:

--- a/tests/parity/toolcalling/vllm.py
+++ b/tests/parity/toolcalling/vllm.py
@@ -233,6 +233,7 @@ _FAMILY_TO_VLLM_KEY = {
     "mistral": "mistral",
     "jamba": "jamba",
     "llama3_json": "llama3_json",
+    "internlm": "internlm",
     "phi4": "phi4_mini_json",
     "harmony": "openai",  # gpt-oss / harmony parser registered as "openai"
     "pythonic": "pythonic",


### PR DESCRIPTION
#### Overview:

This PR adds InternLM tool parser parity coverage and makes Dynamo recover common InternLM marker failures without leaking parser syntax.

#### Details:

- **How is this fixed?** Add an InternLM JSON parser config and replace marker extraction with JSON-aware scanning so malformed wrappers can be skipped, multiple action blocks can be parsed, and orphan markers can be stripped when the remaining body is valid JSON.
- Add InternLM batch and stream parity fixtures for normal calls, multi-call blocks, malformed and recovery cases, argument shapes, marker-looking argument text, and vLLM error cases.
- Mark InternLM action/plugin/end markers as parser markup in the parity HTML so `<|action_start|><|plugin|>` and `<|action_end|>` are highlighted consistently across input and output sections.
- Show expected peer parser errors as normal black `V!`/`S!` cells, with the vLLM reason rendered in the tooltip instead of treating the expected error as a Dynamo attention item.
- Concrete failure mode: `{"name": "get_weather", "parameters": {"location": "NYC"}}<|action_end|>` previously returned no Dynamo tool call; Dynamo now strips the orphan end marker and emits `get_weather(location=NYC)`.

#### Verification:

InternLM Dynamo/vLLM captures have 0/43 drift; `python3 -m pytest tests/parity/toolcalling/test_generate_parity_table.py` passed 6 tests; `python3 -m pytest tests/parity/toolcalling/test_parity_toolcalling.py -k internlm` passed 86 tests with 55 skips; `cargo test --locked -p dynamo-parsers -- --nocapture` passed 578 tests with 4 ignored.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/json/base_json_parser.rs`, then `tests/parity/toolcalling/fixtures/internlm/TOOLCALLING.batch.yaml`

#### Related Issues:

Relates to DIS-2141

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added InternLM tool-calling support with JSON-based parsing
  * Enabled recovery mechanisms for incomplete or malformed tool wrappers
  * Support for name-only tool calls with empty arguments

* **Bug Fixes**
  * Improved JSON parsing robustness across wrapper boundaries
  * Enhanced handling of orphan end tokens and missing markers

* **Tests**
  * Added comprehensive test fixtures for InternLM streaming and batch scenarios

* **Style**
  * Updated error visualization colors in test reports
  * Enhanced markup colorization consistency for tool markers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->