### PR TITLE
feat: add combined parity table UI

### DIFF
--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1346,7 +1346,7 @@ mod tests {
         run_deepseek_v4_tool_call_fixture(&file_path).await;
     }
 
-    /// `PARSER.stream.4.a` — stream ends after a complete invoke but before
+    /// `TOOLCALLING.stream.4.a` — stream ends after a complete invoke but before
     /// `</｜DSML｜tool_calls>`. Finalization should recover the complete invoke
     /// without enabling early stream exit on unterminated DSML wrappers.
     #[tokio::test]

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -2123,7 +2123,7 @@ mod parallel_tool_calling_tests {
     }
 
     // =============================================================================
-    // 1. NEMOTRON/DECI TOOL PARSER FORMAT (JSON Array in XML tags)
+    // 1. NEMOTRON/DECI TOOL-CALL FORMAT (JSON Array in XML tags)
     // =============================================================================
 
     #[tokio::test]
@@ -2179,7 +2179,7 @@ mod parallel_tool_calling_tests {
     }
 
     // =================================================
-    // 2. QWEN3CODER TOOL PARSER FORMAT (XML-style tags)
+    // 2. QWEN3CODER TOOL-CALL FORMAT (XML-style tags)
     // =================================================
 
     #[tokio::test]
@@ -2220,7 +2220,7 @@ fahrenheit
     }
 
     // =============================================================================
-    // 3. xLAM TOOL PARSER FORMAT (Pure JSON Array) - Testing via mistral parser
+    // 3. xLAM TOOL-CALL FORMAT (Pure JSON Array) - Testing via mistral parser
     // =============================================================================
 
     #[tokio::test]
@@ -2251,7 +2251,7 @@ fahrenheit
     }
 
     // =============================================================================
-    // 4. MINIMAX TOOL PARSER FORMAT (Multi-line JSON in XML tags)
+    // 4. MINIMAX TOOL-CALL FORMAT (Multi-line JSON in XML tags)
     // =============================================================================
 
     #[tokio::test]
@@ -2278,7 +2278,7 @@ fahrenheit
     }
 
     // =============================================================================
-    // 5. HARMONY TOOL PARSER FORMAT (Multiple Tool Calls with Harmony Encoding)
+    // 5. HARMONY TOOL-CALL FORMAT (Multiple Tool Calls with Harmony Encoding)
     // =============================================================================
 
     #[tokio::test]

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -65,7 +65,7 @@ text into `reasoning_content` and normal `content` instead of `tool_calls`.
 ```
                                                   ┌─ engine ──────────┐
                                                   │                   │
-   client ─request→ chat-template ─→ tokenize ─→ engine ─→ detokenize ─→ text ─→ PARSER ─→ structured output ─→ client
+   client ─request→ chat-template ─→ tokenize ─→ engine ─→ detokenize ─→ text ─→ parser ─→ structured output ─→ client
               ↑                                                              ↑
               └── M1 / M3 exercise this (real)                               └── M2 starts here (skips everything left)
                   M2 skips it (substituted by direct call)

--- a/tests/parity/generate_parity_table.py
+++ b/tests/parity/generate_parity_table.py
@@ -5,6 +5,7 @@
 """Generate parity tables for each parser stage from one common entrypoint.
 
 Examples:
+    python3 tests/parity/generate_parity_table.py all --html > tests/parity/PARITY.html
     python3 tests/parity/generate_parity_table.py toolcalling --html > tests/parity/toolcalling/PARITY.html
     python3 tests/parity/generate_parity_table.py toolcalling --mode stream > tests/parity/toolcalling/PARITY.stream.md
     python3 tests/parity/generate_parity_table.py reasoning --html > tests/parity/reasoning/PARITY.html
@@ -13,11 +14,131 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import datetime
+import html as html_lib
 import sys
+import zoneinfo
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
+
+
+def _rewrite_panel_paths(panel: dict[str, Any], stage_dir: str) -> dict[str, Any]:
+    """Adjust links from stage-local PARITY.html paths to tests/parity/PARITY.html."""
+    rewritten = dict(panel)
+
+    def rewrite(text: str) -> str:
+        return (
+            text.replace('href="fixtures/', f'href="{stage_dir}/fixtures/')
+            .replace('href="../../../lib/', 'href="../../lib/')
+            .replace('href="../../../pyproject.toml"', 'href="../../pyproject.toml"')
+        )
+
+    rewritten["group_headers"] = rewrite(str(rewritten["group_headers"]))
+    rewritten["sub_headers"] = rewrite(str(rewritten["sub_headers"]))
+    rewritten["body_rows"] = [rewrite(str(row)) for row in rewritten["body_rows"]]
+    return rewritten
+
+
+def _tab_button(panel: dict[str, Any]) -> str:
+    active = " active" if panel["active"] else ""
+    selected = "true" if panel["active"] else "false"
+    panel_id = html_lib.escape(str(panel["id"]))
+    label = html_lib.escape(str(panel["label"]))
+    title = html_lib.escape(str(panel.get("tab_title", panel["label"])))
+    return (
+        f'<button class="tab-button{active}" id="{panel_id}-button" '
+        f'type="button" role="tab" aria-selected="{selected}" '
+        f'aria-label="{title}" title="{title}" '
+        f'data-tab-target="{panel_id}">{label}</button>'
+    )
+
+
+def _combined_toolcalling_panels() -> list[dict[str, Any]]:
+    from tests.parity.toolcalling import table
+
+    panels = []
+    for mode in ("batch", "stream"):
+        _mode, panel, _has_cases = table._load_html_panel(mode)
+        panel = _rewrite_panel_paths(panel, "toolcalling")
+        panel.update(
+            {
+                "id": f"tab-toolcalling-{mode}",
+                "label": f"TC {mode}",
+                "tab_title": f"Tool Calling {mode}",
+                "active": False,
+                "case_docs_href": "../../lib/parsers/TOOLCALLING_CASES.md",
+                "case_docs_label": "lib/parsers/TOOLCALLING_CASES.md",
+                "case_prefix": f"TOOLCALLING.{mode}.",
+                "case_section_id": f"toolcalling-{mode}",
+            }
+        )
+        panels.append(panel)
+    return panels
+
+
+def _combined_reasoning_panels() -> list[dict[str, Any]]:
+    from tests.parity.reasoning import table
+
+    rows, columns, refs = table._load()
+    no_vllm, no_sglang = table._derive_no_peer_sets(rows)
+    panels = []
+    for mode in ("batch", "stream"):
+        mode_columns = table._columns_for_mode(columns, mode)
+        panel = table._html_panel(
+            rows,
+            mode_columns,
+            refs,
+            no_vllm,
+            no_sglang,
+            mode=mode,
+            active=False,
+        )
+        panel = _rewrite_panel_paths(panel, "reasoning")
+        panel.update(
+            {
+                "id": f"tab-reasoning-{mode}",
+                "label": f"Reasoning {mode}",
+                "active": False,
+                "case_docs_href": "../../lib/parsers/REASONING_CASES.md",
+                "case_docs_label": "lib/parsers/REASONING_CASES.md",
+                "case_prefix": "REASONING.",
+                "case_section_id": f"reasoning-{mode}",
+                "legend_html": table._legend_html(rows, mode_columns),
+            }
+        )
+        panels.append(panel)
+    return panels
+
+
+def render_combined_html() -> str:
+    from tests.parity.toolcalling import table
+
+    panels = [*_combined_toolcalling_panels(), *_combined_reasoning_panels()]
+    panels[0]["active"] = True
+
+    now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
+    stamp = now.strftime("%Y-%m-%d %H:%M %Z")
+    sha = table._commit_sha()
+
+    return (
+        table._make_jinja_env()
+        .get_template("parity_table.html.j2")
+        .render(
+            title="Dynamo Parser Parity Table",
+            stamp=stamp,
+            sha=sha,
+            short_sha=sha[:12] if sha else "",
+            command="python3 tests/parity/generate_parity_table.py all --html",
+            output="tests/parity/PARITY.html",
+            tabs=[_tab_button(panel) for panel in panels],
+            panels=panels,
+            peer_versions=table._peer_version_items(table._peer_versions()),
+            peer_versions_href="../../pyproject.toml",
+        )
+    )
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -26,10 +147,25 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "stage",
-        choices=("toolcalling", "reasoning"),
+        choices=("all", "toolcalling", "reasoning"),
         help="Parity stage to render.",
     )
     args, rest = parser.parse_known_args(argv)
+
+    if args.stage == "all":
+        stage_parser = argparse.ArgumentParser(
+            description="Generate the combined Dynamo parser parity HTML page.",
+        )
+        stage_parser.add_argument(
+            "--html",
+            action="store_true",
+            help="Emit the combined HTML page.",
+        )
+        stage_args = stage_parser.parse_args(rest)
+        if not stage_args.html:
+            parser.error("stage 'all' currently supports --html only")
+        print(render_combined_html())
+        return
 
     if args.stage == "toolcalling":
         from tests.parity.toolcalling import table

--- a/tests/parity/generate_parity_table.py
+++ b/tests/parity/generate_parity_table.py
@@ -24,6 +24,9 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+from tests.parity.reasoning import table as reasoning_table  # noqa: E402
+from tests.parity.toolcalling import table as toolcalling_table  # noqa: E402
+
 
 def _rewrite_panel_paths(panel: dict[str, Any], stage_dir: str) -> dict[str, Any]:
     """Adjust links from stage-local PARITY.html paths to tests/parity/PARITY.html."""
@@ -57,11 +60,9 @@ def _tab_button(panel: dict[str, Any]) -> str:
 
 
 def _combined_toolcalling_panels() -> list[dict[str, Any]]:
-    from tests.parity.toolcalling import table
-
     panels = []
     for mode in ("batch", "stream"):
-        _mode, panel, _has_cases = table._load_html_panel(mode)
+        _mode, panel, _has_cases = toolcalling_table._load_html_panel(mode)
         panel = _rewrite_panel_paths(panel, "toolcalling")
         panel.update(
             {
@@ -80,14 +81,12 @@ def _combined_toolcalling_panels() -> list[dict[str, Any]]:
 
 
 def _combined_reasoning_panels() -> list[dict[str, Any]]:
-    from tests.parity.reasoning import table
-
-    rows, columns, refs = table._load()
-    no_vllm, no_sglang = table._derive_no_peer_sets(rows)
+    rows, columns, refs = reasoning_table._load()
+    no_vllm, no_sglang = reasoning_table._derive_no_peer_sets(rows)
     panels = []
     for mode in ("batch", "stream"):
-        mode_columns = table._columns_for_mode(columns, mode)
-        panel = table._html_panel(
+        mode_columns = reasoning_table._columns_for_mode(columns, mode)
+        panel = reasoning_table._html_panel(
             rows,
             mode_columns,
             refs,
@@ -106,7 +105,7 @@ def _combined_reasoning_panels() -> list[dict[str, Any]]:
                 "case_docs_label": "lib/parsers/REASONING_CASES.md",
                 "case_prefix": "REASONING.",
                 "case_section_id": f"reasoning-{mode}",
-                "legend_html": table._legend_html(rows, mode_columns),
+                "legend_html": reasoning_table._legend_html(rows, mode_columns),
             }
         )
         panels.append(panel)
@@ -114,17 +113,15 @@ def _combined_reasoning_panels() -> list[dict[str, Any]]:
 
 
 def render_combined_html() -> str:
-    from tests.parity.toolcalling import table
-
     panels = [*_combined_toolcalling_panels(), *_combined_reasoning_panels()]
     panels[0]["active"] = True
 
     now = datetime.datetime.now(zoneinfo.ZoneInfo("America/Los_Angeles"))
     stamp = now.strftime("%Y-%m-%d %H:%M %Z")
-    sha = table._commit_sha()
+    sha = toolcalling_table._commit_sha()
 
     return (
-        table._make_jinja_env()
+        toolcalling_table._make_jinja_env()
         .get_template("parity_table.html.j2")
         .render(
             title="Dynamo Parser Parity Table",
@@ -135,7 +132,9 @@ def render_combined_html() -> str:
             output="tests/parity/PARITY.html",
             tabs=[_tab_button(panel) for panel in panels],
             panels=panels,
-            peer_versions=table._peer_version_items(table._peer_versions()),
+            peer_versions=toolcalling_table._peer_version_items(
+                toolcalling_table._peer_versions()
+            ),
             peer_versions_href="../../pyproject.toml",
         )
     )
@@ -167,12 +166,8 @@ def main(argv: list[str] | None = None) -> None:
         print(render_combined_html())
         return
 
-    if args.stage == "toolcalling":
-        from tests.parity.toolcalling import table
-    else:
-        from tests.parity.reasoning import table
-
-    table.main(rest)
+    stage_table = toolcalling_table if args.stage == "toolcalling" else reasoning_table
+    stage_table.main(rest)
 
 
 if __name__ == "__main__":

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -161,7 +161,9 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 </tbody>
 </table>
 <p class="legend">
-{% if legend_html is defined and legend_html %}
+{% if panel.legend_html is defined and panel.legend_html %}
+  {{ panel.legend_html|safe }}
+{% elif legend_html is defined and legend_html %}
   {{ legend_html|safe }}
 {% else %}
   <strong>Legend:</strong>
@@ -190,7 +192,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   {% if peer_versions %}
   <br><br>
   <strong>Peer parser versions</strong> pinned in
-  <a href="../../../pyproject.toml">pyproject.toml</a>:
+  <a href="{{ peer_versions_href|default('../../../pyproject.toml') }}">pyproject.toml</a>:
   {% for name, version in peer_versions %}{% if not loop.first %} · {% endif %}{{ name|e }} <code>{{ version|e }}</code>{% endfor %}.
   {% endif %}
 {% endif %}
@@ -208,15 +210,27 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
 </p>
 {% if panel.glossary_groups %}
-<h2 id="case-descriptions-{{ panel.mode|e }}">Case descriptions</h2>
+<h2 id="case-descriptions-{{ panel.case_section_id|default(panel.mode)|e }}">Case descriptions</h2>
 <p>Full case definitions:
-<a href="{{ case_docs_href|default('../../../lib/parsers/TOOLCALLING_CASES.md') }}">{{ case_docs_label|default('lib/parsers/TOOLCALLING_CASES.md') }}</a>.</p>
+{% if panel.case_docs_href is defined %}
+{% set panel_case_docs_href = panel.case_docs_href %}
+{% else %}
+{% set panel_case_docs_href = case_docs_href|default('../../../lib/parsers/TOOLCALLING_CASES.md') %}
+{% endif %}
+{% if panel.case_docs_label is defined %}
+{% set panel_case_docs_label = panel.case_docs_label %}
+{% else %}
+{% set panel_case_docs_label = case_docs_label|default('lib/parsers/TOOLCALLING_CASES.md') %}
+{% endif %}
+<a href="{{ panel_case_docs_href }}">{{ panel_case_docs_label }}</a>.</p>
 <table class="glossary">
 <tbody>
 {% for group in panel.glossary_groups %}
 <tr class="category"><td colspan="2">{{ group.label|e }}</td></tr>
 {% for sub, desc in group.rows %}
-{% if case_prefix is defined and case_prefix %}
+{% if panel.case_prefix is defined and panel.case_prefix %}
+<tr><td class="sub">{{ panel.case_prefix|e }}{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
+{% elif case_prefix is defined and case_prefix %}
 <tr><td class="sub">{{ case_prefix|e }}{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
 {% else %}
 <tr><td class="sub">TOOLCALLING.{{ panel.mode|e }}.{{ sub|e }}</td><td>{{ desc|e }}</td></tr>
@@ -358,7 +372,26 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 
   const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
   const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
-  function activateTab(id) {
+  function readActiveTab() {
+    const params = new URLSearchParams(window.location.search);
+    const requested = params.get('tab');
+    if (requested && document.getElementById(requested)) {
+      return requested;
+    }
+    const active = tabButtons.find(function (button) {
+      return button.classList.contains('active');
+    });
+    return active ? active.dataset.tabTarget : (tabButtons[0] && tabButtons[0].dataset.tabTarget);
+  }
+
+  function updateTabUrl(id) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('tab', id);
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function activateTab(id, shouldUpdateUrl) {
+    if (!id) return;
     tabButtons.forEach(function (button) {
       const selected = button.dataset.tabTarget === id;
       button.classList.toggle('active', selected);
@@ -367,10 +400,14 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     tabPanels.forEach(function (panel) {
       panel.classList.toggle('active', panel.id === id);
     });
+    if (shouldUpdateUrl) {
+      updateTabUrl(id);
+    }
   }
+  activateTab(readActiveTab(), false);
   tabButtons.forEach(function (button) {
     button.addEventListener('click', function () {
-      activateTab(button.dataset.tabTarget);
+      activateTab(button.dataset.tabTarget, true);
     });
   });
 

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -375,7 +375,10 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   function readActiveTab() {
     const params = new URLSearchParams(window.location.search);
     const requested = params.get('tab');
-    if (requested && document.getElementById(requested)) {
+    const validTargets = new Set(tabButtons.map(function (button) {
+      return button.dataset.tabTarget;
+    }));
+    if (requested && validTargets.has(requested)) {
       return requested;
     }
     const active = tabButtons.find(function (button) {

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -1141,7 +1141,7 @@ def _parse_subcase_descriptions(mode: str) -> dict[str, str]:
     if not TOOLCALLING_CASES_MD.exists():
         return {}
     pat = re.compile(
-        rf"\*\*`PARSER\.{re.escape(mode)}\.([0-9]+(?:\.[a-z])?)`\*\*\s+(.+)"
+        rf"\*\*`TOOLCALLING\.{re.escape(mode)}" rf"\.([0-9]+(?:\.[a-z])?)`\*\*\s+(.+)"
     )
     out: dict[str, str] = {}
     lines = TOOLCALLING_CASES_MD.read_text(encoding="utf-8").splitlines()

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -58,6 +58,10 @@ def test_generate_parser_parity_table_html() -> None:
     assert "generate_parity_table.py toolcalling --html" in html
     assert "TOOLCALLING.batch.*" in html
     assert "TOOLCALLING.stream.*" in html
+    assert 'id="case-descriptions-batch"' in html
+    assert 'id="case-descriptions-stream"' in html
+    assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
+    assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families
@@ -95,6 +99,10 @@ def test_generate_combined_parity_table_html() -> None:
     assert "url.searchParams.set('tab', id)" in html
     assert "TOOLCALLING.batch." in html
     assert "TOOLCALLING.stream." in html
+    assert 'id="case-descriptions-toolcalling-batch"' in html
+    assert 'id="case-descriptions-toolcalling-stream"' in html
+    assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
+    assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert "REASONING.batch." in html
     assert "REASONING.stream." in html
     assert "toolcalling/fixtures/" in "".join(links.hrefs)

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -96,6 +96,8 @@ def test_generate_combined_parity_table_html() -> None:
     assert 'data-tab-target="tab-reasoning-batch">Reasoning batch</button>' in html
     assert 'data-tab-target="tab-reasoning-stream">Reasoning stream</button>' in html
     assert "params.get('tab')" in html
+    assert "validTargets.has(requested)" in html
+    assert "document.getElementById(requested)" not in html
     assert "url.searchParams.set('tab', id)" in html
     assert "TOOLCALLING.batch." in html
     assert "TOOLCALLING.stream." in html

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -79,6 +79,32 @@ def test_generate_parser_parity_table_batch_mode_excludes_stream_links() -> None
 
 
 @pytest.mark.timeout(60)
+def test_generate_combined_parity_table_html() -> None:
+    html = _render_html_for("all")
+    links = LinkCollector()
+    links.feed(html)
+
+    assert "Dynamo Parser Parity Table" in html
+    assert "generate_parity_table.py all --html" in html
+    assert 'data-tab-target="tab-toolcalling-batch">TC batch</button>' in html
+    assert 'title="Tool Calling batch"' in html
+    assert 'aria-label="Tool Calling stream"' in html
+    assert 'data-tab-target="tab-reasoning-batch">Reasoning batch</button>' in html
+    assert 'data-tab-target="tab-reasoning-stream">Reasoning stream</button>' in html
+    assert "params.get('tab')" in html
+    assert "url.searchParams.set('tab', id)" in html
+    assert "TOOLCALLING.batch." in html
+    assert "TOOLCALLING.stream." in html
+    assert "REASONING.batch." in html
+    assert "REASONING.stream." in html
+    assert "toolcalling/fixtures/" in "".join(links.hrefs)
+    assert "reasoning/fixtures/" in "".join(links.hrefs)
+    assert "../../lib/parsers/TOOLCALLING_CASES.md" in links.hrefs
+    assert "../../lib/parsers/REASONING_CASES.md" in links.hrefs
+    assert "../../pyproject.toml" in links.hrefs
+
+
+@pytest.mark.timeout(60)
 def test_generate_reasoning_parity_table_leak_markers_are_parser_specific() -> None:
     html = _render_html_for("reasoning")
 


### PR DESCRIPTION
#### Overview:

This PR adds one parser parity HTML entrypoint for Tool Calling and Reasoning views.

#### Details:

<img width="650" height="280" alt="image" src="https://github.com/user-attachments/assets/31bfb5d6-f438-434f-9875-7609722fa93d" />


- **How is this fixed?** Add `tests/parity/generate_parity_table.py all --html` to assemble Tool Calling batch/stream and Reasoning batch/stream panels through the shared parity table template.
- Reuse the existing stage-specific panel builders and rewrite stage-local fixture/docs links so they work from `tests/parity/PARITY.html`.
- Preserve tab and column-collapse state in the URL so links can be copied across browsers.
- Add hover/accessibility labels for compact `TC` tabs so they expand to `Tool Calling batch` and `Tool Calling stream`.
- Add generator regression coverage for the combined page, rewritten links, tab URL state, and compact-tab labels.

#### Verification:

Generated `tests/parity/PARITY.html` with `python3 tests/parity/generate_parity_table.py all --html`; devcontainer `python3 -m pytest tests/parity/toolcalling/test_generate_parity_table.py` passed, 4 tests.

#### Where should the reviewer start?

`tests/parity/generate_parity_table.py`, then `tests/parity/parity_table.html.j2`

#### Related Issues:

Relates to DIS-2150

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating a combined parity HTML page displaying all stages simultaneously
  * Implemented tab navigation with URL query parameter synchronization for easy sharing and bookmarking
  * Added per-panel legend and documentation configuration support

* **Tests**
  * Added test coverage for combined parity table HTML generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->