### PR TITLE
perf(embedding): submit prompts concurrently via asyncio.gather

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3011,9 +3011,7 @@ class EmbeddingWorkerHandler:
         # ``_encode_one`` raises, we cancel siblings still in flight instead
         # of leaving them running -- otherwise vLLM keeps consuming engine
         # capacity for output that this handler will discard.
-        tasks = [
-            asyncio.create_task(_encode_one(i, p)) for i, p in enumerate(prompts)
-        ]
+        tasks = [asyncio.create_task(_encode_one(i, p)) for i, p in enumerate(prompts)]
         try:
             outputs = await asyncio.gather(*tasks)
         finally:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2980,10 +2980,7 @@ class EmbeddingWorkerHandler:
         # unique enough to scope a vLLM ``request_id``.
         base_request_id = context.id()
 
-        embedding_objects: list[Dict[str, Any]] = []
-        prompt_tokens = 0
-
-        for idx, prompt in enumerate(prompts):
+        async def _encode_one(idx: int, prompt: Any):
             request_id = f"{base_request_id}-{idx}"
             encode_arg: Any = (
                 prompt
@@ -2998,12 +2995,24 @@ class EmbeddingWorkerHandler:
                     request_id=request_id,
                 ):
                     final_output = out
-
             if final_output is None:
                 raise RuntimeError(
                     f"vLLM engine.encode produced no output for input index {idx}"
                 )
+            return final_output
 
+        # Submit every prompt to the engine in the same event-loop tick so
+        # vLLM's continuous-batching scheduler can coalesce them into a
+        # single forward pass instead of N sequential ones. ``asyncio.gather``
+        # returns results in input order, so ``outputs[k]`` matches ``prompts[k]``
+        # regardless of engine completion order.
+        outputs = await asyncio.gather(
+            *(_encode_one(i, p) for i, p in enumerate(prompts))
+        )
+
+        embedding_objects: list[Dict[str, Any]] = []
+        prompt_tokens = 0
+        for idx, final_output in enumerate(outputs):
             embedding = _pooling_output_to_list(final_output.outputs.data)
             if dimensions is not None:
                 if dimensions > len(embedding):

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3006,9 +3006,22 @@ class EmbeddingWorkerHandler:
         # single forward pass instead of N sequential ones. ``asyncio.gather``
         # returns results in input order, so ``outputs[k]`` matches ``prompts[k]``
         # regardless of engine completion order.
-        outputs = await asyncio.gather(
-            *(_encode_one(i, p) for i, p in enumerate(prompts))
-        )
+        #
+        # Use explicit tasks + a ``finally`` cancellation pass so that if one
+        # ``_encode_one`` raises, we cancel siblings still in flight instead
+        # of leaving them running -- otherwise vLLM keeps consuming engine
+        # capacity for output that this handler will discard.
+        tasks = [
+            asyncio.create_task(_encode_one(i, p)) for i, p in enumerate(prompts)
+        ]
+        try:
+            outputs = await asyncio.gather(*tasks)
+        finally:
+            pending = [t for t in tasks if not t.done()]
+            for t in pending:
+                t.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
         embedding_objects: list[Dict[str, Any]] = []
         prompt_tokens = 0

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1088,3 +1088,126 @@ class TestClassifyEmbeddingInput:
     def test_unsupported_element_type_rejected(self):
         with pytest.raises(TypeError, match="Unsupported 'input' element"):
             mod._classify_embedding_input([3.14, 2.71])
+
+
+class TestEmbeddingWorkerHandlerCancellation:
+    """Tests for partial-failure cleanup in ``EmbeddingWorkerHandler.generate``.
+
+    Each prompt's encode runs as its own asyncio task in ``asyncio.gather``.
+    If one task raises, gather re-raises but does NOT cancel the others by
+    default -- they keep consuming vLLM engine capacity for output that the
+    handler would discard. The handler's ``try/finally`` block must cancel
+    every still-pending task and await them with ``return_exceptions=True``
+    before propagating the failure to the frontend.
+    """
+
+    def _make_embedding_handler(self) -> "mod.EmbeddingWorkerHandler":
+        """Construct an ``EmbeddingWorkerHandler`` with the engine monitor
+        stubbed so it does not spawn a real background task during the test.
+        """
+        with patch.object(mod, "VllmEngineMonitor"):
+            handler = mod.EmbeddingWorkerHandler(
+                runtime=MagicMock(),
+                engine=MagicMock(),
+                config=MagicMock(served_model_name="test-model"),
+                shutdown_event=None,
+            )
+        # Replace the engine client wholesale: each test installs its own
+        # ``encode`` async generator behaviour. ``abort`` may be called by
+        # the per-prompt ``_monitor_abort`` task on cancellation paths.
+        handler.engine_client = MagicMock()
+        handler.engine_client.abort = AsyncMock()
+        return handler
+
+    def _make_context(self) -> MagicMock:
+        """Mock dynamo.Context whose ``async_killed_or_stopped()`` never
+        resolves (so the per-prompt ``_monitor_abort`` task parks until
+        cancelled by the wrapping ``_abort_monitor`` context manager).
+        """
+        context = MagicMock()
+        context.id.return_value = "test-req"
+        context.async_killed_or_stopped.return_value = (
+            asyncio.get_event_loop().create_future()
+        )
+        return context
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_partial_failure_cancels_in_flight_encodes(self):
+        """When one prompt's encode raises, the siblings must be cancelled.
+
+        Mocks ``engine_client.encode`` as a per-prompt async generator. For
+        the failing index it raises immediately; for the others it parks on
+        ``asyncio.sleep`` and records cancellation when it occurs. Without
+        the ``finally``-cancel pass the test would hang on the asleep
+        siblings until the 5s pytest timeout fires.
+        """
+        handler = self._make_embedding_handler()
+        context = self._make_context()
+        cancelled: set[int] = set()
+        started: dict[int, asyncio.Event] = {i: asyncio.Event() for i in range(4)}
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            idx = int(request_id.rsplit("-", 1)[-1])
+            started[idx].set()
+            if idx == 1:
+                raise RuntimeError("boom")
+            try:
+                # Would hang past the 5s pytest timeout if not cancelled.
+                await asyncio.sleep(60)
+                yield MagicMock()  # unreachable
+            except asyncio.CancelledError:
+                cancelled.add(idx)
+                raise
+
+        handler.engine_client.encode = fake_encode
+
+        request = {"input": ["a", "b", "c", "d"], "model": "test-model"}
+        with pytest.raises(RuntimeError, match="boom"):
+            async for _ in handler.generate(request, context):
+                pass
+
+        # Sibling encodes (0, 2, 3) must have started (so we know they were
+        # in flight when idx=1 failed) AND been observed as cancelled.
+        assert started[0].is_set()
+        assert started[2].is_set()
+        assert started[3].is_set()
+        assert cancelled == {0, 2, 3}, (
+            f"sibling encodes were not cancelled: cancelled={cancelled}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_happy_path_yields_response_without_cancelling(self):
+        """When every prompt succeeds, the ``finally`` block sees no pending
+        tasks and exits cleanly; the handler yields the OpenAI-shaped
+        response. Guards against the cleanup pass accidentally aborting
+        completed tasks.
+        """
+        handler = self._make_embedding_handler()
+        context = self._make_context()
+        aborted: list[str] = []
+        handler.engine_client.abort = AsyncMock(side_effect=aborted.append)
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            output = MagicMock()
+            output.outputs.data = torch.tensor([0.1, 0.2, 0.3])
+            output.prompt_token_ids = [1, 2, 3]
+            yield output
+
+        handler.engine_client.encode = fake_encode
+
+        request = {"input": ["a", "b"], "model": "test-model"}
+        responses = [r async for r in handler.generate(request, context)]
+
+        assert len(responses) == 1
+        response = responses[0]
+        assert response["object"] == "list"
+        assert response["model"] == "test-model"
+        assert len(response["data"]) == 2
+        assert response["data"][0]["index"] == 0
+        assert response["data"][1]["index"] == 1
+        assert response["data"][0]["embedding"] == pytest.approx([0.1, 0.2, 0.3])
+        # No tasks were in flight at gather completion, so the finally
+        # cancel-and-await pass must not have touched the engine.
+        assert aborted == []

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1172,9 +1172,11 @@ class TestEmbeddingWorkerHandlerCancellation:
         assert started[0].is_set()
         assert started[2].is_set()
         assert started[3].is_set()
-        assert cancelled == {0, 2, 3}, (
-            f"sibling encodes were not cancelled: cancelled={cancelled}"
-        )
+        assert cancelled == {
+            0,
+            2,
+            3,
+        }, f"sibling encodes were not cancelled: cancelled={cancelled}"
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)


### PR DESCRIPTION
#### Overview:

Linear issue: [DIS-2154](https://linear.app/nvidia/issue/DIS-2154/debug-dynamovllm-embedding-worker-is-22x-slower-than-raw-vllm-serve)

vLLM's `AsyncLLM.encode` is per-prompt only. The previous `EmbeddingWorkerHandler.generate` loop awaited each `engine.encode()` to completion before submitting the next prompt, turning a batched OpenAI `/v1/embeddings` request into N sequential forward passes. This change replaces the loop with `asyncio.gather` so all prompts hit the engine in the same event-loop tick and vLLM's continuous-batching scheduler can coalesce them into a single forward pass.

#### Details:

- Extracts the per-prompt body into `_encode_one(idx, prompt)`.
- Calls `await asyncio.gather(*(_encode_one(i, p) for i, p in enumerate(prompts)))` instead of the sequential `for` loop.
- `asyncio.gather` preserves input order, so `data[].index` and the `data` list ordering still match the input — no client-visible behavior change beyond latency.
- Per-prompt abort routing is preserved: each coroutine still wraps `engine.encode` in its own `_abort_monitor(context, request_id)`.
- Per dynamo-ops review: tasks are created with `asyncio.create_task` and a `finally` block cancels any still-pending tasks (awaited with `return_exceptions=True`), so a partial failure releases engine capacity instead of leaking sibling encode calls.
- SGLang already avoids this path because `sgl.Engine.async_encode` accepts the full batch as `list[str]` in one call. vLLM does not expose a batched embeddings API on AsyncLLM, so we route the batching through the event loop instead.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/handlers.py` — the `EmbeddingWorkerHandler.generate` method.

#### Benchmark (arm64 GB200, Qwen3-Embedding-0.6B, --batch-size 15, ISL=80, RPS=1)

| Stack | avg | p99 | vs vllm-serve |
|---|---|---|---|
| vllm-serve | 63.41 ms | 69.31 | 1.0× |
| dynamo pre-fix (this PR's parent) | 323.61 ms | 335.24 | 5.1× |
| dynamo post-fix (this PR) | **214.52 ms** | 225.27 | 3.4× |

asyncio.gather saves ~109 ms per request (33.7% faster). A residual gap to vllm-serve remains and is tracked as a follow-up under [DIS-2154](https://linear.app/nvidia/issue/DIS-2154/debug-dynamovllm-embedding-worker-is-22x-slower-than-raw-vllm-serve) (Rust frontend ↔ NATS overhead, ~170 ms outside the Python handler).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Embedding request processing now executes concurrently instead of sequentially, delivering faster throughput and lower latency while maintaining consistent result ordering.

* **Reliability**
  * Enhanced error handling for embedding encoding operations with explicit error detection and reporting when inputs fail to encode properly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
