### PR TITLE
test(ci): VRAM-aware GPU test scheduler + CPU cap + 3x timeout retune

### DIFF
--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
 ]
 
 MODEL = "Qwen/Qwen3-0.6B"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
@@ -39,7 +39,7 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.unified,
     pytest.mark.gpu_1,
-    pytest.mark.timeout(300),
+    pytest.mark.timeout(320),  # 3x ~104s (trtllm gpu_1 log)
     pytest.mark.skipif(
         importlib.util.find_spec("tensorrt_llm") is None,
         reason="tensorrt_llm not installed in this container",

--- a/components/src/dynamo/vllm/tests/omni/test_omni_args.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_args.py
@@ -24,6 +24,7 @@ pytestmark = [
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
 ]
 
 _DIFFUSION_FIELDS = {f.name for f in dataclasses.fields(OmniDiffusionKwargs)}

--- a/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_disagg_types.py
@@ -21,6 +21,7 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
@@ -22,6 +22,7 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -31,6 +31,7 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
 ]
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -24,6 +24,7 @@ pytestmark = [
     pytest.mark.xpu_1,
     pytest.mark.pre_merge,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
 ]
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -44,6 +44,7 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.xpu_1,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
     pytest.mark.pre_merge,
 ]
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -20,6 +20,7 @@ pytestmark = [
     pytest.mark.gpu_1,
     pytest.mark.xpu_1,
     pytest.mark.profiled_vram_gib(0),
+    pytest.mark.timeout(180),  # 0-GiB unit tests, floor 180s
     pytest.mark.pre_merge,
 ]
 

--- a/tests/frontend/test_vllm_prepost_integration.py
+++ b/tests/frontend/test_vllm_prepost_integration.py
@@ -215,7 +215,7 @@ def start_services(
             yield frontend_port, capture_path
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)  # 0-GiB unit test, floor 180s (3x observed 43s)
 def test_vllm_chat_processor_tokenizes_and_streams_tool_calls(
     start_services: tuple[int, Path],
 ) -> None:
@@ -280,7 +280,7 @@ def test_vllm_chat_processor_tokenizes_and_streams_tool_calls(
     assert set(finish_reasons) <= {"stop", "tool_calls"}
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)  # 0-GiB unit test, floor 180s (3x observed 43s)
 def test_vllm_chat_processor_forwards_max_thinking_tokens(
     start_services: tuple[int, Path],
 ) -> None:

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -120,7 +120,9 @@ def tester(llm_server_kvbm):  # noqa: F811
 )
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(140)  # 4x measured (~34s), rounded up
+@pytest.mark.timeout(
+    300
+)  # 3x observed 100s under GPU-parallel load (job-log 2026-05-29)
 def test_chunked_prefill_offload(tester, llm_server_kvbm):  # noqa: F811
     """
     Validate that chunked prefill blocks are offloaded.

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -120,9 +120,7 @@ def tester(llm_server_kvbm):  # noqa: F811
 )
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(
-    300
-)  # 3x observed 100s under GPU-parallel load (job-log 2026-05-29)
+@pytest.mark.timeout(330)  # 3x ~109s under new scheduler (3d1554f)
 def test_chunked_prefill_offload(tester, llm_server_kvbm):  # noqa: F811
     """
     Validate that chunked prefill blocks are offloaded.

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -116,9 +116,7 @@ def tester(llm_server_kvbm):  # noqa: F811
 @pytest.mark.parametrize("llm_server_kvbm", [{"model": KVBM_TEST_MODEL}], indirect=True)
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(
-    320
-)  # 3x observed 104s under GPU-parallel load (job-log 2026-05-29)
+@pytest.mark.timeout(410)  # 3x ~135s under new scheduler (3d1554f)
 def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     """
     Test offload → cache reset → onboard cycle with determinism verification.
@@ -187,9 +185,7 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
 )
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(
-    320
-)  # 3x observed 105s under GPU-parallel load (job-log 2026-05-29)
+@pytest.mark.timeout(420)  # 3x ~137s under new scheduler (3d1554f)
 def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     """
     Test GPU cache eviction mechanics.
@@ -266,9 +262,7 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 )
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(
-    240
-)  # 3x observed 77s under GPU-parallel load (job-log 2026-05-29)
+@pytest.mark.timeout(250)  # 3x ~83s under new scheduler (3d1554f)
 def test_onboarding_determinism(tester, llm_server_kvbm):  # noqa: F811
     """
     Test onboarding determinism under eviction scenario.

--- a/tests/kvbm_integration/test_kvbm.py
+++ b/tests/kvbm_integration/test_kvbm.py
@@ -116,7 +116,9 @@ def tester(llm_server_kvbm):  # noqa: F811
 @pytest.mark.parametrize("llm_server_kvbm", [{"model": KVBM_TEST_MODEL}], indirect=True)
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(170)  # 4x measured (~41s), rounded up
+@pytest.mark.timeout(
+    320
+)  # 3x observed 104s under GPU-parallel load (job-log 2026-05-29)
 def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
     """
     Test offload → cache reset → onboard cycle with determinism verification.
@@ -185,7 +187,9 @@ def test_offload_and_onboard(tester, llm_server_kvbm):  # noqa: F811
 )
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(170)  # 4x measured (~42s), rounded up
+@pytest.mark.timeout(
+    320
+)  # 3x observed 105s under GPU-parallel load (job-log 2026-05-29)
 def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
     """
     Test GPU cache eviction mechanics.
@@ -262,7 +266,9 @@ def test_gpu_cache_eviction(tester, llm_server_kvbm):  # noqa: F811
 )
 @pytest.mark.profiled_vram_gib(3.8)
 @pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000)
-@pytest.mark.timeout(160)  # 4x measured (~39s), rounded up
+@pytest.mark.timeout(
+    240
+)  # 3x observed 77s under GPU-parallel load (job-log 2026-05-29)
 def test_onboarding_determinism(tester, llm_server_kvbm):  # noqa: F811
     """
     Test onboarding determinism under eviction scenario.

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -252,7 +252,7 @@ class SGLangProcess(ManagedEngineProcessMixin):
 @pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
-@pytest.mark.timeout(150)  # ~3x average (~46s/test), rounded up
+@pytest.mark.timeout(270)  # 3x ~89s (sglang gpu_1 log)
 def test_sglang_kv_router_basic(
     request,
     runtime_services_dynamic_ports,
@@ -399,7 +399,7 @@ def test_router_decisions_sglang_disagg(
     ids=["nats_core"],
     indirect=["durable_kv_events", "request_plane"],
 )
-@pytest.mark.timeout(150)  # ~3x average (~46s/test), rounded up
+@pytest.mark.timeout(320)  # 3x ~106s (sglang gpu_1 log)
 def test_sglang_indexers_sync(
     request,
     runtime_services_dynamic_ports,

--- a/tests/router/test_router_e2e_with_unified.py
+++ b/tests/router/test_router_e2e_with_unified.py
@@ -253,7 +253,7 @@ def test_unified_vllm_router_decisions_dp(
 @pytest.mark.model(SGLANG_MODEL_NAME)
 @pytest.mark.profiled_vram_gib(12.0)
 @pytest.mark.requested_sglang_kv_tokens(2048)
-@pytest.mark.timeout(360)
+@pytest.mark.timeout(400)  # 3x ~131s sglang (gpu_1 log)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 def test_unified_sglang_kv_router_basic(
     request,

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -645,9 +645,7 @@ def test_router_decisions_vllm_disagg(
 @pytest.mark.requested_vllm_kv_cache_bytes(
     331_801_000
 )  # KV cache cap (2x safety over min=165_900_288)
-@pytest.mark.timeout(
-    410
-)  # 3x observed 136s under GPU-parallel load (job-log 2026-05-29)
+@pytest.mark.timeout(690)  # 3x ~230s under new scheduler (3d1554f)
 @pytest.mark.parametrize(
     "store_backend,durable_kv_events,request_plane",
     [

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -645,7 +645,9 @@ def test_router_decisions_vllm_disagg(
 @pytest.mark.requested_vllm_kv_cache_bytes(
     331_801_000
 )  # KV cache cap (2x safety over min=165_900_288)
-@pytest.mark.timeout(360)  # vLLM 0.20.x startup can exceed 150s on contended CI runners
+@pytest.mark.timeout(
+    410
+)  # 3x observed 136s under GPU-parallel load (job-log 2026-05-29)
 @pytest.mark.parametrize(
     "store_backend,durable_kv_events,request_plane",
     [

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -307,7 +307,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
-                timeout_s=300,
+                # 3x observed 192s under GPU-parallel load (job-log 2026-05-29);
+                # was 300 (~1.6x), which under-ranked this 12 GiB test in the LPT
+                # scheduler and pushed it onto the tail of the run.
+                timeout_s=580,
                 profiled_vram_gib=12.0,
                 requested_vllm_kv_cache_bytes=922_354_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -307,10 +307,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
-                # 3x observed 192s under GPU-parallel load (job-log 2026-05-29);
-                # was 300 (~1.6x), which under-ranked this 12 GiB test in the LPT
-                # scheduler and pushed it onto the tail of the run.
-                timeout_s=580,
+                # 3x ~221s under the new scheduler (job-log 3d1554f); was 300
+                # (~1.6x) and under-ranked this 12 GiB test in the LPT scheduler,
+                # pushing it onto the tail of the run.
+                timeout_s=670,
                 profiled_vram_gib=12.0,
                 requested_vllm_kv_cache_bytes=922_354_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -87,7 +87,7 @@ sglang_configs = {
             # SGLang 0.5.11 silently hangs (no scheduler activity, no error)
             # when prompt+max_tokens nears max_total_tokens. Bisected hang
             # threshold ~1040 for these payloads; 2048 leaves headroom.
-            pytest.mark.timeout(195),  # profiled 33s on RTX 6000 Ada
+            pytest.mark.timeout(360),  # 3x ~119s (sglang gpu_1 log)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -120,7 +120,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.7),
             pytest.mark.requested_sglang_kv_tokens(2048),  # see "aggregated" above
-            pytest.mark.timeout(195),
+            pytest.mark.timeout(340),  # 3x ~111s (sglang gpu_1 log)
             pytest.mark.pre_merge,
             pytest.mark.unified,
         ],
@@ -168,7 +168,7 @@ sglang_configs = {
             ),  # KV cache cap (2x safety over min=18736)
             # Local repro took ~289s wall time with worker readiness reaching
             # "ready" at ~176s on a warm-cache RTX 6000 Ada.
-            pytest.mark.timeout(420),
+            pytest.mark.timeout(470),  # 3x ~155s (sglang gpu_1 log)
             pytest.mark.pre_merge,
             pytest.mark.skipif(
                 _is_cuda13(),
@@ -209,7 +209,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(13.0),
             pytest.mark.requested_sglang_kv_tokens(37472),
-            pytest.mark.timeout(420),
+            pytest.mark.timeout(470),  # 3x ~156s (sglang gpu_1 log)
             pytest.mark.post_merge,
             pytest.mark.skipif(
                 _is_cuda13(),
@@ -236,7 +236,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(13.0),
             pytest.mark.requested_sglang_kv_tokens(37472),
-            pytest.mark.timeout(420),
+            pytest.mark.timeout(470),  # 3x ~151s (sglang gpu_1 log)
             pytest.mark.post_merge,
             pytest.mark.skipif(
                 _is_cuda13(),
@@ -359,7 +359,7 @@ sglang_configs = {
             pytest.mark.requested_sglang_kv_tokens(
                 1024
             ),  # KV cache cap (2x safety over min=512)
-            pytest.mark.timeout(222),  # profiled 37s on RTX 6000 Ada
+            pytest.mark.timeout(280),  # 3x ~92s (sglang gpu_1 log)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-VL-2B-Instruct",
@@ -404,7 +404,7 @@ sglang_configs = {
             # processor) + 100-token max response + headroom.
             # TODO: bisect via tests/utils/profile_pytest.py for a tighter bound.
             pytest.mark.requested_sglang_kv_tokens(4096),
-            pytest.mark.timeout(300),
+            pytest.mark.timeout(320),  # 3x ~104s (sglang gpu_1 log)
             # post_merge: NIXL stubs outside docker can lack the Decoded
             # transport path. Same gating as vLLM's FD case
             # (tests/serve/multimodal_profiles/vllm.py:67-70).
@@ -501,7 +501,7 @@ sglang_configs = {
             # and peaks at ~35 GiB (won't fit L4).
             pytest.mark.profiled_vram_gib(20.5),
             pytest.mark.requested_sglang_kv_tokens(8736),
-            pytest.mark.timeout(360),
+            pytest.mark.timeout(390),  # 3x ~127s (sglang gpu_1 log)
             pytest.mark.post_merge,
         ],
         model="Qwen/Qwen2-VL-7B-Instruct",
@@ -655,7 +655,7 @@ sglang_configs = {
             # SGLang 0.5.11 silently hangs when prompt+max_tokens nears
             # max_total_tokens (bisected ~1040 for these payloads). Matches
             # the "aggregated" config above.
-            pytest.mark.timeout(341),  # profiled 57s on RTX 6000 Ada
+            pytest.mark.timeout(750),  # 3x ~249s (sglang gpu_1 log)
             pytest.mark.post_merge,
         ],
         model="deepseek-ai/deepseek-llm-7b-base",
@@ -859,7 +859,7 @@ def lora_chat_payload(
 @pytest.mark.model(DEFAULT_LORA_REPO)
 @pytest.mark.profiled_vram_gib(4.7)
 @pytest.mark.requested_sglang_kv_tokens(2848)
-@pytest.mark.timeout(158)
+@pytest.mark.timeout(240)  # 3x ~79s (sglang gpu_1 log)
 @pytest.mark.pre_merge
 def test_sglang_lora_aggregated(
     request,

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -60,7 +60,7 @@ trtllm_configs = {
                 2592
             ),  # KV cache cap (2x safety over min=1296)
             pytest.mark.timeout(
-                300
+                650
             ),  # 3x measured time (44.66s) + download time (150s)
         ],
         model="Qwen/Qwen3-0.6B",
@@ -94,7 +94,7 @@ trtllm_configs = {
             pytest.mark.trtllm,
             pytest.mark.profiled_vram_gib(3.9),
             pytest.mark.requested_trtllm_kv_tokens(2592),
-            pytest.mark.timeout(300),
+            pytest.mark.timeout(600),  # 3x ~200s (trtllm gpu_1 log)
             pytest.mark.pre_merge,
             pytest.mark.unified,
         ],
@@ -169,7 +169,7 @@ trtllm_configs = {
             pytest.mark.requested_trtllm_kv_tokens(
                 2592
             ),  # KV cache cap (2x safety over min=1296)
-            pytest.mark.timeout(300),  # 3x measured time (~44s) + download time (150s)
+            pytest.mark.timeout(440),  # 3x ~145s (trtllm gpu_1 log)
         ],
         model="Qwen/Qwen3-0.6B",
         frontend_port=DefaultPort.FRONTEND.value,
@@ -212,7 +212,7 @@ trtllm_configs = {
             pytest.mark.profiled_vram_gib(3.9),
             pytest.mark.requested_trtllm_kv_tokens(2592),
             pytest.mark.timeout(
-                300
+                360
             ),  # 3x measured time (37.91s) + download time (180s)
         ],
         model="Qwen/Qwen3-0.6B",

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -111,9 +111,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(
-                510
-            ),  # 3x observed 168s under GPU-parallel load (job-log 2026-05-29)
+            pytest.mark.timeout(610),  # 3x ~203s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -163,7 +161,7 @@ vllm_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),
             pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000),
-            pytest.mark.timeout(510),  # 3x observed 170s (job-log 2026-05-29)
+            pytest.mark.timeout(610),  # 3x ~203s unified, new scheduler (3d1554f)
             pytest.mark.pre_merge,
             pytest.mark.unified,
         ],
@@ -218,9 +216,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(
-                550
-            ),  # 3x observed 182s under GPU-parallel load (job-log 2026-05-29)
+            pytest.mark.timeout(600),  # 3x ~200s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -244,9 +240,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(
-                540
-            ),  # 3x observed 177s under GPU-parallel load (job-log 2026-05-29)
+            pytest.mark.timeout(600),  # 3x ~199s multiproc, new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -272,9 +266,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(
-                570
-            ),  # 3x observed 187s under GPU-parallel load (job-log 2026-05-29)
+            pytest.mark.timeout(640),  # 3x ~213s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -296,9 +288,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(
-                500
-            ),  # 3x observed 165s under GPU-parallel load (job-log 2026-05-29)
+            pytest.mark.timeout(600),  # 3x ~199s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -598,7 +588,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(210),  # 3x observed 67s (job-log 2026-05-29)
+            pytest.mark.timeout(220),  # 3x ~72s under new scheduler (3d1554f)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -112,8 +112,8 @@ vllm_configs = {
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
             pytest.mark.timeout(
-                480
-            ),  # vLLM 0.20.x startup can exceed 360s on contended CI runners
+                510
+            ),  # 3x observed 168s under GPU-parallel load (job-log 2026-05-29)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -163,7 +163,7 @@ vllm_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),
             pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000),
-            pytest.mark.timeout(480),
+            pytest.mark.timeout(510),  # 3x observed 170s (job-log 2026-05-29)
             pytest.mark.pre_merge,
             pytest.mark.unified,
         ],
@@ -218,7 +218,9 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(360),  # ~7x observed 49.0s; old value before profiling
+            pytest.mark.timeout(
+                550
+            ),  # 3x observed 182s under GPU-parallel load (job-log 2026-05-29)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -242,7 +244,9 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(360),  # ~7x observed 49.3s; old value before profiling
+            pytest.mark.timeout(
+                540
+            ),  # 3x observed 177s under GPU-parallel load (job-log 2026-05-29)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -268,7 +272,9 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(360),
+            pytest.mark.timeout(
+                570
+            ),  # 3x observed 187s under GPU-parallel load (job-log 2026-05-29)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -291,8 +297,8 @@ vllm_configs = {
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
             pytest.mark.timeout(
-                360
-            ),  # ~8x observed 43.0s; bumped for GPU-parallel headroom
+                500
+            ),  # 3x observed 165s under GPU-parallel load (job-log 2026-05-29)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -592,7 +598,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_119_388_000
             ),  # KV cache cap (2x safety over min=559_693_824)
-            pytest.mark.timeout(180),  # vLLM 0.20.x needs more CI headroom
+            pytest.mark.timeout(210),  # 3x observed 67s (job-log 2026-05-29)
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
@@ -647,6 +653,7 @@ vllm_configs = {
             pytest.mark.requested_vllm_kv_cache_bytes(559_693_824),
             # Cold model load + vLLM startup + warmup for embedding pooling.
             # Mirrors SGLang's 300s embedding-test timeout; refine after profiling.
+            # 360 already >= 3x observed 92s (job-log 2026-05-29); left as headroom.
             pytest.mark.timeout(360),
             pytest.mark.pre_merge,
         ],

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -35,8 +35,6 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import pynvml
-
 _repo_root = str(Path(__file__).resolve().parents[2])
 if _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
@@ -66,6 +64,16 @@ class _TestEntry:
     w_id: int = 0
     assigned_gpu: int | None = None
     retries: int = 0
+
+    @property
+    def est_duration(self) -> float:
+        """Estimated runtime in seconds.
+
+        Repo convention sets ``@pytest.mark.timeout`` to ~3x a test's measured
+        runtime, so ``timeout / 3`` is the best a-priori duration estimate. The
+        scheduler orders longest-first (LPT) on this value to minimize makespan.
+        """
+        return self.timeout / 3.0
 
 
 @dataclass
@@ -235,6 +243,10 @@ def _collect_tests(pytest_args: list[str], max_vram_gib: float) -> list[str]:
 def _get_gpu_used_gib(gpu_index: int = 0) -> float:
     """Query actual GPU memory used via pynvml."""
     try:
+        import pynvml
+    except ImportError:
+        return 0.0
+    try:
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(gpu_index)
         mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -300,6 +312,136 @@ def _parse_cuda_visible(raw: str | None, available: list[dict]) -> list[int]:
             raise ValueError(f"GPU {idx} not found (available: {avail_indices})")
         indices.append(idx)
     return indices
+
+
+def _priority_key(test: _TestEntry) -> tuple[bool, float, float]:
+    """Scheduling-priority sort key (use with ``reverse=True``).
+
+    Ordered so that, highest priority first:
+      1. VRAM tests (``profiled_gib > 0``) come before zero-VRAM fillers, so the
+         memory-bound tests own the schedule and fillers only mop up spare slots.
+      2. Longest ``est_duration`` (= timeout/3) first (LPT) to minimize makespan.
+      3. Largest VRAM first, so a big test anchors an empty GPU at the full
+         single-proc cap and smaller tests pack alongside it.
+
+    Defined as a module function so ``run_parallel`` and its tests share one
+    definition and can't drift.
+    """
+    return (test.profiled_gib > 0, test.est_duration, test.profiled_gib)
+
+
+def _select_launches(
+    pending: list[_TestEntry],
+    gpu_states: dict[int, _GpuState],
+    actual_free: dict[int, float],
+    num_slots: int,
+    running_count: int,
+) -> list[tuple[int, int]]:
+    """Pick which pending tests to launch this pass, and on which GPU.
+
+    Pure (no NVML / no subprocesses): the caller passes the live per-GPU budget
+    state and the actual free VRAM (from nvidia-smi). ``pending`` must already be
+    in scheduling-priority order (VRAM tests by longest est_duration / largest
+    VRAM first, zero-VRAM fillers last -- see the sort in ``run_parallel``).
+
+    Returns a list of ``(pending_index, gpu_index)`` to launch now, honoring:
+
+      * ``num_slots`` -- global cap on concurrently running subprocesses.
+      * Per-GPU VRAM budget with two independent gates (same as before): a test
+        fits only if BOTH the reserved-budget sum AND the actual nvidia-smi
+        usage leave room under the cap. The cap is the full card for the first
+        test on an idle GPU, then ``budget_multi`` once it hosts 2+ (reserving
+        the multi-process margin for CUDA context overhead).
+      * Pairing -- best-fit places each VRAM test on the GPU with the most free
+        budget, so a large test that anchored an empty GPU gets backfilled with
+        smaller tests up to the budget instead of running alone.
+      * Anti-starvation -- when the highest-priority VRAM test does not fit, the
+        GPU where it is closest to fitting is *reserved* for it. Lower-priority
+        tests may still backfill that GPU, but only up to ``cap - required`` so
+        that once the current occupants free, the reserved test is guaranteed to
+        fit (the backfill we add now can never sum past the space it needs).
+        Zero-VRAM fillers bypass the budget gates entirely (they allocate no
+        memory) so transient memory pressure can't strand an otherwise-free slot.
+    """
+    tentative = {
+        gi: _TentativeGpu(
+            budget=gs.budget_used,
+            free=actual_free[gi],
+            count=gs.running_count,
+        )
+        for gi, gs in gpu_states.items()
+    }
+    # GPU -> required GiB of a blocked higher-priority VRAM test, and the budget
+    # we have since added to that GPU via lower-priority backfill. Backfill is
+    # capped at cap - required so the reserved test still fits once occupants free.
+    reserved_req: dict[int, float] = {}
+    backfill_added: dict[int, float] = {}
+    to_launch: list[tuple[int, int]] = []
+
+    def _cap(gi: int) -> float:
+        # First test on an idle GPU may use the whole card; once it hosts 2+,
+        # reserve the multi-process margin for CUDA context overhead.
+        gs = gpu_states[gi]
+        return gs.total_gib if tentative[gi].count < 1 else gs.budget_multi
+
+    for idx, test in enumerate(pending):
+        if running_count + len(to_launch) >= num_slots:
+            break
+
+        # Zero-VRAM filler: no budget impact, just needs a free slot. Place on
+        # the least-loaded GPU for balance; never reserves and is never blocked.
+        if test.profiled_gib <= 0:
+            gi = min(gpu_states, key=lambda g: tentative[g].count)
+            to_launch.append((idx, gi))
+            tentative[gi].count += 1
+            continue
+
+        # VRAM test: best-fit on the GPU with the most free budget that passes
+        # both gates and respects any reservation.
+        best_gi: int | None = None
+        best_avail = -1.0
+        for gi, gs in gpu_states.items():
+            ts = tentative[gi]
+            cap = _cap(gi)
+            avail = cap - ts.budget
+            if avail < test.profiled_gib:
+                continue  # reserved-budget gate
+            actual_used = gs.total_gib - ts.free
+            if actual_used + test.profiled_gib > cap:
+                continue  # actual-usage gate (catches init-time spikes)
+            if gi in reserved_req and (
+                backfill_added[gi] + test.profiled_gib > cap - reserved_req[gi]
+            ):
+                continue  # would crowd out the reserved higher-priority test
+            if avail > best_avail:
+                best_gi, best_avail = gi, avail
+
+        if best_gi is not None:
+            to_launch.append((idx, best_gi))
+            tentative[best_gi].budget += test.profiled_gib
+            tentative[best_gi].free -= test.profiled_gib
+            tentative[best_gi].count += 1
+            if best_gi in reserved_req:
+                backfill_added[best_gi] += test.profiled_gib
+            continue
+
+        # Blocked: reserve the GPU where this test is closest to fitting (most
+        # free budget), unless that GPU is already held for an even-higher-
+        # priority test. Keep scanning -- smaller tests may still fit elsewhere
+        # or backfill under the reservation, and fillers keep filling slots.
+        cand: int | None = None
+        cand_avail = -1.0
+        for gi in gpu_states:
+            if gi in reserved_req:
+                continue
+            a = _cap(gi) - tentative[gi].budget
+            if a > cand_avail:
+                cand, cand_avail = gi, a
+        if cand is not None:
+            reserved_req[cand] = test.profiled_gib
+            backfill_added[cand] = 0.0
+
+    return to_launch
 
 
 def run_parallel(
@@ -369,8 +511,16 @@ def run_parallel(
     skipped_tests = [t for t in tests if t.skip_reason is not None]
     tests = [t for t in tests if t.skip_reason is None]
 
-    # Sort by timeout descending (longest first to minimize tail latency)
-    tests.sort(key=lambda t: t.timeout, reverse=True)
+    # Scheduling priority (highest first):
+    #   1. VRAM tests (profiled_gib > 0) before zero-VRAM fillers, so the
+    #      memory-bound tests own the schedule; fillers only mop up spare slots
+    #      (they never consume the GPU budget, so they must not crowd a VRAM
+    #      test out of a concurrency slot).
+    #   2. Longest est_duration (= timeout/3) first (LPT) to minimize makespan.
+    #   3. Largest VRAM first, so a big test anchors an empty GPU at the full
+    #      single-proc cap and smaller tests pack into the remaining budget
+    #      alongside it instead of the big test running alone on the tail.
+    tests.sort(key=_priority_key, reverse=True)
 
     # Reject tests without a KV marker — without explicit memory control
     # they'd each grab the engine's default (e.g. vLLM 90%) and OOM when
@@ -688,64 +838,26 @@ def run_parallel(
                 next_status = now + 10
 
         # --- Launch pending tests ---
-        # For each pending test, find the GPU with most available budget.
-        # Gate on BOTH budget tracking AND actual GPU free memory.
-        # vLLM stagger is per-GPU only — tests on different GPUs launch
-        # simultaneously.
+        # _select_launches packs VRAM tests up to budget (pairing a big test
+        # with smaller ones), backfills spare slots with zero-VRAM fillers, and
+        # reserves space for a blocked high-priority test so it can't be starved
+        # onto the tail. The vLLM stagger below is per-GPU only — tests on
+        # different GPUs launch simultaneously.
         if pending and len(running) < num_slots:
             actual_free = {
                 gi: gs.total_gib - _get_gpu_used_gib(gi)
                 for gi, gs in gpu_states.items()
             }
-            tentative = {
-                gi: _TentativeGpu(
-                    budget=gs.budget_used,
-                    free=actual_free[gi],
-                    count=gs.running_count,
-                )
-                for gi, gs in gpu_states.items()
-            }
-
-            to_launch: list[tuple[int, int]] = []  # (pending_idx, gpu_idx)
-            n_total = len(running)
-            for i, test in enumerate(pending):
-                if n_total + len(to_launch) >= num_slots:
-                    break
-                best_gi: int | None = None
-                best_avail = -1.0
-                for gi, gs in gpu_states.items():
-                    ts = tentative[gi]
-                    will_be_multi = ts.count >= 1
-                    cap = gs.budget_multi if will_be_multi else gs.total_gib
-                    # Two independent gates against the SAME cap.  Both must
-                    # leave room for the new test or we skip this GPU.
-                    #   (1) Reserved-budget gate: sum of profiled markers of
-                    #       tests already on this GPU + this candidate must
-                    #       fit under cap.
-                    #   (2) Actual-usage gate: nvidia-smi current usage + this
-                    #       candidate must also fit under cap.  This catches
-                    #       transient peaks (e.g. multi-worker tests during
-                    #       model load) where actual usage exceeds the sum of
-                    #       steady-state markers.  Without this, the scheduler
-                    #       trusts markers and over-commits the GPU during
-                    #       init-time spikes.
-                    avail = cap - ts.budget
-                    if avail < test.profiled_gib:
-                        continue
-                    actual_used = gs.total_gib - ts.free
-                    if actual_used + test.profiled_gib > cap:
-                        continue
-                    if avail > best_avail:
-                        best_gi = gi
-                        best_avail = avail
-                if best_gi is not None:
-                    to_launch.append((i, best_gi))
-                    tentative[best_gi].budget += test.profiled_gib
-                    tentative[best_gi].free -= test.profiled_gib
-                    tentative[best_gi].count += 1
+            to_launch = _select_launches(
+                pending=pending,
+                gpu_states=gpu_states,
+                actual_free=actual_free,
+                num_slots=num_slots,
+                running_count=len(running),
+            )
 
             # Pop from pending in reverse to preserve indices, then reverse
-            # back so longest-timeout tests launch first.
+            # back so highest-priority tests launch first.
             batch: list[_TestEntry] = []
             for pending_idx, assigned_gpu in reversed(to_launch):
                 entry = pending.pop(pending_idx)

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -43,6 +43,7 @@ from tests.utils.vram_utils import (  # noqa: E402
     VRAM_MULTI_PROC_MARGIN,
     auto_worker_count,
     detect_gpus,
+    effective_cpu_budget,
     load_test_meta,
 )
 
@@ -468,6 +469,20 @@ def run_parallel(
     if not gpus:
         _print("ERROR: No GPUs detected")
         return 1
+
+    # xdist resolves `-n auto` from os.cpu_count(), which reports HOST cores and
+    # ignores Docker --cpus -- so num_slots can be many times the real CPU budget
+    # (e.g. 32 under --cpus=4). Combined with the zero-VRAM filler backfill that
+    # would oversubscribe the CPU and slow every concurrent test. Cap at the
+    # container's true CPU budget; raise NUM_CPUS (or --cpus) to allow more.
+    cpu_budget = effective_cpu_budget()
+    if num_slots > cpu_budget:
+        _print(
+            f"Capping concurrency: {num_slots} -> {cpu_budget} slots "
+            f"(CPU budget; raise NUM_CPUS to allow more)"
+        )
+        num_slots = cpu_budget
+    num_slots = max(1, num_slots)
 
     if gpu_indices is None:
         gpu_indices = [g["index"] for g in gpus]

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -47,8 +47,9 @@ def _t(name: str, profiled: float, timeout: float = 600.0) -> _TestEntry:
     return _TestEntry(id=name, name=name, profiled_gib=profiled, timeout=timeout)
 
 
-def _select(pending, gpus, *, num_slots, running_count=0):
-    actual_free = {gi: gs.total_gib - gs.budget_used for gi, gs in gpus.items()}
+def _select(pending, gpus, *, num_slots, running_count=0, actual_free=None):
+    if actual_free is None:
+        actual_free = {gi: gs.total_gib - gs.budget_used for gi, gs in gpus.items()}
     return _select_launches(
         pending=pending,
         gpu_states=gpus,
@@ -136,6 +137,22 @@ def test_slot_cap_is_global():
     launches = _select(pending, gpus, num_slots=2, running_count=1)
 
     assert len(launches) == 1  # 1 running + 1 new == 2 slots
+
+
+def test_actual_usage_gate_blocks_when_live_vram_exceeds_budget():
+    # The reserved-budget gate alone would allow a 13 GiB test (the GPU is idle
+    # by markers), but a live nvidia-smi reading of only 5 GiB free (an init
+    # spike or residual allocation the markers don't reflect) must block it via
+    # the independent actual-usage gate.
+    gpus = {0: _gpu(0, 22.0)}  # budget_used=0 -> reserved-budget gate allows 13
+    pending = [_t("big", 13.0)]
+
+    # Budget gate alone (actual_free defaults to total - budget = 22): launches.
+    assert _select(pending, gpus, num_slots=8) == [(0, 0)]
+
+    # Only 5 GiB actually free => 17 GiB live-used; 17 + 13 = 30 > 22 cap -> the
+    # actual-usage gate blocks the launch the budget gate would have allowed.
+    assert _select(pending, gpus, num_slots=8, actual_free={0: 5.0}) == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -365,6 +365,30 @@ def test_full_change_beats_status_quo():
     assert shipped <= 0.85 * status_quo  # >= 15% end-to-end makespan reduction
 
 
+# --------------------------------------------------------------------------- #
+# effective_cpu_budget: don't let -n auto (host os.cpu_count) oversubscribe CPU
+# --------------------------------------------------------------------------- #
+def test_effective_cpu_budget_prefers_num_cpus_env():
+    import os
+
+    from tests.utils.vram_utils import effective_cpu_budget
+
+    old = os.environ.get("NUM_CPUS")
+    try:
+        os.environ["NUM_CPUS"] = "4"
+        assert effective_cpu_budget() == 4
+        os.environ["NUM_CPUS"] = "7"
+        assert effective_cpu_budget() == 7
+        # Invalid value falls through to cgroup/os.cpu_count() and stays positive.
+        os.environ["NUM_CPUS"] = "bogus"
+        assert effective_cpu_budget() >= 1
+    finally:
+        if old is None:
+            os.environ.pop("NUM_CPUS", None)
+        else:
+            os.environ["NUM_CPUS"] = old
+
+
 def test_simulation_conserves_work_and_respects_budget():
     # Sanity guard for the simulator itself: every test runs, and makespan is at
     # least the longest single test and at least total-work / slots.

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit + makespan-simulation tests for the GPU-parallel scheduler.
+
+Covers the pure scheduling core (``_select_launches`` / ``_priority_key``) and a
+discrete-event makespan simulation on the real ``job-log.txt`` workload, showing
+the VRAM-aware ordering beats the legacy timeout-sorted first-fit. No GPU or
+``pynvml`` required -- the scheduler core is pure arithmetic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.utils.pytest_parallel_gpu import (
+    _GpuState,
+    _priority_key,
+    _select_launches,
+    _TestEntry,
+)
+from tests.utils.vram_utils import VRAM_MULTI_PROC_MARGIN
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _gpu(
+    index: int,
+    total_gib: float,
+    *,
+    budget_used: float = 0.0,
+    running_count: int = 0,
+) -> _GpuState:
+    return _GpuState(
+        index=index,
+        total_gib=total_gib,
+        budget_multi=total_gib * (1.0 - VRAM_MULTI_PROC_MARGIN),
+        budget_used=budget_used,
+        running_count=running_count,
+    )
+
+
+def _t(name: str, profiled: float, timeout: float = 600.0) -> _TestEntry:
+    return _TestEntry(id=name, name=name, profiled_gib=profiled, timeout=timeout)
+
+
+def _select(pending, gpus, *, num_slots, running_count=0):
+    actual_free = {gi: gs.total_gib - gs.budget_used for gi, gs in gpus.items()}
+    return _select_launches(
+        pending=pending,
+        gpu_states=gpus,
+        actual_free=actual_free,
+        num_slots=num_slots,
+        running_count=running_count,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _priority_key
+# --------------------------------------------------------------------------- #
+def test_priority_orders_vram_first_then_duration_then_size():
+    filler = _t("filler", 0.0, timeout=600)  # est 200s but zero VRAM
+    short_big = _t("short_big", 13.0, timeout=300)  # est 100s
+    long_small = _t("long_small", 3.8, timeout=1800)  # est 600s
+    long_big = _t("long_big", 7.6, timeout=1800)  # est 600s, ties long_small
+
+    ordered = sorted(
+        [filler, short_big, long_small, long_big], key=_priority_key, reverse=True
+    )
+    names = [t.name for t in ordered]
+
+    # VRAM tests all precede the filler.
+    assert names[-1] == "filler"
+    # Among VRAM tests: longest est_duration first; ties broken by larger VRAM.
+    assert names[:3] == ["long_big", "long_small", "short_big"]
+
+
+# --------------------------------------------------------------------------- #
+# _select_launches: pairing / packing
+# --------------------------------------------------------------------------- #
+def test_pairs_large_with_small_on_one_gpu():
+    # 22 GiB card, 19 GiB multi-proc budget. A 13 GiB test should anchor the GPU
+    # (full-card cap) and a 3.8 GiB test should pack alongside it; a second 3.8
+    # no longer fits (19 - 16.8 = 2.2).
+    gpus = {0: _gpu(0, 22.0)}
+    pending = [_t("big", 13.0), _t("small_a", 3.8), _t("small_b", 3.8)]
+
+    launches = _select(pending, gpus, num_slots=8)
+
+    assert launches == [(0, 0), (1, 0)]
+
+
+def test_first_test_uses_full_card_then_multi_proc_margin():
+    # A 20 GiB test fits only because it is first (full 24 GiB cap). Once it is
+    # placed the cap drops to budget_multi (20.4), so the 4 GiB test is rejected.
+    gpus = {0: _gpu(0, 24.0)}  # budget_multi = 20.4
+    pending = [_t("anchor", 20.0), _t("extra", 4.0)]
+
+    launches = _select(pending, gpus, num_slots=8)
+
+    assert launches == [(0, 0)]
+
+
+def test_multi_gpu_spreads_then_packs():
+    # Two 22 GiB cards. 13 anchors GPU0; 12 cannot share it (19-13<12) so it
+    # anchors GPU1; the 3.8 best-fits onto GPU1 (more free budget than GPU0).
+    gpus = {0: _gpu(0, 22.0), 1: _gpu(1, 22.0)}
+    pending = [_t("a", 13.0), _t("b", 12.0), _t("c", 3.8)]
+
+    launches = _select(pending, gpus, num_slots=8)
+
+    assert launches == [(0, 0), (1, 1), (2, 1)]
+
+
+# --------------------------------------------------------------------------- #
+# _select_launches: fillers
+# --------------------------------------------------------------------------- #
+def test_zero_vram_fillers_bypass_budget():
+    # GPU budget fully committed to a running VRAM test, yet 0-GiB fillers must
+    # still take free slots (they allocate no memory).
+    gpus = {0: _gpu(0, 22.0, budget_used=19.0, running_count=1)}
+    pending = [_t("f0", 0.0), _t("f1", 0.0)]
+
+    launches = _select(pending, gpus, num_slots=8, running_count=1)
+
+    assert launches == [(0, 0), (1, 0)]
+
+
+def test_slot_cap_is_global():
+    gpus = {0: _gpu(0, 80.0)}  # budget is huge; the cap here is the slot count
+    pending = [_t("a", 3.8), _t("b", 3.8), _t("c", 3.8)]
+
+    launches = _select(pending, gpus, num_slots=2, running_count=1)
+
+    assert len(launches) == 1  # 1 running + 1 new == 2 slots
+
+
+# --------------------------------------------------------------------------- #
+# _select_launches: anti-starvation reservation
+# --------------------------------------------------------------------------- #
+def test_reservation_keeps_room_for_blocked_high_priority_test():
+    # An 8 GiB test is running (budget_used=8). The highest-priority pending test
+    # needs 12 GiB and cannot fit yet (19-8=11<12). Without a reservation, two
+    # 3.8 GiB backfills would fit now (8+3.8+3.8=15.6<=19) -- but then when the
+    # 8 GiB test frees, only 19-7.6=11.4 GiB is free and the 12 GiB test is still
+    # blocked. The reservation caps backfill at cap-required (19-12=7), so only
+    # one 3.8 launches, guaranteeing the 12 fits once the 8 frees.
+    gpus = {0: _gpu(0, 22.0, budget_used=8.0, running_count=1)}
+    pending = [_t("blocked12", 12.0), _t("fill_a", 3.8), _t("fill_b", 3.8)]
+
+    launches = _select(pending, gpus, num_slots=8, running_count=1)
+
+    assert launches == [(1, 0)]  # only one 3.8 backfill; room held for the 12
+
+
+def test_blocked_test_launches_once_occupant_frees():
+    # Same setup, but now the 8 GiB occupant has freed (budget_used back to the
+    # single 3.8 backfill). The 12 GiB test is now first and must launch.
+    gpus = {0: _gpu(0, 22.0, budget_used=3.8, running_count=1)}
+    pending = [_t("blocked12", 12.0), _t("fill_b", 3.8)]
+
+    launches = _select(pending, gpus, num_slots=8, running_count=1)
+
+    # 12 fits (19-3.8=15.2) and is highest priority; the extra 3.8 no longer fits
+    # (19-15.8=3.2<3.8).
+    assert launches == [(0, 0)]
+
+
+# --------------------------------------------------------------------------- #
+# makespan simulation: new ordering vs legacy timeout-sorted first-fit
+# --------------------------------------------------------------------------- #
+# (name, profiled_gib, real_runtime_s, timeout_s) for the 26 VRAM tests observed
+# in job-log.txt, plus 213 zero-VRAM "needs vllm container, no GPU memory" unit
+# tests that each pay ~27 s of interpreter/import startup in their own subprocess.
+_GPU_TESTS = [
+    ("mm_shm", 7.6, 233, 1800),
+    ("mm_nixl", 7.6, 227, 1800),
+    ("mm_disabled", 7.6, 184, 1800),
+    ("engine", 3.8, 80, 900),
+    ("serve_mm_agg_video", 8.2, 131, 600),
+    ("self_benchmark", 3.8, 73, 600),
+    ("serve_aggregated", 3.8, 168, 480),
+    ("serve_aggregated_unified", 3.8, 170, 480),
+    ("serve_mm_agg_router_qwen3", 13.0, 98, 400),
+    ("router_unified_kv_basic", 6.9, 110, 360),
+    ("router_unified_decisions", 6.9, 85, 360),
+    ("router_kv_basic", 6.9, 76, 360),
+    ("router_kv_without_block", 6.9, 75, 360),
+    ("router_decisions", 6.9, 79, 360),
+    ("router_indexers_sync", 6.9, 136, 360),
+    ("serve_aggregated_lmcache", 3.8, 182, 360),
+    ("serve_lmcache_multiproc", 3.8, 177, 360),
+    ("serve_lmcache_mp", 3.8, 187, 360),
+    ("serve_agg_request_plane", 3.8, 165, 360),
+    ("serve_embedding_agg", 5.0, 92, 360),
+    ("serve_mm_agg_gemma4", 12.0, 192, 300),
+    ("serve_guided_decoding", 3.8, 67, 180),
+    ("kvbm_offload", 3.8, 104, 170),
+    ("kvbm_eviction", 3.8, 105, 170),
+    ("kvbm_onboarding", 3.8, 77, 160),
+    ("kvbm_chunked", 3.8, 100, 140),
+]
+_N_FILLERS = 213
+_FILLER_RUNTIME = 27
+_FILLER_TIMEOUT = 600  # no @pytest.mark.timeout -> scheduler default
+
+
+class _SimTest(_TestEntry):
+    """_TestEntry carrying a real runtime for the simulator."""
+
+    def __init__(self, name: str, profiled: float, runtime: float, timeout: float):
+        super().__init__(id=name, name=name, profiled_gib=profiled, timeout=timeout)
+        self.runtime = runtime
+
+
+def _build_workload() -> list[_SimTest]:
+    tests = [_SimTest(n, p, r, to) for (n, p, r, to) in _GPU_TESTS]
+    tests += [
+        _SimTest(f"filler_{i}", 0.0, _FILLER_RUNTIME, _FILLER_TIMEOUT)
+        for i in range(_N_FILLERS)
+    ]
+    return tests
+
+
+def _legacy_select(pending, gpu_states, actual_free, num_slots, running_count):
+    """The pre-change algorithm: first-fit (most-available-budget) over pending
+    in its given order, no filler bypass, no reservation."""
+    tent = {
+        gi: {
+            "budget": gs.budget_used,
+            "free": actual_free[gi],
+            "count": gs.running_count,
+        }
+        for gi, gs in gpu_states.items()
+    }
+    to_launch: list[tuple[int, int]] = []
+    for i, test in enumerate(pending):
+        if running_count + len(to_launch) >= num_slots:
+            break
+        best_gi, best_avail = None, -1.0
+        for gi, gs in gpu_states.items():
+            ts = tent[gi]
+            cap = gs.budget_multi if ts["count"] >= 1 else gs.total_gib
+            avail = cap - ts["budget"]
+            if avail < test.profiled_gib:
+                continue
+            if (gs.total_gib - ts["free"]) + test.profiled_gib > cap:
+                continue
+            if avail > best_avail:
+                best_gi, best_avail = gi, avail
+        if best_gi is not None:
+            to_launch.append((i, best_gi))
+            tent[best_gi]["budget"] += test.profiled_gib
+            tent[best_gi]["free"] -= test.profiled_gib
+            tent[best_gi]["count"] += 1
+    return to_launch
+
+
+def _simulate_makespan(tests, *, num_slots, gpus_total, order_key, select) -> float:
+    """Discrete-event makespan model of run_parallel's loop.
+
+    Polls/staggers are omitted (they affect both schedulers equally); GPU actual
+    usage is modeled as the sum of running tests' profiled VRAM. Returns the wall
+    time in seconds.
+    """
+    gpu_states = {i: _gpu(i, tot) for i, tot in enumerate(gpus_total)}
+    pending = sorted(tests, key=order_key, reverse=True)
+    running: list[dict] = []  # {finish, profiled, gpu}
+    now = 0.0
+
+    while pending or running:
+        actual_free = {
+            gi: gs.total_gib - gs.budget_used for gi, gs in gpu_states.items()
+        }
+        sel = select(
+            pending=pending,
+            gpu_states=gpu_states,
+            actual_free=actual_free,
+            num_slots=num_slots,
+            running_count=len(running),
+        )
+        if sel:
+            for idx, gi in sorted(sel, key=lambda x: x[0], reverse=True):
+                t = pending.pop(idx)
+                gpu_states[gi].budget_used += t.profiled_gib
+                gpu_states[gi].running_count += 1
+                running.append(
+                    {"finish": now + t.runtime, "profiled": t.profiled_gib, "gpu": gi}
+                )
+            continue
+        assert running, "deadlock: pending tests but nothing running"
+        now = min(r["finish"] for r in running)
+        still = []
+        for r in running:
+            if r["finish"] <= now:
+                gpu_states[r["gpu"]].budget_used -= r["profiled"]
+                gpu_states[r["gpu"]].running_count -= 1
+            else:
+                still.append(r)
+        running = still
+    return now
+
+
+def _retune_3x(tests):
+    """Set timeout = 3x runtime (repo convention), floored so import-heavy
+    fillers keep headroom. Mutates and returns the freshly-built tests."""
+    for t in tests:
+        floor = 90.0 if t.profiled_gib <= 0 else 30.0
+        t.timeout = max(3.0 * t.runtime, floor)
+    return tests
+
+
+def test_new_algorithm_beats_legacy_at_equal_timeouts():
+    # Isolate the *scheduling logic* change: identical (observed) timeouts and
+    # runtimes for both, only the ordering + selection differ. Single 22 GiB
+    # card, 8 slots -- the configuration from job-log.txt.
+    kwargs = dict(num_slots=8, gpus_total=[22.0])
+
+    legacy = _simulate_makespan(
+        _build_workload(),
+        order_key=lambda t: t.timeout,
+        select=_legacy_select,
+        **kwargs,
+    )
+    new = _simulate_makespan(
+        _build_workload(), order_key=_priority_key, select=_select_launches, **kwargs
+    )
+
+    # The legacy order runs the 0-GiB fillers (default timeout 600) ahead of the
+    # real GPU tests (timeout <= 480), leaving the GPU memory-idle then
+    # serializing the VRAM tests on the tail. The new order front-loads + pairs
+    # them regardless of how (in)accurate the timeouts are.
+    print(
+        f"\nalgo-only: legacy={legacy:.0f}s  new={new:.0f}s  ratio={new / legacy:.2f}"
+    )
+    assert new <= 0.90 * legacy  # >= 10% makespan reduction from the algorithm
+
+
+def test_full_change_beats_status_quo():
+    # What the PR actually ships: the new algorithm AND timeouts retuned to 3x
+    # runtime, vs today's status quo (legacy ordering + observed timeouts, where
+    # the fillers have no timeout marker at all).
+    kwargs = dict(num_slots=8, gpus_total=[22.0])
+
+    status_quo = _simulate_makespan(
+        _build_workload(),
+        order_key=lambda t: t.timeout,
+        select=_legacy_select,
+        **kwargs,
+    )
+    shipped = _simulate_makespan(
+        _retune_3x(_build_workload()),
+        order_key=_priority_key,
+        select=_select_launches,
+        **kwargs,
+    )
+
+    print(
+        f"\nstatus-quo={status_quo:.0f}s  shipped={shipped:.0f}s  "
+        f"ratio={shipped / status_quo:.2f}"
+    )
+    assert shipped <= 0.85 * status_quo  # >= 15% end-to-end makespan reduction
+
+
+def test_simulation_conserves_work_and_respects_budget():
+    # Sanity guard for the simulator itself: every test runs, and makespan is at
+    # least the longest single test and at least total-work / slots.
+    tests = _build_workload()
+    total_work = sum(t.runtime for t in tests)
+    longest = max(t.runtime for t in tests)
+
+    makespan = _simulate_makespan(
+        tests,
+        num_slots=8,
+        gpus_total=[22.0],
+        order_key=_priority_key,
+        select=_select_launches,
+    )
+
+    assert makespan >= longest
+    assert makespan >= total_work / 8 - 1e-6

--- a/tests/utils/vram_utils.py
+++ b/tests/utils/vram_utils.py
@@ -25,8 +25,6 @@ import logging
 import os
 import tempfile
 
-import pynvml
-
 _logger = logging.getLogger(__name__)
 
 # When 2+ tests run concurrently, reserve 15% of GPU VRAM for CUDA context
@@ -42,6 +40,10 @@ def detect_gpus() -> list[dict]:
     Uses pynvml (already a dependency via profile_pytest.py).
     Returns empty list if no GPUs or pynvml is unavailable.
     """
+    try:
+        import pynvml
+    except ImportError:
+        return []
     try:
         pynvml.nvmlInit()
     except pynvml.NVMLError:

--- a/tests/utils/vram_utils.py
+++ b/tests/utils/vram_utils.py
@@ -115,9 +115,10 @@ def effective_cpu_budget() -> int:
     try:
         quota_s, period_s = open("/sys/fs/cgroup/cpu.max").read().split()[:2]
         if quota_s != "max":
-            n = int(int(quota_s) / int(period_s))
-            if n > 0:
-                return n
+            # Floor at 1: fractional --cpus (e.g. 0.5 -> int 0) must not fall
+            # through to the host os.cpu_count() and defeat the cap. Matches the
+            # cgroup-v1 branch below.
+            return max(1, int(int(quota_s) / int(period_s)))
     except (OSError, ValueError, ZeroDivisionError):
         pass
     try:

--- a/tests/utils/vram_utils.py
+++ b/tests/utils/vram_utils.py
@@ -90,6 +90,46 @@ def auto_worker_count(
     return len(gpus) * workers_per_gpu
 
 
+def effective_cpu_budget() -> int:
+    """Best estimate of the CPUs actually available to this container/process.
+
+    ``os.cpu_count()`` / ``os.sched_getaffinity`` / ``psutil`` all report the
+    HOST core count and ignore Docker ``--cpus`` (which is a CFS quota, not an
+    affinity mask). xdist resolves ``-n auto`` from ``os.cpu_count()``, so on a
+    many-core host limited to a few CPUs it overshoots badly (e.g. 32 slots
+    under ``--cpus=4``). Resolve the real budget, in order:
+
+      1. ``NUM_CPUS`` env (CI sets it to the container's ``--cpus``),
+      2. cgroup v2 ``cpu.max`` quota (``quota period``; reflects ``--cpus``),
+      3. cgroup v1 ``cpu.cfs_quota_us`` / ``cpu.cfs_period_us``,
+      4. ``os.cpu_count()`` (no container limit detectable).
+    """
+    env = os.environ.get("NUM_CPUS")
+    if env:
+        try:
+            n = int(float(env))
+            if n > 0:
+                return n
+        except ValueError:
+            pass
+    try:
+        quota_s, period_s = open("/sys/fs/cgroup/cpu.max").read().split()[:2]
+        if quota_s != "max":
+            n = int(int(quota_s) / int(period_s))
+            if n > 0:
+                return n
+    except (OSError, ValueError, ZeroDivisionError):
+        pass
+    try:
+        quota = int(open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read())
+        period = int(open("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read())
+        if quota > 0 and period > 0:
+            return max(1, quota // period)
+    except (OSError, ValueError):
+        pass
+    return os.cpu_count() or 1
+
+
 def write_test_meta(items, dest_dir: str | None = None) -> None:
     """Serialize profiled_vram_gib, timeout, and KV cache markers to JSON.
 


### PR DESCRIPTION
## Problem

The GPU-parallel test runner (`tests/utils/pytest_parallel_gpu.py`) ordered tests by raw `@pytest.mark.timeout` and greedily filled slots front-to-back. In the reference vllm run (`job-log.txt`: 239 tests, 8 slots, 1×22 GiB GPU, **1764s**):

- 213/239 tests are **zero-VRAM** unit tests (need the `gpu_1` *container* for `import vllm`, but `profiled_vram_gib(0)`) with the **default 600s timeout**, so they sorted ahead of the real GPU tests and grabbed all 8 slots.
- **GPU memory sat idle (~0.5/22 GiB) for ~570s**, then the 26 real GPU tests serialized on the tail — **largest last** (the 12 & 13 GiB tests started at elapsed 1474s / 1666s).

## Fix

**1. Scheduler** (`pytest_parallel_gpu.py`): `est_duration = timeout/3`; `_priority_key` orders VRAM tests first (longest est_duration → largest VRAM), zero-VRAM fillers last; `_select_launches` (pure, unit-tested) best-fit **packs a big test with smaller ones**, fillers backfill spare slots (bypassing the budget gates), and a blocked high-priority test **reserves** space (backfill capped at `cap − required`). `pynvml` import made lazy so the pure logic imports/tests on CPU-only runners.

**2. CPU-aware concurrency cap**: xdist resolves `-n auto` from `os.cpu_count()`, which reports HOST cores and ignores Docker `--cpus` (a CFS quota). `effective_cpu_budget()` (NUM_CPUS env → cgroup v2 `cpu.max` → cgroup v1 → `os.cpu_count()`) caps `num_slots`, so the filler backfill can't oversubscribe CPU.

**3. Timeouts → 3× observed runtime** (raise-only — never tightens an existing value):
- **vllm**: re-tuned from the *new-scheduler* run, because running GPU tests concurrently makes them 8–69% slower than the baseline the first pass used (`indexers_sync` 410→690, `mm_agg_gemma4` 580→670, lmcache/serve →600-640, kvbm →410/420, …).
- **sglang/trtllm** (18 GPU tests): from the post-merge gpu_1 logs; fixes already-dangerous timeouts (`sglang completions_only` 341→750 for a 249s run; `trtllm aggregated` 300→650 for 215s). These are *old-scheduler* runtimes — a post-merge run will give new-scheduler numbers for a refinement, same as vllm.
- **zero-VRAM unit modules**: `timeout(180)` floor (they had no marker → defaulted to 600).

## Evidence

**CI makespan** (full vllm gpu_1 suite, 8 slots, 22 GiB): status quo **1764s → 1235s (−30%)**. (Simulation in the unit tests isolates the contributions: algorithm alone −14%, algorithm + retune −21%.)

**CPU cap** (RTX 6000 Ada, `docker --cpus=4`, 71 zero-VRAM tests): before = **24 slots** (ignored `--cpus`) / 276.9s / ~100–134s per *trivial* test; after = `Capping 24 → 4` / **189.2s (−32%)** / ~14s per test. Removes the timeout-flakiness that oversubscription creates. (No-op on the 8-core CI runners where host cores == `--cpus`; it protects big-host / `--cpus`-limited runners.)

## Testing
`tests/utils/test_pytest_parallel_gpu.py` (new, pure / no-GPU, 12 tests): packing, filler backfill, slot cap, multi-proc cap, reservation, `effective_cpu_budget`, plus the makespan simulation that asserts the improvements above.

## Notes / decisions for review
- **Raise-only** timeouts: stale-but-generous values (e.g. `mm_router` 1800) are left as-is — lowering gives no scheduling benefit, only flakiness risk.
- Reservation is **coexistence-aware** (backfill capped at `cap − required`) rather than freezing the whole GPU.
- **sglang/trtllm timeouts are from old-scheduler (main) runs** → plan a post-merge refinement from new-scheduler runtimes.
- CPU-cap ceiling = container `--cpus`/`NUM_CPUS`; pin `-n N` or lower `NUM_CPUS` to go tighter.
- `job-log.txt` intentionally **not** committed.
- Follow-up (out of scope): each 0-GiB test pays ~27s of `import vllm` startup in its own subprocess (~5,700s slot-time); batching them is the biggest remaining win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated timeout configurations across multiple test suites to accommodate performance changes and improved runtime estimations.

* **Chores**
  * Improved GPU-parallel test scheduling with VRAM-aware ordering and better resource packing.
  * Added container-aware CPU budget detection for optimal parallel test slot allocation.
  * Enhanced robustness of test utilities with lazy dependency imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->