### PR TITLE
perf: remove avoidable clones in KV block hot paths

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -1723,7 +1723,7 @@ where
         .zip(priorities.into_iter())
     {
         mutable_block
-            .apply_token_block(token_block.clone())
+            .apply_token_block(token_block)
             .map_err(|e| anyhow::anyhow!("failed to apply token block: {:?}", e))?;
 
         // Set the priority on the block's metadata so it flows through to downstream processing

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/trtllm_worker.rs
@@ -369,7 +369,7 @@ impl Worker for KvConnectorWorker {
     }
 
     fn start_load_kv(&mut self) -> anyhow::Result<()> {
-        let onboarding_operations = self.onboarding_operations.clone();
+        let onboarding_operations = std::mem::take(&mut self.onboarding_operations);
         for operation in onboarding_operations {
             let request_id = operation.request_id.clone();
             self.connector.enqueue_request(operation);

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/worker.rs
@@ -339,13 +339,13 @@ impl Worker for KvConnectorWorker {
             // todo(ryan): capture the context, pass this to the scheduler to do the await on another thread
             // or put the event on a stream and use stream waits to keep it all on device.
             event_sync_blocking(self.layer_events[self.layers_complete - 1]);
-            for operation in &offloading_operations {
+            for operation in offloading_operations {
                 tracing::debug!(
                     request_id = %operation.request_id,
                     operation_id = %operation.uuid,
                     "Enqueuing offload operation to scheduler"
                 );
-                self.connector.enqueue_request(operation.clone());
+                self.connector.enqueue_request(operation);
             }
         }
         Ok(())

--- a/lib/kvbm-engine/src/offload/engine.rs
+++ b/lib/kvbm-engine/src/offload/engine.rs
@@ -633,9 +633,10 @@ async fn remote_g4_offload_task(
     tracing::info!("Remote G4 offload task started");
 
     while let Some(request) = rx.recv().await {
+        let transfer_id = request.transfer_id;
         let num_blocks = request.keys.len();
         tracing::debug!(
-            %request.transfer_id,
+            %transfer_id,
             num_blocks,
             "Processing remote G4 offload request"
         );
@@ -644,10 +645,8 @@ async fn remote_g4_offload_task(
         // This coordinates all workers to upload from their local G2 to object storage
         let result = leader.execute_remote_offload(
             LogicalLayoutHandle::G2, // Source is G2 (host memory)
-            RemoteDescriptor::Object {
-                keys: request.keys.clone(),
-            },
-            request.block_ids.clone(),
+            RemoteDescriptor::Object { keys: request.keys },
+            request.block_ids,
             TransferOptions::default(),
         );
 
@@ -657,14 +656,14 @@ async fn remote_g4_offload_task(
                 match notification.await {
                     Ok(()) => {
                         tracing::info!(
-                            %request.transfer_id,
+                            %transfer_id,
                             num_blocks,
                             "Remote G4 offload completed successfully"
                         );
                     }
                     Err(e) => {
                         tracing::warn!(
-                            %request.transfer_id,
+                            %transfer_id,
                             num_blocks,
                             error = %e,
                             "Remote G4 offload failed"
@@ -674,7 +673,7 @@ async fn remote_g4_offload_task(
             }
             Err(e) => {
                 tracing::warn!(
-                    %request.transfer_id,
+                    %transfer_id,
                     num_blocks,
                     error = %e,
                     "Failed to initiate remote G4 offload"

--- a/lib/kvbm-engine/src/offload/pipeline.rs
+++ b/lib/kvbm-engine/src/offload/pipeline.rs
@@ -1746,17 +1746,18 @@ impl<Src: BlockMetadata> ObjectTransferExecutor<Src> {
 
         // Skip actual transfers when in test mode
         if !shared.skip_transfers {
+            let expected_results = keys.len();
             // Execute object put via ObjectBlockOps
             let results = shared
                 .object_ops
-                .put_blocks(keys.clone(), shared.src_layout, block_ids)
+                .put_blocks(keys, shared.src_layout, block_ids)
                 .await;
 
             // Guard: put_blocks must return exactly one result per input block.
             // If mismatched, mark all blocks as failed since we can't correlate results.
-            if results.len() != keys.len() {
+            if results.len() != expected_results {
                 tracing::error!(
-                    expected = keys.len(),
+                    expected = expected_results,
                     actual = results.len(),
                     "put_blocks returned mismatched result count"
                 );

--- a/lib/llm/src/block_manager/distributed/worker.rs
+++ b/lib/llm/src/block_manager/distributed/worker.rs
@@ -656,7 +656,7 @@ impl KvbmWorker {
 
         let scheduler_client = config.scheduler_client.clone();
 
-        let worker_config = config.clone();
+        let worker_config = config;
         // start background worker task to do layout allocation for host or disk
         let task = CriticalTaskExecutionHandle::new(
             move |cancel_token| {
@@ -707,7 +707,7 @@ impl KvbmWorker {
         let layout_ready_tx_cell = Mutex::new(Some(layout_ready_tx));
 
         // clone what we need inside the orchestrator
-        let worker_config = config.clone();
+        let worker_config = config;
         let cancel_token_for_task = cancel_token.clone();
 
         // Single task that orchestrates everything in-order.

--- a/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
@@ -41,6 +41,10 @@ impl VllmEventBatch {
         &self.1
     }
 
+    fn into_events(self) -> Vec<RawKvEvent> {
+        self.1
+    }
+
     fn data_parallel_rank(&self) -> Option<i32> {
         self.2
     }
@@ -136,8 +140,8 @@ async fn run_listener_loop(
 
                 // Process events
                 let mut tracker_guard = tracker.write().await;
-                for event in batch.events() {
-                    process_event(&mut **tracker_guard, event.clone(), dp_rank, engine_source);
+                for event in batch.into_events() {
+                    process_event(&mut **tracker_guard, event, dp_rank, engine_source);
                 }
             }
         }
@@ -201,8 +205,7 @@ fn process_event(
             // For batches, chain the blocks: each block's parent is the previous block
             let mut current_parent = parent_block_hash.map(|h| h.into_u64().to_string());
 
-            for (i, block_hash) in block_hashes.into_iter().enumerate() {
-                let block_tokens = token_chunks[i].clone();
+            for (block_hash, block_tokens) in block_hashes.into_iter().zip(token_chunks) {
                 let block_hash_u64 = block_hash.into_u64();
 
                 tracker.handle_store(StoreEventInput {

--- a/lib/llm/src/block_manager/state.rs
+++ b/lib/llm/src/block_manager/state.rs
@@ -395,7 +395,7 @@ impl<Metadata: BlockMetadata> KvBlockManagerState<locality::Local, Metadata> {
         for (block_set_idx, block_set_layout) in block_sets {
             // Deserialize the individual layout and create RemoteBlocks
             let remote_blocks =
-                RemoteBlocks::from_serialized(block_set_layout.clone(), block_set_idx, worker_id)?;
+                RemoteBlocks::from_serialized(block_set_layout, block_set_idx, worker_id)?;
 
             // check the storage type of the remote blocks
             let layout = remote_blocks.layout();


### PR DESCRIPTION
## Summary
- move owned KV consolidator events and token chunks instead of cloning them per event/block
- consume queued KVBM worker/offload operations where the source vectors are already drained
- move owned remote offload request/layout/config values after their final read

## Audit notes
Repo-wide clone scan found 4,089 actionable-ish clone sites. This PR intentionally takes only the first narrow KV/block-manager/offload batch; other hot-path findings are left for follow-up PRs because several are semantic ownership, cheap Arc/handle clones, test-only, or structural refactors.

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p dynamo-llm kv_consolidator --lib
- cargo test -p dynamo-llm block_manager --lib
- cargo test --manifest-path lib/bindings/kvbm/Cargo.toml --lib
- cargo test -p kvbm-engine --lib offload
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory usage and performance across block manager and KV consolidation components through improved resource handling patterns, reducing unnecessary memory allocations and improving overall system efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->