### PR TITLE
feat: add clone hotpath audit skill

### DIFF
--- a/.agents/contributor-skills/dynamo-clone-hotpath-audit/SKILL.md
+++ b/.agents/contributor-skills/dynamo-clone-hotpath-audit/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: dynamo-clone-hotpath-audit
+description: Audit Dynamo Rust hot-path `.clone()` calls, explain which clones are removable and why, and only apply clone-removal patches when explicitly requested.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - rust
+    - performance
+    - code-review
+    - allocation
+  permissions:
+    - file_read
+    - file_write
+---
+
+# Dynamo Clone Hotpath Audit
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+## Purpose
+
+Find `.clone()` calls in Dynamo Rust request, scheduling, KV, block-manager, and
+runtime hot paths that can be removed without changing ownership semantics. This
+is an audit-first workflow, not a blanket clone-removal tool.
+
+Default behavior is read-only audit. Do not edit files, commit, or open a PR
+unless the user explicitly asks to fix, patch, apply, implement, or create an
+MR/PR. A skill invocation such as `$dynamo-clone-hotpath-audit`, "audit",
+"check", or "scan" is not patch permission.
+
+## Prerequisites
+
+- Rust source checkout of `ai-dynamo/dynamo`.
+- Python 3.10+ for the inventory script.
+- Ability to run targeted Rust validation commands for touched crates.
+- Subagent tooling if available. If subagents are unavailable, run the same
+  roles as separate, explicit review passes and say they were not independent.
+
+## Instructions
+
+### 1. Build The Inventory
+
+Run the read-only scanner from the repository root:
+
+```bash
+python3 .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py \
+  --only-actionable \
+  --limit 80
+```
+
+Use narrower paths when the user names a subsystem:
+
+```bash
+python3 .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py \
+  --paths lib/kv-router/src/scheduling lib/llm/src/backend \
+  --only-actionable
+```
+
+Treat the scanner as a triage aid. It ranks likely expensive clones but does not
+prove removability.
+
+### 2. Split The Audit By Hot Path
+
+Prioritize in this order:
+
+1. per-request LLM paths: `lib/llm/src/backend.rs`, preprocessor, HTTP/gRPC
+   services, protocol conversion, migration
+2. KV routing and scheduling: `lib/kv-router/src/scheduling`,
+   `lib/kv-router/src/sequences`, `lib/kv-router/src/indexer`
+3. KV/block manager event paths: `lib/llm/src/block_manager`,
+   `lib/bindings/kvbm/src/block_manager`, `lib/kvbm-engine/src/offload`
+4. runtime request/transport paths: `lib/runtime/src/component`,
+   `lib/runtime/src/pipeline`, `lib/runtime/src/transports`
+5. tests, examples, debug paths, and benchmark setup only after hot paths
+
+### 3. Use Independent Review Roles
+
+For non-trivial audits, use subagents. Give each subagent only the inventory
+slice and relevant source files, not your intended answer.
+
+Required roles:
+
+- candidate finder: identify high-value clones and classify cheap/required ones
+- ownership refactorer: propose concrete borrow, move, `Arc`, or `mem::take`
+  changes
+- correctness adversary: reject changes that alter sharing, extend lock
+  lifetimes, borrow across `.await`, break spawned task ownership, or make APIs
+  less clear
+- validation planner: choose the smallest tests, clippy commands, or benchmarks
+  that prove the touched behavior
+
+If two roles disagree, keep the clone unless you can write down a precise
+ownership proof and validation plan.
+
+### 4. Classify Every Candidate
+
+Use these buckets:
+
+- cheap required: `Arc`, sender, cancellation token, runtime handle, watch
+  receiver, metrics handle, or tracing span clone needed to share ownership
+- semantic required: the original value must stay available for a later use,
+  retry, fan-out, or async task
+- cold/test-only: outside production hot paths
+- removable move: value is cloned immediately before its final ownership use
+- removable borrow: callee does not need ownership and can accept `&T`, `&str`,
+  slice, or iterator
+- structural refactor: requires changing data layout, e.g. `Vec<T>` to
+  `Arc<[T]>`, or changing an API family
+
+Do not patch candidates in the first three buckets.
+
+### 5. Patch In Small Batches
+
+Only run this section when the user explicitly asks for fixes or a patch. If the
+user only asked for an audit, stop after the report and list recommended patch
+batches as follow-up work.
+
+Keep each patch batch narrow: one subsystem or one repeated pattern. Avoid a
+single repository-wide clone cleanup PR unless the user explicitly asks for it.
+
+Preferred fixes:
+
+- move a value when the clone is immediately consumed and not used afterward
+- pass `&T`, `&str`, `&[T]`, or an iterator when the callee only reads
+- consume batches with `into_iter()` instead of indexing and cloning
+- extract small `Copy` fields before moving a large event
+- use `std::mem::take` only when leaving the source value empty is part of the
+  intended semantics
+- use `Arc` only when shared ownership is semantically right, not just to avoid
+  borrow-checker work
+
+Do not:
+
+- remove clones that cross `tokio::spawn`, channel send, callback storage, or
+  task lifetime boundaries without proving ownership
+- extend mutex/RwLock guard lifetimes to avoid a clone
+- borrow across `.await` unless the borrow is local and compiler-verified
+- trade a clear cheap clone for a confusing lifetime-heavy API
+- make public APIs borrow data whose ownership was intentionally independent
+
+### 6. Required Finding Format
+
+For every proposed change, report:
+
+- `file:line`
+- hot-path rationale
+- cloned value and likely clone cost
+- bucket and recommended change
+- removal rationale: why this clone is unnecessary, not only why it is expensive
+- required-clone check: why it is not cheap required or semantic required
+- correctness proof: why the old and new ownership semantics match
+- validation command
+
+Example:
+
+```text
+lib/llm/src/preprocessor.rs:123
+Hot path: every embeddings request.
+Cost: clones Vec<String> before moving into spawn_blocking.
+Bucket: removable move.
+Change: move input_strs into the closure.
+Removal rationale: the clone feeds the only owned consumer and the original is
+not read after closure construction.
+Required-clone check: no fan-out, retry, async task sharing, or later logging
+uses the original value.
+Proof: the closure receives the same owned Vec<String>; all later behavior reads
+from that moved value.
+Validation: cargo test -p dynamo-llm preprocessor
+```
+
+### 7. Validate Before Finishing
+
+If patches were made, always run formatting and the narrowest relevant Rust
+tests. For broad API changes, also run clippy or crate-level tests for each
+touched crate. If no patches were made, do not run tests just to make the audit
+look validated; report the inventory command and any read-only review checks.
+
+Return:
+
+- clone candidates reviewed
+- candidates intentionally left alone and why
+- patches made, or `none: audit-only`
+- tests run and results, or `not run: no files changed`
+- residual high-value candidates that should be separate PRs
+
+## Available Scripts
+
+| Script | Purpose | Arguments |
+|---|---|---|
+| `scripts/clone_inventory.py` | Rank Rust `.clone()` call sites by hot-path likelihood and removal potential | `--paths`, `--limit`, `--format`, `--only-actionable`, `--include-tests` |
+
+Invoke via the agentskills.io `run_script()` protocol:
+
+```python
+run_script("scripts/clone_inventory.py", args=["--only-actionable", "--limit", "80"])
+```
+
+## Output Contract
+
+Return a concise audit report or PR summary with:
+
+- scope and inventory command
+- top findings with buckets
+- per finding: removal rationale, required-clone check, correctness proof, and
+  validation command
+- exact refactors made, or `none: audit-only`
+- independent review role outcomes
+- validation commands and status
+- follow-up candidates excluded from the current audit or patch
+
+## Limitations
+
+- The scanner is heuristic and line-based. It can miss macro-expanded clones,
+  multi-line ownership patterns, or clones hidden behind helper methods.
+- Some expensive-looking clones are required for async task ownership, fan-out,
+  retries, or API clarity.
+- Performance impact is inferred unless backed by benchmarks or allocation
+  profiles.

--- a/.agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py
+++ b/.agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Rank Rust .clone() call sites for Dynamo hot-path clone audits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_PATHS = ("lib", "crates", "components")
+
+CLONE_RE = re.compile(r"(?:\bArc::clone\s*\(|\.clone\s*\()")
+
+TEST_PATH_MARKERS = (
+    "/tests/",
+    "/benches/",
+    "/examples/",
+    "/bench/",
+    "_test.rs",
+    "tests.rs",
+)
+
+HOT_PATH_RULES = (
+    ("lib/llm/src/backend", 10, "llm request backend"),
+    ("lib/llm/src/preprocessor", 9, "llm request preprocessing"),
+    ("lib/llm/src/http", 8, "http request path"),
+    ("lib/llm/src/grpc", 8, "grpc request path"),
+    ("lib/llm/src/protocols", 7, "protocol conversion"),
+    ("lib/llm/src/migration", 7, "request retry/migration"),
+    ("lib/llm/src/kv_router", 8, "llm kv routing"),
+    ("lib/llm/src/block_manager", 8, "block manager path"),
+    ("lib/bindings/kvbm/src/block_manager", 8, "kvbm binding block manager"),
+    ("lib/kvbm-engine/src/offload", 8, "kvbm offload path"),
+    ("lib/kvbm-logical/src", 7, "kvbm logical manager"),
+    ("lib/kvbm-physical/src", 7, "kvbm physical manager"),
+    ("lib/kv-router/src/scheduling", 9, "kv-router scheduler"),
+    ("lib/kv-router/src/sequences", 8, "kv-router sequence tracker"),
+    ("lib/kv-router/src/indexer", 8, "kv-router indexer"),
+    ("lib/runtime/src/component", 7, "runtime component path"),
+    ("lib/runtime/src/pipeline", 7, "runtime pipeline path"),
+    ("lib/runtime/src/transports", 7, "runtime transport path"),
+    ("lib/runtime/src/storage", 6, "runtime storage path"),
+)
+
+CHEAP_HINTS = (
+    "Arc::clone",
+    "CancellationToken",
+    "cancel_token",
+    "shutdown_token",
+    "sender",
+    "receiver",
+    "_tx",
+    "_rx",
+    "watch::",
+    "Handle",
+    "span.clone",
+    "metrics",
+)
+
+DEEP_VALUE_HINTS = (
+    "tokens",
+    "token_ids",
+    "token_block",
+    "token_chunks",
+    "request",
+    "response",
+    "event",
+    "payload",
+    "metadata",
+    "blocks",
+    "block_hashes",
+    "scores",
+    "overlap",
+    "runtime_data",
+    "annotations",
+    "messages",
+    "content",
+    "schema",
+    "config",
+)
+
+BOUNDARY_HINTS = (
+    "tokio::spawn",
+    "spawn_blocking",
+    ".send(",
+    ".try_send(",
+    ".instrument(",
+    ".map_err(",
+    "async move",
+)
+
+
+@dataclass(frozen=True)
+class CloneCandidate:
+    score: int
+    tier: str
+    category: str
+    path: str
+    line: int
+    hot_path: str
+    reasons: list[str]
+    text: str
+
+
+def require_under_root(root: Path, path: Path) -> Path:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as exc:
+        msg = f"refusing to scan path outside repository root: {path}"
+        raise SystemExit(msg) from exc
+    return resolved_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repository root. Defaults to current working directory.",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=DEFAULT_PATHS,
+        help="Files or directories to scan, relative to --root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=120,
+        help="Maximum candidates to print. Use 0 for all.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--only-actionable",
+        action="store_true",
+        help="Hide cheap shared-ownership and test-only clones.",
+    )
+    parser.add_argument(
+        "--include-tests",
+        action="store_true",
+        help="Keep test, benchmark, and example clone sites in normal scoring.",
+    )
+    return parser.parse_args()
+
+
+def rust_files(root: Path, paths: Iterable[str]) -> list[Path]:
+    files: set[Path] = set()
+    for raw_path in paths:
+        path = require_under_root(root, root / raw_path)
+        if path.is_file() and path.suffix == ".rs":
+            files.add(path)
+        elif path.is_dir():
+            files.update(p for p in path.rglob("*.rs") if p.is_file())
+    return sorted(files)
+
+
+def rel_path(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def is_test_path(path: str) -> bool:
+    normalized = f"/{path}"
+    return any(marker in normalized for marker in TEST_PATH_MARKERS)
+
+
+def hot_path_score(path: str) -> tuple[int, str]:
+    for prefix, score, label in HOT_PATH_RULES:
+        if path.startswith(prefix):
+            return score, label
+    return 2, "not a known hot path"
+
+
+def context_window(lines: list[str], index: int) -> str:
+    start = max(0, index - 5)
+    end = min(len(lines), index + 3)
+    return "\n".join(lines[start:end])
+
+
+def has_loop_context(window: str) -> bool:
+    return bool(re.search(r"^\s*(for|while|loop)\b", window, re.MULTILINE))
+
+
+def score_candidate(
+    path: str, line: str, window: str, include_tests: bool
+) -> CloneCandidate:
+    base_score, hot_path = hot_path_score(path)
+    score = base_score
+    reasons = [hot_path]
+
+    stripped = line.strip()
+    path_is_test = is_test_path(path)
+    is_cold = path_is_test and not include_tests
+    is_cheap = any(hint in stripped for hint in CHEAP_HINTS)
+    is_loop = has_loop_context(window)
+    is_clone_into_arc = "Arc::new(" in stripped and ".clone" in stripped
+
+    if is_cold:
+        score -= 8
+        reasons.append("test, benchmark, or example path")
+
+    if is_cheap:
+        score -= 5
+        reasons.append("looks like shared-handle or control-plane clone")
+
+    if any(hint in stripped for hint in DEEP_VALUE_HINTS):
+        score += 3
+        reasons.append("name suggests non-trivial owned data")
+
+    if is_loop:
+        score += 4
+        reasons.append("clone appears inside or near a loop")
+
+    if is_clone_into_arc:
+        score += 5
+        reasons.append("owned value may be cloned before Arc wrapping")
+
+    if ".clone()" in stripped and any(hint in window for hint in BOUNDARY_HINTS):
+        score -= 2
+        reasons.append("near async/task/channel boundary; ownership may be required")
+
+    if re.search(r"let\s+\w+\s*=\s*\w+\.clone\(\)\s*;", stripped):
+        score += 2
+        reasons.append("simple clone assignment; check whether final use can move")
+
+    if ".clone()." in stripped or (
+        ".clone()" in stripped and "unwrap_or_else" in stripped
+    ):
+        score += 1
+        reasons.append("clone participates in expression chain")
+
+    if is_cold:
+        category = "cold_or_test"
+    elif is_cheap:
+        category = "cheap_shared"
+    elif is_clone_into_arc:
+        category = "clone_into_arc"
+    elif is_loop:
+        category = "loop_clone"
+    elif score >= 8:
+        category = "suspicious_hotpath"
+    else:
+        category = "needs_review"
+
+    tier = "high" if score >= 12 else "medium" if score >= 8 else "low"
+    return CloneCandidate(
+        score=score,
+        tier=tier,
+        category=category,
+        path=path,
+        line=0,
+        hot_path=hot_path,
+        reasons=reasons,
+        text=stripped,
+    )
+
+
+def scan_file(root: Path, path: Path, include_tests: bool) -> list[CloneCandidate]:
+    rel = rel_path(root, path)
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    candidates: list[CloneCandidate] = []
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        if not CLONE_RE.search(line):
+            continue
+
+        candidate = score_candidate(
+            rel, line, context_window(lines, index), include_tests
+        )
+        candidates.append(
+            CloneCandidate(
+                score=candidate.score,
+                tier=candidate.tier,
+                category=candidate.category,
+                path=rel,
+                line=index + 1,
+                hot_path=candidate.hot_path,
+                reasons=candidate.reasons,
+                text=candidate.text,
+            )
+        )
+
+    return candidates
+
+
+def scan(root: Path, paths: Iterable[str], include_tests: bool) -> list[CloneCandidate]:
+    candidates: list[CloneCandidate] = []
+    for path in rust_files(root, paths):
+        candidates.extend(scan_file(root, path, include_tests))
+    return sorted(candidates, key=lambda c: (-c.score, c.path, c.line))
+
+
+def filtered(
+    candidates: list[CloneCandidate], only_actionable: bool
+) -> list[CloneCandidate]:
+    if not only_actionable:
+        return candidates
+    ignored = {"cheap_shared", "cold_or_test"}
+    return [candidate for candidate in candidates if candidate.category not in ignored]
+
+
+def limited(candidates: list[CloneCandidate], limit: int) -> list[CloneCandidate]:
+    if limit <= 0:
+        return candidates
+    return candidates[:limit]
+
+
+def summarize(candidates: list[CloneCandidate]) -> dict[str, object]:
+    by_tier: dict[str, int] = {}
+    by_category: dict[str, int] = {}
+    for candidate in candidates:
+        by_tier[candidate.tier] = by_tier.get(candidate.tier, 0) + 1
+        by_category[candidate.category] = by_category.get(candidate.category, 0) + 1
+    return {
+        "total": len(candidates),
+        "by_tier": dict(sorted(by_tier.items())),
+        "by_category": dict(sorted(by_category.items())),
+    }
+
+
+def markdown_escape(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def print_markdown(
+    candidates: list[CloneCandidate], all_candidates: list[CloneCandidate]
+) -> None:
+    summary = summarize(all_candidates)
+    print("# Rust Clone Hotpath Inventory")
+    print()
+    print(f"Total candidates after filters: {summary['total']}")
+    print(f"Tier counts: `{summary['by_tier']}`")
+    print(f"Category counts: `{summary['by_category']}`")
+    print()
+    print("| Score | Tier | Category | Location | Reasons | Code |")
+    print("|---:|---|---|---|---|---|")
+    for candidate in candidates:
+        location = f"{candidate.path}:{candidate.line}"
+        reasons = "; ".join(candidate.reasons)
+        print(
+            "| "
+            f"{candidate.score} | "
+            f"{candidate.tier} | "
+            f"{candidate.category} | "
+            f"`{markdown_escape(location)}` | "
+            f"{markdown_escape(reasons)} | "
+            f"`{markdown_escape(candidate.text)}` |"
+        )
+
+
+def print_json(
+    candidates: list[CloneCandidate], all_candidates: list[CloneCandidate]
+) -> None:
+    payload = {
+        "summary": summarize(all_candidates),
+        "candidates": [asdict(candidate) for candidate in candidates],
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    all_candidates = filtered(
+        scan(root, args.paths, args.include_tests),
+        only_actionable=args.only_actionable,
+    )
+    candidates = limited(all_candidates, args.limit)
+
+    if args.format == "json":
+        print_json(candidates, all_candidates)
+    else:
+        print_markdown(candidates, all_candidates)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `.agents/contributor-skills/dynamo-clone-hotpath-audit`, an internal contributor skill for rigorous Rust `.clone()` audits on request, KV routing, block-manager, and runtime hot paths.
- Makes the skill audit-first by default: scans/checks report findings only, and clone-removal patches are applied only when explicitly requested.
- Requires each proposed removal to explain why the clone is unnecessary, why it is not a cheap/semantic required clone, and how ownership semantics remain unchanged.
- Adds a read-only `clone_inventory.py` helper that ranks `.clone()` call sites by hot-path likelihood and filters cheap/test-only cases.

## Validation

- `python3 -B .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py --paths lib/kv-router/src/scheduling --only-actionable --limit 3`
- `python3 -B .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py --paths lib/llm/src/backend.rs --only-actionable --limit 5 --format json`
- `git diff --cached --check`
- `black --check .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py`
- `isort --check-only .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py`
- `ruff check .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py`

`pre-commit run --files .agents/contributor-skills/dynamo-clone-hotpath-audit/scripts/clone_inventory.py` passes the file-scoped formatting/lint hooks locally, then fails in the repo-wide pytest marker hook because this machine invokes pre-commit with Python 3.10 and the current repo imports Python 3.11+ symbols (`typing.Required`, `typing.Self`) during collection. That is unrelated to this contributor-skill change.