### PR TITLE
perf(embedding): always base64 on worker<->frontend wire; decode at HTTP boundary if client wants float

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -110,19 +110,19 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
         dimensions: Optional[int] = None,
         encoding_format: str = "float",
     ) -> Dict[str, Any]:
-        """Transform SGLang response to OpenAI embedding format.
-
-        Honors two optional request fields:
+        """Transform SGLang response to the internal worker->frontend
+        embedding format.
 
         - ``dimensions``: Matryoshka-style truncation; keeps the first N
           values of each embedding vector.
-        - ``encoding_format``: wire format of ``data[].embedding``.
-          ``"float"`` (default) emits a JSON array of floats;
-          ``"base64"`` emits a base64-encoded little-endian ``float32``
-          byte string per the OpenAI spec.
-
-        When both are set, truncation runs first so the base64 byte
-        count matches the requested dimensionality.
+        - ``encoding_format``: validated upstream in ``generate`` for
+          spec compliance, but no longer branches the worker's output.
+          The ``embedding`` field is always emitted as a base64-encoded
+          little-endian ``float32`` byte string; the Rust HTTP frontend
+          decodes back to a JSON array of floats at the HTTP boundary
+          when the client asked for float. Truncation runs before
+          encoding so the base64 byte count matches the requested
+          dimensionality.
         """
         if not isinstance(ret, list):
             ret = [ret]
@@ -142,16 +142,18 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
                     )
                 embedding = embedding[:dimensions]
 
-            embedding_payload: Any
-            if encoding_format == "base64":
-                embedding_payload = _encode_floats_to_base64(embedding)
-            else:
-                embedding_payload = embedding
-
+            # Always emit base64 over the worker->frontend wire format,
+            # mirroring the vLLM embedding handler. The Rust HTTP frontend
+            # decodes back to a float array when the client's
+            # ``encoding_format`` is float (the OpenAI default); when the
+            # client asked for base64 the payload is passed through. JSON
+            # float arrays of 15 x 1024 floats cost ~115 ms per request in
+            # Python ``json.dumps`` + Rust ``serde_json`` parse across NATS;
+            # base64 bytes avoid both halves of that cost.
             embedding_objects.append(
                 {
                     "object": "embedding",
-                    "embedding": embedding_payload,
+                    "embedding": _encode_floats_to_base64(embedding),
                     "index": idx,
                 }
             )

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_encoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_encoding.py
@@ -115,9 +115,12 @@ def test_transform_response_base64_applies_dimensions_truncation_first(monkeypat
     assert decoded == pytest.approx(full[:3])
 
 
-def test_transform_response_defaults_to_float(monkeypatch):
-    """Default behavior (no ``encoding_format`` argument) returns float lists
-    -- preserves the wire shape for clients that have not opted into base64."""
+def test_transform_response_always_emits_base64(monkeypatch):
+    """The worker always emits base64 over the internal worker->frontend wire
+    format regardless of the client's ``encoding_format``. The Rust HTTP
+    frontend decodes back to float at the HTTP boundary if the client asked
+    for float; the worker itself does not branch.
+    """
     monkeypatch.setattr(
         "dynamo.sglang.request_handlers.handler_base.BaseWorkerHandler.__init__",
         lambda self, *a, **kw: None,
@@ -126,6 +129,16 @@ def test_transform_response_defaults_to_float(monkeypatch):
     monkeypatch.setattr(eh, "observe_embedding_input_tokens", lambda *a, **kw: None)
 
     handler = eh.EmbeddingWorkerHandler.__new__(eh.EmbeddingWorkerHandler)
-    ret = [{"embedding": [0.1, 0.2, 0.3], "meta_info": {"prompt_tokens": 1}}]
-    out = handler._transform_response(ret, "m")
-    assert out["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+    floats = [0.1, 0.2, 0.3]
+    ret = [{"embedding": floats, "meta_info": {"prompt_tokens": 1}}]
+    expected = eh._encode_floats_to_base64(floats)
+
+    # Default (no ``encoding_format`` arg) emits base64.
+    out_default = handler._transform_response(ret, "m")
+    assert out_default["data"][0]["embedding"] == expected
+
+    # Explicit ``encoding_format="float"`` also emits base64 -- the
+    # encoding_format kwarg is validated upstream in ``generate`` but no
+    # longer branches the worker's wire output.
+    out_float_kw = handler._transform_response(ret, "m", encoding_format="float")
+    assert out_float_kw["data"][0]["embedding"] == expected

--- a/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_embedding_metrics.py
@@ -202,9 +202,12 @@ def test_metric_failure_does_not_break_transform_response(monkeypatch):
     monkeypatch.setattr(eh, "observe_embedding_batch_size", _boom)
 
     handler = eh.EmbeddingWorkerHandler.__new__(eh.EmbeddingWorkerHandler)
-    ret = [{"embedding": [0.1, 0.2], "meta_info": {"prompt_tokens": 4}}]
+    floats = [0.1, 0.2]
+    ret = [{"embedding": floats, "meta_info": {"prompt_tokens": 4}}]
 
-    # Must not raise.
+    # Must not raise. The worker always emits base64 over the internal
+    # wire format -- the Rust frontend decodes back to float at the HTTP
+    # boundary if the client asked for float.
     out = handler._transform_response(ret, "model-A")
-    assert out["data"][0]["embedding"] == [0.1, 0.2]
+    assert out["data"][0]["embedding"] == eh._encode_floats_to_base64(floats)
     assert out["usage"]["prompt_tokens"] == 4

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3033,16 +3033,17 @@ class EmbeddingWorkerHandler:
                     )
                 embedding = embedding[:dimensions]
 
-            embedding_payload: Any
-            if encoding_format == "base64":
-                embedding_payload = _encode_floats_to_base64(embedding)
-            else:
-                embedding_payload = embedding
-
+            # Always emit base64 over the worker->frontend wire format. The
+            # Rust frontend decodes back to float when the client's
+            # ``encoding_format`` is float (or unset). 15x1024-float responses
+            # serialized as JSON arrays cost ~110 ms in Python json.dumps +
+            # Rust serde parse; base64 bytes are ~3x smaller and ~10x faster
+            # to (de)serialize. Client-visible wire format is preserved
+            # because Rust converts at the HTTP boundary.
             embedding_objects.append(
                 {
                     "object": "embedding",
-                    "embedding": embedding_payload,
+                    "embedding": _encode_floats_to_base64(embedding),
                     "index": idx,
                 }
             )

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1209,7 +1209,13 @@ class TestEmbeddingWorkerHandlerCancellation:
         assert len(response["data"]) == 2
         assert response["data"][0]["index"] == 0
         assert response["data"][1]["index"] == 1
-        assert response["data"][0]["embedding"] == pytest.approx([0.1, 0.2, 0.3])
+        # The worker always emits base64 on the internal worker->frontend
+        # wire format; the Rust HTTP frontend decodes back to float at the
+        # HTTP boundary when the client asks for float. So both data items
+        # have the same base64 of [0.1, 0.2, 0.3] here.
+        expected_b64 = mod._encode_floats_to_base64([0.1, 0.2, 0.3])
+        assert response["data"][0]["embedding"] == expected_b64
+        assert response["data"][1]["embedding"] == expected_b64
         # No tasks were in flight at gather completion, so the finally
         # cancel-and-await pass must not have touched the engine.
         assert aborted == []

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1008,9 +1008,7 @@ async fn embeddings(
     // asked for float (or didn't specify, defaulting to float per spec).
     if client_wants_float {
         for embedding_obj in response.inner.data.iter_mut() {
-            if let dynamo_protocols::types::EmbeddingVector::Base64(s) =
-                &embedding_obj.embedding
-            {
+            if let dynamo_protocols::types::EmbeddingVector::Base64(s) = &embedding_obj.embedding {
                 match decode_base64_embedding_to_floats(s) {
                     Ok(floats) => {
                         embedding_obj.embedding =

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -917,11 +917,12 @@ async fn embeddings(
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
 
-    // The worker always emits base64-encoded vectors over NATS (the
-    // worker->frontend wire format is ~3x smaller and ~10x faster to
-    // (de)serialize than a JSON float array). If the client asked for
-    // float (the default), decode back at the HTTP boundary so the
-    // public response shape matches their ``encoding_format`` choice.
+    // The worker always emits base64-encoded vectors over NATS so we
+    // avoid serializing/parsing a JSON float array on the internal hop.
+    // If the client asked for float (the default), decode back at the
+    // HTTP boundary so the public response shape matches their
+    // ``encoding_format`` choice. See the PR description / DIS-2154 for
+    // measured impact.
     let client_wants_float = !matches!(
         request.inner.encoding_format,
         Some(dynamo_protocols::types::EncodingFormat::Base64)
@@ -4901,6 +4902,57 @@ mod tests {
         assert!(
             !is_empty_completion_stream_response(&make_completion_chunk("", None, Some(usage))),
             "usage present → not empty",
+        );
+    }
+
+    // ── decode_base64_embedding_to_floats ────────────────────────────────
+    //
+    // The Python embedding worker always emits ``embedding`` as a base64
+    // string in the new internal wire format; the HTTP handler decodes
+    // back to ``Vec<f32>`` at the response boundary when the client
+    // requested float. These tests cover the decoder's three invariants:
+    // little-endian f32 byte-for-byte equivalence, invalid base64
+    // rejection, and non-multiple-of-4 byte length rejection.
+
+    #[test]
+    fn decode_base64_embedding_to_floats_round_trips_little_endian_f32() {
+        use base64::Engine as _;
+        let floats: Vec<f32> = vec![0.0, 1.0, -1.0, 3.14, -42.5, f32::MIN, f32::MAX];
+        let mut bytes: Vec<u8> = Vec::with_capacity(floats.len() * 4);
+        for f in &floats {
+            bytes.extend_from_slice(&f.to_le_bytes());
+        }
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let decoded = decode_base64_embedding_to_floats(&encoded)
+            .expect("valid base64 of f32 bytes should decode");
+        assert_eq!(decoded, floats);
+    }
+
+    #[test]
+    fn decode_base64_embedding_to_floats_rejects_invalid_base64() {
+        // Padding and alphabet violations: standard base64 alphabet is
+        // A-Za-z0-9+/= -- the '!' byte forces a decode error.
+        let result = decode_base64_embedding_to_floats("not!valid!base64");
+        assert!(
+            result.is_err(),
+            "non-base64 input should fail decode, got Ok({:?})",
+            result.ok()
+        );
+    }
+
+    #[test]
+    fn decode_base64_embedding_to_floats_rejects_non_multiple_of_4_byte_length() {
+        // 5 raw bytes -> base64 string. The handler must reject because
+        // 5 is not a whole number of f32 values.
+        use base64::Engine as _;
+        let bytes: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let result = decode_base64_embedding_to_floats(&encoded);
+        assert!(result.is_err(), "5-byte payload must fail, got Ok");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not a multiple of 4"),
+            "error should mention the multiple-of-4 check, got: {err_msg}"
         );
     }
 }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -4920,7 +4920,10 @@ mod tests {
     #[test]
     fn decode_base64_embedding_to_floats_round_trips_little_endian_f32() {
         use base64::Engine as _;
-        let floats: Vec<f32> = vec![0.0, 1.0, -1.0, 3.14, -42.5, f32::MIN, f32::MAX];
+        // Avoid 3.14 to side-step ``clippy::approx_constant`` -- the lint
+        // would force importing ``std::f32::consts::PI``, which isn't the
+        // point of the test.
+        let floats: Vec<f32> = vec![0.0, 1.0, -1.0, 2.5, -42.5, f32::MIN, f32::MAX];
         let mut bytes: Vec<u8> = Vec::with_capacity(floats.len() * 4);
         for f in &floats {
             bytes.extend_from_slice(&f.to_le_bytes());

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -923,8 +923,11 @@ async fn embeddings(
     // HTTP boundary so the public response shape matches their
     // ``encoding_format`` choice. See the PR description / DIS-2154 for
     // measured impact.
+    // Borrow rather than move ``encoding_format`` out of ``request`` so the
+    // request value remains intact for the later ``engine.generate(request)``
+    // call below.
     let client_wants_float = !matches!(
-        request.inner.encoding_format,
+        request.inner.encoding_format.as_ref(),
         Some(dynamo_protocols::types::EncodingFormat::Base64)
     );
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -917,6 +917,16 @@ async fn embeddings(
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
 
+    // The worker always emits base64-encoded vectors over NATS (the
+    // worker->frontend wire format is ~3x smaller and ~10x faster to
+    // (de)serialize than a JSON float array). If the client asked for
+    // float (the default), decode back at the HTTP boundary so the
+    // public response shape matches their ``encoding_format`` choice.
+    let client_wants_float = !matches!(
+        request.inner.encoding_format,
+        Some(dynamo_protocols::types::EncodingFormat::Base64)
+    );
+
     // Embeddings are typically not streamed, so we default to non-streaming
     let streaming = false;
 
@@ -980,7 +990,7 @@ async fn embeddings(
 
     // Embeddings are typically returned as a single response (non-streaming)
     // so we fold the stream into a single response
-    let response = NvCreateEmbeddingResponse::from_annotated_stream(stream)
+    let mut response = NvCreateEmbeddingResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
             tracing::error!(
@@ -994,11 +1004,61 @@ async fn embeddings(
             err_response
         })?;
 
+    // Worker always emits Base64 -- convert back to Float when the client
+    // asked for float (or didn't specify, defaulting to float per spec).
+    if client_wants_float {
+        for embedding_obj in response.inner.data.iter_mut() {
+            if let dynamo_protocols::types::EmbeddingVector::Base64(s) =
+                &embedding_obj.embedding
+            {
+                match decode_base64_embedding_to_floats(s) {
+                    Ok(floats) => {
+                        embedding_obj.embedding =
+                            dynamo_protocols::types::EmbeddingVector::Float(floats);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to decode base64 embedding for request {}: {:?}",
+                            request_id,
+                            e
+                        );
+                        let err_response = ErrorMessage::internal_server_error(
+                            "Failed to decode embedding payload",
+                        );
+                        inflight.mark_error(extract_error_type_from_response(&err_response));
+                        return Err(err_response);
+                    }
+                }
+            }
+        }
+    }
+
     state
         .metrics_clone()
         .observe_embedding_latency(&model_name, embedding_start.elapsed().as_secs_f64());
     inflight.mark_ok();
     Ok(Json(response).into_response())
+}
+
+/// Decode a base64-encoded little-endian f32 byte string back into a float
+/// vector. The byte length must be a multiple of 4; trailing bytes are
+/// rejected. Mirrors the encoder in `lib/llm/src/preprocessor.rs` and the
+/// Python `_encode_floats_to_base64` helper in
+/// `components/src/dynamo/vllm/handlers.py`.
+fn decode_base64_embedding_to_floats(s: &str) -> Result<Vec<f32>, anyhow::Error> {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    let bytes = STANDARD.decode(s)?;
+    if bytes.len() % std::mem::size_of::<f32>() != 0 {
+        anyhow::bail!(
+            "base64-decoded byte length {} is not a multiple of 4",
+            bytes.len()
+        );
+    }
+    let mut floats = Vec::with_capacity(bytes.len() / std::mem::size_of::<f32>());
+    for chunk in bytes.chunks_exact(std::mem::size_of::<f32>()) {
+        floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+    Ok(floats)
 }
 
 async fn handler_chat_completions(


### PR DESCRIPTION
#### Overview:

Linear issue: [DIS-2154](https://linear.app/nvidia/issue/DIS-2154/debug-dynamovllm-embedding-worker-is-22x-slower-than-raw-vllm-serve)

**TL;DR.** Embedding responses crossing the worker→frontend hop are big JSON float arrays (~180 KB per `--batch-size 15` request) — slow to serialize in Python, slow to parse in Rust. This PR changes the **internal** wire format between the Python embedding worker and the Rust HTTP frontend to use base64-encoded bytes (~3× smaller, ~10× faster to (de)serialize). The Rust frontend decodes back to floats at the HTTP boundary, so the client-visible response is unchanged.

**Impact.** dynamo's embedding latency at `--batch-size 15` drops from **215 ms → 124 ms** on arm64 GB200 (≈42% faster). Invisible to clients — their wire format is exactly what they asked for. Builds on top of [#10117](https://github.com/ai-dynamo/dynamo/pull/10117) (asyncio.gather).

#### Background — what problem this solves

vllm-serve (single process) handles a batch=15 embedding request in ~63 ms. dynamo with the asyncio.gather fix in [#10117](https://github.com/ai-dynamo/dynamo/pull/10117) takes 215 ms — 3.4× slower. Profiling (see [DIS-2154](https://linear.app/nvidia/issue/DIS-2154)) showed ~115 ms of that gap is **the cost of moving the response across the worker→frontend process boundary as JSON of `Vec<Vec<f32>>`**:

- Python `json.dumps` of 15 × 1024 floats: ~30–60 ms
- NATS bytes-on-wire: 180 KB transfer
- Rust `serde_json::from_slice` parse of 15 K floats: ~20–40 ms

The OpenAI `encoding_format=base64` field exists exactly to avoid this bloat. When a client opts in, the worker emits ~80 KB of bytes instead of 180 KB of JSON, and the costs above collapse to ~5 ms. The catch: most clients don't opt in — `float` is the default.

This PR captures that win for every client by making base64 the **internal** wire format on the worker→frontend hop, while preserving the client's requested format on the frontend→client hop.

#### Wire format change

```
Before                                       After (this PR)
──────────────────────────────────────────   ──────────────────────────────────────────
Python worker                                Python worker
  yield "embedding": [floats]   ─OR─           yield "embedding": "<base64string>"
        "embedding": "<base64>"                (always base64, regardless of client)
   ↓ (matches client's encoding_format)         ↓
NATS  (180 KB JSON  ─OR─  80 KB base64)      NATS  (always 80 KB base64)
   ↓                                            ↓
Rust frontend                                Rust frontend
  pass-through: whatever worker emitted        if client wanted float:
   ↓                                              decode base64 → Vec<f32>
HTTP client                                     else: pass through
  (gets whatever they asked for)                 ↓
                                              HTTP client
                                                (gets whatever they asked for)
```

The client-visible HTTP wire format is **identical to before**. Only the worker→frontend hop changes.

#### Where to start reviewing

1. **`lib/llm/src/http/service/openai.rs`** — three things to look at, all in the `embeddings` HTTP handler:
   1. `client_wants_float` is captured **before** `engine.generate(request)` (which consumes the request). It's `true` when the client asked for `float` or didn't specify (float is the OpenAI default).
   2. After `NvCreateEmbeddingResponse::from_annotated_stream` folds the response, iterate `response.inner.data` and convert each `EmbeddingVector::Base64(s)` → `EmbeddingVector::Float(Vec<f32>)` when `client_wants_float`. When the client wanted base64, the payload is left as-is (pass-through).
   3. `decode_base64_embedding_to_floats` helper mirrors the existing `encode_floats_to_base64` (in `lib/llm/src/preprocessor.rs`) and the Python `_encode_floats_to_base64` (in `components/src/dynamo/vllm/handlers.py`) for byte-exact parity.

2. **`components/src/dynamo/vllm/handlers.py`** — `EmbeddingWorkerHandler.generate` simplifies: instead of branching on `encoding_format` and emitting either floats or base64, it always emits base64. Validation of `encoding_format` for spec compliance is kept.

3. **`lib/protocols/src/types/embeddings.rs`** — **no changes here.** The `EmbeddingVector` enum is already `#[serde(untagged)]` and accepts either shape on the wire. This PR uses the existing flexibility — no protocol change needed.

#### Benchmark (arm64 GB200, Qwen3-Embedding-0.6B, --batch-size 15, ISL=80, RPS=1)

| Stack | float client | base64 client | vs vllm-serve (float) |
|---|---|---|---|
| vllm-serve | 63.41 ms | 62.06 ms | 1.0× |
| dynamo pre-fix | 323.61 ms | — | 5.1× |
| dynamo + gather ([#10117](https://github.com/ai-dynamo/dynamo/pull/10117)) | 214.52 ms | 98.82 ms | 3.4× |
| **dynamo + gather + this PR** | **123.70 ms** | **96.28 ms** | **1.95×** |

Compared to gather-only:
- **Float clients: 214.52 → 123.70 ms = 90.8 ms saved (42% faster)**
- Base64 clients: 98.82 → 96.28 ms = noise (the wire format already matched)

The 27 ms gap between float and base64 clients on this PR is the Rust-side decode cost (`base64::decode` + per-element `f32::from_le_bytes`). Investigated a `bytemuck::pod_collect_to_vec` alternative on a separate branch — measured **slower**, see the [DIS-2154 negative-result comment](https://linear.app/nvidia/issue/DIS-2154#comment-04325edf). The per-element loop is already near-optimal.

#### End-to-end verified

```bash
# Default (no encoding_format) → client gets a JSON float array
$ curl -s -X POST http://localhost:8000/v1/embeddings \
    -d '{"model":"Qwen/Qwen3-Embedding-0.6B","input":["hello","world"]}' \
    | jq '.data[0].embedding | (type), (.[:3])'
"array"
[2.6875, -12.8125, -0.045166016]

# encoding_format=base64 → client gets a base64 string
$ curl -s -X POST http://localhost:8000/v1/embeddings \
    -d '{"input":["hello"],"encoding_format":"base64"}' \
    | jq '.data[0].embedding | (type), (.[0:30])'
"string"
"AAAsQAAATcEAADm9AAB2wQAAWEAAAL"
```

Both paths verified against the live pod.

#### Risks & mitigation

The Python ↔ Rust internal wire format is implementation-internal, but version skew could misalign:

- **New worker + old frontend**: float-asking clients would get base64 strings back (old frontend wouldn't know to decode). Client-visible bug.
- **Old worker + new frontend**: float-asking clients would get floats as before. The new frontend's decode loop sees `EmbeddingVector::Float(...)` already and does nothing. No regression.

In an in-cluster deployment where worker and frontend are upgraded together, this is a non-issue. If needed, mitigation options (not in this PR — happy to add if a reviewer thinks it's required):
- Worker capability advertisement at registration (frontend only requests base64 when the worker advertises support).
- Env-var feature flag, default off; flip on once both sides are deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Embedding prompts are now processed concurrently, significantly improving throughput when handling multiple prompts in batch requests

* **Refactor**
  * Enhanced handling of embedding format requests to ensure consistent and reliable format conversion across client requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
