### PR TITLE
docs(router): add topology-aware KV transfer docs

### DIFF
--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -67,6 +67,21 @@ For Kimi-style TP-only MoE runs, use `--aic-moe-tp-size` equal to `--aic-tp-size
 - `--router-reset-states`: Only applies in JetStream mode (`--router-durable-kv-events`). Resets the router state on startup by clearing both the JetStream event stream and NATS object store, starting from a fresh state.
 - `--router-snapshot-threshold`: Only applies in JetStream mode (`--router-durable-kv-events`). Sets the number of messages in JetStream before triggering a snapshot.
 
+## Topology-Aware KV Transfer
+
+Topology-aware KV transfer is configured on workers through runtime metadata,
+not with frontend router flags. In Kubernetes, use
+`spec.experimental.kvTransferPolicy` on the `DynamoGraphDeployment`; the
+operator injects the worker environment and topology files. Outside Kubernetes,
+set `DYN_TOPOLOGY_ENABLED`, `DYN_TOPOLOGY_MOUNT_PATH`,
+`DYN_KV_TRANSFER_DOMAIN`, `DYN_KV_TRANSFER_ENFORCEMENT`, and
+`DYN_KV_TRANSFER_PREFERRED_WEIGHT` on workers.
+
+For the full runtime contract and routing behavior, see
+[Topology-Aware KV Transfer](topology-aware-kv-transfer.md). For Kubernetes
+deployment examples, see
+[Kubernetes Topology-Aware KV Transfer](../../kubernetes/topology-aware-kv-transfer.md).
+
 ## Block Tracking
 
 - `--no-router-track-active-blocks`: Disables tracking of active blocks used for ongoing generation or decode phases. Disable this when routing to workers that only perform prefill.

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -69,18 +69,10 @@ For Kimi-style TP-only MoE runs, use `--aic-moe-tp-size` equal to `--aic-tp-size
 
 ## Topology-Aware KV Transfer
 
-Topology-aware KV transfer is configured on workers through runtime metadata,
-not with frontend router flags. In Kubernetes, use
-`spec.experimental.kvTransferPolicy` on the `DynamoGraphDeployment`; the
-operator injects the worker environment and topology files. Outside Kubernetes,
-set `DYN_TOPOLOGY_ENABLED`, `DYN_TOPOLOGY_MOUNT_PATH`,
-`DYN_KV_TRANSFER_DOMAIN`, `DYN_KV_TRANSFER_ENFORCEMENT`, and
-`DYN_KV_TRANSFER_PREFERRED_WEIGHT` on workers.
+Topology-aware KV transfer is configured on workers through runtime metadata, not with frontend router flags. In Kubernetes, use `spec.experimental.kvTransferPolicy` on the `DynamoGraphDeployment`; the operator injects the worker environment and topology files. Outside Kubernetes, set `DYN_TOPOLOGY_ENABLED`, `DYN_TOPOLOGY_MOUNT_PATH`, `DYN_KV_TRANSFER_DOMAIN`, `DYN_KV_TRANSFER_ENFORCEMENT`, and `DYN_KV_TRANSFER_PREFERRED_WEIGHT` on workers.
 
-For the full runtime contract and routing behavior, see
-[Topology-Aware KV Transfer](topology-aware-kv-transfer.md). For Kubernetes
-deployment examples, see
-[Kubernetes Topology-Aware KV Transfer](../../kubernetes/topology-aware-kv-transfer.md).
+For the full runtime contract and routing behavior, see [Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
+For Kubernetes deployment examples, see [Kubernetes Topology-Aware KV Transfer](../../kubernetes/topology-aware-kv-transfer.md).
 
 ## Block Tracking
 

--- a/docs/components/router/router-disaggregated-serving.md
+++ b/docs/components/router/router-disaggregated-serving.md
@@ -9,6 +9,10 @@ Dynamo supports disaggregated serving where prefill (prompt processing) and deco
 
 For the high-level deployment matrix, see [Router Guide](router-guide.md). For the router flags used in this setup, see [Configuration and Tuning](router-configuration.md).
 
+If prefill and decode workers span topology domains such as zones or racks, use
+[Topology-Aware KV Transfer](topology-aware-kv-transfer.md) to constrain or bias
+decode routing toward workers in the selected prefill worker's transfer domain.
+
 ## Automatic Prefill Router Activation
 
 The prefill router is automatically created when:
@@ -88,3 +92,7 @@ graph TD
     linkStyle 0,1,2,3,4 stroke:#8b4513,stroke-width:2px
     linkStyle 5 stroke:#2196f3,stroke-width:2px
 ```
+
+When topology-aware KV transfer is enabled, the prefill router also derives
+decode `RoutingConstraints` from the selected prefill worker's runtime topology
+metadata before the request enters the decode router.

--- a/docs/components/router/router-disaggregated-serving.md
+++ b/docs/components/router/router-disaggregated-serving.md
@@ -9,9 +9,7 @@ Dynamo supports disaggregated serving where prefill (prompt processing) and deco
 
 For the high-level deployment matrix, see [Router Guide](router-guide.md). For the router flags used in this setup, see [Configuration and Tuning](router-configuration.md).
 
-If prefill and decode workers span topology domains such as zones or racks, use
-[Topology-Aware KV Transfer](topology-aware-kv-transfer.md) to constrain or bias
-decode routing toward workers in the selected prefill worker's transfer domain.
+If prefill and decode workers span topology domains such as zones or racks, use [Topology-Aware KV Transfer](topology-aware-kv-transfer.md) to constrain or bias decode routing toward workers in the selected prefill worker's transfer domain.
 
 ## Automatic Prefill Router Activation
 
@@ -93,6 +91,4 @@ graph TD
     linkStyle 5 stroke:#2196f3,stroke-width:2px
 ```
 
-When topology-aware KV transfer is enabled, the prefill router also derives
-decode `RoutingConstraints` from the selected prefill worker's runtime topology
-metadata before the request enters the decode router.
+When topology-aware KV transfer is enabled, the prefill router also derives decode `RoutingConstraints` from the selected prefill worker's runtime topology metadata before the request enters the decode router.

--- a/docs/components/router/router-guide.md
+++ b/docs/components/router/router-guide.md
@@ -174,6 +174,7 @@ Disaggregated mode is activated automatically when prefill workers register alon
 - **[Routing Concepts](router-concepts.md)**: Cost model, worker selection, and routing primitives
 - **[Configuration and Tuning](router-configuration.md)**: Router flags, transport modes, load tracking, and metrics
 - **[Disaggregated Serving](router-disaggregated-serving.md)**: Prefill and decode routing setups
+- **[Topology-Aware KV Transfer](topology-aware-kv-transfer.md)**: Runtime metadata and decode routing constraints for topology-aware prefill/decode handoff
 - **[Router Operations](router-operations.md)**: Replicas, remote indexers, persistence, and recovery
 - **[Router Examples](router-examples.md)**: Python API usage, K8s examples, and custom routing patterns
 - **[Router Testing](router-testing.md)**: Recommended test layers for non-trivial router changes

--- a/docs/components/router/topology-aware-kv-transfer.md
+++ b/docs/components/router/topology-aware-kv-transfer.md
@@ -7,13 +7,10 @@ subtitle: Runtime metadata and decode routing semantics for topology-aware prefi
 
 # Topology-Aware KV Transfer
 
-Topology-aware KV transfer constrains or biases decode worker selection after a
-prefill worker has been selected. The router derives standard
-`RoutingConstraints` from the selected prefill worker's published topology
-metadata, then merges those constraints into the decode request.
+Topology-aware KV transfer constrains or biases decode worker selection after a prefill worker has been selected. The router derives standard `RoutingConstraints` from the selected prefill worker's published topology metadata, then merges those constraints into the decode request.
 
-Use the Kubernetes operator path when possible. For deployment examples, see
-[Kubernetes Topology-Aware KV Transfer](../../kubernetes/topology-aware-kv-transfer.md).
+Use the Kubernetes operator path when possible.
+For deployment examples, see [Kubernetes Topology-Aware KV Transfer](../../kubernetes/topology-aware-kv-transfer.md).
 
 ## Runtime Contract
 
@@ -53,8 +50,7 @@ dynamo.topology/zone=us-east-1a
 dynamo.topology/rack=rack-22
 ```
 
-The KV-transfer policy uses only `kv_transfer_domain` to derive the decode
-constraint. Other topology domains remain available as ordinary routing taints.
+The KV-transfer policy uses only `kv_transfer_domain` to derive the decode constraint. Other topology domains remain available as ordinary routing taints.
 
 ## Request Flow
 
@@ -74,25 +70,19 @@ sequenceDiagram
     DR->>D: select compatible or preferred decode worker
 ```
 
-The prefill router builds the decode constraint before dispatching prefill when
-the selected worker is already known. This keeps `required` policy fail-closed:
-if the router cannot derive authoritative decode constraints for a required
-policy, it fails the request instead of dispatching prefill and then discovering
-that decode cannot be routed safely.
+The prefill router builds the decode constraint before dispatching prefill when the selected worker is already known. This keeps `required` policy fail-closed: if the router cannot derive authoritative decode constraints for a required policy, it fails the request instead of dispatching prefill and then discovering that decode cannot be routed safely.
 
 ## Enforcement Modes
 
 ### Required
 
-`required` turns the selected prefill worker's transfer-domain topology into a
-required taint.
+`required` turns the selected prefill worker's transfer-domain topology into a required taint.
 
 ```text
 required_taints = {"dynamo.topology/zone=us-east-1a"}
 ```
 
-Decode workers without that taint are ineligible. If no eligible decode worker
-exists, routing returns no endpoint for that request.
+Decode workers without that taint are ineligible. If no eligible decode worker exists, routing returns no endpoint for that request.
 
 ### Preferred
 
@@ -102,14 +92,11 @@ exists, routing returns no endpoint for that request.
 preferred_taints = {"dynamo.topology/zone=us-east-1a": 0.85}
 ```
 
-All decode workers remain eligible, but matching workers receive a lower
-routing cost. `preferredWeight` controls the strength of the preference from
-`0` to `1`.
+All decode workers remain eligible, but matching workers receive a lower routing cost. `preferredWeight` controls the strength of the preference from `0` to `1`.
 
 ## Worker Environment Contract
 
-The Python backend utility reads topology from files and transfer policy from
-environment variables:
+The Python backend utility reads topology from files and transfer policy from environment variables:
 
 | Environment variable | Description |
 |----------------------|-------------|
@@ -119,9 +106,7 @@ environment variables:
 | `DYN_KV_TRANSFER_ENFORCEMENT` | `required` or `preferred`. Defaults to `required` when a domain is set. |
 | `DYN_KV_TRANSFER_PREFERRED_WEIGHT` | Weight used when enforcement is `preferred`. |
 
-Each non-hidden, non-empty file under `DYN_TOPOLOGY_MOUNT_PATH` is interpreted
-as one topology domain. The file name is the domain; the file content is the
-worker's value for that domain.
+Each non-hidden, non-empty file under `DYN_TOPOLOGY_MOUNT_PATH` is interpreted as one topology domain. The file name is the domain; the file content is the worker's value for that domain.
 
 For example:
 
@@ -135,49 +120,34 @@ export DYN_KV_TRANSFER_DOMAIN=zone
 export DYN_KV_TRANSFER_ENFORCEMENT=required
 ```
 
-When topology is enabled, the worker polls until the selected transfer-domain
-file exists and has content. If it remains missing or empty through the timeout
-window, the worker exits so the bad topology source is visible during startup.
+When topology is enabled, the worker polls until the selected transfer-domain file exists and has content. If it remains missing or empty through the timeout window, the worker exits so the bad topology source is visible during startup.
 
 ## Backend Support
 
-The integrated Python backends apply the topology config during worker
-registration:
+The integrated Python backends apply the topology config during worker registration:
 
 - vLLM
 - SGLang
 - TensorRT-LLM
 
-The topology utility writes the fields onto `ModelRuntimeConfig`; Rust owns
-validation and canonical topology-taint generation.
+The topology utility writes the fields onto `ModelRuntimeConfig`; Rust owns validation and canonical topology-taint generation.
 
 ## Interactions with Existing Routing Constraints
 
-Topology-aware KV transfer uses the existing `RoutingConstraints` path. It does
-not add a topology-specific selector. If a request already has routing
-constraints, the prefill router merges the generated topology constraints into
-the decode request:
+Topology-aware KV transfer uses the existing `RoutingConstraints` path. It does not add a topology-specific selector. If a request already has routing constraints, the prefill router merges the generated topology constraints into the decode request:
 
 - Required topology taints are appended to existing `required_taints`.
 - Preferred topology taints are appended to existing `preferred_taints`.
 
-User-provided constraints still apply. A decode worker must satisfy all required
-constraints to be eligible.
+User-provided constraints still apply. A decode worker must satisfy all required constraints to be eligible.
 
 ## Operational Notes
 
-- Configure this only for disaggregated prefill/decode deployments. Aggregated
-  workers do not perform a remote prefill-to-decode KV transfer.
-- Keep `DYN_ROUTER_MODE=kv` on the frontend so the prefill and decode routing
-  paths use the KV router.
-- Make sure every prefill domain has enough decode capacity when using
-  `required`; otherwise the router can legitimately fail requests in
-  domains without decode workers.
-- Use `preferred` during incremental rollouts when same-domain transfer is a
-  latency preference rather than a hard placement requirement.
-- Transport health is separate from topology selection. Topology-aware routing
-  chooses a better peer, but RDMA, EFA, UCX, or libfabric still need to be
-  configured correctly for NIXL KV transfer.
+- Configure this only for disaggregated prefill/decode deployments. Aggregated workers do not perform a remote prefill-to-decode KV transfer.
+- Keep `DYN_ROUTER_MODE=kv` on the frontend so the prefill and decode routing paths use the KV router.
+- Make sure every prefill domain has enough decode capacity when using `required`; otherwise the router can legitimately fail requests in domains without decode workers.
+- Use `preferred` during incremental rollouts when same-domain transfer is a latency preference rather than a hard placement requirement.
+- Transport health is separate from topology selection. Topology-aware routing chooses a better peer, but RDMA, EFA, UCX, or libfabric still need to be configured correctly for NIXL KV transfer.
 
 ## Troubleshooting Signals
 

--- a/docs/components/router/topology-aware-kv-transfer.md
+++ b/docs/components/router/topology-aware-kv-transfer.md
@@ -1,0 +1,192 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Topology-Aware KV Transfer
+subtitle: Runtime metadata and decode routing semantics for topology-aware prefill/decode handoff
+---
+
+# Topology-Aware KV Transfer
+
+Topology-aware KV transfer constrains or biases decode worker selection after a
+prefill worker has been selected. The router derives standard
+`RoutingConstraints` from the selected prefill worker's published topology
+metadata, then merges those constraints into the decode request.
+
+Use the Kubernetes operator path when possible. For deployment examples, see
+[Kubernetes Topology-Aware KV Transfer](../../kubernetes/topology-aware-kv-transfer.md).
+
+## Runtime Contract
+
+Workers publish topology and policy fields through `ModelRuntimeConfig`:
+
+| Field | Meaning |
+|-------|---------|
+| `topology_domains` | Map of logical domain name to this worker's topology value, for example `{"zone": "us-east-1a"}`. |
+| `kv_transfer_domain` | Domain key used for prefill-to-decode KV transfer routing, for example `zone`. |
+| `kv_transfer_enforcement` | `required` or `preferred`. |
+| `kv_transfer_preferred_weight` | Preferred-taint weight used only when enforcement is `preferred`. |
+
+Each topology entry also becomes a canonical worker taint:
+
+```text
+dynamo.topology/<domain>=<value>
+```
+
+For example:
+
+```json
+{
+  "topology_domains": {
+    "zone": "us-east-1a",
+    "rack": "rack-22"
+  },
+  "kv_transfer_domain": "zone",
+  "kv_transfer_enforcement": "preferred",
+  "kv_transfer_preferred_weight": 0.85
+}
+```
+
+This creates worker taints:
+
+```text
+dynamo.topology/zone=us-east-1a
+dynamo.topology/rack=rack-22
+```
+
+The KV-transfer policy uses only `kv_transfer_domain` to derive the decode
+constraint. Other topology domains remain available as ordinary routing taints.
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant F as Frontend
+    participant PR as Prefill Router
+    participant P as Prefill Worker
+    participant DR as Decode Router
+    participant D as Decode Worker
+
+    F->>PR: request
+    PR->>P: select prefill worker
+    PR->>PR: read selected worker topology metadata
+    PR->>PR: build RoutingConstraints
+    PR->>DR: decode request + topology constraints
+    DR->>D: select compatible or preferred decode worker
+```
+
+The prefill router builds the decode constraint before dispatching prefill when
+the selected worker is already known. This keeps `required` policy fail-closed:
+if the router cannot derive authoritative decode constraints for a required
+policy, it fails the request instead of dispatching prefill and then discovering
+that decode cannot be routed safely.
+
+## Enforcement Modes
+
+### Required
+
+`required` turns the selected prefill worker's transfer-domain topology into a
+required taint.
+
+```text
+required_taints = {"dynamo.topology/zone=us-east-1a"}
+```
+
+Decode workers without that taint are ineligible. If no eligible decode worker
+exists, routing returns no endpoint for that request.
+
+### Preferred
+
+`preferred` turns the same topology into a preferred taint.
+
+```text
+preferred_taints = {"dynamo.topology/zone=us-east-1a": 0.85}
+```
+
+All decode workers remain eligible, but matching workers receive a lower
+routing cost. `preferredWeight` controls the strength of the preference from
+`0` to `1`.
+
+## Worker Environment Contract
+
+The Python backend utility reads topology from files and transfer policy from
+environment variables:
+
+| Environment variable | Description |
+|----------------------|-------------|
+| `DYN_TOPOLOGY_ENABLED` | Set to `true` to enable topology reading. |
+| `DYN_TOPOLOGY_MOUNT_PATH` | Directory containing topology files. Defaults to `/etc/dynamo/topology`. |
+| `DYN_KV_TRANSFER_DOMAIN` | Required when topology is enabled. Names the topology file and runtime domain to use for KV transfer constraints. |
+| `DYN_KV_TRANSFER_ENFORCEMENT` | `required` or `preferred`. Defaults to `required` when a domain is set. |
+| `DYN_KV_TRANSFER_PREFERRED_WEIGHT` | Weight used when enforcement is `preferred`. |
+
+Each non-hidden, non-empty file under `DYN_TOPOLOGY_MOUNT_PATH` is interpreted
+as one topology domain. The file name is the domain; the file content is the
+worker's value for that domain.
+
+For example:
+
+```bash
+mkdir -p /tmp/dynamo-topology
+printf 'us-east-1a\n' > /tmp/dynamo-topology/zone
+
+export DYN_TOPOLOGY_ENABLED=true
+export DYN_TOPOLOGY_MOUNT_PATH=/tmp/dynamo-topology
+export DYN_KV_TRANSFER_DOMAIN=zone
+export DYN_KV_TRANSFER_ENFORCEMENT=required
+```
+
+When topology is enabled, the worker polls until the selected transfer-domain
+file exists and has content. If it remains missing or empty through the timeout
+window, the worker exits so the bad topology source is visible during startup.
+
+## Backend Support
+
+The integrated Python backends apply the topology config during worker
+registration:
+
+- vLLM
+- SGLang
+- TensorRT-LLM
+
+The topology utility writes the fields onto `ModelRuntimeConfig`; Rust owns
+validation and canonical topology-taint generation.
+
+## Interactions with Existing Routing Constraints
+
+Topology-aware KV transfer uses the existing `RoutingConstraints` path. It does
+not add a topology-specific selector. If a request already has routing
+constraints, the prefill router merges the generated topology constraints into
+the decode request:
+
+- Required topology taints are appended to existing `required_taints`.
+- Preferred topology taints are appended to existing `preferred_taints`.
+
+User-provided constraints still apply. A decode worker must satisfy all required
+constraints to be eligible.
+
+## Operational Notes
+
+- Configure this only for disaggregated prefill/decode deployments. Aggregated
+  workers do not perform a remote prefill-to-decode KV transfer.
+- Keep `DYN_ROUTER_MODE=kv` on the frontend so the prefill and decode routing
+  paths use the KV router.
+- Make sure every prefill domain has enough decode capacity when using
+  `required`; otherwise the router can legitimately fail requests in
+  domains without decode workers.
+- Use `preferred` during incremental rollouts when same-domain transfer is a
+  latency preference rather than a hard placement requirement.
+- Transport health is separate from topology selection. Topology-aware routing
+  chooses a better peer, but RDMA, EFA, UCX, or libfabric still need to be
+  configured correctly for NIXL KV transfer.
+
+## Troubleshooting Signals
+
+| Symptom | Likely cause | Check |
+|---------|--------------|-------|
+| Worker exits during startup | `DYN_KV_TRANSFER_DOMAIN` missing, or topology file never populated. | Worker logs and contents of `DYN_TOPOLOGY_MOUNT_PATH`. |
+| Required policy returns no endpoint | No decode worker has the selected prefill worker's generated topology taint. | Worker `ModelRuntimeConfig` topology metadata and decode worker placement. |
+| Preferred policy still routes cross-domain | Matching domain is overloaded or unavailable, or weight is too low relative to load. | Increase `preferredWeight`, add same-domain decode capacity, or switch to `required`. |
+| Router sees no topology metadata | Worker did not publish topology fields. | Backend startup logs and runtime config metrics/discovery data. |
+
+For Kubernetes-specific verification commands, see
+[Verify the Deployment](../../kubernetes/topology-aware-kv-transfer.md#verify-the-deployment).

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -104,6 +104,8 @@ navigation:
             path: kubernetes/shadow-engine-failover.md
           - page: Disagg Communication
             path: kubernetes/disagg-communication-guide.md
+          - page: Topology-Aware KV Transfer
+            path: kubernetes/topology-aware-kv-transfer.md
       - section: Observability (K8s)
         contents:
           - page: Metrics
@@ -330,6 +332,8 @@ navigation:
             path: components/router/router-configuration.md
           - page: Disaggregated Serving
             path: components/router/router-disaggregated-serving.md
+          - page: Topology-Aware KV Transfer
+            path: components/router/topology-aware-kv-transfer.md
           - page: Router Operations
             path: components/router/router-operations.md
           - page: Router Examples

--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -15,9 +15,7 @@ This guide explains how prefill and decode workers communicate in Dynamo's disag
 - **RDMA (InfiniBand, RoCE, or AWS EFA) is required** for production disaggregated deployments
 - **Without RDMA, expect 200-500x performance degradation** in Time To First Token (TTFT) — observed ~98s TTFT with TCP vs ~200-500ms with RDMA
 - **UCX or libfabric** are the communication layers that NIXL uses to transfer KV cache between workers
-- **Topology-aware KV transfer** can constrain or bias decode routing so KV
-  transfers stay within a selected topology domain such as zone or rack. See
-  [Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
+- **Topology-aware KV transfer** can constrain or bias decode routing so KV transfers stay within a selected topology domain such as zone or rack. See [Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
 
 ---
 

--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -15,6 +15,9 @@ This guide explains how prefill and decode workers communicate in Dynamo's disag
 - **RDMA (InfiniBand, RoCE, or AWS EFA) is required** for production disaggregated deployments
 - **Without RDMA, expect 200-500x performance degradation** in Time To First Token (TTFT) — observed ~98s TTFT with TCP vs ~200-500ms with RDMA
 - **UCX or libfabric** are the communication layers that NIXL uses to transfer KV cache between workers
+- **Topology-aware KV transfer** can constrain or bias decode routing so KV
+  transfers stay within a selected topology domain such as zone or rack. See
+  [Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
 
 ---
 

--- a/docs/kubernetes/topology-aware-kv-transfer.md
+++ b/docs/kubernetes/topology-aware-kv-transfer.md
@@ -71,42 +71,175 @@ spec:
       labelKey: topology.kubernetes.io/zone
       domain: zone
       enforcement: required
-  services:
-    Frontend:
-      componentType: frontend
-      replicas: 1
-      envs:
-        - name: DYN_ROUTER_MODE
-          value: kv
-    VllmPrefillWorker:
-      componentType: worker
-      replicas: 2
-      envFromSecret: hf-token-secret
-      resources:
-        limits:
-          gpu: "1"
-      extraPodSpec:
-        mainContainer:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
-          command: ["/bin/sh", "-c"]
-          args:
-            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode prefill
-    VllmDecodeWorker:
-      componentType: worker
-      replicas: 2
-      envFromSecret: hf-token-secret
-      resources:
-        limits:
-          gpu: "1"
-      extraPodSpec:
-        mainContainer:
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+  - name: VllmPrefillWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        containers:
+        - name: main
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
-          command: ["/bin/sh", "-c"]
-          args:
-            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode decode
+          command: ["python3", "-m", "dynamo.vllm"]
+          args: ["--model", "Qwen/Qwen3-0.6B", "--disaggregation-mode", "prefill"]
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+  - name: VllmDecodeWorker
+    type: worker
+    replicas: 2
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          command: ["python3", "-m", "dynamo.vllm"]
+          args: ["--model", "Qwen/Qwen3-0.6B", "--disaggregation-mode", "decode"]
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
 ```
 
 `enforcement` defaults to `required` when omitted.
+
+> [!IMPORTANT]
+> `required` is a decode-routing constraint, not a capacity planner. The `DynamoGraphDeployment` author or cluster administrator must ensure that every topology domain that can receive prefill workers also has sufficient same-domain decode capacity. If a domain has prefill workers but no matching decode workers, or too little decode capacity, the router cannot spill to another domain without violating the policy.
+
+### Capacity Planning Across Domains
+
+Plan prefill and decode capacity per topology domain before enabling `enforcement: required`. For example, assume:
+
+- Two availability zones: `az-1` and `az-2`.
+- The target fleet is 60 prefill workers and 120 decode workers.
+- The fleet should be split evenly across the two zones.
+- The target prefill-to-decode ratio is 1:2 in each zone.
+
+That means each zone should run 30 prefill workers and 60 decode workers:
+
+| Zone | Prefill workers | Decode workers | Ratio |
+|------|-----------------|----------------|-------|
+| `az-1` | 30 | 60 | 1:2 |
+| `az-2` | 30 | 60 | 1:2 |
+
+In a `DynamoGraphDeployment`, express this as separate prefill and decode components per zone. Pin each component to its zone and set `kvTransferPolicy.enforcement` to `required` so the router refuses cross-zone decode selection. The DGD author or cluster administrator must ensure each zone has enough schedulable capacity for its pinned replicas. Worker command and args are omitted here; configure each worker for prefill or decode mode as in the base disaggregated serving manifest:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen3-disagg-zone-capacity
+spec:
+  experimental:
+    kvTransferPolicy:
+      labelKey: topology.kubernetes.io/zone
+      domain: zone
+      enforcement: required
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          env:
+          - name: DYN_ROUTER_MODE
+            value: kv
+  - name: VllmPrefillWorkerAz1
+    type: worker
+    replicas: 30
+    podTemplate:
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values: ["az-1"]
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+  - name: VllmDecodeWorkerAz1
+    type: worker
+    replicas: 60
+    podTemplate:
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values: ["az-1"]
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+  - name: VllmPrefillWorkerAz2
+    type: worker
+    replicas: 30
+    podTemplate:
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values: ["az-2"]
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+  - name: VllmDecodeWorkerAz2
+    type: worker
+    replicas: 60
+    podTemplate:
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values: ["az-2"]
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+```
 
 ## Preferred Same-Domain Routing
 
@@ -204,7 +337,7 @@ When topology is enabled, the worker waits for the transfer-domain file to appea
 
 ### Required Policy Fails Requests
 
-With `enforcement: required`, decode routing fails if no decode worker has the same generated topology taint as the selected prefill worker. Verify both prefill and decode workers publish the same `domain` and that at least one decode worker exists in each domain where prefill workers can be selected.
+With `enforcement: required`, decode routing fails if no decode worker has the same generated topology taint as the selected prefill worker. Verify both prefill and decode workers publish the same `domain`, and that each domain where prefill workers can be selected has enough matching decode workers for the expected p/d ratio.
 
 Use `preferred` while validating a heterogeneous rollout if cross-domain routing is acceptable during partial capacity.
 

--- a/docs/kubernetes/topology-aware-kv-transfer.md
+++ b/docs/kubernetes/topology-aware-kv-transfer.md
@@ -1,0 +1,277 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Topology-Aware KV Transfer
+subtitle: Keep disaggregated prefill and decode KV-cache transfers within a selected topology domain
+---
+
+# Topology-Aware KV Transfer
+
+Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode
+requests toward workers that share the selected prefill worker's topology
+domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers
+when prefill and decode workers exchange KV data over NIXL.
+
+Use this feature when:
+
+- Your deployment uses separate prefill and decode workers.
+- Your cluster exposes useful node labels, such as `topology.kubernetes.io/zone`
+  or a rack/block label.
+- Same-domain KV transfer is required for correctness or strongly preferred for
+  latency and bandwidth.
+
+This page covers the Kubernetes operator path. For router and runtime behavior,
+see [Router Topology-Aware KV Transfer](../components/router/topology-aware-kv-transfer.md).
+For RDMA/NIXL transport setup, see [Disagg Communication](disagg-communication-guide.md).
+
+## How It Works
+
+```mermaid
+flowchart LR
+    DGD["DGD spec.experimental.kvTransferPolicy"] --> Operator["Operator injects worker env + Downward API volume"]
+    Node["Node label"] --> Controller["Topology label controller"]
+    Controller --> Pod["Worker pod label"]
+    Pod --> Volume["/etc/dynamo/topology/<domain>"]
+    Volume --> Runtime["Worker publishes ModelRuntimeConfig topology metadata"]
+    Runtime --> Prefill["Prefill router derives decode constraints"]
+    Prefill --> Decode["Decode router selects same or preferred topology"]
+```
+
+The operator configures worker pods from
+`spec.experimental.kvTransferPolicy`:
+
+- Adds a `nvidia.com/topology-label-key` annotation to worker pods.
+- Runs a topology-label controller that copies the configured node label onto
+  the worker pod after scheduling.
+- Projects that pod label into `/etc/dynamo/topology/<domain>` with a Downward
+  API volume.
+- Injects worker environment variables that tell the backend runtime which
+  topology domain and enforcement policy to publish.
+
+The frontend does not read this policy from its own environment. Workers publish
+the topology metadata in their `ModelRuntimeConfig`; the router reads it from
+runtime discovery.
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Disaggregated serving | Separate prefill and decode worker services. |
+| KV router | The frontend should use `DYN_ROUTER_MODE=kv`. |
+| Node topology labels | Every node that can host a worker must carry the configured `labelKey`. |
+| Dynamo operator | The operator must include topology-label controller and node-read RBAC. |
+| KV transfer transport | RDMA, EFA, or another NIXL-compatible transport should already be configured for production disaggregated deployments. |
+
+Confirm that the label you plan to use exists on worker nodes:
+
+```bash
+kubectl get nodes -L topology.kubernetes.io/zone
+```
+
+## Required Same-Domain Routing
+
+`enforcement: required` constrains decode worker selection to workers whose
+topology value matches the selected prefill worker for the configured domain.
+If no decode worker satisfies the generated constraint, the router fails the
+request instead of silently crossing the domain.
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen3-disagg-zone
+spec:
+  experimental:
+    kvTransferPolicy:
+      labelKey: topology.kubernetes.io/zone
+      domain: zone
+      enforcement: required
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      envs:
+        - name: DYN_ROUTER_MODE
+          value: kv
+    VllmPrefillWorker:
+      componentType: worker
+      replicas: 2
+      envFromSecret: hf-token-secret
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode prefill
+    VllmDecodeWorker:
+      componentType: worker
+      replicas: 2
+      envFromSecret: hf-token-secret
+      resources:
+        limits:
+          gpu: "1"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --disaggregation-mode decode
+```
+
+`enforcement` defaults to `required` when omitted.
+
+## Preferred Same-Domain Routing
+
+`enforcement: preferred` keeps all decode workers eligible but biases worker
+selection toward the same topology domain.
+
+```yaml
+spec:
+  experimental:
+    kvTransferPolicy:
+      labelKey: topology.kubernetes.io/zone
+      domain: zone
+      enforcement: preferred
+      preferredWeight: 0.85
+```
+
+`preferredWeight` is required with `enforcement: preferred`. It must be between
+`0` and `1`. A higher value creates a stronger same-domain preference, but it is
+not a probability and does not guarantee same-domain selection.
+
+## DGDR Override Example
+
+If you deploy through `DynamoGraphDeploymentRequest`, add the policy through
+`spec.overrides.dgd` so it is applied to the generated
+`DynamoGraphDeployment`:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: qwen3-disagg-zone
+spec:
+  model: Qwen/Qwen3-0.6B
+  backend: vllm
+  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1beta1
+      kind: DynamoGraphDeployment
+      spec:
+        experimental:
+          kvTransferPolicy:
+            labelKey: topology.kubernetes.io/zone
+            domain: zone
+            enforcement: required
+```
+
+## Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `labelKey` | Yes | Kubernetes node label key to copy onto worker pods, for example `topology.kubernetes.io/zone`. |
+| `domain` | Yes | Logical topology domain name published by workers, for example `zone` or `rack`. Must match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`. |
+| `enforcement` | No | `required` or `preferred`. Defaults to `required`. |
+| `preferredWeight` | Only with `preferred` | Bias weight from `0` to `1`; only valid with `enforcement: preferred`. |
+
+The runtime uses `domain`, not the Kubernetes label key, when creating routing
+constraints. For example, `labelKey: topology.kubernetes.io/zone` and
+`domain: zone` produce worker topology metadata like:
+
+```json
+{
+  "topology_domains": {
+    "zone": "us-east-1a"
+  },
+  "kv_transfer_domain": "zone",
+  "kv_transfer_enforcement": "required"
+}
+```
+
+## Verify the Deployment
+
+After the DGD creates worker pods, verify the operator pipeline from node label
+to runtime topology file.
+
+```bash
+export NAMESPACE=<namespace>
+export POD=<worker-pod>
+
+kubectl get pod "$POD" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.annotations.nvidia\.com/topology-label-key}{"\n"}'
+
+kubectl get pod "$POD" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
+
+kubectl exec "$POD" -n "$NAMESPACE" -- \
+  sh -c 'find /etc/dynamo/topology -maxdepth 1 -type f -print -exec cat {} \;'
+```
+
+Expected results:
+
+- The annotation value is the configured `labelKey`.
+- The worker pod has the copied topology label.
+- `/etc/dynamo/topology/<domain>` exists and contains the topology value.
+
+Worker logs should include topology config during startup:
+
+```bash
+kubectl logs "$POD" -n "$NAMESPACE" | grep -i "Topology config"
+```
+
+## Troubleshooting
+
+### Pod Has No Copied Topology Label
+
+Check whether the node has the configured label:
+
+```bash
+NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
+kubectl get node "$NODE" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
+```
+
+If the label is missing, the topology-label controller emits a warning event
+with reason `TopologyLabelMissing` and leaves topology metadata unavailable for
+that worker.
+
+```bash
+kubectl get events -n "$NAMESPACE" \
+  --field-selector involvedObject.name="$POD",reason=TopologyLabelMissing
+```
+
+### Worker Exits While Waiting for Topology
+
+When topology is enabled, the worker waits for the transfer-domain file to
+appear and contain data. If it stays empty, check:
+
+- `spec.experimental.kvTransferPolicy.domain` matches the projected file name.
+- `spec.experimental.kvTransferPolicy.labelKey` exists on the worker's node.
+- The worker pod has the `nvidia.com/topology-label-key` annotation.
+- The topology-label controller is running and has node `get` RBAC.
+
+### Required Policy Fails Requests
+
+With `enforcement: required`, decode routing fails if no decode worker has the
+same generated topology taint as the selected prefill worker. Verify both
+prefill and decode workers publish the same `domain` and that at least one
+decode worker exists in each domain where prefill workers can be selected.
+
+Use `preferred` while validating a heterogeneous rollout if cross-domain routing
+is acceptable during partial capacity.
+
+## Relationship to Topology Aware Scheduling
+
+[Topology Aware Scheduling](topology-aware-scheduling.md) controls where
+Kubernetes places pods. Topology-aware KV transfer controls how Dynamo routes
+between already-running prefill and decode workers.
+
+Use them together when possible:
+
+- Topology Aware Scheduling keeps workers placed inside useful topology
+  boundaries.
+- Topology-aware KV transfer prevents the router from choosing a decode worker
+  outside the selected prefill worker's transfer domain.

--- a/docs/kubernetes/topology-aware-kv-transfer.md
+++ b/docs/kubernetes/topology-aware-kv-transfer.md
@@ -7,21 +7,15 @@ subtitle: Keep disaggregated prefill and decode KV-cache transfers within a sele
 
 # Topology-Aware KV Transfer
 
-Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode
-requests toward workers that share the selected prefill worker's topology
-domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers
-when prefill and decode workers exchange KV data over NIXL.
+Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode requests toward workers that share the selected prefill worker's topology domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers when prefill and decode workers exchange KV data over NIXL.
 
 Use this feature when:
 
 - Your deployment uses separate prefill and decode workers.
-- Your cluster exposes useful node labels, such as `topology.kubernetes.io/zone`
-  or a rack/block label.
-- Same-domain KV transfer is required for correctness or strongly preferred for
-  latency and bandwidth.
+- Your cluster exposes useful node labels, such as `topology.kubernetes.io/zone` or a rack/block label.
+- Same-domain KV transfer is required for correctness or strongly preferred for latency and bandwidth.
 
-This page covers the Kubernetes operator path. For router and runtime behavior,
-see [Router Topology-Aware KV Transfer](../components/router/topology-aware-kv-transfer.md).
+This page covers the Kubernetes operator path. For router and runtime behavior, see [Router Topology-Aware KV Transfer](../components/router/topology-aware-kv-transfer.md).
 For RDMA/NIXL transport setup, see [Disagg Communication](disagg-communication-guide.md).
 
 ## How It Works
@@ -37,20 +31,14 @@ flowchart LR
     Prefill --> Decode["Decode router selects same or preferred topology"]
 ```
 
-The operator configures worker pods from
-`spec.experimental.kvTransferPolicy`:
+The operator configures worker pods from `spec.experimental.kvTransferPolicy`:
 
 - Adds a `nvidia.com/topology-label-key` annotation to worker pods.
-- Runs a topology-label controller that copies the configured node label onto
-  the worker pod after scheduling.
-- Projects that pod label into `/etc/dynamo/topology/<domain>` with a Downward
-  API volume.
-- Injects worker environment variables that tell the backend runtime which
-  topology domain and enforcement policy to publish.
+- Runs a topology-label controller that copies the configured node label onto the worker pod after scheduling.
+- Projects that pod label into `/etc/dynamo/topology/<domain>` with a Downward API volume.
+- Injects worker environment variables that tell the backend runtime which topology domain and enforcement policy to publish.
 
-The frontend does not read this policy from its own environment. Workers publish
-the topology metadata in their `ModelRuntimeConfig`; the router reads it from
-runtime discovery.
+The frontend does not read this policy from its own environment. Workers publish the topology metadata in their `ModelRuntimeConfig`; the router reads it from runtime discovery.
 
 ## Prerequisites
 
@@ -70,10 +58,7 @@ kubectl get nodes -L topology.kubernetes.io/zone
 
 ## Required Same-Domain Routing
 
-`enforcement: required` constrains decode worker selection to workers whose
-topology value matches the selected prefill worker for the configured domain.
-If no decode worker satisfies the generated constraint, the router fails the
-request instead of silently crossing the domain.
+`enforcement: required` constrains decode worker selection to workers whose topology value matches the selected prefill worker for the configured domain. If no decode worker satisfies the generated constraint, the router fails the request instead of silently crossing the domain.
 
 ```yaml
 apiVersion: nvidia.com/v1beta1
@@ -125,8 +110,7 @@ spec:
 
 ## Preferred Same-Domain Routing
 
-`enforcement: preferred` keeps all decode workers eligible but biases worker
-selection toward the same topology domain.
+`enforcement: preferred` keeps all decode workers eligible but biases worker selection toward the same topology domain.
 
 ```yaml
 spec:
@@ -138,36 +122,7 @@ spec:
       preferredWeight: 0.85
 ```
 
-`preferredWeight` is required with `enforcement: preferred`. It must be between
-`0` and `1`. A higher value creates a stronger same-domain preference, but it is
-not a probability and does not guarantee same-domain selection.
-
-## DGDR Override Example
-
-If you deploy through `DynamoGraphDeploymentRequest`, add the policy through
-`spec.overrides.dgd` so it is applied to the generated
-`DynamoGraphDeployment`:
-
-```yaml
-apiVersion: nvidia.com/v1beta1
-kind: DynamoGraphDeploymentRequest
-metadata:
-  name: qwen3-disagg-zone
-spec:
-  model: Qwen/Qwen3-0.6B
-  backend: vllm
-  image: nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1
-  overrides:
-    dgd:
-      apiVersion: nvidia.com/v1beta1
-      kind: DynamoGraphDeployment
-      spec:
-        experimental:
-          kvTransferPolicy:
-            labelKey: topology.kubernetes.io/zone
-            domain: zone
-            enforcement: required
-```
+`preferredWeight` is required with `enforcement: preferred`. It must be between `0` and `1`. A higher value creates a stronger same-domain preference, but it is not a probability and does not guarantee same-domain selection.
 
 ## Field Reference
 
@@ -178,9 +133,7 @@ spec:
 | `enforcement` | No | `required` or `preferred`. Defaults to `required`. |
 | `preferredWeight` | Only with `preferred` | Bias weight from `0` to `1`; only valid with `enforcement: preferred`. |
 
-The runtime uses `domain`, not the Kubernetes label key, when creating routing
-constraints. For example, `labelKey: topology.kubernetes.io/zone` and
-`domain: zone` produce worker topology metadata like:
+The runtime uses `domain`, not the Kubernetes label key, when creating routing constraints. For example, `labelKey: topology.kubernetes.io/zone` and `domain: zone` produce worker topology metadata like:
 
 ```json
 {
@@ -194,8 +147,7 @@ constraints. For example, `labelKey: topology.kubernetes.io/zone` and
 
 ## Verify the Deployment
 
-After the DGD creates worker pods, verify the operator pipeline from node label
-to runtime topology file.
+After the DGD creates worker pods, verify the operator pipeline from node label to runtime topology file.
 
 ```bash
 export NAMESPACE=<namespace>
@@ -234,9 +186,7 @@ NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
 kubectl get node "$NODE" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
 ```
 
-If the label is missing, the topology-label controller emits a warning event
-with reason `TopologyLabelMissing` and leaves topology metadata unavailable for
-that worker.
+If the label is missing, the topology-label controller emits a warning event with reason `TopologyLabelMissing` and leaves topology metadata unavailable for that worker.
 
 ```bash
 kubectl get events -n "$NAMESPACE" \
@@ -245,8 +195,7 @@ kubectl get events -n "$NAMESPACE" \
 
 ### Worker Exits While Waiting for Topology
 
-When topology is enabled, the worker waits for the transfer-domain file to
-appear and contain data. If it stays empty, check:
+When topology is enabled, the worker waits for the transfer-domain file to appear and contain data. If it stays empty, check:
 
 - `spec.experimental.kvTransferPolicy.domain` matches the projected file name.
 - `spec.experimental.kvTransferPolicy.labelKey` exists on the worker's node.
@@ -255,23 +204,15 @@ appear and contain data. If it stays empty, check:
 
 ### Required Policy Fails Requests
 
-With `enforcement: required`, decode routing fails if no decode worker has the
-same generated topology taint as the selected prefill worker. Verify both
-prefill and decode workers publish the same `domain` and that at least one
-decode worker exists in each domain where prefill workers can be selected.
+With `enforcement: required`, decode routing fails if no decode worker has the same generated topology taint as the selected prefill worker. Verify both prefill and decode workers publish the same `domain` and that at least one decode worker exists in each domain where prefill workers can be selected.
 
-Use `preferred` while validating a heterogeneous rollout if cross-domain routing
-is acceptable during partial capacity.
+Use `preferred` while validating a heterogeneous rollout if cross-domain routing is acceptable during partial capacity.
 
 ## Relationship to Topology Aware Scheduling
 
-[Topology Aware Scheduling](topology-aware-scheduling.md) controls where
-Kubernetes places pods. Topology-aware KV transfer controls how Dynamo routes
-between already-running prefill and decode workers.
+[Topology Aware Scheduling](topology-aware-scheduling.md) controls where Kubernetes places pods. Topology-aware KV transfer controls how Dynamo routes between already-running prefill and decode workers.
 
 Use them together when possible:
 
-- Topology Aware Scheduling keeps workers placed inside useful topology
-  boundaries.
-- Topology-aware KV transfer prevents the router from choosing a decode worker
-  outside the selected prefill worker's transfer domain.
+- Topology Aware Scheduling keeps workers placed inside useful topology boundaries.
+- Topology-aware KV transfer prevents the router from choosing a decode worker outside the selected prefill worker's transfer domain.

--- a/docs/kubernetes/topology-aware-scheduling.md
+++ b/docs/kubernetes/topology-aware-scheduling.md
@@ -8,9 +8,7 @@ Topology Aware Scheduling (TAS) lets you control where Dynamo places inference w
 
 TAS is **opt-in**. Existing deployments without topology constraints continue to work unchanged.
 
-TAS controls pod placement. To constrain or bias the Dynamo router's
-prefill-to-decode handoff after pods are already running, see
-[Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
+TAS controls pod placement. To constrain or bias the Dynamo router's prefill-to-decode handoff after pods are already running, see [Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
 
 ## Prerequisites
 

--- a/docs/kubernetes/topology-aware-scheduling.md
+++ b/docs/kubernetes/topology-aware-scheduling.md
@@ -8,6 +8,10 @@ Topology Aware Scheduling (TAS) lets you control where Dynamo places inference w
 
 TAS is **opt-in**. Existing deployments without topology constraints continue to work unchanged.
 
+TAS controls pod placement. To constrain or bias the Dynamo router's
+prefill-to-decode handoff after pods are already running, see
+[Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
+
 ## Prerequisites
 
 | Requirement | Details |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -52,6 +52,8 @@ title: Glossary
 
 **KVPublisher** - Dynamo component that emits KV cache events (stored/removed) from individual workers to the global KVIndexer.
 
+**KV Transfer Policy** - Kubernetes DGD policy under `spec.experimental.kvTransferPolicy` that tells Dynamo which worker topology domain to use for disaggregated prefill-to-decode KV-cache transfer routing.
+
 ## L
 
 **LoRA (Low-Rank Adaptation)** - A fine-tuning technique for serving specialized model variants without duplicating full model weights. Dynamo supports dynamic loading and serving of LoRA adapters at runtime using worker APIs (for example, to load/unload,or for discovery in /v1/models).
@@ -95,6 +97,12 @@ title: Glossary
 **TensorRT-LLM** - NVIDIA's optimized LLM inference engine with multinode MPI distributed support.
 
 **Time-To-First-Token (TTFT)** - The latency from receiving a request to generating the first output token.
+
+**Topology-Aware KV Transfer** - Dynamo routing behavior that constrains or biases decode worker selection toward workers sharing the selected prefill worker's topology domain.
+
+**Topology Domain** - A logical level in the cluster topology, such as `zone` or `rack`. For topology-aware KV transfer, workers publish domain values in `ModelRuntimeConfig.topology_domains`.
+
+**Topology Taint** - A canonical worker taint generated from topology metadata in the form `dynamo.topology/<domain>=<value>`. The router uses these taints through normal `RoutingConstraints`.
 
 ## V
 **vLLM** - High-throughput LLM serving engine with distributed tensor/pipeline parallelism and PagedAttention.


### PR DESCRIPTION
#### Overview:

Adds documentation for topology-aware KV transfer: Kubernetes deployment setup, router/runtime semantics, and Fern sidebar indexing.

#### Details:

- Adds a Kubernetes deployment guide for `spec.experimental.kvTransferPolicy`, required vs preferred enforcement, verification, and troubleshooting.
- Adds a router/runtime guide covering `ModelRuntimeConfig` topology metadata, worker env/file contracts, generated topology taints, and decode `RoutingConstraints` behavior.
- Wires both pages into `docs/index.yml` so Fern publishes them under:
  - Kubernetes Deployment -> Deployment Guide -> Topology-Aware KV Transfer
  - Components -> Router -> Topology-Aware KV Transfer
- Adds cross-links from disaggregated serving, router configuration, disagg communication, topology-aware scheduling, and glossary entries.

#### Where should the reviewer start?

- `docs/kubernetes/topology-aware-kv-transfer.md`
- `docs/components/router/topology-aware-kv-transfer.md`
- `docs/index.yml`

#### Validation:

- `git diff --check`
- `python3 .github/workflows/detect_broken_links.py --format json --check-symlinks --output /tmp/dynamo-broken-links.json docs`

Fern CLI was not run locally because `fern` and `npm` are not installed in this environment.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to DYN-2985
- Relates to DYN-2986
- Relates to DYN-2987
- Relates to DYN-2988
- Relates to DYN-2989
- Relates to DYN-2990
- Relates to DYN-3070
- Relates to #9118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Topology-aware KV transfer capability for disaggregated prefill-decode routing, allowing KV transfers to remain within chosen topology domains (zones, racks).

* **Documentation**
  * Added comprehensive guides for topology-aware KV transfer configuration, deployment, and troubleshooting.
  * Added Kubernetes deployment documentation with configuration examples and verification commands.
  * Updated router configuration and disaggregated serving documentation with topology-aware KV transfer guidance.
  * Added glossary terms for topology-related concepts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->