### PR TITLE
test(router): retry topology readiness 404

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2411,6 +2411,46 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                 prefill_endpoint, decode_workers.num_workers
             )
 
+            async def post_expect_status(
+                session: aiohttp.ClientSession,
+                payload: dict,
+                expected_status: int,
+                message: str,
+                retry_statuses: set[int] | None = None,
+                timeout_s: float = 30.0,
+            ) -> str:
+                retry_statuses = retry_statuses or set()
+                deadline = asyncio.get_running_loop().time() + timeout_s
+                attempt = 0
+                last_status = None
+                last_body = ""
+
+                while True:
+                    attempt += 1
+                    async with session.post(chat_url, json=payload) as response:
+                        response_body = await response.text()
+                        if response.status == expected_status:
+                            return response_body
+
+                        last_status = response.status
+                        last_body = response_body
+
+                    if (
+                        last_status not in retry_statuses
+                        or asyncio.get_running_loop().time() >= deadline
+                    ):
+                        raise AssertionError(
+                            f"{message}, got status={last_status} body={last_body}"
+                        )
+
+                    logger.info(
+                        "%s not ready yet: status=%s attempt=%s; retrying...",
+                        message,
+                        last_status,
+                        attempt,
+                    )
+                    await asyncio.sleep(1.0)
+
             zone_a_payload = {
                 **test_payload,
                 "nvext": {
@@ -2418,12 +2458,13 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                 },
             }
             async with aiohttp.ClientSession() as session:
-                async with session.post(chat_url, json=zone_a_payload) as response:
-                    response_body = await response.text()
-                    assert response.status == 200, (
-                        "Expected required KV-transfer topology match to succeed, "
-                        f"got status={response.status} body={response_body}"
-                    )
+                await post_expect_status(
+                    session,
+                    zone_a_payload,
+                    200,
+                    "Expected required KV-transfer topology match to succeed",
+                    retry_statuses={404},
+                )
 
             zone_b_payload = {
                 **test_payload,
@@ -2432,12 +2473,12 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                 },
             }
             async with aiohttp.ClientSession() as session:
-                async with session.post(chat_url, json=zone_b_payload) as response:
-                    response_body = await response.text()
-                    assert response.status == 500, (
-                        "Expected required KV-transfer topology mismatch to fail, "
-                        f"got status={response.status} body={response_body}"
-                    )
+                await post_expect_status(
+                    session,
+                    zone_b_payload,
+                    500,
+                    "Expected required KV-transfer topology mismatch to fail",
+                )
 
         asyncio.run(run_requests())
 


### PR DESCRIPTION
#### Overview:

This draft PR isolates a fix for the intermittent `dynamo-runtime / test / sequential cuda12.9, arm64` failure seen on the engine routes PR. The failing router topology test sometimes receives a transient `404` before the frontend has fully observed the topology-aware route state.

#### Details:

- Adds a small helper in `tests/router/common.py` to post a request and assert the expected status.
- Retries only the zone-a required-topology match request when it returns `404`, for up to 30 seconds.
- Leaves the zone-b mismatch assertion strict: it must still return `500` without retry, so the topology enforcement behavior remains covered.

Validation run locally:

- `git diff --check`
- `python3 -m compileall -q tests/router/common.py`
- `black --check tests/router/common.py`
- `ruff check tests/router/common.py`

Local pytest collection was not runnable in the workstation shell because the repo package was not importable there: `ModuleNotFoundError: No module named 'dynamo'`.

#### Where should the reviewer start?

`tests/router/common.py`, in `_test_disagg_topology_required_prefill_pin_match_and_mismatch`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #10094
- Relates to #10108
