### PR TITLE
fix(parser): stop nemotron_deci leaking TOOLCALL markers into content

### DIFF
--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -45,6 +45,25 @@ pub struct JsonParserConfig {
     /// isn't silently dropped.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// Strict recovery: never leak wrapper markers (e.g. `<TOOLCALL>` /
+    /// `</TOOLCALL>`) into `normal_text`. When the normal parse path produces
+    /// no tool call, strip all configured start/end tokens from the raw text
+    /// and retry a strict parse of the remaining payload. If it yields one or
+    /// more tool calls, surface them (the model just emitted malformed framing,
+    /// e.g. an orphan close tag); otherwise drop the content entirely (empty
+    /// `normal_text`). Either way the wrapper markers never reach the user, and
+    /// a `tracing::warn!` records what was recovered or dropped so the loss is
+    /// debuggable. Default `false` keeps every other JSON family's existing
+    /// impl-defined recovery (which may leave raw text in `normal_text`)
+    /// unchanged. Only `nemotron_deci` opts in today.
+    ///
+    /// Only takes effect when `allow_eof_recovery` is also true (finalize /
+    /// non-streaming aggregate paths). On a mid-stream chunk it would otherwise
+    /// claim a complete call before the end token arrives and strand the
+    /// trailing marker as leaked text on the next chunk.
+    #[serde(default)]
+    pub strip_markup_on_recovery: bool,
 }
 
 impl Default for JsonParserConfig {
@@ -58,6 +77,7 @@ impl Default for JsonParserConfig {
             parser_type: JsonParserType::Basic,
             bare_json_mode: false,
             allow_eof_recovery: false,
+            strip_markup_on_recovery: false,
         }
     }
 }
@@ -392,6 +412,11 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Json(JsonParserConfig {
                 tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
                 tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+                // Nemotron Ultra/Deci is an agent target where leaking a bare
+                // <TOOLCALL> envelope into message.content breaks OpenAI-shaped
+                // clients (they read tool_calls, never the content body). Strip
+                // the markers on recovery and either surface the call or drop it.
+                strip_markup_on_recovery: true,
                 ..Default::default()
             }),
             structural_tag_builder: None,

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -266,6 +266,56 @@ fn try_parse_normal_text(input: &str, start_token: &str) -> String {
 /// let result = try_tool_call_parse_json(input)?;
 /// assert!(result.is_some());
 /// ```
+/// Parse `payload` into tool calls, trying the three canonical JSON shapes in
+/// order: an array of calls, a single `{name, arguments}`, then a single
+/// `{name, parameters}`. Within an array, each element is tried as
+/// `arguments` then `parameters`.
+///
+/// Returns:
+/// - `Ok(Some(calls))` when `payload` matched one of the shapes. The vec may be
+///   empty (e.g. a literal `[]`, or an array whose elements were all malformed),
+///   which still counts as "recognized" so the caller returns rather than
+///   falling through to truncation repair / strict recovery.
+/// - `Ok(None)` when `payload` matched none of the shapes.
+///
+/// `arguments` bytes are passed through verbatim via `RawValue::get()` rather
+/// than re-serializing a parsed `HashMap` / `Value`, which keeps them
+/// byte-identical to what the model emitted (required for KV-cache append-only
+/// prefix matching across multi-step tool use).
+fn parse_calls(payload: &str) -> anyhow::Result<Option<Vec<ToolCallResponse>>> {
+    let mk = |name: String, args: &RawValue| ToolCallResponse {
+        id: format!("call-{}", Uuid::new_v4()),
+        tp: ToolCallType::Function,
+        function: CalledFunction {
+            name,
+            arguments: args.get().to_string(),
+        },
+    };
+
+    if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(payload) {
+        let mut calls = Vec::new();
+        for item in array {
+            let item_str = item.get();
+            if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
+                calls.push(mk(func_args.name, &func_args.arguments));
+            } else if let Ok(func_params) =
+                serde_json::from_str::<CalledFunctionParameters>(item_str)
+            {
+                calls.push(mk(func_params.name, &func_params.parameters));
+            }
+            // Skip malformed entries silently.
+        }
+        return Ok(Some(calls));
+    }
+    if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(payload) {
+        return Ok(Some(vec![mk(single.name, &single.parameters)]));
+    }
+    if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(payload) {
+        return Ok(Some(vec![mk(single.name, &single.arguments)]));
+    }
+    Ok(None)
+}
+
 pub fn try_tool_call_parse_basic_json(
     message: &str,
     config: &JsonParserConfig,
@@ -380,77 +430,12 @@ pub fn try_tool_call_parse_basic_json(
     let json = json.as_str();
     // Anonymous function to attempt deserialization into a known representation.
     //
-    // We pass through the original byte span via `RawValue::get()` rather than
-    // re-serializing a parsed `HashMap` / `Value`. That keeps `arguments`
-    // byte-identical to what the model emitted, which is required for KV-cache
-    // append-only prefix matching across multi-step tool use.
-    let parse = |name: String, args: &RawValue| -> anyhow::Result<ToolCallResponse> {
-        Ok(ToolCallResponse {
-            id: format!("call-{}", Uuid::new_v4()),
-            tp: ToolCallType::Function,
-            function: CalledFunction {
-                name,
-                arguments: args.get().to_string(),
-            },
-        })
-    };
-
-    // CalledFunctionParameters: Single { name, parameters }
-    // Example:
-    // {
-    //   "name": "search_docs",
-    //   "parameters": {
-    //     "query": "how to use Rust",
-    //     "limit": 5
-    //   }
-    // }
-    if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(json) {
-        return Ok((
-            vec![parse(single.name, &single.parameters)?],
-            Some(normal_text),
-        ));
-
-        // CalledFunctionArguments: Single { name, arguments }
-        // Example:
-        // {
-        //   "name": "summarize",
-        //   "arguments": {
-        //     "text": "Rust is a systems programming language.",
-        //     "length": "short"
-        //   }
-        // }
-    } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(json) {
-        return Ok((
-            vec![parse(single.name, &single.arguments)?],
-            Some(normal_text),
-        ));
-
-    // Vec<CalledFunctionParameters> or Vec<CalledFunctionArguments>: Array of tool calls
-    // Example:
-    // [
-    //   { "name": "lookup_user", "parameters": { "user_id": "123" } },
-    //   { "name": "get_weather", "arguments": { "location": "SF", "units": "celsius" } }
-    // ]
-    // Parse the array as `Vec<Box<RawValue>>` so each element retains its
-    // original byte span. Going through `Vec<serde_json::Value>` would
-    // already have mangled the inner `arguments` / `parameters` bytes by the
-    // time we tried to extract them.
-    } else if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(json) {
-        let mut results = Vec::new();
-        for item in array {
-            let item_str = item.get();
-            // Try both CalledFunctionArguments and CalledFunctionParameters formats
-            if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
-                results.push(parse(func_args.name, &func_args.arguments)?);
-            } else if let Ok(func_params) =
-                serde_json::from_str::<CalledFunctionParameters>(item_str)
-            {
-                results.push(parse(func_params.name, &func_params.parameters)?);
-            }
-            // Skip malformed entries silently
-        }
-        // Return with whatever results we have, even if empty (e.g., [] is a valid empty array)
-        return Ok((results, Some(normal_text)));
+    // Try the three canonical JSON shapes (single object with `parameters` or
+    // `arguments`, or an array of either). A recognized shape returns here —
+    // including an empty array, which is a valid empty result and must not fall
+    // through to truncation recovery.
+    if let Some(calls) = parse_calls(json)? {
+        return Ok((calls, Some(normal_text)));
     }
 
     // Truncation recovery: balance unclosed strings/braces (common
@@ -459,34 +444,10 @@ pub fn try_tool_call_parse_basic_json(
     // call while the model is still emitting JSON tokens.
     if config.allow_eof_recovery
         && let Some(repaired) = try_repair_truncated_json(json)
+        && let Some(calls) = parse_calls(repaired.as_str())?
+        && !calls.is_empty()
     {
-        let repaired = repaired.as_str();
-        if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(repaired) {
-            return Ok((
-                vec![parse(single.name, &single.parameters)?],
-                Some(normal_text),
-            ));
-        } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(repaired) {
-            return Ok((
-                vec![parse(single.name, &single.arguments)?],
-                Some(normal_text),
-            ));
-        } else if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(repaired) {
-            let mut results = Vec::new();
-            for item in array {
-                let item_str = item.get();
-                if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
-                    results.push(parse(func_args.name, &func_args.arguments)?);
-                } else if let Ok(func_params) =
-                    serde_json::from_str::<CalledFunctionParameters>(item_str)
-                {
-                    results.push(parse(func_params.name, &func_params.parameters)?);
-                }
-            }
-            if !results.is_empty() {
-                return Ok((results, Some(normal_text)));
-            }
-        }
+        return Ok((calls, Some(normal_text)));
     }
 
     // If we found a start token but no valid JSON, return empty content
@@ -525,7 +486,15 @@ pub fn try_tool_call_parse_basic_json(
             // replace would corrupt literal marker text inside a JSON string
             // value (e.g. an argument that mentions "</TOOLCALL>"); boundary
             // stripping leaves the JSON bytes handed to serde untouched.
-            let mut payload = trimmed;
+            //
+            // Base the payload on `json` (already split from `normal_text` by
+            // the extraction stages above), not `trimmed`. With a preamble like
+            // `Let me check.[{...}]</TOOLCALL>`, `trimmed` re-glues the prose
+            // onto the JSON so it never parses and the call is dropped; `json`
+            // is just `[{...}]</TOOLCALL>` and recovers. `has_marker` still
+            // checks `trimmed` because extraction may have already consumed the
+            // markers from `json`.
+            let mut payload = json;
             loop {
                 payload = payload.trim();
                 match config
@@ -552,24 +521,7 @@ pub fn try_tool_call_parse_basic_json(
             }
             let payload = payload.trim();
 
-            let mut calls = Vec::new();
-            if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(payload) {
-                for item in array {
-                    let item_str = item.get();
-                    if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str)
-                    {
-                        calls.push(parse(func_args.name, &func_args.arguments)?);
-                    } else if let Ok(func_params) =
-                        serde_json::from_str::<CalledFunctionParameters>(item_str)
-                    {
-                        calls.push(parse(func_params.name, &func_params.parameters)?);
-                    }
-                }
-            } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(payload) {
-                calls.push(parse(single.name, &single.arguments)?);
-            } else if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(payload) {
-                calls.push(parse(single.name, &single.parameters)?);
-            }
+            let calls = parse_calls(payload)?.unwrap_or_default();
 
             if !calls.is_empty() {
                 tracing::warn!(

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -492,10 +492,103 @@ pub fn try_tool_call_parse_basic_json(
     // If we found a start token but no valid JSON, return empty content
     // to avoid leaking the token and invalid JSON content
     if found_start_token_with_no_valid_json {
-        Ok((vec![], Some(String::new())))
-    } else {
-        Ok((vec![], Some(trimmed.to_string())))
+        return Ok((vec![], Some(String::new())));
     }
+
+    // Strict recovery (opt-in via `strip_markup_on_recovery`, e.g. nemotron_deci):
+    // every parse above failed, so the fall-through below would return the raw
+    // text verbatim — which leaks the wrapper markers (`<TOOLCALL>` /
+    // `</TOOLCALL>`) into `normal_text`. Instead, strip all configured markers
+    // and retry a strict parse of the remaining payload: recover any well-formed
+    // call (this is what salvages orphan-close framing like
+    // `[{...}]</TOOLCALL>`), otherwise drop the content. Markers never reach the
+    // user either way; `tracing::warn!` records what was recovered or dropped.
+    // Gated on `allow_eof_recovery` so this only runs on finalize / non-streaming
+    // aggregate paths — never on a mid-stream chunk. Firing mid-stream would
+    // claim a "complete" call before the end token arrives (same hazard as
+    // `allow_eof_recovery` itself), which strands the trailing `</TOOLCALL>` as
+    // leaked normal_text on the next chunk.
+    if config.strip_markup_on_recovery && config.allow_eof_recovery {
+        // Only intervene when a wrapper marker is actually present. Plain text
+        // with no tool-call marker is a normal (non-tool) response and MUST
+        // pass through unchanged — it must never be dropped or treated as a
+        // failed tool call.
+        let has_marker = config
+            .tool_call_start_tokens
+            .iter()
+            .chain(config.tool_call_end_tokens.iter())
+            .any(|token| !token.is_empty() && trimmed.contains(token.as_str()));
+
+        if has_marker {
+            // Strip wrapper markers only at the boundaries — start tokens from
+            // the front, end tokens from the end — never globally. A global
+            // replace would corrupt literal marker text inside a JSON string
+            // value (e.g. an argument that mentions "</TOOLCALL>"); boundary
+            // stripping leaves the JSON bytes handed to serde untouched.
+            let mut payload = trimmed;
+            loop {
+                payload = payload.trim();
+                match config
+                    .tool_call_start_tokens
+                    .iter()
+                    .filter(|token| !token.is_empty())
+                    .find_map(|token| payload.strip_prefix(token.as_str()))
+                {
+                    Some(rest) => payload = rest,
+                    None => break,
+                }
+            }
+            loop {
+                payload = payload.trim();
+                match config
+                    .tool_call_end_tokens
+                    .iter()
+                    .filter(|token| !token.is_empty())
+                    .find_map(|token| payload.strip_suffix(token.as_str()))
+                {
+                    Some(rest) => payload = rest,
+                    None => break,
+                }
+            }
+            let payload = payload.trim();
+
+            let mut calls = Vec::new();
+            if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(payload) {
+                for item in array {
+                    let item_str = item.get();
+                    if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str)
+                    {
+                        calls.push(parse(func_args.name, &func_args.arguments)?);
+                    } else if let Ok(func_params) =
+                        serde_json::from_str::<CalledFunctionParameters>(item_str)
+                    {
+                        calls.push(parse(func_params.name, &func_params.parameters)?);
+                    }
+                }
+            } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(payload) {
+                calls.push(parse(single.name, &single.arguments)?);
+            } else if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(payload) {
+                calls.push(parse(single.name, &single.parameters)?);
+            }
+
+            if !calls.is_empty() {
+                tracing::warn!(
+                    recovered_calls = calls.len(),
+                    "Recovered {} tool call(s) from malformed tool-call framing; stripped wrapper markers instead of leaking them into normal_text",
+                    calls.len()
+                );
+                return Ok((calls, Some(String::new())));
+            }
+
+            tracing::warn!(
+                dropped_content = %trimmed,
+                "Dropping unparseable tool-call content; wrapper markers stripped, no valid tool call recovered"
+            );
+            return Ok((vec![], Some(String::new())));
+        }
+    }
+
+    Ok((vec![], Some(trimmed.to_string())))
 }
 
 pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig) -> bool {

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -256,6 +256,39 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
+    /// Strict recovery with a leading preamble + orphan close tag. The model
+    /// emits prose, then a complete JSON array, then a stray `</TOOLCALL>` with
+    /// no opener: `Let me check.[{...}]</TOOLCALL>`. The extraction stages split
+    /// this into normal_text="Let me check." and json="[{...}]</TOOLCALL>", so
+    /// recovery must strip markers off `json` (not the re-glued full message) to
+    /// salvage the call. Regression for dropping recoverable calls when a
+    /// preamble is present.
+    #[test]
+    fn test_parse_nemotron_deci_preamble_orphan_close_recovers() {
+        // Mirror the finalize/batch path: the with-recovery dispatcher flips
+        // `allow_eof_recovery=true`, which is the only path strict recovery runs on.
+        let config = JsonParserConfig {
+            allow_eof_recovery: true,
+            ..nemotron_deci_config()
+        };
+        let input =
+            r#"Let me check.[{"name":"get_weather","arguments":{"location":"NYC"}}]</TOOLCALL>"#;
+        let (calls, normal) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "preamble must not drop the recoverable call"
+        );
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"location": "NYC"}));
+        assert_eq!(
+            normal.as_deref(),
+            Some(""),
+            "wrapper markers and preamble are stripped, not leaked into normal_text"
+        );
+    }
+
     /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls; normal_text
     /// collapses to the empty string.

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -222,6 +222,8 @@ mod tests {
         JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
             tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            // Mirror the production nemotron_deci config (Config::nemotron_deci).
+            strip_markup_on_recovery: true,
             ..Default::default()
         }
     }

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.4.yaml
@@ -18,9 +18,9 @@ cases:
             type: string
     expected:
       dynamo:
-        reason: "Dynamo's nemotron_deci parser leaves <TOOLCALL> envelope in normal_text on malformed input (impl-defined recovery)"
+        reason: Unparseable TOOLCALL content (not a JSON tool-call array); Dynamo strips the wrapper markers and drops the content instead of leaking them into normal_text, and records the drop via tracing::warn
         calls: []
-        normal_text: <TOOLCALL>not a json array</TOOLCALL>
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
@@ -50,6 +50,7 @@ cases:
     - *id001
     expected:
       dynamo:
+        reason: The array element has no name key, so it is not a valid tool call; Dynamo drops it and emits empty normal_text without leaking the wrapper markers
         calls: []
         normal_text: ''
       vllm:

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.5.yaml
@@ -35,9 +35,11 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo's nemotron_deci parser leaves closing </TOOLCALL> envelope plus the JSON array in normal_text when opening <TOOLCALL> marker is missing (impl-defined recovery)"
-        calls: []
-        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
@@ -50,9 +52,8 @@ cases:
     - *id001
     expected:
       dynamo:
-        reason: "Dynamo's nemotron_deci parser leaves closing </TOOLCALL> envelope plus the JSON array in normal_text when opening <TOOLCALL> marker is missing (impl-defined recovery)"
         calls: []
-        normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.4.yaml
@@ -48,7 +48,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
+        normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
       vllm:


### PR DESCRIPTION
## Overview

`nemotron_deci`'s tool-call parser leaked its `<TOOLCALL>` / `</TOOLCALL>` wrapper markers into `message.content` whenever recovery couldn't parse a call. OpenAI-shaped clients read `tool_calls`, never the content body, so a leaked call is silently dropped. Related: [DIS-2109](https://linear.app/nvidia/issue/DIS-2109).

Opt-in `JsonParserConfig.strip_markup_on_recovery` (set only for `nemotron_deci`): on the finalize recovery path, strip wrapper markers boundary-only (start tokens from the front, end tokens from the end, so literal marker text inside a JSON arg isn't corrupted) and retry a strict parse — recover a valid call, otherwise drop the content. Markers never reach the user; a `tracing::warn` records what was recovered or dropped. Gated on `allow_eof_recovery` so it never fires mid-stream; default `false` leaves every other JSON family unchanged.

## Example

Input — orphan close (model emitted the array but no opening `<TOOLCALL>`):

```
[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>
```

| | before | after |
|---|---|---|
| `tool_calls` | `[]` | `[get_weather(location=NYC)]` |
| `content` | `[{...}]</TOOLCALL>` (markup leaked) | `""` (empty) |

Truncated (`<TOOLCALL>[{"name":...{"loc`) and garbage (`<TOOLCALL>not a json array</TOOLCALL>`) inputs: before leaked the raw text; after → `tool_calls=[]`, `content=""` (dropped, with a `tracing::warn`).

## Tests (dev container)

`nemotron_deci` parity 38 passed · full toolcalling parity 1311 passed, 0 failed · `cargo test -p dynamo-parsers` 586 passed.
