### PR TITLE
feat: add vLLM RL metadata uploads via fsspec

### DIFF
--- a/components/src/dynamo/common/metadata_upload.py
+++ b/components/src/dynamo/common/metadata_upload.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+_DEFAULT_FORMAT = "msgpack"
+_FORMATS = {"json", "msgpack"}
+
+
+def _backend_metadata_upload_settings(request: dict[str, Any]) -> dict[str, Any] | None:
+    nvext = request.get("nvext")
+    extra_args = request.get("extra_args") or {}
+    extra_nvext = extra_args.get("nvext") if isinstance(extra_args, dict) else None
+
+    for source in (nvext, extra_nvext):
+        if not isinstance(source, dict):
+            continue
+        settings = source.get("metadata_upload")
+        if settings:
+            return settings
+    return None
+
+
+async def _upload_bytes(url: str, storage_path: str, data: bytes) -> str:
+    try:
+        from dynamo.common.storage import get_fs, upload_to_fs
+    except ImportError as exc:
+        raise RuntimeError(
+            "Metadata upload requires fsspec support. "
+            "Install fsspec and the backend extra, for example `fsspec[s3]` for S3."
+        ) from exc
+
+    return await upload_to_fs(get_fs(url), storage_path, data)
+
+
+def _serialize_payload(payload: dict[str, Any], payload_format: str) -> bytes:
+    try:
+        import zstandard as zstd
+    except ImportError as exc:
+        raise RuntimeError(
+            "Metadata upload requires zstandard. "
+            "Install ai-dynamo with the selected backend extra or add the zstandard package."
+        ) from exc
+
+    if payload_format == "json":
+        raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+    else:
+        try:
+            import msgspec
+        except ImportError as exc:
+            raise RuntimeError("Metadata msgpack upload requires msgspec.") from exc
+        raw = msgspec.msgpack.encode(payload)
+
+    try:
+        return zstd.ZstdCompressor().compress(raw)
+    finally:
+        del raw
+
+
+@dataclass
+class ChoiceMetadata:
+    choice_index: int
+    log_probs: list[float] = field(default_factory=list)
+    top_logprobs: list[list[dict[str, Any]]] = field(default_factory=list)
+    routed_experts: Any = None
+
+    def add_logprobs(
+        self,
+        log_probs: list[float] | None,
+        top_logprobs: list[list[dict[str, Any]]] | None,
+    ) -> None:
+        if log_probs:
+            self.log_probs.extend(log_probs)
+        if top_logprobs:
+            self.top_logprobs.extend(top_logprobs)
+
+    def has_payload(self) -> bool:
+        return bool(
+            self.log_probs or self.top_logprobs or self.routed_experts is not None
+        )
+
+    def release_payload(self) -> None:
+        self.log_probs.clear()
+        self.top_logprobs.clear()
+        self.routed_experts = None
+
+    def to_payload(self) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        if self.log_probs:
+            metadata["log_probs"] = self.log_probs
+        if self.top_logprobs:
+            metadata["top_logprobs"] = self.top_logprobs
+        if self.routed_experts is not None:
+            metadata["routed_experts"] = self.routed_experts
+
+        return {
+            "schema_version": 1,
+            "metadata": metadata,
+        }
+
+
+@dataclass(frozen=True)
+class MetadataUploader:
+    url: str
+    payload_format: str = _DEFAULT_FORMAT
+
+    def __post_init__(self) -> None:
+        url = self.url.strip()
+        if not url:
+            raise ValueError("metadata_upload.url must not be empty")
+
+        payload_format = self.payload_format.strip().lower()
+        if payload_format not in _FORMATS:
+            raise ValueError("metadata_upload.format must be one of: json, msgpack")
+        object.__setattr__(self, "url", url)
+        object.__setattr__(self, "payload_format", payload_format)
+
+    @classmethod
+    def from_settings(cls, settings: dict[str, Any] | None) -> MetadataUploader | None:
+        if not settings or not settings.get("url"):
+            return None
+        return cls(
+            url=settings["url"],
+            payload_format=settings.get("format", _DEFAULT_FORMAT),
+        )
+
+    @classmethod
+    def from_backend_request(cls, request: dict[str, Any]) -> MetadataUploader | None:
+        return cls.from_settings(_backend_metadata_upload_settings(request))
+
+    async def upload_choice(self, choice: ChoiceMetadata) -> None:
+        if not choice.has_payload():
+            return None
+
+        storage_path = f"choice_{choice.choice_index}.{self.payload_format}.zst"
+        payload = choice.to_payload()
+        data = await asyncio.to_thread(_serialize_payload, payload, self.payload_format)
+        try:
+            await _upload_bytes(self.url, storage_path, data)
+        finally:
+            del data
+            del payload

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -267,7 +267,9 @@ def _base_preproc():
     }
 
 
-async def _run_generate(processor, preproc, *, mm_routing_info=None, context=None):
+async def _run_generate(
+    processor, preproc, *, request=None, mm_routing_info=None, context=None
+):
     vllm_preproc = SimpleNamespace(
         sampling_params=SimpleNamespace(n=1),
         request_id="vllm-request",
@@ -279,7 +281,7 @@ async def _run_generate(processor, preproc, *, mm_routing_info=None, context=Non
         item
         async for item in processor._generate_and_stream(
             "request-id",
-            {"model": MODEL},
+            request or {"model": MODEL},
             preproc,
             preproc["token_ids"],
             vllm_preproc,
@@ -338,6 +340,33 @@ class TestRoutedEnginePath:
                 "object": "chat.completion.chunk",
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_routed_stream_metadata_upload_does_not_emit_engine_data(
+        self, vllm_processor_module
+    ):
+        routed_engine = _FakeRoutedEngine(
+            [
+                {
+                    "token_ids": [101],
+                    "index": 0,
+                    "finish_reason": "length",
+                    "engine_data": {"some_backend_payload": True},
+                }
+            ]
+        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
+
+        chunks = await _run_generate(
+            processor,
+            _base_preproc(),
+            request={
+                "model": MODEL,
+                "nvext": {"metadata_upload": {"url": "file:///tmp/rollout"}},
+            },
+        )
+
+        assert "nvext" not in chunks[0]
 
 
 OBJECT_TYPED_TOOL_REQUEST = {

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -41,6 +41,7 @@ from .utils import (
     extract_mm_urls,
     handle_engine_error,
     make_internal_error,
+    nvext_extra_field_requested,
     random_uuid,
 )
 
@@ -454,6 +455,15 @@ class VllmProcessor:
             "annotations": [],
             "routing": request.get("routing"),
         }
+        # Backend preproc carries nvext passthrough in extra_args, matching Rust.
+        nvext = request.get("nvext") or {}
+        nvext_passthrough = {
+            key: nvext[key]
+            for key in ("metadata_upload", "extra_fields")
+            if key in nvext
+        }
+        if nvext_passthrough:
+            dynamo_preproc["extra_args"] = {"nvext": nvext_passthrough}
         if reasoning_ended is not None:
             dynamo_preproc["reasoning_ended"] = reasoning_ended
         if reasoning_parser_kwargs is not None:
@@ -688,6 +698,11 @@ class VllmProcessor:
                     }
                     if usage := engine_response.get("completion_usage"):
                         dynamo_out["usage"] = usage
+                    engine_data = engine_response.get("engine_data")
+                    if engine_data is not None and (
+                        nvext_extra_field_requested(request, "engine_data")
+                    ):
+                        dynamo_out["nvext"] = {"engine_data": engine_data}
 
                     yield dynamo_out
             _nvtx.end_range(rng_stream)

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -127,7 +127,11 @@ def parse_args(argv: list[str] | None = None) -> Config:
 
 
 def _arg_was_provided(argv: list[str], option: str) -> bool:
-    return any(arg == option or arg.startswith(f"{option}=") for arg in argv)
+    aliases = {option, option.replace("-", "_")}
+    return any(
+        arg in aliases or any(arg.startswith(f"{alias}=") for alias in aliases)
+        for arg in argv
+    )
 
 
 def cross_validate_config(

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -135,6 +135,16 @@ def _arg_was_provided(argv: list[str], option: str) -> bool:
     )
 
 
+def configure_rl_logprobs_mode(config: Config) -> None:
+    if (
+        config.enable_rl
+        and not config.logprobs_mode_explicitly_set
+        and config.engine_args.logprobs_mode == "raw_logprobs"
+    ):
+        config.engine_args.logprobs_mode = "processed_logprobs"
+        logger.info("Defaulting logprobs_mode=processed_logprobs (--enable-rl active).")
+
+
 def cross_validate_config(
     dynamo_config: Config, engine_config: AsyncEngineArgs
 ) -> None:

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -127,7 +127,8 @@ def parse_args(argv: list[str] | None = None) -> Config:
 
 
 def _arg_was_provided(argv: list[str], option: str) -> bool:
-    aliases = {option, option.replace("-", "_")}
+    normalized = option[:2] + option[2:].replace("-", "_")
+    aliases = {option, normalized}
     return any(
         arg in aliases or any(arg.startswith(f"{alias}=") for alias in aliases)
         for arg in argv

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import socket
+import sys
 from typing import Any, Dict, Optional
 
 from vllm.distributed.kv_events import KVEventsConfig
@@ -51,6 +52,7 @@ class Config(DynamoRuntimeConfig, DynamoVllmConfig):
 
     # rest vLLM args
     engine_args: AsyncEngineArgs
+    logprobs_mode_explicitly_set: bool = False
 
     def validate(self) -> None:
         DynamoRuntimeConfig.validate(self)
@@ -72,6 +74,7 @@ def parse_args(argv: list[str] | None = None) -> Config:
     Returns:
         Config: Parsed configuration object.
     """
+    raw_argv = sys.argv[1:] if argv is None else argv
     dynamo_runtime_argspec = DynamoRuntimeArgGroup()
     dynamo_vllm_argspec = DynamoVllmArgGroup()
 
@@ -117,7 +120,14 @@ def parse_args(argv: list[str] | None = None) -> Config:
     update_engine_config_with_dynamo(dynamo_config, engine_config)
 
     dynamo_config.engine_args = engine_config
+    dynamo_config.logprobs_mode_explicitly_set = _arg_was_provided(
+        raw_argv, "--logprobs-mode"
+    )
     return dynamo_config
+
+
+def _arg_was_provided(argv: list[str], option: str) -> bool:
+    return any(arg == option or arg.startswith(f"{option}=") for arg in argv)
 
 
 def cross_validate_config(

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import socket
-import sys
 from typing import Any, Dict, Optional
 
 from vllm.distributed.kv_events import KVEventsConfig
@@ -52,7 +51,6 @@ class Config(DynamoRuntimeConfig, DynamoVllmConfig):
 
     # rest vLLM args
     engine_args: AsyncEngineArgs
-    logprobs_mode_explicitly_set: bool = False
 
     def validate(self) -> None:
         DynamoRuntimeConfig.validate(self)
@@ -74,7 +72,6 @@ def parse_args(argv: list[str] | None = None) -> Config:
     Returns:
         Config: Parsed configuration object.
     """
-    raw_argv = sys.argv[1:] if argv is None else argv
     dynamo_runtime_argspec = DynamoRuntimeArgGroup()
     dynamo_vllm_argspec = DynamoVllmArgGroup()
 
@@ -120,29 +117,23 @@ def parse_args(argv: list[str] | None = None) -> Config:
     update_engine_config_with_dynamo(dynamo_config, engine_config)
 
     dynamo_config.engine_args = engine_config
-    dynamo_config.logprobs_mode_explicitly_set = _arg_was_provided(
-        raw_argv, "--logprobs-mode"
-    )
     return dynamo_config
 
 
-def _arg_was_provided(argv: list[str], option: str) -> bool:
-    normalized = option[:2] + option[2:].replace("-", "_")
-    aliases = {option, normalized}
-    return any(
-        arg in aliases or any(arg.startswith(f"{alias}=") for alias in aliases)
-        for arg in argv
-    )
-
-
 def configure_rl_logprobs_mode(config: Config) -> None:
-    if (
-        config.enable_rl
-        and not config.logprobs_mode_explicitly_set
-        and config.engine_args.logprobs_mode == "raw_logprobs"
-    ):
+    if not config.enable_rl:
+        return
+
+    if config.engine_args.logprobs_mode == "raw_logprobs":
         config.engine_args.logprobs_mode = "processed_logprobs"
         logger.info("Defaulting logprobs_mode=processed_logprobs (--enable-rl active).")
+        return
+
+    if config.engine_args.logprobs_mode != "processed_logprobs":
+        raise ValueError(
+            "--enable-rl requires logprobs_mode=processed_logprobs; "
+            f"got {config.engine_args.logprobs_mode!r}."
+        )
 
 
 def cross_validate_config(

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -102,6 +102,18 @@ class DynamoVllmArgGroup(ArgGroup):
             default=False,
             help="Enable multimodal processing. If not set, none of the multimodal components can be used.",
         )
+        # Select defaults used by RL-style token-in/token-out deployments.
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-rl",
+            env_var="DYN_ENABLE_RL",
+            default=False,
+            help=(
+                "Enable RL training support. Mirrors --enable-rl on the SGLang "
+                "backend and selects RL-friendly vLLM defaults for TITO and "
+                "per-token logprob parity."
+            ),
+        )
         add_argument(
             g,
             flag_name="--mm-prompt-template",
@@ -264,6 +276,8 @@ class DynamoVllmConfig(ConfigBase):
     multimodal_worker: bool
     multimodal_decode_worker: bool
     enable_multimodal: bool
+    # Enables RL-style token-in/token-out defaults.
+    enable_rl: bool = False
     mm_prompt_template: str
     frontend_decoding: bool
     embedding_transfer_mode: Union[

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -377,6 +377,18 @@ def _apply_nvext_cache_salt(request: Dict[str, Any], prompt: Any) -> None:
         prompt["cache_salt"] = cache_salt
 
 
+def _prompt_token_ids_for_engine_data(
+    request: Dict[str, Any],
+    prompt: Any,
+) -> list[int]:
+    prompt_token_ids = (
+        prompt.get("prompt_token_ids")
+        if isinstance(prompt, dict)
+        else request.get("token_ids")
+    )
+    return list(prompt_token_ids or [])
+
+
 def _flatten_logprobs(
     log_probs: Any,
 ) -> Optional[list[float]]:
@@ -2667,7 +2679,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # back in engine_data so the client doesn't have to re-derive
                 # them from a request it might no longer hold.
                 request_prompt_token_ids = (
-                    list(request.get("token_ids") or []) if want_engine_data else None
+                    _prompt_token_ids_for_engine_data(request, prompt)
+                    if want_engine_data
+                    else None
                 )
                 accumulated_token_ids: dict[int, list[int]] = {}
                 accumulated_log_probs: dict[int, list[float]] = {}

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -547,7 +547,12 @@ def build_sampling_params(
     sampling_params.detokenize = False
 
     # Handle guided_decoding - convert to StructuredOutputsParams
-    sampling_options = request.get("sampling_options", {})
+    sampling_options = dict(request.get("sampling_options") or {})
+    extra_args = request.get("extra_args") or {}
+    if isinstance(extra_args, dict):
+        passthrough_sampling_options = extra_args.get("sampling_options")
+        if isinstance(passthrough_sampling_options, dict):
+            sampling_options.update(passthrough_sampling_options)
     guided_decoding = sampling_options.get("guided_decoding")
     if guided_decoding is not None and isinstance(guided_decoding, dict):
         sampling_params.structured_outputs = StructuredOutputsParams(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -309,9 +309,10 @@ def _serialize_prompt_logprobs(
     vLLM shape: ``list[dict[int, Logprob] | None]`` where ``Logprob`` has
     ``.logprob``, ``.rank``, ``.decoded_token`` attributes.
 
-    Output shape: ``list[dict[str, {"logprob": float, ...}] | None]`` —
-    matches ``LLMEngineOutput.prompt_logprobs`` so the Rust postprocessor
-    can surface it on ``NvExtResponse.prompt_logprobs``.
+    Output shape: ``list[dict[str, {"logprob": float, ...}] | None]``.
+    Workers carry it under ``engine_data.prompt_logprobs`` so the Rust
+    postprocessor can surface it on ``NvExtResponse.prompt_logprobs`` without
+    changing the public ``LLMEngineOutput`` struct shape.
 
     NOTE: token_id keys are emitted as **strings** (not ints) so that
     pythonize → serde → JSON survives the worker→frontend transport. JSON
@@ -340,6 +341,14 @@ def _serialize_prompt_logprobs(
                 converted[str(int(token_id))] = lp_dict
             result.append(converted)
     return result
+
+
+def _attach_prompt_logprobs_engine_data(
+    tok: Dict[str, Any], prompt_logprobs: list
+) -> None:
+    engine_data = tok.setdefault("engine_data", {})
+    if isinstance(engine_data, dict):
+        engine_data["prompt_logprobs"] = prompt_logprobs
 
 
 def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
@@ -464,10 +473,13 @@ def _accumulate_engine_data(
     if tok.get("finish_reason") is None:
         return
 
-    engine_data: Dict[str, Any] = {
-        "completion_token_ids": list(token_accumulator),
-        "finished": True,
-    }
+    engine_data: Dict[str, Any] = dict(tok.get("engine_data") or {})
+    engine_data.update(
+        {
+            "completion_token_ids": list(token_accumulator),
+            "finished": True,
+        }
+    )
     if logprob_accumulator:
         engine_data["completion_logprobs"] = list(logprob_accumulator)
     if request_prompt_token_ids:
@@ -2414,8 +2426,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             completion_token_counts=total_output_tokens_by_index,
                         )
                         if res.prompt_logprobs is not None:
-                            out["prompt_logprobs"] = _serialize_prompt_logprobs(
-                                res.prompt_logprobs
+                            _attach_prompt_logprobs_engine_data(
+                                out, _serialize_prompt_logprobs(res.prompt_logprobs)
                             )
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -494,6 +494,7 @@ def build_sampling_params(
     request: Dict[str, Any],
     default_sampling_params: Dict[str, Any],
     model_max_len: int | None = None,
+    enable_rl: bool = False,
 ) -> SamplingParams:
     """
     Build SamplingParams from a PreprocessedRequest (internal protocol format).
@@ -509,11 +510,12 @@ def build_sampling_params(
     Returns:
         SamplingParams configured from the request
 
-    Token-in requests use vLLM's default sampling values instead of model
-    `generation_config.json` sampling overrides. Stop-token defaults from the
-    model config are still applied later.
+    RL token-in requests use vLLM's default sampling values instead of model
+    `generation_config.json` sampling overrides. Ordinary token-data requests
+    keep generation_config defaults for Gateway/backward-compatible traffic.
+    Stop-token defaults from the model config are still applied later.
     """
-    if _is_token_in_request(request):
+    if enable_rl and _is_token_in_request(request):
         # Use vLLM defaults without model generation_config overlays.
         sampling_params = SamplingParams()
     else:
@@ -2604,7 +2606,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         # Build sampling params from request
         sampling_params = build_sampling_params(
-            request, self.default_sampling_params, self.model_max_len
+            request,
+            self.default_sampling_params,
+            self.model_max_len,
+            enable_rl=self.config.enable_rl,
         )
 
         if kv_params is not None:
@@ -2882,7 +2887,10 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         # Build sampling params from request using shared utility
         sampling_params = build_sampling_params(
-            request, self.default_sampling_params, self.model_max_len
+            request,
+            self.default_sampling_params,
+            self.model_max_len,
+            enable_rl=self.config.enable_rl,
         )
 
         # One protocol instance per request; carries per-request state

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -297,6 +297,172 @@ def _compute_mm_uuids(
     return {"image": uuids}
 
 
+# Helpers for nvext response fields requested through `nvext.extra_fields`.
+
+
+def _serialize_prompt_logprobs(
+    raw_prompt_logprobs: list,
+) -> list:
+    """Convert vLLM's ``RequestOutput.prompt_logprobs`` into the dict shape
+    expected by Dynamo's Rust ``PromptLogprobEntry`` (serde deserialization).
+
+    vLLM shape: ``list[dict[int, Logprob] | None]`` where ``Logprob`` has
+    ``.logprob``, ``.rank``, ``.decoded_token`` attributes.
+
+    Output shape: ``list[dict[str, {"logprob": float, ...}] | None]`` —
+    matches ``LLMEngineOutput.prompt_logprobs`` so the Rust postprocessor
+    can surface it on ``NvExtResponse.prompt_logprobs``.
+
+    NOTE: token_id keys are emitted as **strings** (not ints) so that
+    pythonize → serde → JSON survives the worker→frontend transport. JSON
+    object keys are required to be strings; ``HashMap<u32, _>`` on the Rust
+    side deserializes string keys via ``u32::from_str``. Emitting int keys
+    here causes the chunk to be silently dropped on pythonize → JSON, which
+    surfaces as ``"Stream ended before generation completed"`` on the
+    frontend (worker emits cleanly, frontend never sees ``complete_final``).
+    """
+    result: list = []
+    for entry in raw_prompt_logprobs:
+        if entry is None:
+            result.append(None)
+        else:
+            converted: Dict[str, Dict[str, Any]] = {}
+            for token_id, logprob_obj in entry.items():
+                lp_dict: Dict[str, Any] = {
+                    "logprob": float(logprob_obj.logprob),
+                }
+                rank = getattr(logprob_obj, "rank", None)
+                if rank is not None:
+                    lp_dict["rank"] = int(rank)
+                decoded = getattr(logprob_obj, "decoded_token", None)
+                if decoded is not None:
+                    lp_dict["decoded_token"] = decoded
+                converted[str(int(token_id))] = lp_dict
+            result.append(converted)
+    return result
+
+
+def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
+    """Return True iff the request opted into the given nvext extra field.
+
+    Looks in two places (in order):
+      1. `request["nvext"]["extra_fields"]` — raw OpenAI request shape
+         (used by SGLang's handler; also covers any direct test injection).
+      2. `request["extra_args"]["nvext"]["extra_fields"]` — what the Rust
+         preprocessor stashes when building PreprocessedRequest from an
+         OpenAI request (PreprocessedRequest itself has no nvext field).
+    """
+    for source in (
+        request.get("nvext"),
+        (request.get("extra_args") or {}).get("nvext")
+        if isinstance(request.get("extra_args"), dict)
+        else None,
+    ):
+        if not isinstance(source, dict):
+            continue
+        extra_fields = source.get("extra_fields")
+        if isinstance(extra_fields, list) and field in extra_fields:
+            return True
+    return False
+
+
+def _apply_nvext_cache_salt(request: Dict[str, Any], prompt: Any) -> None:
+    extra_args = request.get("extra_args") or {}
+    nvext_args = extra_args.get("nvext") if isinstance(extra_args, dict) else None
+    if not isinstance(nvext_args, dict):
+        return
+
+    cache_salt = nvext_args.get("cache_salt")
+    if cache_salt is not None and isinstance(prompt, dict):
+        prompt["cache_salt"] = cache_salt
+
+
+def _flatten_logprobs(
+    log_probs: Any,
+) -> Optional[list[float]]:
+    """Coerce a per-token logprob sequence into a flat list[float].
+
+    The backend's per-chunk `log_probs` field is one float per emitted
+    token (the logprob the engine sampled). Some upstream paths wrap it
+    in dicts or nested lists; this helper accepts:
+      - list[float]               -> returned as-is
+      - list[list[float]]         -> flattened
+      - list[dict{logprob: ...}]  -> .logprob extracted
+      - None                      -> None
+
+    Any element that isn't coercible to float is dropped silently rather
+    than poisoning the entire payload. The trainer treats missing
+    per-token logprobs as off-policy correction = 0 for that token, so a
+    partial list is preferable to a hard failure.
+    """
+    if log_probs is None:
+        return None
+    if not isinstance(log_probs, list):
+        return None
+    out: list[float] = []
+    pending = list(log_probs)
+    while pending:
+        item = pending.pop(0)
+        if isinstance(item, (int, float)):
+            out.append(float(item))
+        elif isinstance(item, list):
+            pending[0:0] = item
+        elif isinstance(item, dict) and "logprob" in item:
+            try:
+                out.append(float(item["logprob"]))
+            except (TypeError, ValueError):
+                continue
+    return out or None
+
+
+def _is_token_in_request(request: Dict[str, Any]) -> bool:
+    nvext = request.get("nvext")
+    if isinstance(nvext, dict) and nvext.get("token_data"):
+        return True
+
+    extra_args = request.get("extra_args") or {}
+    nvext_args = extra_args.get("nvext") if isinstance(extra_args, dict) else None
+    if not isinstance(nvext_args, dict):
+        return False
+
+    if nvext_args.get("token_in"):
+        return True
+
+    return False
+
+
+def _accumulate_engine_data(
+    tok: Dict[str, Any],
+    request_prompt_token_ids: Optional[list[int]],
+    accumulated_token_ids: dict[int, list[int]],
+    accumulated_log_probs: dict[int, list[float]],
+) -> None:
+    output_index = int(tok.get("index") or 0)
+    token_accumulator = accumulated_token_ids.setdefault(output_index, [])
+    logprob_accumulator = accumulated_log_probs.setdefault(output_index, [])
+
+    new_token_ids = tok.get("token_ids")
+    if isinstance(new_token_ids, list):
+        token_accumulator.extend(int(t) for t in new_token_ids)
+
+    flat_lp = _flatten_logprobs(tok.get("log_probs"))
+    if flat_lp:
+        logprob_accumulator.extend(flat_lp)
+
+    if tok.get("finish_reason") is None:
+        return
+
+    engine_data: Dict[str, Any] = {
+        "completion_token_ids": list(token_accumulator),
+        "finished": True,
+    }
+    if logprob_accumulator:
+        engine_data["completion_logprobs"] = list(logprob_accumulator)
+    if request_prompt_token_ids:
+        engine_data["prompt_token_ids"] = list(request_prompt_token_ids)
+    tok["engine_data"] = engine_data
+
+
 # LoRAManager singleton - initialized lazily when DYN_LORA_ENABLED is set
 # None = not yet initialized, False = disabled/failed, LoRAManager = initialized
 _lora_manager = None
@@ -335,12 +501,24 @@ def build_sampling_params(
     Args:
         request: The PreprocessedRequest dict with 'sampling_options', 'stop_conditions',
                  and 'output_options'
-        default_sampling_params: Default sampling parameters to initialize with
+        default_sampling_params: Default sampling parameters from the model's
+            ``generation_config.json`` (vLLM ``ModelConfig.get_diff_sampling_param``).
+            Used for non-RL/chat clients that want the model's recommended
+            sampling defaults applied transparently.
 
     Returns:
         SamplingParams configured from the request
+
+    Token-in requests use vLLM's default sampling values instead of model
+    `generation_config.json` sampling overrides. Stop-token defaults from the
+    model config are still applied later.
     """
-    sampling_params = SamplingParams(**default_sampling_params)
+    if _is_token_in_request(request):
+        # Use vLLM defaults without model generation_config overlays.
+        sampling_params = SamplingParams()
+    else:
+        sampling_params = SamplingParams(**default_sampling_params)
+    sampling_params.detokenize = False
 
     # Handle guided_decoding - convert to StructuredOutputsParams
     sampling_options = request.get("sampling_options", {})
@@ -358,6 +536,9 @@ def build_sampling_params(
     for key, value in sampling_options.items():
         # Skip guided_decoding - already handled above
         if key == "guided_decoding":
+            continue
+        if key == "bad_words_token_ids" and value is not None:
+            sampling_params._bad_words_token_ids = value
             continue
         if value is not None and hasattr(sampling_params, key):
             setattr(sampling_params, key, value)
@@ -420,6 +601,10 @@ def build_sampling_params(
                 logger.warning(
                     f"Invalid prompt_logprobs value: {prompt_logprobs_value} (must be integer), ignoring"
                 )
+
+        skip_special_tokens_value = output_options.get("skip_special_tokens")
+        if skip_special_tokens_value is not None:
+            sampling_params.skip_special_tokens = bool(skip_special_tokens_value)
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
@@ -2214,6 +2399,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             embedding_sequence_length=embedding_sequence_length,
                             completion_token_counts=total_output_tokens_by_index,
                         )
+                        if res.prompt_logprobs is not None:
+                            out["prompt_logprobs"] = _serialize_prompt_logprobs(
+                                res.prompt_logprobs
+                            )
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "
@@ -2411,6 +2600,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             yield error
             return
 
+        _apply_nvext_cache_salt(request, prompt)
+
         # Build sampling params from request
         sampling_params = build_sampling_params(
             request, self.default_sampling_params, self.model_max_len
@@ -2457,6 +2648,24 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             async with self._abort_monitor(
                 context, request_id, abort_guard=abort_guard
             ):
+                # nvext.engine_data opt-in: if the client requested
+                # `nvext.extra_fields=["engine_data"]`, we accumulate
+                # per-chunk token_ids and logprobs and attach them to the
+                # FINAL chunk (the one carrying `finish_reason`). The Rust
+                # frontend's response builder (delta.rs) gates emission via
+                # `NvExtResponseFieldSelection.engine_data` so this payload
+                # only reaches clients that asked for it.
+                want_engine_data = _nvext_extra_field_requested(request, "engine_data")
+                # Prompt token IDs the engine actually saw. Either the
+                # pre-tokenized `nvext.token_data` (TITO) or whatever the
+                # preprocessor produced from messages (MITO). We echo them
+                # back in engine_data so the client doesn't have to re-derive
+                # them from a request it might no longer hold.
+                request_prompt_token_ids = (
+                    list(request.get("token_ids") or []) if want_engine_data else None
+                )
+                accumulated_token_ids: dict[int, list[int]] = {}
+                accumulated_log_probs: dict[int, list[float]] = {}
                 try:
                     async for tok in self.generate_tokens(
                         prompt,
@@ -2476,6 +2685,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                             tok["completion_usage"][
                                 "prompt_tokens_details"
                             ] = prefill_prompt_tokens_details
+
+                        if want_engine_data:
+                            _accumulate_engine_data(
+                                tok,
+                                request_prompt_token_ids,
+                                accumulated_token_ids,
+                                accumulated_log_probs,
+                            )
                         yield tok
                 except EngineDeadError as e:
                     logger.error(f"vLLM EngineDeadError: {e}")
@@ -2660,6 +2877,8 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             error["disaggregated_params"] = None
             yield error
             return
+
+        _apply_nvext_cache_salt(request, prompt)
 
         # Build sampling params from request using shared utility
         sampling_params = build_sampling_params(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import base64
 import inspect
 import logging
 import os
@@ -485,6 +486,25 @@ def _accumulate_engine_data(
     if request_prompt_token_ids:
         engine_data["prompt_token_ids"] = list(request_prompt_token_ids)
     tok["engine_data"] = engine_data
+
+
+def _serialize_routed_experts(routed_experts: Any) -> Optional[Dict[str, Any]]:
+    if routed_experts is None:
+        return None
+
+    shape = getattr(routed_experts, "shape", None)
+    tobytes = getattr(routed_experts, "tobytes", None)
+    if shape is None or not callable(tobytes):
+        logger.warning(
+            "Unable to serialize routed_experts of type %s",
+            type(routed_experts).__name__,
+        )
+        return None
+
+    return {
+        "data": base64.b85encode(tobytes()).decode("ascii"),
+        "shape": [int(dim) for dim in shape],
+    }
 
 
 # LoRAManager singleton - initialized lazily when DYN_LORA_ENABLED is set
@@ -2366,6 +2386,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             )
 
             total_output_tokens_by_index: dict[int, int] = {}
+            routed_experts_by_output: dict[int, Dict[str, Any]] = {}
             async for res in gen:
                 # res is vllm's RequestOutput
 
@@ -2410,6 +2431,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "index": output_idx,
                         "token_ids": token_ids,
                     }
+                    routed_experts = _serialize_routed_experts(
+                        getattr(output, "routed_experts", None)
+                    )
+                    if routed_experts is not None:
+                        routed_experts_by_output[output_idx] = routed_experts
 
                     # vLLM DELTA outputs already align token_ids/logprobs to this chunk.
                     tokenizer = getattr(self.engine_client, "tokenizer", None)
@@ -2434,6 +2460,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             _attach_prompt_logprobs_engine_data(
                                 out, _serialize_prompt_logprobs(res.prompt_logprobs)
                             )
+                        routed_experts = routed_experts_by_output.get(output_idx)
+                        if routed_experts is not None:
+                            disaggregated_params = dict(
+                                out.get("disaggregated_params") or {}
+                            )
+                            disaggregated_params["routed_experts"] = routed_experts
+                            out["disaggregated_params"] = disaggregated_params
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -35,6 +35,7 @@ from dynamo._core import Context
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
+from dynamo.common.metadata_upload import ChoiceMetadata, MetadataUploader
 from dynamo.common.multimodal.audio_loader import AudioLoader
 from dynamo.common.multimodal.embedding_transfer import (
     LocalEmbeddingReceiver,
@@ -451,6 +452,14 @@ def _is_token_in_request(request: Dict[str, Any]) -> bool:
         return True
 
     return False
+
+
+def _metadata_uploader_from_request(
+    config: Config, request: Dict[str, Any]
+) -> MetadataUploader | None:
+    if not getattr(config, "enable_rl", False):
+        return None
+    return MetadataUploader.from_backend_request(request)
 
 
 def _accumulate_engine_data(
@@ -2362,6 +2371,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         priority=0,
         reasoning_ended=None,
         reasoning_parser_kwargs=None,
+        metadata_uploader: Optional[MetadataUploader] = None,
     ):
         try:
             # Log LoRA usage for this generation (debug level to avoid log spam)
@@ -2387,6 +2397,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
             total_output_tokens_by_index: dict[int, int] = {}
             routed_experts_by_output: dict[int, Dict[str, Any]] = {}
+            metadata_by_output: dict[int, ChoiceMetadata] | None = (
+                {} if metadata_uploader is not None else None
+            )
             async for res in gen:
                 # res is vllm's RequestOutput
 
@@ -2442,9 +2455,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     log_probs, top_logprobs = self._extract_logprobs(
                         output, 0, tokenizer=tokenizer
                     )
-                    if log_probs is not None:
+                    if metadata_by_output is None and log_probs is not None:
                         out["log_probs"] = log_probs
-                    if top_logprobs is not None:
+                    if metadata_by_output is None and top_logprobs is not None:
                         out["top_logprobs"] = top_logprobs
 
                     if finish_reason:
@@ -2461,7 +2474,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 out, _serialize_prompt_logprobs(res.prompt_logprobs)
                             )
                         routed_experts = routed_experts_by_output.get(output_idx)
-                        if routed_experts is not None:
+                        if routed_experts is not None and metadata_by_output is None:
                             disaggregated_params = dict(
                                 out.get("disaggregated_params") or {}
                             )
@@ -2478,6 +2491,22 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             ),
                             finish_reason=finish_reason,
                         )
+                    if metadata_by_output is not None:
+                        choice_metadata = metadata_by_output.setdefault(
+                            output_idx, ChoiceMetadata(choice_index=output_idx)
+                        )
+                        choice_metadata.add_logprobs(log_probs, top_logprobs)
+                        routed_experts = routed_experts_by_output.get(output_idx)
+                        if routed_experts is not None:
+                            choice_metadata.routed_experts = routed_experts
+                        if finish_reason:
+                            try:
+                                await metadata_uploader.upload_choice(choice_metadata)
+                            finally:
+                                choice_metadata.release_payload()
+                                metadata_by_output.pop(output_idx, None)
+                    if finish_reason:
+                        routed_experts_by_output.pop(output_idx, None)
                     if stop_reason:
                         out["stop_reason"] = stop_reason
                     yield out
@@ -2702,6 +2731,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         trace_headers = context.trace_headers()
         reasoning_ended, reasoning_parser_kwargs = _request_reasoning_metadata(request)
+        metadata_uploader = _metadata_uploader_from_request(self.config, request)
 
         # In disagg decode mode, defer engine_client.abort() until the first
         # token so we don't abort while a NIXL KV transfer is still in flight
@@ -2747,6 +2777,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         priority=priority,
                         reasoning_ended=reasoning_ended,
                         reasoning_parser_kwargs=reasoning_parser_kwargs,
+                        metadata_uploader=metadata_uploader,
                     ):
                         if abort_guard is not None:
                             abort_guard.signal_first_token()

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -45,7 +45,7 @@ from dynamo.common.backend.publisher import ComponentSnapshot, KvEventSource, Zm
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.llm import ModelInput
-from dynamo.vllm.args import parse_args
+from dynamo.vllm.args import configure_rl_logprobs_mode, parse_args
 from dynamo.vllm.cache_info import (
     configure_kv_event_block_size,
     get_configured_kv_event_block_size,
@@ -135,11 +135,13 @@ class VllmLLMEngine(LLMEngine):
         disaggregation_mode: DisaggregationMode,
         served_model_name: str,
         component: str,
+        enable_rl: bool = False,
     ):
         self.engine_args = engine_args
         self.disaggregation_mode = disaggregation_mode
         self._served_model_name = served_model_name
         self._component = component
+        self.enable_rl = enable_rl
         self.engine_client: AsyncLLM | None = None
         self._vllm_config: Any = None
         self._default_sampling_params: Any = None
@@ -168,6 +170,8 @@ class VllmLLMEngine(LLMEngine):
                 config.engine_args.served_model_name
             ) = config.model
 
+        configure_rl_logprobs_mode(config)
+
         # _resolve_disaggregation_mode() in DynamoVllmConfig has already
         # promoted the field to a DisaggregationMode enum; the field type
         # is still the input union, so narrow it here for mypy (cast
@@ -178,6 +182,7 @@ class VllmLLMEngine(LLMEngine):
             mode,
             served_model_name=config.served_model_name or config.model,
             component=config.component,
+            enable_rl=config.enable_rl,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -256,7 +261,10 @@ class VllmLLMEngine(LLMEngine):
 
         # TODO: remove dict() once build_sampling_params accepts GenerateRequest
         sampling_params = build_sampling_params(
-            dict(request), self._default_sampling_params, self._model_max_len
+            dict(request),
+            self._default_sampling_params,
+            self._model_max_len,
+            enable_rl=self.enable_rl,
         )
 
         # vLLM's KV transfer is internal to NixlConnector

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -105,6 +105,16 @@ def run_dynamo_headless(config: Config) -> None:
     run_headless(args)
 
 
+def configure_rl_logprobs_mode(config: Config) -> None:
+    if (
+        config.enable_rl
+        and not config.logprobs_mode_explicitly_set
+        and config.engine_args.logprobs_mode == "raw_logprobs"
+    ):
+        config.engine_args.logprobs_mode = "processed_logprobs"
+        logger.info("Defaulting logprobs_mode=processed_logprobs (--enable-rl active).")
+
+
 async def worker() -> None:
     config = parse_args()
 
@@ -114,6 +124,8 @@ async def worker() -> None:
     # or the HF name (e.g. "Qwen/Qwen3-0.6B"), depending on cmd line params.
     if not config.served_model_name:
         config.served_model_name = config.engine_args.served_model_name = config.model
+
+    configure_rl_logprobs_mode(config)
 
     # Download the model if necessary using modelexpress.
     # We want it on disk before we start vllm to avoid downloading from HuggingFace.

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -44,7 +44,7 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs
-from .args import Config, _uses_dynamo_connector, parse_args
+from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import per_rank_kv_blocks
 from .constants import DisaggregationMode
@@ -103,16 +103,6 @@ def run_dynamo_headless(config: Config) -> None:
 
     args = build_headless_namespace(config)
     run_headless(args)
-
-
-def configure_rl_logprobs_mode(config: Config) -> None:
-    if (
-        config.enable_rl
-        and not config.logprobs_mode_explicitly_set
-        and config.engine_args.logprobs_mode == "raw_logprobs"
-    ):
-        config.engine_args.logprobs_mode = "processed_logprobs"
-        logger.info("Defaulting logprobs_mode=processed_logprobs (--enable-rl active).")
 
 
 async def worker() -> None:

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -63,6 +63,7 @@ def _request_output(outputs, *, prompt_token_ids=None):
     return SimpleNamespace(
         outputs=outputs,
         prompt_token_ids=prompt_token_ids if prompt_token_ids is not None else [101],
+        prompt_logprobs=None,
         num_cached_tokens=0,
         kv_transfer_params=None,
     )
@@ -214,6 +215,82 @@ async def test_generate_tokens_reads_delta_aligned_logprobs_from_zero_offset():
     assert chunks[0]["token_ids"] == [7, 8]
     assert chunks[0]["log_probs"] == [-0.7, -0.8]
     assert [entry[0]["token_id"] for entry in chunks[0]["top_logprobs"]] == [7, 8]
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_uploads_metadata_on_final_chunk(tmp_path):
+    zstd = pytest.importorskip("zstandard")
+    msgspec = pytest.importorskip("msgspec")
+    from dynamo.common.metadata_upload import MetadataUploader
+
+    logprobs = [
+        {7: SimpleNamespace(logprob=-0.7, rank=1, decoded_token="a")},
+        {8: SimpleNamespace(logprob=-0.8, rank=1, decoded_token="b")},
+    ]
+    responses = [
+        _request_output(
+            [_output([7, 8], finish_reason="length", logprobs=logprobs)],
+            prompt_token_ids=[10],
+        )
+    ]
+    handler = _handler_with_responses(responses)
+    uploader = MetadataUploader(url=(tmp_path / "rollout-1").as_uri())
+
+    chunks = []
+    async for chunk in BaseWorkerHandler.generate_tokens(
+        handler,
+        prompt=None,
+        sampling_params=SamplingParams(),
+        request_id="req-1",
+        metadata_uploader=uploader,
+    ):
+        chunks.append(chunk)
+
+    uploaded_path = tmp_path / "rollout-1" / "choice_0.msgpack.zst"
+    payload = msgspec.msgpack.decode(
+        zstd.ZstdDecompressor().decompress(uploaded_path.read_bytes())
+    )
+
+    assert len(chunks) == 1
+    assert "log_probs" not in chunks[0]
+    assert "top_logprobs" not in chunks[0]
+    assert "engine_data" not in chunks[0]
+    assert payload["metadata"]["log_probs"] == [-0.7, -0.8]
+    assert payload["metadata"]["top_logprobs"][0][0]["token_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_upload_failure_blocks_final_chunk(tmp_path):
+    from dynamo.common.metadata_upload import MetadataUploader
+
+    class FailingUploader(MetadataUploader):
+        async def upload_choice(self, choice):
+            raise RuntimeError("metadata upload failed")
+
+    responses = [
+        _request_output(
+            [
+                _output(
+                    [7],
+                    finish_reason="length",
+                    logprobs=[{7: SimpleNamespace(logprob=-0.7)}],
+                )
+            ]
+        )
+    ]
+    handler = _handler_with_responses(responses)
+
+    with pytest.raises(RuntimeError, match="metadata upload failed"):
+        async for _ in BaseWorkerHandler.generate_tokens(
+            handler,
+            prompt=None,
+            sampling_params=SamplingParams(),
+            request_id="req-1",
+            metadata_uploader=FailingUploader(
+                url=(tmp_path / "rollout-fail").as_uri(),
+            ),
+        ):
+            pass
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -137,7 +137,7 @@ class TestCacheSaltWiring:
 
 class TestTokenInSamplingDefaults:
     @staticmethod
-    def _build(extra_args=None):
+    def _build(extra_args=None, enable_rl=False, nvext=None):
         from dynamo.vllm.handlers import build_sampling_params
 
         req = {
@@ -148,7 +148,9 @@ class TestTokenInSamplingDefaults:
         }
         if extra_args is not None:
             req["extra_args"] = extra_args
-        return build_sampling_params(req, {"top_p": 0.5})
+        if nvext is not None:
+            req["nvext"] = nvext
+        return build_sampling_params(req, {"top_p": 0.5}, enable_rl=enable_rl)
 
     def test_metadata_extra_fields_keep_generation_defaults(self):
         sp = self._build({"nvext": {"extra_fields": ["timing", "worker_id"]}})
@@ -159,7 +161,15 @@ class TestTokenInSamplingDefaults:
         assert sp.top_p == pytest.approx(0.5)
 
     def test_token_in_marker_skips_generation_defaults(self):
-        sp = self._build({"nvext": {"token_in": True}})
+        sp = self._build({"nvext": {"token_in": True}}, enable_rl=True)
+        assert sp.top_p == pytest.approx(1.0)
+
+    def test_token_data_keeps_generation_defaults_when_rl_disabled(self):
+        sp = self._build(nvext={"token_data": [1, 2, 3]}, enable_rl=False)
+        assert sp.top_p == pytest.approx(0.5)
+
+    def test_token_data_skips_generation_defaults_when_rl_enabled(self):
+        sp = self._build(nvext={"token_data": [1, 2, 3]}, enable_rl=True)
         assert sp.top_p == pytest.approx(1.0)
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for vLLM token-in/token-out request handling."""
+
+from __future__ import annotations
+
+import importlib.util
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.skipif(
+        importlib.util.find_spec("vllm") is None,
+        reason="vllm not installed in this container",
+    ),
+]
+
+
+class TestSerializePromptLogprobs:
+    """Validate _serialize_prompt_logprobs against various vLLM outputs."""
+
+    @staticmethod
+    def _import():
+        from dynamo.vllm.handlers import _serialize_prompt_logprobs
+
+        return _serialize_prompt_logprobs
+
+    def test_none_entries_preserved(self):
+        fn = self._import()
+        raw = [None, None]
+        assert fn(raw) == [None, None]
+
+    def test_single_token_entry(self):
+        fn = self._import()
+        logprob = SimpleNamespace(logprob=-1.5, rank=1, decoded_token="hello")
+        raw = [{42: logprob}]
+        result = fn(raw)
+        assert len(result) == 1
+        entry = result[0]
+        assert "42" in entry
+        assert entry["42"]["logprob"] == pytest.approx(-1.5)
+        assert entry["42"]["rank"] == 1
+        assert entry["42"]["decoded_token"] == "hello"
+
+    def test_mixed_none_and_entries(self):
+        fn = self._import()
+        lp1 = SimpleNamespace(logprob=-0.1, rank=1, decoded_token="a")
+        lp2 = SimpleNamespace(logprob=-2.3, rank=5, decoded_token="b")
+        raw = [None, {10: lp1, 20: lp2}, None]
+        result = fn(raw)
+        assert result[0] is None
+        assert result[2] is None
+        assert set(result[1].keys()) == {"10", "20"}
+
+    def test_missing_optional_attributes(self):
+        """Logprob objects without rank/decoded_token should omit those keys."""
+        fn = self._import()
+        logprob = SimpleNamespace(logprob=-3.0)
+        raw = [{7: logprob}]
+        result = fn(raw)
+        assert result[0]["7"]["logprob"] == pytest.approx(-3.0)
+        assert "rank" not in result[0]["7"]
+        assert "decoded_token" not in result[0]["7"]
+
+    def test_empty_list(self):
+        fn = self._import()
+        assert fn([]) == []
+
+    def test_multiple_tokens_per_position(self):
+        fn = self._import()
+        lp_a = SimpleNamespace(logprob=-0.5, rank=1, decoded_token="x")
+        lp_b = SimpleNamespace(logprob=-1.2, rank=2, decoded_token="y")
+        lp_c = SimpleNamespace(logprob=-3.0, rank=3, decoded_token="z")
+        raw = [{100: lp_a, 200: lp_b, 300: lp_c}]
+        result = fn(raw)
+        assert len(result[0]) == 3
+
+
+class TestCacheSaltWiring:
+    """Verify cache_salt is extracted from extra_args and placed on the prompt."""
+
+    @staticmethod
+    def _build_token_mode_request(cache_salt=None, token_ids=None):
+        """Build a minimal TITO request dict mirroring the Rust preprocessor."""
+        req = {
+            "token_ids": token_ids or [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": {},
+        }
+        if cache_salt is not None:
+            req["extra_args"] = {"nvext": {"cache_salt": cache_salt}}
+        return req
+
+    def test_cache_salt_attached_to_prompt(self):
+        """When extra_args.nvext.cache_salt is set, the prompt dict gets it."""
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+        from vllm.inputs import TokensPrompt
+
+        req = self._build_token_mode_request(cache_salt="step_42")
+        prompt = TokensPrompt(prompt_token_ids=req["token_ids"])
+        _apply_nvext_cache_salt(req, prompt)
+
+        assert prompt.get("cache_salt") == "step_42"
+
+    def test_no_cache_salt_when_absent(self):
+        """When extra_args has no cache_salt, prompt should not gain the key."""
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+        from vllm.inputs import TokensPrompt
+
+        req = self._build_token_mode_request()
+        prompt = TokensPrompt(prompt_token_ids=req["token_ids"])
+        _apply_nvext_cache_salt(req, prompt)
+
+        assert "cache_salt" not in prompt
+
+    def test_prefill_and_decode_share_cache_salt_helper(self):
+        """Regression: disaggregated prefill and decode both salt prompt cache."""
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
+
+        req = self._build_token_mode_request(cache_salt="step_43")
+        prefill_prompt = {"prompt_token_ids": req["token_ids"]}
+        decode_prompt = {"prompt_token_ids": req["token_ids"]}
+
+        _apply_nvext_cache_salt(req, prefill_prompt)
+        _apply_nvext_cache_salt(req, decode_prompt)
+
+        assert prefill_prompt["cache_salt"] == "step_43"
+        assert decode_prompt["cache_salt"] == "step_43"
+
+
+class TestTokenInSamplingDefaults:
+    @staticmethod
+    def _build(extra_args=None):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        req = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": {},
+        }
+        if extra_args is not None:
+            req["extra_args"] = extra_args
+        return build_sampling_params(req, {"top_p": 0.5})
+
+    def test_metadata_extra_fields_keep_generation_defaults(self):
+        sp = self._build({"nvext": {"extra_fields": ["timing", "worker_id"]}})
+        assert sp.top_p == pytest.approx(0.5)
+
+    def test_engine_data_extra_field_keeps_generation_defaults(self):
+        sp = self._build({"nvext": {"extra_fields": ["engine_data"]}})
+        assert sp.top_p == pytest.approx(0.5)
+
+    def test_token_in_marker_skips_generation_defaults(self):
+        sp = self._build({"nvext": {"token_in": True}})
+        assert sp.top_p == pytest.approx(1.0)
+
+
+class TestFlattenLogprobs:
+    def test_nested_lists_are_fully_flattened(self):
+        from dynamo.vllm.handlers import _flatten_logprobs
+
+        assert _flatten_logprobs(
+            [[{"logprob": -0.1}, {"logprob": -0.2}], [-0.3]]
+        ) == pytest.approx([-0.1, -0.2, -0.3])
+
+
+class TestEngineDataAccumulation:
+    def test_accumulates_per_output_index(self):
+        from dynamo.vllm.handlers import _accumulate_engine_data
+
+        token_ids: dict[int, list[int]] = {}
+        logprobs: dict[int, list[float]] = {}
+
+        _accumulate_engine_data(
+            {"index": 0, "token_ids": [10], "log_probs": [-0.1]},
+            [1, 2],
+            token_ids,
+            logprobs,
+        )
+        _accumulate_engine_data(
+            {"index": 1, "token_ids": [20], "log_probs": [-0.2]},
+            [1, 2],
+            token_ids,
+            logprobs,
+        )
+
+        final = {
+            "index": 0,
+            "token_ids": [11],
+            "log_probs": [-0.3],
+            "finish_reason": "stop",
+        }
+        _accumulate_engine_data(final, [1, 2], token_ids, logprobs)
+
+        assert final["engine_data"]["completion_token_ids"] == [10, 11]
+        assert final["engine_data"]["completion_logprobs"] == pytest.approx(
+            [-0.1, -0.3]
+        )
+        assert token_ids[1] == [20]
+
+
+class TestSkipSpecialTokens:
+    """Verify skip_special_tokens from output_options flows to SamplingParams."""
+
+    @staticmethod
+    def _build(output_options=None):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        req = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {},
+            "output_options": output_options or {},
+        }
+        return build_sampling_params(req, {})
+
+    def test_skip_special_tokens_true(self):
+        sp = self._build(output_options={"skip_special_tokens": True})
+        assert sp.skip_special_tokens is True
+
+    def test_skip_special_tokens_false(self):
+        sp = self._build(output_options={"skip_special_tokens": False})
+        assert sp.skip_special_tokens is False
+
+    def test_skip_special_tokens_absent(self):
+        """When not provided, build_sampling_params hardcodes detokenize=False
+        and SamplingParams default for skip_special_tokens should be unchanged."""
+        sp = self._build(output_options={})
+        assert sp.detokenize is False
+
+    def test_prompt_logprobs_still_works(self):
+        """Regression: prompt_logprobs should still be wired alongside skip_special_tokens."""
+        sp = self._build(
+            output_options={"prompt_logprobs": 5, "skip_special_tokens": True}
+        )
+        assert sp.prompt_logprobs == 5
+        assert sp.skip_special_tokens is True
+
+    def test_token_id_constraints(self):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        req = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {
+                "allowed_token_ids": [10, 11],
+                "bad_words_token_ids": [[12, 13]],
+            },
+            "stop_conditions": {},
+            "output_options": {},
+        }
+
+        sp = build_sampling_params(req, {})
+        assert sp.allowed_token_ids == [10, 11]
+        assert sp.bad_words_token_ids == [[12, 13]]

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -296,9 +296,13 @@ class TestSkipSpecialTokens:
 
         req = {
             "token_ids": [1, 2, 3],
-            "sampling_options": {
-                "allowed_token_ids": [10, 11],
-                "bad_words_token_ids": [[12, 13]],
+            "sampling_options": {},
+            "extra_args": {
+                "sampling_options": {
+                    "allowed_token_ids": [10, 11],
+                    "bad_words_token_ids": [[12, 13]],
+                    "detokenize": True,
+                }
             },
             "stop_conditions": {},
             "output_options": {},
@@ -307,3 +311,4 @@ class TestSkipSpecialTokens:
         sp = build_sampling_params(req, {})
         assert sp.allowed_token_ids == [10, 11]
         assert sp.bad_words_token_ids == [[12, 13]]
+        assert sp.detokenize is True

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -101,8 +101,9 @@ class TestCacheSaltWiring:
 
     def test_cache_salt_attached_to_prompt(self):
         """When extra_args.nvext.cache_salt is set, the prompt dict gets it."""
-        from dynamo.vllm.handlers import _apply_nvext_cache_salt
         from vllm.inputs import TokensPrompt
+
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
 
         req = self._build_token_mode_request(cache_salt="step_42")
         prompt = TokensPrompt(prompt_token_ids=req["token_ids"])
@@ -112,8 +113,9 @@ class TestCacheSaltWiring:
 
     def test_no_cache_salt_when_absent(self):
         """When extra_args has no cache_salt, prompt should not gain the key."""
-        from dynamo.vllm.handlers import _apply_nvext_cache_salt
         from vllm.inputs import TokensPrompt
+
+        from dynamo.vllm.handlers import _apply_nvext_cache_salt
 
         req = self._build_token_mode_request()
         prompt = TokensPrompt(prompt_token_ids=req["token_ids"])

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -296,13 +296,10 @@ class TestSkipSpecialTokens:
 
         req = {
             "token_ids": [1, 2, 3],
-            "sampling_options": {},
-            "extra_args": {
-                "sampling_options": {
-                    "allowed_token_ids": [10, 11],
-                    "bad_words_token_ids": [[12, 13]],
-                    "detokenize": True,
-                }
+            "sampling_options": {
+                "allowed_token_ids": [10, 11],
+                "bad_words_token_ids": [[12, 13]],
+                "detokenize": True,
             },
             "stop_conditions": {},
             "output_options": {},

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -14,6 +14,7 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.pre_merge,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,
     pytest.mark.skipif(
         importlib.util.find_spec("vllm") is None,
@@ -183,6 +184,21 @@ class TestFlattenLogprobs:
 
 
 class TestEngineDataAccumulation:
+    def test_prompt_token_ids_come_from_built_prompt_when_available(self):
+        from dynamo.vllm.handlers import _prompt_token_ids_for_engine_data
+
+        request = {"token_ids": [1, 2, 3]}
+        prompt = {"prompt_token_ids": [1, 2, 99, 100]}
+
+        assert _prompt_token_ids_for_engine_data(request, prompt) == [1, 2, 99, 100]
+
+    def test_prompt_token_ids_fall_back_to_request_tokens(self):
+        from dynamo.vllm.handlers import _prompt_token_ids_for_engine_data
+
+        request = {"token_ids": [1, 2, 3]}
+
+        assert _prompt_token_ids_for_engine_data(request, "plain prompt") == [1, 2, 3]
+
     def test_accumulates_per_output_index(self):
         from dynamo.vllm.handlers import _accumulate_engine_data
 

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -234,6 +234,25 @@ class TestEngineDataAccumulation:
         )
         assert token_ids[1] == [20]
 
+    def test_engine_data_preserves_prompt_logprobs(self):
+        from dynamo.vllm.handlers import (
+            _accumulate_engine_data,
+            _attach_prompt_logprobs_engine_data,
+        )
+
+        final = {
+            "index": 0,
+            "token_ids": [11],
+            "finish_reason": "stop",
+        }
+        payload = [None, {"42": {"logprob": -0.5, "rank": 1}}]
+
+        _attach_prompt_logprobs_engine_data(final, payload)
+        _accumulate_engine_data(final, [1, 2], {}, {})
+
+        assert final["engine_data"]["prompt_logprobs"] == payload
+        assert final["engine_data"]["completion_token_ids"] == [11]
+
 
 class TestSkipSpecialTokens:
     """Verify skip_special_tokens from output_options flows to SamplingParams."""

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -185,6 +185,35 @@ class TestFlattenLogprobs:
         ) == pytest.approx([-0.1, -0.2, -0.3])
 
 
+class TestMetadataUpload:
+    def test_metadata_upload_requires_enable_rl(self):
+        from dynamo.vllm.handlers import _metadata_uploader_from_request
+
+        request = {
+            "extra_args": {
+                "nvext": {"metadata_upload": {"url": "s3://bucket/rollout/req-1"}}
+            }
+        }
+
+        assert (
+            _metadata_uploader_from_request(SimpleNamespace(enable_rl=False), request)
+            is None
+        )
+        uploader = _metadata_uploader_from_request(
+            SimpleNamespace(enable_rl=True), request
+        )
+        assert uploader is not None
+        assert uploader.url == "s3://bucket/rollout/req-1"
+        assert uploader.payload_format == "msgpack"
+
+        raw_request_uploader = _metadata_uploader_from_request(
+            SimpleNamespace(enable_rl=True),
+            {"nvext": {"metadata_upload": {"url": "s3://bucket/rollout/raw"}}},
+        )
+        assert raw_request_uploader is not None
+        assert raw_request_uploader.url == "s3://bucket/rollout/raw"
+
+
 class TestEngineDataAccumulation:
     def test_prompt_token_ids_come_from_built_prompt_when_available(self):
         from dynamo.vllm.handlers import _prompt_token_ids_for_engine_data

--- a/components/src/dynamo/vllm/tests/test_vllm_trace_propagation.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_trace_propagation.py
@@ -59,6 +59,7 @@ def _make_engine(engine_client) -> VllmLLMEngine:
     engine._default_sampling_params = SimpleNamespace()
     engine._model_max_len = 1024
     engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine.enable_rl = False
     # `_dp_range=None` bypasses the router's DP-rank resolution branch.
     engine._dp_range = None
     return engine

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -16,7 +16,6 @@ from unittest.mock import patch
 import pytest
 
 from dynamo.vllm.args import (
-    _arg_was_provided,
     _connector_to_kv_transfer_json,
     _is_routable,
     _uses_dynamo_connector,
@@ -334,22 +333,9 @@ def test_headless_namespace_has_required_fields(mock_vllm_cli):
     assert hasattr(ns, "tensor_parallel_size")
 
 
-def test_rl_logprobs_default_respects_explicit_override():
+def test_rl_logprobs_force_converts_raw_mode():
     config = SimpleNamespace(
         enable_rl=True,
-        logprobs_mode_explicitly_set=True,
-        engine_args=SimpleNamespace(logprobs_mode="raw_logprobs"),
-    )
-
-    configure_rl_logprobs_mode(config)
-
-    assert config.engine_args.logprobs_mode == "raw_logprobs"
-
-
-def test_rl_logprobs_default_applies_without_override():
-    config = SimpleNamespace(
-        enable_rl=True,
-        logprobs_mode_explicitly_set=False,
         engine_args=SimpleNamespace(logprobs_mode="raw_logprobs"),
     )
 
@@ -358,34 +344,31 @@ def test_rl_logprobs_default_applies_without_override():
     assert config.engine_args.logprobs_mode == "processed_logprobs"
 
 
-def test_logprobs_mode_flag_is_tracked(mock_vllm_cli):
-    mock_vllm_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--logprobs-mode",
-        "raw_logprobs",
+def test_rl_logprobs_keeps_processed_mode():
+    config = SimpleNamespace(
+        enable_rl=True,
+        engine_args=SimpleNamespace(logprobs_mode="processed_logprobs"),
     )
 
-    config = parse_args()
+    configure_rl_logprobs_mode(config)
 
-    assert config.logprobs_mode_explicitly_set is True
+    assert config.engine_args.logprobs_mode == "processed_logprobs"
 
 
-def test_logprobs_mode_underscore_flag_is_tracked(mock_vllm_cli):
-    mock_vllm_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--logprobs_mode=raw_logprobs",
+def test_rl_logprobs_rejects_logits_modes():
+    config = SimpleNamespace(
+        enable_rl=True,
+        engine_args=SimpleNamespace(logprobs_mode="raw_logits"),
     )
 
+    with pytest.raises(ValueError, match="processed_logprobs"):
+        configure_rl_logprobs_mode(config)
+
+
+def test_parse_args_does_not_track_logprobs_mode_presence(mock_vllm_cli):
+    mock_vllm_cli("--model", "Qwen/Qwen3-0.6B")
     config = parse_args()
-
-    assert config.logprobs_mode_explicitly_set is True
-
-
-def test_arg_was_provided_accepts_underscore_alias():
-    assert _arg_was_provided(["--logprobs_mode", "raw_logprobs"], "--logprobs-mode")
-    assert _arg_was_provided(["--logprobs_mode=raw_logprobs"], "--logprobs-mode")
+    assert not hasattr(config, "logprobs_mode_explicitly_set")
 
 
 def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
@@ -394,7 +377,6 @@ def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
 
     config = SimpleNamespace(
         enable_rl=True,
-        logprobs_mode_explicitly_set=False,
         engine_args=SimpleNamespace(
             logprobs_mode="raw_logprobs",
             served_model_name=["Qwen/Qwen3-0.6B"],

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import pytest
 
 from dynamo.vllm.args import (
+    _arg_was_provided,
     _connector_to_kv_transfer_json,
     _is_routable,
     _uses_dynamo_connector,
@@ -382,6 +383,11 @@ def test_logprobs_mode_underscore_flag_is_tracked(mock_vllm_cli):
     config = parse_args()
 
     assert config.logprobs_mode_explicitly_set is True
+
+
+def test_arg_was_provided_accepts_underscore_alias():
+    assert _arg_was_provided(["--logprobs_mode", "raw_logprobs"], "--logprobs-mode")
+    assert _arg_was_provided(["--logprobs_mode=raw_logprobs"], "--logprobs-mode")
 
 
 # --disaggregation-mode tests

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -384,6 +384,7 @@ def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
         served_model_name="Qwen/Qwen3-0.6B",
         model="Qwen/Qwen3-0.6B",
         disaggregation_mode=CommonDisaggregationMode.AGGREGATED,
+        component="backend",
     )
     worker_config = object()
 
@@ -426,6 +427,8 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
     engine = llm_engine.VllmLLMEngine(
         SimpleNamespace(),
         CommonDisaggregationMode.AGGREGATED,
+        served_model_name="test-model",
+        component="backend",
         enable_rl=True,
     )
     engine.engine_client = SimpleNamespace(generate=fake_generate)

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for vLLM backend components."""
 
+import asyncio
 import json
 import re
 import socket
@@ -20,6 +21,7 @@ from dynamo.vllm.args import (
     _is_routable,
     _uses_dynamo_connector,
     _uses_nixl_connector,
+    configure_rl_logprobs_mode,
     ensure_side_channel_host,
     get_host_ip,
     parse_args,
@@ -333,8 +335,6 @@ def test_headless_namespace_has_required_fields(mock_vllm_cli):
 
 
 def test_rl_logprobs_default_respects_explicit_override():
-    from dynamo.vllm.main import configure_rl_logprobs_mode
-
     config = SimpleNamespace(
         enable_rl=True,
         logprobs_mode_explicitly_set=True,
@@ -347,8 +347,6 @@ def test_rl_logprobs_default_respects_explicit_override():
 
 
 def test_rl_logprobs_default_applies_without_override():
-    from dynamo.vllm.main import configure_rl_logprobs_mode
-
     config = SimpleNamespace(
         enable_rl=True,
         logprobs_mode_explicitly_set=False,
@@ -388,6 +386,80 @@ def test_logprobs_mode_underscore_flag_is_tracked(mock_vllm_cli):
 def test_arg_was_provided_accepts_underscore_alias():
     assert _arg_was_provided(["--logprobs_mode", "raw_logprobs"], "--logprobs-mode")
     assert _arg_was_provided(["--logprobs_mode=raw_logprobs"], "--logprobs-mode")
+
+
+def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
+    from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+    from dynamo.vllm import llm_engine
+
+    config = SimpleNamespace(
+        enable_rl=True,
+        logprobs_mode_explicitly_set=False,
+        engine_args=SimpleNamespace(
+            logprobs_mode="raw_logprobs",
+            served_model_name=["Qwen/Qwen3-0.6B"],
+        ),
+        served_model_name="Qwen/Qwen3-0.6B",
+        model="Qwen/Qwen3-0.6B",
+        disaggregation_mode=CommonDisaggregationMode.AGGREGATED,
+    )
+    worker_config = object()
+
+    monkeypatch.setattr(llm_engine, "parse_args", lambda argv: config)
+    monkeypatch.setattr(
+        llm_engine.WorkerConfig,
+        "from_runtime_config",
+        lambda *args, **kwargs: worker_config,
+    )
+
+    async def run_from_args():
+        return await llm_engine.VllmLLMEngine.from_args(["--enable-rl"])
+
+    engine, result_worker_config = asyncio.run(run_from_args())
+
+    assert config.engine_args.logprobs_mode == "processed_logprobs"
+    assert engine.enable_rl is True
+    assert result_worker_config is worker_config
+
+
+def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
+    from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+    from dynamo.vllm import llm_engine
+
+    captured: dict[str, bool] = {}
+
+    def fake_build_sampling_params(
+        request, default_sampling_params, model_max_len=None, *, enable_rl=False
+    ):
+        captured["enable_rl"] = enable_rl
+        return SimpleNamespace(extra_args=None)
+
+    async def empty_generation():
+        if False:
+            yield None
+
+    def fake_generate(*args, **kwargs):
+        return empty_generation()
+
+    engine = llm_engine.VllmLLMEngine(
+        SimpleNamespace(),
+        CommonDisaggregationMode.AGGREGATED,
+        enable_rl=True,
+    )
+    engine.engine_client = SimpleNamespace(generate=fake_generate)
+    engine._default_sampling_params = {}
+    engine._model_max_len = 4096
+
+    monkeypatch.setattr(llm_engine, "build_sampling_params", fake_build_sampling_params)
+
+    async def run_generate():
+        context = SimpleNamespace(id=lambda: "req")
+        async for _ in engine.generate({"token_ids": [1, 2, 3]}, context):
+            pass
+
+    asyncio.run(run_generate())
+
+    assert captured["enable_rl"] is True
 
 
 # --disaggregation-mode tests

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -331,6 +331,47 @@ def test_headless_namespace_has_required_fields(mock_vllm_cli):
     assert hasattr(ns, "tensor_parallel_size")
 
 
+def test_rl_logprobs_default_respects_explicit_override():
+    from dynamo.vllm.main import configure_rl_logprobs_mode
+
+    config = SimpleNamespace(
+        enable_rl=True,
+        logprobs_mode_explicitly_set=True,
+        engine_args=SimpleNamespace(logprobs_mode="raw_logprobs"),
+    )
+
+    configure_rl_logprobs_mode(config)
+
+    assert config.engine_args.logprobs_mode == "raw_logprobs"
+
+
+def test_rl_logprobs_default_applies_without_override():
+    from dynamo.vllm.main import configure_rl_logprobs_mode
+
+    config = SimpleNamespace(
+        enable_rl=True,
+        logprobs_mode_explicitly_set=False,
+        engine_args=SimpleNamespace(logprobs_mode="raw_logprobs"),
+    )
+
+    configure_rl_logprobs_mode(config)
+
+    assert config.engine_args.logprobs_mode == "processed_logprobs"
+
+
+def test_logprobs_mode_flag_is_tracked(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--logprobs-mode",
+        "raw_logprobs",
+    )
+
+    config = parse_args()
+
+    assert config.logprobs_mode_explicitly_set is True
+
+
 # --disaggregation-mode tests
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -372,6 +372,18 @@ def test_logprobs_mode_flag_is_tracked(mock_vllm_cli):
     assert config.logprobs_mode_explicitly_set is True
 
 
+def test_logprobs_mode_underscore_flag_is_tracked(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--logprobs_mode=raw_logprobs",
+    )
+
+    config = parse_args()
+
+    assert config.logprobs_mode_explicitly_set is True
+
+
 # --disaggregation-mode tests
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -438,7 +438,7 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
     monkeypatch.setattr(llm_engine, "build_sampling_params", fake_build_sampling_params)
 
     async def run_generate():
-        context = SimpleNamespace(id=lambda: "req")
+        context = SimpleNamespace(id=lambda: "req", trace_headers=lambda: None)
         async for _ in engine.generate({"token_ids": [1, 2, 3]}, context):
             pass
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -8,10 +8,13 @@
 # Need to revisit the tests and update them to test the worker handlers.
 
 import asyncio
+import base64
 import json
 from collections import defaultdict
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 
@@ -278,6 +281,61 @@ class TestReasoningParserForwarding:
 
         assert chunks == []
         assert calls == {"called": True}
+
+    @pytest.mark.asyncio
+    async def test_generate_tokens_emits_routed_experts_on_final_chunk(self):
+        from vllm.sampling_params import SamplingParams
+
+        handler = _make_handler()
+        handler._extract_logprobs = MagicMock(return_value=(None, None))
+
+        routed_experts = np.array([[[1]], [[2]]], dtype=np.int32)
+
+        async def fake_generate(*args, **kwargs):
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[11],
+                        routed_experts=None,
+                        finish_reason=None,
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2],
+                prompt_logprobs=None,
+            )
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[11, 12],
+                        routed_experts=routed_experts,
+                        finish_reason="stop",
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2],
+                prompt_logprobs=None,
+            )
+
+        handler.engine_client = MagicMock()
+        handler.engine_client.generate = fake_generate
+
+        chunks = []
+        async for chunk in handler.generate_tokens(
+            PatchedTokensPrompt(prompt_token_ids=[1]),
+            SamplingParams(max_tokens=2),
+            "req-1",
+        ):
+            chunks.append(chunk)
+
+        assert [chunk["token_ids"] for chunk in chunks] == [[11], [12]]
+        assert "disaggregated_params" not in chunks[0]
+        routed = chunks[1]["disaggregated_params"]["routed_experts"]
+        assert routed["shape"] == [2, 1, 1]
+        decoded = np.frombuffer(base64.b85decode(routed["data"]), dtype=np.int32)
+        np.testing.assert_array_equal(decoded, routed_experts.reshape(-1))
 
 
 # ── Tests ────────────────────────────────────────────────────────────

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -292,26 +292,6 @@ impl OpenAIPreprocessor {
         }
     }
 
-    fn sampling_passthrough_args<R: NvExtProvider>(
-        request: &R,
-    ) -> Option<serde_json::Map<String, serde_json::Value>> {
-        let mut sampling_passthrough = serde_json::Map::new();
-
-        if let Some(fields) = request.unsupported_fields() {
-            for key in ["detokenize", "allowed_token_ids", "bad_words_token_ids"] {
-                if let Some(value) = fields.get(key) {
-                    sampling_passthrough.insert(key.to_string(), value.clone());
-                }
-            }
-        }
-
-        if sampling_passthrough.is_empty() {
-            None
-        } else {
-            Some(sampling_passthrough)
-        }
-    }
-
     fn backend_extra_args<R: NvExtProvider>(request: &R) -> Option<serde_json::Value> {
         let mut extra_args = serde_json::Map::new();
 
@@ -319,13 +299,6 @@ impl OpenAIPreprocessor {
             extra_args.insert(
                 "nvext".to_string(),
                 serde_json::Value::Object(nvext_passthrough),
-            );
-        }
-
-        if let Some(sampling_passthrough) = Self::sampling_passthrough_args(request) {
-            extra_args.insert(
-                "sampling_options".to_string(),
-                serde_json::Value::Object(sampling_passthrough),
             );
         }
 
@@ -2984,7 +2957,7 @@ mod tests {
     }
 
     #[test]
-    fn test_backend_extra_args_preserves_nvext_and_sampling_extensions() {
+    fn test_sampling_passthrough_uses_top_level_sampling_options() {
         let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "hi"}],
@@ -2999,19 +2972,29 @@ mod tests {
         .unwrap();
 
         let extra_args = OpenAIPreprocessor::backend_extra_args(&request).unwrap();
-
         assert_eq!(extra_args["nvext"]["cache_salt"], "step_7");
         assert_eq!(
             extra_args["nvext"]["extra_fields"],
             serde_json::json!(["completion_token_ids"])
         );
-        assert_eq!(extra_args["sampling_options"]["detokenize"], false);
+        assert!(extra_args.get("sampling_options").is_none());
+
+        let sampling_options = request.extract_sampling_options().unwrap();
+        assert_eq!(sampling_options.detokenize, Some(false));
+        assert_eq!(sampling_options.allowed_token_ids, Some(vec![10, 11]));
         assert_eq!(
-            extra_args["sampling_options"]["allowed_token_ids"],
+            sampling_options.bad_words_token_ids,
+            Some(vec![vec![12, 13]])
+        );
+
+        let sampling_options_json = serde_json::to_value(&sampling_options).unwrap();
+        assert_eq!(sampling_options_json["detokenize"], false);
+        assert_eq!(
+            sampling_options_json["allowed_token_ids"],
             serde_json::json!([10, 11])
         );
         assert_eq!(
-            extra_args["sampling_options"]["bad_words_token_ids"],
+            sampling_options_json["bad_words_token_ids"],
             serde_json::json!([[12, 13]])
         );
     }

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -343,6 +343,15 @@ pub struct SamplingOptions {
 
     /// Guided Decoding Options
     pub guided_decoding: Option<GuidedDecodingOptions>,
+
+    /// Whether the backend engine should detokenize generated output.
+    pub detokenize: Option<bool>,
+
+    /// Restrict generation to this set of token IDs.
+    pub allowed_token_ids: Option<Vec<TokenIdType>>,
+
+    /// Suppress generation of these token ID sequences.
+    pub bad_words_token_ids: Option<Vec<Vec<TokenIdType>>>,
 }
 
 /// Guided Decoding Options

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -55,6 +55,10 @@ pub(crate) trait OpenAISamplingOptionsProvider {
     fn get_best_of(&self) -> Option<u8>;
 
     fn nvext(&self) -> Option<&nvext::NvExt>;
+
+    fn get_sampling_passthrough(&self, _key: &str) -> Option<&serde_json::Value> {
+        None
+    }
 }
 
 pub(crate) trait OpenAIStopConditionsProvider {
@@ -160,6 +164,23 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
                 return Err(e);
             }
         };
+        let detokenize = self
+            .get_sampling_passthrough("detokenize")
+            .map(|value| serde_json::from_value(value.clone()))
+            .transpose()
+            .map_err(|_| anyhow::anyhow!("`detokenize` must be a boolean"))?;
+        let allowed_token_ids = self
+            .get_sampling_passthrough("allowed_token_ids")
+            .map(|value| serde_json::from_value(value.clone()))
+            .transpose()
+            .map_err(|_| anyhow::anyhow!("`allowed_token_ids` must be an array of token IDs"))?;
+        let bad_words_token_ids = self
+            .get_sampling_passthrough("bad_words_token_ids")
+            .map(|value| serde_json::from_value(value.clone()))
+            .transpose()
+            .map_err(|_| {
+                anyhow::anyhow!("`bad_words_token_ids` must be an array of token ID arrays")
+            })?;
 
         Ok(common::SamplingOptions {
             n,
@@ -176,6 +197,9 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             length_penalty: None,
             guided_decoding,
             include_stop_str_in_output,
+            detokenize,
+            allowed_token_ids,
+            bad_words_token_ids,
         })
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -202,6 +202,11 @@ impl OpenAISamplingOptionsProvider for NvCreateChatCompletionRequest {
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
     }
+
+    fn get_sampling_passthrough(&self, key: &str) -> Option<&serde_json::Value> {
+        self.unsupported_fields.get(key)
+    }
+
     /// Retrieves the seed value for random number generation, if set.
     fn get_seed(&self) -> Option<i64> {
         self.inner.seed
@@ -454,7 +459,9 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
 mod tests {
     use super::*;
     use crate::engines::ValidateRequest;
-    use crate::protocols::common::{OutputOptionsProvider, StopConditionsProvider};
+    use crate::protocols::common::{
+        OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider,
+    };
     use serde_json::json;
 
     #[test]
@@ -603,6 +610,7 @@ mod tests {
         let request_json = json!({
             "model": "test-model",
             "messages": [{"role": "user", "content": "Hello"}],
+            "detokenize": false,
             "allowed_token_ids": [10, 11],
             "bad_words_token_ids": [[12, 13]]
         });
@@ -618,6 +626,14 @@ mod tests {
             Some(&serde_json::json!([[12, 13]]))
         );
         assert!(ValidateRequest::validate(&request).is_ok());
+
+        let sampling_options = request.extract_sampling_options().unwrap();
+        assert_eq!(sampling_options.detokenize, Some(false));
+        assert_eq!(sampling_options.allowed_token_ids, Some(vec![10, 11]));
+        assert_eq!(
+            sampling_options.bad_words_token_ids,
+            Some(vec![vec![12, 13]])
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -178,6 +178,10 @@ impl OpenAISamplingOptionsProvider for NvCreateCompletionRequest {
         self.nvext.as_ref()
     }
 
+    fn get_sampling_passthrough(&self, key: &str) -> Option<&serde_json::Value> {
+        self.unsupported_fields.get(key)
+    }
+
     fn get_seed(&self) -> Option<i64> {
         self.inner.seed
     }
@@ -496,7 +500,7 @@ impl ValidateRequest for NvCreateCompletionRequest {
 mod tests {
     use super::*;
     use crate::engines::ValidateRequest;
-    use crate::protocols::common::OutputOptionsProvider;
+    use crate::protocols::common::{OutputOptionsProvider, SamplingOptionsProvider};
     use base64::Engine;
     use serde_json::json;
 
@@ -803,6 +807,7 @@ mod tests {
         let request_json = json!({
             "model": "test-model",
             "prompt": [1, 2, 3],
+            "detokenize": false,
             "allowed_token_ids": [10, 11],
             "bad_words_token_ids": [[12, 13]]
         });
@@ -818,6 +823,14 @@ mod tests {
             Some(&serde_json::json!([[12, 13]]))
         );
         assert!(ValidateRequest::validate(&request).is_ok());
+
+        let sampling_options = request.extract_sampling_options().unwrap();
+        assert_eq!(sampling_options.detokenize, Some(false));
+        assert_eq!(sampling_options.allowed_token_ids, Some(vec![10, 11]));
+        assert_eq!(
+            sampling_options.bad_words_token_ids,
+            Some(vec![vec![12, 13]])
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -325,6 +325,10 @@ impl OpenAISamplingOptionsProvider for UnifiedRequest {
         self.inner.nvext.as_ref()
     }
 
+    fn get_sampling_passthrough(&self, key: &str) -> Option<&serde_json::Value> {
+        self.inner.unsupported_fields.get(key)
+    }
+
     fn get_seed(&self) -> Option<i64> {
         self.inner.inner.seed
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ vllm = [
     "soundfile>=0.13.1",
     "librosa>=0.10.0",
     "ray>=2.55.0",
+    "zstandard>=0.23.0,<1.0",
 ]
 
 sglang = [


### PR DESCRIPTION
## Summary

This stacks the vLLM side of RL metadata uploads on top of Biswa's vLLM RL/TITO branch (#9651).

It reuses the shared `dynamo.common.metadata_upload` helper introduced in #10034 and wires vLLM decode token streaming to:

- honor `nvext.metadata_upload.url` only when `--enable-rl` is enabled
- accept optional `nvext.metadata_upload.format`, defaulting to zstd-compressed `msgpack` and also supporting zstd-compressed `json`
- accumulate logprob/top-logprob/routed-expert metadata per choice
- upload a compressed `choice_<index>.<format>.zst` object only when that choice finishes
- wait for upload success before emitting the final response for that choice
- clear the in-memory per-choice payload after upload
- forward metadata upload passthrough through the Python vLLM frontend path

The upload object reference is derived from the request URL and is not returned to the caller.

## Request shape

```json
{
  "nvext": {
    "metadata_upload": {
      "url": "s3://bucket/root/rollouts/run-123",
      "format": "msgpack"
    }
  }
}
```

`format` is optional. The default is `msgpack` so binary metadata from the engine can round-trip. `json` remains available for text-only consumers.

Uploaded objects use:

```text
<url>/choice_<index>.<format>.zst
```

## Dependency

This PR intentionally depends on #10034 for the public `nvext.metadata_upload` request schema and mainline shared helper. The helper file is included here so this branch is testable directly against #9651; after #10034 lands, this should rebase down to just the vLLM-specific wiring.

## Testing

- `python -m py_compile components/src/dynamo/common/metadata_upload.py components/src/dynamo/vllm/handlers.py components/src/dynamo/frontend/vllm_processor.py components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py`
- `git diff --check`
- Local file-backed uploader smoke test with msgpack bytes round-trip using `/tmp/dynamo-sglang-e2e`
- `PYTHONPATH=components/src /tmp/dynamo-sglang-e2e/bin/python -m pytest components/src/dynamo/vllm/tests/test_vllm_tito_parity.py::TestMetadataUpload::test_metadata_upload_requires_enable_rl -q` skipped because `vllm` is not installed in the available local env

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
