### PR TITLE
docs(backend): refresh unified-backend feature gaps across guides

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -1,13 +1,15 @@
 # Dynamo Python Backend
 
-**Supported today:** aggregated inference, disaggregated
-(prefill/decode) serving with bootstrap (SGLang) or internal KV
-transport (vLLM, TRT-LLM), request cancellation, graceful shutdown,
-`drain()` hook, error chain wrapping.
+**Supported today:** aggregated and disaggregated (prefill/decode)
+inference, metrics + Prometheus bridging, KV event publishing,
+KV-aware (DP-rank) routing, health-check canaries, OpenTelemetry
+tracing, and request-side guided decoding / structural tag.
 
-> **Work in progress.** Multimodal, LoRA, logprobs, guided decoding,
-> and engine-level metrics are still on the non-unified path. See
-> [Feature Gaps](#feature-gaps) for the full matrix.
+> **Work in progress.** Logprob response wire, multimodal, diffusion
+> (image/video/DLLM), LoRA, engine routes (sleep/wake, profiling,
+> weight updates), text-in-text-out, and snapshot/CRIU are still on
+> the non-unified path. See [Feature Gaps](#feature-gaps) for the
+> per-engine matrix.
 
 > **Looking for a walkthrough?** Start with the
 > [Writing a Python Unified Backend](../../../../../docs/development/python-backend-guide.md)
@@ -427,77 +429,142 @@ that the unified path does not yet support.
 
 ### What works today
 
-- Basic aggregated token-in-token-out inference (all three engines)
+Lifecycle and runtime:
+- Aggregated token-in-token-out inference (all three engines)
 - Model registration with endpoint types
 - Request cancellation via `abort()` + `context.is_stopped()` monitoring
-- `DynamoException` error chain wrapping
 - Graceful shutdown with signal handling
-- Finish reason normalization handled by Rust layer
-- **Disaggregated serving** (`agg`/`prefill`/`decode`) — see
-  [Disaggregated Serving](#disaggregated-serving) below
-- **Metrics & Prometheus** — engine-native metrics passthrough
-  (`vllm:`, `sglang:`, `trtllm_`), `dynamo_component_*` gauges
-  (total_blocks, gpu_cache_usage, model_load_time), TRT-LLM
-  `AdditionalMetricsCollector` (abort, KV transfer, request types).
-  See [Metrics](#metrics) below.
+- `drain()` hook for pre-cleanup work
+- `DynamoException` error chain wrapping
+- Finish reason normalization handled by the Rust layer
+- **Disaggregated serving** (`agg`/`prefill`/`decode`) — KV transfer
+  uses NIXL across all three engines; SGLang exchanges a Dynamo-level
+  bootstrap address, vLLM and TRT-LLM use an engine-internal handshake.
+  See [Disaggregated Serving](#disaggregated-serving) below.
+
+Observability:
+- **Health-check canary** — `health_check_payload()` + operator
+  override via `DYN_HEALTH_CHECK_PAYLOAD` /
+  `--health-check-payload`
+- **Metrics & Prometheus** — vendor-prefixed bridge (`vllm:`,
+  `sglang:`, `trtllm_`, `lmcache:`); framework-owned lifecycle
+  gauges (`cleanup_time_seconds`, `drain_time_seconds`,
+  `model_load_time_seconds`); per-rank `dynamo_component_*` gauges
+  (`total_blocks`, `gpu_cache_usage_percent`, `kv_cache_hit_rate`)
+  + router `kv_used_blocks` signal via `SnapshotPublisher`. See
+  [Metrics](#metrics) below.
+- **KV event publishing** — `kv_event_sources()` returning
+  `ZmqSource` or `PushSource` (prefix cache `BlockStored`/`Removed`
+  events to the router via NATS).
+- **KV-aware routing** — `dp_rank.forced_dp_rank` /
+  `validate_global_dp_rank` plus `EngineConfig.data_parallel_size`
+  / `data_parallel_start_rank` for DP-aware scheduling.
+- **OpenTelemetry tracing** — `telemetry.current_span` /
+  `start_span` plus W3C trace-header propagation to the underlying
+  inference engine via `telemetry.engine_trace_kwargs(context)`.
+  See [Telemetry](#telemetry) below.
+
+Request handling:
+- **Guided decoding / structured outputs** — JSON schema / regex /
+  grammar / choice wired per-engine on the request side
+  (`build_sampling_params` → `StructuredOutputsParams` for vLLM;
+  `_get_guided_decoding_params` for SGLang; `GuidedDecodingParams`
+  for TRT-LLM)
+- **Structural tag generation** — `WorkerConfig.structural_tag_{mode,
+  scope, schema}` + `serialize_structural_tag` helper
+- **Custom Jinja chat templates** — `WorkerConfig.custom_jinja_template`
+  flows to `LocalModelBuilder.custom_template_path` (frontend
+  applies the template; the backend just registers the path)
+- **Tool / reasoning parsers** — `WorkerConfig.tool_call_parser`,
+  `reasoning_parser`, `exclude_tools_when_tool_choice_none`
 
 ### Common gaps (all engines)
 
 | Feature | Description |
 |---------|-------------|
-| KV event publishing | Prefix cache events (BlockStored/Removed) to router via ZMQ or NATS |
-| Health check payloads | Per-engine custom health check payloads (BOS token probe, etc.) |
-| Logprobs | Selected token + top-k log probability extraction and streaming |
-| Guided decoding / structured outputs | JSON schema, regex, grammar, choice constraints |
-| OpenTelemetry tracing | `build_trace_headers()`, request performance metrics, OTEL propagation |
-| Engine routes | Profiling (start/stop), memory release/resume, weight update (disk/tensor/distributed/IPC) |
-| Data-parallel routing | DP rank extraction from routing hints, DP-aware scheduling |
-| Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization |
-| Custom Jinja chat templates | `--custom-jinja-template` for model-specific prompt formatting |
-| Snapshot/checkpoint | CRIU-based engine state save/restore, identity reloading |
+| Logprob response wire | Legacy handlers extract logprobs onto response chunks (`vllm/handlers.py:_extract_logprobs`, `sglang/.../decode_handler.py:_extract_logprobs`, `trtllm/.../handler_base.py:_extract_logprobs`); the unified `generate()` loops do not populate `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk`. vLLM's `build_sampling_params` still passes `output_options.logprobs` to the engine on the unified path, so the engine computes them, but the values are dropped before reaching the chunk. SGLang and TRT-LLM unified `generate()` do not read `output_options.logprobs` at all. |
+| Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization. Unified hardcodes `ModelInput.Tokens`. |
+| Multimodal | Images / video / embeddings, NIXL embedding transfer, encode workers. `worker.py:_to_rust_disaggregation_mode` rejects the `ENCODE` role. |
+| Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path. |
+| LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading on prefill. |
+| Engine routes | Profile start/stop, sleep / wake / quiesce, weight updates (disk / tensor / distributed / IPC), KV block clearing, prefix cache reset. |
+| Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload. |
 
 ### vLLM-specific gaps
 
 | Feature | Description |
 |---------|-------------|
-| LoRA adapters | Dynamic load/unload/list, ModelDeploymentCard publishing, per-LoRA serialization locks. Also: unified prefill does not currently thread per-request LoRA adapters into the engine call. |
-| Multimodal (images/video) | Image/video loading, embedding caching, NIXL RDMA transfer, Qwen VL mRoPE. Also: unified prefill does not pack `embedding_params` into the response's `disaggregated_params` — disagg multimodal flows still need the legacy path. |
-| Separate encode worker | `EncodeWorkerHandler` for multimodal encode-only disaggregation |
-| Sleep/wake/quiesce | 3-level engine lifecycle control (weights, buffers, everything) |
-| Elastic EP scaling | `scale_elastic_ep` with Ray node management |
-| GMS shadow mode | GPU Memory Service integration with failover lock |
-| ModelExpress P2P | Distributed model loading via P2P |
+| Sleep/wake/quiesce | 3-level engine lifecycle control (`VllmEngineQuiesceController`) with shutdown-delay tags |
+| Elastic EP scaling | `scale_elastic_ep` endpoint with Ray node management |
+| GMS shadow mode | GPU Memory Service integration with failover lock (`--gms-shadow-mode`, `configure_gms_lock_mode`) |
+| ModelExpress P2P | Distributed model loading via P2P (`--model-express-url`, `register_modelexpress_loaders`, `mx-source` / `mx-target` load formats) |
 | KV block clearing | Prefix cache reset endpoint |
+| `VllmEngineMonitor` | Background `EngineDeadError` detection task |
+| Instrumented scheduler + FPM relay | Per-forward-pass `ForwardPassMetrics` ZMQ telemetry |
+| `KvConnectorProtocol` abstraction | Legacy abstracts NIXL pull / Mooncake push; unified uses vLLM's internal connector only |
+| `--headless` multi-node mode | Secondary-node TP/PP worker mode (`run_dynamo_headless`); unified requires every node to run the backend |
+| `--benchmark-mode` family | The `--benchmark-*` flag family (mode, prefill/decode granularities, warmup, output path, timeout) injects into `vllm_config.additional_config` |
+| "Omni" alternative entry point | `dynamo.vllm.omni.*` parallel mode for alternative tensor workflows |
+| Multimodal (vLLM) | NIXL embedding transfer (`EmbeddingTransferMode`, `--embedding-transfer-mode`), embedding LRU cache (`--multimodal-embedding-cache-capacity-gb`), Qwen VL mRoPE, `EncodeWorkerHandler`, `--route-to-encoder` |
+| LoRA (vLLM) | Three endpoints (`load_lora`, `unload_lora`, `list_loras`); also: unified prefill doesn't thread per-request LoRA adapters into the engine call |
 
 ### SGLang-specific gaps
 
 | Feature | Description |
 |---------|-------------|
-| Embedding inference | `async_encode()` path, OpenAI embedding response format |
-| Image diffusion | `DiffGenerator` for text-to-image (FLUX, etc.) with TP/DP |
-| Video generation | `DiffGenerator` for text-to-video (Wan2.1, etc.) |
-| LLM diffusion (DLLM) | Diffusion language model algorithm support |
-| Multimodal encode worker | Front-facing `MMEncoder`, embedding LRU cache, NIXL transfer |
-| Multimodal worker | Aggregated/disaggregated multimodal inference with `EmbeddingsProcessor` |
-| Deferred signal handling | Capturing SGLang's internal signal registrations for coordinated shutdown |
-| Output modalities override | Required for diffusion workers (default `["text"]` -> `["image"]`/`["video"]`) |
+| Embedding inference | `async_encode()` path, OpenAI embedding response format, `EmbeddingWorkerHandler` |
+| Image diffusion | `DiffGenerator` for text-to-image (FLUX, etc.) with TP/DP; `ImageDiffusionWorkerHandler` |
+| Video generation | `DiffGenerator` for text-to-video (Wan2.1, etc.); `VideoGenerationWorkerHandler` |
+| LLM diffusion (DLLM) | Diffusion language model algorithm support (`--dllm-algorithm`, `DiffusionWorkerHandler`) |
+| Multimodal encode worker | Front-facing `MMEncoder`, embedding LRU cache, NIXL transfer (`MultimodalEncodeWorkerHandler`) |
+| Multimodal worker | Aggregated and disaggregated-prefill multimodal inference with `EmbeddingsProcessor` |
+| Deferred signal handling | `install_graceful_shutdown` captures SGLang's internal `loop.add_signal_handler` registrations for coordinated teardown |
+| Snapshot quiesce | Legacy `prepare_snapshot_engine` wires `SGLangEngineQuiesceController` to the shared `EngineSnapshotController` (CRIU + identity reload); unified path doesn't invoke it |
+| Image/video health-check payloads | `ImageDiffusionHealthCheckPayload`, `VideoGenerationHealthCheckPayload` |
+| `register_model_with_readiness_gate` + image/video fast paths | `register.py` skips HF `config.json` download for `ModelType.Images` / `ModelType.Videos` |
+| Output modalities override | Required for diffusion workers (default `["text"]` -> `["image"]` / `["video"]`) |
+| `protocol.py` Pydantic models | `EmbeddingRequest`, `DisaggPreprocessedRequest`, multimodal content types |
+| `--disagg-config` YAML override | `--disagg-config` / `--disagg-config-key` for YAML-based disagg config |
+| `--enable-rl` | RL support via `call_tokenizer_manager` route |
 
 ### TRT-LLM-specific gaps
 
 | Feature | Description |
 |---------|-------------|
-| Custom logits processors | `TrtllmDynamoLogitsAdapter` with CUDA stream support |
-| Attention DP scheduling | `SchedulingParams` with `attention_dp_rank` and `attention_dp_relax` |
-| Video diffusion | Auto-detect pipeline from `model_index.json`, MP4 encoding, MediaOutput |
-| Multimodal processing | `MultimodalRequestProcessor`, image URL processing, embedding injection |
-| Encode helper (EPD) | Remote encode via `encode_client`, NIXL tensor reading |
-| KV cache connector | KVBM connector config, consolidator ZMQ integration |
-| Fatal vs per-request errors | Distinguishing `RequestError` (recoverable) from fatal engine errors |
+| Custom logits processors | `TrtllmDynamoLogitsAdapter` with CUDA stream support; legacy wraps user processors via `create_trtllm_adapters` |
+| Multimodal processing | `MultimodalRequestProcessor` with image URL fetching (`load_tensor_from_path_or_url`, httpx) and embedding injection |
+| Image / video diffusion | `DiffusionEngine`, auto-detect pipeline from `model_index.json`, MP4 encoding, `MediaOutput`, full `DiffusionConfig` flag family |
+| Encode helper (EPD) | Remote encode via `encode_client`, NIXL tensor reading; full `_encode_and_pack_disaggregated_params` flow |
+| KV cache connector | KVBM connector config (`build_kv_connector_config`), consolidator ZMQ endpoints (`get_consolidator_endpoints`); unified rejects non-`'none'` connectors in `args.py` |
+| Per-role request handlers | Legacy `PrefillHandler` / `DecodeHandler` / `EncodeHandler` / `AggregatedHandler`; unified collapses into one `generate()` |
+| Fatal vs per-request errors | Legacy distinguishes recoverable `RequestError` (`finish_reason == "error"` branch) from fatal engine errors; unified treats them identically |
+| Backend selection | Legacy `Backend` enum supports `PYTORCH` and `AUTODEPLOY`; unified hardcodes `Backend.PYTORCH` |
+| Modality routing | Legacy `init_worker` dispatches `TEXT` / `MULTIMODAL` / `IMAGE_DIFFUSION` / `VIDEO_DIFFUSION` via `--modality`; unified is LLM-only |
+
+> **Attention-DP scheduling is on the unified path.** `from_args()`
+> sets `enable_attention_dp` into the engine args, and
+> `SchedulingParams(attention_dp_rank=..., attention_dp_relax=False)`
+> is constructed in the generate flow.
 
 ### Recommended migration order
 
-1. **Metrics & health checks** -- needed for production observability
-2. **Disaggregated serving** -- largest architectural change, unlocks PD split
-3. **KV event publishing** -- required for KV-aware routing
-4. **Logprobs + guided decoding** -- most-requested inference features
-5. **Multimodal / LoRA / diffusion** -- modality-specific, can be parallelized across leads
+For users picking what to land next on the unified path:
+
+1. **Logprob response wire** — smallest lift. Wire
+   `output_options.{logprobs, prompt_logprobs}` through to each
+   engine's sampling params, and emit the engine's per-token
+   logprobs onto `GenerateChunk.{log_probs, top_logprobs,
+   cum_log_probs}` in each `generate()`. vLLM already has the
+   request-side passthrough (`build_sampling_params`); SGLang and
+   TRT-LLM unified `generate()` need it added.
+2. **Text-in-text-out** (`ModelInput.Text`) — common ask; needs
+   engine-side tokenization + chat templating path.
+3. **LoRA dynamic load/unload + MDC publishing** — production-visible
+   feature with concrete API surface (three endpoints on vLLM
+   `handlers.py`).
+4. **Engine routes / lifecycle endpoints** — sleep/wake, profile
+   start/stop, weight updates, KV block clearing, prefix cache
+   reset. Visible in operator workflows.
+5. **Snapshot / CRIU** — production checkpoint support.
+6. **Multimodal / diffusion / video / DLLM** — biggest functional
+   gap, but largest scope. Best parallelized across modality leads.

--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -465,11 +465,15 @@ Observability:
   See [Telemetry](#telemetry) below.
 
 Request handling:
-- **Guided decoding / structured outputs** — JSON schema / regex /
-  grammar / choice wired per-engine on the request side
-  (`build_sampling_params` → `StructuredOutputsParams` for vLLM;
-  `_get_guided_decoding_params` for SGLang; `GuidedDecodingParams`
-  for TRT-LLM)
+- **Guided decoding / structured outputs** — wired per-engine on the
+  request side, with engine-specific coverage:
+  - vLLM (`build_sampling_params` → `StructuredOutputsParams`):
+    JSON schema, regex, grammar, choice.
+  - TRT-LLM (`GuidedDecodingParams`): JSON schema, regex, grammar,
+    choice, `json_object`.
+  - SGLang (`_get_guided_decoding_params`): JSON schema only;
+    regex / grammar / choice are silently dropped (see SGLang gaps
+    below).
 - **Structural tag generation** — `WorkerConfig.structural_tag_{mode,
   scope, schema}` + `serialize_structural_tag` helper
 - **Custom Jinja chat templates** — `WorkerConfig.custom_jinja_template`
@@ -526,6 +530,7 @@ Request handling:
 | `protocol.py` Pydantic models | `EmbeddingRequest`, `DisaggPreprocessedRequest`, multimodal content types |
 | `--disagg-config` YAML override | `--disagg-config` / `--disagg-config-key` for YAML-based disagg config |
 | `--enable-rl` | RL support via `call_tokenizer_manager` route |
+| Guided-decoding constraint coverage | `_get_guided_decoding_params` forwards only `json` (and `structural_tag`); `regex` / `grammar` / `choice` are silently dropped on the unified path even though SGLang's engine accepts them |
 
 ### TRT-LLM-specific gaps
 
@@ -535,7 +540,7 @@ Request handling:
 | Multimodal processing | `MultimodalRequestProcessor` with image URL fetching (`load_tensor_from_path_or_url`, httpx) and embedding injection |
 | Image / video diffusion | `DiffusionEngine`, auto-detect pipeline from `model_index.json`, MP4 encoding, `MediaOutput`, full `DiffusionConfig` flag family |
 | Encode helper (EPD) | Remote encode via `encode_client`, NIXL tensor reading; full `_encode_and_pack_disaggregated_params` flow |
-| KV cache connector | KVBM connector config (`build_kv_connector_config`), consolidator ZMQ endpoints (`get_consolidator_endpoints`); unified rejects non-`'none'` connectors in `args.py` |
+| KV cache connector | `args.py` accepts `none` or `kvbm` (`VALID_TRTLLM_CONNECTORS`), but unified `TrtllmLLMEngine.from_args()` never calls `build_kv_connector_config()` or `get_consolidator_endpoints()` — `kvbm` is accepted at the CLI but not actually wired |
 | Per-role request handlers | Legacy `PrefillHandler` / `DecodeHandler` / `EncodeHandler` / `AggregatedHandler`; unified collapses into one `generate()` |
 | Fatal vs per-request errors | Legacy distinguishes recoverable `RequestError` (`finish_reason == "error"` branch) from fatal engine errors; unified treats them identically |
 | Backend selection | Legacy `Backend` enum supports `PYTORCH` and `AUTODEPLOY`; unified hardcodes `Backend.PYTORCH` |

--- a/docs/development/backend-guide.md
+++ b/docs/development/backend-guide.md
@@ -14,10 +14,15 @@ subtitle: Create custom Python workers and engines for Dynamo
 > [unified Python backend](python-backend-guide.md) (or
 > [unified Rust backend](rust-backend-guide.md)) — those put the
 > framework in charge of lifecycle, signal handling, cancellation
-> monitoring, and registration. Stay on this path for workloads that
-> depend on multimodal, LoRA, logprobs, guided decoding, metrics,
-> OTEL tracing, or engine routes — features the unified backend does
-> not yet cover.
+> monitoring, and model registration, and ship plumbing for Prometheus
+> metrics, KV event publishing, KV-aware routing, OpenTelemetry
+> tracing, health-check canaries, guided decoding, and custom Jinja
+> chat templates. Stay on this path for workloads that depend on
+> multimodal, LoRA, logprob extraction, engine routes (sleep/wake,
+> profiling, weight updates), text-in-text-out, snapshot/CRIU, or
+> diffusion — features the unified backend does not yet cover. See
+> the [unified-path feature gaps](python-backend-guide.md#feature-gaps)
+> for the current matrix.
 
 This guide explains how to create your own Python worker in Dynamo.
 

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -55,41 +55,69 @@ alongside this guide.
 
 ## Feature gaps
 
-The unified backend is in beta and does not yet cover the full feature
-set of Dynamo's existing (non-unified) backend paths. The summary
-below is the common contract — what every engine on the unified path
-gets. Per-engine gaps (vLLM, SGLang, TRT-LLM specifics like LoRA,
-diffusion, attention DP scheduling) live in the
+The unified backend is in beta. The summary below is the common
+contract — what every engine on the unified path gets — plus the
+gaps that apply to all three engines. Per-engine specifics (vLLM
+sleep/wake, SGLang diffusion, TRT-LLM custom logits processors,
+etc.) live in the
 [package README](../../components/src/dynamo/common/backend/README.md#feature-gaps).
 
 **Supported today**
 
+Lifecycle and runtime:
 - Aggregated token-in-token-out inference
-- Disaggregated serving (`agg` / `prefill` / `decode`) with bootstrap
-  (SGLang) or internal KV transport (vLLM, TRT-LLM)
+- Disaggregated serving (`agg` / `prefill` / `decode`) — KV transfer
+  uses NIXL across all three engines; SGLang exchanges a Dynamo-level
+  bootstrap address (host/port/room), vLLM and TRT-LLM use an
+  engine-internal handshake
 - Model registration with discovery and endpoint types
 - Request cancellation via `abort()` + `context.is_stopped()`
-- `DynamoException` error chain wrapping
 - Graceful shutdown with signal handling
+- `drain()` hook for pre-cleanup work (e.g. in-flight NIXL transfers)
+- `DynamoException` error chain wrapping
 - Finish reason normalization (handled by the Rust layer)
 
-**Not yet on the unified path**
+Observability:
+- Health-check canary via `health_check_payload()` (plus
+  `DYN_HEALTH_CHECK_PAYLOAD` / `--health-check-payload` overrides)
+- Vendor-prefixed Prometheus bridge (`vllm:` / `sglang:` /
+  `trtllm_` / `lmcache:`) via `register_prometheus()`
+- Framework-owned lifecycle gauges (`cleanup_time_seconds`,
+  `drain_time_seconds`, `model_load_time_seconds`) — always on
+- Per-rank `dynamo_component_*` gauges + router `kv_used_blocks`
+  signal via `component_metrics_dp_ranks()` +
+  `attach_snapshot_publisher()` + `ComponentSnapshot` push
+- KV event publishing via `kv_event_sources()` returning
+  `ZmqSource` or `PushSource`
+- KV-aware routing (DP-rank-aware) via `dp_rank.forced_dp_rank` /
+  `validate_global_dp_rank` + `EngineConfig.data_parallel_{size,
+  start_rank}`
+- OpenTelemetry tracing facade — `telemetry.current_span` /
+  `start_span` plus W3C trace header propagation through
+  `telemetry.engine_trace_kwargs(context)`
+
+Request handling:
+- Guided decoding (JSON schema / regex / grammar / choice) wired
+  per-engine on the request side
+- Structural tag generation via `WorkerConfig.structural_tag_{mode,
+  scope, schema}` and `serialize_structural_tag`
+- Custom Jinja chat templates via
+  `WorkerConfig.custom_jinja_template` (frontend applies; the
+  backend advertises through model registration)
+- Tool / reasoning parser configuration (`tool_call_parser`,
+  `reasoning_parser`, `exclude_tools_when_tool_choice_none`)
+
+**Not yet on the unified path (common to all engines)**
 
 | Feature | What's missing |
 |---------|----------------|
-| Metrics & Prometheus | Engine-level metrics, KV utilization gauges, multiprocess registry |
-| KV event publishing | Prefix cache events (BlockStored / Removed) to router via ZMQ or NATS |
-| Health check payloads | Per-engine custom health probes (BOS token probe, etc.) |
-| Logprobs | Selected + top-k logprob extraction and streaming |
-| Guided decoding | JSON schema, regex, grammar, choice constraints |
-| OpenTelemetry tracing | Trace headers, request perf metrics, OTEL propagation |
-| Engine routes | Profiling, memory release/resume, weight updates (disk/tensor/distributed/IPC) |
-| Data-parallel routing | DP rank extraction, DP-aware scheduling |
-| Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization |
-| Custom Jinja chat templates | `--custom-jinja-template` for model-specific prompt formatting |
-| Snapshot/checkpoint | CRIU-based engine state save/restore |
-| Multimodal | Images, video, embeddings, separate encode workers |
-| LoRA adapters | Dynamic load/unload, ModelDeploymentCard publishing, per-adapter serialization |
+| Logprob response wire | Legacy handlers extract logprobs onto response chunks (vLLM `_extract_logprobs`, SGLang `_extract_logprobs` in `decode_handler`, TRT-LLM `_extract_logprobs` in `handler_base`); the unified `generate()` loops do not populate `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk`. vLLM's `build_sampling_params` still passes `output_options.logprobs` to the engine on the unified path, so the engine computes them, but the values are dropped before they reach the chunk. SGLang and TRT-LLM unified `generate()` do not read `output_options.logprobs` at all. |
+| Text-in-text-out mode | Unified hardcodes `ModelInput.Tokens`; no engine-side tokenization or chat templating path |
+| Multimodal | Images / video / embeddings, NIXL embedding transfer, separate encode workers, `ENCODE` disaggregation role |
+| Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
+| LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading on prefill |
+| Engine routes | Profile start/stop, sleep / wake / quiesce, weight updates (disk / tensor / distributed / IPC), KV block clearing, prefix cache reset |
+| Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |
 
 If you need one of these features today, keep that workload on the
 existing per-engine entry point (`dynamo.<backend>.main`) until the

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -97,8 +97,12 @@ Observability:
   `telemetry.engine_trace_kwargs(context)`
 
 Request handling:
-- Guided decoding (JSON schema / regex / grammar / choice) wired
-  per-engine on the request side
+- Guided decoding — wired per-engine on the request side with
+  engine-specific coverage. vLLM (`StructuredOutputsParams`) and
+  TRT-LLM (`GuidedDecodingParams`) cover JSON schema / regex / grammar
+  / choice; SGLang (`_get_guided_decoding_params`) covers JSON schema
+  only — regex / grammar / choice are silently dropped today (see the
+  SGLang-specific gaps in the package README)
 - Structural tag generation via `WorkerConfig.structural_tag_{mode,
   scope, schema}` and `serialize_structural_tag`
 - Custom Jinja chat templates via

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -60,46 +60,83 @@ guide.
 
 ## Feature gaps
 
-The unified backend is in beta and does not yet cover the full feature
-set of Dynamo's existing (non-unified) backend paths. The summary
-below is the common contract — what every engine on the unified path
-gets, whether written in Rust directly or plugged in from Python via
-the PyO3 `Worker` shim. Per-engine gaps (vLLM, SGLang, TRT-LLM
-specifics like LoRA, diffusion, attention DP scheduling) live in the
+The unified backend is in beta. The summary below is the common
+contract — what every engine on the unified path gets, whether
+written in Rust directly or plugged in from Python via the PyO3
+`Worker` shim. Per-engine specifics (vLLM sleep/wake, SGLang
+diffusion, TRT-LLM custom logits processors, etc.) live in the
 [Python package README](../../components/src/dynamo/common/backend/README.md#feature-gaps).
 
 **Supported today**
 
+Lifecycle and runtime:
 - Aggregated token-in-token-out inference
-- Disaggregated serving (`Aggregated` / `Prefill` / `Decode`) with
-  bootstrap (SGLang) or internal KV transport (vLLM, TRT-LLM); the
-  Rust [mocker example](https://github.com/ai-dynamo/dynamo/tree/main/lib/backend-common/examples/mocker)
+- Disaggregated serving (`Aggregated` / `Prefill` / `Decode`) — KV
+  transfer uses NIXL across all production engines; SGLang exchanges
+  a Dynamo-level bootstrap address, vLLM and TRT-LLM use an
+  engine-internal handshake. The Rust
+  [mocker example](https://github.com/ai-dynamo/dynamo/tree/main/lib/backend-common/examples/mocker)
   exercises the same wire format CPU-only
 - Model registration with discovery and endpoint types
 - Request cancellation via in-stream `ctx.is_stopped()` polling plus
   the framework's out-of-band `abort()` monitor
+- `drain()` hook for pre-cleanup work
 - Typed `DynamoError` with `ErrorType::Backend(BackendError::X)`
-- Graceful shutdown with signal handling, `drain()` hook, and 3-phase
+- Graceful shutdown with signal handling and 3-phase
   distributed-runtime teardown
 - Debug-build stream validator and the `testing::run_conformance` kit
 
-**Not yet on the unified path**
+Observability:
+- Health-check canary via `LLMEngine::health_check_payload()` plus
+  the operator override (`DYN_HEALTH_CHECK_PAYLOAD` /
+  `--health-check-payload`)
+- Vendor-registry bridge into the runtime's `/metrics` output via
+  `LLMEngine::setup_metrics()`, plus framework-owned lifecycle
+  gauges (`dynamo_component_{cleanup_time_seconds,
+  drain_time_seconds, model_load_time_seconds}`) and per-rank
+  `dynamo_component_*` gauges driven by `SnapshotPublisher`
+- KV event publishing via `kv_event_sources()` returning
+  `KvEventSource::Zmq` or `KvEventSource::Push`
+- KV-aware routing (DP-rank-aware) — engines advertise their slice
+  via `EngineConfig::data_parallel_size` /
+  `data_parallel_start_rank`; read the router-forced rank off
+  `request.routing.dp_rank` in `generate()`
+- OpenTelemetry tracing — the framework auto-opens an
+  `engine.generate` span around every `generate()` call with
+  attributes for `model` / `input_tokens` / `disagg_role` / `ttft_ms`
+  / `output_tokens` / `finish_reason` / ITL percentiles. Static-name
+  spans opened with `tracing::info_span!` inside `generate()` nest
+  under it automatically; for dynamic span names use
+  `dynamo_backend_common::telemetry::start_span(name)`. For outbound
+  calls that need to carry trace context (custom HTTP/TCP
+  transports), use
+  `dynamo_runtime::logging::inject_trace_headers_into_map`. NATS
+  egress is auto-injected — engines do nothing.
+
+Request handling:
+- Guided decoding (JSON schema / regex / grammar / choice) —
+  request shape carries `SamplingOptions::guided_decoding`
+  (`GuidedDecodingOptions`); engines forward to their underlying API
+- Structural tag generation — `WorkerConfig::structural_tag_{mode,
+  scope, schema}` (typed enums)
+- Custom Jinja chat templates — `WorkerConfig::custom_jinja_template`
+  flows to `LocalModelBuilder::custom_template_path` and the
+  frontend applies the template at preprocessing time
+- Tool / reasoning parser configuration on `WorkerConfig`
+  (`tool_call_parser`, `reasoning_parser`,
+  `exclude_tools_when_tool_choice_none`)
+
+**Not yet on the unified path (common to all engines)**
 
 | Feature | What's missing |
 |---------|----------------|
-| Metrics & Prometheus | Engine-level metrics, KV utilization gauges, multiprocess registry |
-| KV event publishing | Prefix cache events (BlockStored / Removed) to router via ZMQ or NATS |
-| Health check payloads | Per-engine custom health probes |
-| Logprobs | Selected + top-k logprob extraction and streaming |
-| Guided decoding | JSON schema, regex, grammar, choice constraints |
-| OpenTelemetry tracing | Trace headers, request perf metrics, OTEL propagation |
-| Engine routes | Profiling, memory release/resume, weight updates (disk/tensor/distributed/IPC) |
-| Data-parallel routing | DP rank extraction, DP-aware scheduling |
+| Logprob response wire | Request-side is plumbed; `generate()` does not yet emit `log_probs` / `top_logprobs` / `cum_log_probs` on `LLMEngineOutput` |
 | Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
-| Custom Jinja chat templates | Plumbed through `WorkerConfig` but not yet honored end-to-end |
-| Snapshot/checkpoint | CRIU-based engine state save/restore |
-| Multimodal | Images, video, embeddings, separate encode workers |
-| LoRA adapters | Dynamic load/unload, per-adapter serialization |
+| Multimodal | Images / video / embeddings, NIXL embedding transfer, separate encode workers; `ENCODE` disaggregation role |
+| Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
+| LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization |
+| Engine routes | Profile start/stop, sleep / wake / quiesce, weight updates (disk / tensor / distributed / IPC), KV block clearing, prefix cache reset |
+| Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |
 
 If you need one of these features today, keep that workload on the
 existing per-engine entry point until the unified path catches up.

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -114,9 +114,13 @@ Observability:
   egress is auto-injected — engines do nothing.
 
 Request handling:
-- Guided decoding (JSON schema / regex / grammar / choice) —
-  request shape carries `SamplingOptions::guided_decoding`
-  (`GuidedDecodingOptions`); engines forward to their underlying API
+- Guided decoding — request shape carries
+  `SamplingOptions::guided_decoding` (`GuidedDecodingOptions`);
+  engine-side coverage on the existing Python-bridged engines is:
+  vLLM and TRT-LLM forward JSON schema / regex / grammar / choice;
+  SGLang forwards JSON schema only (regex / grammar / choice are
+  silently dropped today). A new Rust engine should forward whichever
+  variants its backend supports
 - Structural tag generation — `WorkerConfig::structural_tag_{mode,
   scope, schema}` (typed enums)
 - Custom Jinja chat templates — `WorkerConfig::custom_jinja_template`
@@ -130,7 +134,7 @@ Request handling:
 
 | Feature | What's missing |
 |---------|----------------|
-| Logprob response wire | Request-side is plumbed; `generate()` does not yet emit `log_probs` / `top_logprobs` / `cum_log_probs` on `LLMEngineOutput` |
+| Logprob response wire | `PreprocessedRequest.output_options.{logprobs, prompt_logprobs}` exists on the request shape. Of the existing engines (Python-bridged through PyO3), only vLLM passes the option through to its sampling params on the unified path; SGLang and TRT-LLM unified `generate()` ignore it. No engine populates `log_probs` / `top_logprobs` / `cum_log_probs` on `LLMEngineOutput` — the response wire is open but unused |
 | Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
 | Multimodal | Images / video / embeddings, NIXL embedding transfer, separate encode workers; `ENCODE` disaggregation role |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -5,10 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 
 # Dynamo Rust Backend (`dynamo-backend-common`)
 
-> **Work in progress.** The unified backend supports aggregated and
-> disaggregated (prefill/decode) inference; multimodal, LoRA, logprobs,
-> guided decoding, and engine-level metrics are still on the
-> non-unified path. The Python `Worker`
+> **Work in progress.** The unified backend covers aggregated and
+> disaggregated (prefill/decode) inference, metrics + Prometheus
+> bridging, KV event publishing, KV-aware (DP-rank) routing,
+> health-check canaries, OpenTelemetry tracing, and request-side
+> guided decoding. Logprob response wire, multimodal, diffusion
+> (image/video/DLLM), LoRA, engine routes (sleep/wake, profiling,
+> weight updates), text-in-text-out, and snapshot/CRIU are still on
+> the non-unified path. See the
+> [Python package README](../../components/src/dynamo/common/backend/README.md#feature-gaps)
+> for the per-engine matrix. The Python `Worker`
 > ([`dynamo.common.backend`](../../components/src/dynamo/common/backend/))
 > is a thin shim over this crate.
 


### PR DESCRIPTION
## Summary

- Refresh the unified-backend feature surface across the five docs that describe it: `docs/development/{python-backend-guide.md, rust-backend-guide.md, backend-guide.md}`, `components/src/dynamo/common/backend/README.md`, and `lib/backend-common/README.md`.
- Move features that have actually landed (metrics + Prometheus bridge, KV event publishing, KV-aware / DP-rank routing, OpenTelemetry tracing, health-check canaries, guided decoding + structural tag, custom Jinja chat templates, tool/reasoning parsers) out of the "not yet" lists and into "supported today".
- Refresh the per-engine gap matrix in the package README with current legacy-vs-unified deltas — adds rows for vLLM (sleep/wake, scale_elastic_ep, GMS, ModelExpress, VllmEngineMonitor, InstrumentedScheduler, KvConnectorProtocol, headless, benchmark flags, omni), SGLang (`async_encode` embedding worker, image/video/DLLM, MMEncoder, deferred shutdown, snapshot quiesce, image/video health-check payloads, `--disagg-config`, `--enable-rl`), TRT-LLM (custom logits processors, MultimodalRequestProcessor, encode_helper EPD, KVBM consolidator, DiffusionEngine, per-role handlers, fatal-vs-recoverable errors, Backend enum, modality routing).
- Pull "attention-DP scheduling" out of the TRT-LLM gap list — it's wired through the unified path.
- Reorder the recommended migration list to reflect actual landing order: logprob response wire first (smallest lift), text-in-text-out, LoRA, engine routes, snapshot/CRIU, multimodal/diffusion last.
- Logprob row honestly describes the partial state: request-side passthrough exists in vLLM (`build_sampling_params`); SGLang and TRT-LLM unified `generate()` don't read it; no engine populates `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk` / `LLMEngineOutput`.
- Disaggregation framing aligned across all five docs: KV transfer uses NIXL across all three engines — SGLang exchanges a Dynamo-level bootstrap address; vLLM and TRT-LLM use an engine-internal handshake.

## Test plan

- [ ] Docs build cleanly (no broken links / anchors).
- [ ] All in-doc references (class names, function names, CLI flags, gauge names) verified against `components/src/dynamo/`, `lib/backend-common/`, and `lib/llm/src/protocols/` source.
- [ ] Cross-reference `#feature-gaps` anchor resolves in the package README.
- [ ] Visual scan in the rendered Markdown view (GitHub or Fern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend capability documentation clarifying supported features and remaining development areas
  * Expanded feature matrices with detailed per-engine implementation specifics and limitation documentation
  * Restructured feature-gap sections across backend guides for improved clarity and navigation
  * Enhanced backend migration guidance with refined roadmap and feature-implementation priorities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->