### PR TITLE
fix(parser): preserve GPT-OSS reasoning tool-call handoff

### DIFF
--- a/lib/parsers/REASONING_CASES.md
+++ b/lib/parsers/REASONING_CASES.md
@@ -112,6 +112,10 @@ content.
 - **`REASONING.batch.2.f`** Complex reasoning body — large blocks, multi-paragraph, special characters, Unicode, newlines, and marker-looking strings inside the reasoning body.
 - **`REASONING.batch.3.a`** Closed reasoning followed by downstream tool-call text — reasoning parser must extract the think content **and leave a valid paired-parser tool-call payload intact in `normal_text`** for the downstream tool-call parser to consume.
 - **`REASONING.batch.3.b`** Open reasoning interrupted by downstream tool-call text — tool-call markers can terminate or escape an open reasoning span for families that define that boundary.
+- **`REASONING.batch.3.c`** Recipientless downstream channel text — format-specific non-tool commentary or equivalent content should remain visible as normal text.
+- **`REASONING.batch.3.d`** Directed downstream tool-call channel without reasoning — parser must suppress tool-call payload from visible normal text when that payload belongs to the downstream tool parser.
+- **`REASONING.batch.3.e`** Directed reasoning-channel tool-call payload — parser must keep the payload in reasoning output when the format labels the channel as reasoning/analysis.
+- **`REASONING.batch.3.f`** Reasoning, downstream directed tool call, then final answer — parser must extract reasoning, suppress downstream tool payload from visible normal text, and preserve later final text.
 - **`REASONING.batch.4`** Malformed reasoning marker syntax — dangling close marker, invalid channel marker, or marker that does not belong to the family grammar.
 - **`REASONING.batch.5`** Missing end-marker recovery — engine hit `max_tokens` mid-think; pin behavior: recover partial reasoning, surface as truncated, or treat all as `normal_text`.
 - **`REASONING.batch.6.a`** Multiple reasoning spans, adjacent or separated by normal text — e.g., two `<think>...</think>` blocks in one response. Behavior is impl-defined: concatenate, surface only the first, or document a divergence.
@@ -223,6 +227,7 @@ extract the reasoning content and preserve the tool-call-shaped text in
   closed before downstream tool-call text begins.
 - `3.b` applies only to parser families that intentionally configure a
   downstream boundary while reasoning is still open.
+- `3.c` through `3.f` pin format-specific downstream channel behavior: visible recipientless channel text, directed tool-call handoff preservation, directed reasoning payload extraction, and final-text recovery after a directed downstream tool call.
 - Failure mode: greedy reasoning parser eats the tool-call content
   that follows. Pin the boundary explicitly.
 

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -127,7 +127,9 @@ fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
 
 fn harmony_analysis_block_regex() -> &'static Regex {
     HARMONY_ANALYSIS_BLOCK_REGEX.get_or_init(|| {
-        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis.*?<\|message\|>.*?(?:<\|end\|>|\z)")
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis.*?<\|message\|>.*?(?:<\|call\|>|<\|end\|>|\z)",
+        )
             .expect("harmony analysis block regex")
     })
 }
@@ -586,6 +588,18 @@ mod tests {
         let text = "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
         let result = parser.detect_and_parse_reasoning(text, &[]);
         assert_eq!(result.reasoning_text, "think");
+        assert_eq!(
+            result.normal_text,
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+        );
+    }
+
+    #[test]
+    fn test_gpt_oss_analysis_call_does_not_swallow_commentary_handoff() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "{\"q\":\"x\"}");
         assert_eq!(
             result.normal_text,
             "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -9,6 +9,7 @@ use crate::ReasoningParser;
 use openai_harmony::StreamableParser;
 use openai_harmony::chat::{Content, Message, TextContent};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, chat::Role, load_harmony_encoding};
+use regex::Regex;
 
 ///// Static initialization of harmony encoder to not affect performance every time a parser is created
 /// This is because load_harmony_encoding downloads some tiktoken files into a directory and we don't want to do this every time we create a parser.
@@ -17,6 +18,7 @@ use std::sync::OnceLock;
 static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::Error>> =
     OnceLock::new();
 static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
+static HARMONY_ANALYSIS_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 const HARMONY_CALL_MARKER: &str = "<|call|>";
 const HARMONY_SPECIAL_TOKENS: &[&str] = &[
     "<|start|>",
@@ -123,6 +125,13 @@ fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
             .any(|window| window == marker_ids)
 }
 
+fn harmony_analysis_block_regex() -> &'static Regex {
+    HARMONY_ANALYSIS_BLOCK_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis.*?<\|message\|>.*?(?:<\|end\|>|\z)")
+            .expect("harmony analysis block regex")
+    })
+}
+
 fn input_contains_call_marker(
     text: &str,
     token_ids: &[u32],
@@ -159,6 +168,16 @@ fn split_incomplete_harmony_suffix(text: &str) -> (&str, &str) {
         .unwrap_or(0);
 
     text.split_at(text.len() - hold_len)
+}
+
+fn contains_directed_harmony_function_call(text: &str) -> bool {
+    text.contains("<|channel|>commentary to=functions.") && text.contains(HARMONY_CALL_MARKER)
+}
+
+fn strip_analysis_blocks_for_tool_handoff(text: &str) -> String {
+    harmony_analysis_block_regex()
+        .replace_all(text, "")
+        .into_owned()
 }
 
 fn append_separated(target: &mut String, text: &str) {
@@ -235,6 +254,7 @@ impl ReasoningParser for GptOssReasoningParser {
     }
 
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
+        let caller_supplied_token_ids = !token_ids.is_empty();
         let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
@@ -284,6 +304,15 @@ impl ReasoningParser for GptOssReasoningParser {
                 current_channel,
                 current,
             );
+        }
+
+        let raw_input_text =
+            raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
+        if contains_directed_harmony_function_call(&raw_input_text) {
+            // The serving pipeline feeds reasoning normal_text into the Harmony
+            // tool parser. Keep directed commentary envelopes intact so tool
+            // calls are not silently dropped.
+            normal_text = strip_analysis_blocks_for_tool_handoff(&raw_input_text);
         }
 
         tracing::debug!(
@@ -429,8 +458,7 @@ impl ReasoningParser for GptOssReasoningParser {
             // Streaming currently feeds the downstream Harmony tool parser through
             // `normal_text`. This is an internal handoff, not visible-content
             // semantics: directed commentary tool payloads must become tool calls,
-            // not assistant `content`. Batch parsing does not use this handoff and
-            // keeps directed commentary out of `normal_text`.
+            // not assistant `content`.
             if !self.pending_tool_call_text.is_empty() {
                 self.pending_tool_call_text.push_str(&raw_input_text);
                 if has_call_marker {
@@ -553,12 +581,15 @@ mod tests {
     }
 
     #[test]
-    fn test_gpt_oss_recipient_commentary_is_not_normal_text() {
+    fn test_gpt_oss_directed_commentary_is_tool_parser_handoff() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
         let result = parser.detect_and_parse_reasoning(text, &[]);
         assert_eq!(result.reasoning_text, "think");
-        assert_eq!(result.normal_text, "It is sunny.");
+        assert_eq!(
+            result.normal_text,
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+        );
     }
 
     #[test]

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -208,10 +208,7 @@ What to look for:
   divergence is not classified. If vLLM/SGLang appears more correct,
   keep it red until Dynamo is fixed or the contract is explicitly
   decided.
-- `↯` — Dynamo leaked parser-owned syntax into the wrong user-visible
-  field. For tool calling, this means tool call markup leaked into
-  `normal_text`; for reasoning, this means reasoning markup or final
-  answer text landed in the wrong split field.
+- `↯` — Dynamo leaks parser-owned syntax into user-visible output. For tool calling, this means tool call markup leaked into `normal_text`; for reasoning, this means Dynamo leaks reasoning markup or final-answer text.
 - `V` / `S` — documented divergence. Re-audit these when an upstream
   version changes or when the reason says the peer preserves text that
   Dynamo loses. If the peer now looks like the better target, delete
@@ -683,11 +680,9 @@ A case with `description` and `reason` but no `expected` block is an
 explicit not-applicable/table-only stub. The harness skips it rather
 than treating it as missing coverage.
 
-`dynamo_leak: true` is a temporary table annotation for a known Dynamo
-reasoning split bug. Use it only when Dynamo leaks reasoning-owned
-syntax or final-answer text into the wrong reasoning field. Do not use
-it when valid downstream tool call text is preserved in `normal_text`;
-that is the intended handoff to the tool call parser.
+`dynamo_leak: true` is a temporary table annotation for a known Dynamo reasoning split bug. Use it only when Dynamo leaks reasoning markup or final-answer text. Do not use it when valid downstream tool call text is preserved in `normal_text`; that is the intended handoff to the tool call parser.
+
+GPT-OSS/Harmony is the case that can look like a leak at the reasoning layer but is normal: directed `commentary to=functions.*` blocks are tool-call protocol text, and Dynamo feeds reasoning `normal_text` to the Harmony tool-call parser. The final OpenAI response should contain structured `tool_calls`, not this markup in user-visible `content`; stripping it in the reasoning parser would silently drop the tool call before the tool parser sees it.
 
 The `ref` field is required on per-sub-case files
 (`TOOLCALLING.<mode>.<n>.yaml`) and takes one of three forms:

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -36,8 +36,12 @@ cases:
     expected:
       dynamo: &d_2
         reasoning_text: choose tool
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+        reason: Unlike vLLM batch reasoning, Dynamo parses reasoning before tool calling. For GPT-OSS/Harmony, directed commentary is tool-call text, so Dynamo passes it in normal_text for the Harmony tool parser to emit structured tool_calls and remove the markup from final content.
+      vllm:
+        reasoning_text: choose tool
         normal_text: ''
-      vllm: *d_2
+        reason: vLLM batch reasoning suppresses directed Harmony commentary at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
       sglang:
         reasoning_text: choose tool
         normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
@@ -55,6 +59,7 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: I will check that.Done.
+        reason: SGLang drops the Harmony block boundary between recipientless commentary and final content, so two visible text blocks concatenate without the separator Dynamo/vLLM insert.
   REASONING.batch.3.d:
     description: Directed Harmony commentary tool call is not visible normal text
     ref: *upstream_ref
@@ -62,8 +67,12 @@ cases:
     expected:
       dynamo: &d_11
         reasoning_text: ''
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
+        reason: Unlike vLLM batch reasoning, Dynamo parses reasoning before tool calling. For GPT-OSS/Harmony, directed commentary is tool-call text, so Dynamo passes it in normal_text for the Harmony tool parser to emit structured tool_calls and remove the markup from final content.
+      vllm:
+        reasoning_text: ''
         normal_text: ''
-      vllm: *d_11
+        reason: vLLM batch reasoning suppresses directed Harmony commentary at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
       sglang:
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
@@ -75,10 +84,12 @@ cases:
       dynamo: &d_12
         reasoning_text: '{"q":"x"}'
         normal_text: ''
+        reason: Unlike SGLang, Dynamo only passes GPT-OSS/Harmony function calls from commentary to=functions.* to the tool-call parser. This analysis to=functions.search block is reasoning-channel text, so Dynamo keeps its payload in reasoning_text.
       vllm: *d_12
       sglang:
         reasoning_text: ''
         normal_text: <|channel|>analysis to=functions.search <|constrain|>json<|message|>{"q":"x"}<|call|>
+        reason: SGLang classifies a directed Harmony analysis channel ending in <|call|> as a tool_call handoff and emits the raw envelope in normal_text; Dynamo/vLLM keep analysis-channel payload hidden in reasoning_text for this parser-level contract.
   REASONING.batch.3.f:
     description: Harmony analysis, directed commentary tool call, then final answer
     ref: *upstream_ref
@@ -86,11 +97,16 @@ cases:
     expected:
       dynamo: &d_13
         reasoning_text: think
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.
+        reason: Unlike vLLM batch reasoning, Dynamo parses reasoning before tool calling. For GPT-OSS/Harmony, directed commentary is tool-call text, so Dynamo passes it in normal_text for the Harmony tool parser to emit structured tool_calls, recover final text, and remove tool-call markup from final content.
+      vllm:
+        reasoning_text: think
         normal_text: It is sunny.
-      vllm: *d_13
+        reason: vLLM batch reasoning suppresses directed Harmony commentary at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
       sglang:
         reasoning_text: think
         normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>It is sunny.
+        reason: SGLang preserves directed Harmony commentary for downstream parsing but strips the final-channel envelope before returning normal_text; Dynamo keeps the final Harmony envelope too so the downstream Harmony tool parser can recover final text after extracting the call.
   REASONING.batch.2.c:
     description: Harmony analysis followed by normal final answer text
     ref: *upstream_ref
@@ -171,6 +187,7 @@ cases:
       sglang:
         reasoning_text: firstsecond
         normal_text: done
+        reason: SGLang concatenates multiple Harmony analysis spans without an inserted separator, while Dynamo/vLLM preserve the span boundary with a newline.
   REASONING.batch.2.d:
     description: Normal text before a Harmony analysis channel is not a portable parser-level fixture
     reason: Harmony reasoning content is channel-framed; prefix text before the first channel is outside this parser-level fixture contract.

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -49,6 +49,7 @@ cases:
       sglang:
         reasoning_text: firstsecond
         normal_text: done
+        reason: SGLang concatenates multiple Harmony analysis spans without an inserted separator, while Dynamo/vLLM preserve the span boundary with a newline.
   REASONING.stream.3.a:
     description: Harmony start marker split across chunks
     ref: *upstream_ref
@@ -76,6 +77,7 @@ cases:
       sglang:
         reasoning_text: thinking<|end|><|start|>assistant<|channel|>final<|message|>answer
         normal_text: ''
+        reason: SGLang does not recognize the split Harmony end marker in text-only streaming chunks, so the final-channel text remains in reasoning_text instead of being emitted as normal_text.
   REASONING.stream.3.c:
     description: Partial Harmony channel marker prefix later becomes non-channel text
     ref: *upstream_ref
@@ -106,6 +108,7 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: I will check that.Done.
+        reason: SGLang drops the Harmony block boundary between recipientless commentary and final content, so two visible text blocks concatenate without the separator Dynamo/vLLM insert.
   REASONING.stream.4.b:
     description: Directed Harmony commentary tool recipient split across chunks
     ref: *upstream_ref
@@ -116,10 +119,11 @@ cases:
       dynamo: &id002
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|>
-        reason: 'This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. Confirmed that the `normal_text` handoff to the tool-call parser is processed properly: the downstream Harmony parser emits the tool call and leaves no final `normal_text` leak. If the reasoning parser removed the directed commentary envelope here, the downstream Harmony tool-call parser would never see the call. Matching vLLM''s reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.'
+        reason: Unlike vLLM streaming reasoning, Dynamo parses reasoning before tool calling. For GPT-OSS/Harmony, directed commentary is tool-call text, so Dynamo passes it in normal_text for the Harmony tool parser to emit structured tool_calls and remove the markup from final content.
       vllm:
         reasoning_text: ''
         normal_text: ''
+        reason: vLLM streaming reasoning suppresses directed Harmony commentary at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
       sglang: *id002
   REASONING.stream.4.c:
     description: Two directed Harmony commentary tool calls in one stream
@@ -131,10 +135,11 @@ cases:
       dynamo: &id003
         reasoning_text: ''
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"SF"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"tz":"PST"}<|call|>
-        reason: 'This is expected in Dynamo today because streaming reasoning parsing and tool-call parsing are separate stages, and `normal_text` is the only handoff path between them. Confirmed that the `normal_text` handoff to the tool-call parser is processed properly: the downstream Harmony parser emits the tool calls and leaves no final `normal_text` leak. If the reasoning parser removed the directed commentary envelopes here, the downstream Harmony tool-call parser would never see the calls. Matching vLLM''s reasoning-layer output would require an architectural change to carry tool-call candidates through a structured side channel instead of reusing `normal_text`.'
+        reason: Unlike vLLM streaming reasoning, Dynamo parses reasoning before tool calling. For GPT-OSS/Harmony, directed commentary is tool-call text, so Dynamo passes it in normal_text for the Harmony tool parser to emit structured tool_calls and remove the markup from final content.
       vllm:
         reasoning_text: ''
         normal_text: ''
+        reason: vLLM streaming reasoning suppresses directed Harmony commentary at the reasoning layer; Dynamo keeps it because normal_text is the handoff to the Harmony tool parser.
       sglang: *id003
   REASONING.stream.1.b:
     description: Plain text without Harmony channel markers

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -54,7 +54,17 @@ CASE_GROUPS = [
             "batch.2.f",
         ),
     ),
-    ("Tool call boundary", ("batch.3.a", "batch.3.b")),
+    (
+        "Tool call boundary",
+        (
+            "batch.3.a",
+            "batch.3.b",
+            "batch.3.c",
+            "batch.3.d",
+            "batch.3.e",
+            "batch.3.f",
+        ),
+    ),
     ("Malformed / recovery", ("batch.4", "batch.5")),
     ("Multi-span", ("batch.6.a", "batch.6.b")),
     (
@@ -441,6 +451,15 @@ def _reasoning_markup_re(family: str | None) -> re.Pattern[str]:
     return _REASONING_MARKUP_BY_FAMILY.get(family or "", _DEFAULT_REASONING_MARKUP_RE)
 
 
+def _is_gpt_oss_tool_handoff(family: str | None, field: str, value: str) -> bool:
+    return (
+        family == "gpt_oss"
+        and field == "normal_text"
+        and "<|channel|>commentary to=functions." in value
+        and "<|call|>" in value
+    )
+
+
 def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | None:
     dynamo = expected.get("dynamo", {})
     if not isinstance(dynamo, dict):
@@ -448,10 +467,14 @@ def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | N
     marker_re = _reasoning_markup_re(family)
     for field in ("reasoning_text", "normal_text"):
         value = dynamo.get(field)
-        if isinstance(value, str) and marker_re.search(value):
+        if (
+            isinstance(value, str)
+            and marker_re.search(value)
+            and not _is_gpt_oss_tool_handoff(family, field, value)
+        ):
             return str(
                 dynamo.get("reason")
-                or f"Dynamo {field} contains reasoning parser markup."
+                or "Dynamo leaks reasoning markup or final-answer text."
             )
     return None
 
@@ -1369,6 +1392,20 @@ def _tooltip_for(
     return "\n".join(parts)
 
 
+def _explanations_for(
+    case: dict[str, Any],
+    dyn: dict[str, Any],
+    family: str | None,
+) -> str:
+    parts = []
+    peer_reasons = _tooltip_for(case, dyn, family)
+    if peer_reasons:
+        parts.append(peer_reasons)
+    if isinstance(dyn.get("reason"), str) and not _has_dynamo_leak(case, family):
+        parts.append(f"Dynamo: {dyn['reason']}")
+    return "\n".join(parts)
+
+
 def _tooltip_html(
     case_id: str,
     family: str,
@@ -1379,17 +1416,7 @@ def _tooltip_html(
     head_family = display_family or family
     head = f"{case_id} — {head_family}"
     description = case.get("description")
-    extra_sections: list[tuple[str, str]] = [
-        (
-            "Harness flags",
-            _harness_flags_html(
-                case_id,
-                family,
-                case,
-                display_family=display_family,
-            ),
-        )
-    ]
+    extra_sections: list[tuple[str, str]] = []
     if display_family and display_family != family:
         extra_sections.append(
             (
@@ -1413,6 +1440,20 @@ def _tooltip_html(
 
     expected = case["expected"]
     dyn = expected.get("dynamo")
+    explanations = _explanations_for(case, dyn, family) if isinstance(dyn, dict) else ""
+    if explanations:
+        extra_sections.append(("Explanations", linkify_text_html(explanations)))
+    extra_sections.append(
+        (
+            "Harness flags",
+            _harness_flags_html(
+                case_id,
+                family,
+                case,
+                display_family=display_family,
+            ),
+        )
+    )
     all_engines_parity = isinstance(dyn, dict) and all(
         isinstance(expected.get(i), dict)
         and not expected[i].get("unavailable")
@@ -1457,10 +1498,8 @@ def _tooltip_html(
         input_label="Input chunks" if "chunks" in case else "Input",
         input_html=_input_text_html(case, family),
         output_sections=output_sections,
-        divergent_reasons=_tooltip_for(case, dyn, family)
-        if isinstance(dyn, dict)
-        else None,
-        leak_label="↯ Dynamo reasoning leaks",
+        divergent_reasons=None,
+        leak_label="↯ Dynamo leaks",
         leak_text=dynamo_leak
         or ("unresolved" if _has_dynamo_leak(case, family) else None),
         extra_sections=extra_sections,
@@ -1914,7 +1953,7 @@ def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
         '<span style="color:#b00">?</span> more research needed '
         "(e.g. V?, S? — diverges with no <code>reason:</code> yet) · "
         '<span style="color:#b00">↯</span> Dynamo leaks reasoning markup '
-        "or final-answer text into the wrong field · "
+        "or final-answer text · "
         '<span style="color:#b00">!</span> expected-error suffix '
         "(e.g. V!, S! — engine crashes by design) · "
         '<span style="color:#aaa">n/a</span> not applicable'

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -95,15 +95,16 @@ def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> N
     )
     split_end_cell = _cell_for(html, "REASONING.stream.3.b — gpt_oss")
     assert re.search(
-        r'<td class="cell research[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">S\?</a>',
+        r'<td class="cell documented[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">S</a>',
         split_end_cell,
     )
     handoff_cell = _cell_for(html, "REASONING.stream.4.b — gpt_oss")
     assert re.search(
-        r'<td class="cell leak[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">↯V</a>',
+        r'<td class="cell documented[^"]*"[^>]*><a href="fixtures/gpt_oss/REASONING\.stream\.yaml">V</a>',
         handoff_cell,
     )
-    assert "↯ Dynamo reasoning leaks" in handoff_cell
+    assert "↯ Dynamo leaks" not in handoff_cell
+    assert "Dynamo: Unlike vLLM streaming reasoning" in handoff_cell
     assert "Divergent reasons" not in handoff_cell
     assert re.search(
         r'<td class="cell ok[^"]*"[^>]*><a href="fixtures/kimi_k25/REASONING\.batch\.yaml">=</a>'


### PR DESCRIPTION
#### Overview:

This PR makes GPT-OSS/Harmony reasoning pass directed commentary tool calls to the downstream Harmony tool parser instead of dropping them.

#### Details:

- **How is this fixed?** `GptOssReasoningParser` detects directed `commentary to=functions.*` plus `<|call|>` and preserves the non-analysis Harmony tail in `normal_text`, which is Dynamo's handoff to the Harmony tool parser.
- Extends `REASONING.batch.3.{c,d,e,f}` and GPT-OSS fixtures to document directed commentary, analysis-channel payloads, and final-text recovery.
- Updates the reasoning parity table so Dynamo handoff explanations and peer divergence reasons render together under `Explanations`.
- Stops marking GPT-OSS directed commentary handoff as a Dynamo leak; this is protocol text passed onward to the paired tool-call parser.
- Adds a regression test for the case where an `analysis ... <|call|>` block is followed by a real `commentary to=functions.*` tool-call handoff.

#### Verification:

In the `dynamo1` devcontainer: `cargo test --locked -p dynamo-parsers gpt_oss -- --nocapture` passed; `python3 -m pytest tests/parity/reasoning/test_reasoning_fixture_schema.py tests/parity/reasoning/test_parity_reasoning.py -q -k gpt_oss` passed with vLLM skipped because it is not installed; `python3 -m pytest tests/parity/toolcalling/test_generate_parity_table.py -q` passed; reasoning parity HTML regenerated.

#### Where should the reviewer start?

`lib/parsers/src/reasoning/gpt_oss_parser.rs`, then `tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml`, then `tests/parity/reasoning/table.py`

#### Related Issues:

Relates to DIS-2135

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced reasoning taxonomy documentation with new items describing format-specific downstream behavior.
  * Clarified parity testing documentation for reasoning channel handling across different backend models.

* **Tests**
  * Extended test fixtures with explanatory metadata for improved transparency of reasoning behavior.
  * Improved parity table generation to better document expected differences across backends.

* **Bug Fixes**
  * Improved handling of directed function calls during batch reasoning to prevent tool payload loss in downstream processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->