### PR TITLE
Add Poolside v1 parser support

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2245,9 +2245,15 @@ impl OpenAIPreprocessor {
         // - harmony / gpt_oss: `<|channel|>analysis<|message|>...<|end|>`.
         // - kimi_k2: `<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>`.
         // - kimi_k25: `</think>` (special token id 163607).
+        // - poolside_v1: mirrors vLLM's Poolside parser adjust_request hook
+        //   so model-native tool-call markers are visible to the parser.
         matches!(
             tool_call_parser,
-            Some("gemma4") | Some("gemma-4") | Some("harmony") | Some("kimi_k2")
+            Some("gemma4")
+                | Some("gemma-4")
+                | Some("harmony")
+                | Some("kimi_k2")
+                | Some("poolside_v1")
         ) || matches!(
             reasoning_parser,
             Some("gemma4") | Some("gemma-4") | Some("gpt_oss") | Some("kimi_k25")
@@ -3031,6 +3037,12 @@ mod tests {
                 true,
                 "kimi_k2 tool-call only → required \
                  (`<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>` are special)",
+            ),
+            (
+                Some("poolside_v1"),
+                None,
+                true,
+                "poolside_v1 tool-call only -> required to mirror vLLM adjust_request",
             ),
             (None, None, false, "no parsers → not required"),
         ];

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2207,13 +2207,15 @@ impl OpenAIPreprocessor {
                         builder = builder.tool_call_parser(parser);
                     }
                 }
-                Some(ChatCompletionToolChoiceOption::Auto)
-                | Some(ChatCompletionToolChoiceOption::None)
-                | None => {
-                    // Traditional marker-based jail for auto/none/unspecified
+                Some(ChatCompletionToolChoiceOption::Auto) | None => {
+                    // Traditional marker-based jail for auto/unspecified.
                     if let Some(parser) = tool_call_parser {
                         builder = builder.tool_call_parser(parser);
                     }
+                }
+                Some(ChatCompletionToolChoiceOption::None) => {
+                    // vLLM-style tool parsers are disabled when the request
+                    // explicitly says tool_choice="none".
                 }
             }
         }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -455,7 +455,7 @@ impl PoolsideV1StreamState {
             return None;
         }
 
-        let value = poolside_deserialize(raw_value);
+        let value = dynamo_parsers::tool_calling::xml::deserialize_poolside_literal(raw_value);
         let key_json = serde_json::to_string(key).ok()?;
         let value_json = serde_json::to_string(&value).ok()?;
         let index = self.current_index();
@@ -514,19 +514,6 @@ fn json_escape_string_content(value: &str) -> String {
                 .map(ToOwned::to_owned)
         })
         .unwrap_or_default()
-}
-
-fn poolside_deserialize(raw_value: &str) -> serde_json::Value {
-    let trimmed = raw_value.trim();
-    if let Ok(value) = serde_json::from_str(trimmed) {
-        return value;
-    }
-    match trimmed {
-        "True" => serde_json::Value::Bool(true),
-        "False" => serde_json::Value::Bool(false),
-        "None" => serde_json::Value::Null,
-        _ => serde_json::Value::String(trimmed.to_string()),
-    }
 }
 
 fn is_poolside_string_type(

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -16,7 +16,7 @@ use dynamo_parsers::tool_calling::{
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::utils::{MarkerMatcher, MatchResult};
@@ -102,6 +102,451 @@ pub enum ToolChoiceFormat {
     ArrayOfTools,
 }
 
+#[derive(Debug, Clone, Default)]
+struct PoolsideV1StreamDelta {
+    content: Option<String>,
+    tool_calls: Vec<ChatCompletionMessageToolCallChunk>,
+}
+
+#[derive(Debug, Clone)]
+struct PoolsideV1StreamState {
+    buffer: String,
+    in_tool_call: bool,
+    current_tool_name_sent: bool,
+    current_tool_id: i32,
+    current_tool_name: Option<String>,
+    pending_key: Option<String>,
+    streaming_string_value: bool,
+    tool_call_ids: Vec<String>,
+    streamed_args_for_tool: Vec<String>,
+    args_started: Vec<bool>,
+    args_closed: Vec<bool>,
+    seen_keys: Vec<HashSet<String>>,
+}
+
+impl Default for PoolsideV1StreamState {
+    fn default() -> Self {
+        Self {
+            buffer: String::new(),
+            in_tool_call: false,
+            current_tool_name_sent: false,
+            current_tool_id: -1,
+            current_tool_name: None,
+            pending_key: None,
+            streaming_string_value: false,
+            tool_call_ids: Vec::new(),
+            streamed_args_for_tool: Vec::new(),
+            args_started: Vec::new(),
+            args_closed: Vec::new(),
+            seen_keys: Vec::new(),
+        }
+    }
+}
+
+impl PoolsideV1StreamState {
+    const TOOL_CALL_START: &'static str = "<tool_call>";
+    const TOOL_CALL_END: &'static str = "</tool_call>";
+    const ARG_KEY_START: &'static str = "<arg_key>";
+    const ARG_KEY_END: &'static str = "</arg_key>";
+    const ARG_VALUE_START: &'static str = "<arg_value>";
+    const ARG_VALUE_END: &'static str = "</arg_value>";
+
+    fn process_delta(
+        &mut self,
+        delta_text: &str,
+        tools: Option<&[dynamo_parsers::tool_calling::ToolDefinition]>,
+    ) -> PoolsideV1StreamDelta {
+        self.buffer.push_str(delta_text);
+
+        let mut pending_deltas: BTreeMap<u32, ChatCompletionMessageToolCallChunk> = BTreeMap::new();
+        let mut content: Option<String> = None;
+
+        loop {
+            if !self.in_tool_call {
+                let Some(start_idx) = self.buffer.find(Self::TOOL_CALL_START) else {
+                    let safe_len = self.safe_len_before_partial_start();
+                    if safe_len > 0 {
+                        let out = self.buffer[..safe_len].to_string();
+                        self.buffer.drain(..safe_len);
+                        append_optional(&mut content, out);
+                    }
+                    break;
+                };
+
+                if start_idx > 0 {
+                    let out = self.buffer[..start_idx].to_string();
+                    append_optional(&mut content, out);
+                    self.buffer.drain(..start_idx);
+                }
+
+                self.buffer.drain(..Self::TOOL_CALL_START.len());
+                self.begin_tool_call();
+                continue;
+            }
+
+            if !self.current_tool_name_sent {
+                let newline = self.buffer.find('\n');
+                let arg_key = self.buffer.find(Self::ARG_KEY_START);
+                let end = self.buffer.find(Self::TOOL_CALL_END);
+                let Some(cut) = [newline, arg_key, end].into_iter().flatten().min() else {
+                    break;
+                };
+
+                let tool_name = self.buffer[..cut].trim().to_string();
+                if tool_name.is_empty() && end == Some(cut) {
+                    self.buffer.drain(..cut + Self::TOOL_CALL_END.len());
+                    self.finish_tool_call();
+                    self.revert_last_tool_call_state();
+                    continue;
+                }
+
+                if newline == Some(cut) {
+                    self.buffer.drain(..cut + 1);
+                } else {
+                    self.buffer.drain(..cut);
+                }
+
+                self.current_tool_name = Some(tool_name.clone());
+                self.current_tool_name_sent = true;
+                self.update_tool_name(&mut pending_deltas, tool_name);
+                continue;
+            }
+
+            if self.streaming_string_value {
+                if let Some(value_end) = self.buffer.find(Self::ARG_VALUE_END) {
+                    let raw_content = self.buffer[..value_end].to_string();
+                    self.buffer.drain(..value_end + Self::ARG_VALUE_END.len());
+                    self.streaming_string_value = false;
+                    self.pending_key = None;
+
+                    let fragment = format!("{}\"", json_escape_string_content(&raw_content));
+                    self.append_current_args_fragment(&fragment);
+                    self.update_tool_args(&mut pending_deltas, &fragment);
+                    continue;
+                }
+
+                let safe_len = safe_len_before_partial_suffix(&self.buffer, Self::ARG_VALUE_END);
+                if safe_len > 0 {
+                    let to_emit = self.buffer[..safe_len].to_string();
+                    self.buffer.drain(..safe_len);
+                    let escaped = json_escape_string_content(&to_emit);
+                    if !escaped.is_empty() {
+                        self.append_current_args_fragment(&escaped);
+                        self.update_tool_args(&mut pending_deltas, &escaped);
+                    }
+                }
+                break;
+            }
+
+            if let Some(key) = self.pending_key.clone() {
+                let Some(value_start) = self.buffer.find(Self::ARG_VALUE_START) else {
+                    break;
+                };
+                if value_start > 0 {
+                    self.buffer.drain(..value_start);
+                }
+
+                let key = key.trim().to_string();
+                let tool_name = self.current_tool_name.as_deref().unwrap_or_default();
+                let is_string = is_poolside_string_type(tool_name, &key, tools);
+
+                if is_string {
+                    self.buffer.drain(..Self::ARG_VALUE_START.len());
+
+                    let index = self.current_index();
+                    if self.seen_keys[index].contains(&key) {
+                        self.pending_key = None;
+                        continue;
+                    }
+
+                    self.seen_keys[index].insert(key.clone());
+                    let key_json = serde_json::to_string(&key).unwrap_or_else(|_| "\"\"".into());
+                    let fragment = if !self.args_started[index] {
+                        self.args_started[index] = true;
+                        format!("{{{key_json}:\"")
+                    } else {
+                        format!(",{key_json}:\"")
+                    };
+
+                    self.append_current_args_fragment(&fragment);
+                    self.streaming_string_value = true;
+                    self.update_tool_args(&mut pending_deltas, &fragment);
+                    continue;
+                }
+
+                let Some(value_end) = self.buffer.find(Self::ARG_VALUE_END) else {
+                    break;
+                };
+
+                let raw_value = self.buffer[Self::ARG_VALUE_START.len()..value_end]
+                    .trim()
+                    .to_string();
+                self.buffer.drain(..value_end + Self::ARG_VALUE_END.len());
+                self.pending_key = None;
+
+                if let Some(fragment) = self.append_arg_fragment(&key, &raw_value) {
+                    self.update_tool_args(&mut pending_deltas, &fragment);
+                }
+                continue;
+            }
+
+            let end_pos = self.buffer.find(Self::TOOL_CALL_END);
+            let key_pos = self.buffer.find(Self::ARG_KEY_START);
+            if let Some(end_pos) = end_pos
+                && (key_pos.is_none() || end_pos < key_pos.unwrap())
+            {
+                self.buffer.drain(..end_pos + Self::TOOL_CALL_END.len());
+                let fragment = self.close_args_if_needed();
+                self.finish_tool_call();
+                if let Some(fragment) = fragment {
+                    self.update_tool_args(&mut pending_deltas, &fragment);
+                }
+                continue;
+            }
+
+            let Some(key_pos) = key_pos else {
+                break;
+            };
+            if key_pos > 0 {
+                self.buffer.drain(..key_pos);
+            }
+            let Some(key_end) = self.buffer.find(Self::ARG_KEY_END) else {
+                break;
+            };
+            let key = self.buffer[Self::ARG_KEY_START.len()..key_end].to_string();
+            self.buffer.drain(..key_end + Self::ARG_KEY_END.len());
+            self.pending_key = Some(key);
+        }
+
+        PoolsideV1StreamDelta {
+            content,
+            tool_calls: pending_deltas.into_values().collect(),
+        }
+    }
+
+    fn finalize_content(&mut self) -> Option<String> {
+        if self.in_tool_call {
+            self.buffer.clear();
+            self.finish_tool_call();
+            return None;
+        }
+
+        if self.buffer.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut self.buffer))
+        }
+    }
+
+    fn safe_len_before_partial_start(&self) -> usize {
+        safe_len_before_partial_suffix(&self.buffer, Self::TOOL_CALL_START)
+    }
+
+    fn begin_tool_call(&mut self) {
+        self.current_tool_id += 1;
+        self.ensure_tool_state();
+        self.current_tool_name_sent = false;
+        self.current_tool_name = None;
+        self.pending_key = None;
+        self.streaming_string_value = false;
+        self.in_tool_call = true;
+    }
+
+    fn finish_tool_call(&mut self) {
+        self.in_tool_call = false;
+        self.current_tool_name = None;
+        self.pending_key = None;
+        self.streaming_string_value = false;
+    }
+
+    fn revert_last_tool_call_state(&mut self) {
+        if self.current_tool_id < 0 {
+            return;
+        }
+        self.tool_call_ids.pop();
+        self.streamed_args_for_tool.pop();
+        self.args_started.pop();
+        self.args_closed.pop();
+        self.seen_keys.pop();
+        self.current_tool_id -= 1;
+    }
+
+    fn ensure_tool_state(&mut self) {
+        while self.tool_call_ids.len() <= self.current_index() {
+            self.tool_call_ids.push(Uuid::new_v4().to_string());
+        }
+        while self.streamed_args_for_tool.len() <= self.current_index() {
+            self.streamed_args_for_tool.push(String::new());
+        }
+        while self.args_started.len() <= self.current_index() {
+            self.args_started.push(false);
+        }
+        while self.args_closed.len() <= self.current_index() {
+            self.args_closed.push(false);
+        }
+        while self.seen_keys.len() <= self.current_index() {
+            self.seen_keys.push(HashSet::new());
+        }
+    }
+
+    fn current_index(&self) -> usize {
+        self.current_tool_id.max(0) as usize
+    }
+
+    fn get_or_create_delta<'a>(
+        &self,
+        pending: &'a mut BTreeMap<u32, ChatCompletionMessageToolCallChunk>,
+    ) -> &'a mut ChatCompletionMessageToolCallChunk {
+        let index = self.current_index() as u32;
+        pending
+            .entry(index)
+            .or_insert_with(|| ChatCompletionMessageToolCallChunk {
+                index,
+                id: None,
+                r#type: None,
+                function: Some(FunctionCallStream {
+                    name: None,
+                    arguments: None,
+                }),
+            })
+    }
+
+    fn update_tool_name(
+        &mut self,
+        pending: &mut BTreeMap<u32, ChatCompletionMessageToolCallChunk>,
+        tool_name: String,
+    ) {
+        let index = self.current_index();
+        let id = self.tool_call_ids[index].clone();
+        let delta = self.get_or_create_delta(pending);
+        delta.id = Some(id);
+        delta.r#type = Some(FunctionType::Function);
+        let function = delta.function.get_or_insert(FunctionCallStream {
+            name: None,
+            arguments: None,
+        });
+        function.name = Some(tool_name);
+        function.arguments.get_or_insert_with(String::new);
+    }
+
+    fn update_tool_args(
+        &self,
+        pending: &mut BTreeMap<u32, ChatCompletionMessageToolCallChunk>,
+        fragment: &str,
+    ) {
+        let delta = self.get_or_create_delta(pending);
+        let function = delta.function.get_or_insert(FunctionCallStream {
+            name: None,
+            arguments: None,
+        });
+        function
+            .arguments
+            .get_or_insert_with(String::new)
+            .push_str(fragment);
+    }
+
+    fn append_current_args_fragment(&mut self, fragment: &str) {
+        let index = self.current_index();
+        self.streamed_args_for_tool[index].push_str(fragment);
+    }
+
+    fn append_arg_fragment(&mut self, key: &str, raw_value: &str) -> Option<String> {
+        if key.is_empty() || self.seen_keys[self.current_index()].contains(key) {
+            return None;
+        }
+
+        let value = poolside_deserialize(raw_value);
+        let key_json = serde_json::to_string(key).ok()?;
+        let value_json = serde_json::to_string(&value).ok()?;
+        let index = self.current_index();
+        let fragment = if !self.args_started[index] {
+            self.args_started[index] = true;
+            format!("{{{key_json}:{value_json}")
+        } else {
+            format!(",{key_json}:{value_json}")
+        };
+
+        self.seen_keys[index].insert(key.to_string());
+        self.streamed_args_for_tool[index].push_str(&fragment);
+        Some(fragment)
+    }
+
+    fn close_args_if_needed(&mut self) -> Option<String> {
+        let index = self.current_index();
+        if self.args_closed[index] {
+            return None;
+        }
+        self.args_closed[index] = true;
+        let fragment = if !self.args_started[index] {
+            self.streamed_args_for_tool[index] = "{}".to_string();
+            "{}".to_string()
+        } else {
+            self.streamed_args_for_tool[index].push('}');
+            "}".to_string()
+        };
+        Some(fragment)
+    }
+}
+
+fn append_optional(target: &mut Option<String>, fragment: String) {
+    if fragment.is_empty() {
+        return;
+    }
+    target.get_or_insert_with(String::new).push_str(&fragment);
+}
+
+fn safe_len_before_partial_suffix(buffer: &str, marker: &str) -> usize {
+    for i in (1..marker.len()).rev() {
+        if buffer.ends_with(&marker[..i]) {
+            return buffer.len() - i;
+        }
+    }
+    buffer.len()
+}
+
+fn json_escape_string_content(value: &str) -> String {
+    serde_json::to_string(value)
+        .ok()
+        .and_then(|encoded| {
+            encoded
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_default()
+}
+
+fn poolside_deserialize(raw_value: &str) -> serde_json::Value {
+    let trimmed = raw_value.trim();
+    if let Ok(value) = serde_json::from_str(trimmed) {
+        return value;
+    }
+    match trimmed {
+        "True" => serde_json::Value::Bool(true),
+        "False" => serde_json::Value::Bool(false),
+        "None" => serde_json::Value::Null,
+        _ => serde_json::Value::String(trimmed.to_string()),
+    }
+}
+
+fn is_poolside_string_type(
+    tool_name: &str,
+    arg_name: &str,
+    tools: Option<&[dynamo_parsers::tool_calling::ToolDefinition]>,
+) -> bool {
+    let Some(tool) = tools.and_then(|tools| tools.iter().find(|tool| tool.name == tool_name))
+    else {
+        return false;
+    };
+    tool.parameters
+        .as_ref()
+        .and_then(|schema| schema.get("properties"))
+        .and_then(|properties| properties.get(arg_name))
+        .and_then(|arg_schema| arg_schema.get("type"))
+        .and_then(|arg_type| arg_type.as_str())
+        == Some("string")
+}
+
 /// State tracking for an individual choice during jail processing
 #[derive(Debug, Clone)]
 struct ChoiceJailState {
@@ -123,6 +568,9 @@ struct ChoiceJailState {
     emitted_tool_calls_count: usize,
     /// Reasoning content collected while waiting for a suitable emission.
     pending_reasoning_content: Option<String>,
+    /// Poolside/vLLM streams schema-declared string args incrementally instead
+    /// of buffering until `</tool_call>`.
+    poolside_v1_state: PoolsideV1StreamState,
 }
 
 fn create_choice_stream(
@@ -151,6 +599,30 @@ fn create_choice_stream(
     }
 }
 
+fn create_choice_stream_optional_content(
+    index: u32,
+    role: Option<Role>,
+    content: Option<String>,
+    tool_calls: Option<Vec<ChatCompletionMessageToolCallChunk>>,
+    finish_reason: Option<FinishReason>,
+    logprobs: Option<ChatChoiceLogprobs>,
+) -> ChatChoiceStream {
+    #[allow(deprecated)]
+    ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role,
+            content: content.map(dynamo_protocols::types::ChatCompletionMessageContent::Text),
+            tool_calls,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason,
+        logprobs,
+    }
+}
+
 impl ChoiceJailState {
     /// Create a new jail state for a choice
     fn new(index: u32, starts_jailed: bool) -> Self {
@@ -163,6 +635,7 @@ impl ChoiceJailState {
             stream_finish_reason: None,
             emitted_tool_calls_count: 0,
             pending_reasoning_content: None,
+            poolside_v1_state: PoolsideV1StreamState::default(),
         }
     }
 
@@ -211,6 +684,10 @@ impl ChoiceJailState {
         content: &str,
         jail_stream: &JailedStream,
     ) -> Vec<ChoiceEmission> {
+        if jail_stream.is_poolside_v1_parser() {
+            return self.process_poolside_v1_content(choice, content, jail_stream);
+        }
+
         let mut emissions = Vec::new();
         if !self.is_jailed {
             // Use the marker matcher to detect complete/partial markers
@@ -446,8 +923,63 @@ impl ChoiceJailState {
         emissions
     }
 
+    fn process_poolside_v1_content(
+        &mut self,
+        choice: &ChatChoiceStream,
+        content: &str,
+        jail_stream: &JailedStream,
+    ) -> Vec<ChoiceEmission> {
+        if !jail_stream.poolside_v1_tools_enabled() {
+            return vec![ChoiceEmission::PassThrough(create_choice_stream(
+                choice.index,
+                choice.delta.role,
+                content,
+                None,
+                choice.finish_reason,
+                choice.logprobs.clone(),
+            ))];
+        }
+
+        let parsed = self
+            .poolside_v1_state
+            .process_delta(content, jail_stream.tool_definitions.as_deref());
+
+        if parsed.content.is_none() && parsed.tool_calls.is_empty() {
+            return Vec::new();
+        }
+
+        let has_tool_calls = !parsed.tool_calls.is_empty();
+        let choice = create_choice_stream_optional_content(
+            choice.index,
+            choice.delta.role.or(Some(Role::Assistant)),
+            parsed.content,
+            has_tool_calls.then_some(parsed.tool_calls),
+            choice.finish_reason,
+            choice.logprobs.clone(),
+        );
+
+        if has_tool_calls {
+            vec![ChoiceEmission::ToolCall(choice)]
+        } else {
+            vec![ChoiceEmission::PassThrough(choice)]
+        }
+    }
+
     /// Finalize any remaining content when stream ends
     async fn finalize(&mut self, jail_stream: &JailedStream) -> Option<ChoiceEmission> {
+        if jail_stream.is_poolside_v1_parser() {
+            let content = self.poolside_v1_state.finalize_content()?;
+            let final_choice = create_choice_stream_optional_content(
+                self.index,
+                Some(Role::Assistant),
+                Some(content),
+                None,
+                self.stream_finish_reason,
+                self.accumulated_logprobs.clone(),
+            );
+            return Some(ChoiceEmission::Content(final_choice));
+        }
+
         if self.is_jailed && !self.accumulated_content.is_empty() {
             // Create a dummy choice for the method call
             #[allow(deprecated)]
@@ -566,6 +1098,17 @@ impl JailedStream {
     /// Whether the jail starts already-jailed (tool_choice=required/named path).
     fn is_immediate(&self) -> bool {
         matches!(self.jail_mode, JailMode::Immediate { .. })
+    }
+
+    fn is_poolside_v1_parser(&self) -> bool {
+        self.tool_call_parser.as_deref() == Some("poolside_v1")
+            && matches!(self.jail_mode, JailMode::MarkerBased)
+    }
+
+    fn poolside_v1_tools_enabled(&self) -> bool {
+        self.tool_definitions
+            .as_ref()
+            .is_some_and(|tools| !tools.is_empty())
     }
 
     /// Apply jail stream transformation with finish_reason fix

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1280,6 +1280,53 @@ async fn drain_stream(
     }
 }
 
+#[tokio::test]
+async fn poolside_v1_postprocessor_ignores_prior_history_think_markers() {
+    let preprocessor = build_preprocessor(Some("poolside_v1"), None);
+    let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test-model",
+        "messages": [
+            {"role": "system", "content": "Tool docs mention a literal </think> marker."},
+            {
+                "role": "assistant",
+                "reasoning_content": "old reasoning",
+                "content": "old answer with a preserved </think> marker"
+            },
+            {"role": "user", "content": "what does </think> mean?"}
+        ],
+        "stream": true,
+        "temperature": 0.0
+    }))
+    .unwrap();
+
+    let input_stream = stream::iter(
+        vec![
+            mock_content_chunk("<think>new "),
+            mock_content_chunk("reasoning</thi"),
+            mock_content_chunk("nk>answer"),
+            mock_final_chunk(),
+        ]
+        .into_iter()
+        .map(Annotated::from_data),
+    );
+
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
+
+    assert_eq!(reasoning, "new reasoning");
+    assert_eq!(content, "answer");
+    assert!(tool_calls.is_empty());
+    assert!(!content.contains("<think>"));
+    assert!(!content.contains("</think>"));
+}
+
 /// Assert the standard "tool call extracted, nothing leaks" success shape
 /// shared by every matrix row that expects a successful extraction.
 fn assert_clean_tool_call(

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3875,4 +3875,282 @@ fahrenheit
             "wrong-tool JSON leaked to content: {emitted_text:?}"
         );
     }
+
+    fn poolside_write_file_tool_defs() -> Vec<dynamo_parsers::tool_calling::ToolDefinition> {
+        vec![dynamo_parsers::tool_calling::ToolDefinition {
+            name: "write_file".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string"},
+                    "meta": {"type": "object"}
+                }
+            })),
+            strict: None,
+        }]
+    }
+
+    fn collect_tool_arg_fragments(
+        results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+        index: u32,
+    ) -> Vec<String> {
+        results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            .filter(|tc| tc.index == index)
+            .filter_map(|tc| tc.function.as_ref())
+            .filter_map(|f| f.arguments.clone())
+            .collect()
+    }
+
+    fn collect_tool_names(
+        results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<String> {
+        results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            .filter_map(|tc| tc.function.as_ref())
+            .filter_map(|f| f.name.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_streams_string_args_incrementally() {
+        let expected_content =
+            "line 1\nline 2 with \"quotes\" and \\ backslash\n{\"json\":\"looking\"}";
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("I will call it.\n<too".to_string(), 0),
+            test_utils::create_mock_response_chunk("l_call>write_file\n<arg_".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                "key>content</arg_key><arg_value>line 1\n".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "line 2 with \"quotes\" and \\ backslash\n".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk("{\"json\":\"looking\"}</arg_".to_string(), 0),
+            test_utils::create_mock_response_chunk("value></tool".to_string(), 0),
+            test_utils::create_mock_response_chunk("_call>".to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_write_file_tool_defs()),
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(
+            test_utils::reconstruct_content(&results),
+            "I will call it.\n"
+        );
+        assert_eq!(collect_tool_names(&results), vec!["write_file".to_string()]);
+
+        let fragments = collect_tool_arg_fragments(&results, 0);
+        assert!(
+            fragments.len() >= 4,
+            "string args should stream in multiple fragments, got {fragments:?}"
+        );
+        assert!(
+            fragments.iter().any(|fragment| {
+                fragment.contains("line 2 with")
+                    && !fragment.contains("</arg_value>")
+                    && !fragment.ends_with('}')
+            }),
+            "long string body was not emitted before the closing arg tag: {fragments:?}"
+        );
+
+        let arguments = fragments.join("");
+        let parsed: serde_json::Value = serde_json::from_str(&arguments).unwrap();
+        assert_eq!(parsed["content"], expected_content);
+        assert!(
+            !arguments.contains("</arg_")
+                && !test_utils::reconstruct_content(&results).contains("<too"),
+            "Poolside protocol tags leaked into output"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_waits_for_complete_non_string_args() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "<tool_call>write_file\n<arg_key>meta</arg_key><arg_value>{\"x\":".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk("1".to_string(), 0),
+            test_utils::create_mock_response_chunk("}</arg_value></tool_call>".to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_write_file_tool_defs()),
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let fragments = collect_tool_arg_fragments(&results, 0);
+        assert_eq!(
+            fragments
+                .iter()
+                .filter(|fragment| fragment.contains("\"meta\""))
+                .count(),
+            1,
+            "object arg should be emitted once after </arg_value>, got {fragments:?}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&fragments.join("")).unwrap();
+        assert_eq!(parsed["meta"], serde_json::json!({"x": 1}));
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_tool_only_stream_omits_empty_content() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "<tool_call>write_file\n<arg_key>content</arg_key><arg_value>x</arg_value></tool_call>"
+                    .to_string(),
+                0,
+            ),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_write_file_tool_defs()),
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(test_utils::reconstruct_content(&results), "");
+        for choice in results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter(|choice| choice.delta.tool_calls.is_some())
+        {
+            assert!(
+                choice.delta.content.is_none(),
+                "tool-only Poolside deltas should not serialize content as an empty string"
+            );
+        }
+
+        let finish_reasons: Vec<_> = results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|choice| choice.finish_reason)
+            .collect();
+        assert!(finish_reasons.contains(&FinishReason::ToolCalls));
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_no_tools_and_tool_choice_none_do_not_parse() {
+        let raw =
+            "<tool_call>write_file\n<arg_key>content</arg_key><arg_value>x</arg_value></tool_call>";
+
+        let no_tools_results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            None,
+            false,
+            stream::iter(vec![test_utils::create_mock_response_chunk(
+                raw.to_string(),
+                0,
+            )]),
+        )
+        .collect()
+        .await;
+        assert_eq!(test_utils::reconstruct_content(&no_tools_results), raw);
+        assert!(collect_tool_arg_fragments(&no_tools_results, 0).is_empty());
+
+        let tool_choice_none_results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            Some(ChatCompletionToolChoiceOption::None),
+            Some(poolside_write_file_tool_defs()),
+            false,
+            stream::iter(vec![test_utils::create_mock_response_chunk(
+                raw.to_string(),
+                0,
+            )]),
+        )
+        .collect()
+        .await;
+        assert_eq!(
+            test_utils::reconstruct_content(&tool_choice_none_results),
+            raw
+        );
+        assert!(collect_tool_arg_fragments(&tool_choice_none_results, 0).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_reasoning_content_tool_boundary_crossing() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("<think>need ".to_string(), 0),
+            test_utils::create_mock_response_chunk("tool</thi".to_string(), 0),
+            test_utils::create_mock_response_chunk("nk>\nI will call it.\n<too".to_string(), 0),
+            test_utils::create_mock_response_chunk("l_call>write_file\n<arg_".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                "key>content</arg_key><arg_value>echo hi</arg_".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk("value></tool".to_string(), 0),
+            test_utils::create_mock_response_chunk("_call>".to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let reasoning_parsed_stream = OpenAIPreprocessor::parse_reasoning_content_from_stream(
+            stream::iter(input_chunks),
+            "poolside_v1".to_string(),
+            false,
+        );
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_write_file_tool_defs()),
+            false,
+            reasoning_parsed_stream,
+        )
+        .collect()
+        .await;
+
+        let reasoning: String = results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|c| c.delta.reasoning_content.as_deref())
+            .collect();
+        assert_eq!(reasoning, "need tool");
+        assert_eq!(
+            test_utils::reconstruct_content(&results),
+            "\nI will call it.\n"
+        );
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&collect_tool_arg_fragments(&results, 0).join("")).unwrap();
+        assert_eq!(parsed["content"], "echo hi");
+
+        let visible_output = format!("{}{}", reasoning, test_utils::reconstruct_content(&results));
+        assert!(
+            !visible_output.contains("<think>")
+                && !visible_output.contains("</thi")
+                && !visible_output.contains("<too")
+                && !visible_output.contains("<arg_"),
+            "protocol boundary fragments leaked: {visible_output:?}"
+        );
+    }
 }

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3883,7 +3883,24 @@ fahrenheit
                 "type": "object",
                 "properties": {
                     "content": {"type": "string"},
-                    "meta": {"type": "object"}
+                    "meta": {"type": "object"},
+                    "paths": {"type": "array"},
+                    "tuple_paths": {"type": "array"},
+                    "dry_run": {"type": "boolean"},
+                    "optional": {"type": "null"}
+                }
+            })),
+            strict: None,
+        }]
+    }
+
+    fn poolside_read_file_tool_defs() -> Vec<dynamo_parsers::tool_calling::ToolDefinition> {
+        vec![dynamo_parsers::tool_calling::ToolDefinition {
+            name: "read_file".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"}
                 }
             })),
             strict: None,
@@ -3916,6 +3933,26 @@ fahrenheit
             .filter_map(|tc| tc.function.as_ref())
             .filter_map(|f| f.name.clone())
             .collect()
+    }
+
+    fn collect_tool_ids_by_index(
+        results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> std::collections::BTreeMap<u32, std::collections::BTreeSet<String>> {
+        let mut ids_by_index = std::collections::BTreeMap::new();
+        for tool_call in results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .flat_map(|c| c.delta.tool_calls.iter().flatten())
+        {
+            if let Some(id) = &tool_call.id {
+                ids_by_index
+                    .entry(tool_call.index)
+                    .or_insert_with(std::collections::BTreeSet::new)
+                    .insert(id.clone());
+            }
+        }
+        ids_by_index
     }
 
     #[tokio::test]
@@ -3980,6 +4017,35 @@ fahrenheit
     }
 
     #[tokio::test]
+    async fn test_poolside_v1_stream_preserves_xml_entities_in_string_args() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "<tool_call>write_file\n<arg_key>content</arg_key><arg_value>&lt;di".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "v&gt;hi&lt;/div&gt;</arg_value></tool_call>".to_string(),
+                0,
+            ),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_write_file_tool_defs()),
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let arguments = collect_tool_arg_fragments(&results, 0).join("");
+        let parsed: serde_json::Value = serde_json::from_str(&arguments).unwrap();
+        assert_eq!(parsed["content"], "&lt;div&gt;hi&lt;/div&gt;");
+    }
+
+    #[tokio::test]
     async fn test_poolside_v1_waits_for_complete_non_string_args() {
         let input_chunks = vec![
             test_utils::create_mock_response_chunk(
@@ -4015,6 +4081,50 @@ fahrenheit
     }
 
     #[tokio::test]
+    async fn test_poolside_v1_streaming_python_literal_non_string_args() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "<tool_call>write_file\n<arg_key>meta</arg_key><arg_value>{'x': ".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "1}</arg_value><arg_key>paths</arg_key><arg_value>['a.py', 'b.py']</arg_value>"
+                    .to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "<arg_key>tuple_paths</arg_key><arg_value>('c.py', 'd.py')</arg_value>"
+                    .to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "<arg_key>dry_run</arg_key><arg_value>True</arg_value><arg_key>optional</arg_key><arg_value>None</arg_value></tool_call>"
+                    .to_string(),
+                0,
+            ),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_write_file_tool_defs()),
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&collect_tool_arg_fragments(&results, 0).join("")).unwrap();
+        assert_eq!(parsed["meta"], serde_json::json!({"x": 1}));
+        assert_eq!(parsed["paths"], serde_json::json!(["a.py", "b.py"]));
+        assert_eq!(parsed["tuple_paths"], serde_json::json!(["c.py", "d.py"]));
+        assert_eq!(parsed["dry_run"], true);
+        assert!(parsed["optional"].is_null());
+    }
+
+    #[tokio::test]
     async fn test_poolside_v1_tool_only_stream_omits_empty_content() {
         let input_chunks = vec![
             test_utils::create_mock_response_chunk(
@@ -4047,6 +4157,62 @@ fahrenheit
                 "tool-only Poolside deltas should not serialize content as an empty string"
             );
         }
+
+        let finish_reasons: Vec<_> = results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter_map(|choice| choice.finish_reason)
+            .collect();
+        assert!(finish_reasons.contains(&FinishReason::ToolCalls));
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_streaming_parallel_tool_calls_keep_stable_indexes() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("<too".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                "l_call>read_file\n<arg_key>path</arg_key><arg_value>a.".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk("py</arg_value></tool".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                "_call><tool_call>read_file\n<arg_".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "key>path</arg_key><arg_value>b.py</arg_value></tool_call>".to_string(),
+                0,
+            ),
+            test_utils::create_final_response_chunk(0),
+        ];
+
+        let results: Vec<_> = OpenAIPreprocessor::apply_tool_calling_jail(
+            Some("poolside_v1".to_string()),
+            None,
+            Some(poolside_read_file_tool_defs()),
+            false,
+            stream::iter(input_chunks),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(
+            collect_tool_names(&results),
+            vec!["read_file".to_string(), "read_file".to_string()]
+        );
+
+        let first_args: serde_json::Value =
+            serde_json::from_str(&collect_tool_arg_fragments(&results, 0).join("")).unwrap();
+        let second_args: serde_json::Value =
+            serde_json::from_str(&collect_tool_arg_fragments(&results, 1).join("")).unwrap();
+        assert_eq!(first_args["path"], "a.py");
+        assert_eq!(second_args["path"], "b.py");
+
+        let ids_by_index = collect_tool_ids_by_index(&results);
+        assert_eq!(ids_by_index.len(), 2);
+        assert_eq!(ids_by_index.get(&0).map(|ids| ids.len()), Some(1));
+        assert_eq!(ids_by_index.get(&1).map(|ids| ids.len()), Some(1));
 
         let finish_reasons: Vec<_> = results
             .iter()

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -39,6 +39,11 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
         map.insert("basic", ReasoningParserType::Basic);
         map.insert("gpt_oss", ReasoningParserType::GptOss);
         map.insert("qwen3", ReasoningParserType::Qwen);
+        // Poolside Laguna XS.2 uses `<think>...</think>`. Unlike vLLM's
+        // Poolside parser, Dynamo does not scan the whole prompt for
+        // `</think>`; prompt-injected `<think>` is handled by
+        // `ReasoningParser::set_in_reasoning(true)`.
+        map.insert("poolside_v1", ReasoningParserType::PoolsideV1);
         // DeepSeek-V4 uses the same `<think>` / `</think>` delimiters as Qwen
         // (confirmed against deepseek-ai/DeepSeek-V4-Pro's encoding_dsv4.py)
         // so it delegates to the same `BasicReasoningParser` config today. We
@@ -153,6 +158,10 @@ pub enum ReasoningParserType {
     Basic,
     GptOss,
     Qwen,
+    /// Poolside Laguna XS.2. Same `<think>` / `</think>` delimiters as Qwen,
+    /// no force-reasoning. Kept as a dedicated variant so Poolside-specific
+    /// behavior can diverge without changing Qwen.
+    PoolsideV1,
     /// DeepSeek-V4-Pro / V4-Flash. Currently uses the same `<think>` /
     /// `</think>` `BasicReasoningParser` config as Qwen (V4 never appends
     /// `<think>` in the completion — the chat template always pre-injects it,
@@ -217,6 +226,9 @@ impl ReasoningParserType {
                 parser: Box::new(basic_parser),
             },
             ReasoningParserType::Qwen => ReasoningParserWrapper {
+                parser: Box::new(basic_parser),
+            },
+            ReasoningParserType::PoolsideV1 => ReasoningParserWrapper {
                 parser: Box::new(basic_parser),
             },
             // Same `<think>` / `</think>` config as Qwen today; kept as a
@@ -316,6 +328,7 @@ mod tests {
             "basic",
             "gpt_oss",
             "qwen3",
+            "poolside_v1",
             "deepseek_v4",
             "deepseek-v4",
             "deepseekv4",
@@ -683,5 +696,32 @@ mod tests {
         }
         assert_eq!(all_reasoning, "Weighing options.");
         assert_eq!(all_content, "Beijing is sunny.");
+    }
+
+    #[test]
+    fn test_poolside_v1_detect_and_parse() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("poolside_v1");
+        let result = parser.detect_and_parse_reasoning("<think>checking</think>answer", &[]);
+
+        assert_eq!(result.reasoning_text, "checking");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test]
+    fn test_poolside_v1_streaming_with_set_in_reasoning() {
+        let mut parser = ReasoningParserType::get_reasoning_parser_from_name("poolside_v1");
+        parser.set_in_reasoning(true);
+
+        let tokens = &["chec", "king", "</think>", "answer"];
+        let mut all_reasoning = String::new();
+        let mut all_content = String::new();
+        for token in tokens {
+            let r = parser.parse_reasoning_streaming_incremental(token, &[]);
+            all_reasoning.push_str(&r.reasoning_text);
+            all_content.push_str(&r.normal_text);
+        }
+
+        assert_eq!(all_reasoning, "checking");
+        assert_eq!(all_content, "answer");
     }
 }

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -201,6 +201,17 @@ pub struct Glm47ParserConfig {
     /// leave this `false`.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// Preserve schema-declared string values as strings even when the value
+    /// text looks like JSON. Poolside/Laguna's vLLM `poolside_v1` parser does
+    /// this so long string/tool payloads are not coerced into objects.
+    #[serde(default)]
+    pub preserve_string_schema_values: bool,
+
+    /// Normalize empty or whitespace-only content before the first tool call
+    /// to `None`. Poolside/vLLM emits null content for tool-only messages.
+    #[serde(default)]
+    pub empty_tool_content_as_none: bool,
 }
 
 impl Default for Glm47ParserConfig {
@@ -213,6 +224,8 @@ impl Default for Glm47ParserConfig {
             arg_value_start: "<arg_value>".to_string(),
             arg_value_end: "</arg_value>".to_string(),
             allow_eof_recovery: false,
+            preserve_string_schema_values: false,
+            empty_tool_content_as_none: false,
         }
     }
 }
@@ -605,6 +618,23 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja
         Self {
             parser_config: ParserConfig::Glm47(Glm47ParserConfig::default()),
+            structural_tag_builder: None,
+        }
+    }
+
+    pub fn poolside_v1() -> Self {
+        // Poolside Laguna XS.2 format:
+        // <tool_call>function_name
+        // <arg_key>param1</arg_key><arg_value>value1</arg_value></tool_call>
+        //
+        // This is GLM-style XML with Poolside/vLLM semantics for schema string
+        // args: string-typed values remain strings even if they look like JSON.
+        Self {
+            parser_config: ParserConfig::Glm47(Glm47ParserConfig {
+                preserve_string_schema_values: true,
+                empty_tool_content_as_none: true,
+                ..Default::default()
+            }),
             structural_tag_builder: None,
         }
     }

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -7,6 +7,10 @@ use super::structural_tag::{
     DsmlToolCallsConfig, StructuralTagBuilder, TOOL_NAME_PLACEHOLDER, TriggeredTagsConfig,
 };
 
+fn default_decode_xml_entities() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct JsonParserConfig {
     /// Start token for individual tool calls (e.g., `<TOOLCALL>`)
@@ -212,6 +216,11 @@ pub struct Glm47ParserConfig {
     /// to `None`. Poolside/vLLM emits null content for tool-only messages.
     #[serde(default)]
     pub empty_tool_content_as_none: bool,
+
+    /// Decode XML entities in argument values before type coercion. GLM-4.7
+    /// keeps this legacy behavior; Poolside/vLLM leaves string arg bytes raw.
+    #[serde(default = "default_decode_xml_entities")]
+    pub decode_xml_entities: bool,
 }
 
 impl Default for Glm47ParserConfig {
@@ -226,6 +235,7 @@ impl Default for Glm47ParserConfig {
             allow_eof_recovery: false,
             preserve_string_schema_values: false,
             empty_tool_content_as_none: false,
+            decode_xml_entities: true,
         }
     }
 }
@@ -633,6 +643,7 @@ impl ToolCallConfig {
             parser_config: ParserConfig::Glm47(Glm47ParserConfig {
                 preserve_string_schema_values: true,
                 empty_tool_content_as_none: true,
+                decode_xml_entities: false,
                 ..Default::default()
             }),
             structural_tag_builder: None,

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -53,6 +53,7 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("jamba", ToolCallConfig::jamba());
         map.insert("minimax_m2", ToolCallConfig::minimax_m2());
         map.insert("glm47", ToolCallConfig::glm47());
+        map.insert("poolside_v1", ToolCallConfig::poolside_v1());
         map.insert("kimi_k2", ToolCallConfig::kimi_k2());
         map.insert("gemma4", ToolCallConfig::gemma4());
         map.insert("gemma-4", ToolCallConfig::gemma4());
@@ -341,6 +342,7 @@ mod tests {
             "nemotron_nano",
             "minimax_m2",
             "glm47",
+            "poolside_v1",
             "kimi_k2",
             "gemma4",
             "gemma-4",
@@ -3536,5 +3538,161 @@ weather forecasting
         assert_eq!(name, "batch_process");
         assert!(args["items"].is_array());
         assert_eq!(args["items"], serde_json::json!([1, 2, 3, 4, 5]));
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_simple_tool_call() {
+        let input = r#"<tool_call>search
+<arg_key>query</arg_key><arg_value>laguna xs.2</arg_value></tool_call>"#;
+
+        let (result, content) = detect_and_parse_tool_call(input, Some("poolside_v1"), None)
+            .await
+            .unwrap();
+
+        assert_eq!(content, None);
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "search");
+        assert_eq!(args["query"], "laguna xs.2");
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_preserves_json_looking_string_args() {
+        let input = r#"<tool_call>write_file
+<arg_key>content</arg_key><arg_value>{"literal": true, "count": 3}</arg_value></tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "write_file".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string"}
+                }
+            })),
+            strict: None,
+        }];
+
+        let (result, _) = detect_and_parse_tool_call(input, Some("poolside_v1"), Some(&tools))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "write_file");
+        assert_eq!(args["content"], r#"{"literal": true, "count": 3}"#);
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_deserializes_non_string_json_args() {
+        let input = r#"<tool_call>search
+<arg_key>filters</arg_key><arg_value>{"category": "books", "limit": 2}</arg_value></tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "search".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "filters": {"type": "object"}
+                }
+            })),
+            strict: None,
+        }];
+
+        let (result, _) = detect_and_parse_tool_call(input, Some("poolside_v1"), Some(&tools))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        let (_, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(
+            args["filters"],
+            serde_json::json!({"category": "books", "limit": 2})
+        );
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_deserializes_non_string_scalar_args() {
+        let input = r#"<tool_call>configure
+<arg_key>limit</arg_key><arg_value>10</arg_value><arg_key>ratio</arg_key><arg_value>0.75</arg_value><arg_key>dry_run</arg_key><arg_value>true</arg_value><arg_key>paths</arg_key><arg_value>["a.py","b.py"]</arg_value><arg_key>meta</arg_key><arg_value>{"x":1}</arg_value><arg_key>optional</arg_key><arg_value>null</arg_value></tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "configure".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer"},
+                    "ratio": {"type": "number"},
+                    "dry_run": {"type": "boolean"},
+                    "paths": {"type": "array"},
+                    "meta": {"type": "object"},
+                    "optional": {"type": "null"}
+                }
+            })),
+            strict: None,
+        }];
+
+        let (result, content) =
+            detect_and_parse_tool_call(input, Some("poolside_v1"), Some(&tools))
+                .await
+                .unwrap();
+
+        assert_eq!(content, None);
+        assert_eq!(result.len(), 1);
+        let (_, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(args["limit"], 10);
+        assert_eq!(args["ratio"], 0.75);
+        assert_eq!(args["dry_run"], true);
+        assert_eq!(args["paths"], serde_json::json!(["a.py", "b.py"]));
+        assert_eq!(args["meta"], serde_json::json!({"x": 1}));
+        assert!(args["optional"].is_null());
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_preserves_long_string_args() {
+        let payload = format!(
+            "line 1\nline 2 with \"quotes\" and \\ backslash\n{}&lt;xml-looking&gt;\n{{\"json\":\"looking but string\"}}",
+            "0123456789abcdef\n".repeat(256)
+        );
+        let input = format!(
+            "<tool_call>write_file\n<arg_key>content</arg_key><arg_value>{payload}</arg_value></tool_call>"
+        );
+        let tools = vec![ToolDefinition {
+            name: "write_file".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string"}
+                }
+            })),
+            strict: None,
+        }];
+
+        let (result, content) =
+            detect_and_parse_tool_call(&input, Some("poolside_v1"), Some(&tools))
+                .await
+                .unwrap();
+
+        assert_eq!(content, None);
+        assert_eq!(result.len(), 1);
+        let (_, args) = extract_name_and_args(result[0].clone());
+        let expected = payload.replace("&lt;", "<").replace("&gt;", ">");
+        assert_eq!(args["content"], expected);
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_parallel_tool_calls() {
+        let input = r#"<tool_call>get_weather
+<arg_key>location</arg_key><arg_value>SF</arg_value></tool_call><tool_call>get_time
+<arg_key>timezone</arg_key><arg_value>America/Los_Angeles</arg_value></tool_call>"#;
+
+        let (result, content) = detect_and_parse_tool_call(input, Some("poolside_v1"), None)
+            .await
+            .unwrap();
+
+        assert_eq!(content, None);
+        assert_eq!(result.len(), 2);
+        let (first_name, first_args) = extract_name_and_args(result[0].clone());
+        let (second_name, second_args) = extract_name_and_args(result[1].clone());
+        assert_eq!(first_name, "get_weather");
+        assert_eq!(first_args["location"], "SF");
+        assert_eq!(second_name, "get_time");
+        assert_eq!(second_args["timezone"], "America/Los_Angeles");
     }
 }

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -3672,8 +3672,65 @@ weather forecasting
         assert_eq!(content, None);
         assert_eq!(result.len(), 1);
         let (_, args) = extract_name_and_args(result[0].clone());
-        let expected = payload.replace("&lt;", "<").replace("&gt;", ">");
-        assert_eq!(args["content"], expected);
+        assert_eq!(args["content"], payload);
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_preserves_xml_entities_in_string_args() {
+        let input = r#"<tool_call>write_file
+<arg_key>content</arg_key><arg_value>&lt;div&gt;hi&lt;/div&gt;</arg_value></tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "write_file".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {"type": "string"}
+                }
+            })),
+            strict: None,
+        }];
+
+        let (result, content) =
+            detect_and_parse_tool_call(input, Some("poolside_v1"), Some(&tools))
+                .await
+                .unwrap();
+
+        assert_eq!(content, None);
+        let (_, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(args["content"], "&lt;div&gt;hi&lt;/div&gt;");
+    }
+
+    #[tokio::test]
+    async fn test_poolside_v1_deserializes_python_literal_non_string_args() {
+        let input = r#"<tool_call>configure
+<arg_key>meta</arg_key><arg_value>{'x': 1}</arg_value><arg_key>paths</arg_key><arg_value>['a.py', 'b.py']</arg_value><arg_key>tuple_paths</arg_key><arg_value>('c.py', 'd.py')</arg_value><arg_key>dry_run</arg_key><arg_value>True</arg_value><arg_key>optional</arg_key><arg_value>None</arg_value></tool_call>"#;
+        let tools = vec![ToolDefinition {
+            name: "configure".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "meta": {"type": "object"},
+                    "paths": {"type": "array"},
+                    "tuple_paths": {"type": "array"},
+                    "dry_run": {"type": "boolean"},
+                    "optional": {"type": "null"}
+                }
+            })),
+            strict: None,
+        }];
+
+        let (result, content) =
+            detect_and_parse_tool_call(input, Some("poolside_v1"), Some(&tools))
+                .await
+                .unwrap();
+
+        assert_eq!(content, None);
+        let (_, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(args["meta"], serde_json::json!({"x": 1}));
+        assert_eq!(args["paths"], serde_json::json!(["a.py", "b.py"]));
+        assert_eq!(args["tuple_paths"], serde_json::json!(["c.py", "d.py"]));
+        assert_eq!(args["dry_run"], true);
+        assert!(args["optional"].is_null());
     }
 
     #[tokio::test]

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -247,6 +247,147 @@ fn decode_xml_entities(s: &str) -> String {
         .replace("&apos;", "'")
 }
 
+/// Deserialize Poolside/vLLM-style argument text. vLLM tries JSON first,
+/// then Python literal syntax, then falls back to the stripped raw string.
+pub fn deserialize_poolside_literal(raw_value: &str) -> Value {
+    let trimmed = raw_value.trim();
+    parse_json_or_python_literal(trimmed).unwrap_or_else(|| Value::String(trimmed.to_string()))
+}
+
+fn parse_json_or_python_literal(trimmed: &str) -> Option<Value> {
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        return Some(value);
+    }
+
+    let jsonish = python_literal_to_jsonish(trimmed)?;
+    serde_json::from_str::<Value>(&jsonish).ok()
+}
+
+fn python_literal_to_jsonish(input: &str) -> Option<String> {
+    let first = input.chars().next()?;
+    if !matches!(first, '\'' | '"' | '[' | '{' | '(') && !matches!(input, "True" | "False" | "None")
+    {
+        return None;
+    }
+
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((_, ch)) = chars.next() {
+        match ch {
+            '\'' | '"' => {
+                let value = read_python_string(&mut chars, ch)?;
+                output.push_str(&serde_json::to_string(&value).ok()?);
+            }
+            '(' => output.push('['),
+            ')' => output.push(']'),
+            c if is_identifier_start(c) => {
+                let mut ident = c.to_string();
+                while let Some((_, next)) = chars.peek().copied() {
+                    if is_identifier_continue(next) {
+                        ident.push(next);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                match ident.as_str() {
+                    "True" => output.push_str("true"),
+                    "False" => output.push_str("false"),
+                    "None" => output.push_str("null"),
+                    _ => output.push_str(&ident),
+                }
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    Some(remove_json_trailing_commas(&output))
+}
+
+fn read_python_string<I>(chars: &mut std::iter::Peekable<I>, quote: char) -> Option<String>
+where
+    I: Iterator<Item = (usize, char)>,
+{
+    let mut value = String::new();
+    while let Some((_, ch)) = chars.next() {
+        if ch == quote {
+            return Some(value);
+        }
+        if ch != '\\' {
+            value.push(ch);
+            continue;
+        }
+
+        let (_, escaped) = chars.next()?;
+        match escaped {
+            '\\' => value.push('\\'),
+            '\'' => value.push('\''),
+            '"' => value.push('"'),
+            'n' => value.push('\n'),
+            'r' => value.push('\r'),
+            't' => value.push('\t'),
+            'b' => value.push('\u{0008}'),
+            'f' => value.push('\u{000c}'),
+            other => value.push(other),
+        }
+    }
+    None
+}
+
+fn is_identifier_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_identifier_continue(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+fn remove_json_trailing_commas(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            output.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            output.push(ch);
+            continue;
+        }
+
+        if ch == ',' {
+            let mut lookahead = chars.clone();
+            while matches!(lookahead.peek(), Some(next) if next.is_whitespace()) {
+                lookahead.next();
+            }
+            if matches!(lookahead.peek(), Some(']' | '}')) {
+                continue;
+            }
+        }
+
+        output.push(ch);
+    }
+
+    output
+}
+
 /// Coerce a raw string value to a JSON Value using the tool's parameter schema.
 /// Falls back to string if no schema is available or the type is unrecognized.
 fn coerce_value(
@@ -260,8 +401,12 @@ fn coerce_value(
         return Value::String(trimmed.to_string());
     }
 
-    // If the value already looks like JSON (object, array, or quoted string), parse it directly
-    if (trimmed.starts_with('{') || trimmed.starts_with('[') || trimmed.starts_with('"'))
+    if preserve_string_schema_values {
+        // Poolside/vLLM accepts both JSON and Python-literal-ish argument values.
+        if let Some(value) = parse_json_or_python_literal(trimmed) {
+            return value;
+        }
+    } else if (trimmed.starts_with('{') || trimmed.starts_with('[') || trimmed.starts_with('"'))
         && let Ok(v) = serde_json::from_str(trimmed)
     {
         return v;
@@ -381,13 +526,19 @@ fn parse_tool_call_block(
         let raw_value = cap.get(2).map(|m| m.as_str()).unwrap_or("");
 
         if !key.is_empty() {
-            // Decode XML entities (e.g. &lt; → <, &amp; → &) before parsing
-            let decoded = decode_xml_entities(raw_value);
+            let value_text = if config.decode_xml_entities {
+                decode_xml_entities(raw_value)
+            } else {
+                raw_value.to_string()
+            };
 
             // Look up the expected type from the tool's parameter schema
             let schema_type = get_param_schema_type(tools, &function_name, key);
-            let json_value =
-                coerce_value(&decoded, schema_type, config.preserve_string_schema_values);
+            let json_value = coerce_value(
+                &value_text,
+                schema_type,
+                config.preserve_string_schema_values,
+            );
 
             arguments.insert(key.to_string(), json_value);
         }

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -103,7 +103,12 @@ pub fn try_tool_call_parse_glm47(
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let (normal_text, tool_calls) = extract_tool_calls(message, config, tools)?;
 
-    let normal_content = if normal_text.is_empty() {
+    let normal_content = if !tool_calls.is_empty()
+        && config.empty_tool_content_as_none
+        && normal_text.trim().is_empty()
+    {
+        None
+    } else if normal_text.is_empty() {
         Some("".to_string())
     } else {
         Some(normal_text)
@@ -244,8 +249,16 @@ fn decode_xml_entities(s: &str) -> String {
 
 /// Coerce a raw string value to a JSON Value using the tool's parameter schema.
 /// Falls back to string if no schema is available or the type is unrecognized.
-fn coerce_value(raw: &str, schema_type: Option<&str>) -> Value {
+fn coerce_value(
+    raw: &str,
+    schema_type: Option<&str>,
+    preserve_string_schema_values: bool,
+) -> Value {
     let trimmed = raw.trim();
+
+    if preserve_string_schema_values && matches!(schema_type, Some("string")) {
+        return Value::String(trimmed.to_string());
+    }
 
     // If the value already looks like JSON (object, array, or quoted string), parse it directly
     if (trimmed.starts_with('{') || trimmed.starts_with('[') || trimmed.starts_with('"'))
@@ -373,7 +386,8 @@ fn parse_tool_call_block(
 
             // Look up the expected type from the tool's parameter schema
             let schema_type = get_param_schema_type(tools, &function_name, key);
-            let json_value = coerce_value(&decoded, schema_type);
+            let json_value =
+                coerce_value(&decoded, schema_type, config.preserve_string_schema_values);
 
             arguments.insert(key.to_string(), json_value);
         }

--- a/lib/parsers/src/tool_calling/xml/mod.rs
+++ b/lib/parsers/src/tool_calling/xml/mod.rs
@@ -7,7 +7,8 @@ mod parser;
 
 pub use super::response;
 pub use glm47_parser::{
-    detect_tool_call_start_glm47, find_tool_call_end_position_glm47, try_tool_call_parse_glm47,
+    deserialize_poolside_literal, detect_tool_call_start_glm47, find_tool_call_end_position_glm47,
+    try_tool_call_parse_glm47,
 };
 pub use kimi_k2_parser::{
     detect_tool_call_start_kimi_k2, find_tool_call_end_position_kimi_k2,


### PR DESCRIPTION
## Summary
- Register `poolside_v1` tool and reasoning parser names for Laguna/Poolside XS.2.
- Preserve schema-declared string arguments for Poolside while keeping non-string JSON/scalar coercion.
- Match vLLM Poolside tool-only content normalization by returning no content for empty/whitespace-only pre-tool text.
- Add a Poolside-specific streaming path that handles split sentinels, stable tool-call indexes, incremental schema-string argument deltas, complete-value emission for non-string args, and `tool_choice="none"` / no-tools pass-through.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p dynamo-parsers poolside_v1`
- `cargo test -p dynamo-parsers`
- Linux container: `cargo test -p dynamo-llm --test test_jail poolside_v1 -- --nocapture`