### PR TITLE
feat(backend): Enable log_probs for unified backends

### DIFF
--- a/components/src/dynamo/common/backend/CLAUDE.md
+++ b/components/src/dynamo/common/backend/CLAUDE.md
@@ -105,10 +105,11 @@ type the `generate()` signature.  `GenerateRequest` has `token_ids`
 (required) plus optional `sampling_options`, `stop_conditions`, and
 `output_options`.  `GenerateChunk` has `token_ids` and `index` (both
 required; use `index=0` for single-choice chunks), plus optional
-`finish_reason` and `completion_usage` (both required on the final chunk).
-Engines may read
-backend-specific request keys, but response chunk keys should be added to
-the shared contract before use.
+`finish_reason` and `completion_usage` (both required on the final chunk),
+`log_probs` (one float per emitted token), and `top_logprobs` (per-position
+list of ranked alternative dicts — see `logprobs.py` for the entry shape).
+Engines may read backend-specific request keys, but response chunk keys
+should be added to the shared contract before use.
 
 Build the `completion_usage` dict inline. Finish reason normalization
 (e.g. `"abort"` → `"cancelled"`) is handled by the Rust layer.
@@ -268,6 +269,7 @@ spans should be.
 | `metrics.py` | Prometheus integration helpers. `register_global_registry` / `register_engine_registry` are engine-facing (vendor-registry bridge inside `register_prometheus`). `ensure_prometheus_multiproc_dir` / `gather_with_labels` remain engine-side utilities. |
 | `worker.py` | `Worker` -- thin shim over `dynamo._core.backend.Worker`; lifecycle state machine and signal handling live in Rust (`lib/backend-common`) |
 | `run.py` | Common entry point -- `run(engine_cls)` used by all `unified_main.py` files |
+| `logprobs.py` | Shared logprob helpers: `parse_logprob_options`, `extract_from_completion_output` (vLLM/TRT-LLM shape), `extract_from_sglang_meta` + `build_sglang_logprob_kwargs` (SGLang cumulative-array shape). Both unified engines and the legacy handlers delegate here. |
 | `sample_engine.py` | Reference engine -- use as template and for testing |
 
 The Rust `Worker` (in `lib/backend-common/src/worker.rs`) owns:

--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -5,11 +5,10 @@ inference, metrics + Prometheus bridging, KV event publishing,
 KV-aware (DP-rank) routing, health-check canaries, OpenTelemetry
 tracing, and request-side guided decoding / structural tag.
 
-> **Work in progress.** Logprob response wire, multimodal, diffusion
-> (image/video/DLLM), LoRA, engine routes (pause/resume, profiling,
-> weight updates), text-in-text-out, and snapshot/CRIU are still on
-> the non-unified path. See [Feature Gaps](#feature-gaps) for the
-> per-engine matrix.
+> **Work in progress.** Multimodal, diffusion (image/video/DLLM), LoRA,
+> engine routes (pause/resume, profiling, weight updates),
+> text-in-text-out, and snapshot/CRIU are still on the non-unified
+> path. See [Feature Gaps](#feature-gaps) for the per-engine matrix.
 
 > **Looking for a walkthrough?** Start with the
 > [Writing Unified Backends](../../../../../docs/development/unified-backends.md)
@@ -402,6 +401,9 @@ common/backend/
     worker.py            # Worker + WorkerConfig (incl. disaggregation_mode)
     disagg.py            # Disagg request helpers (prefill clamp,
                          #   prefill_result extraction)
+    logprobs.py          # Shared logprob helpers
+                         #   (vLLM/TRT-LLM extractor, SGLang variant,
+                         #   option parsing, SGLang gate)
     metrics.py           # Prometheus helpers (gather_with_labels,
                          #   ensure_prometheus_multiproc_dir, registration)
     publisher.py         # ComponentSnapshot dataclass (push payload)
@@ -409,7 +411,7 @@ common/backend/
     sample_engine.py     # SampleLLMEngine (reference impl)
     sample_main.py       # Entry point for sample engine
     tests/               # test_backend_bindings, test_disagg_helpers,
-                         #   test_sample_engine
+                         #   test_logprobs, test_sample_engine
     CLAUDE.md            # Design notes (rationale, invariants)
 
 vllm/llm_engine.py       # VllmLLMEngine (agg + disagg)
@@ -442,6 +444,12 @@ Lifecycle and runtime:
   uses NIXL across all three engines; SGLang exchanges a Dynamo-level
   bootstrap address, vLLM and TRT-LLM use an engine-internal handshake.
   See [Disaggregated Serving](#disaggregated-serving) below.
+- **Logprobs** — selected-token + top-k logprob extraction and
+  streaming, sourced from `dynamo.common.backend.logprobs` and used by
+  both unified engines and the legacy handlers (which now delegate
+  here). vLLM/TRT-LLM share an extractor; SGLang has a cumulative-array
+  variant. The sample engine and Rust mocker emit synthetic logprobs
+  when `output_options.logprobs` is set.
 
 Observability:
 - **Health-check canary** — `health_check_payload()` + operator
@@ -487,7 +495,6 @@ Request handling:
 
 | Feature | Description |
 |---------|-------------|
-| Logprob response wire | Legacy handlers extract logprobs onto response chunks (`vllm/handlers.py:_extract_logprobs`, `sglang/.../decode_handler.py:_extract_logprobs`, `trtllm/.../handler_base.py:_extract_logprobs`); the unified `generate()` loops do not populate `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk`. vLLM's `build_sampling_params` still passes `output_options.logprobs` to the engine on the unified path, so the engine computes them, but the values are dropped before reaching the chunk. SGLang and TRT-LLM unified `generate()` do not read `output_options.logprobs` at all. |
 | Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization. Unified hardcodes `ModelInput.Tokens`. |
 | Multimodal | Images / video / embeddings, NIXL embedding transfer, encode workers. `worker.py:_to_rust_disaggregation_mode` rejects the `ENCODE` role. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path. |
@@ -554,21 +561,14 @@ Request handling:
 
 For users picking what to land next on the unified path:
 
-1. **Logprob response wire** — smallest lift. Wire
-   `output_options.{logprobs, prompt_logprobs}` through to each
-   engine's sampling params, and emit the engine's per-token
-   logprobs onto `GenerateChunk.{log_probs, top_logprobs,
-   cum_log_probs}` in each `generate()`. vLLM already has the
-   request-side passthrough (`build_sampling_params`); SGLang and
-   TRT-LLM unified `generate()` need it added.
-2. **Text-in-text-out** (`ModelInput.Text`) — common ask; needs
+1. **Text-in-text-out** (`ModelInput.Text`) — common ask; needs
    engine-side tokenization + chat templating path.
-3. **LoRA dynamic load/unload + MDC publishing** — production-visible
+2. **LoRA dynamic load/unload + MDC publishing** — production-visible
    feature with concrete API surface (three endpoints on vLLM
    `handlers.py`).
-4. **Engine routes / lifecycle endpoints** — sleep/wake, profile
+3. **Engine routes / lifecycle endpoints** — sleep/wake, profile
    start/stop, weight updates, KV block clearing, prefix cache
    reset. Visible in operator workflows.
-5. **Snapshot / CRIU** — production checkpoint support.
-6. **Multimodal / diffusion / video / DLLM** — biggest functional
+4. **Snapshot / CRIU** — production checkpoint support.
+5. **Multimodal / diffusion / video / DLLM** — biggest functional
    gap, but largest scope. Best parallelized across modality leads.

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -70,6 +70,12 @@ class GenerateChunk(TypedDict, total=False):
     disaggregated_params: dict[str, Any]
     log_probs: list[float]
     top_logprobs: list[list[dict[str, Any]]]
+    # Engine-specific payload forwarded verbatim to the Rust LLMEngineOutput
+    # as a JSON object. Today this carries prompt-side logprobs on the
+    # final chunk when the request asked for them (key:
+    # ``prompt_logprobs``, shape: ``list[Optional[dict[str, ...]]]``
+    # matching ``crate::protocols::common::llm_backend::PromptLogprobs``).
+    engine_data: dict[str, Any]
 
 
 @dataclass

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -70,11 +70,8 @@ class GenerateChunk(TypedDict, total=False):
     disaggregated_params: dict[str, Any]
     log_probs: list[float]
     top_logprobs: list[list[dict[str, Any]]]
-    # Engine-specific payload forwarded verbatim to the Rust LLMEngineOutput
-    # as a JSON object. Today this carries prompt-side logprobs on the
-    # final chunk when the request asked for them (key:
-    # ``prompt_logprobs``, shape: ``list[Optional[dict[str, ...]]]``
-    # matching ``crate::protocols::common::llm_backend::PromptLogprobs``).
+    # Forwarded verbatim to Rust `LLMEngineOutput.engine_data` as a
+    # JSON object. Carries `prompt_logprobs` on the final chunk.
     engine_data: dict[str, Any]
 
 

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -57,7 +57,10 @@ class GenerateChunk(TypedDict, total=False):
     Use ``index=0`` for single-choice responses. The final chunk must
     additionally include ``finish_reason`` and ``completion_usage``.
     Prefill terminals carry ``disaggregated_params`` for the
-    PrefillRouter to forward to the decode peer.
+    PrefillRouter to forward to the decode peer. When the caller
+    requested logprobs, chunks may also carry ``log_probs`` and
+    ``top_logprobs`` aligned to ``token_ids`` — see
+    :mod:`dynamo.common.backend.logprobs`.
     """
 
     token_ids: Required[list[int]]
@@ -65,6 +68,8 @@ class GenerateChunk(TypedDict, total=False):
     finish_reason: str
     completion_usage: dict[str, int]
     disaggregated_params: dict[str, Any]
+    log_probs: list[float]
+    top_logprobs: list[list[dict[str, Any]]]
 
 
 @dataclass

--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared logprob helpers.
+
+vLLM and TRT-LLM expose logprobs through ``CompletionOutput.logprobs``
+(list aligned with ``token_ids``, dicts of ``token_id -> LogprobInfo``).
+SGLang exposes them through ``meta_info["output_token_logprobs"]`` as
+cumulative tuples ``(logprob, token_id, text_or_None)``.
+
+Both paths emit the same Dynamo wire format on ``GenerateChunk``:
+``log_probs`` is a flat ``list[float]``, ``top_logprobs`` is
+``list[list[{rank, token_id, token, logprob, bytes?}]]``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def parse_logprob_options(
+    output_options: dict[str, Any],
+) -> tuple[Optional[int], Optional[int]]:
+    """Return ``(logprobs, prompt_logprobs)`` parsed as non-negative ints,
+    or ``None`` for absent / invalid fields. Bad values are logged."""
+    if not output_options:
+        return None, None
+    return (
+        _parse_non_negative_int(output_options.get("logprobs"), "logprobs"),
+        _parse_non_negative_int(
+            output_options.get("prompt_logprobs"), "prompt_logprobs"
+        ),
+    )
+
+
+def _parse_non_negative_int(value: Any, name: str) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s value: %r (must be integer), ignoring", name, value)
+        return None
+    if parsed < 0:
+        logger.warning(
+            "Invalid %s value: %r (must be non-negative), ignoring", name, value
+        )
+        return None
+    return parsed
+
+
+def extract_from_completion_output(
+    output: Any,
+    num_output_tokens_so_far: int,
+    tokenizer: Any = None,
+    *,
+    fallback_to_first_on_missing: bool = False,
+    include_bytes: bool = False,
+) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]]]:
+    """Extract logprobs from a vLLM/TRT-LLM-shaped CompletionOutput.
+
+    ``num_output_tokens_so_far`` slices the per-chunk window out of the
+    cumulative array. ``tokenizer`` decodes token ids when the engine
+    didn't populate ``decoded_token``. ``fallback_to_first_on_missing``
+    falls back to the first dict entry when the selected token is
+    absent (TRT-LLM corner case). ``include_bytes`` adds a UTF-8 byte
+    array per top entry (matches the vLLM/OpenAI shape).
+
+    Returns ``(None, None)`` when nothing was extracted.
+    """
+    if getattr(output, "logprobs", None) is None:
+        return None, None
+
+    token_ids = list(getattr(output, "token_ids", None) or [])
+    if not token_ids or num_output_tokens_so_far >= len(token_ids):
+        return None, None
+
+    new_logprobs = output.logprobs[num_output_tokens_so_far:]
+    new_token_ids = token_ids[num_output_tokens_so_far:]
+    new_logprobs = new_logprobs[: len(new_token_ids)]
+    if not new_logprobs:
+        return None, None
+
+    # TRT-LLM edge case: the engine sometimes returns a flat list of
+    # floats instead of a list of `{token_id: Logprob}` dicts. Surface
+    # the chosen-token logprobs and bail on top-k.
+    if isinstance(new_logprobs[0], float):
+        return [float(lp) for lp in new_logprobs], None
+
+    log_probs: list[float] = []
+    top_logprobs: list[list[dict[str, Any]]] = []
+
+    for token_idx, token_logprobs_dict in enumerate(new_logprobs):
+        if token_logprobs_dict is None:
+            continue
+
+        actual_token_id = new_token_ids[token_idx]
+        selected = token_logprobs_dict.get(actual_token_id)
+        if selected is None:
+            if not fallback_to_first_on_missing:
+                continue
+            selected = next(iter(token_logprobs_dict.values()), None)
+            if selected is None:
+                continue
+        log_probs.append(float(selected.logprob))
+
+        position_entries: list[dict[str, Any]] = []
+        for tok_id, info in token_logprobs_dict.items():
+            token_str = getattr(info, "decoded_token", None)
+            if not token_str and tokenizer is not None:
+                try:
+                    token_str = tokenizer.decode([tok_id])
+                except Exception:
+                    token_str = None
+            entry: dict[str, Any] = {
+                "rank": info.rank if hasattr(info, "rank") else 0,
+                "token_id": tok_id,
+                "token": token_str,
+                "logprob": float(info.logprob),
+            }
+            if include_bytes:
+                entry["bytes"] = list(token_str.encode("utf-8")) if token_str else None
+            position_entries.append(entry)
+        top_logprobs.append(position_entries)
+
+    return (
+        log_probs if log_probs else None,
+        top_logprobs if top_logprobs else None,
+    )
+
+
+_SGLANG_TOP_LOGPROBS_UNSUPPORTED_MSG = (
+    "Dynamo's SGLang backend does not currently support logprobs >= 1 due to "
+    "an O(N) per-position detokenization in the upstream sglang tokenizer "
+    "manager. Use logprobs=0 for chosen-token logprobs, or set "
+    "DYN_SGL_ALLOW_TOP_LOGPROBS=1 to override at your own risk. "
+    "Track the upstream fix at https://github.com/sgl-project/sglang/pull/24447."
+)
+
+DYN_SGL_ALLOW_TOP_LOGPROBS_ENV = "DYN_SGL_ALLOW_TOP_LOGPROBS"
+
+
+def sglang_top_logprobs_allowed() -> bool:
+    """Read the ``DYN_SGL_ALLOW_TOP_LOGPROBS`` env-var gate."""
+    return os.environ.get(DYN_SGL_ALLOW_TOP_LOGPROBS_ENV, "").lower() not in (
+        "",
+        "0",
+        "false",
+    )
+
+
+def build_sglang_logprob_kwargs(
+    output_options: dict[str, Any],
+    *,
+    allow_top_logprobs: bool,
+) -> dict[str, Any]:
+    """Map ``output_options`` to SGLang's
+    ``return_logprob`` / ``top_logprobs_num`` / ``logprob_start_len`` kwargs.
+
+    Raises ``ValueError`` for ``logprobs >= 1`` when
+    ``allow_top_logprobs`` is ``False``. SGLang's tokenizer manager
+    detokenizes top-k tokens serially (O(N) per generated token), so
+    enabling it without a batched detokenize path degrades latency
+    badly.
+    """
+    if not output_options:
+        return {}
+
+    kwargs: dict[str, Any] = {}
+
+    def _parse(name: str, value: Any) -> Optional[int]:
+        parsed = _parse_non_negative_int(value, name)
+        if parsed is None:
+            return None
+        if parsed >= 1 and not allow_top_logprobs:
+            raise ValueError(_SGLANG_TOP_LOGPROBS_UNSUPPORTED_MSG)
+        return parsed
+
+    logprobs_value = output_options.get("logprobs")
+    if logprobs_value is not None:
+        parsed = _parse("logprobs", logprobs_value)
+        if parsed is not None:
+            kwargs["return_logprob"] = True
+            kwargs["top_logprobs_num"] = parsed
+
+    prompt_logprobs_value = output_options.get("prompt_logprobs")
+    if prompt_logprobs_value is not None:
+        parsed = _parse("prompt_logprobs", prompt_logprobs_value)
+        if parsed is not None:
+            kwargs["return_logprob"] = True
+            kwargs["top_logprobs_num"] = max(kwargs.get("top_logprobs_num", 0), parsed)
+            # logprob_start_len=0 starts logprob computation at the
+            # prompt; SGLang's default (-1) restricts to output tokens.
+            kwargs["logprob_start_len"] = 0
+
+    if kwargs.get("return_logprob") and not allow_top_logprobs:
+        kwargs["top_logprobs_num"] = 0
+
+    return kwargs
+
+
+def extract_from_sglang_meta(
+    meta_info: dict[str, Any],
+    num_output_logprobs_so_far: int,
+    *,
+    return_tokens_as_token_ids: bool = False,
+) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]], int,]:
+    """Extract logprobs from SGLang's ``meta_info`` dict.
+
+    SGLang's ``output_token_logprobs`` / ``output_top_logprobs`` are
+    cumulative across stream chunks even though ``output_ids`` is
+    disjoint — the caller passes the running count to slice the new
+    entries, and the returned third element is the updated count.
+    """
+    output_token_logprobs = meta_info.get("output_token_logprobs")
+    if not output_token_logprobs:
+        return None, None, num_output_logprobs_so_far
+
+    new_logprobs = output_token_logprobs[num_output_logprobs_so_far:]
+    if not new_logprobs:
+        return None, None, num_output_logprobs_so_far
+
+    log_probs = [float(entry[0]) for entry in new_logprobs]
+
+    top_logprobs: Optional[list[list[dict[str, Any]]]] = None
+    output_top = meta_info.get("output_top_logprobs")
+    if output_top:
+        new_top = output_top[num_output_logprobs_so_far:]
+        if new_top:
+            top_logprobs = []
+            for position_entries in new_top:
+                if position_entries is None:
+                    top_logprobs.append([])
+                    continue
+                position_list: list[dict[str, Any]] = []
+                for rank_idx, entry in enumerate(position_entries):
+                    tok_id = entry[1]
+                    token_str = (
+                        f"token_id:{tok_id}" if return_tokens_as_token_ids else entry[2]
+                    )
+                    position_list.append(
+                        {
+                            "rank": rank_idx + 1,
+                            "token_id": tok_id,
+                            "token": token_str,
+                            "logprob": float(entry[0]),
+                        }
+                    )
+                top_logprobs.append(position_list)
+
+    return log_probs, top_logprobs, len(output_token_logprobs)

--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -70,7 +70,11 @@ def extract_from_completion_output(
     absent (TRT-LLM corner case). ``include_bytes`` adds a UTF-8 byte
     array per top entry (matches the vLLM/OpenAI shape).
 
-    Returns ``(None, None)`` when nothing was extracted.
+    Returns ``(None, None)`` when nothing was extracted, or when any
+    selected-token logprob is missing in the slice — the Rust response
+    builder zips ``log_probs`` / ``top_logprobs`` against ``token_ids``
+    by position, so emitting a shorter array would misalign every later
+    token. Bail on the whole chunk instead.
     """
     if getattr(output, "logprobs", None) is None:
         return None, None
@@ -96,16 +100,16 @@ def extract_from_completion_output(
 
     for token_idx, token_logprobs_dict in enumerate(new_logprobs):
         if token_logprobs_dict is None:
-            continue
+            return None, None
 
         actual_token_id = new_token_ids[token_idx]
         selected = token_logprobs_dict.get(actual_token_id)
         if selected is None:
             if not fallback_to_first_on_missing:
-                continue
+                return None, None
             selected = next(iter(token_logprobs_dict.values()), None)
             if selected is None:
-                continue
+                return None, None
         log_probs.append(float(selected.logprob))
 
         position_entries: list[dict[str, Any]] = []
@@ -202,9 +206,6 @@ def build_sglang_logprob_kwargs(
             # prompt; SGLang's default (-1) restricts to output tokens.
             kwargs["logprob_start_len"] = 0
 
-    if kwargs.get("return_logprob") and not allow_top_logprobs:
-        kwargs["top_logprobs_num"] = 0
-
     return kwargs
 
 
@@ -213,7 +214,7 @@ def extract_from_sglang_meta(
     num_output_logprobs_so_far: int,
     *,
     return_tokens_as_token_ids: bool = False,
-) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]], int,]:
+) -> tuple[Optional[list[float]], Optional[list[list[dict[str, Any]]]], int]:
     """Extract logprobs from SGLang's ``meta_info`` dict.
 
     SGLang's ``output_token_logprobs`` / ``output_top_logprobs`` are

--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -142,6 +142,99 @@ def extract_from_completion_output(
     )
 
 
+def extract_prompt_logprobs_from_completion_output(
+    output: Any,
+    tokenizer: Any = None,
+) -> Optional[list[Optional[dict[str, dict[str, Any]]]]]:
+    """Extract prompt logprobs from a vLLM/TRT-LLM-shaped output.
+
+    Reads ``output.prompt_logprobs`` (``list[Optional[dict[int, Logprob]]]``;
+    position 0 is ``None`` because there is no logprob for the very first
+    prompt token / BOS). Returns the Dynamo wire shape: a list aligned
+    with the prompt where each present entry is a ``token_id -> entry``
+    map. ``token_id`` keys are stringified so the JSON round-trip into
+    Rust's ``HashMap<u32, PromptLogprobEntry>`` succeeds. Returns
+    ``None`` when the engine didn't compute prompt logprobs.
+    """
+    prompt_logprobs = getattr(output, "prompt_logprobs", None)
+    if prompt_logprobs is None:
+        return None
+
+    payload: list[Optional[dict[str, dict[str, Any]]]] = []
+    for pos in prompt_logprobs:
+        if pos is None:
+            payload.append(None)
+            continue
+        position_map: dict[str, dict[str, Any]] = {}
+        for tok_id, info in pos.items():
+            decoded_token = getattr(info, "decoded_token", None)
+            if not decoded_token and tokenizer is not None:
+                try:
+                    decoded_token = tokenizer.decode([tok_id])
+                except Exception:
+                    logger.debug(
+                        "tokenizer.decode failed for prompt token_id=%s",
+                        tok_id,
+                        exc_info=True,
+                    )
+                    decoded_token = None
+            entry: dict[str, Any] = {"logprob": float(info.logprob)}
+            rank = getattr(info, "rank", None)
+            if rank is not None:
+                entry["rank"] = int(rank)
+            if decoded_token is not None:
+                entry["decoded_token"] = decoded_token
+            position_map[str(tok_id)] = entry
+        payload.append(position_map)
+    return payload
+
+
+def extract_prompt_logprobs_from_sglang_meta(
+    meta: dict[str, Any],
+) -> Optional[list[Optional[dict[str, dict[str, Any]]]]]:
+    """Extract prompt logprobs from an SGLang meta_info dict.
+
+    Reads ``meta["input_token_logprobs"]`` — a list of
+    ``(logprob, token_id, decoded_token_or_None)`` tuples that SGLang
+    emits when ``return_logprob=True`` and ``logprob_start_len=0`` (one
+    entry per prompt token from position 1 onwards; SGLang doesn't emit
+    a logprob for the very first prompt / BOS token). Returns the
+    Dynamo wire shape with ``None`` at index 0 to mark the missing BOS
+    position, matching the Rust ``PromptLogprobs`` invariant.
+
+    When ``meta["input_top_logprobs"]`` is present (top-k requested and
+    available), each position's map includes those alternatives too.
+    """
+    input_logprobs = meta.get("input_token_logprobs")
+    if not input_logprobs:
+        return None
+
+    input_top_logprobs = meta.get("input_top_logprobs") or []
+
+    payload: list[Optional[dict[str, dict[str, Any]]]] = [None]
+    for idx, item in enumerate(input_logprobs):
+        logprob, tok_id, decoded_token = item
+        position_map: dict[str, dict[str, Any]] = {}
+        selected_entry: dict[str, Any] = {"logprob": float(logprob)}
+        if decoded_token is not None:
+            selected_entry["decoded_token"] = decoded_token
+        position_map[str(tok_id)] = selected_entry
+
+        if idx < len(input_top_logprobs):
+            top_at_pos = input_top_logprobs[idx]
+            if top_at_pos:
+                for top_lp, top_tok_id, top_decoded in top_at_pos:
+                    key = str(top_tok_id)
+                    if key in position_map:
+                        continue
+                    alt_entry: dict[str, Any] = {"logprob": float(top_lp)}
+                    if top_decoded is not None:
+                        alt_entry["decoded_token"] = top_decoded
+                    position_map[key] = alt_entry
+        payload.append(position_map)
+    return payload
+
+
 _SGLANG_TOP_LOGPROBS_UNSUPPORTED_MSG = (
     "Dynamo's SGLang backend does not currently support logprobs >= 1 due to "
     "an O(N) per-position detokenization in the upstream sglang tokenizer "

--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -115,6 +115,11 @@ def extract_from_completion_output(
                 try:
                     token_str = tokenizer.decode([tok_id])
                 except Exception:
+                    logger.debug(
+                        "tokenizer.decode failed for token_id=%s",
+                        tok_id,
+                        exc_info=True,
+                    )
                     token_str = None
             entry: dict[str, Any] = {
                 "rank": info.rank if hasattr(info, "rank") else 0,

--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -148,13 +148,10 @@ def extract_prompt_logprobs_from_completion_output(
 ) -> Optional[list[Optional[dict[str, dict[str, Any]]]]]:
     """Extract prompt logprobs from a vLLM/TRT-LLM-shaped output.
 
-    Reads ``output.prompt_logprobs`` (``list[Optional[dict[int, Logprob]]]``;
-    position 0 is ``None`` because there is no logprob for the very first
-    prompt token / BOS). Returns the Dynamo wire shape: a list aligned
-    with the prompt where each present entry is a ``token_id -> entry``
-    map. ``token_id`` keys are stringified so the JSON round-trip into
-    Rust's ``HashMap<u32, PromptLogprobEntry>`` succeeds. Returns
-    ``None`` when the engine didn't compute prompt logprobs.
+    Reads ``output.prompt_logprobs``. Position 0 stays ``None`` (no
+    logprob for BOS). Token-id keys are stringified for the JSON
+    round-trip into Rust's ``HashMap<u32, PromptLogprobEntry>``.
+    Returns ``None`` if the engine didn't compute prompt logprobs.
     """
     prompt_logprobs = getattr(output, "prompt_logprobs", None)
     if prompt_logprobs is None:
@@ -192,18 +189,12 @@ def extract_prompt_logprobs_from_completion_output(
 def extract_prompt_logprobs_from_sglang_meta(
     meta: dict[str, Any],
 ) -> Optional[list[Optional[dict[str, dict[str, Any]]]]]:
-    """Extract prompt logprobs from an SGLang meta_info dict.
+    """Extract prompt logprobs from an SGLang ``meta_info`` dict.
 
-    Reads ``meta["input_token_logprobs"]`` — a list of
-    ``(logprob, token_id, decoded_token_or_None)`` tuples that SGLang
-    emits when ``return_logprob=True`` and ``logprob_start_len=0`` (one
-    entry per prompt token from position 1 onwards; SGLang doesn't emit
-    a logprob for the very first prompt / BOS token). Returns the
-    Dynamo wire shape with ``None`` at index 0 to mark the missing BOS
-    position, matching the Rust ``PromptLogprobs`` invariant.
-
-    When ``meta["input_top_logprobs"]`` is present (top-k requested and
-    available), each position's map includes those alternatives too.
+    Reads ``input_token_logprobs`` (tuples ``(logprob, token_id, decoded
+    or None)``, starting at prompt position 1) and merges any
+    ``input_top_logprobs`` alternatives. Prepends ``None`` at index 0
+    so the result aligns with Rust's BOS=None ``PromptLogprobs`` shape.
     """
     input_logprobs = meta.get("input_token_logprobs")
     if not input_logprobs:

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -29,6 +29,13 @@ logger = logging.getLogger(__name__)
 
 _SAMPLE_BLOCK_SIZE = 16
 
+# Upper bound on synthesised top-k alternatives. Caps the per-chunk
+# ``top_logprobs`` allocation so a client sending an unbounded
+# ``logprobs`` value can't drive arbitrary memory / CPU here. Matches
+# the Rust mocker's ``MAX_LOGPROBS`` so the two reference engines
+# behave identically.
+_MAX_SYNTHETIC_TOP_LOGPROBS = 20
+
 
 def _stamp_synthetic_logprobs(
     chunk: GenerateChunk, token_ids: list[int], logprobs_k: int
@@ -37,6 +44,7 @@ def _stamp_synthetic_logprobs(
     alternatives appear when ``logprobs_k >= 1``."""
     if not token_ids:
         return
+    logprobs_k = min(logprobs_k, _MAX_SYNTHETIC_TOP_LOGPROBS)
     log_probs: list[float] = []
     top_logprobs: list[list[dict[str, Any]]] = []
     for tid in token_ids:

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -29,11 +29,8 @@ logger = logging.getLogger(__name__)
 
 _SAMPLE_BLOCK_SIZE = 16
 
-# Upper bound on synthesised top-k alternatives. Caps the per-chunk
-# ``top_logprobs`` allocation so a client sending an unbounded
-# ``logprobs`` value can't drive arbitrary memory / CPU here. Matches
-# the Rust mocker's ``MAX_LOGPROBS`` so the two reference engines
-# behave identically.
+# Mirrors the Rust mocker's `MAX_LOGPROBS` so unbounded `logprobs`
+# requests can't drive arbitrary memory / CPU here.
 _MAX_SYNTHETIC_TOP_LOGPROBS = 20
 
 

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -21,12 +21,50 @@ from . import telemetry
 from .disagg import enforce_prefill_max_tokens, require_prefill_result
 from .engine import EngineConfig, GenerateChunk, GenerateRequest, LLMEngine
 from .health_check import build_health_check_payload, is_probe
+from .logprobs import parse_logprob_options
 from .publisher import ComponentSnapshot, KvEventSource, PushSource
 from .worker import WorkerConfig
 
 logger = logging.getLogger(__name__)
 
 _SAMPLE_BLOCK_SIZE = 16
+
+
+def _stamp_synthetic_logprobs(
+    chunk: GenerateChunk, token_ids: list[int], logprobs_k: int
+) -> None:
+    """Stamp deterministic synthetic logprobs onto ``chunk``. Top-k
+    alternatives appear when ``logprobs_k >= 1``."""
+    if not token_ids:
+        return
+    log_probs: list[float] = []
+    top_logprobs: list[list[dict[str, Any]]] = []
+    for tid in token_ids:
+        selected_lp = -0.1 * (tid % 10)
+        log_probs.append(selected_lp)
+        if logprobs_k > 0:
+            position = [
+                {
+                    "rank": 1,
+                    "token_id": tid,
+                    "token": f"token_id:{tid}",
+                    "logprob": selected_lp,
+                }
+            ]
+            for r in range(1, logprobs_k + 1):
+                alt_id = (tid + r) % 32000
+                position.append(
+                    {
+                        "rank": r + 1,
+                        "token_id": alt_id,
+                        "token": f"token_id:{alt_id}",
+                        "logprob": selected_lp - 0.1 * r,
+                    }
+                )
+            top_logprobs.append(position)
+    chunk["log_probs"] = log_probs
+    if top_logprobs:
+        chunk["top_logprobs"] = top_logprobs
 
 
 class SampleLLMEngine(LLMEngine):
@@ -222,18 +260,27 @@ class SampleLLMEngine(LLMEngine):
         prompt_len = len(token_ids)
         stop_conditions = request.get("stop_conditions", {})
         max_new = stop_conditions.get("max_tokens") or self.max_tokens
+        logprobs_k, _prompt_logprobs = parse_logprob_options(
+            request.get("output_options", {}) or {}
+        )
 
         block_hashes = self._emit_synthetic_events(prompt_len)
         try:
             # Parent-chain pinned in test_unified_worker_otlp_export.
             with telemetry.start_span(context, "sample.tokens", prompt_len=prompt_len):
-                async for chunk in self._generate_tokens(prompt_len, max_new, context):
+                async for chunk in self._generate_tokens(
+                    prompt_len, max_new, context, logprobs_k
+                ):
                     yield chunk
         finally:
             self._release_synthetic_blocks(block_hashes)
 
     async def _generate_tokens(
-        self, prompt_len: int, max_new: int, context: Context
+        self,
+        prompt_len: int,
+        max_new: int,
+        context: Context,
+        logprobs_k: Optional[int],
     ) -> AsyncGenerator[GenerateChunk, None]:
         for i in range(max_new):
             if context.is_stopped():
@@ -251,6 +298,8 @@ class SampleLLMEngine(LLMEngine):
             await asyncio.sleep(self.delay)
             token_id = (i + 1) % 32000
             out: GenerateChunk = {"token_ids": [token_id], "index": 0}
+            if logprobs_k is not None:
+                _stamp_synthetic_logprobs(out, [token_id], logprobs_k)
             if i == max_new - 1:
                 out["finish_reason"] = "length"
                 out["completion_usage"] = {

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -674,10 +674,8 @@ def test_parity_sglang_kwargs_rejects_top_logprobs_consistently():
 
 @pytest.mark.vllm
 def test_parity_vllm_legacy_wrapper_matches_shared():
-    # `exc_type=ImportError` skips when the package is importable but
-    # its native deps (e.g. libcuda.so.1) are missing — happens on the
-    # CPU-only test lanes where the engine wheel is installed for
-    # import-path resolution but no GPU runtime is present.
+    # `exc_type=ImportError` also skips on missing native deps (libcuda)
+    # on CPU-only lanes where the wheel is installed but no GPU runtime.
     pytest.importorskip("vllm", reason="vLLM not installed", exc_type=ImportError)
     from dynamo.vllm.handlers import BaseWorkerHandler
 

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -674,7 +674,11 @@ def test_parity_sglang_kwargs_rejects_top_logprobs_consistently():
 
 @pytest.mark.vllm
 def test_parity_vllm_legacy_wrapper_matches_shared():
-    pytest.importorskip("vllm", reason="vLLM not installed")
+    # `exc_type=ImportError` skips when the package is importable but
+    # its native deps (e.g. libcuda.so.1) are missing — happens on the
+    # CPU-only test lanes where the engine wheel is installed for
+    # import-path resolution but no GPU runtime is present.
+    pytest.importorskip("vllm", reason="vLLM not installed", exc_type=ImportError)
     from dynamo.vllm.handlers import BaseWorkerHandler
 
     output = SimpleNamespace(
@@ -695,7 +699,9 @@ def test_parity_vllm_legacy_wrapper_matches_shared():
 
 @pytest.mark.trtllm
 def test_parity_trtllm_legacy_wrapper_matches_shared():
-    pytest.importorskip("tensorrt_llm", reason="TRT-LLM not installed")
+    pytest.importorskip(
+        "tensorrt_llm", reason="TRT-LLM not installed", exc_type=ImportError
+    )
     from dynamo.trtllm.request_handlers.handler_base import HandlerBase
 
     output = SimpleNamespace(
@@ -717,7 +723,7 @@ def test_parity_trtllm_legacy_wrapper_matches_shared():
 
 @pytest.mark.sglang
 def test_parity_sglang_legacy_extract_wrapper_matches_shared():
-    pytest.importorskip("sglang", reason="SGLang not installed")
+    pytest.importorskip("sglang", reason="SGLang not installed", exc_type=ImportError)
     from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 
     meta = {
@@ -735,7 +741,7 @@ def test_parity_sglang_legacy_extract_wrapper_matches_shared():
 
 @pytest.mark.sglang
 def test_parity_sglang_legacy_kwargs_wrapper_matches_shared(monkeypatch):
-    pytest.importorskip("sglang", reason="SGLang not installed")
+    pytest.importorskip("sglang", reason="SGLang not installed", exc_type=ImportError)
     from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 
     # Gate off — both must reject logprobs >= 1 identically.

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -20,6 +20,8 @@ from dynamo.common.backend.logprobs import (
     build_sglang_logprob_kwargs,
     extract_from_completion_output,
     extract_from_sglang_meta,
+    extract_prompt_logprobs_from_completion_output,
+    extract_prompt_logprobs_from_sglang_meta,
     parse_logprob_options,
     sglang_top_logprobs_allowed,
 )
@@ -185,6 +187,110 @@ def test_extract_completion_uses_tokenizer_when_decoded_missing():
     )
     _, top_logprobs = extract_from_completion_output(output, 0, tokenizer=FakeTok())
     assert top_logprobs[0][0]["token"] == "<7>"
+
+
+# ---------------------------------------------------------------------------
+# extract_prompt_logprobs_from_completion_output (vLLM/TRT-LLM shape)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_logprobs_completion_returns_none_when_absent():
+    output = SimpleNamespace(prompt_logprobs=None)
+    assert extract_prompt_logprobs_from_completion_output(output) is None
+
+
+def test_prompt_logprobs_completion_preserves_none_bos_position():
+    # vLLM emits `None` at index 0 (no logprob for the very first token).
+    output = SimpleNamespace(
+        prompt_logprobs=[
+            None,
+            {7: _logprob(-0.5, decoded="a")},
+        ]
+    )
+    payload = extract_prompt_logprobs_from_completion_output(output)
+    assert payload == [
+        None,
+        {"7": {"logprob": -0.5, "rank": 1, "decoded_token": "a"}},
+    ]
+
+
+def test_prompt_logprobs_completion_includes_top_k_alternatives():
+    output = SimpleNamespace(
+        prompt_logprobs=[
+            None,
+            {
+                7: _logprob(-0.5, rank=1, decoded="a"),
+                70: _logprob(-1.5, rank=2, decoded="A"),
+            },
+        ]
+    )
+    payload = extract_prompt_logprobs_from_completion_output(output)
+    assert payload[1] == {
+        "7": {"logprob": -0.5, "rank": 1, "decoded_token": "a"},
+        "70": {"logprob": -1.5, "rank": 2, "decoded_token": "A"},
+    }
+
+
+def test_prompt_logprobs_completion_falls_back_to_tokenizer():
+    class FakeTok:
+        def decode(self, ids):
+            return f"<{ids[0]}>"
+
+    output = SimpleNamespace(
+        prompt_logprobs=[None, {9: _logprob(-0.7, decoded=None)}]
+    )
+    payload = extract_prompt_logprobs_from_completion_output(
+        output, tokenizer=FakeTok()
+    )
+    assert payload[1]["9"]["decoded_token"] == "<9>"
+
+
+# ---------------------------------------------------------------------------
+# extract_prompt_logprobs_from_sglang_meta
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_logprobs_sglang_returns_none_when_absent():
+    assert extract_prompt_logprobs_from_sglang_meta({}) is None
+    assert extract_prompt_logprobs_from_sglang_meta(
+        {"input_token_logprobs": []}
+    ) is None
+
+
+def test_prompt_logprobs_sglang_prepends_none_for_bos():
+    # SGLang's `input_token_logprobs` starts at prompt position 1; we
+    # add `None` at index 0 to align with the Rust PromptLogprobs
+    # invariant (BOS has no logprob).
+    meta = {
+        "input_token_logprobs": [
+            (-0.5, 7, "a"),
+            (-0.6, 8, "b"),
+        ]
+    }
+    payload = extract_prompt_logprobs_from_sglang_meta(meta)
+    assert payload == [
+        None,
+        {"7": {"logprob": -0.5, "decoded_token": "a"}},
+        {"8": {"logprob": -0.6, "decoded_token": "b"}},
+    ]
+
+
+def test_prompt_logprobs_sglang_merges_input_top_logprobs():
+    meta = {
+        "input_token_logprobs": [(-0.5, 7, "a")],
+        "input_top_logprobs": [[(-0.5, 7, "a"), (-1.5, 70, "A")]],
+    }
+    payload = extract_prompt_logprobs_from_sglang_meta(meta)
+    assert payload[1] == {
+        "7": {"logprob": -0.5, "decoded_token": "a"},
+        "70": {"logprob": -1.5, "decoded_token": "A"},
+    }
+
+
+def test_prompt_logprobs_sglang_handles_missing_decoded_token():
+    meta = {"input_token_logprobs": [(-0.7, 9, None)]}
+    payload = extract_prompt_logprobs_from_sglang_meta(meta)
+    assert payload[1] == {"9": {"logprob": -0.7}}
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -1,0 +1,809 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared logprob helpers.
+
+The legacy per-backend extraction logic moved into this module; these
+tests cover the contract directly so both the unified engines and the
+legacy handlers (which now delegate here) get verified at the same time.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+from dynamo.common.backend.logprobs import (
+    DYN_SGL_ALLOW_TOP_LOGPROBS_ENV,
+    build_sglang_logprob_kwargs,
+    extract_from_completion_output,
+    extract_from_sglang_meta,
+    parse_logprob_options,
+    sglang_top_logprobs_allowed,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+# ---------------------------------------------------------------------------
+# parse_logprob_options
+# ---------------------------------------------------------------------------
+
+
+def test_parse_options_returns_both_when_present():
+    assert parse_logprob_options({"logprobs": 3, "prompt_logprobs": 5}) == (3, 5)
+
+
+def test_parse_options_handles_empty_string_as_absent():
+    # vLLM legacy treated empty string as "field absent" — preserved.
+    assert parse_logprob_options({"logprobs": "", "prompt_logprobs": ""}) == (
+        None,
+        None,
+    )
+
+
+def test_parse_options_warns_and_drops_on_negative(caplog):
+    with caplog.at_level("WARNING"):
+        result = parse_logprob_options({"logprobs": -2})
+    assert result == (None, None)
+    assert any("logprobs" in r.getMessage() for r in caplog.records)
+
+
+def test_parse_options_drops_non_integer():
+    assert parse_logprob_options({"logprobs": "abc"}) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# extract_from_completion_output (vLLM/TRT-LLM shape)
+# ---------------------------------------------------------------------------
+
+
+def _logprob(lp: float, rank: int = 1, decoded: str | None = None):
+    return SimpleNamespace(logprob=lp, rank=rank, decoded_token=decoded)
+
+
+def test_extract_completion_returns_none_when_logprobs_absent():
+    output = SimpleNamespace(token_ids=[1, 2], logprobs=None)
+    assert extract_from_completion_output(output, 0) == (None, None)
+
+
+def test_extract_completion_returns_none_past_end_of_tokens():
+    output = SimpleNamespace(
+        token_ids=[7, 8], logprobs=[{7: _logprob(-0.7)}, {8: _logprob(-0.8)}]
+    )
+    assert extract_from_completion_output(output, 5) == (None, None)
+
+
+def test_extract_completion_slices_from_offset():
+    output = SimpleNamespace(
+        token_ids=[7, 8, 9],
+        logprobs=[
+            {7: _logprob(-0.7, decoded="a")},
+            {8: _logprob(-0.8, decoded="b")},
+            {9: _logprob(-0.9, decoded="c")},
+        ],
+    )
+    log_probs, top_logprobs = extract_from_completion_output(output, 1)
+    assert log_probs == [-0.8, -0.9]
+    assert [pos[0]["token_id"] for pos in top_logprobs] == [8, 9]
+
+
+def test_extract_completion_includes_bytes_when_requested():
+    output = SimpleNamespace(
+        token_ids=[7],
+        logprobs=[{7: _logprob(-0.5, decoded="ab")}],
+    )
+    _, top_logprobs = extract_from_completion_output(output, 0, include_bytes=True)
+    assert top_logprobs[0][0]["bytes"] == list("ab".encode("utf-8"))
+
+
+def test_extract_completion_omits_bytes_by_default():
+    output = SimpleNamespace(
+        token_ids=[7], logprobs=[{7: _logprob(-0.5, decoded="ab")}]
+    )
+    _, top_logprobs = extract_from_completion_output(output, 0)
+    assert "bytes" not in top_logprobs[0][0]
+
+
+def test_extract_completion_skips_missing_selected_by_default():
+    # vLLM legacy behaviour: when the selected token isn't in the dict,
+    # skip that position rather than substitute.
+    output = SimpleNamespace(
+        token_ids=[7],
+        logprobs=[{99: _logprob(-1.0, decoded="x")}],
+    )
+    log_probs, top_logprobs = extract_from_completion_output(output, 0)
+    assert log_probs is None
+    assert top_logprobs is None
+
+
+def test_extract_completion_falls_back_to_first_when_flag_set():
+    # TRT-LLM legacy behaviour: fall back to first dict entry.
+    output = SimpleNamespace(
+        token_ids=[7],
+        logprobs=[{99: _logprob(-1.0, decoded="x")}],
+    )
+    log_probs, _ = extract_from_completion_output(
+        output, 0, fallback_to_first_on_missing=True
+    )
+    assert log_probs == [-1.0]
+
+
+def test_extract_completion_handles_trtllm_float_edge_case():
+    # TRT-LLM sometimes returns a list[float] instead of list[dict].
+    output = SimpleNamespace(token_ids=[7, 8], logprobs=[-0.7, -0.8])
+    log_probs, top_logprobs = extract_from_completion_output(output, 0)
+    assert log_probs == [-0.7, -0.8]
+    assert top_logprobs is None
+
+
+def test_extract_completion_skips_none_positions_in_logprobs_array():
+    # Engines occasionally emit `None` for a position in the logprobs
+    # list (no logprobs computed at that slot). Skip without aligning
+    # log_probs to that position so the wire format stays consistent.
+    output = SimpleNamespace(
+        token_ids=[7, 8],
+        logprobs=[None, {8: _logprob(-0.8, decoded="b")}],
+    )
+    log_probs, top_logprobs = extract_from_completion_output(output, 0)
+    assert log_probs == [-0.8]
+    assert len(top_logprobs) == 1
+    assert top_logprobs[0][0]["token_id"] == 8
+
+
+def test_extract_completion_uses_tokenizer_when_decoded_missing():
+    class FakeTok:
+        def decode(self, ids):
+            return f"<{ids[0]}>"
+
+    output = SimpleNamespace(
+        token_ids=[7],
+        logprobs=[{7: _logprob(-0.5, decoded=None)}],
+    )
+    _, top_logprobs = extract_from_completion_output(output, 0, tokenizer=FakeTok())
+    assert top_logprobs[0][0]["token"] == "<7>"
+
+
+# ---------------------------------------------------------------------------
+# build_sglang_logprob_kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_sglang_kwargs_empty_when_no_options():
+    assert build_sglang_logprob_kwargs({}, allow_top_logprobs=True) == {}
+
+
+def test_sglang_kwargs_logprobs_zero_allowed_without_gate():
+    # The default gate forbids logprobs >= 1; logprobs=0 always works.
+    kwargs = build_sglang_logprob_kwargs({"logprobs": 0}, allow_top_logprobs=False)
+    assert kwargs == {"return_logprob": True, "top_logprobs_num": 0}
+
+
+def test_sglang_kwargs_top_logprobs_rejected_without_gate():
+    with pytest.raises(ValueError, match="does not currently support logprobs >= 1"):
+        build_sglang_logprob_kwargs({"logprobs": 2}, allow_top_logprobs=False)
+
+
+def test_sglang_kwargs_top_logprobs_allowed_with_gate():
+    kwargs = build_sglang_logprob_kwargs({"logprobs": 2}, allow_top_logprobs=True)
+    assert kwargs == {"return_logprob": True, "top_logprobs_num": 2}
+
+
+def test_sglang_kwargs_prompt_logprobs_sets_start_len_zero():
+    kwargs = build_sglang_logprob_kwargs(
+        {"prompt_logprobs": 0}, allow_top_logprobs=False
+    )
+    assert kwargs == {
+        "return_logprob": True,
+        "top_logprobs_num": 0,
+        "logprob_start_len": 0,
+    }
+
+
+def test_sglang_kwargs_both_set_picks_max():
+    kwargs = build_sglang_logprob_kwargs(
+        {"logprobs": 3, "prompt_logprobs": 5}, allow_top_logprobs=True
+    )
+    assert kwargs["top_logprobs_num"] == 5
+    assert kwargs["logprob_start_len"] == 0
+
+
+def test_sglang_gate_reads_env(monkeypatch):
+    monkeypatch.setenv(DYN_SGL_ALLOW_TOP_LOGPROBS_ENV, "1")
+    assert sglang_top_logprobs_allowed() is True
+    monkeypatch.setenv(DYN_SGL_ALLOW_TOP_LOGPROBS_ENV, "0")
+    assert sglang_top_logprobs_allowed() is False
+    monkeypatch.delenv(DYN_SGL_ALLOW_TOP_LOGPROBS_ENV, raising=False)
+    assert sglang_top_logprobs_allowed() is False
+
+
+# ---------------------------------------------------------------------------
+# extract_from_sglang_meta
+# ---------------------------------------------------------------------------
+
+
+def test_sglang_extract_returns_none_when_meta_empty():
+    assert extract_from_sglang_meta({}, 0) == (None, None, 0)
+
+
+def test_sglang_extract_slices_cumulative_array():
+    meta = {
+        "output_token_logprobs": [(-0.1, 1, "a"), (-0.2, 2, "b"), (-0.3, 3, "c")],
+    }
+    log_probs, top_logprobs, new_total = extract_from_sglang_meta(meta, 1)
+    assert log_probs == [-0.2, -0.3]
+    assert top_logprobs is None
+    assert new_total == 3
+
+
+def test_sglang_extract_with_top():
+    meta = {
+        "output_token_logprobs": [(-0.1, 101, "a")],
+        "output_top_logprobs": [[(-0.1, 101, "a"), (-0.2, 102, "b")]],
+    }
+    log_probs, top_logprobs, _ = extract_from_sglang_meta(meta, 0)
+    assert log_probs == [-0.1]
+    assert top_logprobs == [
+        [
+            {"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1},
+            {"rank": 2, "token_id": 102, "token": "b", "logprob": -0.2},
+        ]
+    ]
+
+
+def test_sglang_extract_return_tokens_as_token_ids():
+    meta = {
+        "output_token_logprobs": [(-0.1, 101, "a")],
+        "output_top_logprobs": [[(-0.1, 101, "a")]],
+    }
+    _, top_logprobs, _ = extract_from_sglang_meta(
+        meta, 0, return_tokens_as_token_ids=True
+    )
+    assert top_logprobs[0][0]["token"] == "token_id:101"
+
+
+def test_sglang_extract_none_top_position_becomes_empty_list():
+    # SGLang's output_top_logprobs entry can be None for positions
+    # without top-k data — preserve as an empty list per-position so the
+    # caller can still index by position without breaking alignment.
+    meta = {
+        "output_token_logprobs": [(-0.1, 101, "a"), (-0.2, 102, "b")],
+        "output_top_logprobs": [None, [(-0.2, 102, "b")]],
+    }
+    _, top_logprobs, _ = extract_from_sglang_meta(meta, 0)
+    assert top_logprobs == [
+        [],
+        [{"rank": 1, "token_id": 102, "token": "b", "logprob": -0.2}],
+    ]
+
+
+def test_sglang_extract_returns_offset_unchanged_when_no_new_entries():
+    meta = {"output_token_logprobs": [(-0.1, 1, "a")]}
+    _, _, new_total = extract_from_sglang_meta(meta, 1)
+    assert new_total == 1
+
+
+# ---------------------------------------------------------------------------
+# Legacy ↔ unified behavioural parity corner cases.
+#
+# The legacy handlers and unified engines call the same shared helpers, so
+# the call sites should produce byte-identical output for any given input.
+# The tests below simulate each engine's wire format and confirm parity by
+# driving both call patterns side-by-side.
+# ---------------------------------------------------------------------------
+
+
+def _vllm_legacy_call(output, num_so_far, tokenizer=None):
+    """Mirror of ``BaseWorkerHandler._extract_logprobs`` — vLLM legacy."""
+    return extract_from_completion_output(
+        output, num_so_far, tokenizer=tokenizer, include_bytes=True
+    )
+
+
+def _vllm_unified_call(output, tokenizer=None):
+    """Mirror of ``VllmLLMEngine.generate``'s per-chunk extraction.
+    DELTA outputs always slice from offset 0."""
+    return extract_from_completion_output(
+        output, 0, tokenizer=tokenizer, include_bytes=True
+    )
+
+
+def _trtllm_call(output, num_so_far):
+    """Mirror of both ``HandlerBase._extract_logprobs`` and
+    ``TrtllmLLMEngine.generate``'s per-chunk extraction — TRT-LLM uses
+    cumulative arrays on both call sites with the same offset."""
+    return extract_from_completion_output(
+        output,
+        num_so_far,
+        fallback_to_first_on_missing=True,
+        include_bytes=False,
+    )
+
+
+def test_parity_vllm_delta_vs_cumulative_yields_same_logprobs():
+    """vLLM's legacy path slices a *cumulative* CompletionOutput with a
+    growing offset; the unified path receives DELTA chunks and slices
+    from offset 0. For an equivalent token stream both paths must emit
+    the same flat list of logprobs."""
+    cumulative_tokens = [7, 8, 9]
+    cumulative_logprobs = [
+        {7: _logprob(-0.7, decoded="a")},
+        {8: _logprob(-0.8, decoded="b")},
+        {9: _logprob(-0.9, decoded="c")},
+    ]
+
+    legacy_flat: list[float] = []
+    for i in range(len(cumulative_tokens)):
+        output = SimpleNamespace(
+            token_ids=cumulative_tokens[: i + 1],
+            logprobs=cumulative_logprobs[: i + 1],
+        )
+        lp, _ = _vllm_legacy_call(output, i)
+        if lp:
+            legacy_flat.extend(lp)
+
+    unified_flat: list[float] = []
+    for i in range(len(cumulative_tokens)):
+        output = SimpleNamespace(
+            token_ids=[cumulative_tokens[i]],
+            logprobs=[cumulative_logprobs[i]],
+        )
+        lp, _ = _vllm_unified_call(output)
+        if lp:
+            unified_flat.extend(lp)
+
+    assert legacy_flat == unified_flat == [-0.7, -0.8, -0.9]
+
+
+def test_parity_vllm_delta_vs_cumulative_yields_same_top_logprobs():
+    """Top-logprobs are also identical across the two slicing schemes."""
+    cumulative_tokens = [7, 8]
+    cumulative_logprobs = [
+        {7: _logprob(-0.7, decoded="a"), 70: _logprob(-1.7, decoded="A")},
+        {8: _logprob(-0.8, decoded="b"), 80: _logprob(-1.8, decoded="B")},
+    ]
+
+    legacy_top: list[list[dict]] = []
+    for i in range(len(cumulative_tokens)):
+        output = SimpleNamespace(
+            token_ids=cumulative_tokens[: i + 1],
+            logprobs=cumulative_logprobs[: i + 1],
+        )
+        _, top = _vllm_legacy_call(output, i)
+        if top:
+            legacy_top.extend(top)
+
+    unified_top: list[list[dict]] = []
+    for i in range(len(cumulative_tokens)):
+        output = SimpleNamespace(
+            token_ids=[cumulative_tokens[i]],
+            logprobs=[cumulative_logprobs[i]],
+        )
+        _, top = _vllm_unified_call(output)
+        if top:
+            unified_top.extend(top)
+
+    assert legacy_top == unified_top
+    # Confirm `bytes` field is included on both paths (vLLM-specific).
+    assert legacy_top[0][0]["bytes"] == list("a".encode("utf-8"))
+
+
+def test_parity_trtllm_extraction_is_idempotent_across_call_sites():
+    """TRT-LLM's legacy `_extract_logprobs` and the unified call use the
+    same flags and same offset — confirm a representative payload
+    produces byte-identical output through both call patterns."""
+    output = SimpleNamespace(
+        token_ids=[7, 8, 9],
+        logprobs=[
+            {7: _logprob(-0.7), 70: _logprob(-1.7)},
+            {8: _logprob(-0.8)},
+            # Selected-token missing — fallback_to_first must kick in.
+            {99: _logprob(-1.9)},
+        ],
+    )
+
+    legacy_log, legacy_top = _trtllm_call(output, num_so_far=0)
+    unified_log, unified_top = _trtllm_call(output, num_so_far=0)
+
+    assert legacy_log == unified_log == [-0.7, -0.8, -1.9]
+    assert legacy_top == unified_top
+    # Confirm bytes NOT included on TRT-LLM (legacy & unified).
+    assert "bytes" not in legacy_top[0][0]
+
+
+def test_parity_sglang_per_choice_offset_tracking_multi_choice():
+    """The unified SGLang generate() tracks `num_logprobs_per_choice` —
+    a dict keyed by output_idx. Without per-choice tracking, interleaved
+    n>1 chunks would mis-slice each other's cumulative arrays. Simulate
+    interleaved chunks for choice 0 and choice 1 and confirm each
+    choice's logprobs are extracted correctly."""
+    # SGLang emits ONE cumulative array per choice. The unified engine
+    # receives chunks tagged with `index` and tracks an offset per index.
+    # Sim: choice 0 emits 3 tokens, choice 1 emits 2, interleaved.
+    choice_0_arrays = [
+        {  # after step 1
+            "output_token_logprobs": [(-0.1, 100, "a")],
+        },
+        {  # after step 2 (cumulative)
+            "output_token_logprobs": [(-0.1, 100, "a"), (-0.2, 101, "b")],
+        },
+        {  # after step 3 (cumulative)
+            "output_token_logprobs": [
+                (-0.1, 100, "a"),
+                (-0.2, 101, "b"),
+                (-0.3, 102, "c"),
+            ],
+        },
+    ]
+    choice_1_arrays = [
+        {"output_token_logprobs": [(-0.5, 200, "x")]},
+        {
+            "output_token_logprobs": [(-0.5, 200, "x"), (-0.6, 201, "y")],
+        },
+    ]
+
+    # Interleaved arrival order: c0[0], c1[0], c0[1], c1[1], c0[2].
+    arrival = [
+        (0, choice_0_arrays[0]),
+        (1, choice_1_arrays[0]),
+        (0, choice_0_arrays[1]),
+        (1, choice_1_arrays[1]),
+        (0, choice_0_arrays[2]),
+    ]
+
+    num_logprobs_per_choice: dict[int, int] = {}
+    extracted_per_choice: dict[int, list[float]] = {}
+    for idx, meta in arrival:
+        lp, _, next_total = extract_from_sglang_meta(
+            meta, num_logprobs_per_choice.get(idx, 0)
+        )
+        num_logprobs_per_choice[idx] = next_total
+        if lp:
+            extracted_per_choice.setdefault(idx, []).extend(lp)
+
+    assert extracted_per_choice[0] == [-0.1, -0.2, -0.3]
+    assert extracted_per_choice[1] == [-0.5, -0.6]
+
+
+def test_parity_sglang_single_offset_misslices_under_n_gt_1():
+    """Negative control for the bug we fixed: a *scalar* offset (the
+    pre-fix unified behaviour) would mis-slice when chunks for two
+    different choices are interleaved on the same offset cursor. This
+    test exists so the regression is obvious if the per-choice dict
+    ever gets simplified back into a scalar."""
+    choice_0 = {"output_token_logprobs": [(-0.1, 100, "a")]}
+    choice_1 = {"output_token_logprobs": [(-0.5, 200, "x")]}
+
+    # Single scalar offset across both choices (buggy mode).
+    num_logprobs_so_far = 0
+    extracted_logprobs: list[float] = []
+    for meta in (choice_0, choice_1):
+        lp, _, num_logprobs_so_far = extract_from_sglang_meta(meta, num_logprobs_so_far)
+        if lp:
+            extracted_logprobs.extend(lp)
+
+    # The second extraction returns nothing because the scalar offset
+    # (=1 after the first chunk) skips choice 1's first entry. That's the
+    # bug — we'd lose choice 1's logprobs entirely.
+    assert extracted_logprobs == [-0.1]
+
+
+def test_parity_parse_logprob_options_consistent_across_engines():
+    """Every engine path goes through `parse_logprob_options` for the
+    options→ints normalization. Confirm the function is the single source
+    of truth — a battery of edge-case inputs returns the same parsed
+    output regardless of which engine consumes it next."""
+    cases: list[tuple[dict, tuple[Optional[int], Optional[int]]]] = [
+        ({}, (None, None)),
+        ({"logprobs": 0}, (0, None)),
+        ({"logprobs": 5}, (5, None)),
+        ({"prompt_logprobs": 3}, (None, 3)),
+        ({"logprobs": 2, "prompt_logprobs": 4}, (2, 4)),
+        ({"logprobs": ""}, (None, None)),
+        ({"logprobs": "7"}, (7, None)),  # str → int coercion
+        ({"logprobs": -1}, (None, None)),
+        ({"logprobs": "garbage"}, (None, None)),
+    ]
+    for opts, expected in cases:
+        assert parse_logprob_options(opts) == expected, opts
+
+
+def test_parity_sglang_kwargs_rejects_top_logprobs_consistently():
+    """Both legacy decode handler and unified engine call into
+    `build_sglang_logprob_kwargs` with the env-derived gate. With the
+    gate off, any `logprobs >= 1` (or `prompt_logprobs >= 1`) request
+    must raise — regardless of which call site invoked it."""
+    for opts in (
+        {"logprobs": 1},
+        {"logprobs": 5},
+        {"prompt_logprobs": 2},
+        {"logprobs": 0, "prompt_logprobs": 3},
+    ):
+        with pytest.raises(ValueError, match="does not currently support"):
+            build_sglang_logprob_kwargs(opts, allow_top_logprobs=False)
+
+
+# ---------------------------------------------------------------------------
+# Direct wrapper-vs-shared parity. These tests import the legacy static
+# methods on each engine's handler class and assert byte-identical output
+# vs a direct shared call with the same flags. They catch wrapper rot —
+# e.g. someone editing the static method to drop a flag.
+#
+# `pytest.importorskip` skips when the engine package isn't installed
+# (developer machines without vllm/sglang/trtllm). CI envs with the
+# engines will execute them.
+# ---------------------------------------------------------------------------
+
+
+def test_parity_vllm_legacy_wrapper_matches_shared():
+    pytest.importorskip("vllm", reason="vLLM not installed")
+    from dynamo.vllm.handlers import BaseWorkerHandler
+
+    output = SimpleNamespace(
+        token_ids=[11, 12],
+        logprobs=[
+            {11: _logprob(-0.1, decoded="a"), 110: _logprob(-1.1, decoded="A")},
+            {12: _logprob(-0.2, decoded="b")},
+        ],
+    )
+
+    wrapper_lp, wrapper_top = BaseWorkerHandler._extract_logprobs(output, 0)
+    direct_lp, direct_top = extract_from_completion_output(
+        output, 0, include_bytes=True
+    )
+    assert wrapper_lp == direct_lp
+    assert wrapper_top == direct_top
+
+
+def test_parity_trtllm_legacy_wrapper_matches_shared():
+    pytest.importorskip("tensorrt_llm", reason="TRT-LLM not installed")
+    from dynamo.trtllm.request_handlers.handler_base import HandlerBase
+
+    output = SimpleNamespace(
+        token_ids=[11, 12],
+        logprobs=[
+            {11: _logprob(-0.1), 110: _logprob(-1.1)},
+            # Selected token missing — exercises the fallback flag.
+            {99: _logprob(-9.9)},
+        ],
+    )
+
+    wrapper_lp, wrapper_top = HandlerBase._extract_logprobs(output, 0)
+    direct_lp, direct_top = extract_from_completion_output(
+        output, 0, fallback_to_first_on_missing=True, include_bytes=False
+    )
+    assert wrapper_lp == direct_lp
+    assert wrapper_top == direct_top
+
+
+def test_parity_sglang_legacy_extract_wrapper_matches_shared():
+    pytest.importorskip("sglang", reason="SGLang not installed")
+    from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
+
+    meta = {
+        "output_token_logprobs": [(-0.1, 101, "a"), (-0.2, 102, "b")],
+        "output_top_logprobs": [
+            [(-0.1, 101, "a"), (-0.5, 105, "x")],
+            [(-0.2, 102, "b")],
+        ],
+    }
+
+    wrapper = DecodeWorkerHandler._extract_logprobs(meta, 0)
+    direct = extract_from_sglang_meta(meta, 0)
+    assert wrapper == direct
+
+
+def test_parity_sglang_legacy_kwargs_wrapper_matches_shared(monkeypatch):
+    pytest.importorskip("sglang", reason="SGLang not installed")
+    from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
+
+    # Gate off — both must reject logprobs >= 1 identically.
+    monkeypatch.delenv(DYN_SGL_ALLOW_TOP_LOGPROBS_ENV, raising=False)
+    request = {"output_options": {"logprobs": 0, "prompt_logprobs": 0}}
+
+    wrapper_kwargs = DecodeWorkerHandler._build_logprob_kwargs(request)
+    direct_kwargs = build_sglang_logprob_kwargs(
+        request["output_options"], allow_top_logprobs=False
+    )
+    assert wrapper_kwargs == direct_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Whole-stream parity. Drive a simulated multi-chunk generation through both
+# paths and confirm not just the per-chunk logprobs, but the byte-identical
+# top-logprob dict shape (rank/token_id/token/logprob/bytes) lines up.
+# ---------------------------------------------------------------------------
+
+
+def test_parity_vllm_full_stream_byte_identical_top_logprobs():
+    """Whole-stream parity: a 4-token generation with non-trivial top-k
+    alternatives must emit byte-identical top_logprobs through both
+    legacy cumulative+offset and unified DELTA+0 paths."""
+    cumulative_tokens = [10, 20, 30, 40]
+    # Each position has 3 alternatives — selected first, then two off-pol.
+    cumulative_logprobs = [
+        {
+            10: _logprob(-0.1, rank=1, decoded="ten"),
+            11: _logprob(-1.1, rank=2, decoded="11"),
+            12: _logprob(-2.1, rank=3, decoded="12"),
+        },
+        {
+            20: _logprob(-0.2, rank=1, decoded="twenty"),
+            21: _logprob(-1.2, rank=2, decoded="21"),
+        },
+        {
+            30: _logprob(-0.3, rank=1, decoded="thirty"),
+            31: _logprob(-1.3, rank=2, decoded="31"),
+            32: _logprob(-2.3, rank=3, decoded="32"),
+            33: _logprob(-3.3, rank=4, decoded="33"),
+        },
+        {
+            40: _logprob(-0.4, rank=1, decoded="forty"),
+        },
+    ]
+
+    def _run_legacy() -> list[list[dict]]:
+        # Legacy: receives the cumulative array each step, slices by offset.
+        flat: list[list[dict]] = []
+        for i in range(len(cumulative_tokens)):
+            output = SimpleNamespace(
+                token_ids=cumulative_tokens[: i + 1],
+                logprobs=cumulative_logprobs[: i + 1],
+            )
+            _, top = _vllm_legacy_call(output, i)
+            if top:
+                flat.extend(top)
+        return flat
+
+    def _run_unified() -> list[list[dict]]:
+        # Unified: receives the DELTA chunk each step, offset always 0.
+        flat: list[list[dict]] = []
+        for i in range(len(cumulative_tokens)):
+            output = SimpleNamespace(
+                token_ids=[cumulative_tokens[i]],
+                logprobs=[cumulative_logprobs[i]],
+            )
+            _, top = _vllm_unified_call(output)
+            if top:
+                flat.extend(top)
+        return flat
+
+    legacy = _run_legacy()
+    unified = _run_unified()
+
+    # Byte-identical comparison on the full structure: rank, token_id,
+    # token, logprob, bytes are all included.
+    assert legacy == unified
+    assert len(legacy) == 4
+    # Spot-check a representative entry.
+    assert legacy[2] == [
+        {
+            "rank": 1,
+            "token_id": 30,
+            "token": "thirty",
+            "logprob": -0.3,
+            "bytes": list("thirty".encode("utf-8")),
+        },
+        {
+            "rank": 2,
+            "token_id": 31,
+            "token": "31",
+            "logprob": -1.3,
+            "bytes": list("31".encode("utf-8")),
+        },
+        {
+            "rank": 3,
+            "token_id": 32,
+            "token": "32",
+            "logprob": -2.3,
+            "bytes": list("32".encode("utf-8")),
+        },
+        {
+            "rank": 4,
+            "token_id": 33,
+            "token": "33",
+            "logprob": -3.3,
+            "bytes": list("33".encode("utf-8")),
+        },
+    ]
+
+
+def test_parity_vllm_with_none_position_mid_stream():
+    """If the engine emits None for a mid-stream position (no logprobs
+    sampled at that slot), both paths must skip the position consistently
+    without misaligning subsequent entries."""
+    cumulative_tokens = [10, 20, 30]
+    cumulative_logprobs = [
+        {10: _logprob(-0.1, decoded="a")},
+        None,  # engine emitted no logprobs for position 1
+        {30: _logprob(-0.3, decoded="c")},
+    ]
+
+    legacy: list[float] = []
+    for i in range(len(cumulative_tokens)):
+        output = SimpleNamespace(
+            token_ids=cumulative_tokens[: i + 1],
+            logprobs=cumulative_logprobs[: i + 1],
+        )
+        lp, _ = _vllm_legacy_call(output, i)
+        if lp:
+            legacy.extend(lp)
+
+    unified: list[float] = []
+    for i in range(len(cumulative_tokens)):
+        output = SimpleNamespace(
+            token_ids=[cumulative_tokens[i]],
+            logprobs=[cumulative_logprobs[i]],
+        )
+        lp, _ = _vllm_unified_call(output)
+        if lp:
+            unified.extend(lp)
+
+    # Both skip the None position (one fewer entry than tokens emitted).
+    assert legacy == unified == [-0.1, -0.3]
+
+
+def test_parity_trtllm_selected_token_missing_fallback_consistent():
+    """TRT-LLM fallback: when the engine doesn't include the selected
+    token in the logprob dict, both legacy and unified fall back to the
+    first dict entry. Confirm the fallback is consistent across a
+    multi-position stream where SOME positions hit the fallback."""
+    output = SimpleNamespace(
+        token_ids=[100, 200, 300],
+        logprobs=[
+            # Position 0: selected present, normal path.
+            {100: _logprob(-0.5), 101: _logprob(-1.5)},
+            # Position 1: selected missing, fallback to first.
+            {201: _logprob(-2.5), 202: _logprob(-3.5)},
+            # Position 2: selected present again.
+            {300: _logprob(-0.7), 301: _logprob(-1.7)},
+        ],
+    )
+
+    log_probs, top_logprobs = _trtllm_call(output, num_so_far=0)
+    # Position 1 falls back to first dict entry = 201 (-2.5).
+    assert log_probs == [-0.5, -2.5, -0.7]
+    assert top_logprobs is not None
+    # Top remains the full dict at each position — fallback doesn't
+    # change the top list itself.
+    assert [len(p) for p in top_logprobs] == [2, 2, 2]
+
+
+def test_parity_sglang_cumulative_two_chunks_yields_full_stream():
+    """SGLang receives cumulative arrays. After two chunks (3 tokens
+    total), the running extracted-logprobs list matches the engine's
+    final state — proving the offset advances correctly."""
+    chunk_1_meta = {
+        "output_token_logprobs": [(-0.1, 100, "a")],
+        "output_top_logprobs": [[(-0.1, 100, "a"), (-0.5, 105, "x")]],
+    }
+    chunk_2_meta = {
+        "output_token_logprobs": [
+            (-0.1, 100, "a"),
+            (-0.2, 200, "b"),
+            (-0.3, 300, "c"),
+        ],
+        "output_top_logprobs": [
+            [(-0.1, 100, "a"), (-0.5, 105, "x")],
+            [(-0.2, 200, "b"), (-0.6, 205, "y")],
+            [(-0.3, 300, "c")],
+        ],
+    }
+
+    extracted_lp: list[float] = []
+    extracted_top: list[list[dict]] = []
+    offset = 0
+    for meta in (chunk_1_meta, chunk_2_meta):
+        lp, top, offset = extract_from_sglang_meta(meta, offset)
+        if lp:
+            extracted_lp.extend(lp)
+        if top:
+            extracted_top.extend(top)
+
+    assert extracted_lp == [-0.1, -0.2, -0.3]
+    assert [pos[0]["token_id"] for pos in extracted_top] == [100, 200, 300]
+    # First chunk: 1 entry; second chunk: 2 new entries. Total 3.
+    assert len(extracted_top) == 3
+    assert offset == 3

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -24,7 +24,12 @@ from dynamo.common.backend.logprobs import (
     sglang_top_logprobs_allowed,
 )
 
-pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+    pytest.mark.pre_merge,
+]
 
 
 # ---------------------------------------------------------------------------
@@ -139,18 +144,34 @@ def test_extract_completion_handles_trtllm_float_edge_case():
     assert top_logprobs is None
 
 
-def test_extract_completion_skips_none_positions_in_logprobs_array():
+def test_extract_completion_bails_on_none_positions_in_logprobs_array():
     # Engines occasionally emit `None` for a position in the logprobs
-    # list (no logprobs computed at that slot). Skip without aligning
-    # log_probs to that position so the wire format stays consistent.
+    # list (no logprobs computed at that slot). The Rust response
+    # builder zips log_probs against token_ids positionally, so emitting
+    # a shorter array would misalign every later token — drop the
+    # chunk's logprobs entirely instead.
     output = SimpleNamespace(
         token_ids=[7, 8],
         logprobs=[None, {8: _logprob(-0.8, decoded="b")}],
     )
     log_probs, top_logprobs = extract_from_completion_output(output, 0)
-    assert log_probs == [-0.8]
-    assert len(top_logprobs) == 1
-    assert top_logprobs[0][0]["token_id"] == 8
+    assert log_probs is None
+    assert top_logprobs is None
+
+
+def test_extract_completion_bails_when_any_selected_token_missing():
+    # Same invariant: a single missing selected token would shrink
+    # log_probs out of alignment with token_ids — bail on the chunk.
+    output = SimpleNamespace(
+        token_ids=[7, 8],
+        logprobs=[
+            {7: _logprob(-0.7, decoded="a")},
+            {99: _logprob(-0.8, decoded="x")},  # 8 not present
+        ],
+    )
+    log_probs, top_logprobs = extract_from_completion_output(output, 0)
+    assert log_probs is None
+    assert top_logprobs is None
 
 
 def test_extract_completion_uses_tokenizer_when_decoded_missing():
@@ -296,9 +317,15 @@ def test_sglang_extract_returns_offset_unchanged_when_no_new_entries():
 
 
 def _vllm_legacy_call(output, num_so_far, tokenizer=None):
-    """Mirror of ``BaseWorkerHandler._extract_logprobs`` — vLLM legacy."""
+    """Mirror of ``BaseWorkerHandler._extract_logprobs`` — vLLM legacy.
+    `fallback_to_first_on_missing=True` matches the pre-shared-helper
+    extractor that always emitted a logprob when vLLM returned a dict."""
     return extract_from_completion_output(
-        output, num_so_far, tokenizer=tokenizer, include_bytes=True
+        output,
+        num_so_far,
+        tokenizer=tokenizer,
+        fallback_to_first_on_missing=True,
+        include_bytes=True,
     )
 
 
@@ -306,7 +333,11 @@ def _vllm_unified_call(output, tokenizer=None):
     """Mirror of ``VllmLLMEngine.generate``'s per-chunk extraction.
     DELTA outputs always slice from offset 0."""
     return extract_from_completion_output(
-        output, 0, tokenizer=tokenizer, include_bytes=True
+        output,
+        0,
+        tokenizer=tokenizer,
+        fallback_to_first_on_missing=True,
+        include_bytes=True,
     )
 
 
@@ -537,6 +568,7 @@ def test_parity_sglang_kwargs_rejects_top_logprobs_consistently():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.vllm
 def test_parity_vllm_legacy_wrapper_matches_shared():
     pytest.importorskip("vllm", reason="vLLM not installed")
     from dynamo.vllm.handlers import BaseWorkerHandler
@@ -551,12 +583,13 @@ def test_parity_vllm_legacy_wrapper_matches_shared():
 
     wrapper_lp, wrapper_top = BaseWorkerHandler._extract_logprobs(output, 0)
     direct_lp, direct_top = extract_from_completion_output(
-        output, 0, include_bytes=True
+        output, 0, fallback_to_first_on_missing=True, include_bytes=True
     )
     assert wrapper_lp == direct_lp
     assert wrapper_top == direct_top
 
 
+@pytest.mark.trtllm
 def test_parity_trtllm_legacy_wrapper_matches_shared():
     pytest.importorskip("tensorrt_llm", reason="TRT-LLM not installed")
     from dynamo.trtllm.request_handlers.handler_base import HandlerBase
@@ -578,6 +611,7 @@ def test_parity_trtllm_legacy_wrapper_matches_shared():
     assert wrapper_top == direct_top
 
 
+@pytest.mark.sglang
 def test_parity_sglang_legacy_extract_wrapper_matches_shared():
     pytest.importorskip("sglang", reason="SGLang not installed")
     from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
@@ -595,6 +629,7 @@ def test_parity_sglang_legacy_extract_wrapper_matches_shared():
     assert wrapper == direct
 
 
+@pytest.mark.sglang
 def test_parity_sglang_legacy_kwargs_wrapper_matches_shared(monkeypatch):
     pytest.importorskip("sglang", reason="SGLang not installed")
     from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -236,9 +236,7 @@ def test_prompt_logprobs_completion_falls_back_to_tokenizer():
         def decode(self, ids):
             return f"<{ids[0]}>"
 
-    output = SimpleNamespace(
-        prompt_logprobs=[None, {9: _logprob(-0.7, decoded=None)}]
-    )
+    output = SimpleNamespace(prompt_logprobs=[None, {9: _logprob(-0.7, decoded=None)}])
     payload = extract_prompt_logprobs_from_completion_output(
         output, tokenizer=FakeTok()
     )
@@ -252,9 +250,9 @@ def test_prompt_logprobs_completion_falls_back_to_tokenizer():
 
 def test_prompt_logprobs_sglang_returns_none_when_absent():
     assert extract_prompt_logprobs_from_sglang_meta({}) is None
-    assert extract_prompt_logprobs_from_sglang_meta(
-        {"input_token_logprobs": []}
-    ) is None
+    assert (
+        extract_prompt_logprobs_from_sglang_meta({"input_token_logprobs": []}) is None
+    )
 
 
 def test_prompt_logprobs_sglang_prepends_none_for_bos():

--- a/components/src/dynamo/common/backend/tests/test_sample_engine.py
+++ b/components/src/dynamo/common/backend/tests/test_sample_engine.py
@@ -162,3 +162,36 @@ async def test_decode_without_probe_marker_still_requires_prefill_result():
     )
     with pytest.raises(ValueError, match="prefill_result"):
         await _collect(engine, {"token_ids": [1]})
+
+
+async def test_logprobs_absent_when_not_requested():
+    engine = SampleLLMEngine(max_tokens=2, delay=0.0)
+    chunks = await _collect(engine, {"token_ids": [1]})
+    for chunk in chunks:
+        assert "log_probs" not in chunk
+        assert "top_logprobs" not in chunk
+
+
+async def test_logprobs_zero_emits_selected_only():
+    # logprobs=0 means "selected token only" — no top_logprobs.
+    engine = SampleLLMEngine(max_tokens=2, delay=0.0)
+    chunks = await _collect(
+        engine, {"token_ids": [1], "output_options": {"logprobs": 0}}
+    )
+    assert all("log_probs" in c for c in chunks)
+    assert all("top_logprobs" not in c for c in chunks)
+    assert all(len(c["log_probs"]) == len(c["token_ids"]) for c in chunks)
+
+
+async def test_logprobs_with_top_k_emits_alternatives():
+    engine = SampleLLMEngine(max_tokens=2, delay=0.0)
+    chunks = await _collect(
+        engine, {"token_ids": [1], "output_options": {"logprobs": 3}}
+    )
+    for chunk in chunks:
+        assert len(chunk["log_probs"]) == len(chunk["token_ids"])
+        assert len(chunk["top_logprobs"]) == len(chunk["token_ids"])
+        for position in chunk["top_logprobs"]:
+            # k=3 -> selected + 3 alternatives = 4 entries; ranks 1..4.
+            assert len(position) == 4
+            assert [entry["rank"] for entry in position] == [1, 2, 3, 4]

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -434,6 +434,19 @@ class SglangLLMEngine(LLMEngine):
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
                 }
+                # Prompt logprobs ride on the final chunk. SGLang
+                # populates ``meta_info["input_token_logprobs"]`` (and
+                # optionally ``input_top_logprobs``) when the request
+                # set ``return_logprob=True, logprob_start_len=0`` —
+                # which ``build_sglang_logprob_kwargs`` does whenever
+                # ``prompt_logprobs`` is requested.
+                prompt_payload = (
+                    _shared_logprobs.extract_prompt_logprobs_from_sglang_meta(
+                        meta_info
+                    )
+                )
+                if prompt_payload is not None:
+                    out["engine_data"] = {"prompt_logprobs": prompt_payload}
 
             if context.is_stopped():
                 # Mutate `out` instead of building a fresh dict so any

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -33,6 +33,7 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.utils.network import get_local_ip_auto, get_zmq_socket
 
 from dynamo._core import Context
+from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.backend import telemetry
 from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
 from dynamo.common.backend.engine import (
@@ -282,6 +283,20 @@ class SglangLLMEngine(LLMEngine):
 
         sampling_params = self._build_sampling_params(request)
         input_param = self._get_input_param(request)
+        # Prefill discards engine output (it only yields bootstrap info) —
+        # asking SGLang to compute logprobs there would be wasted work,
+        # especially with prompt_logprobs which forces a full prompt pass.
+        logprob_kwargs = (
+            {}
+            if self.serving_mode == DisaggregationMode.PREFILL
+            else _shared_logprobs.build_sglang_logprob_kwargs(
+                request.get("output_options", {}) or {},
+                allow_top_logprobs=_shared_logprobs.sglang_top_logprobs_allowed(),
+            )
+        )
+        return_tokens_as_token_ids = bool(
+            (request.get("output_options") or {}).get("return_tokens_as_token_ids")
+        )
 
         # SGLang disagg keys NIXL transport on a (host, port, room) triple
         # exchanged between prefill and decode peers.
@@ -312,6 +327,7 @@ class SglangLLMEngine(LLMEngine):
                 enabled=self.enable_trace,
             ),
             **bootstrap_kwargs,
+            **logprob_kwargs,
         )
 
         # ORDER MATTERS: async_generate must register the room (the await
@@ -362,6 +378,10 @@ class SglangLLMEngine(LLMEngine):
             task.add_done_callback(self._prefill_consume_tasks.discard)
             return
 
+        # SGLang's logprob arrays are cumulative per choice and `n > 1`
+        # requests interleave choices on the stream, so the offset is
+        # keyed by `output_idx`, not a single scalar.
+        num_logprobs_per_choice: dict[int, int] = {}
         async for res in stream:
             # SGLang sets index when n>1; default to 0 otherwise.
             output_idx = res.get("index") or 0
@@ -370,6 +390,22 @@ class SglangLLMEngine(LLMEngine):
             finish_reason = meta_info["finish_reason"]
 
             output_ids = res.get("output_ids", [])
+            if output_ids or finish_reason:
+                (
+                    log_probs,
+                    top_logprobs,
+                    next_total,
+                ) = _shared_logprobs.extract_from_sglang_meta(
+                    meta_info,
+                    num_logprobs_per_choice.get(output_idx, 0),
+                    return_tokens_as_token_ids=return_tokens_as_token_ids,
+                )
+                num_logprobs_per_choice[output_idx] = next_total
+                if log_probs is not None:
+                    out["log_probs"] = log_probs
+                if top_logprobs is not None:
+                    out["top_logprobs"] = top_logprobs
+
             if not output_ids and not finish_reason:
                 if context.is_stopped():
                     prompt_tokens = meta_info.get("prompt_tokens", 0)
@@ -400,18 +436,18 @@ class SglangLLMEngine(LLMEngine):
                 }
 
             if context.is_stopped():
+                # Mutate `out` instead of building a fresh dict so any
+                # logprobs we already extracted for this chunk's tokens
+                # ride along with the cancellation terminal.
                 prompt_tokens = meta_info.get("prompt_tokens", 0)
                 completion_tokens = meta_info.get("completion_tokens", 0)
-                yield {
-                    "token_ids": output_ids,
-                    "index": output_idx,
-                    "finish_reason": "cancelled",
-                    "completion_usage": {
-                        "prompt_tokens": prompt_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": prompt_tokens + completion_tokens,
-                    },
+                out["finish_reason"] = "cancelled"
+                out["completion_usage"] = {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
                 }
+                yield out
                 break
 
             yield out

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -441,9 +441,7 @@ class SglangLLMEngine(LLMEngine):
                 # which ``build_sglang_logprob_kwargs`` does whenever
                 # ``prompt_logprobs`` is requested.
                 prompt_payload = (
-                    _shared_logprobs.extract_prompt_logprobs_from_sglang_meta(
-                        meta_info
-                    )
+                    _shared_logprobs.extract_prompt_logprobs_from_sglang_meta(meta_info)
                 )
                 if prompt_payload is not None:
                     out["engine_data"] = {"prompt_logprobs": prompt_payload}

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -434,12 +434,6 @@ class SglangLLMEngine(LLMEngine):
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
                 }
-                # Prompt logprobs ride on the final chunk. SGLang
-                # populates ``meta_info["input_token_logprobs"]`` (and
-                # optionally ``input_top_logprobs``) when the request
-                # set ``return_logprob=True, logprob_start_len=0`` —
-                # which ``build_sglang_logprob_kwargs`` does whenever
-                # ``prompt_logprobs`` is requested.
                 prompt_payload = (
                     _shared_logprobs.extract_prompt_logprobs_from_sglang_meta(meta_info)
                 )

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-import os
 import time
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -11,6 +10,7 @@ import sglang as sgl
 from PIL.Image import Image as PILImage
 
 from dynamo._core import Context
+from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.utils.engine_response import normalize_finish_reason
@@ -18,26 +18,6 @@ from dynamo.sglang._compat import filter_supported_async_generate_kwargs
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
 from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
-
-# Escape hatch: set to "1" (or any truthy value) to allow top_logprobs_num >= 1.
-# Default-off because SGLang's tokenizer manager detokenizes top-k tokens
-# per-position serially (O(N) per generated token), causing severe latency
-# degradation. Flip once upstream lands batched top-logprob detokenization:
-# https://github.com/sgl-project/sglang/pull/24447
-_ALLOW_TOP_LOGPROBS_ENV = "DYN_SGL_ALLOW_TOP_LOGPROBS"
-
-_TOP_LOGPROBS_UNSUPPORTED_MSG = (
-    "Dynamo's SGLang backend does not currently support logprobs >= 1 due to "
-    "an O(N) per-position detokenization in the upstream sglang tokenizer "
-    "manager. Use logprobs=0 for chosen-token logprobs, or set "
-    "DYN_SGL_ALLOW_TOP_LOGPROBS=1 to override at your own risk. "
-    "Track the upstream fix at https://github.com/sgl-project/sglang/pull/24447."
-)
-
-
-def _top_logprobs_allowed() -> bool:
-    """Return True if the DYN_SGL_ALLOW_TOP_LOGPROBS escape hatch is enabled."""
-    return os.environ.get(_ALLOW_TOP_LOGPROBS_ENV, "").lower() not in ("", "0", "false")
 
 
 def _extract_media_urls(mm_data: Dict[str, Any], media_key: str) -> list[str] | None:
@@ -313,78 +293,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
     @staticmethod
     def _build_logprob_kwargs(request: Dict[str, Any]) -> Dict[str, Any]:
-        """Build logprob kwargs for SGLang async_generate from output_options.
-
-        Maps the Dynamo output_options format (shared with vLLM/TRT-LLM) to
-        SGLang's async_generate keyword arguments:
-
-          - return_logprob (bool): enables logprob computation
-          - top_logprobs_num (int): number of top-k logprobs per token
-          - logprob_start_len (int): absolute position in the sequence where
-            logprob computation begins. SGLang defaults this to -1, which
-            means len(prompt) - 1 (i.e. output tokens only). Setting it to 0
-            computes logprobs from the start of the prompt — this is how we
-            implement prompt_logprobs. We don't expose logprob_start_len
-            directly; it's an SGLang-internal detail derived from whether the
-            user requested prompt_logprobs.
-
-        Args:
-            request: Request dict containing optional output_options.
-
-        Returns:
-            Dict of logprob-related kwargs for engine.async_generate().
-        """
-        kwargs: Dict[str, Any] = {}
-        output_options = request.get("output_options", {})
-        if not output_options:
-            return kwargs
-
-        allow_top = _top_logprobs_allowed()
-
-        def _parse(name: str, value: Any) -> Optional[int]:
-            try:
-                parsed = int(value)
-            except (ValueError, TypeError):
-                logging.warning(
-                    f"Invalid {name} value: {value} (must be integer), ignoring"
-                )
-                return None
-            if parsed < 0:
-                logging.warning(
-                    f"Invalid {name} value: {value} (must be non-negative), ignoring"
-                )
-                return None
-            if parsed >= 1 and not allow_top:
-                raise ValueError(_TOP_LOGPROBS_UNSUPPORTED_MSG)
-            return parsed
-
-        logprobs_value = output_options.get("logprobs")
-        if logprobs_value is not None:
-            parsed = _parse("logprobs", logprobs_value)
-            if parsed is not None:
-                kwargs["return_logprob"] = True
-                kwargs["top_logprobs_num"] = parsed
-
-        prompt_logprobs_value = output_options.get("prompt_logprobs")
-        if prompt_logprobs_value is not None:
-            parsed = _parse("prompt_logprobs", prompt_logprobs_value)
-            if parsed is not None:
-                kwargs["return_logprob"] = True
-                # SGLang has a single top_logprobs_num for both prompt
-                # and output tokens, so take the max of the two.
-                kwargs["top_logprobs_num"] = max(
-                    kwargs.get("top_logprobs_num", 0), parsed
-                )
-                # logprob_start_len=0 computes from prompt start;
-                # omitting it (or -1) computes output tokens only.
-                kwargs["logprob_start_len"] = 0
-
-        # Belt-and-suspenders: if return_logprob was requested and the gate is
-        # not open, pin top_logprobs_num=0 so no future code path can flip it on.
-        if kwargs.get("return_logprob") and not allow_top:
-            kwargs["top_logprobs_num"] = 0
-
-        return kwargs
+        return _shared_logprobs.build_sglang_logprob_kwargs(
+            request.get("output_options", {}) or {},
+            allow_top_logprobs=_shared_logprobs.sglang_top_logprobs_allowed(),
+        )
 
     @staticmethod
     def _extract_logprobs(
@@ -392,66 +304,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         num_output_logprobs_so_far: int,
         return_tokens_as_token_ids: bool = False,
     ) -> tuple:
-        """Extract logprobs from SGLang meta_info for new tokens.
-
-        While Dynamo forces stream_output=True (args.py) so that output_ids
-        are disjoint per chunk, SGLang's output_token_logprobs and
-        output_top_logprobs in meta_info are always cumulative. We track an
-        offset to slice out only the new entries each chunk.
-
-        Args:
-            meta_info: SGLang response meta_info dict.
-            num_output_logprobs_so_far: Number of logprob entries already
-                processed in previous chunks.
-
-        Returns:
-            Tuple of (log_probs, top_logprobs, new_total):
-            - log_probs: List of floats (selected token logprob per position)
-            - top_logprobs: List of lists of dicts with rank/token_id/token/logprob
-            - new_total: Updated count of logprob entries processed so far
-        """
-        output_token_logprobs = meta_info.get("output_token_logprobs")
-        if not output_token_logprobs:
-            return None, None, num_output_logprobs_so_far
-
-        new_logprobs = output_token_logprobs[num_output_logprobs_so_far:]
-        if not new_logprobs:
-            return None, None, num_output_logprobs_so_far
-
-        # Extract selected-token logprobs: each entry is (logprob, token_id, text_or_None)
-        log_probs = [float(entry[0]) for entry in new_logprobs]
-
-        # Extract top logprobs if available
-        top_logprobs: list[list[dict[str, Any]]] | None = None
-        output_top = meta_info.get("output_top_logprobs")
-        if output_top:
-            new_top = output_top[num_output_logprobs_so_far:]
-            if new_top:
-                top_logprobs = []
-                for position_entries in new_top:
-                    if position_entries is None:
-                        top_logprobs.append([])
-                        continue
-                    position_list = []
-                    for rank_idx, entry in enumerate(position_entries):
-                        tok_id = entry[1]
-                        token_str = (
-                            f"token_id:{tok_id}"
-                            if return_tokens_as_token_ids
-                            else entry[2]
-                        )
-                        position_list.append(
-                            {
-                                "rank": rank_idx + 1,
-                                "token_id": tok_id,
-                                "token": token_str,
-                                "logprob": float(entry[0]),
-                            }
-                        )
-                    top_logprobs.append(position_list)
-
-        new_total = len(output_token_logprobs)
-        return log_probs, top_logprobs, new_total
+        return _shared_logprobs.extract_from_sglang_meta(
+            meta_info,
+            num_output_logprobs_so_far,
+            return_tokens_as_token_ids=return_tokens_as_token_ids,
+        )
 
     async def generate(
         self, request: Dict[str, Any], context: Context

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -666,9 +666,8 @@ class TrtllmLLMEngine(LLMEngine):
         async with self._pause_lock:
             if controller.is_paused:
                 return {"status": "ok", "message": "Memory already released"}
-            if (
-                self._resume_recovery_required
-                or self._controller_needs_resume_recovery(controller)
+            if self._resume_recovery_required or self._controller_needs_resume_recovery(
+                controller
             ):
                 return {
                     "status": "error",
@@ -773,11 +772,9 @@ class TrtllmLLMEngine(LLMEngine):
             self._default_sampling_params, request
         )
 
-        # TRT-LLM's `logprobs` is the top-k count; 0 disables logprob
-        # computation entirely. Floor at 1 so a caller asking for
-        # `logprobs=0` (chosen-token only) still gets the chosen logprob;
-        # keep the raw requested count to suppress top_logprobs below
-        # when the user did NOT ask for alternatives.
+        # TRT-LLM's `logprobs=0` disables computation entirely. Floor at 1
+        # so a `logprobs=0` request still gets the chosen-token logprob;
+        # the raw requested count gates top_logprobs emission below.
         (
             requested_logprobs_count,
             prompt_logprobs_count,
@@ -889,9 +886,6 @@ class TrtllmLLMEngine(LLMEngine):
                     )
                     if log_probs is not None:
                         out["log_probs"] = log_probs
-                    # `requested_logprobs_count == 0` means chosen-token
-                    # only — suppress the top-k that the engine floor
-                    # forced TRT-LLM to compute.
                     if (
                         top_logprobs is not None
                         and requested_logprobs_count is not None
@@ -905,10 +899,7 @@ class TrtllmLLMEngine(LLMEngine):
                     if out.get("finish_reason") or res.finished:
                         if not out.get("finish_reason"):
                             out["finish_reason"] = "unknown"
-                        # Prompt logprobs ride on the final chunk. TRT-LLM
-                        # exposes them on `res.prompt_logprobs` in the same
-                        # ``list[Optional[dict[int, Logprob]]]`` shape that
-                        # vLLM uses, so the shared helper covers both.
+                        # TRT-LLM shares vLLM's prompt_logprobs shape.
                         if prompt_logprobs_count is not None:
                             prompt_payload = _shared_logprobs.extract_prompt_logprobs_from_completion_output(
                                 res

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -33,6 +33,7 @@ from tensorrt_llm.scheduling_params import SchedulingParams
 from torch.cuda import device_count
 
 from dynamo._core import Context
+from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.backend import telemetry
 from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
@@ -772,6 +773,19 @@ class TrtllmLLMEngine(LLMEngine):
             self._default_sampling_params, request
         )
 
+        # TRT-LLM's `logprobs` is the top-k count; 0 disables logprob
+        # computation entirely. Floor it at 1 so a caller asking for
+        # `logprobs=0` (chosen-token only) still gets that back.
+        logprobs_count, prompt_logprobs_count = _shared_logprobs.parse_logprob_options(
+            request.get("output_options", {}) or {}
+        )
+        if logprobs_count is not None and hasattr(sampling_params, "logprobs"):
+            sampling_params.logprobs = max(1, logprobs_count)
+        if prompt_logprobs_count is not None and hasattr(
+            sampling_params, "prompt_logprobs"
+        ):
+            sampling_params.prompt_logprobs = prompt_logprobs_count
+
         # Prefill: context_only handle → packed into the response.
         # Decode: read prefill peer's handle, flip to generation_only.
         disaggregated_params: LlmDisaggregatedParams | None = None
@@ -854,6 +868,22 @@ class TrtllmLLMEngine(LLMEngine):
                         "token_ids": output.token_ids[tokens_so_far:],
                         "index": output_idx,
                     }
+
+                    # output.logprobs is cumulative in lockstep with
+                    # output.token_ids — reuse the same slice offset.
+                    (
+                        log_probs,
+                        top_logprobs,
+                    ) = _shared_logprobs.extract_from_completion_output(
+                        output,
+                        tokens_so_far,
+                        fallback_to_first_on_missing=True,
+                        include_bytes=False,
+                    )
+                    if log_probs is not None:
+                        out["log_probs"] = log_probs
+                    if top_logprobs is not None:
+                        out["top_logprobs"] = top_logprobs
 
                     if output.finish_reason:
                         out["finish_reason"] = str(output.finish_reason)

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -905,6 +905,18 @@ class TrtllmLLMEngine(LLMEngine):
                     if out.get("finish_reason") or res.finished:
                         if not out.get("finish_reason"):
                             out["finish_reason"] = "unknown"
+                        # Prompt logprobs ride on the final chunk. TRT-LLM
+                        # exposes them on `res.prompt_logprobs` in the same
+                        # ``list[Optional[dict[int, Logprob]]]`` shape that
+                        # vLLM uses, so the shared helper covers both.
+                        if prompt_logprobs_count is not None:
+                            prompt_payload = _shared_logprobs.extract_prompt_logprobs_from_completion_output(
+                                res
+                            )
+                            if prompt_payload is not None:
+                                out["engine_data"] = {
+                                    "prompt_logprobs": prompt_payload
+                                }
                         prompt_tokens = len(token_ids)
                         total_completion_tokens = sum(
                             len(o.token_ids) for o in res.outputs

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -774,13 +774,20 @@ class TrtllmLLMEngine(LLMEngine):
         )
 
         # TRT-LLM's `logprobs` is the top-k count; 0 disables logprob
-        # computation entirely. Floor it at 1 so a caller asking for
-        # `logprobs=0` (chosen-token only) still gets that back.
-        logprobs_count, prompt_logprobs_count = _shared_logprobs.parse_logprob_options(
+        # computation entirely. Floor at 1 so a caller asking for
+        # `logprobs=0` (chosen-token only) still gets the chosen logprob;
+        # keep the raw requested count to suppress top_logprobs below
+        # when the user did NOT ask for alternatives.
+        (
+            requested_logprobs_count,
+            prompt_logprobs_count,
+        ) = _shared_logprobs.parse_logprob_options(
             request.get("output_options", {}) or {}
         )
-        if logprobs_count is not None and hasattr(sampling_params, "logprobs"):
-            sampling_params.logprobs = max(1, logprobs_count)
+        if requested_logprobs_count is not None and hasattr(
+            sampling_params, "logprobs"
+        ):
+            sampling_params.logprobs = max(1, requested_logprobs_count)
         if prompt_logprobs_count is not None and hasattr(
             sampling_params, "prompt_logprobs"
         ):
@@ -882,7 +889,14 @@ class TrtllmLLMEngine(LLMEngine):
                     )
                     if log_probs is not None:
                         out["log_probs"] = log_probs
-                    if top_logprobs is not None:
+                    # `requested_logprobs_count == 0` means chosen-token
+                    # only — suppress the top-k that the engine floor
+                    # forced TRT-LLM to compute.
+                    if (
+                        top_logprobs is not None
+                        and requested_logprobs_count is not None
+                        and requested_logprobs_count > 0
+                    ):
                         out["top_logprobs"] = top_logprobs
 
                     if output.finish_reason:

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -666,9 +666,8 @@ class TrtllmLLMEngine(LLMEngine):
         async with self._pause_lock:
             if controller.is_paused:
                 return {"status": "ok", "message": "Memory already released"}
-            if (
-                self._resume_recovery_required
-                or self._controller_needs_resume_recovery(controller)
+            if self._resume_recovery_required or self._controller_needs_resume_recovery(
+                controller
             ):
                 return {
                     "status": "error",
@@ -914,9 +913,7 @@ class TrtllmLLMEngine(LLMEngine):
                                 res
                             )
                             if prompt_payload is not None:
-                                out["engine_data"] = {
-                                    "prompt_logprobs": prompt_payload
-                                }
+                                out["engine_data"] = {"prompt_logprobs": prompt_payload}
                         prompt_tokens = len(token_ids)
                         total_completion_tokens = sum(
                             len(o.token_ids) for o in res.outputs

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -666,8 +666,9 @@ class TrtllmLLMEngine(LLMEngine):
         async with self._pause_lock:
             if controller.is_paused:
                 return {"status": "ok", "message": "Memory already released"}
-            if self._resume_recovery_required or self._controller_needs_resume_recovery(
-                controller
+            if (
+                self._resume_recovery_required
+                or self._controller_needs_resume_recovery(controller)
             ):
                 return {
                     "status": "error",

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -34,6 +34,7 @@ from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
 
 from dynamo._core import Client, Context
+from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
@@ -411,71 +412,12 @@ class HandlerBase(BaseGenerativeHandler):
     def _extract_logprobs(
         output, num_output_tokens_so_far: int
     ) -> tuple[list[float] | None, list[list[dict]] | None]:
-        """
-        Extract logprobs from the TRTLLM output for new tokens.
-
-        Args:
-            output: TRTLLM CompletionOutput object
-            num_output_tokens_so_far: Number of tokens already processed
-        Returns:
-            Tuple of (log_probs, top_logprobs) in Dynamo's expected format:
-            - log_probs: List of log probabilities for each new token
-            - top_logprobs: List of top logprobs dicts for each new token
-        """
-        if output.logprobs is None:
-            return None, None
-
-        # Get logprobs for new tokens only
-        new_logprobs = output.logprobs[num_output_tokens_so_far:]
-        if not new_logprobs:
-            return None, None
-
-        # From TRTLLM CompletionOutput API, logprobs: (TokenLogprobs | List[float], optional)
-        # Expect TokenLogprobs output when logprobs is set, check edge case where list[float] is returned instead
-        if isinstance(new_logprobs[0], float):
-            return [float(lp) for lp in new_logprobs], None
-
-        log_probs = []
-        top_logprobs = []
-
-        for token_idx, token_logprobs_dict in enumerate(new_logprobs):
-            if token_logprobs_dict is None:
-                continue
-
-            # Get the actual token_id that was generated at this position
-            actual_token_id = output.token_ids[num_output_tokens_so_far + token_idx]
-
-            # Extract log probability for the selected token
-            if actual_token_id in token_logprobs_dict:
-                selected_logprob = token_logprobs_dict[actual_token_id]
-                log_probs.append(float(selected_logprob.logprob))
-            else:
-                # Fallback: use the first logprob if selected token not found
-                first_logprob = next(iter(token_logprobs_dict.values()), None)
-                if first_logprob:
-                    log_probs.append(float(first_logprob.logprob))
-
-            # Build top_logprobs list for this token position
-            # NOTE: TRTLLM LogProb API doesn't have decoded_token, will default to None
-            token_top_logprobs = []
-            for tok_id, logprob_info in token_logprobs_dict.items():
-                token_top_logprobs.append(
-                    {
-                        "rank": (
-                            logprob_info.rank if hasattr(logprob_info, "rank") else 0
-                        ),
-                        "token_id": tok_id,
-                        "token": (
-                            logprob_info.decoded_token
-                            if hasattr(logprob_info, "decoded_token")
-                            else None
-                        ),
-                        "logprob": float(logprob_info.logprob),
-                    }
-                )
-            top_logprobs.append(token_top_logprobs)
-
-        return log_probs if log_probs else None, top_logprobs if top_logprobs else None
+        return _shared_logprobs.extract_from_completion_output(
+            output,
+            num_output_tokens_so_far,
+            fallback_to_first_on_missing=True,
+            include_bytes=False,
+        )
 
     async def _handle_cancellation(
         self,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -32,6 +32,7 @@ from vllm.sampling_params import (
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo._core import Context
+from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.lora.manager import LoRAInfo, get_lora_manager
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
@@ -378,39 +379,13 @@ def build_sampling_params(
             sampling_params.thinking_token_budget = value
 
     # Apply output_options (logprobs, prompt_logprobs, etc.)
-    output_options = request.get("output_options", {})
-    if output_options:
-        # Handle logprobs - vLLM expects this as an integer or None
-        logprobs_value = output_options.get("logprobs")
-        if logprobs_value is not None and logprobs_value != "":
-            try:
-                parsed_logprobs = int(logprobs_value)
-                if parsed_logprobs < 0:
-                    logger.warning(
-                        f"Invalid logprobs value: {logprobs_value} (must be non-negative), ignoring"
-                    )
-                else:
-                    sampling_params.logprobs = parsed_logprobs
-            except (ValueError, TypeError):
-                logger.warning(
-                    f"Invalid logprobs value: {logprobs_value} (must be integer), ignoring"
-                )
-
-        # Handle prompt_logprobs - vLLM expects this as an integer or None
-        prompt_logprobs_value = output_options.get("prompt_logprobs")
-        if prompt_logprobs_value is not None and prompt_logprobs_value != "":
-            try:
-                parsed_prompt_logprobs = int(prompt_logprobs_value)
-                if parsed_prompt_logprobs < 0:
-                    logger.warning(
-                        f"Invalid prompt_logprobs value: {prompt_logprobs_value} (must be non-negative), ignoring"
-                    )
-                else:
-                    sampling_params.prompt_logprobs = parsed_prompt_logprobs
-            except (ValueError, TypeError):
-                logger.warning(
-                    f"Invalid prompt_logprobs value: {prompt_logprobs_value} (must be integer), ignoring"
-                )
+    logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(
+        request.get("output_options", {}) or {}
+    )
+    if logprobs is not None:
+        sampling_params.logprobs = logprobs
+    if prompt_logprobs is not None:
+        sampling_params.prompt_logprobs = prompt_logprobs
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
@@ -2031,76 +2006,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def _extract_logprobs(
         output, num_output_tokens_so_far: int, tokenizer=None
     ) -> tuple[list[float] | None, list[list[dict]] | None]:
-        """
-        Extract logprobs from vLLM CompletionOutput for new tokens.
-
-        Args:
-            output: vLLM CompletionOutput object
-            num_output_tokens_so_far: Number of tokens already processed
-            tokenizer: Optional tokenizer for decoding token IDs when
-                       decoded_token is not populated by the engine
-
-        Returns:
-            Tuple of (log_probs, top_logprobs) in Dynamo's expected format:
-            - log_probs: List of log probabilities for each new token
-            - top_logprobs: List of top logprobs dicts for each new token
-        """
-        if output.logprobs is None:
-            return None, None
-
-        token_ids = list(output.token_ids or [])
-        if not token_ids or num_output_tokens_so_far >= len(token_ids):
-            return None, None
-
-        # Get logprobs for new tokens only
-        new_logprobs = output.logprobs[num_output_tokens_so_far:]
-        new_token_ids = token_ids[num_output_tokens_so_far:]
-        new_logprobs = new_logprobs[: len(new_token_ids)]
-        if not new_logprobs:
-            return None, None
-
-        log_probs = []
-        top_logprobs = []
-
-        for token_idx, token_logprobs_dict in enumerate(new_logprobs):
-            if token_logprobs_dict is None:
-                continue
-
-            # Get the actual token_id that was generated at this position
-            actual_token_id = new_token_ids[token_idx]
-
-            # Extract log probability for the selected token
-            # vLLM guarantees the selected token is always in the logprobs dict
-            selected_logprob = token_logprobs_dict.get(actual_token_id)
-            if selected_logprob is None:
-                continue
-            log_probs.append(float(selected_logprob.logprob))
-
-            # Build top_logprobs list for this token position
-            token_top_logprobs = []
-            for tok_id, logprob_info in token_logprobs_dict.items():
-                token_str = getattr(logprob_info, "decoded_token", None)
-                if not token_str and tokenizer:
-                    try:
-                        token_str = tokenizer.decode([tok_id])
-                    except Exception:
-                        token_str = None
-                token_top_logprobs.append(
-                    {
-                        "rank": (
-                            logprob_info.rank if hasattr(logprob_info, "rank") else 0
-                        ),
-                        "token_id": tok_id,
-                        "token": token_str,
-                        "logprob": float(logprob_info.logprob),
-                        "bytes": (
-                            list(token_str.encode("utf-8")) if token_str else None
-                        ),
-                    }
-                )
-            top_logprobs.append(token_top_logprobs)
-
-        return log_probs if log_probs else None, top_logprobs if top_logprobs else None
+        return _shared_logprobs.extract_from_completion_output(
+            output,
+            num_output_tokens_so_far,
+            tokenizer=tokenizer,
+            include_bytes=True,
+        )
 
     @staticmethod
     def _log_with_lora_context(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2006,10 +2006,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def _extract_logprobs(
         output, num_output_tokens_so_far: int, tokenizer=None
     ) -> tuple[list[float] | None, list[list[dict]] | None]:
-        # `fallback_to_first_on_missing=True` preserves the legacy
-        # vLLM handler's behavior of always emitting a logprob when
-        # vLLM returned a dict, even if the sampled token isn't keyed
-        # in it.
+        # Legacy vLLM handler always emits when vLLM returned a dict.
         return _shared_logprobs.extract_from_completion_output(
             output,
             num_output_tokens_so_far,
@@ -2110,9 +2107,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 for output in res.outputs:
                     output_idx = getattr(output, "index", 0) or 0
                     token_ids = list(output.token_ids or [])
-                    total_output_tokens_by_index[
-                        output_idx
-                    ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
+                    total_output_tokens_by_index[output_idx] = (
+                        total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
+                    )
                     finish_reason = getattr(output, "finish_reason", None)
                     stop_reason = getattr(output, "stop_reason", None)
                     if not token_ids and not finish_reason and not stop_reason:
@@ -2145,12 +2142,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
                     if finish_reason:
                         out["finish_reason"] = normalize_finish_reason(finish_reason)
-                        out[
-                            "completion_usage"
-                        ] = BaseWorkerHandler._build_completion_usage(
-                            request_output=res,
-                            embedding_sequence_length=embedding_sequence_length,
-                            completion_token_counts=total_output_tokens_by_index,
+                        out["completion_usage"] = (
+                            BaseWorkerHandler._build_completion_usage(
+                                request_output=res,
+                                embedding_sequence_length=embedding_sequence_length,
+                                completion_token_counts=total_output_tokens_by_index,
+                            )
                         )
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
@@ -2411,9 +2408,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         if abort_guard is not None:
                             abort_guard.signal_first_token()
                         if prefill_result is not None and "completion_usage" in tok:
-                            tok["completion_usage"][
-                                "prompt_tokens_details"
-                            ] = prefill_prompt_tokens_details
+                            tok["completion_usage"]["prompt_tokens_details"] = (
+                                prefill_prompt_tokens_details
+                            )
                         yield tok
                 except EngineDeadError as e:
                     logger.error(f"vLLM EngineDeadError: {e}")
@@ -2611,9 +2608,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         )
         if sampling_params.extra_args is None:
             sampling_params.extra_args = {}
-        sampling_params.extra_args[
-            "kv_transfer_params"
-        ] = kv_protocol.prefill_request_kv_transfer_params()
+        sampling_params.extra_args["kv_transfer_params"] = (
+            kv_protocol.prefill_request_kv_transfer_params()
+        )
         # Override for prefill: only generate 1 token
         sampling_params.max_tokens = 1
         sampling_params.min_tokens = 1
@@ -2705,9 +2702,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         if embedding_params is not None:
             disaggregated_params["embedding_params"] = embedding_params
         if expanded_prompt_token_ids is not None:
-            disaggregated_params[
-                "expanded_prompt_token_ids"
-            ] = expanded_prompt_token_ids
+            disaggregated_params["expanded_prompt_token_ids"] = (
+                expanded_prompt_token_ids
+            )
 
         return disaggregated_params if disaggregated_params else None
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2006,10 +2006,15 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     def _extract_logprobs(
         output, num_output_tokens_so_far: int, tokenizer=None
     ) -> tuple[list[float] | None, list[list[dict]] | None]:
+        # `fallback_to_first_on_missing=True` preserves the legacy
+        # vLLM handler's behavior of always emitting a logprob when
+        # vLLM returned a dict, even if the sampled token isn't keyed
+        # in it.
         return _shared_logprobs.extract_from_completion_output(
             output,
             num_output_tokens_so_far,
             tokenizer=tokenizer,
+            fallback_to_first_on_missing=True,
             include_bytes=True,
         )
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2107,9 +2107,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 for output in res.outputs:
                     output_idx = getattr(output, "index", 0) or 0
                     token_ids = list(output.token_ids or [])
-                    total_output_tokens_by_index[output_idx] = (
-                        total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
-                    )
+                    total_output_tokens_by_index[
+                        output_idx
+                    ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
                     finish_reason = getattr(output, "finish_reason", None)
                     stop_reason = getattr(output, "stop_reason", None)
                     if not token_ids and not finish_reason and not stop_reason:
@@ -2142,12 +2142,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
                     if finish_reason:
                         out["finish_reason"] = normalize_finish_reason(finish_reason)
-                        out["completion_usage"] = (
-                            BaseWorkerHandler._build_completion_usage(
-                                request_output=res,
-                                embedding_sequence_length=embedding_sequence_length,
-                                completion_token_counts=total_output_tokens_by_index,
-                            )
+                        out[
+                            "completion_usage"
+                        ] = BaseWorkerHandler._build_completion_usage(
+                            request_output=res,
+                            embedding_sequence_length=embedding_sequence_length,
+                            completion_token_counts=total_output_tokens_by_index,
                         )
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
@@ -2408,9 +2408,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         if abort_guard is not None:
                             abort_guard.signal_first_token()
                         if prefill_result is not None and "completion_usage" in tok:
-                            tok["completion_usage"]["prompt_tokens_details"] = (
-                                prefill_prompt_tokens_details
-                            )
+                            tok["completion_usage"][
+                                "prompt_tokens_details"
+                            ] = prefill_prompt_tokens_details
                         yield tok
                 except EngineDeadError as e:
                     logger.error(f"vLLM EngineDeadError: {e}")
@@ -2608,9 +2608,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         )
         if sampling_params.extra_args is None:
             sampling_params.extra_args = {}
-        sampling_params.extra_args["kv_transfer_params"] = (
-            kv_protocol.prefill_request_kv_transfer_params()
-        )
+        sampling_params.extra_args[
+            "kv_transfer_params"
+        ] = kv_protocol.prefill_request_kv_transfer_params()
         # Override for prefill: only generate 1 token
         sampling_params.max_tokens = 1
         sampling_params.min_tokens = 1
@@ -2702,9 +2702,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         if embedding_params is not None:
             disaggregated_params["embedding_params"] = embedding_params
         if expanded_prompt_token_ids is not None:
-            disaggregated_params["expanded_prompt_token_ids"] = (
-                expanded_prompt_token_ids
-            )
+            disaggregated_params[
+                "expanded_prompt_token_ids"
+            ] = expanded_prompt_token_ids
 
         return disaggregated_params if disaggregated_params else None
 

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -174,9 +174,9 @@ class VllmLLMEngine(LLMEngine):
             )
 
         if not config.served_model_name:
-            config.served_model_name = config.engine_args.served_model_name = (
-                config.model
-            )
+            config.served_model_name = (
+                config.engine_args.served_model_name
+            ) = config.model
 
         # _resolve_disaggregation_mode() in DynamoVllmConfig has already
         # promoted the field to a DisaggregationMode enum; the field type
@@ -352,9 +352,9 @@ class VllmLLMEngine(LLMEngine):
             for output in res.outputs:
                 output_idx = getattr(output, "index", 0) or 0
                 token_ids = list(output.token_ids or [])
-                total_output_tokens_by_index[output_idx] = (
-                    total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
-                )
+                total_output_tokens_by_index[
+                    output_idx
+                ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
                 finish_reason = getattr(output, "finish_reason", None)
                 if not token_ids and not finish_reason:
                     continue

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -25,6 +25,7 @@ from vllm.v1.metrics.loggers import StatLoggerBase
 from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 from dynamo._core import Context
+from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.backend import telemetry
 from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
@@ -327,6 +328,7 @@ class VllmLLMEngine(LLMEngine):
         )
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
+        tokenizer = getattr(self.engine_client, "tokenizer", None)
 
         total_output_tokens_by_index: dict[int, int] = {}
         async for res in gen:
@@ -348,13 +350,30 @@ class VllmLLMEngine(LLMEngine):
                 finish_reason = getattr(output, "finish_reason", None)
                 if not token_ids and not finish_reason:
                     continue
-                prepared_outputs.append((output_idx, token_ids, finish_reason))
+                prepared_outputs.append((output, output_idx, token_ids, finish_reason))
 
-            for output_idx, token_ids, finish_reason in prepared_outputs:
+            for output, output_idx, token_ids, finish_reason in prepared_outputs:
                 out: GenerateChunk = {
                     "index": output_idx,
                     "token_ids": token_ids,
                 }
+
+                # `build_sampling_params` forces DELTA output, so each
+                # `output.logprobs` slot already aligns to this chunk —
+                # the offset into the cumulative array is 0.
+                (
+                    log_probs,
+                    top_logprobs,
+                ) = _shared_logprobs.extract_from_completion_output(
+                    output,
+                    0,
+                    tokenizer=tokenizer,
+                    include_bytes=True,
+                )
+                if log_probs is not None:
+                    out["log_probs"] = log_probs
+                if top_logprobs is not None:
+                    out["top_logprobs"] = top_logprobs
 
                 if finish_reason:
                     out["finish_reason"] = str(finish_reason)

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -174,9 +174,9 @@ class VllmLLMEngine(LLMEngine):
             )
 
         if not config.served_model_name:
-            config.served_model_name = (
-                config.engine_args.served_model_name
-            ) = config.model
+            config.served_model_name = config.engine_args.served_model_name = (
+                config.model
+            )
 
         # _resolve_disaggregation_mode() in DynamoVllmConfig has already
         # promoted the field to a DisaggregationMode enum; the field type
@@ -329,11 +329,8 @@ class VllmLLMEngine(LLMEngine):
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
         tokenizer = getattr(self.engine_client, "tokenizer", None)
-        # Raw requested count drives top_logprobs gating below;
-        # `build_sampling_params` already passed `logprobs` into the
-        # engine, so a `logprobs=0` (chosen-token only) request still
-        # makes vLLM emit its selected-token logprob dict — we must
-        # suppress the top-k slice here, not at the engine.
+        # vLLM emits a selected-token logprob dict even at `logprobs=0`,
+        # so the top-k suppression happens below, not at the engine.
         (
             requested_logprobs_count,
             requested_prompt_logprobs_count,
@@ -355,9 +352,9 @@ class VllmLLMEngine(LLMEngine):
             for output in res.outputs:
                 output_idx = getattr(output, "index", 0) or 0
                 token_ids = list(output.token_ids or [])
-                total_output_tokens_by_index[
-                    output_idx
-                ] = total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
+                total_output_tokens_by_index[output_idx] = (
+                    total_output_tokens_by_index.get(output_idx, 0) + len(token_ids)
+                )
                 finish_reason = getattr(output, "finish_reason", None)
                 if not token_ids and not finish_reason:
                     continue
@@ -369,13 +366,9 @@ class VllmLLMEngine(LLMEngine):
                     "token_ids": token_ids,
                 }
 
-                # `build_sampling_params` forces DELTA output, so each
-                # `output.logprobs` slot already aligns to this chunk —
-                # the offset into the cumulative array is 0.
-                # `fallback_to_first_on_missing=True` preserves the
-                # legacy handler's behavior of always emitting a logprob
-                # when vLLM returned a dict, even if the sampled token
-                # isn't keyed in it.
+                # `build_sampling_params` forces DELTA output → offset 0.
+                # `fallback_to_first_on_missing=True` matches legacy
+                # vLLM handler: always emit when vLLM returned a dict.
                 (
                     log_probs,
                     top_logprobs,
@@ -388,8 +381,6 @@ class VllmLLMEngine(LLMEngine):
                 )
                 if log_probs is not None:
                     out["log_probs"] = log_probs
-                # `requested_logprobs_count == 0` means chosen-token
-                # only — suppress the top-k that vLLM still emitted.
                 if (
                     top_logprobs is not None
                     and requested_logprobs_count is not None
@@ -399,10 +390,8 @@ class VllmLLMEngine(LLMEngine):
 
                 if finish_reason:
                     out["finish_reason"] = str(finish_reason)
-                    # Prompt logprobs ride on the final chunk (Rust
-                    # nvext.rs suppresses them on intermediate chunks
-                    # anyway). vLLM hangs them off `RequestOutput`, not
-                    # `CompletionOutput`, so we read from `res`.
+                    # vLLM hangs prompt_logprobs off `RequestOutput`, not
+                    # `CompletionOutput` — read from `res`.
                     if requested_prompt_logprobs_count is not None:
                         prompt_payload = _shared_logprobs.extract_prompt_logprobs_from_completion_output(
                             res, tokenizer=tokenizer

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -334,7 +334,10 @@ class VllmLLMEngine(LLMEngine):
         # engine, so a `logprobs=0` (chosen-token only) request still
         # makes vLLM emit its selected-token logprob dict — we must
         # suppress the top-k slice here, not at the engine.
-        requested_logprobs_count, _ = _shared_logprobs.parse_logprob_options(
+        (
+            requested_logprobs_count,
+            requested_prompt_logprobs_count,
+        ) = _shared_logprobs.parse_logprob_options(
             request.get("output_options", {}) or {}
         )
 
@@ -396,6 +399,16 @@ class VllmLLMEngine(LLMEngine):
 
                 if finish_reason:
                     out["finish_reason"] = str(finish_reason)
+                    # Prompt logprobs ride on the final chunk (Rust
+                    # nvext.rs suppresses them on intermediate chunks
+                    # anyway). vLLM hangs them off `RequestOutput`, not
+                    # `CompletionOutput`, so we read from `res`.
+                    if requested_prompt_logprobs_count is not None:
+                        prompt_payload = _shared_logprobs.extract_prompt_logprobs_from_completion_output(
+                            res, tokenizer=tokenizer
+                        )
+                        if prompt_payload is not None:
+                            out["engine_data"] = {"prompt_logprobs": prompt_payload}
                     prompt_tokens = (
                         len(res.prompt_token_ids) if res.prompt_token_ids else 0
                     )

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -329,6 +329,14 @@ class VllmLLMEngine(LLMEngine):
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
         tokenizer = getattr(self.engine_client, "tokenizer", None)
+        # Raw requested count drives top_logprobs gating below;
+        # `build_sampling_params` already passed `logprobs` into the
+        # engine, so a `logprobs=0` (chosen-token only) request still
+        # makes vLLM emit its selected-token logprob dict — we must
+        # suppress the top-k slice here, not at the engine.
+        requested_logprobs_count, _ = _shared_logprobs.parse_logprob_options(
+            request.get("output_options", {}) or {}
+        )
 
         total_output_tokens_by_index: dict[int, int] = {}
         async for res in gen:
@@ -361,6 +369,10 @@ class VllmLLMEngine(LLMEngine):
                 # `build_sampling_params` forces DELTA output, so each
                 # `output.logprobs` slot already aligns to this chunk —
                 # the offset into the cumulative array is 0.
+                # `fallback_to_first_on_missing=True` preserves the
+                # legacy handler's behavior of always emitting a logprob
+                # when vLLM returned a dict, even if the sampled token
+                # isn't keyed in it.
                 (
                     log_probs,
                     top_logprobs,
@@ -368,11 +380,18 @@ class VllmLLMEngine(LLMEngine):
                     output,
                     0,
                     tokenizer=tokenizer,
+                    fallback_to_first_on_missing=True,
                     include_bytes=True,
                 )
                 if log_probs is not None:
                     out["log_probs"] = log_probs
-                if top_logprobs is not None:
+                # `requested_logprobs_count == 0` means chosen-token
+                # only — suppress the top-k that vLLM still emitted.
+                if (
+                    top_logprobs is not None
+                    and requested_logprobs_count is not None
+                    and requested_logprobs_count > 0
+                ):
                     out["top_logprobs"] = top_logprobs
 
                 if finish_reason:

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -847,7 +847,7 @@ Request handling:
 
 | Feature | What's missing |
 |---------|----------------|
-| Prompt logprobs response wire | Completion-side `log_probs` / `top_logprobs` are now populated on the unified path for vLLM, SGLang, and TRT-LLM (shared helpers in `components/src/dynamo/common/backend/logprobs.py`). `PreprocessedRequest.output_options.prompt_logprobs` is plumbed into engine sampling params but no engine extracts prompt-side logprobs onto `LLMEngineOutput` — the engine pays the cost and the client gets nothing back. `cum_log_probs` is also not emitted. |
+| `cum_log_probs` response wire | Completion-side `log_probs` / `top_logprobs` are populated on the unified path for vLLM, SGLang, and TRT-LLM (shared helpers in `components/src/dynamo/common/backend/logprobs.py`). Prompt-side logprobs ride on the final chunk's `LLMEngineOutput.engine_data["prompt_logprobs"]` (consumed by `prompt_logprobs_from_engine_data` in the response builders). `cum_log_probs` is still not emitted. |
 | Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
 | Multimodal | Images / video / embeddings, NIXL embedding transfer, separate encode workers; `ENCODE` disaggregation role |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -847,7 +847,7 @@ Request handling:
 
 | Feature | What's missing |
 |---------|----------------|
-| Logprob response wire | `PreprocessedRequest.output_options.{logprobs, prompt_logprobs}` exists on the request shape. Of the existing engines (Python-bridged through PyO3), only vLLM passes the option through to its sampling params on the unified path; SGLang and TRT-LLM unified `generate()` ignore it. No engine populates `log_probs` / `top_logprobs` / `cum_log_probs` on `LLMEngineOutput` — the response wire is open but unused |
+| Prompt logprobs response wire | Completion-side `log_probs` / `top_logprobs` are now populated on the unified path for vLLM, SGLang, and TRT-LLM (shared helpers in `components/src/dynamo/common/backend/logprobs.py`). `PreprocessedRequest.output_options.prompt_logprobs` is plumbed into engine sampling params but no engine extracts prompt-side logprobs onto `LLMEngineOutput` — the engine pays the cost and the client gets nothing back. `cum_log_probs` is also not emitted. |
 | Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
 | Multimodal | Images / video / embeddings, NIXL embedding transfer, separate encode workers; `ENCODE` disaggregation role |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -9,11 +9,10 @@ SPDX-License-Identifier: Apache-2.0
 > disaggregated (prefill/decode) inference, metrics + Prometheus
 > bridging, KV event publishing, KV-aware (DP-rank) routing,
 > health-check canaries, OpenTelemetry tracing, request-side
-> guided decoding, and completion-side logprobs. Prompt logprobs
-> response wire, multimodal, diffusion (image/video/DLLM), LoRA,
-> engine routes (pause/resume, profiling, weight updates),
-> text-in-text-out, and snapshot/CRIU are still on the non-unified
-> path. See the
+> guided decoding, and both completion-side and prompt-side
+> logprobs. Multimodal, diffusion (image/video/DLLM), LoRA, engine
+> routes (pause/resume, profiling, weight updates), text-in-text-out,
+> and snapshot/CRIU are still on the non-unified path. See the
 > [Python package README](../../components/src/dynamo/common/backend/README.md#feature-gaps)
 > for the per-engine matrix. The Python `Worker`
 > ([`dynamo.common.backend`](../../components/src/dynamo/common/backend/))

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -8,11 +8,12 @@ SPDX-License-Identifier: Apache-2.0
 > **Work in progress.** The unified backend covers aggregated and
 > disaggregated (prefill/decode) inference, metrics + Prometheus
 > bridging, KV event publishing, KV-aware (DP-rank) routing,
-> health-check canaries, OpenTelemetry tracing, and request-side
-> guided decoding. Logprob response wire, multimodal, diffusion
-> (image/video/DLLM), LoRA, engine routes (pause/resume, profiling,
-> weight updates), text-in-text-out, and snapshot/CRIU are still on
-> the non-unified path. See the
+> health-check canaries, OpenTelemetry tracing, request-side
+> guided decoding, and completion-side logprobs. Prompt logprobs
+> response wire, multimodal, diffusion (image/video/DLLM), LoRA,
+> engine routes (pause/resume, profiling, weight updates),
+> text-in-text-out, and snapshot/CRIU are still on the non-unified
+> path. See the
 > [Python package README](../../components/src/dynamo/common/backend/README.md#feature-gaps)
 > for the per-engine matrix. The Python `Worker`
 > ([`dynamo.common.backend`](../../components/src/dynamo/common/backend/))

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -27,7 +27,7 @@ use dynamo_backend_common::{
     AsyncEngineContext, BackendError, CommonArgs, ComponentSnapshot, DisaggregationMode,
     DynamoError, EngineConfig, ErrorType, GenerateContext, HEALTH_CHECK_KEY, KvEventSource,
     LLMEngine, LLMEngineOutput, LLMEngineOutputExt, MetricsBindings, MetricsCtx,
-    PreprocessedRequest, SnapshotPublisher, WorkerConfig, chunk, usage,
+    PreprocessedRequest, SnapshotPublisher, TopLogprob, WorkerConfig, chunk, usage,
 };
 use dynamo_mocker::common::protocols::{
     DirectRequest, EngineType, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
@@ -46,6 +46,39 @@ const DP_RANK: u32 = 0;
 /// Fallback when the client does not set `stop_conditions.max_tokens`. The
 /// conformance suite exercises this path (single-generate uses `None`).
 const DEFAULT_MAX_TOKENS: usize = 16;
+
+/// Upper bound on synthesised top-k alternatives. Caps the per-chunk
+/// `top_logprobs` allocation so a client sending `logprobs=u32::MAX`
+/// can't drive unbounded memory / CPU here. Matches the OpenAI ceiling.
+const MAX_LOGPROBS: u32 = 20;
+
+/// Stamp deterministic synthetic logprobs onto `output` for a single
+/// generated token. Top-k alternatives appear when `top_k >= 1`.
+fn stamp_synthetic_logprobs(output: &mut LLMEngineOutput, token_id: u32, top_k: u32) {
+    let selected_lp = -0.1 * f64::from(token_id % 10);
+    output.log_probs = Some(vec![selected_lp]);
+    if top_k > 0 {
+        let mut entries: Vec<TopLogprob> = Vec::with_capacity(top_k as usize + 1);
+        entries.push(TopLogprob {
+            rank: 1,
+            token_id,
+            token: Some(format!("token_id:{token_id}")),
+            logprob: selected_lp,
+            bytes: None,
+        });
+        for r in 1..=top_k {
+            let alt_id = (token_id + r) % 32000;
+            entries.push(TopLogprob {
+                rank: r + 1,
+                token_id: alt_id,
+                token: Some(format!("token_id:{alt_id}")),
+                logprob: selected_lp - 0.1 * f64::from(r),
+                bytes: None,
+            });
+        }
+        output.top_logprobs = Some(vec![entries]);
+    }
+}
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -353,6 +386,10 @@ impl LLMEngine for MockerBackend {
             .max_tokens
             .map(|n| n as usize)
             .unwrap_or(DEFAULT_MAX_TOKENS);
+        let logprobs_top_k = request
+            .output_options
+            .logprobs
+            .map(|k| k.min(MAX_LOGPROBS));
         // Prefill workers only need to populate KV cache for the prompt; cap
         // generation at one token regardless of what the client asked for, so
         // the response carries a single terminal with disaggregated_params.
@@ -465,6 +502,9 @@ impl LLMEngine for MockerBackend {
                             let mut terminal = LLMEngineOutput::length()
                                 .with_tokens(vec![token_id])
                                 .with_usage(usage(prompt_len, generated));
+                            if let Some(k) = logprobs_top_k {
+                                stamp_synthetic_logprobs(&mut terminal, token_id, k);
+                            }
                             // Prefill workers stamp a synthetic
                             // `disaggregated_params` payload on the terminal
                             // so the frontend's PrefillRouter has something
@@ -480,7 +520,11 @@ impl LLMEngine for MockerBackend {
                             yield Ok(terminal);
                             break;
                         }
-                        yield Ok(chunk::token(token_id));
+                        let mut tok = chunk::token(token_id);
+                        if let Some(k) = logprobs_top_k {
+                            stamp_synthetic_logprobs(&mut tok, token_id, k);
+                        }
+                        yield Ok(tok);
                     }
                 }
             }
@@ -948,5 +992,106 @@ mod tests {
         .unwrap();
         assert_eq!(config.disaggregation_mode, DisaggregationMode::Prefill);
         assert_eq!(engine.disaggregation_mode, DisaggregationMode::Prefill);
+    }
+
+    fn request_with_logprobs(max_tokens: u32, logprobs: Option<u32>) -> PreprocessedRequest {
+        use dynamo_backend_common::OutputOptions;
+        let mut req = request(Some(max_tokens));
+        req.output_options = OutputOptions {
+            logprobs,
+            ..Default::default()
+        };
+        req
+    }
+
+    #[tokio::test]
+    async fn logprobs_absent_when_not_requested() {
+        // Default request has output_options.logprobs = None — confirm no
+        // log_probs / top_logprobs leak onto chunks.
+        let engine = test_engine();
+        engine.start(0).await.unwrap();
+
+        let stream = engine
+            .generate(request(Some(3)), gen_ctx(Context::new(()).context()))
+            .await
+            .expect("stream");
+        let chunks: Vec<_> = collect_ok(stream).await;
+        for c in &chunks {
+            assert!(c.log_probs.is_none());
+            assert!(c.top_logprobs.is_none());
+        }
+
+        engine.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn logprobs_zero_emits_selected_only() {
+        // logprobs=Some(0) means "selected token logprob only" — no top-k.
+        let engine = test_engine();
+        engine.start(0).await.unwrap();
+
+        let stream = engine
+            .generate(
+                request_with_logprobs(2, Some(0)),
+                gen_ctx(Context::new(()).context()),
+            )
+            .await
+            .expect("stream");
+        let chunks: Vec<_> = collect_ok(stream).await;
+        for c in &chunks {
+            assert_eq!(c.log_probs.as_ref().map(|v| v.len()), Some(1));
+            assert!(c.top_logprobs.is_none());
+        }
+
+        engine.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn logprobs_with_top_k_emits_alternatives() {
+        let engine = test_engine();
+        engine.start(0).await.unwrap();
+
+        let stream = engine
+            .generate(
+                request_with_logprobs(2, Some(3)),
+                gen_ctx(Context::new(()).context()),
+            )
+            .await
+            .expect("stream");
+        let chunks: Vec<_> = collect_ok(stream).await;
+        for c in &chunks {
+            let top = c.top_logprobs.as_ref().expect("top_logprobs populated");
+            assert_eq!(top.len(), 1, "one position per emitted token");
+            // k=3 -> selected + 3 alternatives = 4 entries.
+            assert_eq!(top[0].len(), 4);
+            let ranks: Vec<u32> = top[0].iter().map(|e| e.rank).collect();
+            assert_eq!(ranks, vec![1, 2, 3, 4]);
+        }
+
+        engine.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn logprobs_top_k_is_clamped_to_max() {
+        // A client request asking for an unbounded number of top
+        // logprobs must get capped at MAX_LOGPROBS so the per-chunk
+        // top-k allocation stays bounded.
+        let engine = test_engine();
+        engine.start(0).await.unwrap();
+
+        let stream = engine
+            .generate(
+                request_with_logprobs(1, Some(u32::MAX)),
+                gen_ctx(Context::new(()).context()),
+            )
+            .await
+            .expect("stream");
+        let chunks: Vec<_> = collect_ok(stream).await;
+        for c in &chunks {
+            let top = c.top_logprobs.as_ref().expect("top_logprobs populated");
+            assert_eq!(top[0].len() as u32, MAX_LOGPROBS + 1);
+        }
+
+        engine.cleanup().await.unwrap();
     }
 }

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -386,10 +386,7 @@ impl LLMEngine for MockerBackend {
             .max_tokens
             .map(|n| n as usize)
             .unwrap_or(DEFAULT_MAX_TOKENS);
-        let logprobs_top_k = request
-            .output_options
-            .logprobs
-            .map(|k| k.min(MAX_LOGPROBS));
+        let logprobs_top_k = request.output_options.logprobs.map(|k| k.min(MAX_LOGPROBS));
         // Prefill workers only need to populate KV cache for the prompt; cap
         // generation at one token regardless of what the client asked for, so
         // the response carries a single terminal with disaggregated_params.

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -22,7 +22,9 @@ use tokio::sync::watch;
 use crate::error::DynamoError;
 
 pub use dynamo_llm::kv_router::publisher::KvEventPublisher;
-pub use dynamo_llm::protocols::common::llm_backend::LLMEngineOutput;
+pub use dynamo_llm::protocols::common::llm_backend::{
+    LLMEngineOutput, LogProbs, TopLogprob, TopLogprobs,
+};
 pub use dynamo_llm::protocols::common::preprocessor::{
     BootstrapInfo, PrefillResult, PreprocessedRequest,
 };

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -33,9 +33,9 @@ pub use disagg::DisaggregationMode;
 pub use engine::{
     AsyncEngineContext, BootstrapInfo, CompletionUsage, ComponentSnapshot, EngineConfig,
     FinishReason, GenerateContext, HEALTH_CHECK_KEY, KvEventPublisher, KvEventSource, LLMEngine,
-    LLMEngineOutput, LLMEngineOutputExt, Metrics, MetricsBindings, MetricsCtx, OnPublisherReady,
-    OnSnapshotPublisherReady, OutputOptions, PrefillResult, PreprocessedRequest, SamplingOptions,
-    StopConditions, chunk, usage,
+    LLMEngineOutput, LLMEngineOutputExt, LogProbs, Metrics, MetricsBindings, MetricsCtx,
+    OnPublisherReady, OnSnapshotPublisherReady, OutputOptions, PrefillResult, PreprocessedRequest,
+    SamplingOptions, StopConditions, TopLogprob, TopLogprobs, chunk, usage,
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use metrics::{ComponentGauges, EngineMetrics, LifecycleGauges};

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -152,15 +152,9 @@ fn find_dynamo_error_in_chain<'a>(
     None
 }
 
-/// Match an InvalidArgument error anywhere in the chain — at either the
-/// top-level (`ErrorType::InvalidArgument`, raised by the
-/// frontend/preprocessing layers) or under the `Backend()` wrapper
-/// (`ErrorType::Backend(BackendError::InvalidArgument)`, raised when a
-/// Python `ValueError`/`TypeError` propagates out of an engine's
-/// `generate()` via `py_err_to_dynamo`). Both classes are 400-worthy:
-/// the request was malformed; whether the validation tripped at the
-/// frontend or inside the engine is an implementation detail the client
-/// shouldn't care about.
+/// Match `InvalidArgument` at top-level OR under `Backend()`.
+/// `py_err_to_dynamo` wraps Python `ValueError`/`TypeError` as
+/// `Backend(InvalidArgument)`; both variants are 400-worthy.
 fn find_invalid_argument_in_chain<'a>(
     err: &'a (dyn std::error::Error + 'static),
 ) -> Option<&'a dynamo_runtime::error::DynamoError> {
@@ -305,12 +299,7 @@ impl ErrorMessage {
             );
         }
 
-        // Check for DynamoError with InvalidArgument anywhere in the chain → HTTP 400.
-        // This matches *any* nested InvalidArgument DynamoError, including the
-        // `Backend(InvalidArgument)` variant that `py_err_to_dynamo` raises for
-        // engine-side `ValueError`/`TypeError`. Intentional: 400 is the correct
-        // class for a malformed/invalid request whether the validation tripped
-        // at the frontend or inside the engine.
+        // InvalidArgument (top-level OR Backend) → 400.
         if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref()) {
             return (
                 StatusCode::BAD_REQUEST,
@@ -3056,16 +3045,9 @@ mod tests {
 
     #[test]
     fn test_backend_invalid_argument_surfaces_as_400() {
-        // A Python `ValueError` (or `TypeError`) from inside an engine's
-        // `generate()` is wrapped by `py_err_to_dynamo` (lib/bindings/
-        // python/rust/backend.rs) as
-        // `ErrorType::Backend(BackendError::InvalidArgument)`. The HTTP
-        // layer must surface that as 400, not 500 — the request was
-        // malformed and the frontend-vs-engine boundary is an
-        // implementation detail. Regression coverage for the SGLang
-        // gate path, where `build_sglang_logprob_kwargs` raises
-        // `ValueError` from inside the engine's `generate()` when
-        // `logprobs >= 1` and the override env-var isn't set.
+        // `Backend(InvalidArgument)` is what `py_err_to_dynamo` produces
+        // for Python `ValueError` / `TypeError` raised inside an engine's
+        // `generate()` — must map to 400, not 500.
         use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
 
         let err: anyhow::Error = DynamoError::builder()

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -152,6 +152,34 @@ fn find_dynamo_error_in_chain<'a>(
     None
 }
 
+/// Match an InvalidArgument error anywhere in the chain — at either the
+/// top-level (`ErrorType::InvalidArgument`, raised by the
+/// frontend/preprocessing layers) or under the `Backend()` wrapper
+/// (`ErrorType::Backend(BackendError::InvalidArgument)`, raised when a
+/// Python `ValueError`/`TypeError` propagates out of an engine's
+/// `generate()` via `py_err_to_dynamo`). Both classes are 400-worthy:
+/// the request was malformed; whether the validation tripped at the
+/// frontend or inside the engine is an implementation detail the client
+/// shouldn't care about.
+fn find_invalid_argument_in_chain<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> Option<&'a dynamo_runtime::error::DynamoError> {
+    use dynamo_runtime::error::{BackendError, ErrorType};
+    let mut current = Some(err);
+    while let Some(e) = current {
+        if let Some(dynamo_err) = e.downcast_ref::<dynamo_runtime::error::DynamoError>()
+            && matches!(
+                dynamo_err.error_type(),
+                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
+            )
+        {
+            return Some(dynamo_err);
+        }
+        current = e.source();
+    }
+    None
+}
+
 impl ErrorMessage {
     /// Not Found Error
     pub fn model_not_found() -> ErrorResponse {
@@ -278,14 +306,12 @@ impl ErrorMessage {
         }
 
         // Check for DynamoError with InvalidArgument anywhere in the chain → HTTP 400.
-        // This matches *any* nested InvalidArgument DynamoError, not only the NATS
-        // oversized-payload case, so previously-opaque nested InvalidArgument errors
-        // now surface as 400 instead of 500. Intentional: 400 is the correct class
-        // for a malformed/invalid request.
-        if let Some(dynamo_err) = find_dynamo_error_in_chain(
-            err.as_ref(),
-            dynamo_runtime::error::ErrorType::InvalidArgument,
-        ) {
+        // This matches *any* nested InvalidArgument DynamoError, including the
+        // `Backend(InvalidArgument)` variant that `py_err_to_dynamo` raises for
+        // engine-side `ValueError`/`TypeError`. Intentional: 400 is the correct
+        // class for a malformed/invalid request whether the validation tripped
+        // at the frontend or inside the engine.
+        if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref()) {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorMessage {
@@ -3026,6 +3052,33 @@ mod tests {
         assert!(response.1.message.contains("Request payload is too large"));
         assert!(!response.1.message.contains("NATS"));
         assert!(!response.1.message.contains("payload_bytes"));
+    }
+
+    #[test]
+    fn test_backend_invalid_argument_surfaces_as_400() {
+        // A Python `ValueError` (or `TypeError`) from inside an engine's
+        // `generate()` is wrapped by `py_err_to_dynamo` (lib/bindings/
+        // python/rust/backend.rs) as
+        // `ErrorType::Backend(BackendError::InvalidArgument)`. The HTTP
+        // layer must surface that as 400, not 500 — the request was
+        // malformed and the frontend-vs-engine boundary is an
+        // implementation detail. Regression coverage for the SGLang
+        // gate path, where `build_sglang_logprob_kwargs` raises
+        // `ValueError` from inside the engine's `generate()` when
+        // `logprobs >= 1` and the override env-var isn't set.
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+
+        let err: anyhow::Error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("Dynamo's SGLang backend does not currently support logprobs >= 1")
+            .build()
+            .into();
+
+        let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
+
+        assert_eq!(response.0, StatusCode::BAD_REQUEST);
+        assert_eq!(response.1.code, StatusCode::BAD_REQUEST.as_u16());
+        assert!(response.1.message.contains("does not currently support"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `dynamo.common.backend.logprobs` as the single source of truth for logprob option parsing and per-chunk extraction. Legacy vLLM/SGLang/TRT-LLM handlers keep their `_extract_logprobs` / `_build_logprob_kwargs` static methods as thin wrappers that delegate here; unified engines call the shared helpers directly from `generate()`.
- Wires logprobs end-to-end on the unified path: `output_options.{logprobs, prompt_logprobs}` now reaches `sampling_params`, and chunks carry `log_probs` / `top_logprobs` keys (added to the `GenerateChunk` TypedDict).
- Sample engine and Rust mocker emit deterministic synthetic logprobs when `output_options.logprobs` is set, so the wire format can be exercised without a GPU.
- Removes the "Logprob response wire" row from the unified-backend feature gap matrix.

## Test plan

- [x] `pytest components/src/dynamo/common/backend/tests/` — 108 passed, 4 skipped (parity tests that import vllm/sglang/trtllm handler classes — execute in CI when those engines are installed)
- [x] `cargo test -p dynamo-backend-common --features testing` — 92 passed
- [x] `cargo test -p dynamo-mocker-backend --bin dynamo-mocker-backend` — 18 passed (incl. 3 new logprob tests)
- [x] Manual review for comment hygiene — pass added flags WHY-only comments where the syntax doesn't show intent (engine quirks, upstream invariants, magic numbers).
- [ ] Validate vLLM unified path with a real model + `logprobs >= 1` request
- [ ] Validate SGLang unified path with `DYN_SGL_ALLOW_TOP_LOGPROBS=1` + `logprobs >= 1`
- [ ] Validate TRT-LLM unified path with `prompt_logprobs > 0`

## Notes for reviewers

- The shared module documents the per-engine flag pattern at the `extract_from_completion_output` signature — vLLM passes `include_bytes=True`, TRT-LLM passes `fallback_to_first_on_missing=True`. SGLang has a separate extractor due to its cumulative-tuple wire shape.
- SGLang `n > 1` (multi-choice) now tracks the cumulative-array offset per `output_idx` — the unified engine's `num_logprobs_per_choice: dict[int, int]` matches the legacy `output_logprobs_per_choice` behavior. A negative-control test (`test_parity_sglang_single_offset_misslices_under_n_gt_1`) locks in this bug fix.
- TRT-LLM keeps the legacy `max(1, logprobs_count)` floor: the engine treats `logprobs=0` as "off", so we bump to 1 to keep the chosen-token logprob.
- The 4 skipped tests are wrapper-vs-shared parity tests gated on engine installation — they import `BaseWorkerHandler._extract_logprobs` (vllm), `HandlerBase._extract_logprobs` (trtllm), and `DecodeWorkerHandler._extract_logprobs` / `_build_logprob_kwargs` (sglang) and assert byte-identical output vs a direct shared call. CI envs with the engines installed will execute them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token log probability support across vLLM, TRT-LLM, SGLang, and sample backends. Requests can now retrieve `log_probs` (selected token probabilities) and `top_logprobs` (alternative tokens with probabilities) via `output_options` configuration.

* **Documentation**
  * Updated contract documentation and README to reflect new logprob capabilities and unified backend support.

* **Tests**
  * Added comprehensive test coverage for logprob extraction, parsing, and generation across all supported backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/10149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->