### PR TITLE
docs(skill-cards): add Evaluation Agent / Tasks / Metrics / Results

### DIFF
--- a/skills/dynamo-interconnect-check/skill-card.md
+++ b/skills/dynamo-interconnect-check/skill-card.md
@@ -28,6 +28,22 @@ Mitigation: Review and scan skill before deployment. <br>
 **Output Parameters:** [1D] <br>
 **Other Properties Related to Output:** [None] <br>
 
+## Evaluation Agent: <br>
+Claude (Anthropic) running the skill harness end-to-end, supplemented by the NV-ACES Tier 1 / NV-BASE 2.12.0 static scorer for schema, license, quality, security, and PII validation. <br>
+
+## Evaluation Tasks: <br>
+Six prompts in `evals/evals.json`, split between three positive cases the skill should trigger and act on, and three negative cases it should defer to the correct sibling skill. <br>
+- Positive: `confirm-nixl-before-trusting-disagg`, `agg-ok-disagg-slow-suspect-fabric`, `rdma-nvlink-readiness-multinode`. <br>
+- Negative: `neg-deploy-disagg-recipe` (defers to `dynamo-recipe-runner`), `neg-disagg-pods-crashing` (defers to `dynamo-troubleshoot`), `neg-switch-router-mode` (defers to `dynamo-router-starter`). <br>
+
+## Evaluation Metrics: <br>
+- Trigger-routing accuracy: does the prompt invoke this skill on positive cases and correctly defer on negatives? <br>
+- NV-ACES 4-dimension static score: correctness (35% weight), discoverability (25%), reliability (25%), efficiency (15%). <br>
+
+## Evaluation Results: <br>
+- Trigger-routing: 6/6 cases routed correctly (3 positive + 3 negative); part of the 24/24 across the four bring-up skills attested on PR #9782. <br>
+- NV-ACES Tier 1 / NV-BASE 2.12.0: 83.2 / 100 (Grade B). Dimension breakdown: correctness 70.0, discoverability 90.0, reliability 85.0, efficiency 100.0. <br>
+
 ## Skill Version(s): <br>
 1.2.0 (source: pyproject.toml) <br>
 

--- a/skills/dynamo-recipe-runner/skill-card.md
+++ b/skills/dynamo-recipe-runner/skill-card.md
@@ -29,6 +29,22 @@ Mitigation: Review and scan skill before deployment. <br>
 **Output Parameters:** [1D] <br>
 **Other Properties Related to Output:** [None] <br>
 
+## Evaluation Agent: <br>
+Claude (Anthropic) running the skill harness end-to-end, supplemented by the NV-ACES Tier 1 / NV-BASE 2.12.0 static scorer for schema, license, quality, security, and PII validation. <br>
+
+## Evaluation Tasks: <br>
+Six prompts in `evals/evals.json`, split between three positive cases the skill should trigger and act on, and three negative cases it should defer to the correct sibling skill. <br>
+- Positive: `deploy-qwen-vllm-disagg`, `list-sglang-recipes`, `bring-up-nemotron-end-to-end`. <br>
+- Negative: `neg-switch-router-mode` (defers to `dynamo-router-starter`), `neg-pods-crashlooping` (defers to `dynamo-troubleshoot`), `neg-author-cuda-kernel` (out of scope for the bring-up skill set). <br>
+
+## Evaluation Metrics: <br>
+- Trigger-routing accuracy: does the prompt invoke this skill on positive cases and correctly defer on negatives? <br>
+- NV-ACES 4-dimension static score: correctness (35% weight), discoverability (25%), reliability (25%), efficiency (15%). <br>
+
+## Evaluation Results: <br>
+- Trigger-routing: 6/6 cases routed correctly (3 positive + 3 negative); part of the 24/24 across the four bring-up skills attested on PR #9782. <br>
+- NV-ACES Tier 1 / NV-BASE 2.12.0: 83.2 / 100 (Grade B). Dimension breakdown: correctness 70.0, discoverability 90.0, reliability 85.0, efficiency 100.0. <br>
+
 ## Skill Version(s): <br>
 1.2.0 (source: pyproject.toml) <br>
 

--- a/skills/dynamo-router-starter/skill-card.md
+++ b/skills/dynamo-router-starter/skill-card.md
@@ -27,6 +27,22 @@ Mitigation: Review and scan skill before deployment. <br>
 **Output Parameters:** [1D] <br>
 **Other Properties Related to Output:** [None] <br>
 
+## Evaluation Agent: <br>
+Claude (Anthropic) running the skill harness end-to-end, supplemented by the NV-ACES Tier 1 / NV-BASE 2.12.0 static scorer for schema, license, quality, security, and PII validation. <br>
+
+## Evaluation Tasks: <br>
+Six prompts in `evals/evals.json`, split between three positive cases the skill should trigger and act on, and three negative cases it should defer to the correct sibling skill. <br>
+- Positive: `enable-kv-routing`, `compare-roundrobin-vs-kv`, `router-health-check`. <br>
+- Negative: `neg-deploy-recipe` (defers to `dynamo-recipe-runner`), `neg-router-500s-workers-missing` (defers to `dynamo-troubleshoot`), `neg-validate-nixl` (defers to `dynamo-interconnect-check`). <br>
+
+## Evaluation Metrics: <br>
+- Trigger-routing accuracy: does the prompt invoke this skill on positive cases and correctly defer on negatives? <br>
+- NV-ACES 4-dimension static score: correctness (35% weight), discoverability (25%), reliability (25%), efficiency (15%). <br>
+
+## Evaluation Results: <br>
+- Trigger-routing: 6/6 cases routed correctly (3 positive + 3 negative); part of the 24/24 across the four bring-up skills attested on PR #9782. <br>
+- NV-ACES Tier 1 / NV-BASE 2.12.0: 83.2 / 100 (Grade B). Dimension breakdown: correctness 70.0, discoverability 90.0, reliability 85.0, efficiency 100.0. <br>
+
 ## Skill Version(s): <br>
 1.2.0 (source: pyproject.toml) <br>
 

--- a/skills/dynamo-troubleshoot/skill-card.md
+++ b/skills/dynamo-troubleshoot/skill-card.md
@@ -28,6 +28,22 @@ Mitigation: Review and scan skill before deployment. <br>
 **Output Parameters:** [1D] <br>
 **Other Properties Related to Output:** [None] <br>
 
+## Evaluation Agent: <br>
+Claude (Anthropic) running the skill harness end-to-end, supplemented by the NV-ACES Tier 1 / NV-BASE 2.12.0 static scorer for schema, license, quality, security, and PII validation. <br>
+
+## Evaluation Tasks: <br>
+Six prompts in `evals/evals.json`, split between three positive cases the skill should trigger and act on, and three negative cases it should defer to the correct sibling skill. <br>
+- Positive: `model-download-job-stuck`, `frontend-crashloop`, `dgd-not-reconciling`. <br>
+- Negative: `neg-deploy-recipe` (defers to `dynamo-recipe-runner`), `neg-enable-kv-routing` (defers to `dynamo-router-starter`), `neg-check-interconnect-ready` (defers to `dynamo-interconnect-check`). <br>
+
+## Evaluation Metrics: <br>
+- Trigger-routing accuracy: does the prompt invoke this skill on positive cases and correctly defer on negatives? <br>
+- NV-ACES 4-dimension static score: correctness (35% weight), discoverability (25%), reliability (25%), efficiency (15%). <br>
+
+## Evaluation Results: <br>
+- Trigger-routing: 6/6 cases routed correctly (3 positive + 3 negative); part of the 24/24 across the four bring-up skills attested on PR #9782. <br>
+- NV-ACES Tier 1 / NV-BASE 2.12.0: 83.2 / 100 (Grade B). Dimension breakdown: correctness 70.0, discoverability 90.0, reliability 85.0, efficiency 100.0. <br>
+
 ## Skill Version(s): <br>
 1.2.0 (source: pyproject.toml) <br>
 


### PR DESCRIPTION
## Summary

Add the four Evaluation sections (Agent / Tasks / Metrics / Results) to each of the four bring-up skill cards. The NVSkills bot's auto-generated cards skipped these — the [canonical NVIDIA/Trustworthy-AI Skill Card template](https://github.com/NVIDIA/Trustworthy-AI/blob/main/Skill%20Card.md) expects them.

This was originally part of #10069 but landed on the branch after that PR squash-merged, so it never reached main. Cherry-picked onto a fresh branch.

## What's filled in

- **Evaluation Agent** — Claude (Anthropic) end-to-end harness, plus NV-ACES Tier 1 / NV-BASE 2.12.0 static scorer.
- **Evaluation Tasks** — per-skill list of the six \`evals/evals.json\` cases, marked positive vs. negative-defer with the routing target.
- **Evaluation Metrics** — trigger-routing accuracy + NV-ACES 4-dimension static score (correctness 35%, discoverability 25%, reliability 25%, efficiency 15%).
- **Evaluation Results** — 6/6 trigger-routing per skill (part of the 24/24 attested on #9782) + 83.2/100 Grade B from the NV-BASE report with the per-dimension breakdown.

## Scope

Touches only \`skills/<skill>/skill-card.md\` for the four bring-up skills. No SKILL.md changes, no script changes, no signature regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Added comprehensive evaluation documentation to skill cards with testing methodology, evaluation scenarios, performance metrics, and end-to-end results across multiple skills.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->