### PR TITLE
feat: prototype Velo KV recovery transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "utoipa-swagger-ui",
  "uuid",
  "validator",
+ "velo",
  "video-rs",
  "xxhash-rust",
 ]

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -31,6 +31,8 @@ media-ffmpeg = ["dep:video-rs", "dep:ffmpeg-next", "dep:memfile"]
 bench = ["dynamo-kv-router/bench"]
 kv-router-stress = ["dep:clap", "dep:indicatif", "bench"]
 lightseek-mm = ["dep:llm-multimodal", "dep:llm-tokenizer"]
+# Enable optional Velo unary transport for worker KV gap-recovery queries.
+velo-recovery = ["dep:velo"]
 
 [[bench]]
 name = "tokenizer_simple"
@@ -91,6 +93,7 @@ thiserror = { workspace = true }
 tmq = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+velo = { workspace = true, optional = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 validator = { workspace = true }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -140,6 +140,26 @@ pub fn worker_kv_indexer_query_endpoint_for_worker(worker_id: WorkerId, dp_rank:
     )
 }
 
+/// Generates the Dynamo endpoint name under which a worker publishes its Velo `PeerInfo`
+/// for direct-transport peer discovery.
+///
+/// Use this form when the route instance id equals the logical worker id.
+/// When they differ, use [`worker_kv_velo_peer_endpoint_for_worker`] instead.
+///
+/// Workers register this endpoint via [`indexer::recovery::start_worker_kv_velo_peer_endpoint`];
+/// routers query it when `worker_kv_velo_peer_dp{N}` appears in `ComponentEndpoints` discovery.
+#[cfg(feature = "velo-recovery")]
+pub fn worker_kv_velo_peer_endpoint(dp_rank: DpRank) -> String {
+    format!("worker_kv_velo_peer_dp{dp_rank}")
+}
+
+/// Generates the Dynamo endpoint name for a worker whose logical `worker_id` differs
+/// from the route instance id (e.g. multi-worker-per-pod deployments).
+#[cfg(feature = "velo-recovery")]
+pub fn worker_kv_velo_peer_endpoint_for_worker(worker_id: WorkerId, dp_rank: DpRank) -> String {
+    format!("worker_kv_velo_peer_dp{dp_rank}_worker{worker_id}")
+}
+
 fn log_routing_input_hashes(
     request_id: Option<&str>,
     block_size: u32,

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -38,7 +38,9 @@ pub(crate) use recovery::start_subscriber;
 pub(crate) use recovery::start_worker_kv_query_endpoint;
 
 #[cfg(feature = "velo-recovery")]
-pub(crate) use recovery::{register_velo_query_handler, start_worker_kv_velo_peer_endpoint};
+pub(crate) use recovery::{
+    build_velo_messenger, register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
+};
 
 /// `approx` is the optional predict-on-route side indexer. It is always local
 /// to this router, even when the primary indexer is served or consumed

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -34,6 +34,9 @@ pub use self::remote::{ServedIndexerHandle, ServedIndexerMode, ensure_served_ind
 pub use self::side::SideIndexer;
 pub(crate) use recovery::{start_subscriber, start_worker_kv_query_endpoint};
 
+#[cfg(feature = "velo-recovery")]
+pub(crate) use recovery::{register_velo_query_handler, start_worker_kv_velo_peer_endpoint};
+
 /// `approx` is the optional predict-on-route side indexer. It is always local
 /// to this router, even when the primary indexer is served or consumed
 /// remotely. Routing decisions populate it with a short TTL; engine KV events

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -32,7 +32,10 @@ mod side;
 use self::remote::RemoteIndexer;
 pub use self::remote::{ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub use self::side::SideIndexer;
-pub(crate) use recovery::{start_subscriber, start_worker_kv_query_endpoint};
+pub(crate) use recovery::start_subscriber;
+// Legacy NATS query endpoint is not started when velo-recovery is active.
+#[cfg(not(feature = "velo-recovery"))]
+pub(crate) use recovery::start_worker_kv_query_endpoint;
 
 #[cfg(feature = "velo-recovery")]
 pub(crate) use recovery::{register_velo_query_handler, start_worker_kv_velo_peer_endpoint};

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -11,3 +11,8 @@ mod worker_query_transport;
 
 pub(crate) use subscriber::start_subscriber;
 pub(crate) use worker_query_endpoint::start_worker_kv_query_endpoint;
+
+#[cfg(feature = "velo-recovery")]
+pub(crate) use worker_query_endpoint::{
+    VeloQueryDispatch, register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
+};

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -17,3 +17,5 @@ pub(crate) use worker_query_endpoint::start_worker_kv_query_endpoint;
 pub(crate) use worker_query_endpoint::{
     register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
 };
+#[cfg(feature = "velo-recovery")]
+pub(crate) use worker_query_transport::build_velo_messenger;

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -10,9 +10,10 @@ mod worker_query_state;
 mod worker_query_transport;
 
 pub(crate) use subscriber::start_subscriber;
+#[cfg(not(feature = "velo-recovery"))]
 pub(crate) use worker_query_endpoint::start_worker_kv_query_endpoint;
 
 #[cfg(feature = "velo-recovery")]
 pub(crate) use worker_query_endpoint::{
-    VeloQueryDispatch, register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
+    register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
 };

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -121,32 +121,33 @@ async fn start_kv_router_background_event_plane(
 
 /// Build a `WorkerQueryClient` using Velo direct transport.
 ///
-/// Creates a TCP-bound Velo `Messenger`, then delegates to
+/// Constructs a [`velo::Messenger`], then delegates to
 /// [`WorkerQueryClient::spawn_with_velo`].
 #[cfg(feature = "velo-recovery")]
 async fn make_worker_query_client(
     component: Component,
     indexer: Indexer,
 ) -> Result<Arc<WorkerQueryClient>> {
-    use std::net::TcpListener;
-    use velo::backend::tcp::TcpTransportBuilder;
+    use std::path::PathBuf;
 
-    let listener =
-        TcpListener::bind("0.0.0.0:0").map_err(|e| anyhow::anyhow!("Velo TCP bind: {e}"))?;
-    let transport = Arc::new(
-        TcpTransportBuilder::new()
-            .from_listener(listener)
-            .map_err(|e| anyhow::anyhow!("Velo TCP from_listener: {e}"))?
-            .build()
-            .map_err(|e| anyhow::anyhow!("Velo TCP build: {e}"))?,
+    use super::worker_query_transport::build_velo_messenger;
+
+    // Each router instance gets a unique UDS path so that multiple routers on
+    // the same host do not collide.  Process ID + a per-process counter suffices.
+    static ROUTER_UDS_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = ROUTER_UDS_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let router_uds_path = PathBuf::from(format!(
+        "/tmp/dynamo-velo-router-recovery-{}-{seq}.sock",
+        std::process::id()
+    ));
+    // Remove any leftover socket from a previous run at the same path.
+    let _ = std::fs::remove_file(&router_uds_path);
+
+    let messenger = build_velo_messenger(&router_uds_path).await?;
+    tracing::info!(
+        uds_path = %router_uds_path.display(),
+        "Router using Velo/UDS direct transport for KV gap-recovery (same-host)"
     );
-    // Messenger::builder().build() returns Arc<Messenger> directly.
-    let messenger = velo::Messenger::builder()
-        .add_transport(transport as Arc<dyn velo::backend::Transport>)
-        .build()
-        .await
-        .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?;
-    tracing::info!("Router using Velo direct transport for KV gap-recovery queries");
     WorkerQueryClient::spawn_with_velo(component, indexer, messenger).await
 }
 

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -140,13 +140,12 @@ async fn make_worker_query_client(
             .build()
             .map_err(|e| anyhow::anyhow!("Velo TCP build: {e}"))?,
     );
-    let messenger = Arc::new(
-        velo::Messenger::builder()
-            .add_transport(transport as Arc<dyn velo::backend::Transport>)
-            .build()
-            .await
-            .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?,
-    );
+    // Messenger::builder().build() returns Arc<Messenger> directly.
+    let messenger = velo::Messenger::builder()
+        .add_transport(transport as Arc<dyn velo::backend::Transport>)
+        .build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?;
     tracing::info!("Router using Velo direct transport for KV gap-recovery queries");
     WorkerQueryClient::spawn_with_velo(component, indexer, messenger).await
 }

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use super::worker_query::WorkerQueryClient;
 use crate::kv_router::Indexer;
 use anyhow::Result;
@@ -45,7 +47,7 @@ async fn start_kv_router_background_event_plane(
 
     // WorkerQueryClient handles its own discovery loop for lifecycle + initial recovery.
     // No blocking wait — recovery happens asynchronously as endpoints are discovered.
-    let worker_query_client = WorkerQueryClient::spawn(component.clone(), indexer).await?;
+    let worker_query_client = make_worker_query_client(component.clone(), indexer).await?;
     let kv_event_subject = format!(
         "namespace.{}.component.{}.{}",
         component.namespace().name(),
@@ -109,6 +111,53 @@ async fn start_kv_router_background_event_plane(
     });
 
     Ok(())
+}
+
+// WorkerQueryClient factory
+//
+// When the `velo-recovery` feature is enabled the router uses Velo direct
+// transport for gap-recovery queries.  The messenger is constructed here so
+// the caller doesn't need to know about the transport choice.
+
+/// Build a `WorkerQueryClient` using Velo direct transport.
+///
+/// Creates a TCP-bound Velo `Messenger`, then delegates to
+/// [`WorkerQueryClient::spawn_with_velo`].
+#[cfg(feature = "velo-recovery")]
+async fn make_worker_query_client(
+    component: Component,
+    indexer: Indexer,
+) -> Result<Arc<WorkerQueryClient>> {
+    use std::net::TcpListener;
+    use velo::backend::tcp::TcpTransportBuilder;
+
+    let listener =
+        TcpListener::bind("0.0.0.0:0").map_err(|e| anyhow::anyhow!("Velo TCP bind: {e}"))?;
+    let transport = Arc::new(
+        TcpTransportBuilder::new()
+            .from_listener(listener)
+            .map_err(|e| anyhow::anyhow!("Velo TCP from_listener: {e}"))?
+            .build()
+            .map_err(|e| anyhow::anyhow!("Velo TCP build: {e}"))?,
+    );
+    let messenger = Arc::new(
+        velo::Messenger::builder()
+            .add_transport(transport as Arc<dyn velo::backend::Transport>)
+            .build()
+            .await
+            .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?,
+    );
+    tracing::info!("Router using Velo direct transport for KV gap-recovery queries");
+    WorkerQueryClient::spawn_with_velo(component, indexer, messenger).await
+}
+
+/// Build a `WorkerQueryClient` using the default Dynamo runtime transport.
+#[cfg(not(feature = "velo-recovery"))]
+async fn make_worker_query_client(
+    component: Component,
+    indexer: Indexer,
+) -> Result<Arc<WorkerQueryClient>> {
+    WorkerQueryClient::spawn(component, indexer).await
 }
 
 /// Helper to decide which subscriber (JetStream or Event Plane) to start based on config

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -163,12 +163,13 @@ impl WorkerQueryClient {
         use dynamo_runtime::pipeline::AddressedPushRouter;
 
         let velo_transport = Arc::new(VeloWorkerQueryTransport::new(messenger.clone()));
+        // from_runtime_provider returns Arc<AddressedPushRouter> directly.
         let peer_router = AddressedPushRouter::from_runtime_provider(&component).await?;
 
         let velo_state = Some(Arc::new(VeloClientState {
             transport: velo_transport.clone(),
             messenger,
-            peer_router: Arc::new(peer_router),
+            peer_router,
             velo_pending: DashMap::new(),
             velo_commit_lock: DashMap::new(),
         }));
@@ -369,21 +370,34 @@ impl WorkerQueryClient {
     ) {
         // Cancel any in-flight Velo peer resolution for this key so the retry
         // task cannot re-insert a stale endpoint after the removal is processed.
-        // Match on endpoint_id to avoid cancelling a resolution for a *newer*
-        // Added event that may have replaced the removed one.
+        // Acquire the per-key commit lock first so this cancel is mutually
+        // exclusive with the retry task's (token-check + insert) pair — closing
+        // the window where a Removed event arrives after the token check but
+        // before handle_discovered_query_endpoint inserts the entry.
         #[cfg(feature = "velo-recovery")]
         if let Some(velo_state) = &self.velo_state {
-            let should_cancel = velo_state
-                .velo_pending
-                .get(&(worker_id, dp_rank))
-                .map(|entry| entry.value().0 == endpoint_id)
-                .unwrap_or(false);
-            if should_cancel {
-                if let Some((_, (_, token))) = velo_state.velo_pending.remove(&(worker_id, dp_rank))
-                {
-                    token.cancel();
+            let lock = velo_state
+                .velo_commit_lock
+                .entry((worker_id, dp_rank))
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone();
+            {
+                let _guard = lock.lock().await;
+                // Only cancel if the pending entry belongs to *this* endpoint_id.
+                // A newer Added event may have already replaced it.
+                let should_cancel = velo_state
+                    .velo_pending
+                    .get(&(worker_id, dp_rank))
+                    .map(|entry| entry.value().0 == endpoint_id)
+                    .unwrap_or(false);
+                if should_cancel {
+                    if let Some((_, (_, token))) =
+                        velo_state.velo_pending.remove(&(worker_id, dp_rank))
+                    {
+                        token.cancel();
+                    }
                 }
-            }
+            } // commit lock released before remove_if_matches
         }
 
         if !self
@@ -522,6 +536,7 @@ impl WorkerQueryClient {
     ) -> anyhow::Result<()> {
         use super::worker_query_endpoint::{WorkerVeloPeerRequest, WorkerVeloPeerResponse};
         use dynamo_runtime::{
+            engine::AsyncEngine,
             pipeline::{AddressedRequest, ManyOut, SingleIn},
             protocols::maybe_error::MaybeError,
         };
@@ -592,9 +607,20 @@ impl WorkerQueryClient {
             "Registered Velo peer for worker KV recovery"
         );
 
-        // If the peer was removed while we were resolving, unregister it and
-        // return without inserting into query_endpoints.  The removal handler
-        // already cancelled the token and removed the velo_pending entry.
+        // Acquire the per-key commit lock and atomically check the cancellation
+        // token then insert into query_endpoints.  This is mutually exclusive
+        // with the removal handler's (cancel-token + record-tombstone) pair,
+        // closing the race where a Removed event lands after the token check
+        // but before handle_discovered_query_endpoint inserts the entry.
+        //
+        // Lock ordering: velo_commit_lock → worker_states mutex.
+        let commit_lock = velo_state
+            .velo_commit_lock
+            .entry((worker_id, dp_rank))
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let _guard = commit_lock.lock().await;
+
         if token.is_cancelled() {
             tracing::info!(
                 worker_id,
@@ -618,6 +644,7 @@ impl WorkerQueryClient {
             target,
         };
         self.handle_discovered_query_endpoint(endpoint).await;
+        // _guard dropped here — commit lock released after insert
         Ok(())
     }
 

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 use anyhow::Result;
 use dashmap::DashMap;
 use dynamo_runtime::component::{Component, Instance};
-use dynamo_runtime::discovery::{DiscoveryEvent, DiscoveryQuery, EndpointInstanceId};
+use dynamo_runtime::discovery::{
+    DiscoveryEvent, DiscoveryInstance, DiscoveryQuery, EndpointInstanceId,
+};
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use futures::StreamExt;
 use rand::Rng;
@@ -17,6 +19,8 @@ use super::worker_query_directory::{DiscoveredQueryEndpoint, WorkerQueryEndpoint
 #[cfg(test)]
 use super::worker_query_endpoint::WorkerKvQueryEngine;
 use super::worker_query_state::{LiveEventAction, PendingDrainAction, RecoveryKey, WorkerState};
+#[cfg(feature = "velo-recovery")]
+use super::worker_query_transport::VeloWorkerQueryTransport;
 use super::worker_query_transport::{RuntimeWorkerQueryTransport, WorkerQueryTransport};
 use crate::kv_router::Indexer;
 use dynamo_kv_router::{
@@ -44,6 +48,37 @@ const RECOVERY_MAX_RETRIES: u32 = 8;
 const RECOVERY_INITIAL_BACKOFF_MS: u64 = 200;
 const RECOVERY_CONCURRENCY_LIMIT: usize = 16;
 
+/// State held by a [`WorkerQueryClient`] that is running with Velo direct transport.
+///
+/// Bundles the transport, messenger, and a Dynamo `AddressedPushRouter` used to
+/// make one-shot peer-info queries to newly discovered workers.
+#[cfg(feature = "velo-recovery")]
+struct VeloClientState {
+    transport: Arc<VeloWorkerQueryTransport>,
+    messenger: Arc<velo::Messenger>,
+    peer_router: Arc<dynamo_runtime::pipeline::AddressedPushRouter>,
+    /// Tracks in-flight Velo peer resolutions.
+    ///
+    /// Keyed by `(worker_id, dp_rank)`.  Each entry holds the
+    /// `EndpointInstanceId` of the `Added` event that triggered the resolution
+    /// (so it can be matched against the corresponding `Removed` event) and a
+    /// [`tokio_util::sync::CancellationToken`] that wakes the retry task out of
+    /// its backoff sleep immediately when the peer is removed.
+    velo_pending: DashMap<RecoveryKey, (EndpointInstanceId, tokio_util::sync::CancellationToken)>,
+    /// Per-`(worker_id, dp_rank)` mutex that guards the commit window.
+    ///
+    /// The retry task holds this lock for the `(check-token + insert into
+    /// query_endpoints)` pair; the removal handler holds it for the
+    /// `(cancel-token + record-tombstone)` pair.  This ensures the two
+    /// operations are mutually exclusive: either the removal wins and the
+    /// retry sees a cancelled token before inserting, or the retry wins and
+    /// inserts before the removal, at which point `remove_if_matches` will
+    /// find the entry and clean it up.
+    ///
+    /// Lock ordering: `velo_commit_lock` → `worker_states` mutex.
+    velo_commit_lock: DashMap<RecoveryKey, Arc<Mutex<()>>>,
+}
+
 /// Router-side client for querying worker local KV indexers.
 ///
 /// Discovers query endpoints via `ComponentEndpoints` discovery, filtering for
@@ -64,6 +99,9 @@ pub struct WorkerQueryClient {
     worker_states: DashMap<WorkerId, Arc<Mutex<WorkerState>>>,
     query_endpoints: WorkerQueryEndpointDirectory,
     recovery_semaphore: Arc<Semaphore>,
+    /// Present only when using Velo direct transport (`velo-recovery` feature).
+    #[cfg(feature = "velo-recovery")]
+    velo_state: Option<Arc<VeloClientState>>,
 }
 
 impl WorkerQueryClient {
@@ -79,6 +117,8 @@ impl WorkerQueryClient {
             worker_states: DashMap::new(),
             query_endpoints: WorkerQueryEndpointDirectory::default(),
             recovery_semaphore: Arc::new(Semaphore::new(RECOVERY_CONCURRENCY_LIMIT)),
+            #[cfg(feature = "velo-recovery")]
+            velo_state: None,
         })
     }
 
@@ -96,6 +136,60 @@ impl WorkerQueryClient {
         tokio::spawn(async move {
             if let Err(e) = client_bg.run_discovery_loop(cancel_token).await {
                 tracing::error!("WorkerQueryClient discovery loop failed: {e}");
+            }
+        });
+
+        Ok(client)
+    }
+
+    /// Create a [`WorkerQueryClient`] that uses Velo direct transport for gap-recovery queries.
+    ///
+    /// Identical to [`spawn`] in lifecycle, but the recovery queries are sent over Velo
+    /// unary RPCs instead of the Dynamo runtime push-router.  The discovery loop is
+    /// extended to also watch `worker_kv_velo_peer_dp{N}` endpoints: when one appears the
+    /// client makes a one-shot Dynamo request to obtain the worker's `PeerInfo`, registers
+    /// it with `messenger`, and maps the `(worker_id, dp_rank)` to the worker's Velo
+    /// `InstanceId` in the transport.
+    ///
+    /// Workers must call [`start_worker_kv_velo_peer_endpoint`] and
+    /// [`register_velo_query_handler`] (or [`VeloQueryDispatch::register_on`]) before
+    /// their discovery entries will be usable.
+    #[cfg(feature = "velo-recovery")]
+    pub async fn spawn_with_velo(
+        component: Component,
+        indexer: Indexer,
+        messenger: Arc<velo::Messenger>,
+    ) -> Result<Arc<Self>> {
+        use dynamo_runtime::pipeline::AddressedPushRouter;
+
+        let velo_transport = Arc::new(VeloWorkerQueryTransport::new(messenger.clone()));
+        let peer_router = AddressedPushRouter::from_runtime_provider(&component).await?;
+
+        let velo_state = Some(Arc::new(VeloClientState {
+            transport: velo_transport.clone(),
+            messenger,
+            peer_router: Arc::new(peer_router),
+            velo_pending: DashMap::new(),
+            velo_commit_lock: DashMap::new(),
+        }));
+
+        let transport: Arc<dyn WorkerQueryTransport> = velo_transport;
+        // Construct directly to set `velo_state`; same-module access allows this.
+        let client = Arc::new(Self {
+            component: component.clone(),
+            transport,
+            indexer,
+            worker_states: DashMap::new(),
+            query_endpoints: WorkerQueryEndpointDirectory::default(),
+            recovery_semaphore: Arc::new(Semaphore::new(RECOVERY_CONCURRENCY_LIMIT)),
+            velo_state,
+        });
+
+        let client_bg = client.clone();
+        let cancel_token = component.drt().primary_token();
+        tokio::spawn(async move {
+            if let Err(e) = client_bg.run_discovery_loop(cancel_token).await {
+                tracing::error!("WorkerQueryClient (velo) discovery loop failed: {e}");
             }
         });
 
@@ -133,6 +227,27 @@ impl WorkerQueryClient {
 
             match event {
                 DiscoveryEvent::Added(instance) => {
+                    // When velo transport is active, check for velo peer-info endpoints
+                    // before falling through to the standard query endpoint path.
+                    #[cfg(feature = "velo-recovery")]
+                    if self.velo_state.is_some() {
+                        let velo_key = if let DiscoveryInstance::Endpoint(ref ep) = instance {
+                            WorkerQueryEndpointDirectory::parse_velo_peer_endpoint_name(
+                                &ep.endpoint,
+                                ep.instance_id,
+                            )
+                        } else {
+                            None
+                        };
+                        if let Some((worker_id, dp_rank)) = velo_key {
+                            let DiscoveryInstance::Endpoint(ep) = instance else {
+                                continue;
+                            };
+                            self.handle_discovered_velo_peer(worker_id, dp_rank, ep);
+                            continue;
+                        }
+                    }
+
                     let Some(endpoint) = WorkerQueryEndpointDirectory::parse_added(instance) else {
                         continue;
                     };
@@ -140,7 +255,7 @@ impl WorkerQueryClient {
                 }
                 DiscoveryEvent::Removed(id) => {
                     let Some((worker_id, dp_rank, endpoint_id)) =
-                        WorkerQueryEndpointDirectory::parse_removed(id)
+                        WorkerQueryEndpointDirectory::parse_removed_any(id)
                     else {
                         continue;
                     };
@@ -252,6 +367,25 @@ impl WorkerQueryClient {
         dp_rank: DpRank,
         endpoint_id: EndpointInstanceId,
     ) {
+        // Cancel any in-flight Velo peer resolution for this key so the retry
+        // task cannot re-insert a stale endpoint after the removal is processed.
+        // Match on endpoint_id to avoid cancelling a resolution for a *newer*
+        // Added event that may have replaced the removed one.
+        #[cfg(feature = "velo-recovery")]
+        if let Some(velo_state) = &self.velo_state {
+            let should_cancel = velo_state
+                .velo_pending
+                .get(&(worker_id, dp_rank))
+                .map(|entry| entry.value().0 == endpoint_id)
+                .unwrap_or(false);
+            if should_cancel {
+                if let Some((_, (_, token))) = velo_state.velo_pending.remove(&(worker_id, dp_rank))
+                {
+                    token.cancel();
+                }
+            }
+        }
+
         if !self
             .query_endpoints
             .remove_if_matches(worker_id, dp_rank, &endpoint_id)
@@ -260,7 +394,231 @@ impl WorkerQueryClient {
         }
 
         self.transport.cancel_instance_streams(&endpoint_id).await;
+
+        // Clean up the Velo peer map so stale instance ids do not survive until
+        // a later overwrite.  This is a no-op if the entry was already absent.
+        #[cfg(feature = "velo-recovery")]
+        if let Some(velo_state) = &self.velo_state {
+            velo_state.transport.unregister_peer(worker_id, dp_rank);
+        }
+
         self.remove_worker_dp_state(worker_id, dp_rank).await;
+    }
+
+    /// Spawn a bounded-retry task to resolve the worker's Velo peer-info and seed recovery.
+    ///
+    /// Discovery rarely re-emits an unchanged `Added` event, so a single-attempt failure
+    /// would permanently leave the worker without a recovery query owner.  The spawned task
+    /// retries with exponential backoff up to [`RECOVERY_MAX_RETRIES`] times, sharing the
+    /// same concurrency semaphore used by recovery tasks.
+    ///
+    /// A [`tokio_util::sync::CancellationToken`] is registered in
+    /// `velo_state.velo_pending` so that a concurrent `Removed` event can abort
+    /// the retry before it inserts a stale endpoint into `query_endpoints`.
+    #[cfg(feature = "velo-recovery")]
+    fn handle_discovered_velo_peer(
+        self: &Arc<Self>,
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        target: Instance,
+    ) {
+        let Some(velo_state) = &self.velo_state else {
+            return;
+        };
+        let endpoint_id = target.endpoint_instance_id();
+        let token = tokio_util::sync::CancellationToken::new();
+        // Cancel any previous resolution for this key (re-discovery after restart).
+        if let Some((_, (_, old_token))) = velo_state.velo_pending.remove(&(worker_id, dp_rank)) {
+            old_token.cancel();
+        }
+        velo_state
+            .velo_pending
+            .insert((worker_id, dp_rank), (endpoint_id, token.clone()));
+
+        let this = self.clone();
+        let semaphore = self.recovery_semaphore.clone();
+        tokio::spawn(async move {
+            let _permit = semaphore.acquire_owned().await.ok();
+            this.resolve_velo_peer_with_retry(worker_id, dp_rank, target, token)
+                .await;
+        });
+    }
+
+    /// Retry loop for [`handle_discovered_velo_peer`].
+    ///
+    /// Calls [`try_resolve_velo_peer`] up to [`RECOVERY_MAX_RETRIES`] times with
+    /// exponential backoff.  Logs a warning on each transient failure and an error
+    /// after the final attempt.  The `token` is checked at the start of each
+    /// attempt and the inter-attempt sleep is interruptible; the task exits
+    /// immediately if the corresponding `Removed` event arrives.
+    #[cfg(feature = "velo-recovery")]
+    async fn resolve_velo_peer_with_retry(
+        self: &Arc<Self>,
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        target: Instance,
+        token: tokio_util::sync::CancellationToken,
+    ) {
+        for attempt in 0..RECOVERY_MAX_RETRIES {
+            if token.is_cancelled() {
+                tracing::debug!(
+                    worker_id,
+                    dp_rank,
+                    "Velo peer endpoint removed, aborting peer-info resolution"
+                );
+                return;
+            }
+            match self
+                .try_resolve_velo_peer(worker_id, dp_rank, target.clone(), &token)
+                .await
+            {
+                Ok(()) => return,
+                Err(e) if attempt < RECOVERY_MAX_RETRIES - 1 => {
+                    let backoff_ms = RECOVERY_INITIAL_BACKOFF_MS * 2_u64.pow(attempt);
+                    tracing::warn!(
+                        worker_id,
+                        dp_rank,
+                        attempt,
+                        "Velo peer-info query failed, retrying after {backoff_ms}ms: {e}"
+                    );
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => {}
+                        _ = token.cancelled() => {
+                            tracing::debug!(
+                                worker_id,
+                                dp_rank,
+                                "Velo peer removed during backoff, aborting resolution"
+                            );
+                            return;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        worker_id,
+                        dp_rank,
+                        "Velo peer-info resolution failed after {RECOVERY_MAX_RETRIES} \
+                         attempts: {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Single attempt: query the Velo peer-info endpoint, register the peer, seed recovery.
+    ///
+    /// Returns `Ok(())` when the endpoint was fully registered and
+    /// [`handle_discovered_query_endpoint`] was called, `Err` on any transient
+    /// failure.  Checks `token` immediately before inserting into
+    /// `query_endpoints`; if the peer was removed during the attempt the peer
+    /// registration is rolled back and `Ok(())` is returned to stop the loop.
+    #[cfg(feature = "velo-recovery")]
+    async fn try_resolve_velo_peer(
+        self: &Arc<Self>,
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        target: Instance,
+        token: &tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<()> {
+        use super::worker_query_endpoint::{WorkerVeloPeerRequest, WorkerVeloPeerResponse};
+        use dynamo_runtime::{
+            pipeline::{AddressedRequest, ManyOut, SingleIn},
+            protocols::maybe_error::MaybeError,
+        };
+
+        let velo_state = self
+            .velo_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("velo_state absent"))?;
+
+        let addressed = SingleIn::new(WorkerVeloPeerRequest)
+            .map(|req| AddressedRequest::for_instance(req, target.clone()));
+
+        let mut stream: ManyOut<WorkerVeloPeerResponse> = velo_state
+            .peer_router
+            .generate(addressed)
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "peer_router.generate failed for worker {worker_id} dp_rank {dp_rank}: {e}"
+                )
+            })?;
+
+        let response = stream.next().await.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Velo peer-info endpoint returned empty stream \
+                 for worker {worker_id} dp_rank {dp_rank}"
+            )
+        })?;
+
+        if let Some(err) = response.err() {
+            return Err(anyhow::anyhow!(
+                "Velo peer-info response error for worker {worker_id} dp_rank {dp_rank}: {err}"
+            ));
+        }
+
+        let WorkerVeloPeerResponse::Success {
+            peer_info_bytes,
+            instance_id_bytes,
+        } = response
+        else {
+            anyhow::bail!(
+                "unexpected non-Success Velo peer-info response variant \
+                 for worker {worker_id} dp_rank {dp_rank}"
+            );
+        };
+
+        let peer_info = serde_json::from_slice::<velo::PeerInfo>(&peer_info_bytes)
+            .map_err(|e| anyhow::anyhow!("failed to deserialize velo::PeerInfo: {e}"))?;
+        let instance_id = serde_json::from_slice::<velo::InstanceId>(&instance_id_bytes)
+            .map_err(|e| anyhow::anyhow!("failed to deserialize velo::InstanceId: {e}"))?;
+
+        // Propagate register_peer errors.  NoCompatibleTransports and similar
+        // are real failures that would silently break all subsequent Velo queries
+        // for this peer if ignored.
+        velo_state.messenger.register_peer(peer_info).map_err(|e| {
+            anyhow::anyhow!(
+                "messenger.register_peer failed for worker {worker_id} \
+                     dp_rank {dp_rank}: {e}"
+            )
+        })?;
+        velo_state
+            .transport
+            .register_peer(worker_id, dp_rank, instance_id);
+
+        tracing::info!(
+            worker_id,
+            dp_rank,
+            "Registered Velo peer for worker KV recovery"
+        );
+
+        // If the peer was removed while we were resolving, unregister it and
+        // return without inserting into query_endpoints.  The removal handler
+        // already cancelled the token and removed the velo_pending entry.
+        if token.is_cancelled() {
+            tracing::info!(
+                worker_id,
+                dp_rank,
+                "Velo peer was removed during resolution; unregistering and aborting"
+            );
+            velo_state.transport.unregister_peer(worker_id, dp_rank);
+            return Ok(());
+        }
+
+        // Resolution committed.  Remove from the pending map now so the removal
+        // handler does not try to cancel a token that is no longer in use.
+        velo_state.velo_pending.remove(&(worker_id, dp_rank));
+
+        // Seed the query_endpoints directory and schedule recovery.
+        // The Velo transport ignores the target Instance (uses its internal peers map),
+        // so the velo peer-info endpoint's Instance is a valid lifecycle anchor.
+        let endpoint = DiscoveredQueryEndpoint {
+            worker_id,
+            dp_rank,
+            target,
+        };
+        self.handle_discovered_query_endpoint(endpoint).await;
+        Ok(())
     }
 
     async fn remove_worker_dp_state(&self, worker_id: WorkerId, dp_rank: DpRank) {

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_directory.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_directory.rs
@@ -11,6 +11,10 @@ use super::worker_query_state::RecoveryKey;
 /// Prefix for worker KV indexer query endpoint names.
 const QUERY_ENDPOINT_PREFIX: &str = "worker_kv_indexer_query_dp";
 
+/// Prefix for worker Velo peer-info endpoint names (velo-recovery feature only).
+#[cfg(feature = "velo-recovery")]
+const VELO_PEER_ENDPOINT_PREFIX: &str = "worker_kv_velo_peer_dp";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct DiscoveredQueryEndpoint {
     pub(super) worker_id: WorkerId,
@@ -69,6 +73,52 @@ impl WorkerQueryEndpointDirectory {
         self.targets
             .get(&(worker_id, dp_rank))
             .map(|target| target.value().clone())
+    }
+
+    /// Parse a velo peer-info endpoint name.
+    ///
+    /// Accepts both `worker_kv_velo_peer_dp{N}` (route instance = logical worker)
+    /// and `worker_kv_velo_peer_dp{N}_worker{W}` (multi-worker-per-pod), mirroring
+    /// the `_worker{id}` convention used by the legacy query endpoint.
+    #[cfg(feature = "velo-recovery")]
+    pub(super) fn parse_velo_peer_endpoint_name(
+        endpoint_name: &str,
+        route_instance_id: WorkerId,
+    ) -> Option<(WorkerId, DpRank)> {
+        let suffix = endpoint_name.strip_prefix(VELO_PEER_ENDPOINT_PREFIX)?;
+        let (dp_rank, worker_id) = match suffix.split_once("_worker") {
+            Some((dp_str, worker_str)) => (dp_str.parse().ok()?, worker_str.parse().ok()?),
+            None => (suffix.parse().ok()?, route_instance_id),
+        };
+        Some((worker_id, dp_rank))
+    }
+
+    /// Parse a removal id, accepting either endpoint-name format.
+    ///
+    /// Tries `worker_kv_indexer_query_dp{N}[_worker{W}]` first, then
+    /// `worker_kv_velo_peer_dp{N}[_worker{W}]`.  In practice only one of the two
+    /// is active at a time: velo-recovery mode uses the Velo peer endpoint as the
+    /// lifecycle anchor and skips the legacy query endpoint.
+    pub(super) fn parse_removed_any(
+        id: DiscoveryInstanceId,
+    ) -> Option<(WorkerId, DpRank, EndpointInstanceId)> {
+        let DiscoveryInstanceId::Endpoint(eid) = id else {
+            return None;
+        };
+        // Standard query endpoint.
+        if let Some((worker_id, dp_rank)) =
+            Self::parse_endpoint_name(&eid.endpoint, eid.instance_id)
+        {
+            return Some((worker_id, dp_rank, eid));
+        }
+        // Velo peer endpoint.
+        #[cfg(feature = "velo-recovery")]
+        if let Some((worker_id, dp_rank)) =
+            Self::parse_velo_peer_endpoint_name(&eid.endpoint, eid.instance_id)
+        {
+            return Some((worker_id, dp_rank, eid));
+        }
+        None
     }
 
     #[cfg(test)]

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
@@ -14,6 +14,7 @@ use dynamo_runtime::{
         AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn,
         network::Ingress,
     },
+    protocols::maybe_error::MaybeError,
     stream,
     traits::DistributedRuntimeProvider,
 };
@@ -23,7 +24,13 @@ use crate::kv_router::{
     worker_kv_indexer_query_endpoint, worker_kv_indexer_query_endpoint_for_worker,
 };
 
-/// Worker-side endpoint registration for Router -> LocalKvIndexer query service
+/// Velo endpoint name for worker KV gap-recovery queries.
+///
+/// Workers register a unary handler under this name; the router's
+/// [`super::worker_query_transport::VeloWorkerQueryTransport`] sends to it.
+pub(super) const VELO_WORKER_QUERY_HANDLER: &str = "kv_router.worker.recovery_query";
+
+/// Worker-side endpoint registration for the Router -> LocalKvIndexer query service.
 pub(crate) async fn start_worker_kv_query_endpoint(
     component: Component,
     worker_id: u64,
@@ -41,7 +48,8 @@ pub(crate) async fn start_worker_kv_query_endpoint(
         Ok(ingress) => ingress,
         Err(e) => {
             tracing::error!(
-                "Failed to build WorkerKvQuery endpoint handler for worker {worker_id} dp_rank {dp_rank}: {e}"
+                "Failed to build WorkerKvQuery endpoint handler \
+                 for worker {worker_id} dp_rank {dp_rank}: {e}"
             );
             return;
         }
@@ -72,13 +80,346 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     }
 }
 
+// Velo handler registration
+
+/// Per-messenger dispatch table for Velo worker KV gap-recovery queries.
+///
+/// A single Velo handler (named [`VELO_WORKER_QUERY_HANDLER`]) is registered per
+/// `Messenger`.  Internally it dispatches to the appropriate
+/// [`WorkerKvQueryEngine`] based on the `(worker_id, dp_rank)` in the request,
+/// so workers with multiple dp-ranks share one handler without naming conflicts.
+///
+/// ## Usage
+///
+/// ```rust,ignore
+/// let dispatch = VeloQueryDispatch::new();
+/// dispatch.add_engine(worker_id, 0, local_indexer_rank_0);
+/// dispatch.add_engine(worker_id, 1, local_indexer_rank_1);
+/// dispatch.register_on(&messenger)?;
+/// ```
+///
+/// For single-rank workers the [`register_velo_query_handler`] convenience
+/// wrapper does all of the above in one call.
+#[cfg(feature = "velo-recovery")]
+type EngineMap = dashmap::DashMap<super::worker_query_state::RecoveryKey, Arc<WorkerKvQueryEngine>>;
+
+#[cfg(feature = "velo-recovery")]
+pub(crate) struct VeloQueryDispatch {
+    engines: Arc<EngineMap>,
+}
+
+#[cfg(feature = "velo-recovery")]
+impl VeloQueryDispatch {
+    pub(crate) fn new() -> Self {
+        Self {
+            engines: Arc::new(dashmap::DashMap::new()),
+        }
+    }
+
+    /// Add a `(worker_id, dp_rank)` engine to the dispatch table.
+    ///
+    /// Overwrites any previously registered engine for the same key.
+    pub(crate) fn add_engine(
+        &self,
+        worker_id: u64,
+        dp_rank: DpRank,
+        local_indexer: Arc<LocalKvIndexer>,
+    ) {
+        let engine = Arc::new(WorkerKvQueryEngine {
+            worker_id,
+            dp_rank,
+            local_indexer,
+            processing_semaphore: Semaphore::new(1),
+        });
+        self.engines.insert((worker_id, dp_rank), engine);
+    }
+
+    /// Register the Velo unary handler on `messenger`.
+    ///
+    /// Must be called exactly once per messenger after all engines have been
+    /// added via [`add_engine`].  Returns an error if the handler name is
+    /// already registered on this messenger.
+    pub(crate) fn register_on(self, messenger: &Arc<velo::Messenger>) -> anyhow::Result<()> {
+        use bytes::Bytes;
+        use velo::Handler;
+
+        let engines = self.engines.clone();
+
+        let handler = Handler::unary_handler_async(VELO_WORKER_QUERY_HANDLER, move |ctx| {
+            let engines = engines.clone();
+            async move {
+                let request: WorkerKvQueryRequest =
+                    serde_json::from_slice(&ctx.payload).map_err(|e| {
+                        anyhow::anyhow!(
+                            "failed to deserialize WorkerKvQueryRequest \
+                                 from {}: {e}",
+                            VELO_WORKER_QUERY_HANDLER
+                        )
+                    })?;
+
+                tracing::debug!(
+                    worker_id = request.worker_id,
+                    dp_rank = request.dp_rank,
+                    start_event_id = ?request.start_event_id,
+                    "Velo worker KV recovery query received"
+                );
+
+                let engine = match engines.get(&(request.worker_id, request.dp_rank)) {
+                    Some(e) => e.clone(),
+                    None => {
+                        let msg = format!(
+                            "no engine registered for worker_id={} dp_rank={}",
+                            request.worker_id, request.dp_rank
+                        );
+                        tracing::warn!("{msg}");
+                        let resp = WorkerKvQueryResponse::Error(msg);
+                        return Ok(Some(Bytes::from(serde_json::to_vec(&resp)?)));
+                    }
+                };
+
+                let response = engine.handle(request).await;
+                Ok(Some(Bytes::from(serde_json::to_vec(&response)?)))
+            }
+        })
+        .build();
+
+        messenger.register_handler(handler)?;
+        tracing::info!(
+            handler = VELO_WORKER_QUERY_HANDLER,
+            n_engines = self.engines.len(),
+            "Registered Velo worker KV recovery query handler"
+        );
+        Ok(())
+    }
+}
+
+/// Convenience wrapper for single-rank workers.
+///
+/// Builds a [`VeloQueryDispatch`] with one engine and registers it on
+/// `messenger`.  Multi-rank workers must use [`VeloQueryDispatch`] directly to
+/// avoid registering the handler twice on the same messenger.
+///
+/// Call this after the Velo `Messenger` is built and before publishing the
+/// worker's peer info for routers to discover.
+#[cfg(feature = "velo-recovery")]
+pub(crate) fn register_velo_query_handler(
+    messenger: &Arc<velo::Messenger>,
+    worker_id: u64,
+    dp_rank: DpRank,
+    local_indexer: Arc<LocalKvIndexer>,
+) -> anyhow::Result<()> {
+    let dispatch = VeloQueryDispatch::new();
+    dispatch.add_engine(worker_id, dp_rank, local_indexer);
+    dispatch.register_on(messenger)
+}
+
+// Velo peer-info endpoint
+
+/// Wire request for the worker Velo peer-info endpoint (empty — no parameters needed).
+#[cfg(feature = "velo-recovery")]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(super) struct WorkerVeloPeerRequest;
+
+/// Wire response for the worker Velo peer-info endpoint.
+#[cfg(feature = "velo-recovery")]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(super) enum WorkerVeloPeerResponse {
+    /// Serialized peer connection info for the worker's Velo messenger.
+    Success {
+        /// `serde_json`-encoded `velo::PeerInfo`.
+        peer_info_bytes: Vec<u8>,
+        /// `serde_json`-encoded `velo::InstanceId` for
+        /// [`VeloWorkerQueryTransport::register_peer`].
+        instance_id_bytes: Vec<u8>,
+    },
+    Error(String),
+}
+
+#[cfg(feature = "velo-recovery")]
+impl MaybeError for WorkerVeloPeerResponse {
+    fn from_err(err: impl std::error::Error + 'static) -> Self {
+        WorkerVeloPeerResponse::Error(err.to_string())
+    }
+
+    fn err(&self) -> Option<dynamo_runtime::error::DynamoError> {
+        match self {
+            Self::Error(msg) => Some(dynamo_runtime::error::DynamoError::msg(msg.clone())),
+            _ => None,
+        }
+    }
+}
+
+/// Worker-side engine that serves the local Velo messenger's `PeerInfo` on demand.
+#[cfg(feature = "velo-recovery")]
+struct WorkerVeloPeerEngine {
+    messenger: Arc<velo::Messenger>,
+}
+
+#[cfg(feature = "velo-recovery")]
+#[async_trait]
+impl AsyncEngine<SingleIn<WorkerVeloPeerRequest>, ManyOut<WorkerVeloPeerResponse>, anyhow::Error>
+    for WorkerVeloPeerEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<WorkerVeloPeerRequest>,
+    ) -> anyhow::Result<ManyOut<WorkerVeloPeerResponse>> {
+        let (_req, ctx) = request.into_parts();
+
+        let peer_info_bytes = serde_json::to_vec(&self.messenger.peer_info())
+            .map_err(|e| anyhow::anyhow!("failed to serialize velo::PeerInfo: {e}"))?;
+        let instance_id_bytes = serde_json::to_vec(&self.messenger.instance_id())
+            .map_err(|e| anyhow::anyhow!("failed to serialize velo::InstanceId: {e}"))?;
+
+        let response = WorkerVeloPeerResponse::Success {
+            peer_info_bytes,
+            instance_id_bytes,
+        };
+        Ok(ResponseStream::new(
+            Box::pin(stream::iter(vec![response])),
+            ctx.context(),
+        ))
+    }
+}
+
+/// Worker-side endpoint that publishes the local Velo `PeerInfo` for routers to discover.
+///
+/// Registers a Dynamo endpoint named `worker_kv_velo_peer_dp{dp_rank}` (or
+/// `worker_kv_velo_peer_dp{dp_rank}_worker{worker_id}` when the route instance id
+/// differs from the logical worker id, matching the convention used by
+/// [`start_worker_kv_query_endpoint`]).  When the router's Velo-aware discovery
+/// loop sees this endpoint it issues a bounded-retry query to obtain the `PeerInfo`
+/// and register the worker as a Velo peer.
+///
+/// Under `velo-recovery` this endpoint is the sole recovery lifecycle anchor for
+/// `(worker_id, dp_rank)`.  The legacy [`start_worker_kv_query_endpoint`] is not
+/// started when the feature is active.
+#[cfg(feature = "velo-recovery")]
+pub(crate) async fn start_worker_kv_velo_peer_endpoint(
+    component: Component,
+    worker_id: u64,
+    dp_rank: DpRank,
+    messenger: Arc<velo::Messenger>,
+) {
+    use crate::kv_router::{worker_kv_velo_peer_endpoint, worker_kv_velo_peer_endpoint_for_worker};
+    use dynamo_runtime::traits::DistributedRuntimeProvider;
+
+    let route_worker_id = component.drt().connection_id();
+    let endpoint_name = if route_worker_id == worker_id {
+        worker_kv_velo_peer_endpoint(dp_rank)
+    } else {
+        worker_kv_velo_peer_endpoint_for_worker(worker_id, dp_rank)
+    };
+
+    let engine = Arc::new(WorkerVeloPeerEngine { messenger });
+    let ingress = match Ingress::for_engine(engine) {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::error!(
+                worker_id,
+                dp_rank,
+                "Failed to build WorkerVeloPeer endpoint handler: {e}"
+            );
+            return;
+        }
+    };
+
+    tracing::info!(
+        worker_id,
+        dp_rank,
+        endpoint = %endpoint_name,
+        "WorkerVeloPeer endpoint starting"
+    );
+
+    if let Err(e) = component
+        .endpoint(&endpoint_name)
+        .endpoint_builder()
+        .handler(ingress)
+        .graceful_shutdown(true)
+        .start()
+        .await
+    {
+        tracing::error!(worker_id, dp_rank, "WorkerVeloPeer endpoint failed: {e}");
+    }
+}
+
 pub(super) struct WorkerKvQueryEngine {
     pub(super) worker_id: u64,
     pub(super) dp_rank: DpRank,
     pub(super) local_indexer: Arc<LocalKvIndexer>,
-    /// Semaphore limiting concurrent recovery request processing to 1.
-    /// Prevents multiple routers from overwhelming the worker with heavy tree dump operations.
+    /// Limits concurrent tree-dump operations to 1 per worker.
+    /// Prevents multiple routers from issuing heavy dump operations simultaneously.
     pub(super) processing_semaphore: Semaphore,
+}
+
+impl WorkerKvQueryEngine {
+    /// Validate that the request targets this engine's worker and rank.
+    ///
+    /// Returns `Some(error_response)` on mismatch, `None` if valid.
+    fn validate_ids(&self, req: &WorkerKvQueryRequest) -> Option<WorkerKvQueryResponse> {
+        if req.worker_id != self.worker_id {
+            return Some(WorkerKvQueryResponse::Error(format!(
+                "WorkerKvQueryEngine worker_id mismatch: \
+                 request={} this={}",
+                req.worker_id, self.worker_id
+            )));
+        }
+        if req.dp_rank != self.dp_rank {
+            return Some(WorkerKvQueryResponse::Error(format!(
+                "WorkerKvQueryEngine dp_rank mismatch: \
+                 request={} this={}",
+                req.dp_rank, self.dp_rank
+            )));
+        }
+        None
+    }
+
+    /// Execute the indexer call after validation and semaphore acquisition.
+    ///
+    /// Callers are responsible for holding the semaphore permit for tree-dump
+    /// requests before calling this method.
+    async fn do_query(&self, req: WorkerKvQueryRequest) -> WorkerKvQueryResponse {
+        self.local_indexer
+            .get_events_in_id_range(req.start_event_id, req.end_event_id)
+            .await
+    }
+
+    /// Handle a recovery query: validate, acquire semaphore, execute.
+    ///
+    /// Used by the Velo unary handler.  Does not implement client-side
+    /// cancellation; callers that need it (the Dynamo runtime endpoint) use
+    /// `validate_ids` + a `select!`-guarded semaphore acquire + `do_query`
+    /// directly instead.
+    pub(super) async fn handle(&self, req: WorkerKvQueryRequest) -> WorkerKvQueryResponse {
+        if let Some(err) = self.validate_ids(&req) {
+            return err;
+        }
+
+        let likely_buffer_read = self
+            .local_indexer
+            .likely_served_from_buffer(req.start_event_id);
+
+        let _permit = if !likely_buffer_read {
+            match self.processing_semaphore.acquire().await {
+                Ok(permit) => Some(permit),
+                Err(_) => {
+                    return WorkerKvQueryResponse::Error(
+                        "Worker KV query semaphore closed".to_string(),
+                    );
+                }
+            }
+        } else {
+            None
+        };
+
+        let _slow_query_guard = if !likely_buffer_read {
+            Some(SlowQueryGuard::spawn(self.worker_id))
+        } else {
+            None
+        };
+
+        self.do_query(req).await
+    }
 }
 
 #[async_trait]
@@ -92,54 +433,37 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
         let (request, ctx) = request.into_parts();
 
         tracing::debug!(
-            "Received query request for worker {}: {:?}",
-            self.worker_id,
-            request
+            worker_id = self.worker_id,
+            start_event_id = ?request.start_event_id,
+            "Received Dynamo runtime worker KV query request"
         );
 
-        if request.worker_id != self.worker_id {
-            let error_message = format!(
-                "WorkerKvQueryEngine::generate worker_id mismatch: request.worker_id={} this.worker_id={}",
-                request.worker_id, self.worker_id
-            );
-            let response = WorkerKvQueryResponse::Error(error_message);
+        if let Some(err) = self.validate_ids(&request) {
             return Ok(ResponseStream::new(
-                Box::pin(stream::iter(vec![response])),
+                Box::pin(stream::iter(vec![err])),
                 ctx.context(),
             ));
         }
 
-        if request.dp_rank != self.dp_rank {
-            let error_message = format!(
-                "WorkerKvQueryEngine::generate dp_rank mismatch: request.dp_rank={} this.dp_rank={}",
-                request.dp_rank, self.dp_rank
-            );
-            let response = WorkerKvQueryResponse::Error(error_message);
-            return Ok(ResponseStream::new(
-                Box::pin(stream::iter(vec![response])),
-                ctx.context(),
-            ));
-        }
-
-        // Check if this request can likely be served from buffer (fast path).
-        // If not, acquire semaphore for tree dump (heavy operation).
         let likely_buffer_read = self
             .local_indexer
             .likely_served_from_buffer(request.start_event_id);
 
+        // Acquire the semaphore for tree-dump requests, with client-cancellation
+        // support: if the Dynamo runtime cancels the request while we are queued,
+        // return an error response rather than blocking indefinitely.
         let _maybe_permit = if !likely_buffer_read {
-            // Acquire semaphore permit before processing tree dump.
-            // This prevents multiple heavy tree dump operations from running concurrently
             let engine_ctx = ctx.context();
             let permit = tokio::select! {
                 result = self.processing_semaphore.acquire() => {
                     result.map_err(|_| anyhow::anyhow!("Worker KV query semaphore closed"))?
                 }
                 _ = futures::future::select(engine_ctx.stopped(), engine_ctx.killed()) => {
-                    tracing::warn!("Worker<>Router KV query request cancelled while waiting for semaphore");
+                    tracing::warn!(
+                        worker_id = self.worker_id,
+                        "Worker KV query request cancelled while waiting for semaphore"
+                    );
                     return Ok(ResponseStream::new(
-                        // this response will be dropped on the router side since the request was cancelled,
-                        // but we return it here to satisfy the function signature and provide some context in logs if it does get processed for some reason.
                         Box::pin(stream::iter(vec![WorkerKvQueryResponse::Error(
                             "Request cancelled by client".to_string(),
                         )])),
@@ -149,23 +473,18 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
             };
             Some(permit)
         } else {
-            // Fast buffer read - no semaphore needed
             None
         };
 
-        // Start slow-query logging only once the request is actively executing the slow path.
-        // Queued requests waiting on the semaphore should remain silent.
+        // Start slow-query logging only once the request is actively running.
+        // Requests queued behind the semaphore should remain silent.
         let _slow_query_guard = if !likely_buffer_read {
             Some(SlowQueryGuard::spawn(self.worker_id))
         } else {
             None
         };
 
-        let response = self
-            .local_indexer
-            .get_events_in_id_range(request.start_event_id, request.end_event_id)
-            .await;
-
+        let response = self.do_query(request).await;
         Ok(ResponseStream::new(
             Box::pin(stream::iter(vec![response])),
             ctx.context(),
@@ -173,7 +492,7 @@ impl AsyncEngine<SingleIn<WorkerKvQueryRequest>, ManyOut<WorkerKvQueryResponse>,
     }
 }
 
-/// RAII guard that aborts a slow query logger task on drop.
+/// RAII guard that aborts a slow-query logger task on drop.
 struct SlowQueryGuard(tokio::task::JoinHandle<()>);
 
 impl SlowQueryGuard {

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_transport.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_transport.rs
@@ -99,3 +99,325 @@ impl WorkerQueryTransport for RuntimeWorkerQueryTransport {
         self.addressed.clear_instance_tombstone(endpoint_id).await;
     }
 }
+
+// Velo transport
+
+/// Velo unary transport for worker KV gap-recovery queries.
+///
+/// Each `(worker_id, dp_rank)` pair must be registered via [`register_peer`]
+/// before queries can be sent.  Registration is driven by the caller after it
+/// resolves a worker's Velo `InstanceId` through peer discovery.
+///
+/// The `target: Instance` parameter of [`WorkerQueryTransport::query_worker`]
+/// is ignored — Velo uses the `InstanceId` from the internal peers map.
+/// The existing [`RuntimeWorkerQueryTransport`] remains the default; this
+/// transport is only active when the `velo-recovery` feature is compiled in.
+#[cfg(feature = "velo-recovery")]
+pub(super) struct VeloWorkerQueryTransport {
+    messenger: Arc<velo::Messenger>,
+    peers: dashmap::DashMap<super::worker_query_state::RecoveryKey, velo::InstanceId>,
+}
+
+#[cfg(feature = "velo-recovery")]
+impl VeloWorkerQueryTransport {
+    pub(super) fn new(messenger: Arc<velo::Messenger>) -> Self {
+        Self {
+            messenger,
+            peers: dashmap::DashMap::new(),
+        }
+    }
+
+    /// Register a worker's Velo `InstanceId` so it can receive recovery queries.
+    ///
+    /// Must be called before the first `query_worker` call for this
+    /// `(worker_id, dp_rank)` pair.  Overwrites any previously registered peer.
+    pub(super) fn register_peer(
+        &self,
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        instance_id: velo::InstanceId,
+    ) {
+        self.peers.insert((worker_id, dp_rank), instance_id);
+        tracing::info!(
+            worker_id,
+            dp_rank,
+            ?instance_id,
+            "Registered Velo peer for worker KV recovery queries"
+        );
+    }
+
+    /// Unregister a worker's Velo peer (called on worker removal from discovery).
+    pub(super) fn unregister_peer(&self, worker_id: WorkerId, dp_rank: DpRank) {
+        if self.peers.remove(&(worker_id, dp_rank)).is_some() {
+            tracing::debug!(
+                worker_id,
+                dp_rank,
+                "Unregistered Velo peer for worker KV recovery queries"
+            );
+        }
+    }
+}
+
+#[cfg(feature = "velo-recovery")]
+#[async_trait]
+impl WorkerQueryTransport for VeloWorkerQueryTransport {
+    async fn query_worker(
+        &self,
+        worker_id: WorkerId,
+        dp_rank: DpRank,
+        _target: Instance,
+        start_event_id: Option<u64>,
+        end_event_id: Option<u64>,
+    ) -> Result<WorkerKvQueryResponse> {
+        use super::worker_query_endpoint::VELO_WORKER_QUERY_HANDLER;
+        use bytes::Bytes;
+
+        let instance_id = self
+            .peers
+            .get(&(worker_id, dp_rank))
+            .map(|r| *r)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no Velo peer registered for worker {worker_id} dp_rank {dp_rank}; \
+                     call register_peer after resolving the worker's InstanceId"
+                )
+            })?;
+
+        let request = WorkerKvQueryRequest {
+            worker_id,
+            dp_rank,
+            start_event_id,
+            end_event_id,
+        };
+        let payload = Bytes::from(
+            serde_json::to_vec(&request).context("failed to serialize WorkerKvQueryRequest")?,
+        );
+
+        let response_bytes = self
+            .messenger
+            .unary(VELO_WORKER_QUERY_HANDLER)?
+            .raw_payload(payload)
+            .instance(instance_id)
+            .send()
+            .await
+            .with_context(|| {
+                format!(
+                    "Velo worker KV recovery query failed \
+                     for worker {worker_id} dp_rank {dp_rank}"
+                )
+            })?;
+
+        let response = serde_json::from_slice::<WorkerKvQueryResponse>(&response_bytes)
+            .context("failed to deserialize WorkerKvQueryResponse from Velo")?;
+
+        if let Some(err) = response.err() {
+            return Err(err).context("Velo worker KV query response error");
+        }
+
+        Ok(response)
+    }
+}
+
+// Tests
+
+#[cfg(all(test, feature = "velo-recovery"))]
+mod tests {
+    use std::net::TcpListener;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use dynamo_kv_router::indexer::{KvIndexerMetrics, LocalKvIndexer};
+    use tokio_util::sync::CancellationToken;
+    use velo::backend::tcp::TcpTransportBuilder;
+
+    use super::super::worker_query_endpoint::register_velo_query_handler;
+    use super::*;
+
+    // Helpers
+
+    async fn make_messenger() -> Arc<velo::Messenger> {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let transport: Arc<dyn velo::backend::Transport> = Arc::new(
+            TcpTransportBuilder::new()
+                .from_listener(listener)
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+        velo::Messenger::builder()
+            .add_transport(transport)
+            .build()
+            .await
+            .unwrap()
+    }
+
+    fn make_local_indexer() -> Arc<LocalKvIndexer> {
+        Arc::new(LocalKvIndexer::new(
+            CancellationToken::new(),
+            16,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            128,
+        ))
+    }
+
+    /// Create a bidirectional messenger pair with peer registration.
+    async fn make_pair() -> (Arc<velo::Messenger>, Arc<velo::Messenger>) {
+        let a = make_messenger().await;
+        let b = make_messenger().await;
+        a.register_peer(b.peer_info()).unwrap();
+        b.register_peer(a.peer_info()).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        (a, b)
+    }
+
+    /// Dummy Dynamo Instance — not used by VeloWorkerQueryTransport but
+    /// required by the WorkerQueryTransport trait signature.
+    fn dummy_instance() -> Instance {
+        Instance {
+            namespace: "test".to_string(),
+            component: "test".to_string(),
+            endpoint: "test".to_string(),
+            instance_id: 0,
+            transport: dynamo_runtime::component::TransportType::Nats(String::new()),
+            device_type: None,
+        }
+    }
+
+    // Tests
+
+    /// Basic end-to-end: router messenger sends a query, worker messenger
+    /// handles it via the Velo unary handler, router receives the response.
+    #[tokio::test]
+    async fn velo_transport_end_to_end_empty_response() {
+        let (router_messenger, worker_messenger) = make_pair().await;
+        let local_indexer = make_local_indexer();
+
+        register_velo_query_handler(&worker_messenger, 1, 0, local_indexer).unwrap();
+
+        let transport = VeloWorkerQueryTransport::new(router_messenger.clone());
+        transport.register_peer(1, 0, worker_messenger.instance_id());
+
+        let response = transport
+            .query_worker(1, 0, dummy_instance(), None, None)
+            .await
+            .unwrap();
+
+        // Empty indexer returns an empty tree dump or buffer response — not an Error.
+        assert!(
+            !matches!(response, WorkerKvQueryResponse::Error(_)),
+            "expected a non-error response from empty indexer, got {response:?}"
+        );
+    }
+
+    /// Validation: querying a (worker_id, dp_rank) with no registered engine returns
+    /// `Err` — not `Ok(WorkerKvQueryResponse::Error(...))`.
+    ///
+    /// The transport now maps application-level `Error` responses to `Err` so
+    /// that the retry loop in `fetch_recovery_response` can act on them.
+    ///
+    /// The handler dispatch table holds an engine for (1, 0).  The transport has a
+    /// peer entry for (99, 0) pointing at the same worker messenger, so the
+    /// transport layer succeeds.  The handler returns `WorkerKvQueryResponse::Error`
+    /// for the unregistered key, and the transport converts that to `Err`.
+    #[tokio::test]
+    async fn velo_transport_unregistered_worker_id_returns_err() {
+        let (router_messenger, worker_messenger) = make_pair().await;
+        let local_indexer = make_local_indexer();
+
+        // Handler dispatch table has an engine only for (worker_id=1, dp_rank=0).
+        register_velo_query_handler(&worker_messenger, 1, 0, local_indexer).unwrap();
+
+        let transport = VeloWorkerQueryTransport::new(router_messenger.clone());
+        // Route (99, 0) to the same worker messenger so the request reaches the handler.
+        transport.register_peer(99, 0, worker_messenger.instance_id());
+
+        let result = transport
+            .query_worker(99, 0, dummy_instance(), None, None)
+            .await;
+
+        assert!(result.is_err(), "expected Err for unregistered worker_id");
+        let chain = format!("{:#}", result.unwrap_err());
+        assert!(
+            chain.contains("no engine registered"),
+            "expected 'no engine registered' in error chain, got: {chain}"
+        );
+    }
+
+    /// Validation: querying a (worker_id, dp_rank) with no registered engine returns
+    /// `Err` for an unregistered dp_rank.
+    ///
+    /// Same rationale as `velo_transport_unregistered_worker_id_returns_err`.
+    #[tokio::test]
+    async fn velo_transport_unregistered_dp_rank_returns_err() {
+        let (router_messenger, worker_messenger) = make_pair().await;
+        let local_indexer = make_local_indexer();
+
+        // Handler dispatch table has an engine only for (worker_id=1, dp_rank=0).
+        register_velo_query_handler(&worker_messenger, 1, 0, local_indexer).unwrap();
+
+        let transport = VeloWorkerQueryTransport::new(router_messenger.clone());
+        // Route (1, 3) to the same worker messenger so the request reaches the handler.
+        transport.register_peer(1, 3, worker_messenger.instance_id());
+
+        let result = transport
+            .query_worker(1, 3, dummy_instance(), None, None)
+            .await;
+
+        assert!(result.is_err(), "expected Err for unregistered dp_rank");
+        let chain = format!("{:#}", result.unwrap_err());
+        assert!(
+            chain.contains("no engine registered"),
+            "expected 'no engine registered' in error chain, got: {chain}"
+        );
+    }
+
+    /// query_worker returns an Err (not a WorkerKvQueryResponse::Error) when
+    /// no Velo peer has been registered for the given (worker_id, dp_rank).
+    #[tokio::test]
+    async fn velo_transport_no_peer_returns_transport_error() {
+        let router_messenger = make_messenger().await;
+        let transport = VeloWorkerQueryTransport::new(router_messenger);
+
+        let result = transport
+            .query_worker(42, 0, dummy_instance(), None, None)
+            .await;
+
+        assert!(result.is_err(), "expected Err when no peer is registered");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("no Velo peer registered"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    /// `register_peer` overwrites a stale entry; subsequent queries use the new `InstanceId`.
+    ///
+    /// First registration uses the router's own `InstanceId` (which has no handler), so a
+    /// query would fail if the stale entry were used.  After overwriting with the worker's
+    /// real `InstanceId`, the query must succeed.
+    #[tokio::test]
+    async fn velo_transport_register_peer_overwrites_stale_entry() {
+        let (router_messenger, worker_messenger) = make_pair().await;
+        let local_indexer = make_local_indexer();
+
+        register_velo_query_handler(&worker_messenger, 1, 0, local_indexer).unwrap();
+
+        let transport = VeloWorkerQueryTransport::new(router_messenger.clone());
+
+        // Stale registration: router's own InstanceId, which has no query handler.
+        transport.register_peer(1, 0, router_messenger.instance_id());
+
+        // Overwrite with the real worker InstanceId.
+        transport.register_peer(1, 0, worker_messenger.instance_id());
+
+        let response = transport
+            .query_worker(1, 0, dummy_instance(), None, None)
+            .await
+            .unwrap();
+
+        assert!(
+            !matches!(response, WorkerKvQueryResponse::Error(_)),
+            "query should succeed after re-registration, got {response:?}"
+        );
+    }
+}

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_transport.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_transport.rs
@@ -218,6 +218,34 @@ impl WorkerQueryTransport for VeloWorkerQueryTransport {
     }
 }
 
+/// Build a same-host `velo::Messenger` backed by a Unix domain socket.
+///
+/// This MR targets same-host deployments only.  UDS is the sole registered
+/// transport; there is no TCP fallback.  Cross-host support (TCP) is deferred
+/// to a follow-up once the same-host path is benchmarked and validated.
+///
+/// The caller is responsible for creating (by calling this function) and later
+/// cleaning up the UDS socket file.
+#[cfg(feature = "velo-recovery")]
+pub(crate) async fn build_velo_messenger(
+    uds_path: &std::path::Path,
+) -> anyhow::Result<Arc<velo::Messenger>> {
+    use velo::backend::uds::UdsTransportBuilder;
+
+    let uds_transport = Arc::new(
+        UdsTransportBuilder::new()
+            .socket_path(uds_path)
+            .build()
+            .map_err(|e| anyhow::anyhow!("Velo UDS transport build: {e}"))?,
+    ) as Arc<dyn velo::backend::Transport>;
+
+    velo::Messenger::builder()
+        .add_transport(uds_transport)
+        .build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))
+}
+
 // Tests
 
 #[cfg(all(test, feature = "velo-recovery"))]

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -21,9 +21,11 @@ use dynamo_runtime::{
 };
 
 use crate::kv_router::{
-    KV_EVENT_SUBJECT, WORKER_KV_INDEXER_BUFFER_SIZE, indexer::start_worker_kv_query_endpoint,
-    metrics::KvPublisherMetrics,
+    KV_EVENT_SUBJECT, WORKER_KV_INDEXER_BUFFER_SIZE, metrics::KvPublisherMetrics,
 };
+// Legacy NATS query endpoint is only started when velo-recovery is not compiled in.
+#[cfg(not(feature = "velo-recovery"))]
+use crate::kv_router::indexer::start_worker_kv_query_endpoint;
 
 mod batching;
 mod dedup;
@@ -421,13 +423,12 @@ async fn start_worker_velo_kv_transport(
             .build()
             .map_err(|e| anyhow::anyhow!("Velo TCP build: {e}"))?,
     ) as Arc<dyn velo::backend::Transport>;
-    let messenger = Arc::new(
-        velo::Messenger::builder()
-            .add_transport(transport)
-            .build()
-            .await
-            .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?,
-    );
+    // Messenger::builder().build() returns Arc<Messenger> directly.
+    let messenger = velo::Messenger::builder()
+        .add_transport(transport)
+        .build()
+        .await
+        .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?;
 
     register_velo_query_handler(&messenger, worker_id, dp_rank, local_indexer)
         .map_err(|e| anyhow::anyhow!("register_velo_query_handler: {e}"))?;

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -393,13 +393,14 @@ impl Drop for KvEventPublisher {
 
 // Velo direct-transport helpers
 
-/// Create a Velo Messenger, register the worker KV query handler, and start the
-/// peer-info endpoint so routers using Velo direct transport can discover and
-/// query this worker.
+/// Create a Velo/UDS Messenger, register the worker KV query handler,
+/// and start the peer-info endpoint so routers can discover and query this worker.
 ///
-/// This is gated behind `velo-recovery` and called once per `(worker_id, dp_rank)`
-/// that has a local KV indexer.  It runs until the peer-info Dynamo endpoint shuts
-/// down (i.e., for the lifetime of the worker process).
+/// Targets same-host deployments only (UDS transport).  Cross-host TCP support
+/// is deferred as future work.
+///
+/// Gated behind `velo-recovery` and called once per `(worker_id, dp_rank)` that
+/// has a local KV indexer.  Runs for the lifetime of the worker process.
 #[cfg(feature = "velo-recovery")]
 async fn start_worker_velo_kv_transport(
     component: Component,
@@ -407,28 +408,23 @@ async fn start_worker_velo_kv_transport(
     dp_rank: DpRank,
     local_indexer: Arc<LocalKvIndexer>,
 ) -> anyhow::Result<()> {
-    use std::net::TcpListener;
-    use velo::backend::tcp::TcpTransportBuilder;
+    use std::path::PathBuf;
 
     use crate::kv_router::indexer::{
-        register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
+        build_velo_messenger, register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
     };
 
-    let listener = TcpListener::bind("0.0.0.0:0")
-        .map_err(|e| anyhow::anyhow!("Velo TCP bind for worker {worker_id}: {e}"))?;
-    let transport = Arc::new(
-        TcpTransportBuilder::new()
-            .from_listener(listener)
-            .map_err(|e| anyhow::anyhow!("Velo TCP from_listener: {e}"))?
-            .build()
-            .map_err(|e| anyhow::anyhow!("Velo TCP build: {e}"))?,
-    ) as Arc<dyn velo::backend::Transport>;
-    // Messenger::builder().build() returns Arc<Messenger> directly.
-    let messenger = velo::Messenger::builder()
-        .add_transport(transport)
-        .build()
-        .await
-        .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?;
+    // Deterministic UDS path keyed by (worker_id, dp_rank) so the router can
+    // find this socket without any out-of-band coordination.  The path is also
+    // included in the PeerInfo that the router fetches via the peer-info endpoint,
+    // so there is no need for the router to know the naming scheme in advance.
+    let worker_uds_path = PathBuf::from(format!(
+        "/tmp/dynamo-velo-worker-recovery-{worker_id}-dp{dp_rank}.sock"
+    ));
+    // Remove any leftover socket from a previous run (worker restart).
+    let _ = std::fs::remove_file(&worker_uds_path);
+
+    let messenger = build_velo_messenger(&worker_uds_path).await?;
 
     register_velo_query_handler(&messenger, worker_id, dp_rank, local_indexer)
         .map_err(|e| anyhow::anyhow!("register_velo_query_handler: {e}"))?;
@@ -436,10 +432,17 @@ async fn start_worker_velo_kv_transport(
     tracing::info!(
         worker_id,
         dp_rank,
-        "Worker Velo KV transport started; publishing peer-info endpoint"
+        uds_path = %worker_uds_path.display(),
+        "Worker Velo/UDS KV transport started (same-host); publishing peer-info endpoint"
     );
 
     // Runs until the component shuts down.
     start_worker_kv_velo_peer_endpoint(component, worker_id, dp_rank, messenger).await;
+
+    // Clean up the UDS socket file when the worker exits so stale paths do not
+    // accumulate across restarts.
+    let _ = std::fs::remove_file(&worker_uds_path);
+    tracing::debug!(worker_id, dp_rank, "Removed Velo worker UDS socket");
+
     Ok(())
 }

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -234,6 +234,11 @@ impl KvEventPublisher {
             None
         };
 
+        // Start the legacy Dynamo/NATS query endpoint.  When `velo-recovery` is
+        // compiled in, the Velo peer endpoint below serves as the sole recovery
+        // lifecycle anchor so we skip this to avoid a second entry in the router's
+        // query_endpoints directory for the same (worker_id, dp_rank).
+        #[cfg(not(feature = "velo-recovery"))]
         let _local_indexer_query_handle = local_indexer.as_ref().map(|local_indexer_ref| {
             let component = component.clone();
             let local_indexer = local_indexer_ref.clone();
@@ -248,6 +253,24 @@ impl KvEventPublisher {
                     dp_rank,
                     local_indexer,
                 ))
+        });
+
+        // When the `velo-recovery` feature is enabled, also start the Velo query
+        // handler and the peer-info endpoint so routers using Velo direct transport
+        // can discover this worker and query it.
+        #[cfg(feature = "velo-recovery")]
+        let _velo_kv_handle = local_indexer.as_ref().map(|local_indexer_ref| {
+            let component_v = component.clone();
+            let local_indexer_v = local_indexer_ref.clone();
+
+            component.drt().runtime().secondary().spawn(async move {
+                if let Err(e) =
+                    start_worker_velo_kv_transport(component_v, worker_id, dp_rank, local_indexer_v)
+                        .await
+                {
+                    tracing::error!(worker_id, dp_rank, "Failed to start Velo KV transport: {e}");
+                }
+            })
         });
 
         let cancellation_token_clone = cancellation_token.clone();
@@ -364,4 +387,58 @@ impl Drop for KvEventPublisher {
     fn drop(&mut self) {
         self.shutdown();
     }
+}
+
+// Velo direct-transport helpers
+
+/// Create a Velo Messenger, register the worker KV query handler, and start the
+/// peer-info endpoint so routers using Velo direct transport can discover and
+/// query this worker.
+///
+/// This is gated behind `velo-recovery` and called once per `(worker_id, dp_rank)`
+/// that has a local KV indexer.  It runs until the peer-info Dynamo endpoint shuts
+/// down (i.e., for the lifetime of the worker process).
+#[cfg(feature = "velo-recovery")]
+async fn start_worker_velo_kv_transport(
+    component: Component,
+    worker_id: u64,
+    dp_rank: DpRank,
+    local_indexer: Arc<LocalKvIndexer>,
+) -> anyhow::Result<()> {
+    use std::net::TcpListener;
+    use velo::backend::tcp::TcpTransportBuilder;
+
+    use crate::kv_router::indexer::{
+        register_velo_query_handler, start_worker_kv_velo_peer_endpoint,
+    };
+
+    let listener = TcpListener::bind("0.0.0.0:0")
+        .map_err(|e| anyhow::anyhow!("Velo TCP bind for worker {worker_id}: {e}"))?;
+    let transport = Arc::new(
+        TcpTransportBuilder::new()
+            .from_listener(listener)
+            .map_err(|e| anyhow::anyhow!("Velo TCP from_listener: {e}"))?
+            .build()
+            .map_err(|e| anyhow::anyhow!("Velo TCP build: {e}"))?,
+    ) as Arc<dyn velo::backend::Transport>;
+    let messenger = Arc::new(
+        velo::Messenger::builder()
+            .add_transport(transport)
+            .build()
+            .await
+            .map_err(|e| anyhow::anyhow!("Velo Messenger build: {e}"))?,
+    );
+
+    register_velo_query_handler(&messenger, worker_id, dp_rank, local_indexer)
+        .map_err(|e| anyhow::anyhow!("register_velo_query_handler: {e}"))?;
+
+    tracing::info!(
+        worker_id,
+        dp_rank,
+        "Worker Velo KV transport started; publishing peer-info endpoint"
+    );
+
+    // Runs until the component shuts down.
+    start_worker_kv_velo_peer_endpoint(component, worker_id, dp_rank, messenger).await;
+    Ok(())
 }


### PR DESCRIPTION
#### Overview:

Following discussion in #10107 , this MR adds a `velo-recovery` feature to `dynamo-llm` that routes worker KV indexer gap-recovery queries over [Velo](https://github.com/NVIDIA/velo) direct P2P transport instead of the NATS push-router.

Status: paused

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx
