### PR TITLE
WIP: feat: add --publish_metrics to decouple iter-stats from --publish_metrics_and_events

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -156,6 +156,14 @@ class DynamoTrtllmArgGroup(ArgGroup):
             default=False,
             help="If set, publish events and metrics to Dynamo components.",
         )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--publish-metrics",
+            env_var="DYN_TRTLLM_PUBLISH_METRICS",
+            default=False,
+            help="If set, publish Prometheus metrics without enabling KV-cache event "
+            "routing. Safe to use with approximate KV routing (--no-router-kv-events).",
+        )
         add_argument(
             g,
             flag_name="--load-format",
@@ -489,6 +497,7 @@ class DynamoTrtllmConfig(ConfigBase):
     extra_engine_args: str
     override_engine_args: str
     publish_events_and_metrics: bool
+    publish_metrics: bool
     load_format: str
     model_loader_extra_config: str
     guided_decoding_backend: Optional[str] = None

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -27,6 +27,7 @@ from tensorrt_llm.llmapi import KvCacheConfig, SchedulerConfig
 from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
+from tensorrt_llm.metrics import MetricsCollector
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
 from torch.cuda import device_count
@@ -146,6 +147,12 @@ class TrtllmLLMEngine(LLMEngine):
         # Written by `_metrics_poll_loop`, read by snapshot lambdas under the
         # GIL. Per-rank key-level writes are GIL-serialized.
         self._latest_metrics: dict[int, Metrics] = {}
+        # Upstream tensorrt_llm.metrics.MetricsCollector instance fed from
+        # `_metrics_poll_loop`. The legacy worker wires log_iteration_stats
+        # via publisher.py; the unified path has no equivalent hook, so the
+        # engine owns instantiation here. None when publish_events_and_metrics
+        # is disabled or when the installed tensorrt_llm lacks the collector.
+        self._metrics_collector: Optional[MetricsCollector] = None
         # Per-rank hashes of partial blocks; their later "removed" events
         # must not reach the router (which never saw them stored). Scoping
         # by rank prevents a partial block on one rank from suppressing a
@@ -269,6 +276,22 @@ class TrtllmLLMEngine(LLMEngine):
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
         if self._kv_routing_enabled():
+            # Mirrors `workers/llm_worker.py:529` for the unified path.
+            # The legacy `engine_args` already sets `enable_iter_perf_stats`
+            # and `return_perf_metrics` to `publish_events_and_metrics`,
+            # so the engine is producing iteration snapshots; this collector
+            # is what turns those snapshots into Prometheus gauges.
+            try:
+                self._metrics_collector = MetricsCollector(
+                    {
+                        "model_name": self.served_model_name or self.model_name,
+                        "engine_type": "trtllm",
+                    }
+                )
+                logger.info("TensorRT-LLM MetricsCollector initialized")
+            except Exception as e:
+                logger.warning("Failed to initialize MetricsCollector: %s", e)
+                self._metrics_collector = None
             self._metrics_thread = threading.Thread(
                 target=self._metrics_poll_loop,
                 daemon=True,
@@ -354,11 +377,21 @@ class TrtllmLLMEngine(LLMEngine):
             # Per-rank latest snapshot. Stats from different ranks are
             # interleaved; keep the freshest per `attentionDpRank`.
             for snap in snaps:
-                kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
-                if kv_used is None:
-                    continue
                 rank = int(snap.get("attentionDpRank", 0))
-                self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
+                kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
+                if kv_used is not None:
+                    self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
+                # Drive upstream Prometheus collector with the same snapshot.
+                # Mirrors the legacy publisher.py path; under attention-DP,
+                # later ranks overwrite earlier within a tick — same behavior
+                # as upstream trtllm-serve's openai_server.py:1067.
+                if self._metrics_collector is not None and hasattr(
+                    self._metrics_collector, "log_iteration_stats"
+                ):
+                    try:
+                        self._metrics_collector.log_iteration_stats(snap)
+                    except Exception as e:
+                        logger.debug("trtllm log_iteration_stats raised: %s", e)
 
     def _kv_events_poll_loop(self) -> None:
         assert self._engine is not None

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -112,6 +112,7 @@ class TrtllmLLMEngine(LLMEngine):
         kv_block_size: int = 32,
         disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED,
         publish_events_and_metrics: bool = False,
+        publish_metrics: bool = False,
     ):
         self.engine_args = engine_args
         self.model_name = model_name
@@ -125,6 +126,7 @@ class TrtllmLLMEngine(LLMEngine):
         # Gates the metrics-poll thread and the kv_event/metrics source
         # publishers. See `_kv_routing_enabled`.
         self.publish_events_and_metrics = publish_events_and_metrics
+        self.publish_metrics = publish_metrics
         self._engine: TensorRTLLMEngine | None = None
         self._default_sampling_params = SamplingParams(detokenize=False)
         # Per-request GenerationResult handles for `abort()` lookup. TRT-LLM's
@@ -196,11 +198,11 @@ class TrtllmLLMEngine(LLMEngine):
             "max_seq_len": config.max_seq_len,
             "max_beam_width": config.max_beam_width,
             "max_batch_size": config.max_batch_size,
-            "return_perf_metrics": config.publish_events_and_metrics,
+            "return_perf_metrics": config.publish_events_and_metrics or config.publish_metrics,
             # enable_iter_perf_stats is required by the PyTorch backend to
             # compute iteration-level stats (KV cache utilization, hit rate).
             # See TRT-LLM PR #11243.
-            "enable_iter_perf_stats": config.publish_events_and_metrics,
+            "enable_iter_perf_stats": config.publish_events_and_metrics or config.publish_metrics,
         }
 
         # Apply --extra-engine-args / --override-engine-args. Match the
@@ -250,6 +252,7 @@ class TrtllmLLMEngine(LLMEngine):
             kv_block_size=config.kv_block_size,
             disaggregation_mode=config.disaggregation_mode,
             publish_events_and_metrics=config.publish_events_and_metrics,
+            publish_metrics=config.publish_metrics,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -275,12 +278,15 @@ class TrtllmLLMEngine(LLMEngine):
         await self._engine.initialize()
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
-        if self._kv_routing_enabled():
+        if self._metrics_enabled():
             # Mirrors `workers/llm_worker.py:529` for the unified path.
             # The legacy `engine_args` already sets `enable_iter_perf_stats`
             # and `return_perf_metrics` to `publish_events_and_metrics`,
             # so the engine is producing iteration snapshots; this collector
             # is what turns those snapshots into Prometheus gauges.
+            # TODO: register_engine_metrics_callback (HTTP exposure) needs a dynamo
+            # endpoint handle that start() does not receive, so metrics are not yet
+            # served over HTTP in the unified path.
             try:
                 self._metrics_collector = MetricsCollector(
                     {
@@ -317,6 +323,10 @@ class TrtllmLLMEngine(LLMEngine):
         # Matches the legacy `workers/llm_worker.py` gate. Decode workers
         # publish too — legacy only flips `enable_local_indexer` off.
         return self.publish_events_and_metrics
+
+    def _metrics_enabled(self) -> bool:
+        # MetricsCollector gate: either publish flag enables Prometheus metrics.
+        return self.publish_events_and_metrics or self.publish_metrics
 
     async def kv_event_sources(self) -> list[KvEventSource]:
         if not self._kv_routing_enabled():

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -253,11 +253,11 @@ async def init_llm_worker(
         "max_seq_len": config.max_seq_len,
         "max_beam_width": config.max_beam_width,
         "max_batch_size": config.max_batch_size,
-        "return_perf_metrics": config.publish_events_and_metrics,
+        "return_perf_metrics": config.publish_events_and_metrics or config.publish_metrics,
         # enable_iter_perf_stats is required for PyTorch backend to compute iteration-level
         # stats (KV cache utilization, hit rate). TensorRT backend always has this enabled.
         # See TRT-LLM PR #11243: MetricsCollector.log_iteration_stats() needs these stats.
-        "enable_iter_perf_stats": config.publish_events_and_metrics,
+        "enable_iter_perf_stats": config.publish_events_and_metrics or config.publish_metrics,
         "kv_connector_config": kv_connector_config,
     }
 
@@ -523,7 +523,7 @@ async def init_llm_worker(
         # This enables exposing TRT-LLM's native Prometheus metrics (request latency, TTFT, TPOT, etc.)
         metrics_collector = None
         additional_metrics = None
-        if config.publish_events_and_metrics:
+        if config.publish_events_and_metrics or config.publish_metrics:
             try:
                 model_name_for_metrics = config.served_model_name or config.model
                 metrics_collector = MetricsCollector(


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--publish-metrics` configuration flag to enable Prometheus metrics publishing independently of KV-cache event routing, avoiding serialization overhead when approximate-KV routing is active.
  * Updated help documentation for event and metrics publishing options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->