### PR TITLE
feat(parity): add overview mode to parity table

### DIFF
--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -189,7 +189,7 @@ def parity_cell_class(marker: str) -> str:
         return "missing"
     if marker == "n/a":
         return "na"
-    if marker == "D":
+    if marker in {"D", "·"}:
         return "donly"
     if "!" in marker:
         return "err"

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -20,7 +20,7 @@ th a:hover { background: #ffd; }
 td.model, td.parser { white-space: nowrap; }
 td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
-td.cell { text-align: center; min-width: 24px; }
+td.cell { text-align: center; min-width: 24px; font-weight: 700; }
 td.cell.ok         { color: #0a7d2c; }
 td.cell.donly      { color: #555; }
 td.cell.documented { color: #555; }
@@ -37,6 +37,48 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .stats span { font-family: ui-monospace, monospace; font-weight: bold; }
 .generated { color: #888; font-size: 12px; margin-top: -0.5em; }
 .versions { color: #555; font-size: 12px; margin-top: 0.2em; }
+.table-toolbar { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin: 0.7em 0 0.8em; }
+.radio-group { display: flex; align-items: center; gap: 8px; border: 1px solid #d0d7de; background: #f8fafc; border-radius: 6px; padding: 6px 8px; }
+.radio-group-label { font-size: 13px; font-weight: 600; }
+.radio-option { display: inline-flex; align-items: center; gap: 4px; font-size: 13px; cursor: pointer; }
+.radio-option input { margin: 0; }
+.view-overview .details-only { display: none; }
+.view-details .summary-only { display: none; }
+.summary-key { display: inline-block; width: 12px; height: 12px; border: 1px solid rgba(0,0,0,0.22); margin: 0 4px 0 10px; vertical-align: -2px; }
+.summary-key:first-of-type { margin-left: 0; }
+.summary-key.ok { background: #76b884; }
+.summary-key.problem { background: #db7777; }
+.summary-key.na { background: #c4ccd4; }
+.view-overview td.cell, .view-details td.cell { box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04); }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="ok"],
+.view-overview.parser-vllm td.cell[data-status-vllm="ok"],
+.view-overview.parser-sglang td.cell[data-status-sglang="ok"] { background: #76b884; color: #76b884; }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="problem"],
+.view-overview.parser-vllm td.cell[data-status-vllm="problem"],
+.view-overview.parser-sglang td.cell[data-status-sglang="problem"] { background: #db7777; color: #db7777; }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="na"],
+.view-overview.parser-vllm td.cell[data-status-vllm="na"],
+.view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #c4ccd4; color: #c4ccd4; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="ok"],
+.view-details.parser-vllm td.cell[data-status-vllm="ok"],
+.view-details.parser-sglang td.cell[data-status-sglang="ok"] { background: #bfe3c6; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="problem"],
+.view-details.parser-vllm td.cell[data-status-vllm="problem"],
+.view-details.parser-sglang td.cell[data-status-sglang="problem"] { background: #efb3b3; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="na"],
+.view-details.parser-vllm td.cell[data-status-vllm="na"],
+.view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #d8dee4; }
+.view-overview td.cell > a { color: inherit; }
+.view-overview td.cell > a:hover { background: transparent; }
+.view-overview td.cell:hover { filter: brightness(0.98); }
+.view-details td.cell { color: transparent; }
+.view-details td.cell::before { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #111; pointer-events: none; }
+.view-details.parser-dynamo td.cell::before { content: attr(data-marker-dynamo); }
+.view-details.parser-vllm td.cell::before { content: attr(data-marker-vllm); }
+.view-details.parser-sglang td.cell::before { content: attr(data-marker-sglang); }
+.view-details td.cell a { color: transparent; }
+.view-details td.cell a:hover { background: rgba(255,255,255,0.35); }
+.view-details td.cell .ttip { font-weight: 400; }
 .tabs { display: flex; gap: 4px; border-bottom: 1px solid #ccc; margin: 1em 0; }
 .tab-button { appearance: none; border: 1px solid #ccc; border-bottom: 0; background: #f5f5f5; color: #222; padding: 6px 10px; font: inherit; cursor: pointer; border-radius: 4px 4px 0 0; }
 .tab-button.active { background: #fff; font-weight: 600; position: relative; top: 1px; }
@@ -77,13 +119,14 @@ table.glossary tr.category td { background: #eef; font-family: -apple-system, sy
  * `td.parser` participates so parser metadata tooltips use the same styling
  * as data-cell tooltips. */
 td.cell, td.parser { position: relative; }
+td.cell:hover, td.parser:hover, td.cell:focus-within, td.parser:focus-within { z-index: 2000; }
 .ttip {
     visibility: hidden;
     opacity: 0;
     position: absolute;
     left: 0;
     top: 100%;
-    z-index: 100;
+    z-index: 3000;
     background: #1f2937;
     color: #e5e7eb;
     padding: 8px 10px;
@@ -131,7 +174,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 .tt-h-other { color: #22d3ee; }
 </style>
 </head>
-<body>
+<body class="view-overview parser-dynamo">
 <h1>{{ title|e }}</h1>
 <p class="generated">
   Auto-generated on {{ stamp|e }}{% if sha %} on commit <a href="https://github.com/ai-dynamo/dynamo/commit/{{ sha|e }}"><code>{{ short_sha|e }}</code></a>{% endif %}:
@@ -147,6 +190,19 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% endfor %}
 </div>
 {% endif %}
+<div class="table-toolbar">
+  <div class="radio-group" role="radiogroup" aria-label="Parity table view">
+    <span class="radio-group-label">View:</span>
+    <label class="radio-option"><input type="radio" name="parity-view" value="overview" data-view-toggle checked> Overview</label>
+    <label class="radio-option"><input type="radio" name="parity-view" value="details" data-view-toggle> Details</label>
+  </div>
+  <div class="radio-group" role="radiogroup" aria-label="Parser implementation">
+    <span class="radio-group-label">Parser:</span>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="dynamo" data-parser-toggle checked> Dynamo Rust parser</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="vllm" data-parser-toggle> vLLM Python parser</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="sglang" data-parser-toggle> SGLang Python parser</label>
+  </div>
+</div>
 {% for panel in panels %}
 <section id="{{ panel.id|e }}" class="tab-panel{% if panel.active %} active{% endif %}" role="tabpanel"{% if tabs|length > 1 %} aria-labelledby="{{ panel.id|e }}-button"{% endif %}>
 <table data-parity-table>
@@ -160,7 +216,13 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% endfor %}
 </tbody>
 </table>
-<p class="legend">
+<p class="legend summary-only">
+  <strong>Overview:</strong>
+  <span class="summary-key ok" aria-hidden="true"></span>green = selected implementation output is clean ·
+  <span class="summary-key problem" aria-hidden="true"></span>red = selected implementation leaks parser markup or has an expected error ·
+  <span class="summary-key na" aria-hidden="true"></span>gray = not applicable, unavailable, or missing fixture.
+</p>
+<p class="legend details-only">
 {% if panel.legend_html is defined and panel.legend_html %}
   {{ panel.legend_html|safe }}
 {% elif legend_html is defined and legend_html %}
@@ -197,7 +259,13 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   {% endif %}
 {% endif %}
 </p>
-<p class="stats">
+<p class="stats summary-only">
+  Stats for selected perspective:
+  <span style="color:#0a7d2c" data-overview-count="ok">0</span> green ·
+  <span style="color:#b00" data-overview-count="problem">0</span> red ·
+  <span style="color:#555" data-overview-count="na">0</span> gray.
+</p>
+<p class="stats details-only">
   Stats: {{ panel.stats.families }} families × {{ panel.stats.sub_cases }} sub-cases
   = {{ panel.stats.slots }} grid slots ({{ panel.stats.na }} n/a, {{ panel.stats.missing }} missing).
   <strong>{{ panel.stats.real }}</strong> real cases:
@@ -210,6 +278,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
 </p>
 {% if panel.glossary_groups %}
+<div class="details-only">
 <h2 id="case-descriptions-{{ panel.case_section_id|default(panel.mode)|e }}">Case descriptions</h2>
 <p>Full case definitions:
 {% if panel.case_docs_href is defined %}
@@ -239,6 +308,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% endfor %}
 </tbody>
 </table>
+</div>
 {% endif %}
 </section>
 {% endfor %}
@@ -251,6 +321,108 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   const columnKeys = Array.from(new Set(columnButtons.map(function (button) {
     return button.dataset.colToggle;
   })));
+  const viewRadios = Array.from(document.querySelectorAll('[data-view-toggle]'));
+  const viewKeys = new Set(viewRadios.map(function (radio) {
+    return radio.value;
+  }));
+  const parserRadios = Array.from(document.querySelectorAll('[data-parser-toggle]'));
+  const parserKeys = new Set(parserRadios.map(function (radio) {
+    return radio.value;
+  }));
+
+  function readActiveView() {
+    const requested = new URLSearchParams(window.location.search).get('view');
+    return viewKeys.has(requested) ? requested : 'overview';
+  }
+
+  function readActiveParser() {
+    const params = new URLSearchParams(window.location.search);
+    const requested = params.get('parser') || params.get('perspective');
+    return parserKeys.has(requested) ? requested : 'dynamo';
+  }
+
+  function updateViewUrl(view) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('view');
+    if (view !== 'overview') {
+      url.searchParams.set('view', view);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function updateParserUrl(parser) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('parser');
+    url.searchParams.delete('perspective');
+    if (parser !== 'dynamo') {
+      url.searchParams.set('parser', parser);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function activeParser() {
+    const checked = parserRadios.find(function (radio) {
+      return radio.checked;
+    });
+    return checked ? checked.value : 'dynamo';
+  }
+
+  function updateOverviewStats() {
+    const parser = activeParser();
+    document.querySelectorAll('.tab-panel').forEach(function (panel) {
+      const counts = {ok: 0, problem: 0, na: 0};
+      panel.querySelectorAll('td.cell').forEach(function (cell) {
+        const status = cell.getAttribute('data-status-' + parser) || 'na';
+        counts[status] = (counts[status] || 0) + 1;
+      });
+      panel.querySelectorAll('[data-overview-count]').forEach(function (el) {
+        el.textContent = String(counts[el.dataset.overviewCount] || 0);
+      });
+    });
+  }
+
+  function applyView(view, shouldUpdateUrl) {
+    const activeView = viewKeys.has(view) ? view : 'overview';
+    document.body.classList.toggle('view-overview', activeView === 'overview');
+    document.body.classList.toggle('view-details', activeView === 'details');
+    viewRadios.forEach(function (radio) {
+      radio.checked = radio.value === activeView;
+    });
+    if (shouldUpdateUrl) {
+      updateViewUrl(activeView);
+    }
+  }
+
+  function applyParser(parser, shouldUpdateUrl) {
+    const active = parserKeys.has(parser) ? parser : 'dynamo';
+    parserKeys.forEach(function (key) {
+      document.body.classList.toggle('parser-' + key, active === key);
+    });
+    parserRadios.forEach(function (radio) {
+      radio.checked = radio.value === active;
+    });
+    updateOverviewStats();
+    if (shouldUpdateUrl) {
+      updateParserUrl(active);
+    }
+  }
+
+  applyView(readActiveView(), false);
+  applyParser(readActiveParser(), false);
+  viewRadios.forEach(function (radio) {
+    radio.addEventListener('change', function () {
+      if (radio.checked) {
+        applyView(radio.value, true);
+      }
+    });
+  });
+  parserRadios.forEach(function (radio) {
+    radio.addEventListener('change', function () {
+      if (radio.checked) {
+        applyParser(radio.value, true);
+      }
+    });
+  });
 
   function defaultVisibleColumns() {
     const visible = new Set();

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -20,14 +20,14 @@ th a:hover { background: #ffd; }
 td.model, td.parser { white-space: nowrap; }
 td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
-td.cell { text-align: center; min-width: 24px; font-weight: 700; }
+td.cell { text-align: center; min-width: 24px; font-weight: 400; }
 td.cell.ok         { color: #0a7d2c; }
-td.cell.donly      { color: #555; }
+td.cell.donly      { color: #8b949e; }
 td.cell.documented { color: #555; }
-td.cell.research   { color: #b00;    font-weight: bold; }
-td.cell.leak       { color: #b00;    font-weight: bold; }
-td.cell.err        { color: #b00;    font-weight: bold; }
-td.cell.na         { color: #aaa; }
+td.cell.research   { color: #b00; }
+td.cell.leak       { color: #b00; }
+td.cell.err        { color: #b00; }
+td.cell.na         { color: #aeb6bf; }
 td.cell.missing    { color: #8a6d3b; }
 td.cell a { color: inherit; text-decoration: none; display: block; }
 td.cell a:hover { background: #ffd; }
@@ -42,13 +42,18 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .radio-group-label { font-size: 13px; font-weight: 600; }
 .radio-option { display: inline-flex; align-items: center; gap: 4px; font-size: 13px; cursor: pointer; }
 .radio-option input { margin: 0; }
+.checkbox-option { display: inline-flex; align-items: center; gap: 5px; border: 1px solid #d0d7de; background: #f8fafc; border-radius: 6px; padding: 6px 8px; font-size: 13px; cursor: pointer; }
+.checkbox-option input { margin: 0; }
+.view-overview .parity-option { display: none; }
 .view-overview .details-only { display: none; }
 .view-details .summary-only { display: none; }
+.parity-explainer { display: none; }
+.view-details.parity-mode .parity-explainer { display: block; }
 .summary-key { display: inline-block; width: 12px; height: 12px; border: 1px solid rgba(0,0,0,0.22); margin: 0 4px 0 10px; vertical-align: -2px; }
 .summary-key:first-of-type { margin-left: 0; }
 .summary-key.ok { background: #76b884; }
 .summary-key.problem { background: #db7777; }
-.summary-key.na { background: #c4ccd4; }
+.summary-key.na { background: #d3d8de; }
 .view-overview td.cell, .view-details td.cell { box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04); }
 .view-overview.parser-dynamo td.cell[data-status-dynamo="ok"],
 .view-overview.parser-vllm td.cell[data-status-vllm="ok"],
@@ -58,7 +63,7 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .view-overview.parser-sglang td.cell[data-status-sglang="problem"] { background: #db7777; color: #db7777; }
 .view-overview.parser-dynamo td.cell[data-status-dynamo="na"],
 .view-overview.parser-vllm td.cell[data-status-vllm="na"],
-.view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #c4ccd4; color: #c4ccd4; }
+.view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #d3d8de; color: #d3d8de; }
 .view-details.parser-dynamo td.cell[data-status-dynamo="ok"],
 .view-details.parser-vllm td.cell[data-status-vllm="ok"],
 .view-details.parser-sglang td.cell[data-status-sglang="ok"] { background: #bfe3c6; }
@@ -67,15 +72,22 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .view-details.parser-sglang td.cell[data-status-sglang="problem"] { background: #efb3b3; }
 .view-details.parser-dynamo td.cell[data-status-dynamo="na"],
 .view-details.parser-vllm td.cell[data-status-vllm="na"],
-.view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #d8dee4; }
+.view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #e4e8ec; }
 .view-overview td.cell > a { color: inherit; }
 .view-overview td.cell > a:hover { background: transparent; }
 .view-overview td.cell:hover { filter: brightness(0.98); }
 .view-details td.cell { color: transparent; }
 .view-details td.cell::before { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #111; pointer-events: none; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="na"]::before,
+.view-details.parser-vllm td.cell[data-status-vllm="na"]::before,
+.view-details.parser-sglang td.cell[data-status-sglang="na"]::before { color: #aeb6bf; }
+.view-details td.cell.donly::before { color: #8b949e; }
 .view-details.parser-dynamo td.cell::before { content: attr(data-marker-dynamo); }
 .view-details.parser-vllm td.cell::before { content: attr(data-marker-vllm); }
 .view-details.parser-sglang td.cell::before { content: attr(data-marker-sglang); }
+.view-details.parity-mode.parser-dynamo td.cell::before { content: attr(data-marker-parity-dynamo); }
+.view-details.parity-mode.parser-vllm td.cell::before { content: attr(data-marker-parity-vllm); }
+.view-details.parity-mode.parser-sglang td.cell::before { content: attr(data-marker-parity-sglang); }
 .view-details td.cell a { color: transparent; }
 .view-details td.cell a:hover { background: rgba(255,255,255,0.35); }
 .view-details td.cell .ttip { font-weight: 400; }
@@ -198,10 +210,11 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   </div>
   <div class="radio-group" role="radiogroup" aria-label="Parser implementation">
     <span class="radio-group-label">Parser:</span>
-    <label class="radio-option"><input type="radio" name="parity-parser" value="dynamo" data-parser-toggle checked> Dynamo Rust parser</label>
-    <label class="radio-option"><input type="radio" name="parity-parser" value="vllm" data-parser-toggle> vLLM Python parser</label>
-    <label class="radio-option"><input type="radio" name="parity-parser" value="sglang" data-parser-toggle> SGLang Python parser</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="dynamo" data-parser-toggle checked> Dynamo</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="vllm" data-parser-toggle> vLLM</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="sglang" data-parser-toggle> SGLang</label>
   </div>
+  <label class="checkbox-option parity-option"><input type="checkbox" data-parity-toggle> Parity</label>
 </div>
 {% for panel in panels %}
 <section id="{{ panel.id|e }}" class="tab-panel{% if panel.active %} active{% endif %}" role="tabpanel"{% if tabs|length > 1 %} aria-labelledby="{{ panel.id|e }}-button"{% endif %}>
@@ -230,7 +243,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% else %}
   <strong>Legend:</strong>
   <span style="color:#0a7d2c">=</span> all captured peers match Dynamo ·
-  <span style="color:#555">D</span> Dynamo-only fixture
+  <span style="color:#8b949e">·</span> Dynamo-only fixture
   (both peers unavailable) ·
   <span style="color:#555">V/S</span> divergence
   (V = vLLM, S = SGLang; intentional, has <code>reason:</code>) ·
@@ -258,6 +271,12 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   {% for name, version in peer_versions %}{% if not loop.first %} · {% endif %}{{ name|e }} <code>{{ version|e }}</code>{% endfor %}.
   {% endif %}
 {% endif %}
+</p>
+<p class="legend details-only parity-explainer">
+  <strong>Parity:</strong>
+  <span style="color:#0a7d2c">=</span> all three outputs match ·
+  <span style="color:#555">D</span>/<span style="color:#555">V</span>/<span style="color:#555">S</span> names parser output that differs from the selected parser ·
+  multiple letters mean multiple peer outputs differ from the selected parser.
 </p>
 <p class="stats summary-only">
   Stats for selected perspective:
@@ -329,6 +348,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   const parserKeys = new Set(parserRadios.map(function (radio) {
     return radio.value;
   }));
+  const parityToggle = document.querySelector('[data-parity-toggle]');
 
   function readActiveView() {
     const requested = new URLSearchParams(window.location.search).get('view');
@@ -339,6 +359,11 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     const params = new URLSearchParams(window.location.search);
     const requested = params.get('parser') || params.get('perspective');
     return parserKeys.has(requested) ? requested : 'dynamo';
+  }
+
+  function readParityMode() {
+    const requested = new URLSearchParams(window.location.search).get('parity');
+    return requested === '1' || requested === 'true';
   }
 
   function updateViewUrl(view) {
@@ -356,6 +381,15 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     url.searchParams.delete('perspective');
     if (parser !== 'dynamo') {
       url.searchParams.set('parser', parser);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function updateParityUrl(enabled) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('parity');
+    if (enabled) {
+      url.searchParams.set('parity', '1');
     }
     window.history.replaceState(null, '', url.toString());
   }
@@ -407,8 +441,19 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     }
   }
 
+  function applyParityMode(enabled, shouldUpdateUrl) {
+    document.body.classList.toggle('parity-mode', Boolean(enabled));
+    if (parityToggle) {
+      parityToggle.checked = Boolean(enabled);
+    }
+    if (shouldUpdateUrl) {
+      updateParityUrl(Boolean(enabled));
+    }
+  }
+
   applyView(readActiveView(), false);
   applyParser(readActiveParser(), false);
+  applyParityMode(readParityMode(), false);
   viewRadios.forEach(function (radio) {
     radio.addEventListener('change', function () {
       if (radio.checked) {
@@ -423,6 +468,11 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
       }
     });
   });
+  if (parityToggle) {
+    parityToggle.addEventListener('change', function () {
+      applyParityMode(parityToggle.checked, true);
+    });
+  }
 
   function defaultVisibleColumns() {
     const visible = new Set();

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -460,23 +460,29 @@ def _is_gpt_oss_tool_handoff(family: str | None, field: str, value: str) -> bool
     )
 
 
-def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | None:
-    dynamo = expected.get("dynamo", {})
-    if not isinstance(dynamo, dict):
+def _block_leak_reason(block: dict[str, Any], family: str | None) -> str | None:
+    if not isinstance(block, dict):
         return None
     marker_re = _reasoning_markup_re(family)
     for field in ("reasoning_text", "normal_text"):
-        value = dynamo.get(field)
+        value = block.get(field)
         if (
             isinstance(value, str)
             and marker_re.search(value)
             and not _is_gpt_oss_tool_handoff(family, field, value)
         ):
             return str(
-                dynamo.get("reason")
+                block.get("reason")
                 or "Dynamo leaks reasoning markup or final-answer text."
             )
     return None
+
+
+def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | None:
+    dynamo = expected.get("dynamo", {})
+    if not isinstance(dynamo, dict):
+        return None
+    return _block_leak_reason(dynamo, family)
 
 
 def _has_dynamo_leak(case: dict[str, Any], family: str | None) -> bool:
@@ -485,6 +491,56 @@ def _has_dynamo_leak(case: dict[str, Any], family: str | None) -> bool:
     expected = case.get("expected")
     return (
         isinstance(expected, dict) and _dynamo_leak_reason(expected, family) is not None
+    )
+
+
+def _overview_status(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
+    if case is None or "expected" not in case:
+        return "na"
+    block = case.get("expected", {}).get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "na"
+    if "error" in block or _block_leak_reason(block, family):
+        return "problem"
+    return "ok"
+
+
+def _overview_status_attrs(case: dict[str, Any] | None, family: str | None) -> str:
+    return " ".join(
+        f'data-status-{impl}="{_overview_status(case, family, impl)}"'
+        for impl in ("dynamo", "vllm", "sglang")
+    )
+
+
+def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
+    if case is None:
+        return "—"
+    if "expected" not in case:
+        return "n/a"
+    expected = case.get("expected", {})
+    block = expected.get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "n/a"
+    if "error" in block:
+        return "!"
+    if _block_leak_reason(block, family):
+        return "↯"
+    if impl == "dynamo":
+        return _cell(case, family)[0].replace("↯", "") or "="
+
+    dyn = expected.get("dynamo")
+    if not isinstance(dyn, dict):
+        return "n/a"
+    if _canonical(block) == _canonical(dyn):
+        return "="
+    suffix = "?" if "reason" not in block else ""
+    return ("V" if impl == "vllm" else "S") + suffix
+
+
+def _parser_marker_attrs(case: dict[str, Any] | None, family: str | None) -> str:
+    return " ".join(
+        f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, family, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
     )
 
 
@@ -1564,6 +1620,8 @@ def _render_cell_html(
         )
 
     classes = f"cell {parity_cell_class(marker)} {_case_band_class(case_id)}"
+    status_attrs = _overview_status_attrs(case, family)
+    marker_attrs = _parser_marker_attrs(case, family)
     group_key = html_lib.escape(_case_group_key(case_id))
     label = html_lib.escape(marker)
     if href:
@@ -1571,7 +1629,8 @@ def _render_cell_html(
     else:
         body = label
     return (
-        f'<td class="{classes}" data-col-hide-group="{group_key}">'
+        f'<td class="{classes}" data-col-hide-group="{group_key}" '
+        f"{status_attrs} {marker_attrs}>"
         f"{body}{tooltip}</td>"
     )
 
@@ -1581,7 +1640,10 @@ def _render_no_reasoning_cell_html(tool_family: str, case_id: str) -> str:
     group_key = html_lib.escape(_case_group_key(case_id))
     tooltip = _no_reasoning_tooltip_html(case_id, tool_family)
     return (
-        f'<td class="{classes}" data-col-hide-group="{group_key}">' f"n/a{tooltip}</td>"
+        f'<td class="{classes}" data-col-hide-group="{group_key}" '
+        'data-status-dynamo="na" data-status-vllm="na" data-status-sglang="na" '
+        'data-marker-dynamo="n/a" data-marker-vllm="n/a" data-marker-sglang="n/a">'
+        f"n/a{tooltip}</td>"
     )
 
 

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -512,6 +512,64 @@ def _overview_status_attrs(case: dict[str, Any] | None, family: str | None) -> s
     )
 
 
+def _canonical_reasoning_output(block: object) -> str | None:
+    if not isinstance(block, dict) or "unavailable" in block or "error" in block:
+        return None
+    return _canonical(block)
+
+
+def _selected_parity_marker(
+    case: dict[str, Any] | None,
+    family: str | None,
+    impl: str,
+) -> str | None:
+    if case is None or "expected" not in case:
+        return None
+    expected = case.get("expected", {})
+    outputs = {
+        impl: _canonical_reasoning_output(expected.get(impl))
+        for impl in ("dynamo", "vllm", "sglang")
+    }
+    if any(value is None for value in outputs.values()):
+        return None
+    if outputs["dynamo"] == outputs["vllm"] == outputs["sglang"]:
+        return "="
+    selected = outputs[impl]
+    peers = (
+        ("dynamo", "D"),
+        ("vllm", "V"),
+        ("sglang", "S"),
+    )
+    marker = "".join(
+        letter for peer, letter in peers if peer != impl and outputs[peer] != selected
+    )
+    return marker or "="
+
+
+def _selected_parity_suffix(
+    case: dict[str, Any] | None,
+    family: str | None,
+    impl: str,
+) -> str:
+    if case is None or "expected" not in case:
+        return ""
+    block = case.get("expected", {}).get(impl)
+    if isinstance(block, dict) and _block_leak_reason(block, family):
+        return "↯"
+    return ""
+
+
+def _parity_marker(
+    case: dict[str, Any] | None,
+    family: str | None,
+    impl: str,
+) -> str:
+    marker = _selected_parity_marker(case, family, impl)
+    if marker is None:
+        return _parser_marker(case, family, impl)
+    return marker + _selected_parity_suffix(case, family, impl)
+
+
 def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
     if case is None:
         return "—"
@@ -526,22 +584,22 @@ def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -
     if _block_leak_reason(block, family):
         return "↯"
     if impl == "dynamo":
-        return _cell(case, family)[0].replace("↯", "") or "="
-
-    dyn = expected.get("dynamo")
-    if not isinstance(dyn, dict):
-        return "n/a"
-    if _canonical(block) == _canonical(dyn):
-        return "="
-    suffix = "?" if "reason" not in block else ""
-    return ("V" if impl == "vllm" else "S") + suffix
+        peers = (expected.get("vllm"), expected.get("sglang"))
+        if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
+            return "·"
+    return "="
 
 
 def _parser_marker_attrs(case: dict[str, Any] | None, family: str | None) -> str:
-    return " ".join(
+    attrs = [
         f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, family, impl))}"'
         for impl in ("dynamo", "vllm", "sglang")
+    ]
+    attrs.extend(
+        f'data-marker-parity-{impl}="{html_lib.escape(_parity_marker(case, family, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
     )
+    return " ".join(attrs)
 
 
 def _load() -> tuple[dict[str, dict[str, Any]], list[str], dict[tuple[str, str], Path]]:
@@ -718,8 +776,8 @@ def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, 
 
     if unavailable == 2:
         if dynamo_leak:
-            return "↯D", "\n".join(p for p in tooltip_parts if p)
-        return "D", "\n".join(p for p in tooltip_parts if p)
+            return "↯·", "\n".join(p for p in tooltip_parts if p)
+        return "·", "\n".join(p for p in tooltip_parts if p)
     if dynamo_leak:
         return "↯" + ("".join(markers) or "?"), "\n".join(p for p in tooltip_parts if p)
     if markers:
@@ -1490,7 +1548,7 @@ def _tooltip_html(
         return build_parity_tooltip_html(
             head=head,
             description=str(description) if description else None,
-            extra_sections=[("Why n/a", linkify_text_html(str(reason)))],
+            extra_sections=[("Why not applicable", linkify_text_html(str(reason)))],
             refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
         )
 
@@ -1583,7 +1641,7 @@ def _no_reasoning_tooltip_html(case_id: str, tool_family: str) -> str:
         head=f"{case_id} — {tool_family}",
         extra_sections=[
             (
-                "Why n/a",
+                "Why not applicable",
                 html_lib.escape(
                     "This tool calling parser row has no mapped Dynamo reasoning "
                     "parser fixture."
@@ -1642,7 +1700,9 @@ def _render_no_reasoning_cell_html(tool_family: str, case_id: str) -> str:
     return (
         f'<td class="{classes}" data-col-hide-group="{group_key}" '
         'data-status-dynamo="na" data-status-vllm="na" data-status-sglang="na" '
-        'data-marker-dynamo="n/a" data-marker-vllm="n/a" data-marker-sglang="n/a">'
+        'data-marker-dynamo="n/a" data-marker-vllm="n/a" data-marker-sglang="n/a" '
+        'data-marker-parity-dynamo="n/a" data-marker-parity-vllm="n/a" '
+        'data-marker-parity-sglang="n/a">'
         f"n/a{tooltip}</td>"
     )
 
@@ -1953,7 +2013,7 @@ def _compute_stats(
                 stats["real"] += 1
                 if marker == "=":
                     stats["parity"] += 1
-                elif marker == "D":
+                elif marker in {"D", "·"}:
                     stats["dynamo_only"] += 1
                 elif "!" in marker:
                     stats["errors"] += 1
@@ -2008,7 +2068,7 @@ def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
     legend = (
         "<strong>Legend:</strong> "
         '<span style="color:#0a7d2c">=</span> all captured peers match Dynamo · '
-        '<span style="color:#555">D</span> Dynamo-only fixture '
+        '<span style="color:#8b949e">·</span> Dynamo-only fixture '
         "(both peers unavailable) · "
         '<span style="color:#555">V/S</span> divergence '
         "(V = vLLM, S = SGLang; intentional, has <code>reason:</code>) · "

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -587,7 +587,7 @@ def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -
         peers = (expected.get("vllm"), expected.get("sglang"))
         if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
             return "·"
-    return "="
+    return ""
 
 
 def _parser_marker_attrs(case: dict[str, Any] | None, family: str | None) -> str:

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -567,7 +567,7 @@ def _parity_marker(
     marker = _selected_parity_marker(case, family, impl)
     if marker is None:
         return _parser_marker(case, family, impl)
-    return marker + _selected_parity_suffix(case, family, impl)
+    return _selected_parity_suffix(case, family, impl) + marker
 
 
 def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -> str:

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -601,6 +601,67 @@ def _dynamo_tool_call_leak(dyn: dict) -> str | None:
     return str(dyn["reason"])
 
 
+def _block_tool_call_leaks(block: dict) -> bool:
+    normal_text = block.get("normal_text")
+    return isinstance(normal_text, str) and bool(
+        _TOOL_CALL_MARKUP_RE.search(normal_text)
+    )
+
+
+def _overview_status(case: dict | None, impl: str) -> str:
+    if case is None or "expected" not in case:
+        return "na"
+    block = case.get("expected", {}).get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "na"
+    if "error" in block or _block_tool_call_leaks(block):
+        return "problem"
+    return "ok"
+
+
+def _overview_status_attrs(case: dict | None) -> str:
+    return " ".join(
+        f'data-status-{impl}="{_overview_status(case, impl)}"'
+        for impl in ("dynamo", "vllm", "sglang")
+    )
+
+
+def _parser_marker(case: dict | None, impl: str) -> str:
+    if case is None:
+        return "—"
+    if "expected" not in case:
+        return "n/a"
+    expected = case.get("expected", {})
+    block = expected.get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "n/a"
+    if "error" in block:
+        return "!"
+    if _block_tool_call_leaks(block):
+        return "↯"
+    if impl == "dynamo":
+        return cell_for(case).replace("↯", "") or "="
+
+    dyn = expected.get("dynamo")
+    if not isinstance(dyn, dict):
+        return "n/a"
+    kind, unknown = peer_status(case, dyn, impl)
+    if kind == "div":
+        return ("V" if impl == "vllm" else "S") + ("?" if unknown else "")
+    if kind == "err":
+        return "!"
+    if kind in {"na", "unavail"}:
+        return "n/a"
+    return "="
+
+
+def _parser_marker_attrs(case: dict | None) -> str:
+    return " ".join(
+        f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
+    )
+
+
 def cell_for(case: dict | None) -> str:
     if case is None:
         return "—"
@@ -881,7 +942,12 @@ def render_cell_html(case: dict | None, mode: str, family: str, sub: str) -> str
     cls = parity_cell_class(text)
     band_cls = _subcase_band_class(mode, sub)
     col_group = html_lib.escape(_subcase_group_key(mode, sub))
-    td_open = f'<td class="cell {cls} {band_cls}" data-col-hide-group="{col_group}">'
+    status_attrs = _overview_status_attrs(case)
+    marker_attrs = _parser_marker_attrs(case)
+    td_open = (
+        f'<td class="cell {cls} {band_cls}" data-col-hide-group="{col_group}" '
+        f"{status_attrs} {marker_attrs}>"
+    )
     if case is None:
         ttip = _build_missing_tooltip_html(mode, family, sub)
         return f"{td_open}{text}{ttip}</td>"

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -694,7 +694,7 @@ def _parser_marker(case: dict | None, impl: str) -> str:
         peers = (expected.get("vllm"), expected.get("sglang"))
         if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
             return "·"
-    return "="
+    return ""
 
 
 def _parser_marker_attrs(case: dict | None) -> str:

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -587,6 +587,7 @@ def peer_status(case: dict, dyn: dict, impl: str) -> tuple[str, bool]:
 
 _TOOL_CALL_MARKUP_RE = re.compile(
     r"</?tool_call|</?tool_calls|<\|tool_call|<\|tool_calls|"
+    r"<\|(?:channel|message|call|python_tag)\|>|"
     r"</?TOOLCALL|TOOL_CALLS|<｜(?:DSML｜)?(?:tool|tool▁call|tool▁calls)|"
     r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value"
 )

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -674,7 +674,7 @@ def _parity_marker(case: dict | None, impl: str) -> str:
     marker = _selected_parity_marker(case, impl)
     if marker is None:
         return _parser_marker(case, impl)
-    return marker + _selected_parity_suffix(case, impl)
+    return _selected_parity_suffix(case, impl) + marker
 
 
 def _parser_marker(case: dict | None, impl: str) -> str:

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -28,7 +28,7 @@ Cell markers (per peer, vllm + sglang):
         (research-needed; we observed it but haven't classified it)
   V!/S! peer has `error: <substring>` (expected to crash)
   VS, V?S, VS!, etc. — combinations
-  D     Dynamo-only fixture; both peer blocks are `unavailable`
+  ·     Dynamo-only fixture; both peer blocks are `unavailable`
   n/a   family/case doesn't apply
   —     no fixture entry exists for this family/case yet
 
@@ -626,6 +626,57 @@ def _overview_status_attrs(case: dict | None) -> str:
     )
 
 
+def _canonical_tool_output(block: object) -> dict | None:
+    if not isinstance(block, dict) or "unavailable" in block or "error" in block:
+        return None
+    if "calls" not in block and "normal_text" not in block:
+        return None
+    return {
+        "calls": block.get("calls") or [],
+        "normal_text": block.get("normal_text") or "",
+    }
+
+
+def _selected_parity_marker(case: dict | None, impl: str) -> str | None:
+    if case is None or "expected" not in case:
+        return None
+    expected = case.get("expected", {})
+    outputs = {
+        impl: _canonical_tool_output(expected.get(impl))
+        for impl in ("dynamo", "vllm", "sglang")
+    }
+    if any(value is None for value in outputs.values()):
+        return None
+    if outputs["dynamo"] == outputs["vllm"] == outputs["sglang"]:
+        return "="
+    selected = outputs[impl]
+    peers = (
+        ("dynamo", "D"),
+        ("vllm", "V"),
+        ("sglang", "S"),
+    )
+    marker = "".join(
+        letter for peer, letter in peers if peer != impl and outputs[peer] != selected
+    )
+    return marker or "="
+
+
+def _selected_parity_suffix(case: dict | None, impl: str) -> str:
+    if case is None or "expected" not in case:
+        return ""
+    block = case.get("expected", {}).get(impl)
+    if isinstance(block, dict) and _block_tool_call_leaks(block):
+        return "↯"
+    return ""
+
+
+def _parity_marker(case: dict | None, impl: str) -> str:
+    marker = _selected_parity_marker(case, impl)
+    if marker is None:
+        return _parser_marker(case, impl)
+    return marker + _selected_parity_suffix(case, impl)
+
+
 def _parser_marker(case: dict | None, impl: str) -> str:
     if case is None:
         return "—"
@@ -640,26 +691,22 @@ def _parser_marker(case: dict | None, impl: str) -> str:
     if _block_tool_call_leaks(block):
         return "↯"
     if impl == "dynamo":
-        return cell_for(case).replace("↯", "") or "="
-
-    dyn = expected.get("dynamo")
-    if not isinstance(dyn, dict):
-        return "n/a"
-    kind, unknown = peer_status(case, dyn, impl)
-    if kind == "div":
-        return ("V" if impl == "vllm" else "S") + ("?" if unknown else "")
-    if kind == "err":
-        return "!"
-    if kind in {"na", "unavail"}:
-        return "n/a"
+        peers = (expected.get("vllm"), expected.get("sglang"))
+        if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
+            return "·"
     return "="
 
 
 def _parser_marker_attrs(case: dict | None) -> str:
-    return " ".join(
+    attrs = [
         f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, impl))}"'
         for impl in ("dynamo", "vllm", "sglang")
+    ]
+    attrs.extend(
+        f'data-marker-parity-{impl}="{html_lib.escape(_parity_marker(case, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
     )
+    return " ".join(attrs)
 
 
 def cell_for(case: dict | None) -> str:
@@ -687,7 +734,7 @@ def cell_for(case: dict | None) -> str:
     # markup, so don't mark those as `↯`.
     if isinstance(dyn, dict) and _dynamo_tool_call_leak(dyn):
         if v_kind == "unavail" and s_kind == "unavail":
-            return "↯D"
+            return "↯·"
         if parts:
             return "↯" + "".join(parts)
         return "↯"
@@ -695,7 +742,7 @@ def cell_for(case: dict | None) -> str:
     if parts:
         return "".join(parts)
     if v_kind == "unavail" and s_kind == "unavail":
-        return "D"
+        return "·"
     return "="
 
 
@@ -716,7 +763,7 @@ def render_row(
 _LEGEND_MD = (
     "**Legend:** "
     "`=` all captured peers match Dynamo · "
-    "`D` Dynamo-only fixture (both peers unavailable) · "
+    "`·` Dynamo-only fixture (both peers unavailable) · "
     "`V`/`S` divergence (V = vLLM, S = SGLang; intentional, has `reason:`) · "
     "`?` research-needed suffix (e.g. V?, S? — diverges with no `reason:` yet) · "
     "`↯` Dynamo leaks tool call markup into `normal_text` "
@@ -909,7 +956,7 @@ def _build_na_tooltip_html(case: dict) -> str:
     reason = case.get("reason") or "n/a (no reason given)"
     return build_parity_tooltip_html(
         head=head,
-        extra_sections=[("Why n/a", linkify_text_html(str(reason)))],
+        extra_sections=[("Why not applicable", linkify_text_html(str(reason)))],
         refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
     )
 
@@ -1396,7 +1443,7 @@ def _compute_stats(
             s["real"] += 1
             if text == "=":
                 s["parity"] += 1
-            elif text == "D":
+            elif text in {"D", "·"}:
                 s["dynamo_only"] += 1
             elif "!" in text:
                 s["errors"] += 1

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -57,15 +57,49 @@ def test_generate_parser_parity_table_html() -> None:
     assert '<body class="view-overview parser-dynamo">' in html
     assert 'value="overview" data-view-toggle checked> Overview' in html
     assert 'value="details" data-view-toggle> Details' in html
-    assert 'value="dynamo" data-parser-toggle checked> Dynamo Rust parser' in html
-    assert 'value="vllm" data-parser-toggle> vLLM Python parser' in html
-    assert 'value="sglang" data-parser-toggle> SGLang Python parser' in html
+    assert 'value="dynamo" data-parser-toggle checked> Dynamo' in html
+    assert 'value="vllm" data-parser-toggle> vLLM' in html
+    assert 'value="sglang" data-parser-toggle> SGLang' in html
+    assert (
+        '<label class="checkbox-option parity-option"><input type="checkbox" data-parity-toggle> Parity</label>'
+        in html
+    )
+    assert ".view-overview .parity-option { display: none; }" in html
+    assert "td.cell { text-align: center; min-width: 24px; font-weight: 400; }" in html
+    assert 'td.cell[data-status-dynamo="na"]::before' in html
+    assert "data-marker-parity-vllm" in html
+    assert "content: attr(data-marker-parity-vllm)" in html
+    assert 'data-marker-dynamo="' in html
+    assert 'data-marker-dynamo="="' in html
+    assert 'data-marker-vllm="="' in html
+    assert 'data-marker-sglang="="' in html
+    assert "color: #aeb6bf;" in html
+    assert "background: #e4e8ec;" in html
+    assert 'data-marker-parity-dynamo="D"' not in html
+    assert 'data-marker-parity-vllm="V"' not in html
+    assert 'data-marker-parity-sglang="S"' not in html
+    assert 'data-marker-parity-dynamo="VS"' in html
+    assert 'data-marker-parity-vllm="DS"' in html
+    assert 'data-marker-parity-sglang="DV"' in html
+    assert 'data-marker-parity-dynamo="=↯"' in html
+    assert 'data-marker-parity-dynamo="VS↯"' in html
+    assert 'data-marker-dynamo="D!"' not in html
+    assert ".view-details.parity-mode .parity-explainer { display: block; }" in html
+    assert "<strong>Parity:</strong>" in html
+    assert "color: #8b949e;" in html
+    assert '<span style="color:#8b949e">·</span> Dynamo-only fixture' in html
+    assert 'data-marker-dynamo="·"' in html
+    assert '<span style="color:#555">D</span> Dynamo-only fixture' not in html
     assert "green = selected implementation output is clean" in html
     assert "red = selected implementation leaks parser markup" in html
+    assert "Why not applicable" in html
+    assert "Why n/a" not in html
     assert "get('view')" in html
     assert "get('parser')" in html
+    assert "get('parity')" in html
     assert "url.searchParams.set('view', view)" in html
     assert "url.searchParams.set('parser', parser)" in html
+    assert "url.searchParams.set('parity', '1')" in html
     assert "Tool calling family" in html
     assert "generate_parity_table.py toolcalling --html" in html
     assert "TOOLCALLING.batch.*" in html
@@ -74,13 +108,16 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'id="case-descriptions-stream"' in html
     assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
-    assert (
-        'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
-        'data-marker-dynamo="V" data-marker-vllm="↯" data-marker-sglang="n/a">'
-        '<a href="fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml">V</a>'
-        '<div class="ttip"><div class="ttip-head">TOOLCALLING.batch.4.a — deepseek_v4'
-        in html
+    assert re.search(
+        r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
+        r'data-marker-dynamo="=" data-marker-vllm="↯" data-marker-sglang="n/a" '
+        r'data-marker-parity-dynamo="=" data-marker-parity-vllm="↯" '
+        r'data-marker-parity-sglang="n/a"><a href="fixtures/deepseek_v4/TOOLCALLING\.batch\.4\.yaml">V</a>'
+        r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — deepseek_v4',
+        html,
     )
+    assert 'data-marker-vllm="!"' in html
+    assert 'data-marker-parity-vllm="!"' in html
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families
@@ -126,6 +163,8 @@ def test_generate_combined_parity_table_html() -> None:
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert "REASONING.batch." in html
     assert "REASONING.stream." in html
+    assert "Why not applicable" in html
+    assert "Why n/a" not in html
     assert "toolcalling/fixtures/" in "".join(links.hrefs)
     assert "reasoning/fixtures/" in "".join(links.hrefs)
     assert "../../lib/parsers/TOOLCALLING_CASES.md" in links.hrefs

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -118,6 +118,22 @@ def test_generate_parser_parity_table_html() -> None:
     )
     assert 'data-marker-vllm="!"' in html
     assert 'data-marker-parity-vllm="!"' in html
+    assert re.search(
+        r'data-status-dynamo="ok" data-status-vllm="ok" data-status-sglang="problem" '
+        r'data-marker-dynamo="" data-marker-vllm="" data-marker-sglang="↯" '
+        r'data-marker-parity-dynamo="S" data-marker-parity-vllm="S" '
+        r'data-marker-parity-sglang="↯DV"><a href="fixtures/harmony/TOOLCALLING\.batch\.yaml">S</a>'
+        r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.1 — harmony',
+        html,
+    )
+    assert re.search(
+        r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="ok" '
+        r'data-marker-dynamo="" data-marker-vllm="↯" data-marker-sglang="" '
+        r'data-marker-parity-dynamo="VS" data-marker-parity-vllm="↯DS" '
+        r'data-marker-parity-sglang="DV"><a href="fixtures/llama3_json/TOOLCALLING\.batch\.4\.yaml">VS</a>'
+        r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — llama3_json',
+        html,
+    )
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -81,8 +81,8 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'data-marker-parity-dynamo="VS"' in html
     assert 'data-marker-parity-vllm="DS"' in html
     assert 'data-marker-parity-sglang="DV"' in html
-    assert 'data-marker-parity-dynamo="=↯"' in html
-    assert 'data-marker-parity-dynamo="VS↯"' in html
+    assert 'data-marker-parity-dynamo="↯="' in html
+    assert 'data-marker-parity-dynamo="↯VS"' in html
     assert 'data-marker-dynamo="D!"' not in html
     assert ".view-details.parity-mode .parity-explainer { display: block; }" in html
     assert "<strong>Parity:</strong>" in html

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -54,6 +54,18 @@ def test_generate_parser_parity_table_html() -> None:
         r'data-col-toggle="model"[^>]+data-default-visible="true"[^>]+aria-pressed="true"',
         html,
     )
+    assert '<body class="view-overview parser-dynamo">' in html
+    assert 'value="overview" data-view-toggle checked> Overview' in html
+    assert 'value="details" data-view-toggle> Details' in html
+    assert 'value="dynamo" data-parser-toggle checked> Dynamo Rust parser' in html
+    assert 'value="vllm" data-parser-toggle> vLLM Python parser' in html
+    assert 'value="sglang" data-parser-toggle> SGLang Python parser' in html
+    assert "green = selected implementation output is clean" in html
+    assert "red = selected implementation leaks parser markup" in html
+    assert "get('view')" in html
+    assert "get('parser')" in html
+    assert "url.searchParams.set('view', view)" in html
+    assert "url.searchParams.set('parser', parser)" in html
     assert "Tool calling family" in html
     assert "generate_parity_table.py toolcalling --html" in html
     assert "TOOLCALLING.batch.*" in html
@@ -62,6 +74,13 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'id="case-descriptions-stream"' in html
     assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
+    assert (
+        'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
+        'data-marker-dynamo="V" data-marker-vllm="↯" data-marker-sglang="n/a">'
+        '<a href="fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml">V</a>'
+        '<div class="ttip"><div class="ttip-head">TOOLCALLING.batch.4.a — deepseek_v4'
+        in html
+    )
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -70,9 +70,9 @@ def test_generate_parser_parity_table_html() -> None:
     assert "data-marker-parity-vllm" in html
     assert "content: attr(data-marker-parity-vllm)" in html
     assert 'data-marker-dynamo="' in html
-    assert 'data-marker-dynamo="="' in html
-    assert 'data-marker-vllm="="' in html
-    assert 'data-marker-sglang="="' in html
+    assert 'data-marker-dynamo="="' not in html
+    assert 'data-marker-vllm="="' not in html
+    assert 'data-marker-sglang="="' not in html
     assert "color: #aeb6bf;" in html
     assert "background: #e4e8ec;" in html
     assert 'data-marker-parity-dynamo="D"' not in html
@@ -110,8 +110,8 @@ def test_generate_parser_parity_table_html() -> None:
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert re.search(
         r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
-        r'data-marker-dynamo="=" data-marker-vllm="↯" data-marker-sglang="n/a" '
-        r'data-marker-parity-dynamo="=" data-marker-parity-vllm="↯" '
+        r'data-marker-dynamo="" data-marker-vllm="↯" data-marker-sglang="n/a" '
+        r'data-marker-parity-dynamo="" data-marker-parity-vllm="↯" '
         r'data-marker-parity-sglang="n/a"><a href="fixtures/deepseek_v4/TOOLCALLING\.batch\.4\.yaml">V</a>'
         r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — deepseek_v4',
         html,


### PR DESCRIPTION
#### Overview:

This PR adds an Overview option to the combined parser parity table so PMs can scan clean/problem/not-applicable status without the detailed parity markers.

#### Details:

<img width="1019" height="627" alt="image" src="https://github.com/user-attachments/assets/f5f8b4f2-bd6d-47e6-b73a-98e9b42934a7" />

<img width="1030" height="631" alt="image" src="https://github.com/user-attachments/assets/39d408c5-ec84-426c-8d76-d84ff3a280c6" />

- **How is this fixed?** Add Overview/Details controls, parser-focused coloring, and a Details-only Parity checkbox in `tests/parity/parity_table.html.j2`, backed by URL state.
- Overview mode gives PM-facing clean/problem/not-applicable color blocks from the selected parser perspective.
- Details mode keeps the engineer view, but clean selected-parser cells are visually quiet; parity markers (`=`, `D`, `V`, `S`, `DVS`) appear only when the Parity checkbox is enabled.
- Tool-calling and reasoning table cells now emit per-parser status, selected-parser markers, and pairwise parity markers.
- `n/a` cells are more subtle, Dynamo-only cells use a muted center dot, and tooltip copy says `Why not applicable`.

#### Verification:

Regenerated `tests/parity/PARITY.html`; `python3 -m pytest -q tests/parity/toolcalling/test_generate_parity_table.py` passed in the `dynamo1` devcontainer.

#### Where should the reviewer start?

`tests/parity/parity_table.html.j2`, then `tests/parity/toolcalling/table.py` and `tests/parity/reasoning/table.py`

#### Related Issues:

Relates to DIS-2150

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive view and parser selection controls to the parity test results display.
  * Introduced overview and details modes for better data organization.
  * Added per-engine status indicators and visual markers in the parity table.
  * Enhanced toolbar UI with toggle controls for different viewing perspectives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
