### PR TITLE
ci: enable EFA builds in PR on framework or aws dockerfile changes

### DIFF
--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -15,7 +15,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | `vllm` / `sglang` / `trtllm` | Backend-specific tests |
 | `benchmarks` | Dynamo runtime pipeline (runs `tests/benchmarks/**` pytest suite) |
 | `sample` | Sample-backend unified test (piggybacks on vllm image) |
-| `container` | EFA runtime image builds for vLLM, SGLang, TRT-LLM (any `container/**` change) |
+| `efa` | EFA runtime image builds for vLLM, SGLang, TRT-LLM (`container/templates/aws.Dockerfile` change) |
 | `docs` | Nothing (classification only) |
 | `examples` | Nothing (classification only) |
 | `ignore` | Nothing (classification only) |

--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -15,6 +15,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | `vllm` / `sglang` / `trtllm` | Backend-specific tests |
 | `benchmarks` | Dynamo runtime pipeline (runs `tests/benchmarks/**` pytest suite) |
 | `sample` | Sample-backend unified test (piggybacks on vllm image) |
+| `container` | EFA runtime image builds for vLLM, SGLang, TRT-LLM (any `container/**` change) |
 | `docs` | Nothing (classification only) |
 | `examples` | Nothing (classification only) |
 | `ignore` | Nothing (classification only) |

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -40,9 +40,9 @@ outputs:
   benchmarks:
     description: 'Whether benchmarks files changed'
     value: ${{ steps.filter.outputs.benchmarks_any_modified }}
-  container:
-    description: 'Whether container/** files changed'
-    value: ${{ steps.filter.outputs.container_any_modified }}
+  efa:
+    description: 'Whether AWS EFA Dockerfile changed'
+    value: ${{ steps.filter.outputs.efa_any_modified }}
   rust:
     description: 'Whether rust files changed'
     value: ${{ steps.filter.outputs.rust_any_modified }}
@@ -129,7 +129,7 @@ runs:
         echo "sample: ${{ steps.filter.outputs.sample_any_modified }}"
         echo "frontend: ${{ steps.filter.outputs.frontend_any_modified }}"
         echo "benchmarks: ${{ steps.filter.outputs.benchmarks_any_modified }}"
-        echo "container: ${{ steps.filter.outputs.container_any_modified }}"
+        echo "efa: ${{ steps.filter.outputs.efa_any_modified }}"
         echo "rust: ${{ steps.filter.outputs.rust_any_modified }}"
         echo ""
         echo "=== Files Matching Each Filter ==="
@@ -146,14 +146,14 @@ runs:
         echo "sample: ${{ steps.filter.outputs.sample_all_modified_files }}"
         echo "frontend: ${{ steps.filter.outputs.frontend_all_modified_files }}"
         echo "benchmarks: ${{ steps.filter.outputs.benchmarks_all_modified_files }}"
-        echo "container: ${{ steps.filter.outputs.container_all_modified_files }}"
+        echo "efa: ${{ steps.filter.outputs.efa_all_modified_files }}"
         echo "rust: ${{ steps.filter.outputs.rust_all_modified_files }}"
 
     - name: Check for uncovered files
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.container_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -40,6 +40,9 @@ outputs:
   benchmarks:
     description: 'Whether benchmarks files changed'
     value: ${{ steps.filter.outputs.benchmarks_any_modified }}
+  container:
+    description: 'Whether container/** files changed'
+    value: ${{ steps.filter.outputs.container_any_modified }}
   rust:
     description: 'Whether rust files changed'
     value: ${{ steps.filter.outputs.rust_any_modified }}
@@ -126,6 +129,7 @@ runs:
         echo "sample: ${{ steps.filter.outputs.sample_any_modified }}"
         echo "frontend: ${{ steps.filter.outputs.frontend_any_modified }}"
         echo "benchmarks: ${{ steps.filter.outputs.benchmarks_any_modified }}"
+        echo "container: ${{ steps.filter.outputs.container_any_modified }}"
         echo "rust: ${{ steps.filter.outputs.rust_any_modified }}"
         echo ""
         echo "=== Files Matching Each Filter ==="
@@ -142,13 +146,14 @@ runs:
         echo "sample: ${{ steps.filter.outputs.sample_all_modified_files }}"
         echo "frontend: ${{ steps.filter.outputs.frontend_all_modified_files }}"
         echo "benchmarks: ${{ steps.filter.outputs.benchmarks_all_modified_files }}"
+        echo "container: ${{ steps.filter.outputs.container_all_modified_files }}"
         echo "rust: ${{ steps.filter.outputs.rust_all_modified_files }}"
 
     - name: Check for uncovered files
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.container_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -11,7 +11,7 @@
 #   trtllm   -> trtllm build and test
 #   frontend -> frontend EPP image build, dynamo build-test
 #   benchmarks -> dynamo build-test (runs tests/benchmarks/** pytest suite)
-#   container -> vllm/sglang/trtllm EFA runtime image builds (container/** changes)
+#   efa      -> all framework EFA runtime image builds (changes to container/templates/aws.Dockerfile)
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
 #
 # Filters for coverage only (no CI triggered):
@@ -67,7 +67,6 @@ ignore:
   - 'container/run.sh'
   - 'container/use-sccache.sh'
   - 'container/dev/**'
-  - 'container/templates/aws.Dockerfile'
   - 'container/templates/local_dev.Dockerfile'
   - 'container/templates/dev.Dockerfile'
   # Removed by trtllm upstream-base migration; claim here so changed-files
@@ -212,7 +211,5 @@ benchmarks:
   - '!**/*.md'
   - '!**/*.rst'
 
-container:
-  - 'container/**'
-  - '!**/*.md'
-  - '!**/*.rst'
+efa:
+  - 'container/templates/aws.Dockerfile'

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -11,6 +11,7 @@
 #   trtllm   -> trtllm build and test
 #   frontend -> frontend EPP image build, dynamo build-test
 #   benchmarks -> dynamo build-test (runs tests/benchmarks/** pytest suite)
+#   container -> vllm/sglang/trtllm EFA runtime image builds (container/** changes)
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
 #
 # Filters for coverage only (no CI triggered):
@@ -208,5 +209,10 @@ rust:
 
 benchmarks:
   - 'benchmarks/**'
+  - '!**/*.md'
+  - '!**/*.rst'
+
+container:
+  - 'container/**'
   - '!**/*.md'
   - '!**/*.rst'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,7 @@ jobs:
       frontend: ${{ steps.changes.outputs.frontend }}
       benchmarks: ${{ steps.changes.outputs.benchmarks }}
       sample: ${{ steps.changes.outputs.sample }}
-      container: ${{ steps.changes.outputs.container }}
+      efa: ${{ steps.changes.outputs.efa }}
       builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
     steps:
       - name: Checkout code
@@ -274,7 +274,7 @@ jobs:
   vllm-efa-build:
     name: vllm-runtime-efa
     needs: [changed-files]
-    if: needs.changed-files.outputs.container == 'true'
+    if: needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.efa == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: vllm
@@ -289,7 +289,7 @@ jobs:
   sglang-efa-build:
     name: sglang-runtime-efa
     needs: [changed-files]
-    if: needs.changed-files.outputs.container == 'true'
+    if: needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.efa == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: sglang
@@ -304,7 +304,7 @@ jobs:
   trtllm-efa-build:
     name: trtllm-runtime-efa
     needs: [changed-files]
-    if: needs.changed-files.outputs.container == 'true'
+    if: needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.efa == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: trtllm

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -283,7 +283,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       make_efa: true
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
-      build_timeout_minutes: 120
+      build_timeout_minutes: 60
     secrets: inherit
 
   sglang-efa-build:
@@ -298,7 +298,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       make_efa: true
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
-      build_timeout_minutes: 120
+      build_timeout_minutes: 60
     secrets: inherit
 
   trtllm-efa-build:
@@ -313,7 +313,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       make_efa: true
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
-      build_timeout_minutes: 120
+      build_timeout_minutes: 60
     secrets: inherit
 
   planner-build:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,6 +34,7 @@ jobs:
       frontend: ${{ steps.changes.outputs.frontend }}
       benchmarks: ${{ steps.changes.outputs.benchmarks }}
       sample: ${{ steps.changes.outputs.sample }}
+      container: ${{ steps.changes.outputs.container }}
       builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
     steps:
       - name: Checkout code
@@ -71,6 +72,9 @@ jobs:
       - trtllm-test
       - trtllm-multi-gpu-test
       - trtllm-copy-to-acr
+      - vllm-efa-build
+      - sglang-efa-build
+      - trtllm-efa-build
       - planner-build
       - planner-test
       - frontend-build
@@ -265,6 +269,51 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
       build_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-efa-build:
+    name: vllm-runtime-efa
+    needs: [changed-files]
+    if: needs.changed-files.outputs.container == 'true'
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: vllm
+      target: runtime
+      cuda_version: '["12.9"]'
+      platform: 'linux/amd64,linux/arm64'
+      make_efa: true
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      build_timeout_minutes: 120
+    secrets: inherit
+
+  sglang-efa-build:
+    name: sglang-runtime-efa
+    needs: [changed-files]
+    if: needs.changed-files.outputs.container == 'true'
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: sglang
+      target: runtime
+      cuda_version: '["12.9"]'
+      platform: 'linux/amd64,linux/arm64'
+      make_efa: true
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      build_timeout_minutes: 120
+    secrets: inherit
+
+  trtllm-efa-build:
+    name: trtllm-runtime-efa
+    needs: [changed-files]
+    if: needs.changed-files.outputs.container == 'true'
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: trtllm
+      target: runtime
+      cuda_version: '["13.1"]'
+      platform: 'linux/amd64,linux/arm64'
+      make_efa: true
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      build_timeout_minutes: 120
     secrets: inherit
 
   planner-build:
@@ -681,10 +730,13 @@ jobs:
       - planner-test
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
+      - vllm-efa-build
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
+      - sglang-efa-build
       - trtllm-copy-to-acr
       - trtllm-multi-gpu-test
+      - trtllm-efa-build
       - dynamo-pipeline
     steps:
       - name: Checkout repository

--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #}
 # === BEGIN templates/aws.Dockerfile ===
+# TEMP: trigger EFA builds in PR for container-filter validation (revert before merge)
 #############################
 ########## AWS EFA ##########
 #############################

--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #}
 # === BEGIN templates/aws.Dockerfile ===
-# TEMP: trigger EFA builds in PR for container-filter validation (revert before merge)
 #############################
 ########## AWS EFA ##########
 #############################


### PR DESCRIPTION
Adds vllm/sglang/trtllm EFA runtime image builds to the PR workflow, gated with a narrow `efa` filter that
matches only container/templates/aws.Dockerfile, and gate each EFA build on its framework filter OR the new efa filter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added EFA CI filter configuration to detect changes to EFA-related Dockerfile updates
  * Extended GitHub Actions to expose EFA detection output and track EFA-modified files
  * Added three new EFA runtime image build jobs (vLLM, SGLang, TRT-LLM) to CI pipeline, triggered by relevant code changes or EFA Dockerfile modifications
  * Updated workflow cleanup sequencing to account for new build stages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->