### PR TITLE
fix(parsers): enable EOF recovery for non-streaming tool-call parse aggregator (#9864)

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -4,7 +4,7 @@
 use futures::{Stream, StreamExt};
 use std::collections::{BTreeMap, HashMap};
 
-use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate;
+use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate_finalize;
 
 use super::{NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse};
 use crate::protocols::{
@@ -64,7 +64,7 @@ struct DeltaChoice {
     tool_call_chunks: BTreeMap<u32, dynamo_protocols::types::ChatCompletionMessageToolCallChunk>,
     // Optional tool calls for the chat choice, populated *after* fold either
     // by finalizing `tool_call_chunks` above, or by
-    // `try_tool_call_parse_aggregate` running against `text` for producers
+    // `try_tool_call_parse_aggregate_finalize` running against `text` for producers
     // that put tool calls in content rather than as structured chunks.
     tool_calls: Option<Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>>,
 
@@ -347,8 +347,8 @@ impl DeltaAggregator {
                 .filter_map(finalize_merged_tool_chunk)
                 .collect();
             // choice.tool_calls is always None at this point: or_insert
-            // initializes it to None, try_tool_call_parse_aggregate runs
-            // strictly after this loop. Unconditional assign is the only
+            // initializes it to None, try_tool_call_parse_aggregate_finalize
+            // runs strictly after this loop. Unconditional assign is the only
             // reachable path; no merge-with-existing needed.
             if !finalized.is_empty() {
                 choice.tool_calls = Some(finalized);
@@ -367,7 +367,9 @@ impl DeltaAggregator {
                 }
 
                 let (tool_calls, content) =
-                    match try_tool_call_parse_aggregate(&choice.text, Some(parser), None).await {
+                    match try_tool_call_parse_aggregate_finalize(&choice.text, Some(parser), None)
+                        .await
+                    {
                         Ok(result) => result,
                         Err(error) => {
                             tracing::debug!(


### PR DESCRIPTION
## Summary
- Cherry-pick of #9864 to release/1.2.0
- Enables EOF recovery for the non-streaming tool-call parse aggregator so a truncated/early-terminated tool call is still recovered instead of dropped

Clean cherry-pick (auto-merge in `aggregator.rs`, no manual conflict resolution).

## Original PR
- Main PR: #9864
- Merge commit: 59cbaf0de1814344195a072cb4c69eca32d695b4

## Test plan
- [ ] CI passes