### PR TITLE
fix(parsers): recover Top-N damaged tool calls

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -696,7 +696,11 @@ impl JailedStream {
                             if choice.finish_reason.is_some() {
                                 choice_state.stream_finish_reason = choice.finish_reason;
                             }
-                            let was_ever_jailed = !choice_state.accumulated_content.is_empty() || choice_state.is_jailed;
+                            let has_pending_buffered_output =
+                                !choice_state.partial_match_buffer.is_empty();
+                            let was_ever_jailed = !choice_state.accumulated_content.is_empty()
+                                || choice_state.is_jailed
+                                || has_pending_buffered_output;
 
                             // Reasoning-only chunks must pass through even when jailed; only
                             // `content` is subject to accumulation.

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -216,6 +216,26 @@ impl ChoiceJailState {
             return;
         }
 
+        if let MatchResult::Partial {
+            prefix, partial, ..
+        } = jail_stream.marker_matcher.process_chunk(content, "")
+        {
+            if !prefix.is_empty() {
+                #[allow(deprecated)]
+                let trailing_choice = create_choice_stream(
+                    choice.index,
+                    choice.delta.role,
+                    &prefix,
+                    None,
+                    None,
+                    choice.logprobs.clone(),
+                );
+                emissions.push(ChoiceEmission::Trailing(trailing_choice));
+            }
+            self.partial_match_buffer = partial;
+            return;
+        }
+
         if let Some((prefix, partial)) = jail_stream.split_partial_tool_call_start(content) {
             if !prefix.is_empty() {
                 #[allow(deprecated)]

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -494,6 +494,17 @@ impl ChoiceJailState {
             } else {
                 Some(ChoiceEmission::Content(final_choice))
             }
+        } else if !self.partial_match_buffer.is_empty() {
+            let content = std::mem::take(&mut self.partial_match_buffer);
+            let choice = create_choice_stream(
+                self.index,
+                Some(Role::Assistant),
+                &content,
+                None,
+                self.stream_finish_reason,
+                None,
+            );
+            Some(ChoiceEmission::Content(choice))
         } else {
             None
         }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -205,6 +205,49 @@ impl ChoiceJailState {
         std::mem::take(&mut self.accumulated_content)
     }
 
+    fn handle_trailing_content(
+        &mut self,
+        content: &str,
+        choice: &ChatChoiceStream,
+        jail_stream: &JailedStream,
+        emissions: &mut Vec<ChoiceEmission>,
+    ) {
+        if content.is_empty() {
+            return;
+        }
+
+        if let Some((prefix, partial)) = jail_stream.split_partial_tool_call_start(content) {
+            if !prefix.is_empty() {
+                #[allow(deprecated)]
+                let trailing_choice = create_choice_stream(
+                    choice.index,
+                    choice.delta.role,
+                    prefix,
+                    None,
+                    None,
+                    choice.logprobs.clone(),
+                );
+                emissions.push(ChoiceEmission::Trailing(trailing_choice));
+            }
+            self.partial_match_buffer = partial.to_string();
+        } else if jail_stream.should_start_jail(content) {
+            self.is_jailed = true;
+            self.accumulated_content = content.to_string();
+            self.accumulated_logprobs = None;
+        } else {
+            #[allow(deprecated)]
+            let trailing_choice = create_choice_stream(
+                choice.index,
+                choice.delta.role,
+                content,
+                None,
+                choice.finish_reason,
+                choice.logprobs.clone(),
+            );
+            emissions.push(ChoiceEmission::Trailing(trailing_choice));
+        }
+    }
+
     /// Process incoming content and return what should be emitted (if anything)
     async fn process_content(
         &mut self,
@@ -253,6 +296,7 @@ impl ChoiceJailState {
 
                     // Check if this already contains the end marker
                     let (should_end, split_pos) = jail_stream.should_end_jail(&full_content).await;
+                    self.partial_match_buffer.clear();
 
                     if should_end {
                         // Complete tool call found in this chunk
@@ -279,25 +323,12 @@ impl ChoiceJailState {
                         }
 
                         // Handle trailing content if any
-                        if !trailing_part.is_empty() {
-                            if jail_stream.should_start_jail(trailing_part) {
-                                self.is_jailed = true;
-                                self.accumulated_content = trailing_part.to_string();
-                                // No logprobs to seed here — they were already emitted with the tool call
-                                self.accumulated_logprobs = None;
-                            } else {
-                                #[allow(deprecated)]
-                                let trailing_choice = create_choice_stream(
-                                    choice.index,
-                                    choice.delta.role,
-                                    trailing_part,
-                                    None,
-                                    choice.finish_reason,
-                                    choice.logprobs.clone(),
-                                );
-                                emissions.push(ChoiceEmission::Trailing(trailing_choice));
-                            }
-                        }
+                        self.handle_trailing_content(
+                            trailing_part,
+                            choice,
+                            jail_stream,
+                            &mut emissions,
+                        );
                     } else {
                         // Start jailing with the marker and suffix
                         self.is_jailed = true;
@@ -305,8 +336,6 @@ impl ChoiceJailState {
                         // Seed accumulated logprobs with this chunk's logprobs
                         self.accumulated_logprobs = choice.logprobs.clone();
                     }
-
-                    self.partial_match_buffer.clear();
                 }
 
                 MatchResult::Partial {
@@ -360,7 +389,7 @@ impl ChoiceJailState {
                                 choice.delta.role,
                                 prefix,
                                 None,
-                                choice.finish_reason,
+                                None,
                                 choice.logprobs.clone(),
                             );
                             emissions.push(ChoiceEmission::PassThrough(prefix_choice));
@@ -433,23 +462,7 @@ impl ChoiceJailState {
                 self.end_jail();
 
                 // Handle trailing content if any
-                if !trailing_owned.is_empty() {
-                    if jail_stream.should_start_jail(&trailing_owned) {
-                        self.is_jailed = true;
-                        self.accumulated_content = trailing_owned;
-                    } else {
-                        #[allow(deprecated)]
-                        let trailing_choice = create_choice_stream(
-                            choice.index,
-                            choice.delta.role,
-                            &trailing_owned,
-                            None,
-                            choice.finish_reason,
-                            choice.logprobs.clone(),
-                        );
-                        emissions.push(ChoiceEmission::Trailing(trailing_choice));
-                    }
-                }
+                self.handle_trailing_content(&trailing_owned, choice, jail_stream, &mut emissions);
             }
             // If not unjailing, don't emit anything (still accumulating)
         }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -7,7 +7,7 @@ use dynamo_protocols::types::{
     ChatCompletionStreamResponseDelta, FinishReason, FunctionCallStream, FunctionType, Role,
 };
 
-use dynamo_parsers::tool_calling::config::JsonParserConfig;
+use dynamo_parsers::tool_calling::config::{JsonParserConfig, ParserConfig};
 use dynamo_parsers::tool_calling::json::try_tool_call_parse_basic_json;
 use dynamo_parsers::tool_calling::parsers::get_tool_parser_map;
 use dynamo_parsers::tool_calling::{
@@ -1551,6 +1551,15 @@ impl JailedStreamBuilder {
             if let Some(config) = parser_map.get(parser_name.as_str()) {
                 // Add start tokens from the parser config
                 all_patterns.extend(config.parser_config.tool_call_start_tokens());
+                if let ParserConfig::Glm47(glm_config) = &config.parser_config
+                    && let Some(tools) = self.tool_definitions.as_ref()
+                {
+                    for tool in tools {
+                        if !tool.name.is_empty() {
+                            all_patterns.push(format!("{}{}", tool.name, glm_config.arg_key_start));
+                        }
+                    }
+                }
             }
         }
 

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -8,6 +8,7 @@ use dynamo_protocols::types::{
 };
 
 use dynamo_parsers::tool_calling::config::{JsonParserConfig, ParserConfig};
+use dynamo_parsers::tool_calling::gemma4::split_partial_call_prefix_gemma4;
 use dynamo_parsers::tool_calling::json::try_tool_call_parse_basic_json;
 use dynamo_parsers::tool_calling::parsers::get_tool_parser_map;
 use dynamo_parsers::tool_calling::{
@@ -349,17 +350,26 @@ impl ChoiceJailState {
                 }
 
                 MatchResult::None { content } => {
-                    // Check if this content (combined with partial buffer) should start jailing
-                    let combined_content = if self.partial_match_buffer.is_empty() {
-                        content.clone()
-                    } else {
-                        format!("{}{}", self.partial_match_buffer, content)
-                    };
-
-                    if jail_stream.should_start_jail(&combined_content) {
+                    if let Some((prefix, partial)) =
+                        jail_stream.split_partial_tool_call_start(&content)
+                    {
+                        if !prefix.is_empty() {
+                            #[allow(deprecated)]
+                            let prefix_choice = create_choice_stream(
+                                choice.index,
+                                choice.delta.role,
+                                prefix,
+                                None,
+                                choice.finish_reason,
+                                choice.logprobs.clone(),
+                            );
+                            emissions.push(ChoiceEmission::PassThrough(prefix_choice));
+                        }
+                        self.partial_match_buffer = partial.to_string();
+                    } else if jail_stream.should_start_jail(&content) {
                         // Start jailing with the combined content
                         self.is_jailed = true;
-                        self.accumulated_content = combined_content;
+                        self.accumulated_content = content;
                         // Seed accumulated logprobs with this chunk's logprobs
                         self.accumulated_logprobs = choice.logprobs.clone();
                         self.partial_match_buffer.clear();
@@ -864,6 +874,13 @@ impl JailedStream {
     }
 
     /// Check if content matches any jail start patterns
+    fn split_partial_tool_call_start<'a>(&self, content: &'a str) -> Option<(&'a str, &'a str)> {
+        if self.tool_call_parser.as_deref() == Some("gemma4") {
+            return split_partial_call_prefix_gemma4(content);
+        }
+        None
+    }
+
     fn should_start_jail(&self, content: &str) -> bool {
         // Path 1: Check configured start sequences
         let sequence_match = !self.jail_start_sequences.is_empty()

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3707,6 +3707,32 @@ fahrenheit
             assert_eq!(test_utils::reconstruct_content(&results), expected);
             assert!(tool_call_names(&results).is_empty());
         }
+
+        let expected = "I will call";
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(expected.to_string(), 0),
+            test_utils::create_final_response_chunk(0),
+        ];
+        let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(test_utils::reconstruct_content(&results), expected);
+        let finish_chunks: Vec<_> = results
+            .iter()
+            .filter_map(|result| result.data.as_ref())
+            .flat_map(|data| data.inner.choices.iter())
+            .filter(|choice| choice.finish_reason.is_some())
+            .collect();
+        assert_eq!(finish_chunks.len(), 1);
+        let content = finish_chunks[0]
+            .delta
+            .content
+            .as_ref()
+            .expect("partial marker buffer should flush with the final finish chunk");
+        assert_eq!(test_utils::extract_text(content), "call");
     }
 
     #[tokio::test]

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3723,6 +3723,15 @@ fahrenheit
                 ],
                 &["<|tool_call_begin|>", "<|tool_calls_section_end|>"][..],
             ),
+            (
+                "gemma4",
+                "Gemma 4",
+                vec![
+                    "I will check that. ca",
+                    "ll:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
+                ],
+                &["call:get_weather", "<tool_call|>"][..],
+            ),
         ];
 
         for (parser, label, chunks, markers) in cases {

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3580,11 +3580,11 @@ fahrenheit
         }
     }
 
-    /// MiniMax uses a strict reference parser: incomplete paired XML fences do
-    /// not recover a call. At stream end, the jail must still avoid surfacing
-    /// the raw `<minimax:tool_call>` protocol block as assistant content.
+    /// MiniMax recovers complete inner invokes even when the outer wrapper is
+    /// damaged. Incomplete paired XML fences still do not recover a call, and
+    /// the jail must not surface raw MiniMax protocol markers as content.
     #[tokio::test]
-    async fn test_minimax_m2_stream_finalize_zero_call_truncation_drops_markup() {
+    async fn test_minimax_m2_stream_finalize_recovers_complete_inner_invokes() {
         // These are jail/finalize regression checks for existing parser parity cases:
         // the first and prefix-preservation rows cover TOOLCALLING.stream.4.a, and
         // the mid-call body truncation row covers TOOLCALLING.stream.4.b.
@@ -3596,6 +3596,7 @@ fahrenheit
                  <parameter name=\"location\">NYC</parameter>\n\
                  </invoke>",
                 "",
+                1,
             ),
             (
                 "mid-call body truncation",
@@ -3603,6 +3604,7 @@ fahrenheit
                  <invoke name=\"get_weather\">\n\
                  <parameter name=\"location\">NY",
                 "",
+                0,
             ),
             (
                 "pre-marker prose before truncated call",
@@ -3611,10 +3613,11 @@ fahrenheit
                  <parameter name=\"location\">NYC</parameter>\n\
                  </invoke>",
                 "I will check that. ",
+                1,
             ),
         ];
 
-        for (label, partial_tool_call, expected_content) in cases {
+        for (label, partial_tool_call, expected_content, expected_tool_call_count) in cases {
             let input_chunks = vec![
                 test_utils::create_mock_response_chunk(partial_tool_call.to_string(), 0),
                 test_utils::create_final_response_chunk(0),
@@ -3643,8 +3646,8 @@ fahrenheit
                 })
                 .sum();
             assert_eq!(
-                tool_call_count, 0,
-                "{label}: strict MiniMax must not recover a call"
+                tool_call_count, expected_tool_call_count,
+                "{label}: unexpected recovered MiniMax tool call count"
             );
 
             let content = test_utils::reconstruct_content(&results);

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3694,6 +3694,22 @@ fahrenheit
     /// split across stream chunks. Otherwise the jail emits protocol bytes as
     /// normal content before the aggregate parser gets a chance to recover.
     #[tokio::test]
+    async fn test_partial_marker_buffer_flushes_at_stream_end() {
+        for suffix in ["c", "ca", "cal", "call"] {
+            let expected = format!("I will {suffix}");
+            let input_chunks = vec![test_utils::create_mock_response_chunk(expected.clone(), 0)];
+            let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+            let results: Vec<_> = jail
+                .apply_with_finish_reason(stream::iter(input_chunks))
+                .collect()
+                .await;
+
+            assert_eq!(test_utils::reconstruct_content(&results), expected);
+            assert!(tool_call_names(&results).is_empty());
+        }
+    }
+
+    #[tokio::test]
     async fn test_split_bare_recovery_markers_are_jailed() {
         let cases = [
             (

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3977,6 +3977,55 @@ fahrenheit
         );
     }
 
+    #[tokio::test]
+    async fn test_glm47_trailing_split_bare_call_stays_jailed() {
+        use dynamo_parsers::tool_calling::ToolDefinition;
+
+        let tool_defs = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+            })),
+            strict: None,
+        }];
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>get_weat"
+                    .to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "her<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call>"
+                    .to_string(),
+                0,
+            ),
+        ];
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("glm47")
+            .tool_definitions(tool_defs)
+            .build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(
+            tool_call_names(&results),
+            vec!["get_weather".to_string(), "get_weather".to_string()]
+        );
+        assert_eq!(test_utils::reconstruct_content(&results), "");
+        assert_content_omits_markers(
+            "GLM-4.7 trailing split",
+            &results,
+            &["get_weat", "her<arg_key>", "<arg_value>", "</tool_call>"],
+        );
+    }
+
     /// tool_choice=required with the alternate `arguments` key (SGLang's
     /// JsonArrayParser and some vLLM paths emit this variant).  The
     /// base_json_parser accepts either `parameters` or `arguments`.

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3722,11 +3722,41 @@ fahrenheit
                 &["<invoke", "</minimax:tool_call>"][..],
             ),
             (
+                "minimax_m2",
+                "MiniMax delayed outer close",
+                vec![
+                    "I will check that. <invoke name=\"get_weather\">\n<parameter name=\"location\">NYC</parameter>\n",
+                    "</invoke>",
+                    "\n</minimax:tool_call>",
+                ],
+                &["<invoke", "</minimax:tool_call>"][..],
+            ),
+            (
+                "qwen3_coder",
+                "Qwen3-Coder delayed outer close",
+                vec![
+                    "I will check that. <function=get_weather>\n<parameter=location>NYC</parameter>\n",
+                    "</function>",
+                    "\n</tool_call>",
+                ],
+                &["<function=", "</tool_call>"][..],
+            ),
+            (
                 "deepseek_v4",
                 "DeepSeek V4",
                 vec![
                     "I will check that. <｜DSML｜inv",
                     "oke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+                ],
+                &["<｜DSML｜invoke", "</｜DSML｜tool_calls>"][..],
+            ),
+            (
+                "deepseek_v4",
+                "DeepSeek V4 delayed outer close",
+                vec![
+                    "I will check that. <｜DSML｜invoke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n",
+                    "</｜DSML｜invoke>",
+                    "\n</｜DSML｜tool_calls>",
                 ],
                 &["<｜DSML｜invoke", "</｜DSML｜tool_calls>"][..],
             ),

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3738,7 +3738,11 @@ fahrenheit
     #[tokio::test]
     async fn test_gemma4_call_prefix_prose_passes_without_waiting_for_eof() {
         let expected = "I will call: you tomorrow";
-        let cases = [vec![expected], vec!["I will ca", "ll: you tomorrow"]];
+        let cases = [
+            vec![expected],
+            vec!["I will ca", "ll: you tomorrow"],
+            vec!["I will call:", " you tomorrow"],
+        ];
 
         for chunks in cases {
             let input_chunks = chunks
@@ -3830,6 +3834,15 @@ fahrenheit
                 vec![
                     "I will check that. ca",
                     "ll:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
+                ],
+                &["call:get_weather", "<tool_call|>"][..],
+            ),
+            (
+                "gemma4",
+                "Gemma 4 split after call prefix",
+                vec![
+                    "I will check that. call:",
+                    "get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
                 ],
                 &["call:get_weather", "<tool_call|>"][..],
             ),

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3733,6 +3733,32 @@ fahrenheit
             .as_ref()
             .expect("partial marker buffer should flush with the final finish chunk");
         assert_eq!(test_utils::extract_text(content), "call");
+
+        let mut terminal_content_chunk =
+            test_utils::create_mock_response_chunk(expected.to_string(), 0);
+        terminal_content_chunk.data.as_mut().unwrap().inner.choices[0].finish_reason =
+            Some(FinishReason::Stop);
+        let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(vec![terminal_content_chunk]))
+            .collect()
+            .await;
+        let content_chunks: Vec<_> = results
+            .iter()
+            .filter_map(|result| result.data.as_ref())
+            .flat_map(|data| data.inner.choices.iter())
+            .filter_map(|choice| {
+                choice
+                    .delta
+                    .content
+                    .as_ref()
+                    .map(|content| (test_utils::extract_text(content), choice.finish_reason))
+            })
+            .collect();
+        assert_eq!(
+            content_chunks,
+            vec![("I will ", None), ("call", Some(FinishReason::Stop))]
+        );
     }
 
     #[tokio::test]
@@ -3766,6 +3792,37 @@ fahrenheit
                 .collect();
             assert_eq!(content_before_finish, expected);
         }
+    }
+
+    #[tokio::test]
+    async fn test_gemma4_trailing_partial_after_unjail_is_buffered() {
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk(
+                "<|tool_call>call:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|> ca".to_string(),
+                0,
+            ),
+            test_utils::create_mock_response_chunk(
+                "ll:get_weather{location:<|\"|>Boston<|\"|>}<tool_call|>".to_string(),
+                0,
+            ),
+        ];
+        let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(
+            tool_call_names(&results),
+            vec!["get_weather".to_string(), "get_weather".to_string()]
+        );
+        let content = test_utils::reconstruct_content(&results);
+        assert_eq!(content, " ");
+        assert_content_omits_markers(
+            "Gemma 4 trailing partial",
+            &results,
+            &["call:get_weather", "ca", "ll:get_weather", "<tool_call|>"],
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3662,6 +3662,141 @@ fahrenheit
         }
     }
 
+    fn tool_call_names(results: &[Annotated<NvCreateChatCompletionStreamResponse>]) -> Vec<String> {
+        results
+            .iter()
+            .flat_map(|r| r.data.as_ref().into_iter())
+            .flat_map(|d| d.inner.choices.iter())
+            .flat_map(|c| c.delta.tool_calls.iter().flatten())
+            .filter_map(|tc| {
+                tc.function
+                    .as_ref()
+                    .and_then(|function| function.name.clone())
+            })
+            .collect()
+    }
+
+    fn assert_content_omits_markers(
+        label: &str,
+        results: &[Annotated<NvCreateChatCompletionStreamResponse>],
+        markers: &[&str],
+    ) {
+        let content = test_utils::reconstruct_content(results);
+        for marker in markers {
+            assert!(
+                !content.contains(marker),
+                "{label}: marker {marker:?} leaked into content: {content:?}"
+            );
+        }
+    }
+
+    /// Bare-body recovery must also work when the recovery marker itself is
+    /// split across stream chunks. Otherwise the jail emits protocol bytes as
+    /// normal content before the aggregate parser gets a chance to recover.
+    #[tokio::test]
+    async fn test_split_bare_recovery_markers_are_jailed() {
+        let cases = [
+            (
+                "minimax_m2",
+                "MiniMax",
+                vec![
+                    "I will check that. <inv",
+                    "oke name=\"get_weather\">\n<parameter name=\"location\">NYC</parameter>\n</invoke>\n</minimax:tool_call>",
+                ],
+                &["<invoke", "</minimax:tool_call>"][..],
+            ),
+            (
+                "deepseek_v4",
+                "DeepSeek V4",
+                vec![
+                    "I will check that. <｜DSML｜inv",
+                    "oke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+                ],
+                &["<｜DSML｜invoke", "</｜DSML｜tool_calls>"][..],
+            ),
+            (
+                "kimi_k2",
+                "Kimi K2",
+                vec![
+                    "I will check that. <|tool_call_beg",
+                    "in|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"NYC\"}<|tool_call_end|><|tool_calls_section_end|>",
+                ],
+                &["<|tool_call_begin|>", "<|tool_calls_section_end|>"][..],
+            ),
+        ];
+
+        for (parser, label, chunks, markers) in cases {
+            let input_chunks = chunks
+                .into_iter()
+                .map(|chunk| test_utils::create_mock_response_chunk(chunk.to_string(), 0));
+            let jail = JailedStream::builder().tool_call_parser(parser).build();
+            let results: Vec<_> = jail
+                .apply_with_finish_reason(stream::iter(input_chunks))
+                .collect()
+                .await;
+
+            assert_eq!(
+                tool_call_names(&results),
+                vec!["get_weather".to_string()],
+                "{label}: expected recovered get_weather call"
+            );
+            assert_eq!(
+                test_utils::reconstruct_content(&results),
+                "I will check that. ",
+                "{label}: expected only prefix prose as content"
+            );
+            assert_content_omits_markers(label, &results, markers);
+        }
+    }
+
+    /// GLM-4.7's bare-call marker starts at `<arg_key>`, after the function
+    /// name. The stream jail therefore needs parser-aware tool-name patterns
+    /// so a split between the function name and `<arg_key>` does not leak the
+    /// function name as user-visible content.
+    #[tokio::test]
+    async fn test_glm47_split_bare_call_jails_function_name_suffix() {
+        use dynamo_parsers::tool_calling::ToolDefinition;
+
+        let tool_defs = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+            })),
+            strict: None,
+        }];
+
+        let input_chunks = vec![
+            test_utils::create_mock_response_chunk("I will check that. get_weat".to_string(), 0),
+            test_utils::create_mock_response_chunk(
+                "her<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>".to_string(),
+                0,
+            ),
+        ];
+
+        let jail = JailedStream::builder()
+            .tool_call_parser("glm47")
+            .tool_definitions(tool_defs)
+            .build();
+        let results: Vec<_> = jail
+            .apply_with_finish_reason(stream::iter(input_chunks))
+            .collect()
+            .await;
+
+        assert_eq!(tool_call_names(&results), vec!["get_weather".to_string()]);
+        assert_eq!(
+            test_utils::reconstruct_content(&results),
+            "I will check that. "
+        );
+        assert_content_omits_markers(
+            "GLM-4.7",
+            &results,
+            &["get_weather<arg_key>", "<arg_value>", "</tool_call>"],
+        );
+    }
+
     /// tool_choice=required with the alternate `arguments` key (SGLang's
     /// JsonArrayParser and some vLLM paths emit this variant).  The
     /// base_json_parser accepts either `parameters` or `arguments`.

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -3736,6 +3736,35 @@ fahrenheit
     }
 
     #[tokio::test]
+    async fn test_gemma4_call_prefix_prose_passes_without_waiting_for_eof() {
+        let expected = "I will call: you tomorrow";
+        let cases = [vec![expected], vec!["I will ca", "ll: you tomorrow"]];
+
+        for chunks in cases {
+            let input_chunks = chunks
+                .into_iter()
+                .map(|chunk| test_utils::create_mock_response_chunk(chunk.to_string(), 0))
+                .chain(std::iter::once(test_utils::create_final_response_chunk(0)));
+            let jail = JailedStream::builder().tool_call_parser("gemma4").build();
+            let results: Vec<_> = jail
+                .apply_with_finish_reason(stream::iter(input_chunks))
+                .collect()
+                .await;
+
+            assert_eq!(test_utils::reconstruct_content(&results), expected);
+            let content_before_finish: String = results
+                .iter()
+                .filter_map(|result| result.data.as_ref())
+                .flat_map(|data| data.inner.choices.iter())
+                .filter(|choice| choice.finish_reason.is_none())
+                .filter_map(|choice| choice.delta.content.as_ref())
+                .map(test_utils::extract_text)
+                .collect();
+            assert_eq!(content_before_finish, expected);
+        }
+    }
+
+    #[tokio::test]
     async fn test_split_bare_recovery_markers_are_jailed() {
         let cases = [
             (

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -84,9 +84,9 @@ pub struct XmlParserConfig {
 
     /// When true, the function- and parameter-regex omit the `|$` end-of-block
     /// fallback (so missing `</function>` / `</parameter>` causes the match to
-    /// fail rather than being silently recovered), AND `detect_and_parse_tool_
-    /// call_with_recovery` does not flip `allow_eof_recovery=true` for this
-    /// config. Used by families whose official reference parser is
+    /// fail rather than being silently recovered). Finalize recovery may still
+    /// accept a missing outer wrapper end marker if the inner blocks are
+    /// complete. Used by families whose official reference parser is
     /// strict-match (e.g. MiniMax-M2 — see
     /// https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md).
     #[serde(default)]
@@ -102,11 +102,10 @@ pub struct XmlParserConfig {
 
     /// When true, if `tool_call_start_token` is absent but `function_start_
     /// token` is present, parse the entire input as a single tool-call block
-    /// (back-off strategy). Matches the `if len(raw_tool_calls) == 0:
-    /// raw_tool_calls = [model_output]` back-off in Qwen3-Coder's reference
-    /// parser. Independent of `passthrough_when_no_function` (different
-    /// trigger: this one fires when function tags exist but the outer wrapper
-    /// does not).
+    /// (back-off strategy). Used by XML families that can recover a complete
+    /// function/invoke body even when the outer wrapper opener is missing.
+    /// Independent of `passthrough_when_no_function` (different trigger: this
+    /// one fires when function tags exist but the outer wrapper does not).
     #[serde(default)]
     pub backoff_when_no_wrapper: bool,
 }
@@ -576,12 +575,9 @@ impl ToolCallConfig {
         // </minimax:tool_call>
         // Reference: https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
         //
-        // MiniMax's official reference parser is strict-match — its three
-        // regexes (outer/invoke/parameter) all require paired fences and
-        // return [] on any mismatch. `strict_match=true` enforces that:
-        // it drops the `|$` end-of-block fallback from the function- and
-        // parameter-regex AND prevents the PyO3 `with_recovery` shim from
-        // flipping `allow_eof_recovery=true`.
+        // MiniMax uses strict inner invoke/parameter fences. Dynamo still
+        // recovers complete inner invokes when only the outer wrapper is
+        // missing or truncated so valid tool calls do not disappear.
         Self {
             parser_config: ParserConfig::Xml(XmlParserConfig {
                 tool_call_start_token: "<minimax:tool_call>".to_string(),
@@ -593,7 +589,7 @@ impl ToolCallConfig {
                 allow_eof_recovery: false,
                 strict_match: true,
                 passthrough_when_no_function: false,
-                backoff_when_no_wrapper: false,
+                backoff_when_no_wrapper: true,
             }),
             structural_tag_builder: None,
         }

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -313,10 +313,9 @@ impl ParserConfig {
                 tokens.push(config.call_start.clone());
                 tokens
             }
-            ParserConfig::Gemma4 => vec![
-                crate::tool_calling::gemma4::TOOL_CALL_START.to_string(),
-                crate::tool_calling::gemma4::CALL_PREFIX.to_string(),
-            ],
+            ParserConfig::Gemma4 => {
+                vec![crate::tool_calling::gemma4::TOOL_CALL_START.to_string()]
+            }
         }
     }
 

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -313,7 +313,10 @@ impl ParserConfig {
                 tokens.push(config.call_start.clone());
                 tokens
             }
-            ParserConfig::Gemma4 => vec![crate::tool_calling::gemma4::TOOL_CALL_START.to_string()],
+            ParserConfig::Gemma4 => vec![
+                crate::tool_calling::gemma4::TOOL_CALL_START.to_string(),
+                crate::tool_calling::gemma4::CALL_PREFIX.to_string(),
+            ],
         }
     }
 

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -292,12 +292,27 @@ impl ParserConfig {
         match self {
             ParserConfig::Json(config) => config.tool_call_start_tokens.clone(),
             ParserConfig::Harmony(config) => config.tool_call_start_tokens.clone(),
-            ParserConfig::Xml(config) => vec![config.tool_call_start_token.clone()],
+            ParserConfig::Xml(config) => {
+                let mut tokens = vec![config.tool_call_start_token.clone()];
+                if config.backoff_when_no_wrapper {
+                    tokens.push(config.function_start_token.clone());
+                }
+                tokens
+            }
             ParserConfig::Pythonic => vec![],
             ParserConfig::Typescript => vec![],
-            ParserConfig::Dsml(config) => vec![config.block_start.clone()],
+            ParserConfig::Dsml(config) => {
+                vec![
+                    config.block_start.clone(),
+                    config.invoke_start_prefix.clone(),
+                ]
+            }
             ParserConfig::Glm47(config) => vec![config.tool_call_start.clone()],
-            ParserConfig::KimiK2(config) => config.section_start_variants.clone(),
+            ParserConfig::KimiK2(config) => {
+                let mut tokens = config.section_start_variants.clone();
+                tokens.push(config.call_start.clone());
+                tokens
+            }
             ParserConfig::Gemma4 => vec![crate::tool_calling::gemma4::TOOL_CALL_START.to_string()],
         }
     }

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -28,8 +28,9 @@ use super::super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 pub fn detect_tool_call_start_dsml(chunk: &str, config: &DsmlParserConfig) -> bool {
     let start_token = &config.block_start;
 
-    // Check for complete start token
-    if chunk.contains(start_token.as_str()) {
+    // Check for complete outer block start, or a bare invoke when the outer
+    // wrapper opener is missing.
+    if chunk.contains(start_token.as_str()) || chunk.contains(config.invoke_start_prefix.as_str()) {
         return true;
     }
 
@@ -82,6 +83,23 @@ pub fn try_tool_call_parse_dsml(
 
     let Some(start_idx) = trimmed.find(&config.block_start) else {
         if let Some(marker_idx) = first_orphan_dsml_marker_index(trimmed, config) {
+            let marker_tail = &trimmed[marker_idx..];
+            if marker_tail.starts_with(config.invoke_start_prefix.as_str()) {
+                let tool_calls = extract_invokes(marker_tail, config)?;
+                if !tool_calls.is_empty() {
+                    tracing::warn!(
+                        why = "bare_invoke_recovery",
+                        recovered_calls = tool_calls.len(),
+                        recovered_bytes = marker_tail.len(),
+                        kept_prefix_bytes = marker_idx,
+                        "DSML recovery: recovered complete bare invoke(s) without outer block_start"
+                    );
+                    return Ok((
+                        tool_calls,
+                        Some(trimmed[..marker_idx].trim_end().to_string()),
+                    ));
+                }
+            }
             let stripped = &trimmed[marker_idx..];
             tracing::warn!(
                 why = "DSML tool-call marker found without the outer block_start; dropping orphan marker tail so wire tags do not leak into normal_text",

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -86,22 +86,22 @@ pub fn try_tool_call_parse_dsml(
     let Some(start_idx) = trimmed.find(&config.block_start) else {
         if let Some(marker_idx) = first_orphan_dsml_marker_index(trimmed, config) {
             let marker_tail = &trimmed[marker_idx..];
-            if marker_tail.starts_with(config.invoke_start_prefix.as_str()) {
-                if marker_tail.contains(config.block_end.as_str()) || config.allow_eof_recovery {
-                    let tool_calls = extract_invokes(marker_tail, config)?;
-                    if !tool_calls.is_empty() {
-                        tracing::warn!(
-                            why = "bare_invoke_recovery",
-                            recovered_calls = tool_calls.len(),
-                            recovered_bytes = marker_tail.len(),
-                            kept_prefix_bytes = marker_idx,
-                            "DSML recovery: recovered complete bare invoke(s) without outer block_start"
-                        );
-                        return Ok((
-                            tool_calls,
-                            Some(trimmed[..marker_idx].trim_end().to_string()),
-                        ));
-                    }
+            if marker_tail.starts_with(config.invoke_start_prefix.as_str())
+                && (marker_tail.contains(config.block_end.as_str()) || config.allow_eof_recovery)
+            {
+                let tool_calls = extract_invokes(marker_tail, config)?;
+                if !tool_calls.is_empty() {
+                    tracing::warn!(
+                        why = "bare_invoke_recovery",
+                        recovered_calls = tool_calls.len(),
+                        recovered_bytes = marker_tail.len(),
+                        kept_prefix_bytes = marker_idx,
+                        "DSML recovery: recovered complete bare invoke(s) without outer block_start"
+                    );
+                    return Ok((
+                        tool_calls,
+                        Some(trimmed[..marker_idx].trim_end().to_string()),
+                    ));
                 }
             }
             let stripped = &trimmed[marker_idx..];

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -120,7 +120,11 @@ pub fn try_tool_call_parse_dsml(
     // Whether or not invokes parsed, normal_text is the prefix before the
     // first block_start — mirrors vLLM's success path. On no-invokes the
     // markup-leak warning still fires for the diagnostic trail.
-    let pre_block_text = trimmed[..start_idx].to_string();
+    let pre_block_span = &trimmed[..start_idx];
+    let pre_block_text = first_orphan_dsml_marker_index(pre_block_span, config)
+        .filter(|idx| pre_block_span[*idx..].starts_with(config.invoke_start_prefix.as_str()))
+        .map(|idx| pre_block_span[..idx].trim_end().to_string())
+        .unwrap_or_else(|| pre_block_span.to_string());
 
     if tool_calls.is_empty() {
         // A block-start was detected but no valid invokes parsed. Do NOT leak
@@ -184,9 +188,21 @@ fn extract_tool_calls(
 
     while cursor < text.len() {
         let Some(rel_start) = text[cursor..].find(config.block_start.as_str()) else {
+            if let Some((_, mut recovered)) =
+                recover_orphan_invokes_in_span(&text[cursor..], config)?
+            {
+                tool_calls.append(&mut recovered);
+            }
             break;
         };
-        let block_content_start = cursor + rel_start + config.block_start.len();
+        let abs_start = cursor + rel_start;
+        if let Some((_, mut recovered)) =
+            recover_orphan_invokes_in_span(&text[cursor..abs_start], config)?
+        {
+            tool_calls.append(&mut recovered);
+        }
+
+        let block_content_start = abs_start + config.block_start.len();
         let after_start = &text[block_content_start..];
 
         let (block, next_cursor) =
@@ -208,6 +224,36 @@ fn extract_tool_calls(
     }
 
     Ok(tool_calls)
+}
+
+fn recover_orphan_invokes_in_span(
+    span: &str,
+    config: &DsmlParserConfig,
+) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+    let Some(marker_idx) = first_orphan_dsml_marker_index(span, config) else {
+        return Ok(None);
+    };
+    let marker_tail = &span[marker_idx..];
+    if !marker_tail.starts_with(config.invoke_start_prefix.as_str()) {
+        return Ok(None);
+    }
+
+    let tool_calls = extract_invokes(marker_tail, config)?;
+    if tool_calls.is_empty() {
+        return Ok(None);
+    }
+
+    tracing::warn!(
+        why = "bare_invoke_gap_recovery",
+        recovered_calls = tool_calls.len(),
+        recovered_bytes = marker_tail.len(),
+        kept_prefix_bytes = marker_idx,
+        "DSML recovery: recovered complete bare invoke(s) before a later outer block"
+    );
+    Ok(Some((
+        span[..marker_idx].trim_end().to_string(),
+        tool_calls,
+    )))
 }
 
 /// Extract individual invoke blocks from function_calls content

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -80,11 +80,18 @@ pub fn try_tool_call_parse_dsml(
         return Ok((vec![], Some(String::new())));
     }
 
-    // Check if tool call block exists
-    let start_idx = trimmed.find(&config.block_start);
-    if start_idx.is_none() {
+    let Some(start_idx) = trimmed.find(&config.block_start) else {
+        if let Some(marker_idx) = first_orphan_dsml_marker_index(trimmed, config) {
+            let stripped = &trimmed[marker_idx..];
+            tracing::warn!(
+                why = "DSML tool-call marker found without the outer block_start; dropping orphan marker tail so wire tags do not leak into normal_text",
+                stripped_bytes = stripped.len(),
+                "DSML strip (orphan markers)"
+            );
+            return Ok((vec![], Some(trimmed[..marker_idx].trim_end().to_string())));
+        }
         return Ok((vec![], Some(trimmed.to_string())));
-    }
+    };
 
     // Extract tool calls blocks. Finalize paths can opt into EOF recovery so
     // a missing outer block end still yields any complete inner invokes.
@@ -93,9 +100,7 @@ pub fn try_tool_call_parse_dsml(
     // Whether or not invokes parsed, normal_text is the prefix before the
     // first block_start — mirrors vLLM's success path. On no-invokes the
     // markup-leak warning still fires for the diagnostic trail.
-    let pre_block_text = start_idx
-        .map(|idx| trimmed[..idx].to_string())
-        .unwrap_or_default();
+    let pre_block_text = trimmed[..start_idx].to_string();
 
     if tool_calls.is_empty() {
         // A block-start was detected but no valid invokes parsed. Do NOT leak
@@ -105,16 +110,14 @@ pub fn try_tool_call_parse_dsml(
         // Note: an unterminated block-start here means `block_regex` finds no
         // match at all, so any valid block *after* the unterminated one is
         // lost. This matches the pre-existing conservative P1-3 contract.
-        if let Some(idx) = start_idx {
-            let failed = &trimmed[idx..];
-            let prefix: String = failed.chars().take(120).collect();
-            tracing::warn!(
-                why = "no_invokes_parsed",
-                stripped_bytes = failed.len(),
-                "DSML strip (recovery): block_start detected but extract_tool_calls returned 0 invokes; suppressing all bytes from block_start onward so tool-call markup never bleeds into normal_text. preview={:?}",
-                prefix
-            );
-        }
+        let failed = &trimmed[start_idx..];
+        let prefix: String = failed.chars().take(120).collect();
+        tracing::warn!(
+            why = "no_invokes_parsed",
+            stripped_bytes = failed.len(),
+            "DSML strip (recovery): block_start detected but extract_tool_calls returned 0 invokes; suppressing all bytes from block_start onward so tool-call markup never bleeds into normal_text. preview={:?}",
+            prefix
+        );
         return Ok((vec![], Some(pre_block_text)));
     }
 
@@ -122,22 +125,33 @@ pub fn try_tool_call_parse_dsml(
     // onward (the block(s) themselves plus any inter-block / trailing narration)
     // is stripped from normal_text. Mirrors vLLM's
     // `content = model_output[:content_end]`.
-    if let Some(idx) = start_idx {
-        let stripped = &trimmed[idx..];
-        if !stripped.is_empty() {
-            let preview: String = stripped.chars().take(120).collect();
-            tracing::debug!(
-                why = "prefix_only_contract",
-                n_calls = tool_calls.len(),
-                kept_prefix_bytes = pre_block_text.len(),
-                stripped_bytes = stripped.len(),
-                "DSML strip (success): kept prefix before first block_start; dropped parsed-block(s) + any inter-block / trailing narration. preview={:?}",
-                preview
-            );
-        }
+    let stripped = &trimmed[start_idx..];
+    if !stripped.is_empty() {
+        let preview: String = stripped.chars().take(120).collect();
+        tracing::debug!(
+            why = "prefix_only_contract",
+            n_calls = tool_calls.len(),
+            kept_prefix_bytes = pre_block_text.len(),
+            stripped_bytes = stripped.len(),
+            "DSML strip (success): kept prefix before first block_start; dropped parsed-block(s) + any inter-block / trailing narration. preview={:?}",
+            preview
+        );
     }
 
     Ok((tool_calls, Some(pre_block_text)))
+}
+
+fn first_orphan_dsml_marker_index(text: &str, config: &DsmlParserConfig) -> Option<usize> {
+    [
+        config.block_end.as_str(),
+        config.invoke_start_prefix.as_str(),
+        config.invoke_end.as_str(),
+        config.parameter_prefix.as_str(),
+        config.parameter_end.as_str(),
+    ]
+    .into_iter()
+    .filter_map(|marker| text.find(marker))
+    .min()
 }
 
 /// Extract all tool calls from DSML formatted text.

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -87,19 +87,21 @@ pub fn try_tool_call_parse_dsml(
         if let Some(marker_idx) = first_orphan_dsml_marker_index(trimmed, config) {
             let marker_tail = &trimmed[marker_idx..];
             if marker_tail.starts_with(config.invoke_start_prefix.as_str()) {
-                let tool_calls = extract_invokes(marker_tail, config)?;
-                if !tool_calls.is_empty() {
-                    tracing::warn!(
-                        why = "bare_invoke_recovery",
-                        recovered_calls = tool_calls.len(),
-                        recovered_bytes = marker_tail.len(),
-                        kept_prefix_bytes = marker_idx,
-                        "DSML recovery: recovered complete bare invoke(s) without outer block_start"
-                    );
-                    return Ok((
-                        tool_calls,
-                        Some(trimmed[..marker_idx].trim_end().to_string()),
-                    ));
+                if marker_tail.contains(config.block_end.as_str()) || config.allow_eof_recovery {
+                    let tool_calls = extract_invokes(marker_tail, config)?;
+                    if !tool_calls.is_empty() {
+                        tracing::warn!(
+                            why = "bare_invoke_recovery",
+                            recovered_calls = tool_calls.len(),
+                            recovered_bytes = marker_tail.len(),
+                            kept_prefix_bytes = marker_idx,
+                            "DSML recovery: recovered complete bare invoke(s) without outer block_start"
+                        );
+                        return Ok((
+                            tool_calls,
+                            Some(trimmed[..marker_idx].trim_end().to_string()),
+                        ));
+                    }
                 }
             }
             let stripped = &trimmed[marker_idx..];
@@ -235,6 +237,9 @@ fn recover_orphan_invokes_in_span(
     };
     let marker_tail = &span[marker_idx..];
     if !marker_tail.starts_with(config.invoke_start_prefix.as_str()) {
+        return Ok(None);
+    }
+    if !marker_tail.contains(config.block_end.as_str()) && !config.allow_eof_recovery {
         return Ok(None);
     }
 

--- a/lib/parsers/src/tool_calling/dsml/parser.rs
+++ b/lib/parsers/src/tool_calling/dsml/parser.rs
@@ -34,12 +34,14 @@ pub fn detect_tool_call_start_dsml(chunk: &str, config: &DsmlParserConfig) -> bo
         return true;
     }
 
-    // Check for partial match at the end (streaming scenario)
-    let start_chars: Vec<char> = start_token.chars().collect();
-    for i in 1..start_chars.len() {
-        let partial: String = start_chars[..i].iter().collect();
-        if chunk.ends_with(&partial) {
-            return true;
+    // Check for partial match at the end (streaming scenario).
+    for token in [start_token, &config.invoke_start_prefix] {
+        let chars: Vec<char> = token.chars().collect();
+        for i in 1..chars.len() {
+            let partial: String = chars[..i].iter().collect();
+            if chunk.ends_with(&partial) {
+                return true;
+            }
         }
     }
 

--- a/lib/parsers/src/tool_calling/gemma4/mod.rs
+++ b/lib/parsers/src/tool_calling/gemma4/mod.rs
@@ -3,7 +3,8 @@
 
 mod parser;
 
-pub(crate) use parser::{CALL_PREFIX, TOOL_CALL_END, TOOL_CALL_START};
+pub(crate) use parser::{TOOL_CALL_END, TOOL_CALL_START};
 pub use parser::{
-    detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4, try_tool_call_parse_gemma4,
+    detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4,
+    split_partial_call_prefix_gemma4, try_tool_call_parse_gemma4,
 };

--- a/lib/parsers/src/tool_calling/gemma4/mod.rs
+++ b/lib/parsers/src/tool_calling/gemma4/mod.rs
@@ -3,7 +3,7 @@
 
 mod parser;
 
-pub(crate) use parser::{TOOL_CALL_END, TOOL_CALL_START};
+pub(crate) use parser::{CALL_PREFIX, TOOL_CALL_END, TOOL_CALL_START};
 pub use parser::{
     detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4, try_tool_call_parse_gemma4,
 };

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -41,11 +41,125 @@ fn tool_call_regex() -> &'static Regex {
     })
 }
 
+fn parse_gemma_call_parts(
+    name: &str,
+    args_raw: &str,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<ToolCallResponse> {
+    let name = name.to_string();
+    if let Some(tools) = tools
+        && !tools.iter().any(|t| t.name == name)
+    {
+        tracing::warn!(
+            "Tool '{}' is not defined in the tools list (Gemma 4 parser).",
+            name
+        );
+    }
+
+    let args_value = match parse_args_object(args_raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to parse Gemma 4 args for '{}': {}. Falling back to empty object.",
+                name,
+                e
+            );
+            Value::Object(Map::new())
+        }
+    };
+    let arguments = serde_json::to_string(&args_value)?;
+
+    Ok(ToolCallResponse {
+        id: format!("call-{}", Uuid::new_v4()),
+        tp: ToolCallType::Function,
+        function: CalledFunction { name, arguments },
+    })
+}
+
+fn find_balanced_args_end(input: &str, open_brace: usize) -> Option<usize> {
+    debug_assert_eq!(input.as_bytes().get(open_brace), Some(&b'{'));
+    let mut cursor = open_brace;
+    let mut depth = 0usize;
+    let mut in_string = false;
+
+    while cursor < input.len() {
+        let rest = &input[cursor..];
+        if rest.starts_with(STRING_DELIM) {
+            in_string = !in_string;
+            cursor += STRING_DELIM.len();
+            continue;
+        }
+
+        let ch = rest.chars().next()?;
+        if !in_string {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 {
+                        return Some(cursor);
+                    }
+                }
+                _ => {}
+            }
+        }
+        cursor += ch.len_utf8();
+    }
+
+    None
+}
+
+fn parse_recoverable_call_at(
+    input: &str,
+    allow_missing_start: bool,
+    allow_missing_end: bool,
+) -> Option<(&str, &str, usize)> {
+    let after_start_offset = if let Some(rest) = input.strip_prefix(TOOL_CALL_START) {
+        input.len() - rest.len()
+    } else if allow_missing_start && input.starts_with(CALL_PREFIX) {
+        0
+    } else {
+        return None;
+    };
+
+    let after_start = &input[after_start_offset..];
+    let after_prefix = after_start.strip_prefix(CALL_PREFIX)?;
+    let name_len = after_prefix.find('{').filter(|idx| *idx > 0)?;
+    let name = &after_prefix[..name_len];
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return None;
+    }
+
+    let open_brace = after_start_offset + CALL_PREFIX.len() + name_len;
+    let close_brace = find_balanced_args_end(input, open_brace)?;
+    let args_start = open_brace + 1;
+    let args_raw = &input[args_start..close_brace];
+    let after_args = &input[close_brace + 1..];
+
+    if after_args.starts_with(TOOL_CALL_END) {
+        return Some((name, args_raw, close_brace + 1 + TOOL_CALL_END.len()));
+    }
+
+    if allow_missing_end && after_args.trim().is_empty() {
+        return Some((name, args_raw, close_brace + 1));
+    }
+
+    None
+}
+
 /// Detect whether `chunk` contains the start of a Gemma 4 tool call, including
 /// partial-prefix matches at the chunk boundary so streaming pipelines can hold
 /// off emitting bytes that may belong to a tool-call marker.
 pub fn detect_tool_call_start_gemma4(chunk: &str) -> bool {
     if chunk.contains(TOOL_CALL_START) {
+        return true;
+    }
+    if chunk.contains(CALL_PREFIX)
+        && (chunk.contains(TOOL_CALL_END) || chunk.contains(STRING_DELIM))
+    {
         return true;
     }
     for i in 1..TOOL_CALL_START.len() {
@@ -92,44 +206,47 @@ pub fn try_tool_call_parse_gemma4(
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let regex = tool_call_regex();
     let mut calls = Vec::new();
+    let mut first_tool_start = None;
+    let mut last_complete_end = 0usize;
 
     for caps in regex.captures_iter(message) {
-        let name = caps
-            .name("name")
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_default();
+        if let Some(m) = caps.get(0) {
+            first_tool_start.get_or_insert(m.start());
+            last_complete_end = m.end();
+        }
+        let name = caps.name("name").map(|m| m.as_str()).unwrap_or_default();
         if name.is_empty() {
             continue;
         }
         let args_raw = caps.name("args").map(|m| m.as_str()).unwrap_or("");
 
-        if let Some(tools) = tools
-            && !tools.iter().any(|t| t.name == name)
-        {
+        calls.push(parse_gemma_call_parts(name, args_raw, tools)?);
+    }
+
+    if let Some(rel_start) = message[last_complete_end..].find(TOOL_CALL_START) {
+        let abs_start = last_complete_end + rel_start;
+        if let Some(recovered) = parse_recoverable_call_at(&message[abs_start..], false, true) {
+            first_tool_start.get_or_insert(abs_start);
             tracing::warn!(
-                "Tool '{}' is not defined in the tools list (Gemma 4 parser).",
-                name
+                why = "missing_end_recovery",
+                recovered_calls = 1,
+                recovered_bytes = recovered.2,
+                "gemma4 recovery: recovered complete call body without trailing <tool_call|>"
             );
+            calls.push(parse_gemma_call_parts(recovered.0, recovered.1, tools)?);
         }
-
-        let args_value = match parse_args_object(args_raw) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to parse Gemma 4 args for '{}': {}. Falling back to empty object.",
-                    name,
-                    e
-                );
-                Value::Object(Map::new())
-            }
-        };
-        let arguments = serde_json::to_string(&args_value)?;
-
-        calls.push(ToolCallResponse {
-            id: format!("call-{}", Uuid::new_v4()),
-            tp: ToolCallType::Function,
-            function: CalledFunction { name, arguments },
-        });
+    } else if let Some(rel_call) = message[last_complete_end..].find(CALL_PREFIX) {
+        let abs_start = last_complete_end + rel_call;
+        if let Some(recovered) = parse_recoverable_call_at(&message[abs_start..], true, false) {
+            first_tool_start.get_or_insert(abs_start);
+            tracing::warn!(
+                why = "missing_start_recovery",
+                recovered_calls = 1,
+                recovered_bytes = recovered.2,
+                "gemma4 recovery: recovered complete call body without leading <|tool_call>"
+            );
+            calls.push(parse_gemma_call_parts(recovered.0, recovered.1, tools)?);
+        }
     }
 
     // No-leak contract for `normal_text`:
@@ -173,7 +290,7 @@ pub fn try_tool_call_parse_gemma4(
         // `<|tool_call>` onward (inter-call text, trailing narration,
         // truncation tails). Mirrors vLLM's
         // `content = model_output[:content_end].strip()`.
-        match message.find(TOOL_CALL_START) {
+        match first_tool_start {
             Some(idx) => {
                 let stripped = &message[idx..];
                 let preview: String = stripped.chars().take(120).collect();

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -178,29 +178,53 @@ pub fn detect_tool_call_start_gemma4(chunk: &str) -> bool {
     if chunk.contains(TOOL_CALL_START) {
         return true;
     }
-    if find_call_prefix_at_boundary(chunk, 0).is_some()
-        && (chunk.contains(TOOL_CALL_END) || chunk.contains(STRING_DELIM))
-    {
-        return true;
+
+    let mut cursor = 0usize;
+    while let Some(idx) = find_call_prefix_at_boundary(chunk, cursor) {
+        let candidate = &chunk[idx..];
+        if parse_recoverable_call_at(candidate, true, true).is_some()
+            || has_bare_call_body_start(candidate)
+        {
+            return true;
+        }
+        cursor = idx + CALL_PREFIX.len();
     }
-    for token in [TOOL_CALL_START, CALL_PREFIX] {
-        for i in 1..token.len() {
-            if !token.is_char_boundary(i) {
-                continue;
-            }
-            if !chunk.ends_with(&token[..i]) {
-                continue;
-            }
-            if token == CALL_PREFIX {
-                let partial_start = chunk.len() - i;
-                if !is_call_prefix_boundary(chunk, partial_start) {
-                    continue;
-                }
-            }
+
+    for i in 1..TOOL_CALL_START.len() {
+        if TOOL_CALL_START.is_char_boundary(i) && chunk.ends_with(&TOOL_CALL_START[..i]) {
             return true;
         }
     }
+
     false
+}
+
+fn has_bare_call_body_start(input: &str) -> bool {
+    let Some(after_prefix) = input.strip_prefix(CALL_PREFIX) else {
+        return false;
+    };
+    let Some(open_brace) = after_prefix.find('{') else {
+        return false;
+    };
+    if open_brace == 0 {
+        return false;
+    }
+    after_prefix[..open_brace]
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+pub fn split_partial_call_prefix_gemma4(chunk: &str) -> Option<(&str, &str)> {
+    for i in 1..CALL_PREFIX.len() {
+        if !CALL_PREFIX.is_char_boundary(i) || !chunk.ends_with(&CALL_PREFIX[..i]) {
+            continue;
+        }
+        let partial_start = chunk.len() - i;
+        if is_call_prefix_boundary(chunk, partial_start) {
+            return Some((&chunk[..partial_start], &chunk[partial_start..]));
+        }
+    }
+    None
 }
 
 /// Returns the position immediately after the last *complete* tool-call match
@@ -702,8 +726,13 @@ mod tests {
     fn detect_full_and_partial_start() {
         assert!(detect_tool_call_start_gemma4("<|tool_call>"));
         assert!(detect_tool_call_start_gemma4("blah <|tool_call>"));
+        assert!(detect_tool_call_start_gemma4(
+            "call:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>"
+        ));
+        assert!(detect_tool_call_start_gemma4("call:get_weather{"));
         assert!(detect_tool_call_start_gemma4("<|tool_"));
         assert!(detect_tool_call_start_gemma4("<|"));
+        assert!(!detect_tool_call_start_gemma4("I will call: you tomorrow"));
         assert!(!detect_tool_call_start_gemma4("nothing here"));
         assert!(!detect_tool_call_start_gemma4("toolcall"));
     }

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -23,7 +23,7 @@ use super::super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 pub(crate) const TOOL_CALL_START: &str = "<|tool_call>";
 pub(crate) const TOOL_CALL_END: &str = "<tool_call|>";
 pub(crate) const STRING_DELIM: &str = "<|\"|>";
-const CALL_PREFIX: &str = "call:";
+pub(crate) const CALL_PREFIX: &str = "call:";
 
 static TOOL_CALL_REGEX: OnceLock<Regex> = OnceLock::new();
 
@@ -150,6 +150,27 @@ fn parse_recoverable_call_at(
     None
 }
 
+fn is_call_prefix_boundary(input: &str, idx: usize) -> bool {
+    idx == 0
+        || input[..idx]
+            .chars()
+            .next_back()
+            .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
+}
+
+fn find_call_prefix_at_boundary(input: &str, from: usize) -> Option<usize> {
+    let mut cursor = from;
+    while cursor < input.len() {
+        let rel = input[cursor..].find(CALL_PREFIX)?;
+        let idx = cursor + rel;
+        if is_call_prefix_boundary(input, idx) {
+            return Some(idx);
+        }
+        cursor = idx + CALL_PREFIX.len();
+    }
+    None
+}
+
 /// Detect whether `chunk` contains the start of a Gemma 4 tool call, including
 /// partial-prefix matches at the chunk boundary so streaming pipelines can hold
 /// off emitting bytes that may belong to a tool-call marker.
@@ -157,16 +178,25 @@ pub fn detect_tool_call_start_gemma4(chunk: &str) -> bool {
     if chunk.contains(TOOL_CALL_START) {
         return true;
     }
-    if chunk.contains(CALL_PREFIX)
+    if find_call_prefix_at_boundary(chunk, 0).is_some()
         && (chunk.contains(TOOL_CALL_END) || chunk.contains(STRING_DELIM))
     {
         return true;
     }
-    for i in 1..TOOL_CALL_START.len() {
-        if !TOOL_CALL_START.is_char_boundary(i) {
-            continue;
-        }
-        if chunk.ends_with(&TOOL_CALL_START[..i]) {
+    for token in [TOOL_CALL_START, CALL_PREFIX] {
+        for i in 1..token.len() {
+            if !token.is_char_boundary(i) {
+                continue;
+            }
+            if !chunk.ends_with(&token[..i]) {
+                continue;
+            }
+            if token == CALL_PREFIX {
+                let partial_start = chunk.len() - i;
+                if !is_call_prefix_boundary(chunk, partial_start) {
+                    continue;
+                }
+            }
             return true;
         }
     }
@@ -179,7 +209,112 @@ pub fn detect_tool_call_start_gemma4(chunk: &str) -> bool {
 /// `<tool_call|>` literal embedded inside a `<|"|>` string value does not
 /// false-trigger a "section complete" signal here — matches upstream.
 pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
-    tool_call_regex().find_iter(chunk).last().map(|m| m.end())
+    let mut cursor = 0usize;
+    let mut last_end = None;
+
+    while cursor < chunk.len() {
+        let next_start = chunk[cursor..]
+            .find(TOOL_CALL_START)
+            .map(|rel| (cursor + rel, false, TOOL_CALL_START.len()));
+        let next_bare =
+            find_call_prefix_at_boundary(chunk, cursor).map(|idx| (idx, true, CALL_PREFIX.len()));
+        let Some((rel_start, allow_missing_start, marker_len)) = [next_start, next_bare]
+            .into_iter()
+            .flatten()
+            .min_by_key(|(idx, _, _)| *idx)
+        else {
+            break;
+        };
+
+        if let Some((_, _, consumed)) =
+            parse_recoverable_call_at(&chunk[rel_start..], allow_missing_start, false)
+        {
+            let mut end = rel_start + consumed;
+            while chunk[end..].starts_with(TOOL_CALL_END) {
+                end += TOOL_CALL_END.len();
+            }
+            last_end = Some(end);
+            cursor = end;
+        } else {
+            cursor = rel_start + marker_len;
+        }
+    }
+
+    last_end
+}
+
+fn push_recovered_call(
+    calls: &mut Vec<ToolCallResponse>,
+    first_tool_start: &mut Option<usize>,
+    absolute_start: usize,
+    recovered: (&str, &str, usize),
+    tools: Option<&[ToolDefinition]>,
+    reason: &'static str,
+) -> anyhow::Result<()> {
+    if first_tool_start.is_none_or(|idx| absolute_start < idx) {
+        *first_tool_start = Some(absolute_start);
+    }
+    tracing::warn!(
+        why = reason,
+        recovered_calls = 1,
+        recovered_bytes = recovered.2,
+        "gemma4 recovery: recovered complete call body from damaged wrapper"
+    );
+    calls.push(parse_gemma_call_parts(recovered.0, recovered.1, tools)?);
+    Ok(())
+}
+
+fn recover_calls_in_span(
+    span: &str,
+    span_offset: usize,
+    allow_missing_end: bool,
+    tools: Option<&[ToolDefinition]>,
+    calls: &mut Vec<ToolCallResponse>,
+    first_tool_start: &mut Option<usize>,
+) -> anyhow::Result<()> {
+    let mut cursor = 0usize;
+
+    while cursor < span.len() {
+        let next_start = span[cursor..]
+            .find(TOOL_CALL_START)
+            .map(|rel| (cursor + rel, false, TOOL_CALL_START.len()));
+        let next_bare =
+            find_call_prefix_at_boundary(span, cursor).map(|idx| (idx, true, CALL_PREFIX.len()));
+        let Some((rel_start, allow_missing_start, marker_len)) = [next_start, next_bare]
+            .into_iter()
+            .flatten()
+            .min_by_key(|(idx, _, _)| *idx)
+        else {
+            break;
+        };
+
+        let parsed = parse_recoverable_call_at(
+            &span[rel_start..],
+            allow_missing_start,
+            allow_missing_end && !allow_missing_start,
+        );
+
+        if let Some(recovered) = parsed {
+            let reason = if allow_missing_start {
+                "missing_start_recovery"
+            } else {
+                "missing_end_recovery"
+            };
+            push_recovered_call(
+                calls,
+                first_tool_start,
+                span_offset + rel_start,
+                recovered,
+                tools,
+                reason,
+            )?;
+            cursor = rel_start + recovered.2;
+        } else {
+            cursor = rel_start + marker_len;
+        }
+    }
+
+    Ok(())
 }
 
 /// Parse a Gemma 4 model response into structured tool calls + leftover text.
@@ -207,12 +342,20 @@ pub fn try_tool_call_parse_gemma4(
     let regex = tool_call_regex();
     let mut calls = Vec::new();
     let mut first_tool_start = None;
-    let mut last_complete_end = 0usize;
+    let mut cursor = 0usize;
 
     for caps in regex.captures_iter(message) {
         if let Some(m) = caps.get(0) {
+            recover_calls_in_span(
+                &message[cursor..m.start()],
+                cursor,
+                false,
+                tools,
+                &mut calls,
+                &mut first_tool_start,
+            )?;
             first_tool_start.get_or_insert(m.start());
-            last_complete_end = m.end();
+            cursor = m.end();
         }
         let name = caps.name("name").map(|m| m.as_str()).unwrap_or_default();
         if name.is_empty() {
@@ -223,31 +366,14 @@ pub fn try_tool_call_parse_gemma4(
         calls.push(parse_gemma_call_parts(name, args_raw, tools)?);
     }
 
-    if let Some(rel_start) = message[last_complete_end..].find(TOOL_CALL_START) {
-        let abs_start = last_complete_end + rel_start;
-        if let Some(recovered) = parse_recoverable_call_at(&message[abs_start..], false, true) {
-            first_tool_start.get_or_insert(abs_start);
-            tracing::warn!(
-                why = "missing_end_recovery",
-                recovered_calls = 1,
-                recovered_bytes = recovered.2,
-                "gemma4 recovery: recovered complete call body without trailing <tool_call|>"
-            );
-            calls.push(parse_gemma_call_parts(recovered.0, recovered.1, tools)?);
-        }
-    } else if let Some(rel_call) = message[last_complete_end..].find(CALL_PREFIX) {
-        let abs_start = last_complete_end + rel_call;
-        if let Some(recovered) = parse_recoverable_call_at(&message[abs_start..], true, false) {
-            first_tool_start.get_or_insert(abs_start);
-            tracing::warn!(
-                why = "missing_start_recovery",
-                recovered_calls = 1,
-                recovered_bytes = recovered.2,
-                "gemma4 recovery: recovered complete call body without leading <|tool_call>"
-            );
-            calls.push(parse_gemma_call_parts(recovered.0, recovered.1, tools)?);
-        }
-    }
+    recover_calls_in_span(
+        &message[cursor..],
+        cursor,
+        true,
+        tools,
+        &mut calls,
+        &mut first_tool_start,
+    )?;
 
     // No-leak contract for `normal_text`:
     //   - Success path (≥1 call extracted): prefix BEFORE the first

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -215,7 +215,7 @@ fn has_bare_call_body_start(input: &str) -> bool {
 }
 
 pub fn split_partial_call_prefix_gemma4(chunk: &str) -> Option<(&str, &str)> {
-    for i in 1..CALL_PREFIX.len() {
+    for i in 1..=CALL_PREFIX.len() {
         if !CALL_PREFIX.is_char_boundary(i) || !chunk.ends_with(&CALL_PREFIX[..i]) {
             continue;
         }

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -169,11 +169,7 @@ async fn detect_and_parse_tool_call_with_recovery_options(
         }
         ParserConfig::Xml(c) => {
             let mut c = c.clone();
-            // Strict-match families opt out — flipping recovery here would
-            // contradict their per-spec strictness.
-            if !c.strict_match {
-                c.allow_eof_recovery = true;
-            }
+            c.allow_eof_recovery = true;
             ParserConfig::Xml(c)
         }
         ParserConfig::Dsml(c) if recover_dsml_eof => {

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -133,16 +133,18 @@ fn extract_tool_calls(
     if !text.contains(start_token.as_str())
         && let Some(marker_idx) = first_orphan_glm47_marker_index(text, config)
     {
-        if let Some(parsed_call) = recover_bare_glm47_call(text, marker_idx, config, tools)? {
+        if let Some((prefix, parsed_call)) =
+            recover_bare_glm47_call(text, marker_idx, config, tools)?
+        {
             warn!(
                 why = "bare_body_recovery",
                 recovered_calls = 1,
-                recovered_bytes = text.len(),
-                kept_prefix_bytes = 0,
+                recovered_bytes = text.len() - prefix.len(),
+                kept_prefix_bytes = prefix.len(),
                 "GLM-4.7 parser recovered complete bare call body without <tool_call> start"
             );
             calls.push(parsed_call);
-            return Ok((String::new(), calls));
+            return Ok((prefix, calls));
         }
         warn!(
             why = "GLM-4.7 tool-call marker found without <tool_call> start; dropping orphan marker tail so wire tags do not leak into normal_text",
@@ -297,12 +299,20 @@ fn recover_bare_glm47_call(
     marker_idx: usize,
     config: &Glm47ParserConfig,
     tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<Option<ToolCallResponse>> {
+) -> anyhow::Result<Option<(String, ToolCallResponse)>> {
     if !text[marker_idx..].contains(config.tool_call_end.as_str()) {
         return Ok(None);
     }
 
-    let candidate_name = text[..marker_idx].trim();
+    let before_marker = text[..marker_idx].trim_end();
+    let function_name_start = before_marker
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| ch.is_whitespace())
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .unwrap_or(0);
+
+    let candidate_name = before_marker[function_name_start..].trim();
     if candidate_name.is_empty()
         || !candidate_name
             .chars()
@@ -311,8 +321,9 @@ fn recover_bare_glm47_call(
         return Ok(None);
     }
 
-    let wrapped = format!("{}{}", config.tool_call_start, text);
-    parse_tool_call_block(&wrapped, config, tools).map(Some)
+    let prefix = text[..function_name_start].to_string();
+    let wrapped = format!("{}{}", config.tool_call_start, &text[function_name_start..]);
+    parse_tool_call_block(&wrapped, config, tools).map(|call| Some((prefix, call)))
 }
 
 /// Decode XML character entities in a string.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -71,7 +71,7 @@ pub fn find_tool_call_end_position_glm47(chunk: &str, config: &Glm47ParserConfig
     let end_token = &config.tool_call_end;
 
     if !chunk.contains(start_token.as_str()) && chunk.contains(config.arg_key_start.as_str()) {
-        return chunk.len();
+        return find_bare_glm47_tool_call_end_position(chunk, config).unwrap_or(chunk.len());
     }
 
     let Some(first_end) = chunk.find(end_token.as_str()) else {
@@ -96,6 +96,48 @@ pub fn find_tool_call_end_position_glm47(chunk: &str, config: &Glm47ParserConfig
     }
 
     cursor
+}
+
+fn find_bare_glm47_tool_call_end_position(text: &str, config: &Glm47ParserConfig) -> Option<usize> {
+    let marker_idx = first_orphan_glm47_marker_index(text, config)?;
+    let before_marker = text[..marker_idx].trim_end();
+    let function_name_start = before_marker
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| ch.is_whitespace())
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .unwrap_or(0);
+
+    let candidate_name = before_marker[function_name_start..].trim();
+    if candidate_name.is_empty()
+        || !candidate_name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return None;
+    }
+
+    let mut cursor = function_name_start;
+    let mut last_complete_end = None;
+    while cursor < text.len() {
+        let rest = &text[cursor..];
+        let trim_offset = rest.len() - rest.trim_start().len();
+        let call_start = cursor + trim_offset;
+        let tail = &text[call_start..];
+        let Some(end_pos) = tail.find(config.tool_call_end.as_str()) else {
+            break;
+        };
+
+        let call_end = call_start + end_pos + config.tool_call_end.len();
+        cursor = consume_glm47_close_markers(text, call_end, config);
+        last_complete_end = Some(cursor);
+
+        if first_orphan_glm47_marker_index(&text[cursor..], config).is_none() {
+            break;
+        }
+    }
+
+    last_complete_end
 }
 
 /// Try to parse GLM-4.7 formatted tool calls from a message.
@@ -415,6 +457,18 @@ fn is_glm47_close_marker_spam(text: &str, config: &Glm47ParserConfig) -> bool {
         rest = after_close.trim_start();
     }
     saw_close && rest.is_empty()
+}
+
+fn consume_glm47_close_markers(text: &str, mut cursor: usize, config: &Glm47ParserConfig) -> usize {
+    loop {
+        let rest = &text[cursor..];
+        let trim_offset = rest.len() - rest.trim_start().len();
+        let close_start = cursor + trim_offset;
+        if !text[close_start..].starts_with(config.tool_call_end.as_str()) {
+            return cursor;
+        }
+        cursor = close_start + config.tool_call_end.len();
+    }
 }
 
 /// Decode XML character entities in a string.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -125,6 +125,17 @@ fn extract_tool_calls(
     let start_token = &config.tool_call_start;
     let end_token = &config.tool_call_end;
 
+    if !text.contains(start_token.as_str())
+        && let Some(marker_idx) = first_orphan_glm47_marker_index(text, config)
+    {
+        warn!(
+            why = "GLM-4.7 tool-call marker found without <tool_call> start; dropping orphan marker tail so wire tags do not leak into normal_text",
+            dropped_block = %truncate_for_log(&text[marker_idx..]),
+            "GLM-4.7 parser dropping orphan tool-call marker tail"
+        );
+        return Ok((orphan_glm47_prefix(text, marker_idx), calls));
+    }
+
     while cursor < text.len() {
         // Find next tool call start
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
@@ -230,6 +241,39 @@ fn extract_tool_calls(
         normal_text
     };
     Ok((normal_text, calls))
+}
+
+fn first_orphan_glm47_marker_index(text: &str, config: &Glm47ParserConfig) -> Option<usize> {
+    [
+        config.tool_call_end.as_str(),
+        config.arg_key_start.as_str(),
+        config.arg_key_end.as_str(),
+        config.arg_value_start.as_str(),
+        config.arg_value_end.as_str(),
+    ]
+    .into_iter()
+    .filter_map(|marker| text.find(marker))
+    .min()
+}
+
+fn orphan_glm47_prefix(text: &str, marker_idx: usize) -> String {
+    let prefix = text[..marker_idx].trim_end();
+    let token_start = prefix
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| ch.is_whitespace())
+        .map(|(idx, ch)| idx + ch.len_utf8())
+        .unwrap_or(0);
+    let tail = &prefix[token_start..];
+    if !tail.is_empty()
+        && tail
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        prefix[..token_start].trim().to_string()
+    } else {
+        prefix.trim().to_string()
+    }
 }
 
 /// Decode XML character entities in a string.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -133,17 +133,18 @@ fn extract_tool_calls(
     if !text.contains(start_token.as_str())
         && let Some(marker_idx) = first_orphan_glm47_marker_index(text, config)
     {
-        if let Some((prefix, parsed_call)) =
-            recover_bare_glm47_call(text, marker_idx, config, tools)?
+        if let Some((prefix, mut parsed_calls)) =
+            recover_bare_glm47_calls(text, marker_idx, config, tools)?
         {
+            let recovered_calls = parsed_calls.len();
             warn!(
                 why = "bare_body_recovery",
-                recovered_calls = 1,
+                recovered_calls,
                 recovered_bytes = text.len() - prefix.len(),
                 kept_prefix_bytes = prefix.len(),
-                "GLM-4.7 parser recovered complete bare call body without <tool_call> start"
+                "GLM-4.7 parser recovered complete bare call body/bodies without <tool_call> start"
             );
-            calls.push(parsed_call);
+            calls.append(&mut parsed_calls);
             return Ok((prefix, calls));
         }
         warn!(
@@ -159,13 +160,13 @@ fn extract_tool_calls(
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
             let gap = &text[cursor..abs_start];
-            if let Some((prefix, parsed_call)) =
-                recover_bare_glm47_call_in_span(gap, config, tools)?
+            if let Some((prefix, mut parsed_calls)) =
+                recover_bare_glm47_calls_in_span(gap, config, tools)?
             {
                 if calls.is_empty() {
                     normal_parts.push(prefix);
                 }
-                calls.push(parsed_call);
+                calls.append(&mut parsed_calls);
             } else if calls.is_empty() {
                 if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
                     normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
@@ -258,13 +259,13 @@ fn extract_tool_calls(
         } else {
             // No more tool calls
             let gap = &text[cursor..];
-            if let Some((prefix, parsed_call)) =
-                recover_bare_glm47_call_in_span(gap, config, tools)?
+            if let Some((prefix, mut parsed_calls)) =
+                recover_bare_glm47_calls_in_span(gap, config, tools)?
             {
                 if calls.is_empty() {
                     normal_parts.push(prefix);
                 }
-                calls.push(parsed_call);
+                calls.append(&mut parsed_calls);
             } else if calls.is_empty() {
                 if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
                     normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
@@ -285,24 +286,25 @@ fn extract_tool_calls(
     Ok((normal_text, calls))
 }
 
-fn recover_bare_glm47_call_in_span(
+fn recover_bare_glm47_calls_in_span(
     span: &str,
     config: &Glm47ParserConfig,
     tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<Option<(String, ToolCallResponse)>> {
+) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
     let Some(marker_idx) = first_orphan_glm47_marker_index(span, config) else {
         return Ok(None);
     };
-    let recovered = recover_bare_glm47_call(span, marker_idx, config, tools)?;
-    if let Some((prefix, parsed_call)) = recovered {
+    let recovered = recover_bare_glm47_calls(span, marker_idx, config, tools)?;
+    if let Some((prefix, parsed_calls)) = recovered {
+        let recovered_calls = parsed_calls.len();
         warn!(
             why = "bare_body_gap_recovery",
-            recovered_calls = 1,
+            recovered_calls,
             recovered_bytes = span.len() - prefix.len(),
             kept_prefix_bytes = prefix.len(),
-            "GLM-4.7 parser recovered complete bare call body before a later <tool_call>"
+            "GLM-4.7 parser recovered complete bare call body/bodies before a later <tool_call>"
         );
-        return Ok(Some((prefix, parsed_call)));
+        return Ok(Some((prefix, parsed_calls)));
     }
     Ok(None)
 }
@@ -340,12 +342,12 @@ fn orphan_glm47_prefix(text: &str, marker_idx: usize) -> String {
     }
 }
 
-fn recover_bare_glm47_call(
+fn recover_bare_glm47_calls(
     text: &str,
     marker_idx: usize,
     config: &Glm47ParserConfig,
     tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<Option<(String, ToolCallResponse)>> {
+) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
     if !text[marker_idx..].contains(config.tool_call_end.as_str()) {
         return Ok(None);
     }
@@ -368,8 +370,32 @@ fn recover_bare_glm47_call(
     }
 
     let prefix = text[..function_name_start].to_string();
-    let wrapped = format!("{}{}", config.tool_call_start, &text[function_name_start..]);
-    parse_tool_call_block(&wrapped, config, tools).map(|call| Some((prefix, call)))
+    let mut cursor = function_name_start;
+    let mut calls = Vec::new();
+
+    while cursor < text.len() {
+        let rest = &text[cursor..];
+        let trim_offset = rest.len() - rest.trim_start().len();
+        cursor += trim_offset;
+
+        let tail = &text[cursor..];
+        let Some(end_pos) = tail.find(config.tool_call_end.as_str()) else {
+            break;
+        };
+        let call_end = cursor + end_pos + config.tool_call_end.len();
+        let wrapped = format!("{}{}", config.tool_call_start, &text[cursor..call_end]);
+        calls.push(parse_tool_call_block(&wrapped, config, tools)?);
+        cursor = call_end;
+
+        if first_orphan_glm47_marker_index(&text[cursor..], config).is_none() {
+            break;
+        }
+    }
+
+    if calls.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some((prefix, calls)))
 }
 
 /// Decode XML character entities in a string.
@@ -742,6 +768,25 @@ mod tests {
             text,
             "I'll check the weather for both cities at the same time!"
         );
+    }
+
+    #[test]
+    fn test_parse_two_bare_calls_without_start_markers_recovers_independently() {
+        let config = get_test_config();
+        let message = "I will check both. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>";
+
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_time");
+        let args0: HashMap<String, Value> =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: HashMap<String, Value> =
+            serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(args0["location"], "NYC");
+        assert_eq!(args1["timezone"], "EST");
+        assert_eq!(normal_text.unwrap(), "I will check both. ");
     }
 
     // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.b in tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.7.yaml.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -42,9 +42,10 @@ fn truncate_for_log(s: &str) -> String {
 /// Format: <tool_call>function_name<arg_key>...</arg_key><arg_value>...</arg_value></tool_call>
 pub fn detect_tool_call_start_glm47(chunk: &str, config: &Glm47ParserConfig) -> bool {
     let start_token = &config.tool_call_start;
+    let arg_key_start = &config.arg_key_start;
 
     // Check if we have the complete start token
-    if chunk.contains(start_token.as_str()) {
+    if chunk.contains(start_token.as_str()) || chunk.contains(arg_key_start.as_str()) {
         return true;
     }
 
@@ -68,6 +69,10 @@ pub fn detect_tool_call_start_glm47(chunk: &str, config: &Glm47ParserConfig) -> 
 pub fn find_tool_call_end_position_glm47(chunk: &str, config: &Glm47ParserConfig) -> usize {
     let start_token = &config.tool_call_start;
     let end_token = &config.tool_call_end;
+
+    if !chunk.contains(start_token.as_str()) && chunk.contains(config.arg_key_start.as_str()) {
+        return chunk.len();
+    }
 
     let Some(first_end) = chunk.find(end_token.as_str()) else {
         return chunk.len();
@@ -128,6 +133,17 @@ fn extract_tool_calls(
     if !text.contains(start_token.as_str())
         && let Some(marker_idx) = first_orphan_glm47_marker_index(text, config)
     {
+        if let Some(parsed_call) = recover_bare_glm47_call(text, marker_idx, config, tools)? {
+            warn!(
+                why = "bare_body_recovery",
+                recovered_calls = 1,
+                recovered_bytes = text.len(),
+                kept_prefix_bytes = 0,
+                "GLM-4.7 parser recovered complete bare call body without <tool_call> start"
+            );
+            calls.push(parsed_call);
+            return Ok((String::new(), calls));
+        }
         warn!(
             why = "GLM-4.7 tool-call marker found without <tool_call> start; dropping orphan marker tail so wire tags do not leak into normal_text",
             dropped_block = %truncate_for_log(&text[marker_idx..]),
@@ -274,6 +290,29 @@ fn orphan_glm47_prefix(text: &str, marker_idx: usize) -> String {
     } else {
         prefix.trim().to_string()
     }
+}
+
+fn recover_bare_glm47_call(
+    text: &str,
+    marker_idx: usize,
+    config: &Glm47ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<ToolCallResponse>> {
+    if !text[marker_idx..].contains(config.tool_call_end.as_str()) {
+        return Ok(None);
+    }
+
+    let candidate_name = text[..marker_idx].trim();
+    if candidate_name.is_empty()
+        || !candidate_name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return Ok(None);
+    }
+
+    let wrapped = format!("{}{}", config.tool_call_start, text);
+    parse_tool_call_block(&wrapped, config, tools).map(Some)
 }
 
 /// Decode XML character entities in a string.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -387,6 +387,15 @@ fn recover_bare_glm47_calls(
         calls.push(parse_tool_call_block(&wrapped, config, tools)?);
         cursor = call_end;
 
+        if is_glm47_close_marker_spam(&text[cursor..], config) {
+            warn!(
+                why = "orphan_close_marker_spam",
+                dropped_block = %truncate_for_log(&text[cursor..]),
+                "GLM-4.7 parser dropping orphan close-marker spam after recovered bare call"
+            );
+            break;
+        }
+
         if first_orphan_glm47_marker_index(&text[cursor..], config).is_none() {
             break;
         }
@@ -396,6 +405,16 @@ fn recover_bare_glm47_calls(
         return Ok(None);
     }
     Ok(Some((prefix, calls)))
+}
+
+fn is_glm47_close_marker_spam(text: &str, config: &Glm47ParserConfig) -> bool {
+    let mut rest = text.trim_start();
+    let mut saw_close = false;
+    while let Some(after_close) = rest.strip_prefix(config.tool_call_end.as_str()) {
+        saw_close = true;
+        rest = after_close.trim_start();
+    }
+    saw_close && rest.is_empty()
 }
 
 /// Decode XML character entities in a string.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -158,14 +158,26 @@ fn extract_tool_calls(
         // Find next tool call start
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
+            let gap = &text[cursor..abs_start];
+            if let Some((prefix, parsed_call)) =
+                recover_bare_glm47_call_in_span(gap, config, tools)?
+            {
+                if calls.is_empty() {
+                    normal_parts.push(prefix);
+                }
+                calls.push(parsed_call);
+            } else if calls.is_empty() {
+                if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
+                    normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
+                } else {
+                    normal_parts.push(gap.to_string());
+                }
+            }
 
             // Only surface normal text that precedes the first parsed call.
             // Text after any </tool_call> is not response content; matches the
             // convention ported into the generic XML parser by PR #9350 and
             // vLLM's glm47_moe_tool_parser.
-            if calls.is_empty() {
-                normal_parts.push(&text[cursor..abs_start]);
-            }
 
             // Find the corresponding end token
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
@@ -245,8 +257,20 @@ fn extract_tool_calls(
             }
         } else {
             // No more tool calls
-            if calls.is_empty() {
-                normal_parts.push(&text[cursor..]);
+            let gap = &text[cursor..];
+            if let Some((prefix, parsed_call)) =
+                recover_bare_glm47_call_in_span(gap, config, tools)?
+            {
+                if calls.is_empty() {
+                    normal_parts.push(prefix);
+                }
+                calls.push(parsed_call);
+            } else if calls.is_empty() {
+                if let Some(marker_idx) = first_orphan_glm47_marker_index(gap, config) {
+                    normal_parts.push(orphan_glm47_prefix(gap, marker_idx));
+                } else {
+                    normal_parts.push(gap.to_string());
+                }
             }
             break;
         }
@@ -259,6 +283,28 @@ fn extract_tool_calls(
         normal_text
     };
     Ok((normal_text, calls))
+}
+
+fn recover_bare_glm47_call_in_span(
+    span: &str,
+    config: &Glm47ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<(String, ToolCallResponse)>> {
+    let Some(marker_idx) = first_orphan_glm47_marker_index(span, config) else {
+        return Ok(None);
+    };
+    let recovered = recover_bare_glm47_call(span, marker_idx, config, tools)?;
+    if let Some((prefix, parsed_call)) = recovered {
+        warn!(
+            why = "bare_body_gap_recovery",
+            recovered_calls = 1,
+            recovered_bytes = span.len() - prefix.len(),
+            kept_prefix_bytes = prefix.len(),
+            "GLM-4.7 parser recovered complete bare call body before a later <tool_call>"
+        );
+        return Ok(Some((prefix, parsed_call)));
+    }
+    Ok(None)
 }
 
 fn first_orphan_glm47_marker_index(text: &str, config: &Glm47ParserConfig) -> Option<usize> {

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -55,7 +55,10 @@ pub fn detect_tool_call_start_kimi_k2(chunk: &str, config: &KimiK2ParserConfig) 
         return true;
     }
 
-    for start_token in &config.section_start_variants {
+    let mut start_tokens = config.section_start_variants.clone();
+    start_tokens.push(config.call_start.clone());
+
+    for start_token in &start_tokens {
         debug_assert!(
             start_token.is_ascii(),
             "Kimi K2 section tokens must be ASCII for safe byte slicing, got: {start_token:?}"

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -225,6 +225,12 @@ fn extract_tool_calls(
     let mut calls = Vec::new();
     let mut cursor = 0;
 
+    if find_section_start(text, 0, config).is_none()
+        && let Some(marker_idx) = first_orphan_kimi_marker_index(text, config)
+    {
+        return Ok((text[..marker_idx].trim().to_string(), calls));
+    }
+
     while cursor < text.len() {
         if let Some((start_pos, _start_len)) = find_section_start(text, cursor, config) {
             let abs_start = cursor + start_pos;
@@ -282,6 +288,25 @@ fn extract_tool_calls(
             joined_normal_text.trim().to_string()
         };
     Ok((normal_text, calls))
+}
+
+fn first_orphan_kimi_marker_index(text: &str, config: &KimiK2ParserConfig) -> Option<usize> {
+    let mut best = [
+        config.call_start.as_str(),
+        config.call_end.as_str(),
+        config.argument_begin.as_str(),
+    ]
+    .into_iter()
+    .filter_map(|marker| text.find(marker))
+    .min();
+
+    for marker in &config.section_end_variants {
+        if let Some(idx) = text.find(marker.as_str()) {
+            best = Some(best.map_or(idx, |current| current.min(idx)));
+        }
+    }
+
+    best
 }
 
 /// Parse a tool calls section block, extracting individual tool calls.

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -51,6 +51,10 @@ fn get_id_regex() -> &'static Regex {
 /// Check if a chunk contains the start of a Kimi K2 style tool call.
 /// Detects `<|tool_calls_section_begin|>` (or singular variant) or partial match for streaming.
 pub fn detect_tool_call_start_kimi_k2(chunk: &str, config: &KimiK2ParserConfig) -> bool {
+    if chunk.contains(config.call_start.as_str()) {
+        return true;
+    }
+
     for start_token in &config.section_start_variants {
         debug_assert!(
             start_token.is_ascii(),
@@ -228,6 +232,21 @@ fn extract_tool_calls(
     if find_section_start(text, 0, config).is_none()
         && let Some(marker_idx) = first_orphan_kimi_marker_index(text, config)
     {
+        let orphan_tail = &text[marker_idx..];
+        if orphan_tail.starts_with(config.call_start.as_str()) {
+            let mut recovered = parse_section_block(orphan_tail, config, tools)?;
+            if !recovered.is_empty() {
+                tracing::warn!(
+                    why = "bare_call_recovery",
+                    recovered_calls = recovered.len(),
+                    recovered_bytes = orphan_tail.len(),
+                    kept_prefix_bytes = marker_idx,
+                    "Kimi K2 parser recovered complete call(s) without section_begin"
+                );
+                calls.append(&mut recovered);
+                return Ok((text[..marker_idx].trim().to_string(), calls));
+            }
+        }
         return Ok((text[..marker_idx].trim().to_string(), calls));
     }
 

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -161,7 +161,7 @@ fn find_section_end(
 
 /// True for prefix-only narration before a tool section where vLLM preserves
 /// the wrapper-adjacent trailing space (TOOLCALLING.batch.8.a).
-fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[&str]) -> bool {
+fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[String]) -> bool {
     let mut non_empty_parts = normal_parts
         .iter()
         .enumerate()
@@ -176,7 +176,7 @@ fn should_preserve_vllm_prefix_trailing_space(normal_parts: &[&str]) -> bool {
 /// True when the first visible normal text appears only after a parsed tool
 /// section, so the intermediate Kimi tool-call turn should expose no content
 /// (TOOLCALLING.batch.8.b).
-fn should_drop_post_tool_text_without_prefix(normal_parts: &[&str]) -> bool {
+fn should_drop_post_tool_text_without_prefix(normal_parts: &[String]) -> bool {
     normal_parts
         .iter()
         .enumerate()
@@ -187,7 +187,7 @@ fn should_drop_post_tool_text_without_prefix(normal_parts: &[&str]) -> bool {
 /// True when there is prefix narration before the first tool section plus
 /// post-wrapper or inter-wrapper narration that should be dropped for Kimi
 /// tool-call turns (TOOLCALLING.batch.2.c, 8.c, 8.d).
-fn should_drop_post_tool_text_after_prefix(normal_parts: &[&str]) -> bool {
+fn should_drop_post_tool_text_after_prefix(normal_parts: &[String]) -> bool {
     normal_parts
         .first()
         .is_some_and(|prefix| !prefix.trim().is_empty())
@@ -256,9 +256,17 @@ fn extract_tool_calls(
     while cursor < text.len() {
         if let Some((start_pos, _start_len)) = find_section_start(text, cursor, config) {
             let abs_start = cursor + start_pos;
+            let gap = &text[cursor..abs_start];
+            if let Some((prefix, mut recovered)) =
+                recover_bare_kimi_calls_in_span(gap, config, tools)?
+            {
+                normal_parts.push(prefix);
+                calls.append(&mut recovered);
+            } else {
+                normal_parts.push(gap.to_string());
+            }
 
             // Add text before tool call section to normal parts.
-            normal_parts.push(&text[cursor..abs_start]);
 
             let (block, next_cursor) =
                 if let Some((end_pos, end_len)) = find_section_end(text, abs_start, config) {
@@ -279,7 +287,15 @@ fn extract_tool_calls(
             cursor = next_cursor;
         } else {
             // No more tool call sections.
-            normal_parts.push(&text[cursor..]);
+            let gap = &text[cursor..];
+            if let Some((prefix, mut recovered)) =
+                recover_bare_kimi_calls_in_span(gap, config, tools)?
+            {
+                normal_parts.push(prefix);
+                calls.append(&mut recovered);
+            } else {
+                normal_parts.push(gap.to_string());
+            }
             break;
         }
     }
@@ -310,6 +326,34 @@ fn extract_tool_calls(
             joined_normal_text.trim().to_string()
         };
     Ok((normal_text, calls))
+}
+
+fn recover_bare_kimi_calls_in_span(
+    span: &str,
+    config: &KimiK2ParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+    let Some(marker_idx) = first_orphan_kimi_marker_index(span, config) else {
+        return Ok(None);
+    };
+    let orphan_tail = &span[marker_idx..];
+    if !orphan_tail.starts_with(config.call_start.as_str()) {
+        return Ok(None);
+    }
+
+    let recovered = parse_section_block(orphan_tail, config, tools)?;
+    if recovered.is_empty() {
+        return Ok(None);
+    }
+
+    tracing::warn!(
+        why = "bare_call_gap_recovery",
+        recovered_calls = recovered.len(),
+        recovered_bytes = orphan_tail.len(),
+        kept_prefix_bytes = marker_idx,
+        "Kimi K2 parser recovered complete bare call(s) before a later section_begin"
+    );
+    Ok(Some((span[..marker_idx].trim().to_string(), recovered)))
 }
 
 fn first_orphan_kimi_marker_index(text: &str, config: &KimiK2ParserConfig) -> Option<usize> {

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -155,9 +155,8 @@ pub fn try_tool_call_parse_xml(
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     // Qwen3-Coder-style passthrough: if the function-start token is absent
     // anywhere in the input, the reference parser returns the raw input as
-    // content with no tool calls. Gated so it only fires for parsers that
-    // opt in (e.g. qwen3_coder, nemotron_nano); other XML-style families
-    // (minimax_m2, kimi_k2 alias paths) keep their stricter behavior.
+    // content with no tool calls. Gated so it only fires for parsers that opt
+    // in (e.g. qwen3_coder, nemotron_nano).
     if config.passthrough_when_no_function
         && !message.contains(config.function_start_token.as_str())
         && !message.contains(config.tool_call_start_token.as_str())
@@ -165,9 +164,10 @@ pub fn try_tool_call_parse_xml(
         return Ok((vec![], Some(message.to_string())));
     }
 
-    // Qwen3-Coder-style back-off: outer wrapper missing but `<function=...>`
-    // tags are present — parse the whole input as a single tool-call block
-    // (mirrors `qwen3coder_tool_parser._get_function_calls`'s fallback).
+    // Back-off: outer wrapper missing but function/invoke tags are present —
+    // parse the whole input as a single tool-call block. Qwen3-Coder uses this
+    // in its reference parser. MiniMax uses the same path to recover complete
+    // inner invokes when the outer wrapper opener is missing.
     //
     // Gated on `function_end_token` being present OR `allow_eof_recovery` set,
     // mirroring the wrapped path's recovery gate in `extract_tool_calls`. The
@@ -247,16 +247,17 @@ fn extract_tool_calls(
             } else {
                 // Recovery: outer end token absent (max_tokens / EOS truncation).
                 // Gated on `allow_eof_recovery` so streaming early-exit doesn't
-                // fire mid-stream. Recovery also requires the trailing slice
-                // to contain a function-start opener — structural signal that
-                // a real tool call was emitted, so plain text starting with
-                // `<tool_call>` is preserved verbatim.
+                // fire mid-stream. Strict XML families still require paired
+                // inner invoke/parameter fences before a call is recovered.
+                // Recovery also requires the trailing slice to contain a
+                // function-start opener — structural signal that a real tool
+                // call was emitted, so plain text starting with `<tool_call>`
+                // is preserved verbatim.
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
                 let looks_like_tool_call = block.contains(function_start.as_str())
                     || block.contains(config.parameter_start_token.as_str());
                 if config.allow_eof_recovery
-                    && !config.strict_match
                     && looks_like_tool_call
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
@@ -1198,14 +1199,11 @@ NYC
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test] // TOOLCALLING.batch.5.a — minimax_m2 spec-strict
-    fn test_parse_minimax_m2_no_outer_close_drops_call() {
-        // MiniMax-M2's reference parser (huggingface.co/MiniMaxAI/MiniMax-M2)
-        // requires both outer fences — missing `</minimax:tool_call>` means
-        // the regex does not match and zero calls are recovered. Strict-match
-        // mode opts into that behavior even when `allow_eof_recovery=true`
-        // would otherwise apply (and the binding-layer override is also
-        // suppressed for strict configs).
+    #[test] // TOOLCALLING.batch.5.a — minimax_m2
+    fn test_parse_minimax_m2_no_outer_close_recovers_complete_inner_call() {
+        // Finalize recovery may accept a missing outer MiniMax wrapper close,
+        // but strict_match still requires complete inner invoke/parameter
+        // fences before surfacing a call.
         let config = XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
             tool_call_end_token: "</minimax:tool_call>".to_string(),
@@ -1216,15 +1214,15 @@ NYC
             allow_eof_recovery: true,
             strict_match: true,
             passthrough_when_no_function: false,
-            backoff_when_no_wrapper: false,
+            backoff_when_no_wrapper: true,
         };
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
 
         let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
-        assert!(
-            calls.is_empty(),
-            "strict_match config must not recover when outer </minimax:tool_call> is absent"
-        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "NYC");
     }
 
     #[test] // helper
@@ -1414,7 +1412,7 @@ NYC
 
     /// Helper for the new corner-case tests below (TOOLCALLING.batch.6 / PIPELINE.finish_reason / TOOLCALLING.batch.9
     /// / TOOLCALLING.batch.10) — matches the production `ToolCallConfig::minimax_m2()`
-    /// factory: strict-match per MiniMax's reference parser.
+    /// factory: strict inner blocks plus bare-invoke recovery.
     fn minimax_m2_config() -> XmlParserConfig {
         XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
@@ -1426,7 +1424,7 @@ NYC
             allow_eof_recovery: false,
             strict_match: true,
             passthrough_when_no_function: false,
-            backoff_when_no_wrapper: false,
+            backoff_when_no_wrapper: true,
         }
     }
 

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -178,13 +178,12 @@ pub fn try_tool_call_parse_xml(
     // in its reference parser. MiniMax uses the same path to recover complete
     // inner invokes when the outer wrapper opener is missing.
     //
-    // Gated on `function_end_token` being present OR `allow_eof_recovery` set,
-    // mirroring the wrapped path's recovery gate in `extract_tool_calls`. The
-    // lenient inner regex has a `|$` fallback that would otherwise match a
-    // partial `<function=...>` block mid-stream and cause `should_exit_jail_
-    // early` to release the jail before the closing tag arrives.
+    // Streaming recovery needs the orphan outer close marker as well as the
+    // inner close marker. Otherwise a split `</tool_call>` / MiniMax close can
+    // arrive after the jail has already released.
     if config.is_bare_function_mode(message)
         && (message.contains(config.function_end_token.as_str()) || config.allow_eof_recovery)
+        && (message.contains(config.tool_call_end_token.as_str()) || config.allow_eof_recovery)
     {
         let calls = parse_tool_call_block(message, config, tools).unwrap_or_default();
         if !calls.is_empty() {
@@ -340,7 +339,9 @@ fn recover_bare_xml_calls_in_span(
     };
 
     let tail = &span[marker_idx..];
-    if !tail.contains(config.function_end_token.as_str()) && !config.allow_eof_recovery {
+    let has_inner_close = tail.contains(config.function_end_token.as_str());
+    let has_outer_close = tail.contains(config.tool_call_end_token.as_str());
+    if (!has_inner_close || !has_outer_close) && !config.allow_eof_recovery {
         return Ok(None);
     }
 
@@ -1213,10 +1214,21 @@ NYC
     }
 
     #[test]
-    fn test_parse_qwen3_bare_function_complete_streaming_recovers() {
-        // Same scenario but `</function>` has arrived — back-off should fire
-        // even with recovery off (streaming-complete path).
+    fn test_parse_qwen3_bare_function_complete_without_outer_close_waits_in_streaming() {
+        // `</function>` alone is not enough for streaming recovery: the orphan
+        // `</tool_call>` may still arrive in a later chunk and must stay jailed.
         let input = "<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn test_parse_qwen3_bare_function_outer_close_streaming_recovers() {
+        let input = "<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>\n</tool_call>";
         let config = XmlParserConfig {
             backoff_when_no_wrapper: true,
             ..XmlParserConfig::default()

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -160,6 +160,7 @@ pub fn try_tool_call_parse_xml(
     // (minimax_m2, kimi_k2 alias paths) keep their stricter behavior.
     if config.passthrough_when_no_function
         && !message.contains(config.function_start_token.as_str())
+        && !message.contains(config.tool_call_start_token.as_str())
     {
         return Ok((vec![], Some(message.to_string())));
     }
@@ -186,6 +187,13 @@ pub fn try_tool_call_parse_xml(
                 .unwrap_or_default();
             return Ok((calls, Some(prefix)));
         }
+    }
+
+    if config.strict_match
+        && !message.contains(config.tool_call_start_token.as_str())
+        && let Some(prefix) = prefix_before_orphan_xml_marker(message, config)
+    {
+        return Ok((vec![], Some(prefix)));
     }
 
     let (normal_text, tool_calls) = extract_tool_calls(message, config, tools)?;
@@ -245,16 +253,18 @@ fn extract_tool_calls(
                 // `<tool_call>` is preserved verbatim.
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
+                let looks_like_tool_call = block.contains(function_start.as_str())
+                    || block.contains(config.parameter_start_token.as_str());
                 if config.allow_eof_recovery
                     && !config.strict_match
-                    && block.contains(function_start.as_str())
+                    && looks_like_tool_call
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
                 {
                     calls.append(&mut parsed_calls);
                     break;
                 }
-                if calls.is_empty() {
+                if calls.is_empty() && !looks_like_tool_call {
                     normal_parts.push(&text[abs_start..]);
                 }
                 break;
@@ -275,6 +285,20 @@ fn extract_tool_calls(
         normal_text
     };
     Ok((normal_text, calls))
+}
+
+fn prefix_before_orphan_xml_marker(text: &str, config: &XmlParserConfig) -> Option<String> {
+    [
+        config.tool_call_end_token.as_str(),
+        config.function_start_token.as_str(),
+        config.function_end_token.as_str(),
+        config.parameter_start_token.as_str(),
+        config.parameter_end_token.as_str(),
+    ]
+    .into_iter()
+    .filter_map(|marker| text.find(marker))
+    .min()
+    .map(|idx| text[..idx].trim().to_string())
 }
 
 /// Parse a single tool call block

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -222,7 +222,7 @@ fn extract_tool_calls(
     config: &XmlParserConfig,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(String, Vec<ToolCallResponse>)> {
-    let mut normal_parts = Vec::new();
+    let mut normal_text = String::new();
     let mut calls = Vec::new();
     let mut cursor = 0;
 
@@ -233,14 +233,22 @@ fn extract_tool_calls(
         // Find next tool call start.
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
+            let gap = &text[cursor..abs_start];
+            if let Some((prefix, mut recovered_calls)) =
+                recover_bare_xml_calls_in_span(gap, config, tools)?
+            {
+                if calls.is_empty() {
+                    normal_text.push_str(&prefix);
+                }
+                calls.append(&mut recovered_calls);
+            } else if calls.is_empty() {
+                normal_text.push_str(gap);
+            }
 
             // Qwen3-Coder-style templates allow natural language before the
             // tool call, but text after the tool-call block is not response
             // content. Keep scanning for additional calls, but only surface
             // normal text that precedes the first parsed call.
-            if calls.is_empty() {
-                normal_parts.push(&text[cursor..abs_start]);
-            }
 
             // Find the corresponding end token.
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
@@ -275,20 +283,27 @@ fn extract_tool_calls(
                     break;
                 }
                 if calls.is_empty() && !looks_like_tool_call {
-                    normal_parts.push(&text[abs_start..]);
+                    normal_text.push_str(&text[abs_start..]);
                 }
                 break;
             }
         } else {
             // No more tool calls.
-            if calls.is_empty() {
-                normal_parts.push(&text[cursor..]);
+            let gap = &text[cursor..];
+            if let Some((prefix, mut recovered_calls)) =
+                recover_bare_xml_calls_in_span(gap, config, tools)?
+            {
+                if calls.is_empty() {
+                    normal_text.push_str(&prefix);
+                }
+                calls.append(&mut recovered_calls);
+            } else if calls.is_empty() {
+                normal_text.push_str(gap);
             }
             break;
         }
     }
 
-    let normal_text = normal_parts.join("");
     let normal_text = if calls.is_empty() {
         normal_text.trim().to_string()
     } else {
@@ -309,6 +324,39 @@ fn prefix_before_orphan_xml_marker(text: &str, config: &XmlParserConfig) -> Opti
     .filter_map(|marker| text.find(marker))
     .min()
     .map(|idx| text[..idx].trim().to_string())
+}
+
+fn recover_bare_xml_calls_in_span(
+    span: &str,
+    config: &XmlParserConfig,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<(String, Vec<ToolCallResponse>)>> {
+    if !config.backoff_when_no_wrapper {
+        return Ok(None);
+    }
+
+    let Some(marker_idx) = span.find(config.function_start_token.as_str()) else {
+        return Ok(None);
+    };
+
+    let tail = &span[marker_idx..];
+    if !tail.contains(config.function_end_token.as_str()) && !config.allow_eof_recovery {
+        return Ok(None);
+    }
+
+    let calls = parse_tool_call_block(tail, config, tools)?;
+    if calls.is_empty() {
+        return Ok(None);
+    }
+
+    tracing::warn!(
+        why = "bare_function_gap_recovery",
+        recovered_calls = calls.len(),
+        recovered_bytes = tail.len(),
+        kept_prefix_bytes = marker_idx,
+        "XML recovery: recovered complete bare function block(s) before a later outer wrapper"
+    );
+    Ok(Some((span[..marker_idx].to_string(), calls)))
 }
 
 /// Parse a single tool call block

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -84,9 +84,11 @@ pub fn detect_tool_call_start_xml(chunk: &str, config: &XmlParserConfig) -> bool
     }
 
     // Check for partial match at the end of the chunk (for streaming).
-    for i in 1..start_token.len() {
-        if chunk.ends_with(&start_token[..i]) {
-            return true;
+    for token in [start_token, &config.function_start_token] {
+        for i in 1..token.len() {
+            if chunk.ends_with(&token[..i]) {
+                return true;
+            }
         }
     }
 
@@ -127,6 +129,13 @@ pub fn find_tool_call_end_position_xml(chunk: &str, config: &XmlParserConfig) ->
             let trim_offset = rest.len() - trimmed.len();
             cursor += trim_offset + end_token.len();
             continue;
+        }
+        if config.is_bare_function_mode(chunk)
+            && trimmed.starts_with(config.tool_call_end_token.as_str())
+        {
+            let trim_offset = rest.len() - trimmed.len();
+            cursor += trim_offset + config.tool_call_end_token.len();
+            break;
         }
         if !trimmed.starts_with(start_token.as_str()) {
             break;

--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -189,7 +189,7 @@ def parity_cell_class(marker: str) -> str:
         return "missing"
     if marker == "n/a":
         return "na"
-    if marker == "D":
+    if marker in {"D", "·"}:
         return "donly"
     if "!" in marker:
         return "err"

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -20,7 +20,7 @@ th a:hover { background: #ffd; }
 td.model, td.parser { white-space: nowrap; }
 td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
-td.cell { text-align: center; min-width: 24px; }
+td.cell { text-align: center; min-width: 24px; font-weight: 700; }
 td.cell.ok         { color: #0a7d2c; }
 td.cell.donly      { color: #555; }
 td.cell.documented { color: #555; }
@@ -37,6 +37,48 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .stats span { font-family: ui-monospace, monospace; font-weight: bold; }
 .generated { color: #888; font-size: 12px; margin-top: -0.5em; }
 .versions { color: #555; font-size: 12px; margin-top: 0.2em; }
+.table-toolbar { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin: 0.7em 0 0.8em; }
+.radio-group { display: flex; align-items: center; gap: 8px; border: 1px solid #d0d7de; background: #f8fafc; border-radius: 6px; padding: 6px 8px; }
+.radio-group-label { font-size: 13px; font-weight: 600; }
+.radio-option { display: inline-flex; align-items: center; gap: 4px; font-size: 13px; cursor: pointer; }
+.radio-option input { margin: 0; }
+.view-overview .details-only { display: none; }
+.view-details .summary-only { display: none; }
+.summary-key { display: inline-block; width: 12px; height: 12px; border: 1px solid rgba(0,0,0,0.22); margin: 0 4px 0 10px; vertical-align: -2px; }
+.summary-key:first-of-type { margin-left: 0; }
+.summary-key.ok { background: #76b884; }
+.summary-key.problem { background: #db7777; }
+.summary-key.na { background: #c4ccd4; }
+.view-overview td.cell, .view-details td.cell { box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04); }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="ok"],
+.view-overview.parser-vllm td.cell[data-status-vllm="ok"],
+.view-overview.parser-sglang td.cell[data-status-sglang="ok"] { background: #76b884; color: #76b884; }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="problem"],
+.view-overview.parser-vllm td.cell[data-status-vllm="problem"],
+.view-overview.parser-sglang td.cell[data-status-sglang="problem"] { background: #db7777; color: #db7777; }
+.view-overview.parser-dynamo td.cell[data-status-dynamo="na"],
+.view-overview.parser-vllm td.cell[data-status-vllm="na"],
+.view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #c4ccd4; color: #c4ccd4; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="ok"],
+.view-details.parser-vllm td.cell[data-status-vllm="ok"],
+.view-details.parser-sglang td.cell[data-status-sglang="ok"] { background: #bfe3c6; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="problem"],
+.view-details.parser-vllm td.cell[data-status-vllm="problem"],
+.view-details.parser-sglang td.cell[data-status-sglang="problem"] { background: #efb3b3; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="na"],
+.view-details.parser-vllm td.cell[data-status-vllm="na"],
+.view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #d8dee4; }
+.view-overview td.cell > a { color: inherit; }
+.view-overview td.cell > a:hover { background: transparent; }
+.view-overview td.cell:hover { filter: brightness(0.98); }
+.view-details td.cell { color: transparent; }
+.view-details td.cell::before { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #111; pointer-events: none; }
+.view-details.parser-dynamo td.cell::before { content: attr(data-marker-dynamo); }
+.view-details.parser-vllm td.cell::before { content: attr(data-marker-vllm); }
+.view-details.parser-sglang td.cell::before { content: attr(data-marker-sglang); }
+.view-details td.cell a { color: transparent; }
+.view-details td.cell a:hover { background: rgba(255,255,255,0.35); }
+.view-details td.cell .ttip { font-weight: 400; }
 .tabs { display: flex; gap: 4px; border-bottom: 1px solid #ccc; margin: 1em 0; }
 .tab-button { appearance: none; border: 1px solid #ccc; border-bottom: 0; background: #f5f5f5; color: #222; padding: 6px 10px; font: inherit; cursor: pointer; border-radius: 4px 4px 0 0; }
 .tab-button.active { background: #fff; font-weight: 600; position: relative; top: 1px; }
@@ -77,13 +119,14 @@ table.glossary tr.category td { background: #eef; font-family: -apple-system, sy
  * `td.parser` participates so parser metadata tooltips use the same styling
  * as data-cell tooltips. */
 td.cell, td.parser { position: relative; }
+td.cell:hover, td.parser:hover, td.cell:focus-within, td.parser:focus-within { z-index: 2000; }
 .ttip {
     visibility: hidden;
     opacity: 0;
     position: absolute;
     left: 0;
     top: 100%;
-    z-index: 100;
+    z-index: 3000;
     background: #1f2937;
     color: #e5e7eb;
     padding: 8px 10px;
@@ -131,7 +174,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 .tt-h-other { color: #22d3ee; }
 </style>
 </head>
-<body>
+<body class="view-overview parser-dynamo">
 <h1>{{ title|e }}</h1>
 <p class="generated">
   Auto-generated on {{ stamp|e }}{% if sha %} on commit <a href="https://github.com/ai-dynamo/dynamo/commit/{{ sha|e }}"><code>{{ short_sha|e }}</code></a>{% endif %}:
@@ -147,6 +190,19 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% endfor %}
 </div>
 {% endif %}
+<div class="table-toolbar">
+  <div class="radio-group" role="radiogroup" aria-label="Parity table view">
+    <span class="radio-group-label">View:</span>
+    <label class="radio-option"><input type="radio" name="parity-view" value="overview" data-view-toggle checked> Overview</label>
+    <label class="radio-option"><input type="radio" name="parity-view" value="details" data-view-toggle> Details</label>
+  </div>
+  <div class="radio-group" role="radiogroup" aria-label="Parser implementation">
+    <span class="radio-group-label">Parser:</span>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="dynamo" data-parser-toggle checked> Dynamo Rust parser</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="vllm" data-parser-toggle> vLLM Python parser</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="sglang" data-parser-toggle> SGLang Python parser</label>
+  </div>
+</div>
 {% for panel in panels %}
 <section id="{{ panel.id|e }}" class="tab-panel{% if panel.active %} active{% endif %}" role="tabpanel"{% if tabs|length > 1 %} aria-labelledby="{{ panel.id|e }}-button"{% endif %}>
 <table data-parity-table>
@@ -160,7 +216,13 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% endfor %}
 </tbody>
 </table>
-<p class="legend">
+<p class="legend summary-only">
+  <strong>Overview:</strong>
+  <span class="summary-key ok" aria-hidden="true"></span>green = selected implementation output is clean ·
+  <span class="summary-key problem" aria-hidden="true"></span>red = selected implementation leaks parser markup or has an expected error ·
+  <span class="summary-key na" aria-hidden="true"></span>gray = not applicable, unavailable, or missing fixture.
+</p>
+<p class="legend details-only">
 {% if panel.legend_html is defined and panel.legend_html %}
   {{ panel.legend_html|safe }}
 {% elif legend_html is defined and legend_html %}
@@ -197,7 +259,13 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   {% endif %}
 {% endif %}
 </p>
-<p class="stats">
+<p class="stats summary-only">
+  Stats for selected perspective:
+  <span style="color:#0a7d2c" data-overview-count="ok">0</span> green ·
+  <span style="color:#b00" data-overview-count="problem">0</span> red ·
+  <span style="color:#555" data-overview-count="na">0</span> gray.
+</p>
+<p class="stats details-only">
   Stats: {{ panel.stats.families }} families × {{ panel.stats.sub_cases }} sub-cases
   = {{ panel.stats.slots }} grid slots ({{ panel.stats.na }} n/a, {{ panel.stats.missing }} missing).
   <strong>{{ panel.stats.real }}</strong> real cases:
@@ -210,6 +278,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <span style="color:#b00">{{ panel.stats.errors }} expected-errors</span>.
 </p>
 {% if panel.glossary_groups %}
+<div class="details-only">
 <h2 id="case-descriptions-{{ panel.case_section_id|default(panel.mode)|e }}">Case descriptions</h2>
 <p>Full case definitions:
 {% if panel.case_docs_href is defined %}
@@ -239,6 +308,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% endfor %}
 </tbody>
 </table>
+</div>
 {% endif %}
 </section>
 {% endfor %}
@@ -251,6 +321,108 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   const columnKeys = Array.from(new Set(columnButtons.map(function (button) {
     return button.dataset.colToggle;
   })));
+  const viewRadios = Array.from(document.querySelectorAll('[data-view-toggle]'));
+  const viewKeys = new Set(viewRadios.map(function (radio) {
+    return radio.value;
+  }));
+  const parserRadios = Array.from(document.querySelectorAll('[data-parser-toggle]'));
+  const parserKeys = new Set(parserRadios.map(function (radio) {
+    return radio.value;
+  }));
+
+  function readActiveView() {
+    const requested = new URLSearchParams(window.location.search).get('view');
+    return viewKeys.has(requested) ? requested : 'overview';
+  }
+
+  function readActiveParser() {
+    const params = new URLSearchParams(window.location.search);
+    const requested = params.get('parser') || params.get('perspective');
+    return parserKeys.has(requested) ? requested : 'dynamo';
+  }
+
+  function updateViewUrl(view) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('view');
+    if (view !== 'overview') {
+      url.searchParams.set('view', view);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function updateParserUrl(parser) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('parser');
+    url.searchParams.delete('perspective');
+    if (parser !== 'dynamo') {
+      url.searchParams.set('parser', parser);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function activeParser() {
+    const checked = parserRadios.find(function (radio) {
+      return radio.checked;
+    });
+    return checked ? checked.value : 'dynamo';
+  }
+
+  function updateOverviewStats() {
+    const parser = activeParser();
+    document.querySelectorAll('.tab-panel').forEach(function (panel) {
+      const counts = {ok: 0, problem: 0, na: 0};
+      panel.querySelectorAll('td.cell').forEach(function (cell) {
+        const status = cell.getAttribute('data-status-' + parser) || 'na';
+        counts[status] = (counts[status] || 0) + 1;
+      });
+      panel.querySelectorAll('[data-overview-count]').forEach(function (el) {
+        el.textContent = String(counts[el.dataset.overviewCount] || 0);
+      });
+    });
+  }
+
+  function applyView(view, shouldUpdateUrl) {
+    const activeView = viewKeys.has(view) ? view : 'overview';
+    document.body.classList.toggle('view-overview', activeView === 'overview');
+    document.body.classList.toggle('view-details', activeView === 'details');
+    viewRadios.forEach(function (radio) {
+      radio.checked = radio.value === activeView;
+    });
+    if (shouldUpdateUrl) {
+      updateViewUrl(activeView);
+    }
+  }
+
+  function applyParser(parser, shouldUpdateUrl) {
+    const active = parserKeys.has(parser) ? parser : 'dynamo';
+    parserKeys.forEach(function (key) {
+      document.body.classList.toggle('parser-' + key, active === key);
+    });
+    parserRadios.forEach(function (radio) {
+      radio.checked = radio.value === active;
+    });
+    updateOverviewStats();
+    if (shouldUpdateUrl) {
+      updateParserUrl(active);
+    }
+  }
+
+  applyView(readActiveView(), false);
+  applyParser(readActiveParser(), false);
+  viewRadios.forEach(function (radio) {
+    radio.addEventListener('change', function () {
+      if (radio.checked) {
+        applyView(radio.value, true);
+      }
+    });
+  });
+  parserRadios.forEach(function (radio) {
+    radio.addEventListener('change', function () {
+      if (radio.checked) {
+        applyParser(radio.value, true);
+      }
+    });
+  });
 
   function defaultVisibleColumns() {
     const visible = new Set();

--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -20,14 +20,14 @@ th a:hover { background: #ffd; }
 td.model, td.parser { white-space: nowrap; }
 td.parser a { color: inherit; text-decoration: none; }
 td.parser a:hover { background: #ffd; }
-td.cell { text-align: center; min-width: 24px; font-weight: 700; }
+td.cell { text-align: center; min-width: 24px; font-weight: 400; }
 td.cell.ok         { color: #0a7d2c; }
-td.cell.donly      { color: #555; }
+td.cell.donly      { color: #8b949e; }
 td.cell.documented { color: #555; }
-td.cell.research   { color: #b00;    font-weight: bold; }
-td.cell.leak       { color: #b00;    font-weight: bold; }
-td.cell.err        { color: #b00;    font-weight: bold; }
-td.cell.na         { color: #aaa; }
+td.cell.research   { color: #b00; }
+td.cell.leak       { color: #b00; }
+td.cell.err        { color: #b00; }
+td.cell.na         { color: #aeb6bf; }
 td.cell.missing    { color: #8a6d3b; }
 td.cell a { color: inherit; text-decoration: none; display: block; }
 td.cell a:hover { background: #ffd; }
@@ -42,13 +42,18 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .radio-group-label { font-size: 13px; font-weight: 600; }
 .radio-option { display: inline-flex; align-items: center; gap: 4px; font-size: 13px; cursor: pointer; }
 .radio-option input { margin: 0; }
+.checkbox-option { display: inline-flex; align-items: center; gap: 5px; border: 1px solid #d0d7de; background: #f8fafc; border-radius: 6px; padding: 6px 8px; font-size: 13px; cursor: pointer; }
+.checkbox-option input { margin: 0; }
+.view-overview .parity-option { display: none; }
 .view-overview .details-only { display: none; }
 .view-details .summary-only { display: none; }
+.parity-explainer { display: none; }
+.view-details.parity-mode .parity-explainer { display: block; }
 .summary-key { display: inline-block; width: 12px; height: 12px; border: 1px solid rgba(0,0,0,0.22); margin: 0 4px 0 10px; vertical-align: -2px; }
 .summary-key:first-of-type { margin-left: 0; }
 .summary-key.ok { background: #76b884; }
 .summary-key.problem { background: #db7777; }
-.summary-key.na { background: #c4ccd4; }
+.summary-key.na { background: #d3d8de; }
 .view-overview td.cell, .view-details td.cell { box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04); }
 .view-overview.parser-dynamo td.cell[data-status-dynamo="ok"],
 .view-overview.parser-vllm td.cell[data-status-vllm="ok"],
@@ -58,7 +63,7 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .view-overview.parser-sglang td.cell[data-status-sglang="problem"] { background: #db7777; color: #db7777; }
 .view-overview.parser-dynamo td.cell[data-status-dynamo="na"],
 .view-overview.parser-vllm td.cell[data-status-vllm="na"],
-.view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #c4ccd4; color: #c4ccd4; }
+.view-overview.parser-sglang td.cell[data-status-sglang="na"] { background: #d3d8de; color: #d3d8de; }
 .view-details.parser-dynamo td.cell[data-status-dynamo="ok"],
 .view-details.parser-vllm td.cell[data-status-vllm="ok"],
 .view-details.parser-sglang td.cell[data-status-sglang="ok"] { background: #bfe3c6; }
@@ -67,15 +72,22 @@ tr.section td { background: #eef; font-weight: bold; text-align: left; }
 .view-details.parser-sglang td.cell[data-status-sglang="problem"] { background: #efb3b3; }
 .view-details.parser-dynamo td.cell[data-status-dynamo="na"],
 .view-details.parser-vllm td.cell[data-status-vllm="na"],
-.view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #d8dee4; }
+.view-details.parser-sglang td.cell[data-status-sglang="na"] { background: #e4e8ec; }
 .view-overview td.cell > a { color: inherit; }
 .view-overview td.cell > a:hover { background: transparent; }
 .view-overview td.cell:hover { filter: brightness(0.98); }
 .view-details td.cell { color: transparent; }
 .view-details td.cell::before { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #111; pointer-events: none; }
+.view-details.parser-dynamo td.cell[data-status-dynamo="na"]::before,
+.view-details.parser-vllm td.cell[data-status-vllm="na"]::before,
+.view-details.parser-sglang td.cell[data-status-sglang="na"]::before { color: #aeb6bf; }
+.view-details td.cell.donly::before { color: #8b949e; }
 .view-details.parser-dynamo td.cell::before { content: attr(data-marker-dynamo); }
 .view-details.parser-vllm td.cell::before { content: attr(data-marker-vllm); }
 .view-details.parser-sglang td.cell::before { content: attr(data-marker-sglang); }
+.view-details.parity-mode.parser-dynamo td.cell::before { content: attr(data-marker-parity-dynamo); }
+.view-details.parity-mode.parser-vllm td.cell::before { content: attr(data-marker-parity-vllm); }
+.view-details.parity-mode.parser-sglang td.cell::before { content: attr(data-marker-parity-sglang); }
 .view-details td.cell a { color: transparent; }
 .view-details td.cell a:hover { background: rgba(255,255,255,0.35); }
 .view-details td.cell .ttip { font-weight: 400; }
@@ -198,10 +210,11 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   </div>
   <div class="radio-group" role="radiogroup" aria-label="Parser implementation">
     <span class="radio-group-label">Parser:</span>
-    <label class="radio-option"><input type="radio" name="parity-parser" value="dynamo" data-parser-toggle checked> Dynamo Rust parser</label>
-    <label class="radio-option"><input type="radio" name="parity-parser" value="vllm" data-parser-toggle> vLLM Python parser</label>
-    <label class="radio-option"><input type="radio" name="parity-parser" value="sglang" data-parser-toggle> SGLang Python parser</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="dynamo" data-parser-toggle checked> Dynamo</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="vllm" data-parser-toggle> vLLM</label>
+    <label class="radio-option"><input type="radio" name="parity-parser" value="sglang" data-parser-toggle> SGLang</label>
   </div>
+  <label class="checkbox-option parity-option"><input type="checkbox" data-parity-toggle> Parity</label>
 </div>
 {% for panel in panels %}
 <section id="{{ panel.id|e }}" class="tab-panel{% if panel.active %} active{% endif %}" role="tabpanel"{% if tabs|length > 1 %} aria-labelledby="{{ panel.id|e }}-button"{% endif %}>
@@ -230,7 +243,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
 {% else %}
   <strong>Legend:</strong>
   <span style="color:#0a7d2c">=</span> all captured peers match Dynamo ·
-  <span style="color:#555">D</span> Dynamo-only fixture
+  <span style="color:#8b949e">·</span> Dynamo-only fixture
   (both peers unavailable) ·
   <span style="color:#555">V/S</span> divergence
   (V = vLLM, S = SGLang; intentional, has <code>reason:</code>) ·
@@ -258,6 +271,12 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   {% for name, version in peer_versions %}{% if not loop.first %} · {% endif %}{{ name|e }} <code>{{ version|e }}</code>{% endfor %}.
   {% endif %}
 {% endif %}
+</p>
+<p class="legend details-only parity-explainer">
+  <strong>Parity:</strong>
+  <span style="color:#0a7d2c">=</span> all three outputs match ·
+  <span style="color:#555">D</span>/<span style="color:#555">V</span>/<span style="color:#555">S</span> names parser output that differs from the selected parser ·
+  multiple letters mean multiple peer outputs differ from the selected parser.
 </p>
 <p class="stats summary-only">
   Stats for selected perspective:
@@ -329,6 +348,7 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   const parserKeys = new Set(parserRadios.map(function (radio) {
     return radio.value;
   }));
+  const parityToggle = document.querySelector('[data-parity-toggle]');
 
   function readActiveView() {
     const requested = new URLSearchParams(window.location.search).get('view');
@@ -339,6 +359,11 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     const params = new URLSearchParams(window.location.search);
     const requested = params.get('parser') || params.get('perspective');
     return parserKeys.has(requested) ? requested : 'dynamo';
+  }
+
+  function readParityMode() {
+    const requested = new URLSearchParams(window.location.search).get('parity');
+    return requested === '1' || requested === 'true';
   }
 
   function updateViewUrl(view) {
@@ -356,6 +381,15 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     url.searchParams.delete('perspective');
     if (parser !== 'dynamo') {
       url.searchParams.set('parser', parser);
+    }
+    window.history.replaceState(null, '', url.toString());
+  }
+
+  function updateParityUrl(enabled) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('parity');
+    if (enabled) {
+      url.searchParams.set('parity', '1');
     }
     window.history.replaceState(null, '', url.toString());
   }
@@ -407,8 +441,19 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
     }
   }
 
+  function applyParityMode(enabled, shouldUpdateUrl) {
+    document.body.classList.toggle('parity-mode', Boolean(enabled));
+    if (parityToggle) {
+      parityToggle.checked = Boolean(enabled);
+    }
+    if (shouldUpdateUrl) {
+      updateParityUrl(Boolean(enabled));
+    }
+  }
+
   applyView(readActiveView(), false);
   applyParser(readActiveParser(), false);
+  applyParityMode(readParityMode(), false);
   viewRadios.forEach(function (radio) {
     radio.addEventListener('change', function () {
       if (radio.checked) {
@@ -423,6 +468,11 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
       }
     });
   });
+  if (parityToggle) {
+    parityToggle.addEventListener('change', function () {
+      applyParityMode(parityToggle.checked, true);
+    });
+  }
 
   function defaultVisibleColumns() {
     const visible = new Set();

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -460,23 +460,29 @@ def _is_gpt_oss_tool_handoff(family: str | None, field: str, value: str) -> bool
     )
 
 
-def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | None:
-    dynamo = expected.get("dynamo", {})
-    if not isinstance(dynamo, dict):
+def _block_leak_reason(block: dict[str, Any], family: str | None) -> str | None:
+    if not isinstance(block, dict):
         return None
     marker_re = _reasoning_markup_re(family)
     for field in ("reasoning_text", "normal_text"):
-        value = dynamo.get(field)
+        value = block.get(field)
         if (
             isinstance(value, str)
             and marker_re.search(value)
             and not _is_gpt_oss_tool_handoff(family, field, value)
         ):
             return str(
-                dynamo.get("reason")
+                block.get("reason")
                 or "Dynamo leaks reasoning markup or final-answer text."
             )
     return None
+
+
+def _dynamo_leak_reason(expected: dict[str, Any], family: str | None) -> str | None:
+    dynamo = expected.get("dynamo", {})
+    if not isinstance(dynamo, dict):
+        return None
+    return _block_leak_reason(dynamo, family)
 
 
 def _has_dynamo_leak(case: dict[str, Any], family: str | None) -> bool:
@@ -485,6 +491,56 @@ def _has_dynamo_leak(case: dict[str, Any], family: str | None) -> bool:
     expected = case.get("expected")
     return (
         isinstance(expected, dict) and _dynamo_leak_reason(expected, family) is not None
+    )
+
+
+def _overview_status(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
+    if case is None or "expected" not in case:
+        return "na"
+    block = case.get("expected", {}).get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "na"
+    if "error" in block or _block_leak_reason(block, family):
+        return "problem"
+    return "ok"
+
+
+def _overview_status_attrs(case: dict[str, Any] | None, family: str | None) -> str:
+    return " ".join(
+        f'data-status-{impl}="{_overview_status(case, family, impl)}"'
+        for impl in ("dynamo", "vllm", "sglang")
+    )
+
+
+def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
+    if case is None:
+        return "—"
+    if "expected" not in case:
+        return "n/a"
+    expected = case.get("expected", {})
+    block = expected.get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "n/a"
+    if "error" in block:
+        return "!"
+    if _block_leak_reason(block, family):
+        return "↯"
+    if impl == "dynamo":
+        return _cell(case, family)[0].replace("↯", "") or "="
+
+    dyn = expected.get("dynamo")
+    if not isinstance(dyn, dict):
+        return "n/a"
+    if _canonical(block) == _canonical(dyn):
+        return "="
+    suffix = "?" if "reason" not in block else ""
+    return ("V" if impl == "vllm" else "S") + suffix
+
+
+def _parser_marker_attrs(case: dict[str, Any] | None, family: str | None) -> str:
+    return " ".join(
+        f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, family, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
     )
 
 
@@ -1564,6 +1620,8 @@ def _render_cell_html(
         )
 
     classes = f"cell {parity_cell_class(marker)} {_case_band_class(case_id)}"
+    status_attrs = _overview_status_attrs(case, family)
+    marker_attrs = _parser_marker_attrs(case, family)
     group_key = html_lib.escape(_case_group_key(case_id))
     label = html_lib.escape(marker)
     if href:
@@ -1571,7 +1629,8 @@ def _render_cell_html(
     else:
         body = label
     return (
-        f'<td class="{classes}" data-col-hide-group="{group_key}">'
+        f'<td class="{classes}" data-col-hide-group="{group_key}" '
+        f"{status_attrs} {marker_attrs}>"
         f"{body}{tooltip}</td>"
     )
 
@@ -1581,7 +1640,10 @@ def _render_no_reasoning_cell_html(tool_family: str, case_id: str) -> str:
     group_key = html_lib.escape(_case_group_key(case_id))
     tooltip = _no_reasoning_tooltip_html(case_id, tool_family)
     return (
-        f'<td class="{classes}" data-col-hide-group="{group_key}">' f"n/a{tooltip}</td>"
+        f'<td class="{classes}" data-col-hide-group="{group_key}" '
+        'data-status-dynamo="na" data-status-vllm="na" data-status-sglang="na" '
+        'data-marker-dynamo="n/a" data-marker-vllm="n/a" data-marker-sglang="n/a">'
+        f"n/a{tooltip}</td>"
     )
 
 

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -512,6 +512,64 @@ def _overview_status_attrs(case: dict[str, Any] | None, family: str | None) -> s
     )
 
 
+def _canonical_reasoning_output(block: object) -> str | None:
+    if not isinstance(block, dict) or "unavailable" in block or "error" in block:
+        return None
+    return _canonical(block)
+
+
+def _selected_parity_marker(
+    case: dict[str, Any] | None,
+    family: str | None,
+    impl: str,
+) -> str | None:
+    if case is None or "expected" not in case:
+        return None
+    expected = case.get("expected", {})
+    outputs = {
+        impl: _canonical_reasoning_output(expected.get(impl))
+        for impl in ("dynamo", "vllm", "sglang")
+    }
+    if any(value is None for value in outputs.values()):
+        return None
+    if outputs["dynamo"] == outputs["vllm"] == outputs["sglang"]:
+        return "="
+    selected = outputs[impl]
+    peers = (
+        ("dynamo", "D"),
+        ("vllm", "V"),
+        ("sglang", "S"),
+    )
+    marker = "".join(
+        letter for peer, letter in peers if peer != impl and outputs[peer] != selected
+    )
+    return marker or "="
+
+
+def _selected_parity_suffix(
+    case: dict[str, Any] | None,
+    family: str | None,
+    impl: str,
+) -> str:
+    if case is None or "expected" not in case:
+        return ""
+    block = case.get("expected", {}).get(impl)
+    if isinstance(block, dict) and _block_leak_reason(block, family):
+        return "↯"
+    return ""
+
+
+def _parity_marker(
+    case: dict[str, Any] | None,
+    family: str | None,
+    impl: str,
+) -> str:
+    marker = _selected_parity_marker(case, family, impl)
+    if marker is None:
+        return _parser_marker(case, family, impl)
+    return marker + _selected_parity_suffix(case, family, impl)
+
+
 def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -> str:
     if case is None:
         return "—"
@@ -526,22 +584,22 @@ def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -
     if _block_leak_reason(block, family):
         return "↯"
     if impl == "dynamo":
-        return _cell(case, family)[0].replace("↯", "") or "="
-
-    dyn = expected.get("dynamo")
-    if not isinstance(dyn, dict):
-        return "n/a"
-    if _canonical(block) == _canonical(dyn):
-        return "="
-    suffix = "?" if "reason" not in block else ""
-    return ("V" if impl == "vllm" else "S") + suffix
+        peers = (expected.get("vllm"), expected.get("sglang"))
+        if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
+            return "·"
+    return "="
 
 
 def _parser_marker_attrs(case: dict[str, Any] | None, family: str | None) -> str:
-    return " ".join(
+    attrs = [
         f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, family, impl))}"'
         for impl in ("dynamo", "vllm", "sglang")
+    ]
+    attrs.extend(
+        f'data-marker-parity-{impl}="{html_lib.escape(_parity_marker(case, family, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
     )
+    return " ".join(attrs)
 
 
 def _load() -> tuple[dict[str, dict[str, Any]], list[str], dict[tuple[str, str], Path]]:
@@ -718,8 +776,8 @@ def _cell(case: dict[str, Any] | None, family: str | None = None) -> tuple[str, 
 
     if unavailable == 2:
         if dynamo_leak:
-            return "↯D", "\n".join(p for p in tooltip_parts if p)
-        return "D", "\n".join(p for p in tooltip_parts if p)
+            return "↯·", "\n".join(p for p in tooltip_parts if p)
+        return "·", "\n".join(p for p in tooltip_parts if p)
     if dynamo_leak:
         return "↯" + ("".join(markers) or "?"), "\n".join(p for p in tooltip_parts if p)
     if markers:
@@ -1490,7 +1548,7 @@ def _tooltip_html(
         return build_parity_tooltip_html(
             head=head,
             description=str(description) if description else None,
-            extra_sections=[("Why n/a", linkify_text_html(str(reason)))],
+            extra_sections=[("Why not applicable", linkify_text_html(str(reason)))],
             refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
         )
 
@@ -1583,7 +1641,7 @@ def _no_reasoning_tooltip_html(case_id: str, tool_family: str) -> str:
         head=f"{case_id} — {tool_family}",
         extra_sections=[
             (
-                "Why n/a",
+                "Why not applicable",
                 html_lib.escape(
                     "This tool calling parser row has no mapped Dynamo reasoning "
                     "parser fixture."
@@ -1642,7 +1700,9 @@ def _render_no_reasoning_cell_html(tool_family: str, case_id: str) -> str:
     return (
         f'<td class="{classes}" data-col-hide-group="{group_key}" '
         'data-status-dynamo="na" data-status-vllm="na" data-status-sglang="na" '
-        'data-marker-dynamo="n/a" data-marker-vllm="n/a" data-marker-sglang="n/a">'
+        'data-marker-dynamo="n/a" data-marker-vllm="n/a" data-marker-sglang="n/a" '
+        'data-marker-parity-dynamo="n/a" data-marker-parity-vllm="n/a" '
+        'data-marker-parity-sglang="n/a">'
         f"n/a{tooltip}</td>"
     )
 
@@ -1953,7 +2013,7 @@ def _compute_stats(
                 stats["real"] += 1
                 if marker == "=":
                     stats["parity"] += 1
-                elif marker == "D":
+                elif marker in {"D", "·"}:
                     stats["dynamo_only"] += 1
                 elif "!" in marker:
                     stats["errors"] += 1
@@ -2008,7 +2068,7 @@ def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
     legend = (
         "<strong>Legend:</strong> "
         '<span style="color:#0a7d2c">=</span> all captured peers match Dynamo · '
-        '<span style="color:#555">D</span> Dynamo-only fixture '
+        '<span style="color:#8b949e">·</span> Dynamo-only fixture '
         "(both peers unavailable) · "
         '<span style="color:#555">V/S</span> divergence '
         "(V = vLLM, S = SGLang; intentional, has <code>reason:</code>) · "

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -587,7 +587,7 @@ def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -
         peers = (expected.get("vllm"), expected.get("sglang"))
         if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
             return "·"
-    return "="
+    return ""
 
 
 def _parser_marker_attrs(case: dict[str, Any] | None, family: str | None) -> str:

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -567,7 +567,7 @@ def _parity_marker(
     marker = _selected_parity_marker(case, family, impl)
     if marker is None:
         return _parser_marker(case, family, impl)
-    return marker + _selected_parity_suffix(case, family, impl)
+    return _selected_parity_suffix(case, family, impl) + marker
 
 
 def _parser_marker(case: dict[str, Any] | None, family: str | None, impl: str) -> str:

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -47,10 +47,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm: &d_5_b
-        reason: "vLLM and SGLang preserve orphan DSML markers as content when the opening <｜DSML｜function_calls> wrapper is missing; Dynamo strips the orphan marker tail."
+        reason: "vLLM and SGLang preserve orphan DSML markers as content when the opening <｜DSML｜function_calls> wrapper is missing; Dynamo recovers the complete bare <｜DSML｜invoke> call and strips the orphan marker tail."
         calls: []
         normal_text: |-
           <｜DSML｜invoke name="get_weather">

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.batch.5.yaml
@@ -46,15 +46,17 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
-        reason: "Dynamo's DSML parser leaves <｜DSML｜…> envelope in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &d_5_b
+        reason: "vLLM and SGLang preserve orphan DSML markers as content when the opening <｜DSML｜function_calls> wrapper is missing; Dynamo strips the orphan marker tail."
         calls: []
         normal_text: |-
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
           </｜DSML｜function_calls>
-      vllm: *d_5_b
       sglang: *d_5_b
   TOOLCALLING.batch.5.c:
     description: Truncation mid-parameter value

--- a/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v3_2/TOOLCALLING.stream.4.yaml
@@ -83,13 +83,11 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
-        normal_text: |-
-          <｜DSML｜invoke name="get_weather">
-          <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-          </｜DSML｜invoke>
-          </｜DSML｜invoke>
-          </｜DSML｜invoke>
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
       vllm:
         calls:
         - name: get_weather

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -46,10 +46,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
-        reason: "vLLM leaks the DSML envelope into normal_text on missing/orphan end marker recovery; Dynamo strips the orphan DSML marker tail."
+        reason: "vLLM leaks the DSML envelope into normal_text on missing/orphan end marker recovery; Dynamo recovers the complete bare <｜DSML｜invoke> call and strips the orphan DSML marker tail."
         calls: []
         normal_text: |-
           <｜DSML｜invoke name="get_weather">

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -177,11 +177,11 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: |-
+        normal_text: |
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
           </｜DSML｜tool_calls>
-        reason: "vLLM preserves the bare DSML invoke before the first <｜DSML｜tool_calls> as content; Dynamo recovers it as the first structured call before parsing the wrapped call."
+        reason: "vLLM preserves the bare DSML invoke before the first <｜DSML｜tool_calls> as content, including the trailing newline; Dynamo recovers it as the first structured call before parsing the wrapped call."
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -147,3 +147,41 @@ cases:
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">New York
         reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"
+  TOOLCALLING.batch.5.f:
+    description: Bare valid invoke before a complete wrapped call
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |-
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          </｜DSML｜tool_calls>
+        reason: "vLLM preserves the bare DSML invoke before the first <｜DSML｜tool_calls> as content; Dynamo recovers it as the first structured call before parsing the wrapped call."
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.batch.5.yaml
@@ -45,15 +45,17 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
-        reason: "Dynamo's DSML parser leaves <｜DSML｜…> envelope in normal_text on missing/orphan end marker (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        reason: "vLLM leaks the DSML envelope into normal_text on missing/orphan end marker recovery; Dynamo strips the orphan DSML marker tail."
         calls: []
         normal_text: |-
           <｜DSML｜invoke name="get_weather">
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
           </｜DSML｜invoke>
           </｜DSML｜tool_calls>
-      vllm: *d_5_b
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   TOOLCALLING.batch.5.c:

--- a/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/deepseek_v4/TOOLCALLING.stream.4.yaml
@@ -81,13 +81,11 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
-        normal_text: |-
-          <｜DSML｜invoke name="get_weather">
-          <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-          </｜DSML｜invoke>
-          </｜DSML｜invoke>
-          </｜DSML｜invoke>
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
       vllm:
         calls:
         - name: get_weather

--- a/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.4.yaml
@@ -69,8 +69,8 @@ cases:
         reason: SGLang leaks the tool call tag into normal_text on the recovery path
   TOOLCALLING.batch.4.d:
     description: Mismatched sentinels
-    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L252
-    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+    ref: dynamo
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}</tool_call>
     tools:
     - *id001
     expected:
@@ -79,11 +79,11 @@ cases:
         normal_text: ''
       vllm:
         calls: []
-        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}</tool_call>
         reason: vLLM leaks the tool call tag into normal_text on the recovery path
       sglang:
         calls: []
-        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}</tool_call>
         reason: SGLang leaks the tool call tag into normal_text on the recovery path
   TOOLCALLING.batch.4.e:
     description: Malformed-prefix recovery — n/a for this family's syntax

--- a/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.5.yaml
@@ -18,16 +18,19 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-        reason: vLLM leaks the tool call tag into normal_text on the recovery path
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path; Dynamo recovers the complete call body with only the end marker missing.
       sglang:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-        reason: SGLang leaks the tool call tag into normal_text on the recovery path
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path; Dynamo recovers the complete call body with only the end marker missing.
   TOOLCALLING.batch.5.b:
     description: Closing <tool_call|> without matching <|tool_call> open
     ref: dynamo
@@ -36,16 +39,19 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
         normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-        reason: vLLM leaks the tool call tag into normal_text on the recovery path
+        reason: vLLM leaks the tool call tag into normal_text on the recovery path; Dynamo recovers the complete call body with only the start marker missing.
       sglang:
         calls: []
         normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-        reason: SGLang leaks the tool call tag into normal_text on the recovery path
+        reason: SGLang leaks the tool call tag into normal_text on the recovery path; Dynamo recovers the complete call body with only the start marker missing.
   TOOLCALLING.batch.5.c:
     description: Truncation mid-argument value
     ref: dynamo
@@ -72,13 +78,22 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: &id002
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *id002
+        reason: vLLM drops the trailing Gemma call when only the final <tool_call|> marker is missing; Dynamo recovers the complete trailing call body.
       sglang: *id002
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value

--- a/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.batch.5.yaml
@@ -111,3 +111,27 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm: *id003
       sglang: *id003
+  TOOLCALLING.batch.5.f:
+    description: Bare valid call before a complete wrapped call
+    ref: dynamo
+    model_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>Boston<|"|>}<tool_call|>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm: &id004
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+        reason: vLLM and SGLang treat the bare Gemma call before the first <|tool_call> marker as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+      sglang: *id004

--- a/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/gemma4/TOOLCALLING.stream.4.yaml
@@ -20,22 +20,19 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      sglang:
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-        reason: SGLang recovers a call before the required `<tool_call|>` end marker; Dynamo follows Gemma4 batch.5 and drops incomplete envelopes without leaking markup.
+      sglang: *id001
       vllm:
         calls:
         - name: get_weather
           arguments: '{"location": "NYC'
         normal_text: ''
-        reason: vLLM emits partial arguments before the required `<tool_call|>` end marker; Dynamo follows Gemma4 batch.5 and drops incomplete envelopes without leaking markup.
+        reason: vLLM emits partial arguments before the required `<tool_call|>` end marker; Dynamo and SGLang recover the complete call body.
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from TOOLCALLING.batch.5.c
@@ -83,8 +80,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &id002
         calls: []
         normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><tool_call|><tool_call|>
-      vllm: *id001
-      sglang: *id001
+        reason: vLLM preserves the raw Gemma call body as content when the opening <|tool_call> marker is missing; Dynamo recovers the complete bare call body and drops close-marker spam.
+      sglang: *id002

--- a/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
@@ -132,3 +132,27 @@ cases:
         calls: []
         normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       sglang: *id005
+  TOOLCALLING.batch.5.g:
+    description: Bare valid call before a complete wrapped call
+    ref: dynamo
+    model_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call>
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm: &id006
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+        reason: vLLM and SGLang preserve the bare GLM call before the first <tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+      sglang: *id006

--- a/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
@@ -114,3 +114,21 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
           York
         reason: SGLang preserves the trailing truncated <tool_call>... block as content; Dynamo and vLLM both drop it
+  TOOLCALLING.batch.5.f:
+    description: Closing </tool_call> without matching <tool_call> open after prefix prose
+    ref: dynamo
+    model_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check that. '
+      vllm: &id005
+        reason: "vLLM and SGLang preserve orphan GLM <arg_key>/<arg_value>/</tool_call> markup as content when opening <tool_call> is missing; Dynamo preserves the prefix prose, recovers the complete bare call body, and strips the orphan close marker."
+        calls: []
+        normal_text: I will check that. get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+      sglang: *id005

--- a/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
@@ -33,10 +33,13 @@ cases:
     - *id002
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm: &id003
-        reason: "vLLM and SGLang preserve orphan GLM <arg_key>/<arg_value>/</tool_call> markup as content when opening <tool_call> is missing; Dynamo strips the orphan marker tail."
+        reason: "vLLM and SGLang preserve orphan GLM <arg_key>/<arg_value>/</tool_call> markup as content when opening <tool_call> is missing; Dynamo recovers the complete bare call body and strips the orphan close marker."
         calls: []
         normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       sglang: *id003

--- a/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.batch.5.yaml
@@ -32,11 +32,13 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's glm47 parser leaves closing </tool_call> tag, <arg_key>/<arg_value> tags in normal_text when opening <tool_call> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id003
+        reason: "vLLM and SGLang preserve orphan GLM <arg_key>/<arg_value>/</tool_call> markup as content when opening <tool_call> is missing; Dynamo strips the orphan marker tail."
         calls: []
         normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arg_value

--- a/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/glm47/TOOLCALLING.stream.4.yaml
@@ -126,10 +126,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call></tool_call></tool_call>
-      vllm: *id001
+        reason: vLLM preserves the raw GLM call body as content when the opening <tool_call> marker is missing; Dynamo recovers the complete bare call body and drops close-marker spam.
       sglang:
         calls: []
         normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+        reason: SGLang strips orphan GLM close markers but does not recover the complete bare call body; Dynamo emits the recovered call.

--- a/tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml
@@ -28,20 +28,23 @@ cases:
         normal_text: ''
         reason: "impl-defined recovery contract (see TOOLCALLING_CASES.md)"
   TOOLCALLING.batch.5.b:
-    description: Bare <|call|> without preceding channel envelope
+    description: Complete commentary tool call without <|start|>assistant prefix
     ref: "OpenAI Harmony tool-call stop token: https://developers.openai.com/cookbook/articles/openai-harmony#receiving-tool-calls"
-    model_text: <|call|>
+    model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
     tools:
     - *id001
     expected:
       dynamo: &d_5_b
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm: *d_5_b
       sglang:
         calls: []
-        normal_text: <|call|>
-        reason: "Dynamo/vLLM are more spec-correct: '<|call|>' is a control stop token, not user-visible text; SGLang preserves raw markup"
+        normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+        reason: "SGLang requires the full Harmony <|start|>assistant prefix before it classifies a commentary function call; Dynamo recovers the complete call without that prefix."
   TOOLCALLING.batch.5.c:
     description: Truncation mid-message JSON
     ref: dynamo

--- a/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -103,11 +103,20 @@ cases:
           arguments:
             location: Boston
         normal_text: ''
-      vllm: &id007
+      vllm:
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
-        reason: vLLM and SGLang preserve the bare Kimi call before the first <|tool_calls_section_begin|> as content; Dynamo recovers it as the first structured call before parsing the wrapped section.
-      sglang: *id007
+        reason: vLLM preserves the bare Kimi call before the first <|tool_calls_section_begin|> as content; Dynamo recovers it as the first structured call before parsing the wrapped section.
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+        reason: SGLang parses the bare Kimi call as a structured call and also preserves the orphan section as normal_text; Dynamo recovers both calls and strips the orphan section markers.

--- a/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -32,11 +32,13 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id003
-        reason: "Dynamo's kimi_k2 parser leaves <|tool_call_begin|>, <|tool_call_argument_begin|>, <|tool_call_end|>, <|tool_calls_section_end|> tokens in normal_text when opening <|tool_calls_section_begin|> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id003
+        reason: "vLLM and SGLang preserve orphan Kimi tool-call markers as content when opening <|tool_calls_section_begin|> is missing; Dynamo strips the orphan marker tail."
         calls: []
         normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
-      vllm: *id003
       sglang: *id003
   TOOLCALLING.batch.5.c:
     description: Truncation mid-arguments (incomplete JSON body)

--- a/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -107,9 +107,12 @@ cases:
         calls:
         - name: get_weather
           arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
             location: Boston
         normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
-        reason: vLLM preserves the bare Kimi call before the first <|tool_calls_section_begin|> as content; Dynamo recovers it as the first structured call before parsing the wrapped section.
+        reason: vLLM parses the bare Kimi call as a structured call and also preserves the orphan section as normal_text; Dynamo recovers both calls and strips the orphan section markers.
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -33,10 +33,13 @@ cases:
     - *id002
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm: &id003
-        reason: "vLLM and SGLang preserve orphan Kimi tool-call markers as content when opening <|tool_calls_section_begin|> is missing; Dynamo strips the orphan marker tail."
+        reason: "vLLM and SGLang preserve orphan Kimi tool-call markers as content when opening <|tool_calls_section_begin|> is missing; Dynamo recovers the complete bare <|tool_call_begin|> body and strips the orphan section close marker."
         calls: []
         normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       sglang: *id003

--- a/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.batch.5.yaml
@@ -87,3 +87,27 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm: *id006
       sglang: *id006
+  TOOLCALLING.batch.5.f:
+    description: Bare valid call before a complete wrapped section
+    ref: dynamo
+    model_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|><|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"Boston"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm: &id007
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+        reason: vLLM and SGLang preserve the bare Kimi call before the first <|tool_calls_section_begin|> as content; Dynamo recovers it as the first structured call before parsing the wrapped section.
+      sglang: *id007

--- a/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/kimi_k2/TOOLCALLING.stream.4.yaml
@@ -92,12 +92,13 @@ cases:
             type: string
     expected:
       dynamo: &id001
-        calls: []
-        normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_end|><|tool_call_end|>
-      vllm: *id001
-      sglang:
         calls:
         - arguments:
             location: NYC
           name: get_weather
         normal_text: ''
+      vllm:
+        calls: []
+        normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_end|><|tool_call_end|>
+        reason: vLLM preserves the raw Kimi call body as content when the opening <|tool_calls_section_begin|> marker is missing; Dynamo recovers the complete bare call body and drops close-marker spam.
+      sglang: *id001

--- a/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -23,11 +23,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: |-
-          <minimax:tool_call>
-          <invoke name="get_weather">
-          <parameter name="location">NYC</parameter>
-          </invoke>
+        normal_text: ''
       vllm:
         calls: []
         normal_text: |-
@@ -55,15 +51,17 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &id002
-        reason: "Dynamo's minimax_m2 parser leaves </invoke>, </parameter> closing tags plus their content in normal_text when opening <minimax:tool_call> marker is missing (impl-defined recovery)"
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id002
+        reason: "vLLM and SGLang preserve orphan MiniMax invoke/parameter markers as content when opening <minimax:tool_call> is missing; Dynamo strips the orphan marker tail."
         calls: []
         normal_text: |-
           <invoke name="get_weather">
           <parameter name="location">NYC</parameter>
           </invoke>
           </minimax:tool_call>
-      vllm: *id002
       sglang: *id002
   TOOLCALLING.batch.5.c:
     description: Truncation mid-parameter value
@@ -77,10 +75,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: |-
-          <minimax:tool_call>
-          <invoke name="get_weather">
-          <parameter name="location">NY
+        normal_text: ''
       vllm:
         calls: []
         normal_text: |-
@@ -112,15 +107,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: |-
-          I'll start by fetching the weather for both Boston and New York at the same time!
-          <minimax:tool_call>
-          <invoke name="get_weather">
-          <parameter name="location">Boston</parameter>
-          </invoke>
-          <invoke name="get_weather">
-          <parameter name="location">New York</parameter>
-          </invoke>
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls: []
         normal_text: |-
@@ -132,6 +119,7 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">New York</parameter>
           </invoke>
+        reason: vLLM preserves the unterminated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
       sglang:
         calls: []
         normal_text: |-
@@ -143,6 +131,7 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">New York</parameter>
           </invoke>
+        reason: SGLang preserves the unterminated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -159,14 +148,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: |-
-          I'll start by fetching the weather for both Boston and New York at the same time!
-          <minimax:tool_call>
-          <invoke name="get_weather">
-          <parameter name="location">Boston</parameter>
-          </invoke>
-          <invoke name="get_weather">
-          <parameter name="location">New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls: []
         normal_text: |-
@@ -177,6 +159,7 @@ cases:
           </invoke>
           <invoke name="get_weather">
           <parameter name="location">New York
+        reason: vLLM preserves the truncated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
       sglang:
         calls: []
         normal_text: |-
@@ -187,3 +170,4 @@ cases:
           </invoke>
           <invoke name="get_weather">
           <parameter name="location">New York
+        reason: SGLang preserves the truncated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.

--- a/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -188,3 +188,40 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">New York
         reason: SGLang preserves the truncated MiniMax tool-call block as content; Dynamo preserves prefix text, recovers the complete prior <invoke> call, and drops the incomplete trailing invoke.
+  TOOLCALLING.batch.5.f:
+    description: Bare valid invoke before a complete wrapped call
+    ref: dynamo
+    model_text: |-
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      </minimax:tool_call>
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">Boston</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm: &id003
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |-
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          </minimax:tool_call>
+        reason: vLLM and SGLang preserve the bare MiniMax invoke before the first <minimax:tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+      sglang: *id003

--- a/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -22,7 +22,10 @@ cases:
             type: string
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm:
         calls: []
@@ -31,7 +34,7 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">NYC</parameter>
           </invoke>
-        reason: impl-defined recovery contract (see TOOLCALLING_CASES.md)
+        reason: vLLM preserves a MiniMax block with a missing outer </minimax:tool_call> close as content; Dynamo recovers the complete inner <invoke> call.
       sglang:
         calls: []
         normal_text: |-
@@ -39,7 +42,7 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">NYC</parameter>
           </invoke>
-        reason: impl-defined recovery contract (see TOOLCALLING_CASES.md)
+        reason: SGLang preserves a MiniMax block with a missing outer </minimax:tool_call> close as content; Dynamo recovers the complete inner <invoke> call.
   TOOLCALLING.batch.5.b:
     description: Closing </minimax:tool_call> without matching open
     ref: dynamo
@@ -52,10 +55,13 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
         normal_text: ''
       vllm: &id002
-        reason: "vLLM and SGLang preserve orphan MiniMax invoke/parameter markers as content when opening <minimax:tool_call> is missing; Dynamo strips the orphan marker tail."
+        reason: "vLLM and SGLang preserve orphan MiniMax invoke/parameter markers as content when opening <minimax:tool_call> is missing; Dynamo recovers the complete inner <invoke> call and drops the orphan close marker."
         calls: []
         normal_text: |-
           <invoke name="get_weather">
@@ -106,8 +112,15 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls: []
         normal_text: |-
@@ -119,7 +132,7 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">New York</parameter>
           </invoke>
-        reason: vLLM preserves the unterminated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
+        reason: vLLM preserves the unterminated MiniMax tool-call block as content; Dynamo preserves prefix text and recovers the complete inner <invoke> calls.
       sglang:
         calls: []
         normal_text: |-
@@ -131,7 +144,7 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">New York</parameter>
           </invoke>
-        reason: SGLang preserves the unterminated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
+        reason: SGLang preserves the unterminated MiniMax tool-call block as content; Dynamo preserves prefix text and recovers the complete inner <invoke> calls.
   TOOLCALLING.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -147,8 +160,12 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls: []
         normal_text: |-
@@ -159,7 +176,7 @@ cases:
           </invoke>
           <invoke name="get_weather">
           <parameter name="location">New York
-        reason: vLLM preserves the truncated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
+        reason: vLLM preserves the truncated MiniMax tool-call block as content; Dynamo preserves prefix text, recovers the complete prior <invoke> call, and drops the incomplete trailing invoke.
       sglang:
         calls: []
         normal_text: |-
@@ -170,4 +187,4 @@ cases:
           </invoke>
           <invoke name="get_weather">
           <parameter name="location">New York
-        reason: SGLang preserves the truncated MiniMax tool-call block as content; Dynamo strips it after preserving prefix text.
+        reason: SGLang preserves the truncated MiniMax tool-call block as content; Dynamo preserves prefix text, recovers the complete prior <invoke> call, and drops the incomplete trailing invoke.

--- a/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -218,12 +218,12 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: |-
+        normal_text: |
           <invoke name="get_weather">
           <parameter name="location">NYC</parameter>
           </invoke>
           </minimax:tool_call>
-        reason: vLLM preserves the bare MiniMax invoke before the first <minimax:tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+        reason: vLLM preserves the bare MiniMax invoke before the first <minimax:tool_call> as content, including the trailing newline; Dynamo recovers it as the first structured call before parsing the wrapped call.
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.batch.5.yaml
@@ -213,7 +213,7 @@ cases:
           arguments:
             location: Boston
         normal_text: ''
-      vllm: &id003
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -223,5 +223,15 @@ cases:
           <parameter name="location">NYC</parameter>
           </invoke>
           </minimax:tool_call>
-        reason: vLLM and SGLang preserve the bare MiniMax invoke before the first <minimax:tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
-      sglang: *id003
+        reason: vLLM preserves the bare MiniMax invoke before the first <minimax:tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          </minimax:tool_call>
+        reason: SGLang preserves the bare MiniMax invoke before the first <minimax:tool_call> as content, including the trailing newline; Dynamo recovers it as the first structured call before parsing the wrapped call.

--- a/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.stream.4.yaml
+++ b/tests/parity/toolcalling/fixtures/minimax_m2/TOOLCALLING.stream.4.yaml
@@ -25,35 +25,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        reason: |-
-          Strict per MiniMax-M2.7's published parser regexes: the outer
-          <minimax:tool_call>...</minimax:tool_call> block must be paired, so
-          a stream that ends before </minimax:tool_call> recovers no call.
-          Dynamo drops the buffered protocol block from normal_text so
-          tool-call markup does not leak to user-facing content.
-        calls: []
-        normal_text: ''
-      sglang:
+      dynamo: &d_4_a
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-        reason: |-
-          SGLang's streaming parser recovers a MiniMax call from a body that
-          lacks the required closing </minimax:tool_call>; that contradicts
-          the strict MiniMax-M2.7 reference parser.
-      vllm:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
-        reason: |-
-          vLLM's streaming parser recovers a MiniMax call from a body that
-          lacks the required closing </minimax:tool_call>; that contradicts
-          the strict MiniMax-M2.7 reference parser.
+      sglang: *d_4_a
+      vllm: *d_4_a
   TOOLCALLING.stream.4.b:
     description: Stream terminates mid-call body before the in-flight argument payload is complete
     ref: derived from TOOLCALLING.batch.5.c
@@ -115,7 +94,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id002
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm: &id002
         calls: []
         normal_text: |-
           <invoke name="get_weather">
@@ -123,5 +108,7 @@ cases:
           </invoke>
           </invoke>
           </invoke>
-      vllm: *id002
-      sglang: *id002
+        reason: vLLM preserves the bare MiniMax invoke and orphan close-marker spam as content; Dynamo recovers the complete inner <invoke> call and drops the orphan marker tail.
+      sglang:
+        <<: *id002
+        reason: SGLang preserves the bare MiniMax invoke and orphan close-marker spam as content; Dynamo recovers the complete inner <invoke> call and drops the orphan marker tail.

--- a/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/nemotron_nano/TOOLCALLING.batch.4.yaml
@@ -22,10 +22,7 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: |-
-          <tool_call>
-          random text
-          </tool_call>
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.4.yaml
@@ -20,28 +20,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
+      dynamo: &d_4_a
         calls: []
-        normal_text: |-
-          <tool_call>
-          random text without function tag
-          </tool_call>
+        normal_text: ''
       vllm:
         calls: []
         normal_text: |-
           <tool_call>
           random text without function tag
           </tool_call>
-        reason: impl-defined recovery contract (see TOOLCALLING_CASES.md)
-      sglang:
-        calls: []
-        normal_text: ''
-        reason: |-
-          SGLang consumes the <tool_call>...</tool_call> wrapper into the parsed
-          region (normal_text=text[:start_idx_of_<tool_call>]) before scanning for
-          <function=...> bodies; when no body is found it emits zero calls and an
-          empty normal_text. Dynamo/vLLM preserve the unrecognized wrapper as
-          normal_text per impl-defined recovery contract (see TOOLCALLING_CASES.md).
+        reason: vLLM preserves a <tool_call> wrapper with no <function=...> body as content; Dynamo/SGLang strip the invalid wrapper.
+      sglang: *d_4_a
   TOOLCALLING.batch.4.d:
     description: Missing </parameter> closing tag
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L729
@@ -92,14 +81,9 @@ cases:
           command:
             type: string
     expected:
-      dynamo:
+      dynamo: &d_4_f
         calls: []
-        normal_text: |-
-          <tool_call>
-          <terminal>
-          echo hello
-          </function>
-          </tool_call>
+        normal_text: ''
       vllm:
         calls: []
         normal_text: |-
@@ -108,8 +92,5 @@ cases:
           echo hello
           </function>
           </tool_call>
-        reason: <terminal> is not valid Qwen3-Coder grammar; the function opener must be <function=Terminal>.
-      sglang:
-        calls: []
-        normal_text: ''
-        reason: SGLang consumes the outer <tool_call> region before scanning for <function=...>; with no valid function opener it emits no calls and no normal_text.
+        reason: <terminal> is not valid Qwen3-Coder grammar; vLLM preserves the invalid wrapper as content, while Dynamo/SGLang strip it.
+      sglang: *d_4_f

--- a/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
@@ -178,3 +178,46 @@ cases:
           requires the closing sentinel, so the trailing call truncated mid-arg
           value is dropped. Dynamo/vLLM recover the partial value
           (location='New York') and emit the call.
+  TOOLCALLING.batch.5.f:
+    description: Bare valid function before a complete wrapped call
+    ref: dynamo
+    model_text: |-
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Boston
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+      vllm: &id006
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |-
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>
+        reason: vLLM and SGLang preserve the bare Qwen function before the first <tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+      sglang: *id006

--- a/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
@@ -212,14 +212,14 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: |-
+        normal_text: |
           <function=get_weather>
           <parameter=location>
           NYC
           </parameter>
           </function>
           </tool_call>
-        reason: vLLM preserves the bare Qwen function before the first <tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+        reason: vLLM preserves the bare Qwen function before the first <tool_call> as content, including the trailing newline; Dynamo recovers it as the first structured call before parsing the wrapped call.
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
+++ b/tests/parity/toolcalling/fixtures/qwen3_coder/TOOLCALLING.batch.5.yaml
@@ -207,7 +207,7 @@ cases:
           arguments:
             location: Boston
         normal_text: ''
-      vllm: &id006
+      vllm:
         calls:
         - name: get_weather
           arguments:
@@ -219,5 +219,17 @@ cases:
           </parameter>
           </function>
           </tool_call>
-        reason: vLLM and SGLang preserve the bare Qwen function before the first <tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
-      sglang: *id006
+        reason: vLLM preserves the bare Qwen function before the first <tool_call> as content; Dynamo recovers it as the first structured call before parsing the wrapped call.
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>
+        reason: SGLang preserves the bare Qwen function before the first <tool_call> as content, including the trailing newline; Dynamo recovers it as the first structured call before parsing the wrapped call.

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -601,6 +601,67 @@ def _dynamo_tool_call_leak(dyn: dict) -> str | None:
     return str(dyn["reason"])
 
 
+def _block_tool_call_leaks(block: dict) -> bool:
+    normal_text = block.get("normal_text")
+    return isinstance(normal_text, str) and bool(
+        _TOOL_CALL_MARKUP_RE.search(normal_text)
+    )
+
+
+def _overview_status(case: dict | None, impl: str) -> str:
+    if case is None or "expected" not in case:
+        return "na"
+    block = case.get("expected", {}).get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "na"
+    if "error" in block or _block_tool_call_leaks(block):
+        return "problem"
+    return "ok"
+
+
+def _overview_status_attrs(case: dict | None) -> str:
+    return " ".join(
+        f'data-status-{impl}="{_overview_status(case, impl)}"'
+        for impl in ("dynamo", "vllm", "sglang")
+    )
+
+
+def _parser_marker(case: dict | None, impl: str) -> str:
+    if case is None:
+        return "—"
+    if "expected" not in case:
+        return "n/a"
+    expected = case.get("expected", {})
+    block = expected.get(impl)
+    if not isinstance(block, dict) or "unavailable" in block:
+        return "n/a"
+    if "error" in block:
+        return "!"
+    if _block_tool_call_leaks(block):
+        return "↯"
+    if impl == "dynamo":
+        return cell_for(case).replace("↯", "") or "="
+
+    dyn = expected.get("dynamo")
+    if not isinstance(dyn, dict):
+        return "n/a"
+    kind, unknown = peer_status(case, dyn, impl)
+    if kind == "div":
+        return ("V" if impl == "vllm" else "S") + ("?" if unknown else "")
+    if kind == "err":
+        return "!"
+    if kind in {"na", "unavail"}:
+        return "n/a"
+    return "="
+
+
+def _parser_marker_attrs(case: dict | None) -> str:
+    return " ".join(
+        f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
+    )
+
+
 def cell_for(case: dict | None) -> str:
     if case is None:
         return "—"
@@ -881,7 +942,12 @@ def render_cell_html(case: dict | None, mode: str, family: str, sub: str) -> str
     cls = parity_cell_class(text)
     band_cls = _subcase_band_class(mode, sub)
     col_group = html_lib.escape(_subcase_group_key(mode, sub))
-    td_open = f'<td class="cell {cls} {band_cls}" data-col-hide-group="{col_group}">'
+    status_attrs = _overview_status_attrs(case)
+    marker_attrs = _parser_marker_attrs(case)
+    td_open = (
+        f'<td class="cell {cls} {band_cls}" data-col-hide-group="{col_group}" '
+        f"{status_attrs} {marker_attrs}>"
+    )
     if case is None:
         ttip = _build_missing_tooltip_html(mode, family, sub)
         return f"{td_open}{text}{ttip}</td>"

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -694,7 +694,7 @@ def _parser_marker(case: dict | None, impl: str) -> str:
         peers = (expected.get("vllm"), expected.get("sglang"))
         if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
             return "·"
-    return "="
+    return ""
 
 
 def _parser_marker_attrs(case: dict | None) -> str:

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -587,6 +587,7 @@ def peer_status(case: dict, dyn: dict, impl: str) -> tuple[str, bool]:
 
 _TOOL_CALL_MARKUP_RE = re.compile(
     r"</?tool_call|</?tool_calls|<\|tool_call|<\|tool_calls|"
+    r"<\|(?:channel|message|call|python_tag)\|>|"
     r"</?TOOLCALL|TOOL_CALLS|<｜(?:DSML｜)?(?:tool|tool▁call|tool▁calls)|"
     r"<｜DSML｜|</?minimax:tool_call|</?invoke|</?arg_key|</?arg_value"
 )

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -674,7 +674,7 @@ def _parity_marker(case: dict | None, impl: str) -> str:
     marker = _selected_parity_marker(case, impl)
     if marker is None:
         return _parser_marker(case, impl)
-    return marker + _selected_parity_suffix(case, impl)
+    return _selected_parity_suffix(case, impl) + marker
 
 
 def _parser_marker(case: dict | None, impl: str) -> str:

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -28,7 +28,7 @@ Cell markers (per peer, vllm + sglang):
         (research-needed; we observed it but haven't classified it)
   V!/S! peer has `error: <substring>` (expected to crash)
   VS, V?S, VS!, etc. — combinations
-  D     Dynamo-only fixture; both peer blocks are `unavailable`
+  ·     Dynamo-only fixture; both peer blocks are `unavailable`
   n/a   family/case doesn't apply
   —     no fixture entry exists for this family/case yet
 
@@ -626,6 +626,57 @@ def _overview_status_attrs(case: dict | None) -> str:
     )
 
 
+def _canonical_tool_output(block: object) -> dict | None:
+    if not isinstance(block, dict) or "unavailable" in block or "error" in block:
+        return None
+    if "calls" not in block and "normal_text" not in block:
+        return None
+    return {
+        "calls": block.get("calls") or [],
+        "normal_text": block.get("normal_text") or "",
+    }
+
+
+def _selected_parity_marker(case: dict | None, impl: str) -> str | None:
+    if case is None or "expected" not in case:
+        return None
+    expected = case.get("expected", {})
+    outputs = {
+        impl: _canonical_tool_output(expected.get(impl))
+        for impl in ("dynamo", "vllm", "sglang")
+    }
+    if any(value is None for value in outputs.values()):
+        return None
+    if outputs["dynamo"] == outputs["vllm"] == outputs["sglang"]:
+        return "="
+    selected = outputs[impl]
+    peers = (
+        ("dynamo", "D"),
+        ("vllm", "V"),
+        ("sglang", "S"),
+    )
+    marker = "".join(
+        letter for peer, letter in peers if peer != impl and outputs[peer] != selected
+    )
+    return marker or "="
+
+
+def _selected_parity_suffix(case: dict | None, impl: str) -> str:
+    if case is None or "expected" not in case:
+        return ""
+    block = case.get("expected", {}).get(impl)
+    if isinstance(block, dict) and _block_tool_call_leaks(block):
+        return "↯"
+    return ""
+
+
+def _parity_marker(case: dict | None, impl: str) -> str:
+    marker = _selected_parity_marker(case, impl)
+    if marker is None:
+        return _parser_marker(case, impl)
+    return marker + _selected_parity_suffix(case, impl)
+
+
 def _parser_marker(case: dict | None, impl: str) -> str:
     if case is None:
         return "—"
@@ -640,26 +691,22 @@ def _parser_marker(case: dict | None, impl: str) -> str:
     if _block_tool_call_leaks(block):
         return "↯"
     if impl == "dynamo":
-        return cell_for(case).replace("↯", "") or "="
-
-    dyn = expected.get("dynamo")
-    if not isinstance(dyn, dict):
-        return "n/a"
-    kind, unknown = peer_status(case, dyn, impl)
-    if kind == "div":
-        return ("V" if impl == "vllm" else "S") + ("?" if unknown else "")
-    if kind == "err":
-        return "!"
-    if kind in {"na", "unavail"}:
-        return "n/a"
+        peers = (expected.get("vllm"), expected.get("sglang"))
+        if all(isinstance(peer, dict) and "unavailable" in peer for peer in peers):
+            return "·"
     return "="
 
 
 def _parser_marker_attrs(case: dict | None) -> str:
-    return " ".join(
+    attrs = [
         f'data-marker-{impl}="{html_lib.escape(_parser_marker(case, impl))}"'
         for impl in ("dynamo", "vllm", "sglang")
+    ]
+    attrs.extend(
+        f'data-marker-parity-{impl}="{html_lib.escape(_parity_marker(case, impl))}"'
+        for impl in ("dynamo", "vllm", "sglang")
     )
+    return " ".join(attrs)
 
 
 def cell_for(case: dict | None) -> str:
@@ -687,7 +734,7 @@ def cell_for(case: dict | None) -> str:
     # markup, so don't mark those as `↯`.
     if isinstance(dyn, dict) and _dynamo_tool_call_leak(dyn):
         if v_kind == "unavail" and s_kind == "unavail":
-            return "↯D"
+            return "↯·"
         if parts:
             return "↯" + "".join(parts)
         return "↯"
@@ -695,7 +742,7 @@ def cell_for(case: dict | None) -> str:
     if parts:
         return "".join(parts)
     if v_kind == "unavail" and s_kind == "unavail":
-        return "D"
+        return "·"
     return "="
 
 
@@ -716,7 +763,7 @@ def render_row(
 _LEGEND_MD = (
     "**Legend:** "
     "`=` all captured peers match Dynamo · "
-    "`D` Dynamo-only fixture (both peers unavailable) · "
+    "`·` Dynamo-only fixture (both peers unavailable) · "
     "`V`/`S` divergence (V = vLLM, S = SGLang; intentional, has `reason:`) · "
     "`?` research-needed suffix (e.g. V?, S? — diverges with no `reason:` yet) · "
     "`↯` Dynamo leaks tool call markup into `normal_text` "
@@ -909,7 +956,7 @@ def _build_na_tooltip_html(case: dict) -> str:
     reason = case.get("reason") or "n/a (no reason given)"
     return build_parity_tooltip_html(
         head=head,
-        extra_sections=[("Why n/a", linkify_text_html(str(reason)))],
+        extra_sections=[("Why not applicable", linkify_text_html(str(reason)))],
         refs=[("Ref", case.get("ref")), ("Spec ref", case.get("spec_ref"))],
     )
 
@@ -1396,7 +1443,7 @@ def _compute_stats(
             s["real"] += 1
             if text == "=":
                 s["parity"] += 1
-            elif text == "D":
+            elif text in {"D", "·"}:
                 s["dynamo_only"] += 1
             elif "!" in text:
                 s["errors"] += 1

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -57,15 +57,49 @@ def test_generate_parser_parity_table_html() -> None:
     assert '<body class="view-overview parser-dynamo">' in html
     assert 'value="overview" data-view-toggle checked> Overview' in html
     assert 'value="details" data-view-toggle> Details' in html
-    assert 'value="dynamo" data-parser-toggle checked> Dynamo Rust parser' in html
-    assert 'value="vllm" data-parser-toggle> vLLM Python parser' in html
-    assert 'value="sglang" data-parser-toggle> SGLang Python parser' in html
+    assert 'value="dynamo" data-parser-toggle checked> Dynamo' in html
+    assert 'value="vllm" data-parser-toggle> vLLM' in html
+    assert 'value="sglang" data-parser-toggle> SGLang' in html
+    assert (
+        '<label class="checkbox-option parity-option"><input type="checkbox" data-parity-toggle> Parity</label>'
+        in html
+    )
+    assert ".view-overview .parity-option { display: none; }" in html
+    assert "td.cell { text-align: center; min-width: 24px; font-weight: 400; }" in html
+    assert 'td.cell[data-status-dynamo="na"]::before' in html
+    assert "data-marker-parity-vllm" in html
+    assert "content: attr(data-marker-parity-vllm)" in html
+    assert 'data-marker-dynamo="' in html
+    assert 'data-marker-dynamo="="' in html
+    assert 'data-marker-vllm="="' in html
+    assert 'data-marker-sglang="="' in html
+    assert "color: #aeb6bf;" in html
+    assert "background: #e4e8ec;" in html
+    assert 'data-marker-parity-dynamo="D"' not in html
+    assert 'data-marker-parity-vllm="V"' not in html
+    assert 'data-marker-parity-sglang="S"' not in html
+    assert 'data-marker-parity-dynamo="VS"' in html
+    assert 'data-marker-parity-vllm="DS"' in html
+    assert 'data-marker-parity-sglang="DV"' in html
+    assert 'data-marker-parity-dynamo="=↯"' in html
+    assert 'data-marker-parity-dynamo="VS↯"' in html
+    assert 'data-marker-dynamo="D!"' not in html
+    assert ".view-details.parity-mode .parity-explainer { display: block; }" in html
+    assert "<strong>Parity:</strong>" in html
+    assert "color: #8b949e;" in html
+    assert '<span style="color:#8b949e">·</span> Dynamo-only fixture' in html
+    assert 'data-marker-dynamo="·"' in html
+    assert '<span style="color:#555">D</span> Dynamo-only fixture' not in html
     assert "green = selected implementation output is clean" in html
     assert "red = selected implementation leaks parser markup" in html
+    assert "Why not applicable" in html
+    assert "Why n/a" not in html
     assert "get('view')" in html
     assert "get('parser')" in html
+    assert "get('parity')" in html
     assert "url.searchParams.set('view', view)" in html
     assert "url.searchParams.set('parser', parser)" in html
+    assert "url.searchParams.set('parity', '1')" in html
     assert "Tool calling family" in html
     assert "generate_parity_table.py toolcalling --html" in html
     assert "TOOLCALLING.batch.*" in html
@@ -74,13 +108,16 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'id="case-descriptions-stream"' in html
     assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
-    assert (
-        'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
-        'data-marker-dynamo="V" data-marker-vllm="↯" data-marker-sglang="n/a">'
-        '<a href="fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml">V</a>'
-        '<div class="ttip"><div class="ttip-head">TOOLCALLING.batch.4.a — deepseek_v4'
-        in html
+    assert re.search(
+        r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
+        r'data-marker-dynamo="=" data-marker-vllm="↯" data-marker-sglang="n/a" '
+        r'data-marker-parity-dynamo="=" data-marker-parity-vllm="↯" '
+        r'data-marker-parity-sglang="n/a"><a href="fixtures/deepseek_v4/TOOLCALLING\.batch\.4\.yaml">V</a>'
+        r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — deepseek_v4',
+        html,
     )
+    assert 'data-marker-vllm="!"' in html
+    assert 'data-marker-parity-vllm="!"' in html
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families
@@ -126,6 +163,8 @@ def test_generate_combined_parity_table_html() -> None:
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert "REASONING.batch." in html
     assert "REASONING.stream." in html
+    assert "Why not applicable" in html
+    assert "Why n/a" not in html
     assert "toolcalling/fixtures/" in "".join(links.hrefs)
     assert "reasoning/fixtures/" in "".join(links.hrefs)
     assert "../../lib/parsers/TOOLCALLING_CASES.md" in links.hrefs

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -118,6 +118,22 @@ def test_generate_parser_parity_table_html() -> None:
     )
     assert 'data-marker-vllm="!"' in html
     assert 'data-marker-parity-vllm="!"' in html
+    assert re.search(
+        r'data-status-dynamo="ok" data-status-vllm="ok" data-status-sglang="problem" '
+        r'data-marker-dynamo="" data-marker-vllm="" data-marker-sglang="↯" '
+        r'data-marker-parity-dynamo="S" data-marker-parity-vllm="S" '
+        r'data-marker-parity-sglang="↯DV"><a href="fixtures/harmony/TOOLCALLING\.batch\.yaml">S</a>'
+        r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.1 — harmony',
+        html,
+    )
+    assert re.search(
+        r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="ok" '
+        r'data-marker-dynamo="" data-marker-vllm="↯" data-marker-sglang="" '
+        r'data-marker-parity-dynamo="VS" data-marker-parity-vllm="↯DS" '
+        r'data-marker-parity-sglang="DV"><a href="fixtures/llama3_json/TOOLCALLING\.batch\.4\.yaml">VS</a>'
+        r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — llama3_json',
+        html,
+    )
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -81,8 +81,8 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'data-marker-parity-dynamo="VS"' in html
     assert 'data-marker-parity-vllm="DS"' in html
     assert 'data-marker-parity-sglang="DV"' in html
-    assert 'data-marker-parity-dynamo="=↯"' in html
-    assert 'data-marker-parity-dynamo="VS↯"' in html
+    assert 'data-marker-parity-dynamo="↯="' in html
+    assert 'data-marker-parity-dynamo="↯VS"' in html
     assert 'data-marker-dynamo="D!"' not in html
     assert ".view-details.parity-mode .parity-explainer { display: block; }" in html
     assert "<strong>Parity:</strong>" in html

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -54,6 +54,18 @@ def test_generate_parser_parity_table_html() -> None:
         r'data-col-toggle="model"[^>]+data-default-visible="true"[^>]+aria-pressed="true"',
         html,
     )
+    assert '<body class="view-overview parser-dynamo">' in html
+    assert 'value="overview" data-view-toggle checked> Overview' in html
+    assert 'value="details" data-view-toggle> Details' in html
+    assert 'value="dynamo" data-parser-toggle checked> Dynamo Rust parser' in html
+    assert 'value="vllm" data-parser-toggle> vLLM Python parser' in html
+    assert 'value="sglang" data-parser-toggle> SGLang Python parser' in html
+    assert "green = selected implementation output is clean" in html
+    assert "red = selected implementation leaks parser markup" in html
+    assert "get('view')" in html
+    assert "get('parser')" in html
+    assert "url.searchParams.set('view', view)" in html
+    assert "url.searchParams.set('parser', parser)" in html
     assert "Tool calling family" in html
     assert "generate_parity_table.py toolcalling --html" in html
     assert "TOOLCALLING.batch.*" in html
@@ -62,6 +74,13 @@ def test_generate_parser_parity_table_html() -> None:
     assert 'id="case-descriptions-stream"' in html
     assert "TOOLCALLING.batch.1</td><td>Single tool call" in html
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
+    assert (
+        'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
+        'data-marker-dynamo="V" data-marker-vllm="↯" data-marker-sglang="n/a">'
+        '<a href="fixtures/deepseek_v4/TOOLCALLING.batch.4.yaml">V</a>'
+        '<div class="ttip"><div class="ttip-head">TOOLCALLING.batch.4.a — deepseek_v4'
+        in html
+    )
     assert fixture_links
     assert len(fixture_families) > 10
     assert "deepseek_v3" in fixture_families

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -70,9 +70,9 @@ def test_generate_parser_parity_table_html() -> None:
     assert "data-marker-parity-vllm" in html
     assert "content: attr(data-marker-parity-vllm)" in html
     assert 'data-marker-dynamo="' in html
-    assert 'data-marker-dynamo="="' in html
-    assert 'data-marker-vllm="="' in html
-    assert 'data-marker-sglang="="' in html
+    assert 'data-marker-dynamo="="' not in html
+    assert 'data-marker-vllm="="' not in html
+    assert 'data-marker-sglang="="' not in html
     assert "color: #aeb6bf;" in html
     assert "background: #e4e8ec;" in html
     assert 'data-marker-parity-dynamo="D"' not in html
@@ -110,8 +110,8 @@ def test_generate_parser_parity_table_html() -> None:
     assert "TOOLCALLING.stream.1.a</td><td>Single complete tool-call payload" in html
     assert re.search(
         r'data-status-dynamo="ok" data-status-vllm="problem" data-status-sglang="na" '
-        r'data-marker-dynamo="=" data-marker-vllm="↯" data-marker-sglang="n/a" '
-        r'data-marker-parity-dynamo="=" data-marker-parity-vllm="↯" '
+        r'data-marker-dynamo="" data-marker-vllm="↯" data-marker-sglang="n/a" '
+        r'data-marker-parity-dynamo="" data-marker-parity-vllm="↯" '
         r'data-marker-parity-sglang="n/a"><a href="fixtures/deepseek_v4/TOOLCALLING\.batch\.4\.yaml">V</a>'
         r'<div class="ttip"><div class="ttip-head">TOOLCALLING\.batch\.4\.a — deepseek_v4',
         html,


### PR DESCRIPTION
#### Overview:

This PR recovers complete Top-N tool calls when only the wrapper marker is damaged, and keeps malformed marker tails out of `normal_text`.

#### Details:

Before:
<img width="1073" height="342" alt="image" src="https://github.com/user-attachments/assets/18a2ac1f-57ee-41b2-8f3c-24ce1513a04b" />

After:
<img width="1070" height="340" alt="image" src="https://github.com/user-attachments/assets/36b41a03-1f81-4c56-a152-0a3c95ca2279" />


- **How is this fixed?** Add family-specific recovery in the DSML, Gemma 4, GLM-4.7, Kimi K2, MiniMax, Qwen3-Coder XML, and Harmony parser paths so complete inner calls still become `tool_calls` while incomplete or malformed tails are stripped from `normal_text`.
- MiniMax recovers complete inner `<invoke>...</invoke>` calls when the outer `<minimax:tool_call>` wrapper is missing or truncated, while still dropping incomplete inner invoke/parameter tails.
- DSML recovers complete bare `<｜DSML｜invoke ...>` bodies without the outer block marker, with DeepSeek V4 and V3.2 fixtures aligned for `TOOLCALLING.batch.5.b` and `TOOLCALLING.stream.4.c`.
- Gemma 4 recovers complete `call:name{...}` bodies when either `<|tool_call>` or `<tool_call|>` is missing, including `TOOLCALLING.batch.5.{a,b,d}` and `TOOLCALLING.stream.4.{a,c}`.
- GLM-4.7 and Kimi K2 recover complete orphan call bodies when the section/tool-call opener is missing, and continue to drop incomplete bodies.
- Harmony `TOOLCALLING.batch.5.b` now covers the same recoverable orphan-wrapper shape for a complete commentary function call; SGLang divergence is documented in the fixture.
- Updated Top-N parity fixtures for the affected batch/stream recovery rows.
- Stacked on #10143.

#### Verification:

`cargo fmt`; `cargo test --locked -p dynamo-parsers --lib tool_calling -- --nocapture`; `cargo test --locked -p dynamo-llm --test test_jail test_minimax_m2_stream_finalize_recovers_complete_inner_invokes -- --nocapture`; rebuilt `_core` with `maturin develop --uv`; `python3 -m pytest -q tests/parity/toolcalling/test_parity_toolcalling.py::test_parity`; regenerated `tests/parity/PARITY.html`; `python3 -m pytest -q tests/parity/toolcalling/test_generate_parity_table.py`.

#### Where should the reviewer start?

`tests/parity/toolcalling/fixtures/*/TOOLCALLING.batch.5.yaml`, then `lib/parsers/src/tool_calling/gemma4/parser.rs`, `lib/parsers/src/tool_calling/dsml/parser.rs`, `lib/parsers/src/tool_calling/xml/glm47_parser.rs`, and `lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs`

#### Related Issues:

Relates to DIS-2150

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
