### PR TITLE
Fix flaky test_sglang_deployment timeout

### DIFF
--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -404,7 +404,7 @@ sglang_configs = {
             # processor) + 100-token max response + headroom.
             # TODO: bisect via tests/utils/profile_pytest.py for a tighter bound.
             pytest.mark.requested_sglang_kv_tokens(4096),
-            pytest.mark.timeout(300),
+            pytest.mark.timeout(420),
             # post_merge: NIXL stubs outside docker can lack the Decoded
             # transport path. Same gating as vLLM's FD case
             # (tests/serve/multimodal_profiles/vllm.py:67-70).


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9e467c5e-e7d2-4593-8491-b1dc327031a5","source":"chat","resourceId":"9d1d5966-a28e-4b95-a77a-a0d2f4af2802","workflowId":"61bc3604-b3a0-4e93-9082-d7424d98c840","codeChangeId":"61bc3604-b3a0-4e93-9082-d7424d98c840","sourceType":"test-optimization"} -->
#### Overview:

Fixing `test_sglang_deployment[multimodal_agg_fd_qwen-2]`

`test_sglang_deployment[multimodal_agg_fd_qwen-2]` was flaking due to a timeout budget mismatch in the test configuration: this scenario allowed up to 360s for engine readiness, but the pytest timeout marker was set to 300s. Under slower CI startup, pytest could terminate the test before the deployment health checks completed.

#### Details:

- Updated the `multimodal_agg_fd_qwen` scenario timeout marker in `tests/serve/test_sglang.py` from `pytest.mark.timeout(300)` to `pytest.mark.timeout(420)`.
- Kept the change scoped to the test file only.
- Reverted unrelated formatter-induced style-only changes in the same file to keep the patch minimal.

#### Testing:

- Attempted to reproduce by running the target test 4 times:
  - `pytest -q tests/serve/test_sglang.py::test_sglang_deployment[multimodal_agg_fd_qwen-2] --maxfail=1` (x4)
  - Could not execute the test in this environment due to missing dependency: `ModuleNotFoundError: No module named 'pydantic'` during pytest startup.
- Ran lint on changed file:
  - `ruff check tests/serve/test_sglang.py` (passes)

#### Where should the reviewer start?

- `tests/serve/test_sglang.py` around the `multimodal_agg_fd_qwen` config timeout marker.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to flaky test: `test_sglang_deployment[multimodal_agg_fd_qwen-2]`

---

PR by Bits - [View session in Datadog](https://us3.datadoghq.com/code/9d1d5966-a28e-4b95-a77a-a0d2f4af2802)

Comment @datadog to request changes