### PR TITLE
test(parsers): document Nemotron Nano and DeepSeek V3 SGLang reasoning parity

### DIFF
--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -126,3 +126,4 @@ cases:
       sglang:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span in normal_text.

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -54,6 +54,7 @@ cases:
       sglang:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo re-enters reasoning on each open marker across chunks and concatenates all spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
@@ -88,6 +89,7 @@ cases:
       sglang:
         reasoning_text: thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers an end marker split across chunk boundaries and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the split marker is never reassembled and the answer stays in reasoning_text.
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
     ref: *upstream_ref

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -12,6 +12,7 @@ cases:
   REASONING.batch.1.b:
     description: Plain text stays in force-reasoning mode
     ref: *upstream_ref
+    spec_ref: lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo
     model_text: plain answer
     expected:
       dynamo: &d_0
@@ -21,6 +22,7 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: plain answer
+        reason: Dynamo/vLLM treat DeepSeek V3 as force-reasoning when thinking is enabled; SGLang only enters reasoning after an explicit start marker.
   REASONING.batch.2.a:
     description: DeepSeek V3.x thinking output with explicit think tags
     ref: *upstream_ref
@@ -69,6 +71,7 @@ cases:
   REASONING.batch.4:
     description: Thinking-mode completion exits on a dangling end marker
     ref: *upstream_ref
+    spec_ref: lib/parsers/REASONING_CASES.md; https://api-docs.deepseek.com/guides/thinking_mode; https://docs.nvidia.com/dynamo/dev/user-guides/reasoning/reasoning-parsing-dynamo
     model_text: normal</think>answer
     expected:
       dynamo: &d_4
@@ -78,6 +81,7 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: normal</think>answer
+        reason: Dynamo/vLLM treat a dangling end marker as the close for force-reasoning content; SGLang only enters reasoning after an explicit start marker.
   REASONING.batch.5:
     description: Missing end marker keeps the remaining text as reasoning
     ref: *upstream_ref
@@ -142,3 +146,4 @@ cases:
       sglang:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span in normal_text.

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -56,6 +56,7 @@ cases:
       sglang:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
+        reason: Dynamo re-enters reasoning on each open marker across chunks and concatenates all spans; SGLang exits at the first end marker and does not re-enter, leaving the later span in normal_text.
   REASONING.stream.3.a:
     description: Start marker split across chunks
     ref: *upstream_ref
@@ -90,6 +91,7 @@ cases:
       sglang:
         reasoning_text: thinking</think>answer
         normal_text: ''
+        reason: Dynamo buffers an end marker split across chunk boundaries and resumes normal_text after it; SGLang streams the partial delimiter as reasoning, so the split marker is never reassembled and the answer stays in reasoning_text.
   REASONING.stream.3.c:
     description: Partial start-marker prefix later resolves as force-reasoning text
     ref: *upstream_ref
@@ -104,6 +106,7 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: plain <thesis answer
+        reason: Dynamo/vLLM keep marker-free chunks in force-reasoning mode; SGLang treats the unresolved partial marker as normal_text.
   REASONING.stream.1.b:
     description: Plain text stays in force-reasoning mode until an end marker
     ref: *upstream_ref
@@ -118,3 +121,4 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: plain answer
+        reason: Dynamo/vLLM keep marker-free stream text in force-reasoning mode; SGLang only enters reasoning after an explicit start marker.


### PR DESCRIPTION
#### Overview:

This PR documents the new SGLang reasoning parity divergences for DeepSeek V3 / V3.1 / V3.2 and Nemotron Nano.

There is no Dynamo parser code change. After SGLang reasoning parser coverage was added for these families, the affected cells became research-needed again. Dynamo is still following the force-reasoning contract, so this PR records the SGLang peer divergences in the YAML fixtures.

#### Details:

DeepSeek V3 / V3.1 / V3.2 share the `deepseek_v3` reasoning fixture family. Nemotron Nano uses the `deepseek_r1` fixture family. Both use force-reasoning `<think>` semantics, where marker-free text can be reasoning until an end marker or stop condition.

This PR documents SGLang divergences for cases where SGLang only enters reasoning after an explicit start marker, exits after the first complete span, or streams split end-marker bytes as reasoning instead of buffering them.

The affected target rows move from research-needed cells to documented divergences:

```text
DeepSeek V3 / V3.1 / V3.2 batch:  S?/VS? -> S/VS
DeepSeek V3 / V3.1 / V3.2 stream: S?/VS? -> S/VS
Nemotron Nano batch:              VS? -> VS
Nemotron Nano stream:             VS? -> VS
```

#### Where should the reviewer start?

- `tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml`
- `tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml`
- `tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml`
- `tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml`

#### Related Issues:

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated reasoning parsing test fixture documentation for DeepSeek R1 and V3 models, clarifying how different frameworks handle reasoning marker parsing across batch and stream processing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->