### PR TITLE
fix(tool-calling): recover bare DeepSeek tool calls without outer wrapper

### DIFF
--- a/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs
@@ -167,6 +167,47 @@ pub fn parse_tool_calls_deepseek_v3_1(
     // Batch parsing requires a complete outer wrapper start; the public
     // detector also accepts partial prefixes for streaming chunk detection.
     if wrapper_start_index(trimmed, config).is_none() {
+        if trimmed.contains("<｜tool▁call▁begin｜>") {
+            let normal_text = trimmed
+                .find("<｜tool▁call▁begin｜>")
+                .map(|idx| trimmed[..idx].to_string())
+                .unwrap_or_default();
+            let blocks = extract_tool_call_blocks_v3_1(
+                trimmed,
+                &tool_call_start_tokens,
+                &tool_call_end_tokens,
+            );
+            let mut tool_calls: Vec<ToolCallResponse> = Vec::new();
+            for block in blocks {
+                if let Some((function_name, arguments)) =
+                    parse_single_tool_call_v3_1(&block, separator_tokens)
+                {
+                    tool_calls.push(ToolCallResponse {
+                        id: format!("call-{}", Uuid::new_v4()),
+                        tp: ToolCallType::Function,
+                        function: CalledFunction {
+                            name: function_name,
+                            arguments: serde_json::to_string(&arguments)?,
+                        },
+                    });
+                }
+            }
+            if !tool_calls.is_empty() {
+                tracing::warn!(
+                    why = "bare_deepseek_v31_call_without_outer_wrapper",
+                    recovered_calls = tool_calls.len(),
+                    stripped_bytes = trimmed.len(),
+                    "DeepSeek V3.1 parser recovered bare inner tool-call block and suppressed parser markup from normal_text"
+                );
+                return Ok((tool_calls, Some(normal_text)));
+            }
+            tracing::warn!(
+                why = "bare_deepseek_v31_call_without_outer_wrapper",
+                stripped_bytes = trimmed.len(),
+                "DeepSeek V3.1 parser suppressed malformed bare inner tool-call block so parser markup does not leak into normal_text"
+            );
+            return Ok((vec![], Some(String::new())));
+        }
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
@@ -229,6 +270,10 @@ pub fn detect_tool_call_start_deepseek_v3_1(chunk: &str, config: &JsonParserConf
         .any(|token| !token.is_empty() && trimmed.contains(token));
 
     if has_complete_token {
+        return true;
+    }
+
+    if trimmed.contains("<｜tool▁call▁begin｜>") {
         return true;
     }
 
@@ -358,7 +403,7 @@ mod tests {
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
-        assert_eq!(content, Some(text.to_string()));
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 0);
     }
 
@@ -479,6 +524,21 @@ mod tests {
             Some("I'll help you understand this codebase. Let me start by exploring the structure and key\n  files to provide you with a comprehensive\n  explanation.".to_string())
         );
     }
+
+    #[test] // TOOLCALLING.stream.4.c
+    fn test_parse_deepseek_v3_1_bare_inner_call_recovers_without_marker_leak() {
+        let text = r#"Before <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁end｜><｜tool▁call▁end｜>"#;
+        let config = match ToolCallConfig::deepseek_v3_1().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+        let (result, content) = parse_tool_calls_deepseek_v3_1(text, &config, None).unwrap();
+        assert_eq!(content, Some("Before ".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
 }
 
 #[cfg(test)]
@@ -504,7 +564,7 @@ mod detect_parser_tests {
             _ => panic!("Expected JSON parser config"),
         };
         let result = detect_tool_call_start_deepseek_v3_1(text, &config);
-        assert!(!result);
+        assert!(result);
     }
 
     #[test] // helper

--- a/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
+++ b/lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs
@@ -178,6 +178,47 @@ pub fn parse_tool_calls_deepseek_v3(
     // Batch parsing requires a complete outer wrapper start; the public
     // detector also accepts partial prefixes for streaming chunk detection.
     if wrapper_start_index(trimmed, config).is_none() {
+        if trimmed.contains("<｜tool▁call▁begin｜>") {
+            let normal_text = trimmed
+                .find("<｜tool▁call▁begin｜>")
+                .map(|idx| trimmed[..idx].to_string())
+                .unwrap_or_default();
+            let blocks = extract_tool_call_blocks_v3(
+                trimmed,
+                &tool_call_start_tokens,
+                &tool_call_end_tokens,
+            );
+            let mut tool_calls: Vec<ToolCallResponse> = Vec::new();
+            for block in blocks {
+                if let Some((function_name, arguments)) =
+                    parse_single_tool_call_v3(&block, separator_tokens)
+                {
+                    tool_calls.push(ToolCallResponse {
+                        id: format!("call-{}", Uuid::new_v4()),
+                        tp: ToolCallType::Function,
+                        function: CalledFunction {
+                            name: function_name,
+                            arguments: serde_json::to_string(&arguments)?,
+                        },
+                    });
+                }
+            }
+            if !tool_calls.is_empty() {
+                tracing::warn!(
+                    why = "bare_deepseek_v3_call_without_outer_wrapper",
+                    recovered_calls = tool_calls.len(),
+                    stripped_bytes = trimmed.len(),
+                    "DeepSeek V3 parser recovered bare inner tool-call block and suppressed parser markup from normal_text"
+                );
+                return Ok((tool_calls, Some(normal_text)));
+            }
+            tracing::warn!(
+                why = "bare_deepseek_v3_call_without_outer_wrapper",
+                stripped_bytes = trimmed.len(),
+                "DeepSeek V3 parser suppressed malformed bare inner tool-call block so parser markup does not leak into normal_text"
+            );
+            return Ok((vec![], Some(String::new())));
+        }
         return Ok((vec![], Some(trimmed.to_string())));
     }
 
@@ -240,6 +281,10 @@ pub fn detect_tool_call_start_deepseek_v3(chunk: &str, config: &JsonParserConfig
         .any(|token| !token.is_empty() && trimmed.contains(token));
 
     if has_complete_token {
+        return true;
+    }
+
+    if trimmed.contains("<｜tool▁call▁begin｜>") {
         return true;
     }
 
@@ -384,7 +429,7 @@ mod tests {
             _ => panic!("Expected JSON parser config"),
         };
         let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
-        assert_eq!(content, Some(text.to_string()));
+        assert_eq!(content, Some("".to_string()));
         assert_eq!(result.len(), 0);
     }
 
@@ -529,6 +574,27 @@ mod tests {
             Some("I'll help you understand this Xiaohongshu codebase. Let me start by exploring the structure\n  and key files to provide you with a comprehensive\n  explanation.".to_string())
         );
     }
+
+    #[test] // TOOLCALLING.stream.4.c
+    fn test_parse_deepseek_v3_bare_inner_call_recovers_without_marker_leak() {
+        let text = r#"Before <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+```json
+{"location": "NYC"}
+```
+<｜tool▁call▁end｜>
+<｜tool▁call▁end｜>
+<｜tool▁call▁end｜>"#;
+        let config = match ToolCallConfig::deepseek_v3().parser_config {
+            super::super::config::ParserConfig::Json(cfg) => cfg,
+            _ => panic!("Expected JSON parser config"),
+        };
+        let (result, content) = parse_tool_calls_deepseek_v3(text, &config, None).unwrap();
+        assert_eq!(content, Some("Before ".to_string()));
+        assert_eq!(result.len(), 1);
+        let (name, args) = extract_name_and_args(result[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
 }
 
 #[cfg(test)]
@@ -554,7 +620,7 @@ mod detect_parser_tests {
             _ => panic!("Expected JSON parser config"),
         };
         let result = detect_tool_call_start_deepseek_v3(text, &config);
-        assert!(!result);
+        assert!(result);
     }
 
     #[test] // helper

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -89,6 +89,47 @@ pub fn find_tool_call_end_position_json(
                 chunk.len()
             }
         }
+        "deepseek_v3" | "deepseek_v3_1" => {
+            if config
+                .tool_call_start_tokens
+                .iter()
+                .any(|token| !token.is_empty() && chunk.contains(token.as_str()))
+            {
+                return config
+                    .tool_call_end_tokens
+                    .iter()
+                    .find(|token| !token.is_empty())
+                    .and_then(|token| chunk.find(token.as_str()).map(|pos| pos + token.len()))
+                    .unwrap_or(chunk.len());
+            }
+            let begin_token = "<｜tool▁call▁begin｜>";
+            let end_token = "<｜tool▁call▁end｜>";
+            if let Some(pos) = chunk.find(end_token) {
+                let mut cursor = pos + end_token.len();
+                loop {
+                    let rest = &chunk[cursor..];
+                    let trimmed = rest.trim_start();
+                    let trim_offset = rest.len() - trimmed.len();
+                    if trimmed.starts_with(end_token) {
+                        // Orphan repeated close marker — consume it.
+                        cursor += trim_offset + end_token.len();
+                    } else if trimmed.starts_with(begin_token) {
+                        // Another complete bare call follows in the same buffer;
+                        // advance past its close marker so a multi-call buffer is
+                        // not split after the first recovered call.
+                        match trimmed.find(end_token) {
+                            Some(next_end) => cursor += trim_offset + next_end + end_token.len(),
+                            None => break,
+                        }
+                    } else {
+                        break;
+                    }
+                }
+                cursor
+            } else {
+                chunk.len()
+            }
+        }
         _ => chunk.len(),
     }
 }
@@ -147,6 +188,48 @@ mod tests {
         assert_eq!(
             pos_inc, first_end,
             "should stop at end of first complete call when second is incomplete"
+        );
+    }
+
+    // Bare DeepSeek inner calls (no outer <｜tool▁calls▁begin｜> wrapper) arriving
+    // in one streaming buffer must all be captured, not split after the first
+    // <｜tool▁call▁end｜>, so the jail hands the whole group to the parser.
+    #[test] // TOOLCALLING.stream.4 — deepseek bare multi-call end-position
+    fn test_find_tool_call_end_position_deepseek_bare_multi_call() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<｜tool▁calls▁begin｜>".to_string()],
+            tool_call_end_tokens: vec!["<｜tool▁calls▁end｜>".to_string()],
+            ..Default::default()
+        };
+
+        // Two bare inner calls back-to-back, then trailing text.
+        let two = concat!(
+            "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{\"location\":\"NYC\"}<｜tool▁call▁end｜>",
+            "<｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{\"tz\":\"EST\"}<｜tool▁call▁end｜>",
+            "trailing"
+        );
+        let pos = find_tool_call_end_position_json(two, "deepseek_v3", &config);
+        assert!(
+            two[..pos].ends_with("<｜tool▁call▁end｜>"),
+            "should end at last call_end, got: {:?}",
+            &two[..pos]
+        );
+        assert_eq!(
+            &two[pos..],
+            "trailing",
+            "must span BOTH bare calls, not split after the first"
+        );
+
+        // Incomplete second bare call — stop after the first complete one.
+        let incomplete = concat!(
+            "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{\"location\":\"NYC\"}<｜tool▁call▁end｜>",
+            "<｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{\"tz\":"
+        );
+        let pos_inc = find_tool_call_end_position_json(incomplete, "deepseek_v3", &config);
+        assert!(incomplete[..pos_inc].ends_with("<｜tool▁call▁end｜>"));
+        assert!(
+            incomplete[pos_inc..].starts_with("<｜tool▁call▁begin｜>"),
+            "incomplete trailing call must remain unconsumed"
         );
     }
 

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -2941,7 +2941,7 @@ mod detect_parser_tests {
 {"location": "Tokyo"}
 ```<｜tool▁call▁end｜>"#;
         let result = detect_tool_call_start(text, Some("deepseek_v3")).unwrap();
-        assert!(!result);
+        assert!(result);
     }
 
     #[test]
@@ -2959,7 +2959,7 @@ mod detect_parser_tests {
     fn test_e2e_detect_incomplete_tool_call_start_deepseek_v3_1() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜>"#;
         let result = detect_tool_call_start(text, Some("deepseek_v3_1")).unwrap();
-        assert!(!result);
+        assert!(result);
     }
 
     #[test]

--- a/tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.5.yaml
@@ -13,7 +13,7 @@ cases:
       {"location": "NYC"}
       ```
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -21,11 +21,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls: []
         normal_text: ''
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   TOOLCALLING.batch.5.b:
     description: Closing tool_calls_end without matching tool_calls_begin
     ref: dynamo
@@ -35,18 +35,23 @@ cases:
       {"location": "NYC"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &id002
-        reason: "Dynamo's deepseek_v3 parser leaves <｜tool▁call…｜> deepseek_v3 token, <｜tool▁sep｜> in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &id003
+        reason: vLLM/SGLang deepseek_v3 handling leaves the <｜tool▁call…｜> envelope and <｜tool▁sep｜> in normal_text on this orphan end-marker case.
         calls: []
         normal_text: |-
           <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
           ```json
           {"location": "NYC"}
           ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-      vllm: *id002
-      sglang: *id002
+      sglang: *id003
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments JSON inside fenced block
     ref: dynamo
@@ -55,13 +60,13 @@ cases:
       ```json
       {"loc
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id004
+      sglang: *id004
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
@@ -75,16 +80,16 @@ cases:
       {"location": "New York"}
       ```
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *d_5_d
+      vllm: *id005
       sglang:
         reason: SGLang recovers the completed leading DeepSeek V3 call but trims the trailing newline from prefix normal_text.
         calls:
@@ -104,16 +109,16 @@ cases:
       ```json
       {"location": "New York
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_e
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *d_5_e
+      vllm: *id006
       sglang:
         reason: SGLang recovers the completed leading DeepSeek V3 call but trims the trailing newline from prefix normal_text.
         calls:

--- a/tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.stream.4.yaml
@@ -94,7 +94,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: |-
           <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
@@ -104,7 +110,8 @@ cases:
           <｜tool▁call▁end｜>
           <｜tool▁call▁end｜>
           <｜tool▁call▁end｜>
-      vllm: *id003
+        reason: vllm preserves malformed bare-wrapper parser syntax in normal_text for this recovery case; Dynamo recovers
+          the call and suppresses parser-owned markers so they do not leak into message.content.
       sglang:
         calls:
         - arguments:

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.5.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,68 +17,73 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   TOOLCALLING.batch.5.b:
     description: Closing tool_calls_end without matching tool_calls_begin
     ref: dynamo
     model_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &id002
-        reason: "Dynamo's deepseek_v3_1 parser leaves <｜tool▁call…｜> deepseek_v3 token, <｜tool▁sep｜> in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &id003
+        reason: vLLM/SGLang deepseek_v3_1 handling leaves the <｜tool▁call…｜> envelope and <｜tool▁sep｜> in normal_text on this orphan end-marker case.
         calls: []
         normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-      vllm: *id002
-      sglang: *id002
+      sglang: *id003
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id004
+      sglang: *id004
   TOOLCALLING.batch.5.d:
     description: Multi-call, last call missing only end marker (body complete)
     ref: dynamo
     model_text: I'll start by fetching the weather for both Boston and New York at the same time!<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"New
       York"}
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *d_5_d
-      sglang: *d_5_d
+      vllm: *id005
+      sglang: *id005
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
     model_text: I'll start by fetching the weather for both Boston and New York at the same time!<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"New
       York
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_e
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *d_5_e
-      sglang: *d_5_e
+      vllm: *id006
+      sglang: *id006

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.stream.4.yaml
@@ -73,10 +73,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id003
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁end｜><｜tool▁call▁end｜>
-      vllm: *id003
+        reason: vllm preserves malformed bare-wrapper parser syntax in normal_text for this recovery case; Dynamo recovers
+          the call and suppresses parser-owned markers so they do not leak into message.content.
       sglang:
         calls:
         - arguments:


### PR DESCRIPTION
#### Overview:

Recover **DeepSeek V3/V3.1** tool calls when the outer wrapper marker is missing but complete inner `<｜tool▁call▁begin｜>…<｜tool▁call▁end｜>` blocks are present, and suppress the orphan parser markup from `normal_text` instead of leaking it into `message.content`.

#### Before / After — case 5.b (closing markers present, outer `<｜tool▁calls▁begin｜>` wrapper missing):

Input (`deepseek_v3`, `deepseek_v3_1`):

````text
<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
```json
{"location": "NYC"}
```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
````

| 5.b | Dynamo before (main `3a0f5d9b65`) | Dynamo after (this PR `0901fb7c55`) |
|---|---|---|
| Parity cell | `↯` leak | `VS` documented |
| `tool_calls` | none | `get_weather(location="NYC")` |
| `normal_text` | whole `<｜tool▁call▁begin｜>…<｜tool▁calls▁end｜>` block leaked verbatim | empty |
| vs vLLM / SGLang | matched both — all three leak (`↯=`) | diverges — vLLM/SGLang still leak, Dynamo recovers the call (`VS`) |

Both `deepseek_v3` and `deepseek_v3_1` flip `↯` → `VS` on 5.b. Glyph legend: `↯` = Dynamo leaks parser markup into `normal_text`; `VS` = Dynamo intentionally diverges from both vLLM and SGLang (divergence documented via fixture `reason:`).

#### Details:

- `deepseek_v3` / `deepseek_v3_1`: recover bare inner tool-call blocks without the outer wrapper; the detector returns true on the bare inner begin marker.
- `json/mod.rs`: DeepSeek streaming end-position advances past repeated close markers **and** any following complete `begin…end` block, so a multi-call buffer is not split after the first recovered call.
- Parity fixtures (`deepseek_v3`, `deepseek_v3_1` — batch.5 + stream.4) updated to the recovered behavior.

Scope note: limited to DeepSeek. The kimi/glm47/gemma4/dsml/minimax orphan-recovery and the streaming-jail marker strip are already covered on `main` by #10144 (Top-N damaged tool-call recovery), so they are intentionally not in this PR.

#### Verification:

- `cargo fmt -p dynamo-parsers -- --check` (devcontainer)
- `cargo clippy -p dynamo-parsers --lib -- -D warnings`
- `cargo test -p dynamo-parsers --lib` — 593 passed
- `python3 -m pytest tests/parity/toolcalling/test_parity_toolcalling.py -k deepseek_v3` — 224 passed

/coderabbit profile chill
