### PR TITLE
test(parser): document non-Harmony reasoning boundary cases n/a

### DIFF
--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -143,3 +143,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers do not use Harmony commentary channels; visible text and downstream tool handoff use model-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers do not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use model-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers do not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside their grammar.

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -133,3 +133,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to DeepSeek R1-family parsers
+    reason: DeepSeek R1-family parsers have no Harmony commentary protocol, so partial commentary-boundary recovery is outside their grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek R1-family parsers
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -163,3 +163,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to DeepSeek V3
+    reason: DeepSeek V3 does not use Harmony commentary channels; visible text and downstream tool handoff use DeepSeek-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to DeepSeek V3
+    reason: DeepSeek V3 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use DeepSeek-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V3
+    reason: DeepSeek V3 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -141,3 +141,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to DeepSeek V3
+    reason: DeepSeek V3 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V3
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -174,3 +174,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to DeepSeek V4
+    reason: DeepSeek V4 does not use Harmony commentary channels; visible text and downstream tool handoff use DeepSeek-specific think and DSML tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to DeepSeek V4
+    reason: DeepSeek V4 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use DeepSeek-specific DSML tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V4
+    reason: DeepSeek V4 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -136,3 +136,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to DeepSeek V4
+    reason: DeepSeek V4 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to DeepSeek V4
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -192,3 +192,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body<channel|>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Gemma 4
+    reason: Gemma 4 uses Gemma thought channels, not Harmony commentary channels; visible text and downstream tool handoff use Gemma-specific markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Gemma 4
+    reason: Gemma 4 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Gemma-specific tool markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Gemma 4
+    reason: Gemma 4 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Gemma thought channels.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Gemma 4
+    reason: Gemma 4 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -156,3 +156,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body<channel|>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Gemma 4
+    reason: Gemma 4 has no configured Harmony commentary boundary; closed-channel handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Gemma 4
+    reason: Gemma 4 has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Gemma 4
+    reason: Gemma 4 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Gemma 4
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -154,3 +154,15 @@ cases:
         unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
       sglang:
         unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Granite
+    reason: Granite does not use Harmony commentary channels; visible text and reasoning are separated by Granite thought-process and response markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Granite
+    reason: Granite does not use Harmony `commentary to=functions.*` envelopes and has no paired Dynamo Harmony tool-call parser fixture.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Granite
+    reason: Granite does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Granite thought-process markers.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Granite
+    reason: Granite has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -121,3 +121,15 @@ cases:
         unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
       sglang:
         unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Granite
+    reason: Granite has no configured Harmony commentary boundary; it has no paired Dynamo Harmony tool-call parser fixture.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Granite
+    reason: Granite has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Granite
+    reason: Granite has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Granite
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -156,3 +156,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body◁/think▷answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony commentary channels; visible text and downstream tool handoff use Kimi-specific reasoning and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Kimi-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Kimi-specific reasoning delimiters.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to this Kimi delimiter family
+    reason: This parser family has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -119,3 +119,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body◁/think▷answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to this Kimi delimiter family
+    reason: This parser family has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to this Kimi delimiter family
+    reason: This parser family has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to this Kimi delimiter family
+    reason: This parser family has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to this Kimi delimiter family
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -180,3 +180,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Kimi K2.5
+    reason: Kimi K2.5 uses Kimi tool-section markers, not Harmony commentary channels; visible text and downstream tool handoff use Kimi-specific markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Kimi K2.5
+    reason: Kimi K2.5 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Kimi tool-section markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Kimi K2.5
+    reason: Kimi K2.5 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Kimi K2.5
+    reason: Kimi K2.5 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -138,3 +138,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Kimi K2.5
+    reason: Kimi K2.5 uses Kimi tool-section markers, not Harmony commentary channels; Harmony stream boundary cases are GPT-OSS specific.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Kimi K2.5
+    reason: Kimi K2.5 does not use Harmony `commentary to=functions.*` envelopes, so there is no Harmony stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Kimi K2.5
+    reason: Kimi K2.5 has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Kimi K2.5
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
@@ -153,3 +153,15 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: '<think>preamble</think>body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to MiniMax append-think
+    reason: MiniMax append-think does not use Harmony commentary channels; it emits a synthetic normal-text wrapper around model output.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to MiniMax append-think
+    reason: MiniMax append-think does not use Harmony `commentary to=functions.*` envelopes; downstream tool handoff uses MiniMax-specific output shape when applicable.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to MiniMax append-think
+    reason: MiniMax append-think does not use Harmony `analysis to=functions.*` envelopes; reasoning-shaped text remains inside the synthetic normal-text wrapper.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -110,3 +110,15 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: '<think>preamble</think>body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no configured Harmony commentary boundary; it emits a synthetic normal-text wrapper around model output.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to MiniMax append-think
+    reason: MiniMax append-think has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to MiniMax append-think
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -155,3 +155,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body[/THINK]answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Mistral
+    reason: Mistral reasoning parsers do not use Harmony commentary channels; visible text and downstream tool handoff use Mistral-specific reasoning and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Mistral
+    reason: Mistral reasoning parsers do not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Mistral-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Mistral
+    reason: Mistral reasoning parsers do not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by Mistral THINK tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Mistral
+    reason: Mistral reasoning parsers have no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside their grammar.

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -132,3 +132,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body[/THINK]answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Mistral
+    reason: Mistral has no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Mistral
+    reason: Mistral has no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Mistral
+    reason: Mistral has no Harmony commentary protocol, so partial commentary-boundary recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Mistral
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -166,3 +166,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers do not use Harmony commentary channels; visible text and downstream tool handoff use model-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers do not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use model-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers do not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron reasoning parsers have no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside their grammar.

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -141,3 +141,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron parsers have no configured Harmony commentary boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron parsers have no Harmony `commentary to=functions.*` stream boundary to split across chunks.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to GLM/Nemotron
+    reason: GLM/Nemotron parsers have no Harmony commentary protocol, so partial commentary-boundary recovery is outside their grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to GLM/Nemotron
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -180,3 +180,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.batch.3.c:
+    description: Recipientless Harmony commentary is not applicable to Qwen3
+    reason: Qwen3 does not use Harmony commentary channels; visible text and downstream tool handoff use Qwen-specific think and tool-call markers.
+  REASONING.batch.3.d:
+    description: Directed Harmony commentary tool calls are not applicable to Qwen3
+    reason: Qwen3 does not use Harmony `commentary to=functions.*` envelopes; downstream tool calls use Qwen-specific tool-call markers.
+  REASONING.batch.3.e:
+    description: Directed Harmony analysis tool calls are not applicable to Qwen3
+    reason: Qwen3 does not use Harmony `analysis to=functions.*` envelopes; reasoning is represented by think tags.
+  REASONING.batch.3.f:
+    description: Harmony analysis/commentary/final channel sequencing is not applicable to Qwen3
+    reason: Qwen3 has no Harmony channel protocol, so mixed analysis, commentary tool call, and final-channel sequencing is outside its grammar.

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -137,3 +137,15 @@ cases:
       sglang:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'
+  REASONING.stream.4.a:
+    description: Downstream streaming boundary is not applicable to Qwen3
+    reason: Qwen3 has no configured tool-call start marker that force-exits open streaming reasoning; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.stream.4.b:
+    description: Split downstream streaming boundary is not applicable to Qwen3
+    reason: Qwen3 has no configured tool-call start marker that force-exits open streaming reasoning, so there is no split downstream boundary to buffer.
+  REASONING.stream.4.c:
+    description: Partial downstream boundary recovery is not applicable to Qwen3
+    reason: Qwen3 has no configured tool-call start marker that force-exits open streaming reasoning, so partial tool-marker recovery is outside its grammar.
+  REASONING.stream.4.d:
+    description: Directed Harmony analysis tool calls are not applicable to Qwen3
+    reason: This parser family does not use Harmony `analysis to=functions.*` envelopes, so split analysis-channel tool-call handoff is outside its grammar.

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -74,6 +74,7 @@ CASE_GROUPS = [
     ("Reasoning extraction", ("stream.2.a",)),
     ("Multi-span", ("stream.2.b", "stream.2.c")),
     ("Chunk boundaries", ("stream.3.a", "stream.3.b", "stream.3.c")),
+    ("Other", ("stream.4.a", "stream.4.b", "stream.4.c", "stream.4.d")),
 ]
 _CASE_GROUP_BY_CASE = {
     case_id: label for label, case_ids in CASE_GROUPS for case_id in case_ids


### PR DESCRIPTION
#### Overview:

Adds explicit parity-table coverage for reasoning cases that are not applicable outside GPT-OSS/Harmony channel parsing.

#### Details:
- Marks `REASONING.batch.3.c` through `3.f` as `n/a` for all non-Harmony reasoning families.
- Marks `REASONING.stream.4.a` through `4.c` as `n/a` for all non-Harmony reasoning families.

#### Where should the reviewer start?

- `lib/parsers/REASONING_CASES.md` for the intended case taxonomy.
- `tests/parity/reasoning/fixtures/gpt_oss/` for the real Harmony cases.
- `tests/parity/reasoning/fixtures/*/REASONING.{batch,stream}.yaml` for the new `n/a` stubs.
- `tests/parity/reasoning/table.py` for the added `stream.4.*` display group.

#### Related Issues:

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases for reasoning parser functionality across multiple model families (DeepSeek R1/V3/V4, Gemma4, Granite, Kimi, Kimi K2.5, MiniMax, Mistral, Nemotron, and Qwen3).
  * Enhanced test coverage to document model-specific parsing behavior and unsupported features.
  * Updated test case organization and grouping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->