### PR TITLE
fix: metadata-only register_model + cache-first from_hf

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -427,9 +427,11 @@ fn register_model<'p>(
 
         // For non-TensorBased models, resolve the model path (local or fetch from HuggingFace).
         // Pass ignore_weights=true: register_model only consumes metadata (config.json,
-        // tokenizer*, generation_config.json, chat template) when building the MDC, so the
-        // weight files would be downloaded and discarded. Backends (SGLang/vLLM) handle their
-        // own weight loading via fetch_model before register_model is called. See DIS-1798.
+        // tokenizer*, generation_config.json, chat template) when building the MDC, so any
+        // weight files would be downloaded and discarded. Engines load weights independently
+        // before register_model runs — SGLang and vLLM via an explicit fetch_model pre-flight,
+        // TRT-LLM via a pre-staged local path (which takes the fs::exists branch above) or
+        // via its own runtime resolving the HF repo.
         let model_path = if fs::exists(&source_path)? {
             PathBuf::from(&source_path)
         } else {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -425,11 +425,15 @@ fn register_model<'p>(
             return Ok(());
         }
 
-        // For non-TensorBased models, resolve the model path (local or fetch from HuggingFace)
+        // For non-TensorBased models, resolve the model path (local or fetch from HuggingFace).
+        // Pass ignore_weights=true: register_model only consumes metadata (config.json,
+        // tokenizer*, generation_config.json, chat template) when building the MDC, so the
+        // weight files would be downloaded and discarded. Backends (SGLang/vLLM) handle their
+        // own weight loading via fetch_model before register_model is called. See DIS-1798.
         let model_path = if fs::exists(&source_path)? {
             PathBuf::from(&source_path)
         } else {
-            LocalModel::fetch(&source_path, false)
+            LocalModel::fetch(&source_path, true)
                 .await
                 .map_err(to_pyerr)?
         };

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -93,9 +93,7 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let model_name = name.display().to_string();
 
     // Cache-first in all modes: if the snapshot is already on disk with the files we
-    // need, return it without touching the network. Previously this short-circuit was
-    // gated behind HF_HUB_OFFLINE=1, which forced operators to set the env var to avoid
-    // HF API hangs on nodes whose cache was already populated. See DIS-1803.
+    // need, return it without touching the network.
     if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {
         return Ok(cached_path);
     }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -262,10 +262,7 @@ mod tests {
     /// `get_model_express_cache_dir()` resolves deterministically.
     unsafe fn set_hub_cache_env(path: &Path) {
         unsafe {
-            env::set_var(
-                env_model::huggingface::HF_HUB_CACHE,
-                path.to_str().unwrap(),
-            );
+            env::set_var(env_model::huggingface::HF_HUB_CACHE, path.to_str().unwrap());
             env::remove_var(env_model::huggingface::HF_HOME);
             env::remove_var(env_model::model_express::MODEL_EXPRESS_CACHE_PATH);
             env::remove_var(env_model::huggingface::HF_HUB_OFFLINE);

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -35,13 +35,18 @@ fn get_cached_model_path(model_name: &str, ignore_weights: bool) -> Option<PathB
         return None;
     }
 
-    // For full downloads, check for weight files
+    // For full downloads, check for weight files. When an index file is present,
+    // verify the shard files it references are also cached — an index without its
+    // shards is an incomplete cache that should fall through to download.
     if !ignore_weights {
-        // Check common weight file patterns - at least one must exist
         let has_weights = repo.get("model.safetensors").is_some()
             || repo.get("pytorch_model.bin").is_some()
-            || repo.get("model.safetensors.index.json").is_some()
-            || repo.get("pytorch_model.bin.index.json").is_some();
+            || repo
+                .get("model.safetensors.index.json")
+                .is_some_and(|p| shard_files_present(&p))
+            || repo
+                .get("pytorch_model.bin.index.json")
+                .is_some_and(|p| shard_files_present(&p));
 
         if !has_weights {
             return None;
@@ -61,6 +66,33 @@ fn has_tiktoken_file(dir: &Path) -> bool {
         .flatten()
         .flatten()
         .any(|e| e.path().extension().is_some_and(|ext| ext == "tiktoken"))
+}
+
+/// For a sharded-weights index file (e.g. `model.safetensors.index.json`), verify
+/// that every shard file it references is present in the same snapshot directory.
+/// Returns false on parse error, missing weight_map, empty weight_map, or any
+/// missing shard file.
+fn shard_files_present(index_path: &Path) -> bool {
+    let Some(snapshot_dir) = index_path.parent() else {
+        return false;
+    };
+    let Ok(contents) = std::fs::read_to_string(index_path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+    let Some(weight_map) = value.get("weight_map").and_then(|v| v.as_object()) else {
+        return false;
+    };
+    let shards: std::collections::HashSet<&str> = weight_map
+        .values()
+        .filter_map(|v| v.as_str())
+        .collect();
+    if shards.is_empty() {
+        return false;
+    }
+    shards.iter().all(|s| snapshot_dir.join(s).exists())
 }
 
 /// Check if offline mode is enabled via HF_HUB_OFFLINE environment variable.
@@ -256,21 +288,55 @@ mod tests {
         snapshot_dir
     }
 
-    /// Point HF_HUB_CACHE at `path` and clear the other cache env vars so
-    /// `get_model_express_cache_dir()` resolves deterministically.
-    unsafe fn set_hub_cache_env(path: &Path) {
-        unsafe {
-            env::set_var(env_model::huggingface::HF_HUB_CACHE, path.to_str().unwrap());
-            env::remove_var(env_model::huggingface::HF_HOME);
-            env::remove_var(env_model::model_express::MODEL_EXPRESS_CACHE_PATH);
-            env::remove_var(env_model::huggingface::HF_HUB_OFFLINE);
+    /// Snapshot every cache-related env var and restore the exact prior state on Drop.
+    /// Use `EnvGuard::with_hub_cache(path)` to point HF_HUB_CACHE at a test directory
+    /// while ensuring no leak across tests (including the non-serial ones that read
+    /// these vars).
+    struct EnvGuard {
+        hub_cache: Option<String>,
+        hub_offline: Option<String>,
+        hf_home: Option<String>,
+        mx_cache_path: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn with_hub_cache(path: &Path) -> Self {
+            let guard = Self {
+                hub_cache: env::var(env_model::huggingface::HF_HUB_CACHE).ok(),
+                hub_offline: env::var(env_model::huggingface::HF_HUB_OFFLINE).ok(),
+                hf_home: env::var(env_model::huggingface::HF_HOME).ok(),
+                mx_cache_path: env::var(env_model::model_express::MODEL_EXPRESS_CACHE_PATH).ok(),
+            };
+            unsafe {
+                env::set_var(env_model::huggingface::HF_HUB_CACHE, path.to_str().unwrap());
+                env::remove_var(env_model::huggingface::HF_HOME);
+                env::remove_var(env_model::model_express::MODEL_EXPRESS_CACHE_PATH);
+                env::remove_var(env_model::huggingface::HF_HUB_OFFLINE);
+            }
+            guard
         }
     }
 
-    unsafe fn clear_hub_cache_env() {
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                restore(env_model::huggingface::HF_HUB_CACHE, &self.hub_cache);
+                restore(env_model::huggingface::HF_HUB_OFFLINE, &self.hub_offline);
+                restore(env_model::huggingface::HF_HOME, &self.hf_home);
+                restore(
+                    env_model::model_express::MODEL_EXPRESS_CACHE_PATH,
+                    &self.mx_cache_path,
+                );
+            }
+        }
+    }
+
+    unsafe fn restore(key: &str, value: &Option<String>) {
         unsafe {
-            env::remove_var(env_model::huggingface::HF_HUB_CACHE);
-            env::remove_var(env_model::huggingface::HF_HUB_OFFLINE);
+            match value {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
         }
     }
 
@@ -283,10 +349,9 @@ mod tests {
         let model = "test-org/metadata-only";
         let snapshot = build_hf_cache(temp.path(), model, &["config.json", "tokenizer.json"]);
 
-        unsafe { set_hub_cache_env(temp.path()) };
+        let _guard = EnvGuard::with_hub_cache(temp.path());
         let with_weights = get_cached_model_path(model, false);
         let no_weights = get_cached_model_path(model, true);
-        unsafe { clear_hub_cache_env() };
 
         assert!(
             with_weights.is_none(),
@@ -310,21 +375,49 @@ mod tests {
             &["config.json", "tokenizer.json", "model.safetensors"],
         );
 
-        unsafe { set_hub_cache_env(temp.path()) };
+        let _guard = EnvGuard::with_hub_cache(temp.path());
         let with_weights = get_cached_model_path(model, false);
         let no_weights = get_cached_model_path(model, true);
-        unsafe { clear_hub_cache_env() };
 
         assert_eq!(with_weights.as_deref(), Some(snapshot.as_path()));
         assert_eq!(no_weights.as_deref(), Some(snapshot.as_path()));
     }
 
     #[serial_test::serial]
+    #[test]
+    fn test_cached_path_sharded_requires_all_shard_files() {
+        // A cache containing only `model.safetensors.index.json` (without the
+        // shard files it points to) is incomplete and must NOT satisfy
+        // ignore_weights=false. Once all shards are written, it should.
+        let temp = TempDir::new().unwrap();
+        let model = "test-org/sharded";
+        let snapshot = build_hf_cache(temp.path(), model, &["config.json", "tokenizer.json"]);
+        fs::write(
+            snapshot.join("model.safetensors.index.json"),
+            r#"{"weight_map": {"a.weight": "model-00001-of-00002.safetensors", "b.weight": "model-00002-of-00002.safetensors"}}"#,
+        )
+        .unwrap();
+
+        let _guard = EnvGuard::with_hub_cache(temp.path());
+
+        let incomplete = get_cached_model_path(model, false);
+        assert!(
+            incomplete.is_none(),
+            "sharded cache without shard files must NOT satisfy ignore_weights=false"
+        );
+
+        fs::write(snapshot.join("model-00001-of-00002.safetensors"), "").unwrap();
+        fs::write(snapshot.join("model-00002-of-00002.safetensors"), "").unwrap();
+        let complete = get_cached_model_path(model, false);
+        assert_eq!(complete.as_deref(), Some(snapshot.as_path()));
+    }
+
+    #[serial_test::serial]
     #[tokio::test]
     async fn test_from_hf_cache_first_in_online_mode() {
-        // DIS-1803: cache-first short-circuit must fire even when HF_HUB_OFFLINE
-        // is not set. If the short-circuit works, from_hf returns the cached path
-        // without touching MxClient or the HF network.
+        // The cache-first short-circuit must fire even when HF_HUB_OFFLINE is
+        // not set. If it does, from_hf returns the cached path without touching
+        // MxClient or the HF network.
         let temp = TempDir::new().unwrap();
         let model = "test-org/cache-first-online";
         let snapshot = build_hf_cache(
@@ -333,9 +426,8 @@ mod tests {
             &["config.json", "tokenizer.json", "model.safetensors"],
         );
 
-        unsafe { set_hub_cache_env(temp.path()) };
+        let _guard = EnvGuard::with_hub_cache(temp.path());
         let result = from_hf(PathBuf::from(model), false).await;
-        unsafe { clear_hub_cache_env() };
 
         assert_eq!(
             result.ok().as_deref(),

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -85,10 +85,8 @@ fn shard_files_present(index_path: &Path) -> bool {
     let Some(weight_map) = value.get("weight_map").and_then(|v| v.as_object()) else {
         return false;
     };
-    let shards: std::collections::HashSet<&str> = weight_map
-        .values()
-        .filter_map(|v| v.as_str())
-        .collect();
+    let shards: std::collections::HashSet<&str> =
+        weight_map.values().filter_map(|v| v.as_str()).collect();
     if shards.is_empty() {
         return false;
     }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -25,9 +25,13 @@ fn get_cached_model_path(model_name: &str, ignore_weights: bool) -> Option<PathB
     // Check for required config file
     let config_path = repo.get("config.json")?;
 
-    // Check for tokenizer files (at least one must exist)
+    // Check for tokenizer files (at least one must exist). Only count
+    // artifacts that ``ModelDeploymentCard::TokenizerKind::from_disk`` can
+    // actually load -- ``tokenizer_config.json`` is metadata describing the
+    // tokenizer and cannot be used on its own, so a snapshot with only
+    // ``config.json`` + ``tokenizer_config.json`` would fall through to a
+    // download even though the cache appears "populated".
     let has_tokenizer = repo.get("tokenizer.json").is_some()
-        || repo.get("tokenizer_config.json").is_some()
         || repo.get("tiktoken.model").is_some()
         || has_tiktoken_file(config_path.parent()?);
 
@@ -408,6 +412,35 @@ mod tests {
         fs::write(snapshot.join("model-00002-of-00002.safetensors"), "").unwrap();
         let complete = get_cached_model_path(model, false);
         assert_eq!(complete.as_deref(), Some(snapshot.as_path()));
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn test_cached_path_rejects_tokenizer_config_without_real_tokenizer() {
+        // A snapshot with only ``config.json`` and ``tokenizer_config.json``
+        // (no ``tokenizer.json`` / ``tiktoken.model`` / ``*.tiktoken``) cannot
+        // actually load a tokenizer at runtime via
+        // ``TokenizerKind::from_disk``. The cache-hit probe must reject this
+        // partial state in BOTH modes so ``from_hf`` falls through to a
+        // download that populates the real tokenizer artifact.
+        let temp = TempDir::new().unwrap();
+        let model = "test-org/tokenizer-config-only";
+        build_hf_cache(
+            temp.path(),
+            model,
+            &["config.json", "tokenizer_config.json"],
+        );
+
+        let _guard = EnvGuard::with_hub_cache(temp.path());
+
+        assert!(
+            get_cached_model_path(model, true).is_none(),
+            "tokenizer_config.json alone must NOT satisfy ignore_weights=true",
+        );
+        assert!(
+            get_cached_model_path(model, false).is_none(),
+            "tokenizer_config.json alone must NOT satisfy ignore_weights=false",
+        );
     }
 
     #[serial_test::serial]

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -86,20 +86,21 @@ fn is_no_shared_storage() -> bool {
 /// If ignore_weights is true, model weight files will be skipped
 /// Returns the path to the model files
 ///
-/// If HF_HUB_OFFLINE=1 is set and the model is already cached, returns the cached
-/// path without making any API calls to HuggingFace.
+/// If the model is already cached locally with the required files, returns the cached
+/// path without making any API calls to HuggingFace, regardless of HF_HUB_OFFLINE.
 pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Result<PathBuf> {
     let name = name.as_ref();
     let model_name = name.display().to_string();
 
-    // In offline mode, check cache first and return immediately if found
+    // Cache-first in all modes: if the snapshot is already on disk with the files we
+    // need, return it without touching the network. Previously this short-circuit was
+    // gated behind HF_HUB_OFFLINE=1, which forced operators to set the env var to avoid
+    // HF API hangs on nodes whose cache was already populated. See DIS-1803.
+    if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {
+        return Ok(cached_path);
+    }
+
     if is_offline_mode() {
-        if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {
-            tracing::info!(
-                "Offline mode: using cached model '{model_name}' without API validation"
-            );
-            return Ok(cached_path);
-        }
         tracing::warn!(
             "Offline mode enabled but model '{model_name}' not found in cache, attempting download anyway"
         );
@@ -207,6 +208,8 @@ fn get_model_express_cache_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_from_hf_with_model_express() {
@@ -236,5 +239,113 @@ mod tests {
             // Clean up
             env::remove_var(env_model::huggingface::HF_HOME);
         }
+    }
+
+    /// Build an hf-hub-format cache layout for `model_name` in `cache_root`,
+    /// populated with the given filenames at a fake snapshot revision. Returns
+    /// the snapshot directory path that `Cache::model().get()` should resolve to.
+    fn build_hf_cache(cache_root: &Path, model_name: &str, files: &[&str]) -> PathBuf {
+        let repo_dir = cache_root.join(format!("models--{}", model_name.replace('/', "--")));
+        let snapshot_hash = "0000000000000000000000000000000000000000";
+        let snapshot_dir = repo_dir.join("snapshots").join(snapshot_hash);
+        let refs_dir = repo_dir.join("refs");
+        fs::create_dir_all(&snapshot_dir).unwrap();
+        fs::create_dir_all(&refs_dir).unwrap();
+        fs::write(refs_dir.join("main"), snapshot_hash).unwrap();
+        for f in files {
+            fs::write(snapshot_dir.join(f), "{}").unwrap();
+        }
+        snapshot_dir
+    }
+
+    /// Point HF_HUB_CACHE at `path` and clear the other cache env vars so
+    /// `get_model_express_cache_dir()` resolves deterministically.
+    unsafe fn set_hub_cache_env(path: &Path) {
+        unsafe {
+            env::set_var(
+                env_model::huggingface::HF_HUB_CACHE,
+                path.to_str().unwrap(),
+            );
+            env::remove_var(env_model::huggingface::HF_HOME);
+            env::remove_var(env_model::model_express::MODEL_EXPRESS_CACHE_PATH);
+            env::remove_var(env_model::huggingface::HF_HUB_OFFLINE);
+        }
+    }
+
+    unsafe fn clear_hub_cache_env() {
+        unsafe {
+            env::remove_var(env_model::huggingface::HF_HUB_CACHE);
+            env::remove_var(env_model::huggingface::HF_HUB_OFFLINE);
+        }
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn test_cached_path_metadata_only_satisfies_ignore_weights_true() {
+        // A cache with only metadata files should satisfy ignore_weights=true
+        // but NOT ignore_weights=false (no weight files present).
+        let temp = TempDir::new().unwrap();
+        let model = "test-org/metadata-only";
+        let snapshot = build_hf_cache(temp.path(), model, &["config.json", "tokenizer.json"]);
+
+        unsafe { set_hub_cache_env(temp.path()) };
+        let with_weights = get_cached_model_path(model, false);
+        let no_weights = get_cached_model_path(model, true);
+        unsafe { clear_hub_cache_env() };
+
+        assert!(
+            with_weights.is_none(),
+            "metadata-only cache must NOT satisfy ignore_weights=false"
+        );
+        assert_eq!(
+            no_weights.as_deref(),
+            Some(snapshot.as_path()),
+            "metadata-only cache must satisfy ignore_weights=true"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn test_cached_path_full_cache_satisfies_both_modes() {
+        let temp = TempDir::new().unwrap();
+        let model = "test-org/full-cache";
+        let snapshot = build_hf_cache(
+            temp.path(),
+            model,
+            &["config.json", "tokenizer.json", "model.safetensors"],
+        );
+
+        unsafe { set_hub_cache_env(temp.path()) };
+        let with_weights = get_cached_model_path(model, false);
+        let no_weights = get_cached_model_path(model, true);
+        unsafe { clear_hub_cache_env() };
+
+        assert_eq!(with_weights.as_deref(), Some(snapshot.as_path()));
+        assert_eq!(no_weights.as_deref(), Some(snapshot.as_path()));
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn test_from_hf_cache_first_in_online_mode() {
+        // DIS-1803: cache-first short-circuit must fire even when HF_HUB_OFFLINE
+        // is not set. If the short-circuit works, from_hf returns the cached path
+        // without touching MxClient or the HF network.
+        let temp = TempDir::new().unwrap();
+        let model = "test-org/cache-first-online";
+        let snapshot = build_hf_cache(
+            temp.path(),
+            model,
+            &["config.json", "tokenizer.json", "model.safetensors"],
+        );
+
+        unsafe { set_hub_cache_env(temp.path()) };
+        let result = from_hf(PathBuf::from(model), false).await;
+        unsafe { clear_hub_cache_env() };
+
+        assert_eq!(
+            result.ok().as_deref(),
+            Some(snapshot.as_path()),
+            "from_hf must return cached path in online mode without network"
+        );
     }
 }


### PR DESCRIPTION
#### Overview:

Fixes [DIS-1798](https://linear.app/nvidia/issue/DIS-1798) and [DIS-1803](https://linear.app/nvidia/issue/DIS-1803) (closed as duplicate of DIS-1798 with a comment asking that it be addressed in the same PR). Together these were the root cause of the multi-hour silent hang of the GLM-5.1-FP8 deployment on Astra pdx04 in April 2026 when HF was unreachable. The fix removes a redundant full-repo HF download from `register_model` and makes `hub::from_hf` cache-first in all modes (not just `HF_HUB_OFFLINE=1`).

#### Details:

**DIS-1798 — `register_model` should not download weights** (`lib/bindings/python/rust/lib.rs`)

The Python binding called `LocalModel::fetch(&source_path, false)` (ignore_weights=false), pulling the entire HF repo — weights included — every time `register_model` ran. MDC construction downstream (`LocalModelBuilder::build` → `ModelDeploymentCard::from_repo_checkout`) only reads `config.json`, `tokenizer*`, `generation_config.json`, and the chat template, so the weights were downloaded and immediately discarded. Backends (SGLang/vLLM) handle their own weight loading via `fetch_model` pre-flight before `register_model` is invoked, so weights are already on disk or in GPU memory by then. Flipped to `ignore_weights=true`.

**DIS-1803 — `hub::from_hf` cache-first** (`lib/llm/src/hub.rs`)

`get_cached_model_path` was only consulted inside the `is_offline_mode()` branch, so any pod with a fully populated HF cache still made an HTTP revision lookup against `huggingface.co/api/models/<repo>/revision/main` on every restart. When HF was unreachable that lookup hung silently with no timeout — the source of "Mode A" hangs from the incident. Moved the short-circuit above the offline-mode gate so a populated cache returns immediately in any mode. Kept the offline-mode warning for the cache-miss case. The existing info log inside `get_cached_model_path` still traces the cache hit, so operator visibility is unchanged.

**Tests** — added 3 unit tests in `hub.rs` covering the matrix:
- metadata-only cache satisfies `ignore_weights=true` but not `=false`
- full cache satisfies both modes
- `from_hf` returns the cached path in online mode without any network call

All 6 hub-module tests pass locally (`cargo test -p dynamo-llm --no-default-features --lib hub::`). Block-manager feature is disabled because macOS dev environment lacks NUMA / `fallocate` / `O_DIRECT`; CI runs the full feature set on Linux.

#### Where should the reviewer start?

- [`lib/bindings/python/rust/lib.rs:432`](../blob/fix/dis-1798-dis-1803-cache-and-weights/lib/bindings/python/rust/lib.rs#L432) — the one-line bool flip with explanatory comment. Verify the contract: `register_model` is metadata-only, backends own weight pre-flight.
- [`lib/llm/src/hub.rs:91-110`](../blob/fix/dis-1798-dis-1803-cache-and-weights/lib/llm/src/hub.rs#L91-L110) — `from_hf` restructured so cache-first fires before the offline-mode gate. Check that the offline-mode warning still fires correctly on cache-miss, and that the doc comment matches the new behavior.
- [`lib/llm/src/hub.rs` tests](../blob/fix/dis-1798-dis-1803-cache-and-weights/lib/llm/src/hub.rs) — `test_cached_path_*` and `test_from_hf_cache_first_in_online_mode`. The `build_hf_cache` helper builds an `hf-hub`-format cache layout in a tempdir; if you doubt the layout, the existing `get_cached_model_path` info log will fire on a real cached model with the same shape.

Refs: DIS-1798, DIS-1803, internal ITBU-2026-04-18 ("GLM5.1 Model Download Issue").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * HuggingFace models now prioritize local cache checking before network requests, improving load times.

* **Behavior Changes**
  * Remote model registration now separates metadata loading from weight handling.

* **Tests**
  * Expanded test coverage for cache behavior and offline mode functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->