### PR TITLE
docs: add DynoSim Digest pointer

### DIFF
--- a/docs/digest/dynosim/dynosim-pareto-frontier.md
+++ b/docs/digest/dynosim/dynosim-pareto-frontier.md
@@ -1,0 +1,11 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "DynoSim: Simulating the Pareto Frontier"
+subtitle: "A short pointer to the NVIDIA Technical Blog deep dive - May 2026"
+description: "DynoSim helps Dynamo teams simulate serving tradeoffs before spending GPU time on full deployments."
+keywords: DynoSim, Dynamo, simulation, Pareto frontier, Planner, Router, KVBM, LLM inference
+last-updated: May 29, 2026
+---
+
+DynoSim is a workload-driven discrete-event simulation of NVIDIA Dynamo that lets teams explore the serving design space before spending GPU time on full deployments. The NVIDIA Technical Blog post, [DynoSim: Simulating the Pareto Frontier](https://developer.nvidia.com/blog/dynosim-simulating-the-pareto-frontier/), walks through how DynoSim composes workload replay, scheduler-aware engine timing, Router, Planner, and KVBM behavior on a shared virtual timeline; why a Rust replay can screen thousands of configurations far faster than real time; and how the same loop can map throughput-latency Pareto frontiers, tune Planner behavior, and shortlist candidates for real-cluster validation.

--- a/docs/digest/index.mdx
+++ b/docs/digest/index.mdx
@@ -7,6 +7,14 @@ Technical deep dives, announcements, and updates from the Dynamo team.
 
 <CardGroup cols={2}>
   <Card
+    title="DynoSim: Simulating the Pareto Frontier"
+    icon="regular chart-line"
+    href="/dynamo/dev/digest/dynosim-pareto-frontier"
+  >
+    A short pointer to the DynoSim deep dive on fast, workload-driven
+    simulation for finding Dynamo deployment Pareto frontiers.
+  </Card>
+  <Card
     title="Dynamo Day 0 support for TokenSpeed"
     icon="regular newspaper"
     href="/dynamo/dev/digest/tokenspeed-day-0"

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -52,6 +52,9 @@ navigation:
     path: digest/index.mdx
     slug: digest
     contents:
+      - page: "DynoSim: Simulating the Pareto Frontier"
+        path: digest/dynosim/dynosim-pareto-frontier.md
+        slug: dynosim-pareto-frontier
       - page: "Dynamo Day 0 support for TokenSpeed"
         path: digest/tokenspeed/tokenspeed-day-0.md
         slug: tokenspeed-day-0

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -133,6 +133,8 @@ navbar-links:
     links:
       - text: All Posts
         href: /dynamo/dev/digest
+      - text: "DynoSim: Simulating the Pareto Frontier"
+        href: /dynamo/dev/digest/dynosim-pareto-frontier
       - text: "Dynamo Day 0 support for TokenSpeed"
         href: /dynamo/dev/digest/tokenspeed-day-0
       - text: "Multi-Turn Agentic Harnesses"


### PR DESCRIPTION
## Summary
- Add a short Dynamo Digest pointer post for the NVIDIA Technical Blog DynoSim article.
- Add the new post to the Digest landing page, docs navigation, and Digest navbar dropdown.

## Why
The full DynoSim technical deep dive now lives on the NVIDIA Technical Blog, and the Dynamo docs Digest should offer a concise entry that routes readers there.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('docs/index.yml')); yaml.safe_load(open('fern/docs.yml')); print('YAML OK')"`
- `fern check` was not run because the Fern CLI is not installed in this environment.