### PR TITLE
docs(parity): tag nemotron parser rows with model generations

### DIFF
--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron Deci / GLM 4.5
+model_label: Nemotron Deci v1 / GLM 4.5
 mode: batch
 refs:
   upstream: &upstream_ref 'inspired by vLLM GLM/Nemotron think-tag reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_glm4_moe_reasoning_parser.py and https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_nemotron_v3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron Deci / GLM 4.5
+model_label: Nemotron Deci v1 / GLM 4.5
 mode: stream
 refs:
   upstream: &upstream_ref 'inspired by vLLM GLM/Nemotron think-tag reasoning tests: https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_glm4_moe_reasoning_parser.py and https://github.com/vllm-project/vllm/blob/39910f2b25aacc09f5e7f166cdf0030b19f8b9e8/tests/reasoning/test_nemotron_v3_reasoning_parser.py; local taxonomy: lib/parsers/REASONING_CASES.md'

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.batch.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron (DeciLM)
+model_label: Nemotron (DeciLM) v1/v2
 mode: batch
 cases:
   TOOLCALLING.batch.1:

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.1.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.1.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron (DeciLM)
+model_label: Nemotron (DeciLM) v1/v2
 mode: stream
 cases:
   TOOLCALLING.stream.1.a:

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.2.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.2.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron (DeciLM)
+model_label: Nemotron (DeciLM) v1/v2
 mode: stream
 cases:
   TOOLCALLING.stream.2:

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.3.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.3.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron (DeciLM)
+model_label: Nemotron (DeciLM) v1/v2
 mode: stream
 cases:
   TOOLCALLING.stream.3:

--- a/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_deci/TOOLCALLING.stream.4.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_deci
-model_label: Nemotron (DeciLM)
+model_label: Nemotron (DeciLM) v1/v2
 mode: stream
 cases:
   TOOLCALLING.stream.4.a:

--- a/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_nano
-model_label: Nemotron Nano
+model_label: Nemotron Nano v3
 mode: batch
 cases:
   TOOLCALLING.batch.1:

--- a/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.1.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.1.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_nano
-model_label: Nemotron Nano
+model_label: Nemotron Nano v3
 mode: stream
 cases:
   TOOLCALLING.stream.1.a:

--- a/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.2.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.2.yaml
@@ -4,7 +4,7 @@
 # `|2+` simply means a single newline ("\n"); see tests/parity/README.md for the full decode.
 
 family: nemotron_nano
-model_label: Nemotron Nano
+model_label: Nemotron Nano v3
 mode: stream
 cases:
   TOOLCALLING.stream.2:

--- a/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.3.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.3.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_nano
-model_label: Nemotron Nano
+model_label: Nemotron Nano v3
 mode: stream
 cases:
   TOOLCALLING.stream.3:

--- a/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.stream.4.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 family: nemotron_nano
-model_label: Nemotron Nano
+model_label: Nemotron Nano v3
 mode: stream
 cases:
   TOOLCALLING.stream.4.a:


### PR DESCRIPTION
## Summary

Append generation tags to the `model_label:` strings on the two Nemotron parity rows so the rendered tables under `tests/parity/` disambiguate which Nemotron generation each parser key actually covers.

| Family | Old label | New label |
|---|---|---|
| `nemotron_deci` (tool calling) | `Nemotron (DeciLM)` | `Nemotron (DeciLM) v1/v2` |
| `nemotron_nano` (tool calling) | `Nemotron Nano` | `Nemotron Nano v3` |
| `nemotron_deci` (reasoning) | `Nemotron Deci / GLM 4.5` | `Nemotron Deci v1 / GLM 4.5` |

## Why

Verified the actual wire format each Nemotron model emits by reading its HF `chat_template`. The result didn't match the implicit assumption in the old row labels:

- `nemotron_deci` covers `Llama-3_3-Nemotron-Super-49B-v1`, `Llama-3_1-Nemotron-Ultra-253B-v1`, **and** `NVIDIA-Nemotron-Nano-12B-v2` — the v2 Nano chat template literally instructs the model to emit `<TOOLCALL>[{...}]</TOOLCALL>`, same family as v1 Llama-Nemotron.
- `nemotron_nano` (which aliases to `qwen3_coder` in `lib/parsers/src/tool_calling/parsers.rs:60`) only fits the v3 generation: `NVIDIA-Nemotron-3-Super-120B-A12B-*` and `Nemotron-3-Nano-Omni-30B-A3B-*` (both verified emitting `<tool_call><function=><parameter=>` qwen3_coder XML in their chat templates).
- On the reasoning side, `nemotron_deci` covers v1 Llama-Nemotron and GLM 4.5/4.7 — not v2/v3 Nemotron, whose reasoning is force-thinking via the `nemotron_nano`/`nemotron_v3` alias chain.

The asymmetric v1/v2 (tool) vs v1-only (reasoning) framing in the labels reflects that real-world split.

## Scope

Pure `model_label:` text edits — 12 fixture YAMLs touched, one line per file, no code or schema changes. The generator (`tests/parity/generate_parity_table.py`) renders the new labels without modification.

The stream-mode fixtures (`TOOLCALLING.stream.{1..4}.yaml` ×2) also carry `model_label:` and got the same update so the Stream tab of the combined HTML stays consistent with the Batch tab.

## Verification

Regenerated all four panels locally and confirmed unique, correct row labels:

```bash
python3 tests/parity/generate_parity_table.py toolcalling          # batch markdown
python3 tests/parity/generate_parity_table.py toolcalling --mode stream
python3 tests/parity/generate_parity_table.py reasoning
python3 tests/parity/generate_parity_table.py reasoning --mode stream
python3 tests/parity/generate_parity_table.py all --html > /tmp/PARITY-all.html
```

All four show `Nemotron (DeciLM) v1/v2` and `Nemotron Nano v3` under the **Others** section (alphabetical position unchanged).

## Out of scope

These are tracked separately:
- `lib/parsers/src/tool_calling/parsers.rs:60` — `nemotron_nano` parser key silently mismatches `Nemotron-Nano-12B-v2`'s actual wire format. Needs a deprecation/rename design touching user-facing flags.
- `docs/digest/agentic-inference/agentic-harnesses.md:86` recommends `--dyn-reasoning-parser nemotron_deci` for Nemotron-3-Super, while `recipes/nemotron-3-super-fp8/` uses `nemotron_nano`. Worth picking one canonical answer.
- `recipes/nemotron-3-super-fp8/README.md:144` 0.9.1 fallback from `nemotron_nano` to `deepseek_r1` reasoning silently drops `force_nonempty_content: true` handling.
- A net-new `reasoning/fixtures/nemotron_nano/` row would add real cross-impl signal because vLLM's `nemotron_v3` and SGLang's `nemotron_3` both have peers — separate ~3-4 hr PR.

## Test plan

- [ ] Regenerate the HTML and confirm the two Nemotron rows render with the new labels on the Batch + Stream tabs of both the toolcalling and reasoning panels.
- [ ] Confirm no other parity rows change (alphabetical position of Nemotron rows under **Others** is unaffected).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture metadata with more specific model version labels for Nemotron Deci and Nemotron Nano models across reasoning and tool-calling test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->