### PR TITLE
fix(frontend): pass tools to ToolParser ctor in vllm chat processor (#9865)

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -119,7 +119,7 @@ def _prepare_request(
     has_tools = bool(request_for_sampling.tools)
     if tool_parser_class and (has_tools or enable_auto_tool_choice):
         if request_for_sampling.tool_choice != "none":
-            tool_parser = tool_parser_class(tokenizer)
+            tool_parser = tool_parser_class(tokenizer, request_for_sampling.tools)
             request_for_sampling = tool_parser.adjust_request(request_for_sampling)
 
     # Strip tools from the template when tool_choice=none so the model doesn't

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -7,10 +7,12 @@ Tests for the tool-stripping behaviour of _prepare_request when
 tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
 from transformers import AutoTokenizer
+from vllm.tool_parsers.qwen3coder_tool_parser import Qwen3CoderToolParser
 
 from dynamo.frontend.prepost import _prepare_request
 
@@ -196,3 +198,74 @@ class TestReasoningParserMetadata:
                 "chat_template_kwargs": {"reasoning_effort": "high"}
             },
         }
+
+
+OBJECT_TYPED_TOOL_REQUEST = {
+    "model": MODEL,
+    "messages": [{"role": "user", "content": "set my profile"}],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "set_profile",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "profile": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "age": {"type": "integer"},
+                            },
+                        }
+                    },
+                    "required": ["profile"],
+                },
+            },
+        }
+    ],
+    "tool_choice": "auto",
+}
+
+
+# ---------------------------------------------------------------------------
+# _prepare_request: schema-aware tool-parser end-to-end regression
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaAwareToolParser:
+    """Schema-aware parsers (e.g. qwen3_coder) need ``tools`` at construction
+    to coerce object/array-typed parameter values from raw text into JSON;
+    without them, the value comes through as a string-in-a-string inside the
+    final ``arguments`` JSON.
+    """
+
+    def test_qwen3_coder_coerces_object_typed_arg(self, tokenizer):
+        """qwen3_coder must coerce object-typed parameter values into nested
+        objects, not leave them as JSON-encoded strings inside ``arguments``.
+        """
+        model_output = (
+            "<tool_call><function=set_profile>\n"
+            "<parameter=profile>\n"
+            '{"name": "Alice", "age": 30}\n'
+            "</parameter>\n"
+            "</function></tool_call>"
+        )
+
+        request_for_sampling, parser, _, _, _ = _prepare_request(
+            OBJECT_TYPED_TOOL_REQUEST,
+            tokenizer=tokenizer,
+            tool_parser_class=Qwen3CoderToolParser,
+        )
+        assert parser is not None, "Expected _prepare_request to construct the parser"
+
+        result = parser.extract_tool_calls(model_output, request_for_sampling)
+
+        assert result.tools_called, f"Expected tools_called=True; got {result!r}"
+        assert len(result.tool_calls) == 1
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert isinstance(args["profile"], dict), (
+            f"Schema-aware parser should coerce object-typed arg to dict; "
+            f"got {type(args['profile']).__name__}: {args['profile']!r}"
+        )
+        assert args["profile"] == {"name": "Alice", "age": 30}

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -221,6 +221,7 @@ STUB_MODULES = [
     "vllm.tool_parsers",
     "vllm.tool_parsers.hermes_tool_parser",
     "vllm.tool_parsers.mistral_tool_parser",
+    "vllm.tool_parsers.qwen3coder_tool_parser",
     "vllm.utils",
     "vllm.utils.async_utils",
     "vllm.utils.hashing",


### PR DESCRIPTION
## Summary
- Cherry-pick of #9865 to release/1.2.0
- Passes `request_for_sampling.tools` to the `ToolParser` constructor in the vLLM chat processor so schema-aware parsers (e.g. qwen3_coder) coerce object/array-typed parameter values into JSON instead of emitting a string-in-a-string inside `arguments`

Note: Conflict in `components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — this test file has diverged on release/1.2.0 (it lacks the `_FakeOutputProcessor` / `TestRoutedEnginePath` content present on main). Applied only #9865's additive change: the `import json` / `Qwen3CoderToolParser` imports plus the `TestSchemaAwareToolParser` regression test, appended to the release-branch copy. The functional fix (`prepost.py`) and the marker stub (`report_pytest_markers.py`) applied cleanly. Net result is identical to the original (+75/-1).

## Original PR
- Main PR: #9865
- Merge commit: f61fefb5a3d024a69544f336e4658adf76ef1842

## Test plan
- [ ] CI passes
- [ ] `TestSchemaAwareToolParser::test_qwen3_coder_coerces_object_typed_arg` passes in the vLLM gpu_1 container