### PR TITLE
fix(vllm-test): rewrite vllm prefill cancel test (#10002)

### DIFF
--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -20,6 +20,7 @@ from tests.fault_tolerance.cancellation.utils import (
     DynamoFrontendProcess,
     poll_for_pattern,
     read_streaming_responses,
+    read_worker_generate_summary,
     send_cancellable_request,
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
@@ -346,6 +347,8 @@ def test_request_cancellation_vllm_decode_cancel(
                     process=decode_worker,
                     pattern="Decode Request ID: ",
                     match_type="contains",
+                    max_wait_ms=10000,
+                    poll_interval_ms=50,
                 )
 
                 # Verify same request ID reached prefill worker (as "Prefill Request ID")
@@ -395,7 +398,7 @@ def test_request_cancellation_vllm_decode_cancel(
                 )
 
 
-@pytest.mark.timeout(150)  # 3x average
+@pytest.mark.timeout(660)  # 3x average (~219s)
 @pytest.mark.nightly
 @pytest.mark.gpu_2
 def test_request_cancellation_vllm_prefill_cancel(
@@ -404,13 +407,17 @@ def test_request_cancellation_vllm_prefill_cancel(
     """
     End-to-end test for request cancellation during prefill phase.
 
-    This test verifies that when a request is cancelled by the client during the prefill phase,
-    the system properly handles the cancellation and cleans up resources
-    on both the decode and prefill workers in a disaggregated setup.
+    This test verifies that when a client disconnects during the prefill
+    phase in a disaggregated setup, the prefill worker still runs the
+    request to completion so KV blocks are released via the normal path
+    (rather than leaking on a torn-down NIXL transfer), and decode routing
+    still proceeds so the KV-transfer-complete guard can free the blocks.
 
-    Timing (Last Run: 2025-12-09): ~53s total (requires 2 GPUs)
+    Reference: PR ai-dynamo/dynamo#7489
+
+    Timing (Last Run: 2026-05-26): ~219s total (requires 2 GPUs)
     - Engine initialization: ~23s (decode + prefill workers)
-    - Testing cancellation during prefill: ~28s
+    - Testing graceful disconnect during prefill: ~83s
     - Teardown: ~2s
     """
 
@@ -442,8 +449,6 @@ def test_request_cancellation_vllm_prefill_cancel(
                     frontend.frontend_port, "completion", use_long_prompt=True
                 )
 
-                # Poll for "Prefill Request ID" pattern in prefill worker (vLLM v2 pattern)
-                # With new architecture, prefill is routed by frontend's internal router
                 request_id, prefill_log_offset = poll_for_pattern(
                     process=prefill_worker,
                     pattern="Prefill Request ID: ",
@@ -454,41 +459,59 @@ def test_request_cancellation_vllm_prefill_cancel(
                 cancellable_req.cancel()
                 logger.info(f"Cancelled request ID: {request_id} during prefill")
 
-                # Poll for "Aborted Prefill Request ID" in prefill worker (where cancellation happens)
-                _, prefill_log_offset = poll_for_pattern(
+                # Prefill must complete despite client disconnect.
+                poll_for_pattern(
                     process=prefill_worker,
-                    pattern=f"Aborted Prefill Request ID: {request_id}",
+                    pattern=f"Prefill completed for request {request_id}",
                     log_offset=prefill_log_offset,
+                    match_type="contains",
+                    max_wait_ms=15000,
+                    poll_interval_ms=50,
                 )
 
-                # Verify frontend log has kill message
-                _, frontend_log_offset = poll_for_pattern(
+                poll_for_pattern(
                     process=frontend,
-                    pattern="issued control message control_msg=Kill",
+                    pattern="Connection closed unexpectedly",
+                    match_type="contains",
+                    max_wait_ms=2000,
+                    poll_interval_ms=50,
                 )
 
-                # Verify decode worker never received the request
-                pattern = "Request ID: "
-                try:
-                    _, decode_log_offset = poll_for_pattern(
-                        process=decode_worker,
-                        pattern=pattern,
-                        max_wait_ms=10,
-                        match_type="contains",
-                    )
-                    pytest.fail(
-                        "Decode worker received request cancelled during prefill phase"
-                    )
-                except AssertionError as e:
-                    assert str(e).startswith(
-                        f"Failed to find '{pattern}' pattern after 2 iterations "
-                    ), f"Unexpected error: {e}"
-
-                logger.info(
-                    "Completion request cancellation during prefill phase detected successfully"
+                # Wait for the runtime to log "request completed" for our request — this
+                # fires on the same RequestMetricsGuard::drop that observes the histogram,
+                # so once we see this log line the metric is already up to date.
+                poll_for_pattern(
+                    process=prefill_worker,
+                    pattern=f"request completed request_id={request_id}",
+                    log_offset=prefill_log_offset,
+                    match_type="contains",
+                    max_wait_ms=5000,
+                    poll_interval_ms=100,
+                )
+                summary = read_worker_generate_summary(
+                    worker_system_port=prefill_worker.system_port,
+                    component="prefill",
+                )
+                logger.info(f"Prefill generate summary: {summary}")
+                assert summary["duration_count"] == 1.0, (
+                    f"Prefill histogram count={summary['duration_count']} — "
+                    "request was aborted mid-flight."
+                )
+                assert summary["duration_sum"] >= 0.1, (
+                    f"Prefill generate took only {summary['duration_sum']}s — "
+                    "suspiciously short."
+                )
+                assert summary["response_bytes"] > 0, (
+                    "Prefill sent 0 response bytes — handler exited before "
+                    "yielding KV-transfer params."
                 )
 
-                # Verify cancellation metrics
+                # Verify cancellation metrics. The decode-side counter
+                # increments in tcp/client.rs:347 only after the reader loop
+                # exits (which lags the prefill drain by: decode dispatch +
+                # frontend->decode ControlMessage::Kill + Python handler exit +
+                # writer drain). Poll until it matches to avoid scraping before
+                # the async chain finishes on slow runners.
                 verify_frontend_cancellation_metrics(
                     frontend_port=frontend.frontend_port,
                     request_type="completion",
@@ -496,10 +519,11 @@ def test_request_cancellation_vllm_prefill_cancel(
                 )
                 verify_runtime_cancellation_metrics(
                     worker_system_port=decode_worker.system_port,
-                    expected_count=0,
+                    expected_count=1,
+                    max_wait_ms=15000,
                 )
                 verify_runtime_cancellation_metrics(
                     worker_system_port=prefill_worker.system_port,
-                    expected_count=1,
+                    expected_count=0,
                     component="prefill",
                 )

--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -435,6 +435,8 @@ def verify_runtime_cancellation_metrics(
     worker_system_port: int,
     expected_count: int = 0,
     component: str = "backend",
+    max_wait_ms: int = 0,
+    poll_interval_ms: int = 100,
 ) -> None:
     """
     Verify runtime (worker) cancellation metrics.
@@ -443,6 +445,65 @@ def verify_runtime_cancellation_metrics(
         worker_system_port: Port where the worker /metrics is served
         expected_count: Expected cumulative cancellation count
         component: The dynamo_component label value (e.g. "backend", "prefill")
+        max_wait_ms: If > 0, retry the scrape until the metric matches
+            expected_count or the timeout expires. Use this when the counter
+            increment is asynchronous to whatever signal triggered the check
+        poll_interval_ms: Interval between retries when max_wait_ms > 0.
+    """
+    worker_metrics_url = f"http://localhost:{worker_system_port}/metrics"
+
+    deadline = time.monotonic() + max_wait_ms / 1000.0
+    count = -1
+    while True:
+        try:
+            response = requests.get(worker_metrics_url, timeout=5)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            pytest.fail(
+                f"Failed to fetch worker metrics from {worker_metrics_url}: {e}"
+            )
+
+        worker_text = response.text
+        count = _parse_runtime_cancellation_metric(worker_text, component=component)
+        if count == expected_count or time.monotonic() >= deadline:
+            break
+        time.sleep(poll_interval_ms / 1000.0)
+
+    logger.info(f"Runtime cancellation metrics (component={component}): {count}")
+
+    assert count == expected_count, (
+        f"Runtime (component={component}): expected {expected_count} cancellations, "
+        f"but got {count}"
+    )
+
+
+def _parse_labeled_metric(
+    metrics_text: str, metric_name: str, label_filters: Dict[str, str]
+) -> float | None:
+    """Return the first matching line's value, or None if not found."""
+    for line in metrics_text.splitlines():
+        if not line.startswith(f"{metric_name}{{"):
+            continue
+        if not all(f'{k}="{v}"' in line for k, v in label_filters.items()):
+            continue
+        parts = line.rsplit(None, 1)
+        if len(parts) == 2:
+            try:
+                return float(parts[1])
+            except ValueError:
+                pass
+    return None
+
+
+def read_worker_generate_summary(
+    worker_system_port: int,
+    component: str,
+) -> Dict[str, float]:
+    """
+    Read the dynamo-runtime ingress summary metrics for the worker `generate`
+    endpoint. `duration_count` increments only after RequestMetricsGuard::drop,
+    so it confirms the response stream fully drained (i.e. the request wasn't
+    aborted mid-flight).
     """
     worker_metrics_url = f"http://localhost:{worker_system_port}/metrics"
     try:
@@ -451,15 +512,22 @@ def verify_runtime_cancellation_metrics(
     except requests.RequestException as e:
         pytest.fail(f"Failed to fetch worker metrics from {worker_metrics_url}: {e}")
 
-    worker_text = response.text
-    count = _parse_runtime_cancellation_metric(worker_text, component=component)
-
-    logger.info(f"Runtime cancellation metrics (component={component}): {count}")
-
-    assert count == expected_count, (
-        f"Runtime (component={component}): expected {expected_count} cancellations, "
-        f"but got {count}"
-    )
+    text = response.text
+    filters = {"dynamo_component": component, "dynamo_endpoint": "generate"}
+    return {
+        "duration_sum": _parse_labeled_metric(
+            text, "dynamo_component_request_duration_seconds_sum", filters
+        )
+        or 0.0,
+        "duration_count": _parse_labeled_metric(
+            text, "dynamo_component_request_duration_seconds_count", filters
+        )
+        or 0.0,
+        "response_bytes": _parse_labeled_metric(
+            text, "dynamo_component_response_bytes_total", filters
+        )
+        or 0.0,
+    }
 
 
 def read_log_content(log_path: str | None) -> str:


### PR DESCRIPTION
#### Summary

- Cherry-pick of #10002 to `release/1.2.0`.
- Rewrites the vLLM prefill cancellation test to match the post-#7489 contract, which unlinked the prefill context from `engine_ctx` to prevent KV block leaks during disaggregated KV transfers. Test assertions are updated from expecting mid-flight request aborts to validating completion metrics and client-disconnection scenarios.
- Fixes DYN-3028 

#### Original PR
- Main PR: #10002 
- Merge commit: `e072c41cedb9bfddf63374eb4a20d3dea5057de3`                                                                                                                                                                                                                                                                                                                                                                                                                                            

#### Cherry-pick notes
- Clean cherry-pick — no conflicts. Two test files (`tests/fault_tolerance/cancellation/test_vllm.py`, `tests/fault_tolerance/cancellation/utils.py`), +135/-43, identical to upstream.
- Test-only change; depends on the #7489 behavioral contract already being present on `release/1.2.0`.                                                                                                                                                                                                                                                                                                                                                                                       
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->