### PR TITLE
fix: revert gpt-oss-120b recipe to version 1.0.0

### DIFF
--- a/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml
@@ -45,7 +45,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
       replicas: 1
     TrtllmWorker:
       componentType: worker
@@ -79,7 +79,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
           env:
           - name: TRTLLM_ENABLE_PDL
             value: "1"


### PR DESCRIPTION
#### Overview:

Revert the gpt-oss-120b TRT-LLM aggregated recipe to runtime image `1.0.0`.

#### Details:

Pins both services in `recipes/gpt-oss-120b/trtllm/agg/deploy.yaml` back to `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0`:

- `Frontend.mainContainer.image`: `1.1.1` → `1.0.0`
- `TrtllmWorker.mainContainer.image`: `1.1.1` → `1.0.0`

The `1.1.1` runtime regressed this recipe on GB200, so the recipe is reverted to the last known-good `1.0.0` image. No other recipe settings change.

#### Where should the reviewer start?

- `recipes/gpt-oss-120b/trtllm/agg/deploy.yaml` — the only file changed (two image-tag lines).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to DYN-3090

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment version used by application services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
