### PR TITLE
fix(media): pre-convert RGB→YUV420p in numpy to fix corrupted video colors

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -278,7 +278,7 @@ License: `Apache-2.0`
 Apache License
 ==============
 
-_Version 2.0, January 2004_  
+_Version 2.0, January 2004_
 _&lt;<http://www.apache.org/licenses/>&gt;_
 
 ### Terms and Conditions for use, reproduction, and distribution
@@ -457,13 +457,13 @@ the same “printed page” as the copyright notice for easier identification wi
 third-party archives.
 
     Copyright [yyyy] [name of copyright owner]
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
       http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -475,7 +475,7 @@ third-party archives.
 Apache License
 ==============
 
-_Version 2.0, January 2004_  
+_Version 2.0, January 2004_
 _&lt;<http://www.apache.org/licenses/>&gt;_
 
 ### Terms and Conditions for use, reproduction, and distribution
@@ -654,13 +654,13 @@ the same “printed page” as the copyright notice for easier identification wi
 third-party archives.
 
     Copyright [yyyy] [name of copyright owner]
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
       http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -2481,7 +2481,7 @@ License: `Apache-2.0`
   - `licenses/NOTICE`:
 ```
 AWS Crt Python
-Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0.
 
 ** XXHash - https://xxhash.com/
@@ -4025,24 +4025,24 @@ Other contributors:
 
 Except when otherwise stated (look for LICENSE files in directories or
 information at the beginning of each file) all software and
-documentation is licensed as follows: 
+documentation is licensed as follows:
 
     MIT No Attribution
 
-    Permission is hereby granted, free of charge, to any person 
-    obtaining a copy of this software and associated documentation 
-    files (the "Software"), to deal in the Software without 
-    restriction, including without limitation the rights to use, 
-    copy, modify, merge, publish, distribute, sublicense, and/or 
-    sell copies of the Software, and to permit persons to whom the 
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the
     Software is furnished to do so.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
 ```
 
@@ -8443,7 +8443,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -10480,7 +10480,7 @@ License: `LGPL v3`
 the terms and conditions of version 3 of the GNU General Public
 License, supplemented by the additional permissions listed below.
 
-  0. Additional Definitions. 
+  0. Additional Definitions.
 
   As used herein, "this License" refers to version 3 of the GNU Lesser
 General Public License, and the "GNU GPL" refers to version 3 of the GNU
@@ -10581,7 +10581,7 @@ the following:
        a copy of the Library already present on the user's computer
        system, and (b) will operate properly with a modified version
        of the Library that is interface-compatible with the Linked
-       Version. 
+       Version.
 
    e) Provide Installation Information, but only if you would otherwise
    be required to provide such information under section 6 of the
@@ -12457,7 +12457,7 @@ License: `MIT`
 ```
 The MIT License (MIT)
 
-Copyright (c) Microsoft Corporation. 
+Copyright (c) Microsoft Corporation.
 All rights reserved.
 
 This code is licensed under the MIT License.
@@ -13644,7 +13644,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 jquery.graphviz.svg (https://github.com/mountainstorm/jquery.graphviz.svg/)
 ---------------------------------------------------------------------------
-The DAG roadmap rendering code in docs/dagmap/ uses Javascript from this 
+The DAG roadmap rendering code in docs/dagmap/ uses Javascript from this
 package to draw graphs in HTML.
 
 Copyright (c) 2015 Mountainstorm
@@ -14076,9 +14076,9 @@ https://docs.nvidia.com/cuda/archive/11.2.2/eula/index.html#attachment-a
 pythoncapi_compat
 -----------------
 
-The file numba/pythoncapi_compat.h is vendored from 
-https://github.com/python/pythoncapi_compat under the terms of 
-the Zero Clause BSD (0BSD) license, which is available at: 
+The file numba/pythoncapi_compat.h is vendored from
+https://github.com/python/pythoncapi_compat under the terms of
+the Zero Clause BSD (0BSD) license, which is available at:
 https://github.com/python/pythoncapi-compat/blob/main/COPYING and its text is
 reproduced below:
 
@@ -14144,23 +14144,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### Licenses
 License: `Copyright (c) 2005-2024, NumPy Developers.
          All rights reserved.
-         
+
          Redistribution and use in source and binary forms, with or without
          modification, are permitted provided that the following conditions are
          met:
-         
+
              * Redistributions of source code must retain the above copyright
                 notice, this list of conditions and the following disclaimer.
-         
+
              * Redistributions in binary form must reproduce the above
                 copyright notice, this list of conditions and the following
                 disclaimer in the documentation and/or other materials provided
                 with the distribution.
-         
+
              * Neither the name of the NumPy Developers nor the names of any
                 contributors may be used to endorse or promote products derived
                 from this software without specific prior written permission.
-         
+
          THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
          "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
          LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -14172,50 +14172,50 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
          (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
          OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-         
+
          ----
-         
+
          The NumPy repository and source distributions bundle several libraries that are
          compatibly licensed.  We list these here.
-         
+
          Name: lapack-lite
          Files: numpy/linalg/lapack_lite/*
          License: BSD-3-Clause
            For details, see numpy/linalg/lapack_lite/LICENSE.txt
-         
+
          Name: dragon4
          Files: numpy/_core/src/multiarray/dragon4.c
          License: MIT
            For license text, see numpy/_core/src/multiarray/dragon4.c
-         
+
          Name: libdivide
          Files: numpy/_core/include/numpy/libdivide/*
          License: Zlib
            For license text, see numpy/_core/include/numpy/libdivide/LICENSE.txt
-         
-         
+
+
          Note that the following files are vendored in the repository and sdist but not
          installed in built numpy packages:
-         
+
          Name: Meson
          Files: vendored-meson/meson/*
          License: Apache 2.0
            For license text, see vendored-meson/meson/COPYING
-         
+
          Name: spin
          Files: .spin/cmds.py
          License: BSD-3
            For license text, see .spin/LICENSE
-         
+
          Name: tempita
          Files: numpy/_build_utils/tempita/*
          License: MIT
            For details, see numpy/_build_utils/tempita/LICENCE.txt
-         
+
          ----
-         
+
          This binary distribution of NumPy also bundles the following software:
-         
+
          Name: OpenBLAS
          Files: numpy/.dylibs/libscipy_openblas*.so
          Description: bundled as a dynamically linked library
@@ -14223,14 +14223,14 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          License: BSD-3-Clause
            Copyright (c) 2011-2014, The OpenBLAS Project
            All rights reserved.
-         
+
            Redistribution and use in source and binary forms, with or without
            modification, are permitted provided that the following conditions are
            met:
-         
+
               1. Redistributions of source code must retain the above copyright
                  notice, this list of conditions and the following disclaimer.
-         
+
               2. Redistributions in binary form must reproduce the above copyright
                  notice, this list of conditions and the following disclaimer in
                  the documentation and/or other materials provided with the
@@ -14239,7 +14239,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
                  its contributors may be used to endorse or promote products
                  derived from this software without specific prior written
                  permission.
-         
+
            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
            AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
            IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -14250,8 +14250,8 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
            CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
            OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
            USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-         
-         
+
+
          Name: LAPACK
          Files: numpy/.dylibs/libscipy_openblas*.so
          Description: bundled in OpenBLAS
@@ -14264,36 +14264,36 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
                                    rights reserved.
            Copyright (c) 2006-2013 The University of Colorado Denver.  All rights
                                    reserved.
-         
+
            $COPYRIGHT$
-         
+
            Additional copyrights may follow
-         
+
            $HEADER$
-         
+
            Redistribution and use in source and binary forms, with or without
            modification, are permitted provided that the following conditions are
            met:
-         
+
            - Redistributions of source code must retain the above copyright
              notice, this list of conditions and the following disclaimer.
-         
+
            - Redistributions in binary form must reproduce the above copyright
              notice, this list of conditions and the following disclaimer listed
              in this license in the documentation and/or other materials
              provided with the distribution.
-         
+
            - Neither the name of the copyright holders nor the names of its
              contributors may be used to endorse or promote products derived from
              this software without specific prior written permission.
-         
+
            The copyright holders provide no reassurances that the source code
            provided does not infringe any patent, copyright, or any other
            intellectual property rights of third parties.  The copyright holders
            disclaim any liability to any recipient for claims brought against
            recipient by any third party for infringement of that parties
            intellectual property rights.
-         
+
            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
            "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
            LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -14305,86 +14305,86 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
            THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
            OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-         
-         
+
+
          Name: GCC runtime library
          Files: numpy/.dylibs/libgfortran*, numpy/.dylibs/libgcc*
          Description: dynamically linked to files compiled with gcc
          Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
          License: GPL-3.0-with-GCC-exception
            Copyright (C) 2002-2017 Free Software Foundation, Inc.
-         
+
            Libgfortran is free software; you can redistribute it and/or modify
            it under the terms of the GNU General Public License as published by
            the Free Software Foundation; either version 3, or (at your option)
            any later version.
-         
+
            Libgfortran is distributed in the hope that it will be useful,
            but WITHOUT ANY WARRANTY; without even the implied warranty of
            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
            GNU General Public License for more details.
-         
+
            Under Section 7 of GPL version 3, you are granted additional
            permissions described in the GCC Runtime Library Exception, version
            3.1, as published by the Free Software Foundation.
-         
+
            You should have received a copy of the GNU General Public License and
            a copy of the GCC Runtime Library Exception along with this program;
            see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
            <http://www.gnu.org/licenses/>.
-         
+
          ----
-         
+
          Full text of license texts referred to above follows (that they are
          listed below does not necessarily imply the conditions apply to the
          present binary release):
-         
+
          ----
-         
+
          GCC RUNTIME LIBRARY EXCEPTION
-         
+
          Version 3.1, 31 March 2009
-         
+
          Copyright (C) 2009 Free Software Foundation, Inc. <http://fsf.org/>
-         
+
          Everyone is permitted to copy and distribute verbatim copies of this
          license document, but changing it is not allowed.
-         
+
          This GCC Runtime Library Exception ("Exception") is an additional
          permission under section 7 of the GNU General Public License, version
          3 ("GPLv3"). It applies to a given file (the "Runtime Library") that
          bears a notice placed by the copyright holder of the file stating that
          the file is governed by GPLv3 along with this Exception.
-         
+
          When you use GCC to compile a program, GCC may combine portions of
          certain GCC header files and runtime libraries with the compiled
          program. The purpose of this Exception is to allow compilation of
          non-GPL (including proprietary) programs to use, in this way, the
          header files and runtime libraries covered by this Exception.
-         
+
          0. Definitions.
-         
+
          A file is an "Independent Module" if it either requires the Runtime
          Library for execution after a Compilation Process, or makes use of an
          interface provided by the Runtime Library, but is not otherwise based
          on the Runtime Library.
-         
+
          "GCC" means a version of the GNU Compiler Collection, with or without
          modifications, governed by version 3 (or a specified later version) of
          the GNU General Public License (GPL) with the option of using any
          subsequent versions published by the FSF.
-         
+
          "GPL-compatible Software" is software whose conditions of propagation,
          modification and use would permit combination with GCC in accord with
          the license of GCC.
-         
+
          "Target Code" refers to output from any compiler for a real or virtual
          target processor architecture, in executable form or suitable for
          input to an assembler, loader, linker and/or execution
          phase. Notwithstanding that, Target Code does not include data in any
          format that is used as a compiler intermediate representation, or used
          for producing a compiler intermediate representation.
-         
+
          The "Compilation Process" transforms code entirely represented in
          non-intermediate languages designed for human-written code, and/or in
          Java Virtual Machine byte code, into Target Code. Thus, for example,
@@ -14392,42 +14392,42 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          part of the Compilation Process, since the Compilation Process can be
          understood as starting with the output of the generators or
          preprocessors.
-         
+
          A Compilation Process is "Eligible" if it is done using GCC, alone or
          with other GPL-compatible software, or if it is done without using any
          work based on GCC. For example, using non-GPL-compatible Software to
          optimize any GCC intermediate representations would not qualify as an
          Eligible Compilation Process.
-         
+
          1. Grant of Additional Permission.
-         
+
          You have permission to propagate a work of Target Code formed by
          combining the Runtime Library with Independent Modules, even if such
          propagation would otherwise violate the terms of GPLv3, provided that
          all Target Code was generated by Eligible Compilation Processes. You
          may then convey such a combination under terms of your choice,
          consistent with the licensing of the Independent Modules.
-         
+
          2. No Weakening of GCC Copyleft.
-         
+
          The availability of this Exception does not imply any general
          presumption that third-party software is unaffected by the copyleft
          requirements of the license of GCC.
-         
+
          ----
-         
+
                              GNU GENERAL PUBLIC LICENSE
                                 Version 3, 29 June 2007
-         
+
           Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
           Everyone is permitted to copy and distribute verbatim copies
           of this license document, but changing it is not allowed.
-         
+
                                      Preamble
-         
+
            The GNU General Public License is a free, copyleft license for
          software and other kinds of works.
-         
+
            The licenses for most software and other practical works are designed
          to take away your freedom to share and change the works.  By contrast,
          the GNU General Public License is intended to guarantee your freedom to
@@ -14436,35 +14436,35 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          GNU General Public License for most of our software; it applies also to
          any other work released this way by its authors.  You can apply it to
          your programs, too.
-         
+
            When we speak of free software, we are referring to freedom, not
          price.  Our General Public Licenses are designed to make sure that you
          have the freedom to distribute copies of free software (and charge for
          them if you wish), that you receive source code or can get it if you
          want it, that you can change the software or use pieces of it in new
          free programs, and that you know you can do these things.
-         
+
            To protect your rights, we need to prevent others from denying you
          these rights or asking you to surrender the rights.  Therefore, you have
          certain responsibilities if you distribute copies of the software, or if
          you modify it: responsibilities to respect the freedom of others.
-         
+
            For example, if you distribute copies of such a program, whether
          gratis or for a fee, you must pass on to the recipients the same
          freedoms that you received.  You must make sure that they, too, receive
          or can get the source code.  And you must show them these terms so they
          know their rights.
-         
+
            Developers that use the GNU GPL protect your rights with two steps:
          (1) assert copyright on the software, and (2) offer you this License
          giving you legal permission to copy, distribute and/or modify it.
-         
+
            For the developers' and authors' protection, the GPL clearly explains
          that there is no warranty for this free software.  For both users' and
          authors' sake, the GPL requires that modified versions be marked as
          changed, so that their problems will not be attributed erroneously to
          authors of previous versions.
-         
+
            Some devices are designed to deny users access to install or run
          modified versions of the software inside them, although the manufacturer
          can do so.  This is fundamentally incompatible with the aim of
@@ -14475,49 +14475,49 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          products.  If such problems arise substantially in other domains, we
          stand ready to extend this provision to those domains in future versions
          of the GPL, as needed to protect the freedom of users.
-         
+
            Finally, every program is threatened constantly by software patents.
          States should not allow patents to restrict development and use of
          software on general-purpose computers, but in those that do, we wish to
          avoid the special danger that patents applied to a free program could
          make it effectively proprietary.  To prevent this, the GPL assures that
          patents cannot be used to render the program non-free.
-         
+
            The precise terms and conditions for copying, distribution and
          modification follow.
-         
+
                                 TERMS AND CONDITIONS
-         
+
            0. Definitions.
-         
+
            "This License" refers to version 3 of the GNU General Public License.
-         
+
            "Copyright" also means copyright-like laws that apply to other kinds of
          works, such as semiconductor masks.
-         
+
            "The Program" refers to any copyrightable work licensed under this
          License.  Each licensee is addressed as "you".  "Licensees" and
          "recipients" may be individuals or organizations.
-         
+
            To "modify" a work means to copy from or adapt all or part of the work
          in a fashion requiring copyright permission, other than the making of an
          exact copy.  The resulting work is called a "modified version" of the
          earlier work or a work "based on" the earlier work.
-         
+
            A "covered work" means either the unmodified Program or a work based
          on the Program.
-         
+
            To "propagate" a work means to do anything with it that, without
          permission, would make you directly or secondarily liable for
          infringement under applicable copyright law, except executing it on a
          computer or modifying a private copy.  Propagation includes copying,
          distribution (with or without modification), making available to the
          public, and in some countries other activities as well.
-         
+
            To "convey" a work means any kind of propagation that enables other
          parties to make or receive copies.  Mere interaction with a user through
          a computer network, with no transfer of a copy, is not conveying.
-         
+
            An interactive user interface displays "Appropriate Legal Notices"
          to the extent that it includes a convenient and prominently visible
          feature that (1) displays an appropriate copyright notice, and (2)
@@ -14526,18 +14526,18 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          work under this License, and how to view a copy of this License.  If
          the interface presents a list of user commands or options, such as a
          menu, a prominent item in the list meets this criterion.
-         
+
            1. Source Code.
-         
+
            The "source code" for a work means the preferred form of the work
          for making modifications to it.  "Object code" means any non-source
          form of a work.
-         
+
            A "Standard Interface" means an interface that either is an official
          standard defined by a recognized standards body, or, in the case of
          interfaces specified for a particular programming language, one that
          is widely used among developers working in that language.
-         
+
            The "System Libraries" of an executable work include anything, other
          than the work as a whole, that (a) is included in the normal form of
          packaging a Major Component, but which is not part of that Major
@@ -14548,7 +14548,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          (kernel, window system, and so on) of the specific operating system
          (if any) on which the executable work runs, or a compiler used to
          produce the work, or an object code interpreter used to run it.
-         
+
            The "Corresponding Source" for a work in object code form means all
          the source code needed to generate, install, and (for an executable
          work) run the object code and to modify the work, including scripts to
@@ -14561,16 +14561,16 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          linked subprograms that the work is specifically designed to require,
          such as by intimate data communication or control flow between those
          subprograms and other parts of the work.
-         
+
            The Corresponding Source need not include anything that users
          can regenerate automatically from other parts of the Corresponding
          Source.
-         
+
            The Corresponding Source for a work in source code form is that
          same work.
-         
+
            2. Basic Permissions.
-         
+
            All rights granted under this License are granted for the term of
          copyright on the Program, and are irrevocable provided the stated
          conditions are met.  This License explicitly affirms your unlimited
@@ -14578,7 +14578,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          covered work is covered by this License only if the output, given its
          content, constitutes a covered work.  This License acknowledges your
          rights of fair use or other equivalent, as provided by copyright law.
-         
+
            You may make, run and propagate covered works that you do not
          convey, without conditions so long as your license otherwise remains
          in force.  You may convey covered works to others for the sole purpose
@@ -14589,19 +14589,19 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          for you must do so exclusively on your behalf, under your direction
          and control, on terms that prohibit them from making any copies of
          your copyrighted material outside their relationship with you.
-         
+
            Conveying under any other circumstances is permitted solely under
          the conditions stated below.  Sublicensing is not allowed; section 10
          makes it unnecessary.
-         
+
            3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-         
+
            No covered work shall be deemed part of an effective technological
          measure under any applicable law fulfilling obligations under article
          11 of the WIPO copyright treaty adopted on 20 December 1996, or
          similar laws prohibiting or restricting circumvention of such
          measures.
-         
+
            When you convey a covered work, you waive any legal power to forbid
          circumvention of technological measures to the extent such circumvention
          is effected by exercising rights under this License with respect to
@@ -14609,9 +14609,9 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          modification of the work as a means of enforcing, against the work's
          users, your or third parties' legal rights to forbid circumvention of
          technological measures.
-         
+
            4. Conveying Verbatim Copies.
-         
+
            You may convey verbatim copies of the Program's source code as you
          receive it, in any medium, provided that you conspicuously and
          appropriately publish on each copy an appropriate copyright notice;
@@ -14619,24 +14619,24 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          non-permissive terms added in accord with section 7 apply to the code;
          keep intact all notices of the absence of any warranty; and give all
          recipients a copy of this License along with the Program.
-         
+
            You may charge any price or no price for each copy that you convey,
          and you may offer support or warranty protection for a fee.
-         
+
            5. Conveying Modified Source Versions.
-         
+
            You may convey a work based on the Program, or the modifications to
          produce it from the Program, in the form of source code under the
          terms of section 4, provided that you also meet all of these conditions:
-         
+
              a) The work must carry prominent notices stating that you modified
              it, and giving a relevant date.
-         
+
              b) The work must carry prominent notices stating that it is
              released under this License and any conditions added under section
              7.  This requirement modifies the requirement in section 4 to
              "keep intact all notices".
-         
+
              c) You must license the entire work, as a whole, under this
              License to anyone who comes into possession of a copy.  This
              License will therefore apply, along with any applicable section 7
@@ -14644,12 +14644,12 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
              regardless of how they are packaged.  This License gives no
              permission to license the work in any other way, but it does not
              invalidate such permission if you have separately received it.
-         
+
              d) If the work has interactive user interfaces, each must display
              Appropriate Legal Notices; however, if the Program has interactive
              interfaces that do not display Appropriate Legal Notices, your
              work need not make them do so.
-         
+
            A compilation of a covered work with other separate and independent
          works, which are not by their nature extensions of the covered work,
          and which are not combined with it such as to form a larger program,
@@ -14659,19 +14659,19 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          beyond what the individual works permit.  Inclusion of a covered work
          in an aggregate does not cause this License to apply to the other
          parts of the aggregate.
-         
+
            6. Conveying Non-Source Forms.
-         
+
            You may convey a covered work in object code form under the terms
          of sections 4 and 5, provided that you also convey the
          machine-readable Corresponding Source under the terms of this License,
          in one of these ways:
-         
+
              a) Convey the object code in, or embodied in, a physical product
              (including a physical distribution medium), accompanied by the
              Corresponding Source fixed on a durable physical medium
              customarily used for software interchange.
-         
+
              b) Convey the object code in, or embodied in, a physical product
              (including a physical distribution medium), accompanied by a
              written offer, valid for at least three years and valid for as
@@ -14683,13 +14683,13 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
              more than your reasonable cost of physically performing this
              conveying of source, or (2) access to copy the
              Corresponding Source from a network server at no charge.
-         
+
              c) Convey individual copies of the object code with a copy of the
              written offer to provide the Corresponding Source.  This
              alternative is allowed only occasionally and noncommercially, and
              only if you received the object code with such an offer, in accord
              with subsection 6b.
-         
+
              d) Convey the object code by offering access from a designated
              place (gratis or for a charge), and offer equivalent access to the
              Corresponding Source in the same way through the same place at no
@@ -14702,16 +14702,16 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
              Corresponding Source.  Regardless of what server hosts the
              Corresponding Source, you remain obligated to ensure that it is
              available for as long as needed to satisfy these requirements.
-         
+
              e) Convey the object code using peer-to-peer transmission, provided
              you inform other peers where the object code and Corresponding
              Source of the work are being offered to the general public at no
              charge under subsection 6d.
-         
+
            A separable portion of the object code, whose source code is excluded
          from the Corresponding Source as a System Library, need not be
          included in conveying the object code work.
-         
+
            A "User Product" is either (1) a "consumer product", which means any
          tangible personal property which is normally used for personal, family,
          or household purposes, or (2) anything designed or sold for incorporation
@@ -14724,7 +14724,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          is a consumer product regardless of whether the product has substantial
          commercial, industrial or non-consumer uses, unless such uses represent
          the only significant mode of use of the product.
-         
+
            "Installation Information" for a User Product means any methods,
          procedures, authorization keys, or other information required to install
          and execute modified versions of a covered work in that User Product from
@@ -14732,7 +14732,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          suffice to ensure that the continued functioning of the modified object
          code is in no case prevented or interfered with solely because
          modification has been made.
-         
+
            If you convey an object code work under this section in, or with, or
          specifically for use in, a User Product, and the conveying occurs as
          part of a transaction in which the right of possession and use of the
@@ -14743,7 +14743,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          if neither you nor any third party retains the ability to install
          modified object code on the User Product (for example, the work has
          been installed in ROM).
-         
+
            The requirement to provide Installation Information does not include a
          requirement to continue to provide support service, warranty, or updates
          for a work that has been modified or installed by the recipient, or for
@@ -14751,15 +14751,15 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          network may be denied when the modification itself materially and
          adversely affects the operation of the network or violates the rules and
          protocols for communication across the network.
-         
+
            Corresponding Source conveyed, and Installation Information provided,
          in accord with this section must be in a format that is publicly
          documented (and with an implementation available to the public in
          source code form), and must require no special password or key for
          unpacking, reading or copying.
-         
+
            7. Additional Terms.
-         
+
            "Additional permissions" are terms that supplement the terms of this
          License by making exceptions from one or more of its conditions.
          Additional permissions that are applicable to the entire Program shall
@@ -14768,41 +14768,41 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          apply only to part of the Program, that part may be used separately
          under those permissions, but the entire Program remains governed by
          this License without regard to the additional permissions.
-         
+
            When you convey a copy of a covered work, you may at your option
          remove any additional permissions from that copy, or from any part of
          it.  (Additional permissions may be written to require their own
          removal in certain cases when you modify the work.)  You may place
          additional permissions on material, added by you to a covered work,
          for which you have or can give appropriate copyright permission.
-         
+
            Notwithstanding any other provision of this License, for material you
          add to a covered work, you may (if authorized by the copyright holders of
          that material) supplement the terms of this License with terms:
-         
+
              a) Disclaiming warranty or limiting liability differently from the
              terms of sections 15 and 16 of this License; or
-         
+
              b) Requiring preservation of specified reasonable legal notices or
              author attributions in that material or in the Appropriate Legal
              Notices displayed by works containing it; or
-         
+
              c) Prohibiting misrepresentation of the origin of that material, or
              requiring that modified versions of such material be marked in
              reasonable ways as different from the original version; or
-         
+
              d) Limiting the use for publicity purposes of names of licensors or
              authors of the material; or
-         
+
              e) Declining to grant rights under trademark law for use of some
              trade names, trademarks, or service marks; or
-         
+
              f) Requiring indemnification of licensors and authors of that
              material by anyone who conveys the material (or modified versions of
              it) with contractual assumptions of liability to the recipient, for
              any liability that these contractual assumptions directly impose on
              those licensors and authors.
-         
+
            All other non-permissive additional terms are considered "further
          restrictions" within the meaning of section 10.  If the Program as you
          received it, or any part of it, contains a notice stating that it is
@@ -14812,46 +14812,46 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          License, you may add to a covered work material governed by the terms
          of that license document, provided that the further restriction does
          not survive such relicensing or conveying.
-         
+
            If you add terms to a covered work in accord with this section, you
          must place, in the relevant source files, a statement of the
          additional terms that apply to those files, or a notice indicating
          where to find the applicable terms.
-         
+
            Additional terms, permissive or non-permissive, may be stated in the
          form of a separately written license, or stated as exceptions;
          the above requirements apply either way.
-         
+
            8. Termination.
-         
+
            You may not propagate or modify a covered work except as expressly
          provided under this License.  Any attempt otherwise to propagate or
          modify it is void, and will automatically terminate your rights under
          this License (including any patent licenses granted under the third
          paragraph of section 11).
-         
+
            However, if you cease all violation of this License, then your
          license from a particular copyright holder is reinstated (a)
          provisionally, unless and until the copyright holder explicitly and
          finally terminates your license, and (b) permanently, if the copyright
          holder fails to notify you of the violation by some reasonable means
          prior to 60 days after the cessation.
-         
+
            Moreover, your license from a particular copyright holder is
          reinstated permanently if the copyright holder notifies you of the
          violation by some reasonable means, this is the first time you have
          received notice of violation of this License (for any work) from that
          copyright holder, and you cure the violation prior to 30 days after
          your receipt of the notice.
-         
+
            Termination of your rights under this section does not terminate the
          licenses of parties who have received copies or rights from you under
          this License.  If your rights have been terminated and not permanently
          reinstated, you do not qualify to receive new licenses for the same
          material under section 10.
-         
+
            9. Acceptance Not Required for Having Copies.
-         
+
            You are not required to accept this License in order to receive or
          run a copy of the Program.  Ancillary propagation of a covered work
          occurring solely as a consequence of using peer-to-peer transmission
@@ -14860,14 +14860,14 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          modify any covered work.  These actions infringe copyright if you do
          not accept this License.  Therefore, by modifying or propagating a
          covered work, you indicate your acceptance of this License to do so.
-         
+
            10. Automatic Licensing of Downstream Recipients.
-         
+
            Each time you convey a covered work, the recipient automatically
          receives a license from the original licensors, to run, modify and
          propagate that work, subject to this License.  You are not responsible
          for enforcing compliance by third parties with this License.
-         
+
            An "entity transaction" is a transaction transferring control of an
          organization, or substantially all assets of one, or subdividing an
          organization, or merging organizations.  If propagation of a covered
@@ -14877,7 +14877,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          give under the previous paragraph, plus a right to possession of the
          Corresponding Source of the work from the predecessor in interest, if
          the predecessor has it or can get it with reasonable efforts.
-         
+
            You may not impose any further restrictions on the exercise of the
          rights granted or affirmed under this License.  For example, you may
          not impose a license fee, royalty, or other charge for exercise of
@@ -14885,13 +14885,13 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          (including a cross-claim or counterclaim in a lawsuit) alleging that
          any patent claim is infringed by making, using, selling, offering for
          sale, or importing the Program or any portion of it.
-         
+
            11. Patents.
-         
+
            A "contributor" is a copyright holder who authorizes use under this
          License of the Program or a work on which the Program is based.  The
          work thus licensed is called the contributor's "contributor version".
-         
+
            A contributor's "essential patent claims" are all patent claims
          owned or controlled by the contributor, whether already acquired or
          hereafter acquired, that would be infringed by some manner, permitted
@@ -14901,19 +14901,19 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          purposes of this definition, "control" includes the right to grant
          patent sublicenses in a manner consistent with the requirements of
          this License.
-         
+
            Each contributor grants you a non-exclusive, worldwide, royalty-free
          patent license under the contributor's essential patent claims, to
          make, use, sell, offer for sale, import and otherwise run, modify and
          propagate the contents of its contributor version.
-         
+
            In the following three paragraphs, a "patent license" is any express
          agreement or commitment, however denominated, not to enforce a patent
          (such as an express permission to practice a patent or covenant not to
          sue for patent infringement).  To "grant" such a patent license to a
          party means to make such an agreement or commitment not to enforce a
          patent against the party.
-         
+
            If you convey a covered work, knowingly relying on a patent license,
          and the Corresponding Source of the work is not available for anyone
          to copy, free of charge and under the terms of this License, through a
@@ -14927,7 +14927,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          covered work in a country, or your recipient's use of the covered work
          in a country, would infringe one or more identifiable patents in that
          country that you have reason to believe are valid.
-         
+
            If, pursuant to or in connection with a single transaction or
          arrangement, you convey, or propagate by procuring conveyance of, a
          covered work, and grant a patent license to some of the parties
@@ -14935,7 +14935,7 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          or convey a specific copy of the covered work, then the patent license
          you grant is automatically extended to all recipients of the covered
          work and works based on it.
-         
+
            A patent license is "discriminatory" if it does not include within
          the scope of its coverage, prohibits the exercise of, or is
          conditioned on the non-exercise of one or more of the rights that are
@@ -14950,13 +14950,13 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          for and in connection with specific products or compilations that
          contain the covered work, unless you entered into that arrangement,
          or that patent license was granted, prior to 28 March 2007.
-         
+
            Nothing in this License shall be construed as excluding or limiting
          any implied license or other defenses to infringement that may
          otherwise be available to you under applicable patent law.
-         
+
            12. No Surrender of Others' Freedom.
-         
+
            If conditions are imposed on you (whether by court order, agreement or
          otherwise) that contradict the conditions of this License, they do not
          excuse you from the conditions of this License.  If you cannot convey a
@@ -14966,9 +14966,9 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          to collect a royalty for further conveying from those to whom you convey
          the Program, the only way you could satisfy both those terms and this
          License would be to refrain entirely from conveying the Program.
-         
+
            13. Use with the GNU Affero General Public License.
-         
+
            Notwithstanding any other provision of this License, you have
          permission to link or combine any covered work with a work licensed
          under version 3 of the GNU Affero General Public License into a single
@@ -14977,14 +14977,14 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          but the special requirements of the GNU Affero General Public License,
          section 13, concerning interaction through a network will apply to the
          combination as such.
-         
+
            14. Revised Versions of this License.
-         
+
            The Free Software Foundation may publish revised and/or new versions of
          the GNU General Public License from time to time.  Such new versions will
          be similar in spirit to the present version, but may differ in detail to
          address new problems or concerns.
-         
+
            Each version is given a distinguishing version number.  If the
          Program specifies that a certain numbered version of the GNU General
          Public License "or any later version" applies to it, you have the
@@ -14993,19 +14993,19 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          Foundation.  If the Program does not specify a version number of the
          GNU General Public License, you may choose any version ever published
          by the Free Software Foundation.
-         
+
            If the Program specifies that a proxy can decide which future
          versions of the GNU General Public License can be used, that proxy's
          public statement of acceptance of a version permanently authorizes you
          to choose that version for the Program.
-         
+
            Later license versions may give you additional or different
          permissions.  However, no additional obligations are imposed on any
          author or copyright holder as a result of your choosing to follow a
          later version.
-         
+
            15. Disclaimer of Warranty.
-         
+
            THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
          APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
          HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
@@ -15014,9 +15014,9 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
          IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
          ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-         
+
            16. Limitation of Liability.
-         
+
            IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
          WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
          THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
@@ -15026,87 +15026,87 @@ License: `Copyright (c) 2005-2024, NumPy Developers.
          PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
          EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
          SUCH DAMAGES.
-         
+
            17. Interpretation of Sections 15 and 16.
-         
+
            If the disclaimer of warranty and limitation of liability provided
          above cannot be given local legal effect according to their terms,
          reviewing courts shall apply local law that most closely approximates
          an absolute waiver of all civil liability in connection with the
          Program, unless a warranty or assumption of liability accompanies a
          copy of the Program in return for a fee.
-         
+
                               END OF TERMS AND CONDITIONS
-         
+
                      How to Apply These Terms to Your New Programs
-         
+
            If you develop a new program, and you want it to be of the greatest
          possible use to the public, the best way to achieve this is to make it
          free software which everyone can redistribute and change under these terms.
-         
+
            To do so, attach the following notices to the program.  It is safest
          to attach them to the start of each source file to most effectively
          state the exclusion of warranty; and each file should have at least
          the "copyright" line and a pointer to where the full notice is found.
-         
+
              <one line to give the program's name and a brief idea of what it does.>
              Copyright (C) <year>  <name of author>
-         
+
              This program is free software: you can redistribute it and/or modify
              it under the terms of the GNU General Public License as published by
              the Free Software Foundation, either version 3 of the License, or
              (at your option) any later version.
-         
+
              This program is distributed in the hope that it will be useful,
              but WITHOUT ANY WARRANTY; without even the implied warranty of
              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
              GNU General Public License for more details.
-         
+
              You should have received a copy of the GNU General Public License
              along with this program.  If not, see <http://www.gnu.org/licenses/>.
-         
+
          Also add information on how to contact you by electronic and paper mail.
-         
+
            If the program does terminal interaction, make it output a short
          notice like this when it starts in an interactive mode:
-         
+
              <program>  Copyright (C) <year>  <name of author>
              This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
              This is free software, and you are welcome to redistribute it
              under certain conditions; type `show c' for details.
-         
+
          The hypothetical commands `show w' and `show c' should show the appropriate
          parts of the General Public License.  Of course, your program's commands
          might be different; for a GUI interface, you would use an "about box".
-         
+
            You should also get your employer (if you work as a programmer) or school,
          if any, to sign a "copyright disclaimer" for the program, if necessary.
          For more information on this, and how to apply and follow the GNU GPL, see
          <http://www.gnu.org/licenses/>.
-         
+
            The GNU General Public License does not permit incorporating your program
          into proprietary programs.  If your program is a subroutine library, you
          may consider it more useful to permit linking proprietary applications with
          the library.  If this is what you want to do, use the GNU Lesser General
          Public License instead of this License.  But first, please read
          <http://www.gnu.org/philosophy/why-not-lgpl.html>.
-         
+
          Name: libquadmath
          Files: numpy/.dylibs/libquadmath*.so
          Description: dynamically linked to files compiled with gcc
          Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libquadmath
          License: LGPL-2.1-or-later
-         
+
              GCC Quad-Precision Math Library
              Copyright (C) 2010-2019 Free Software Foundation, Inc.
              Written by Francois-Xavier Coudert  <fxcoudert@gcc.gnu.org>
-         
+
              This file is part of the libquadmath library.
              Libquadmath is free software; you can redistribute it and/or
              modify it under the terms of the GNU Library General Public
              License as published by the Free Software Foundation; either
              version 2.1 of the License, or (at your option) any later version.
-         
+
              Libquadmath is distributed in the hope that it will be useful,
              but WITHOUT ANY WARRANTY; without even the implied warranty of
              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -23848,7 +23848,7 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-  * Redistributions of source code must retain the above copyright notice, 
+  * Redistributions of source code must retain the above copyright notice,
     this list of conditions and the following disclaimer.
 
   * Redistributions in binary form must reproduce the above copyright notice,
@@ -23856,8 +23856,8 @@ modification, are permitted provided that the following conditions are met:
     and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
 LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
@@ -23889,7 +23889,7 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-  * Redistributions of source code must retain the above copyright notice, 
+  * Redistributions of source code must retain the above copyright notice,
     this list of conditions and the following disclaimer.
 
   * Redistributions in binary form must reproduce the above copyright notice,
@@ -23897,8 +23897,8 @@ modification, are permitted provided that the following conditions are met:
     and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
 LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
@@ -24445,24 +24445,24 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this 
+* Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, 
-  this list of conditions and the following disclaimer in the documentation 
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-* Neither the name of the copyright holder nor the names of its contributors may 
-  be used to endorse or promote products derived from this software without 
+* Neither the name of the copyright holder nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
   specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
@@ -24782,7 +24782,7 @@ Other contributors, listed alphabetically, are:
 * Brian R. Jackson -- Tea lexer
 * Alex Jeffery, ChromaWay AB -- Rell lexer
 * Christian Jann -- ShellSession lexer
-* Jonas Camillus Jeppesen -- Line numbers and line highlighting for 
+* Jonas Camillus Jeppesen -- Line numbers and line highlighting for
   RTF-formatter
 * Dennis Kaarsemaker -- sources.list lexer
 * Dmitri Kabak -- Inferno Limbo lexer
@@ -25144,7 +25144,7 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-  
+
   1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an
@@ -25980,25 +25980,25 @@ SOFTWARE.
 
 ### Licenses
 License: `BSD 3-Clause License
-         
+
          Copyright (c) 2009-2012, Brian Granger, Min Ragan-Kelley
-         
+
          All rights reserved.
-         
+
          Redistribution and use in source and binary forms, with or without
          modification, are permitted provided that the following conditions are met:
-         
+
          1. Redistributions of source code must retain the above copyright notice, this
             list of conditions and the following disclaimer.
-         
+
          2. Redistributions in binary form must reproduce the above copyright notice,
             this list of conditions and the following disclaimer in the documentation
             and/or other materials provided with the distribution.
-         
+
          3. Neither the name of the copyright holder nor the names of its
             contributors may be used to endorse or promote products derived from
             this software without specific prior written permission.
-         
+
          THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
          AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
          IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28839,23 +28839,23 @@ License: `Apache-2.0`
 ### Licenses
 License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          All rights reserved.
-         
+
          Redistribution and use in source and binary forms, with or without
          modification, are permitted provided that the following conditions
          are met:
-         
+
          1. Redistributions of source code must retain the above copyright
             notice, this list of conditions and the following disclaimer.
-         
+
          2. Redistributions in binary form must reproduce the above
             copyright notice, this list of conditions and the following
             disclaimer in the documentation and/or other materials provided
             with the distribution.
-         
+
          3. Neither the name of the copyright holder nor the names of its
             contributors may be used to endorse or promote products derived
             from this software without specific prior written permission.
-         
+
          THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
          "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
          LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -28867,16 +28867,16 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
          (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
          OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-         
+
          ----
-         
-         
+
+
          ----
-         
+
          This binary distribution of SciPy can also bundle the following software
          (depending on the build):
-         
-         
+
+
          Name: OpenBLAS
          Files: scipy/.dylibs/libscipy_openblas*.so
          Description: bundled as a dynamically linked library
@@ -28884,14 +28884,14 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          License: BSD-3-Clause
            Copyright (c) 2011-2014, The OpenBLAS Project
            All rights reserved.
-         
+
            Redistribution and use in source and binary forms, with or without
            modification, are permitted provided that the following conditions are
            met:
-         
+
               1. Redistributions of source code must retain the above copyright
                  notice, this list of conditions and the following disclaimer.
-         
+
               2. Redistributions in binary form must reproduce the above copyright
                  notice, this list of conditions and the following disclaimer in
                  the documentation and/or other materials provided with the
@@ -28900,7 +28900,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
                  its contributors may be used to endorse or promote products
                  derived from this software without specific prior written
                  permission.
-         
+
            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
            AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
            IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28911,8 +28911,8 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
            CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
            OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
            USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-         
-         
+
+
          Name: LAPACK
          Files: scipy/.dylibs/libscipy_openblas*.so
          Description: bundled in OpenBLAS
@@ -28925,36 +28925,36 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
                                    rights reserved.
            Copyright (c) 2006-2013 The University of Colorado Denver.  All rights
                                    reserved.
-         
+
            $COPYRIGHT$
-         
+
            Additional copyrights may follow
-         
+
            $HEADER$
-         
+
            Redistribution and use in source and binary forms, with or without
            modification, are permitted provided that the following conditions are
            met:
-         
+
            - Redistributions of source code must retain the above copyright
              notice, this list of conditions and the following disclaimer.
-         
+
            - Redistributions in binary form must reproduce the above copyright
              notice, this list of conditions and the following disclaimer listed
              in this license in the documentation and/or other materials
              provided with the distribution.
-         
+
            - Neither the name of the copyright holders nor the names of its
              contributors may be used to endorse or promote products derived from
              this software without specific prior written permission.
-         
+
            The copyright holders provide no reassurances that the source code
            provided does not infringe any patent, copyright, or any other
            intellectual property rights of third parties.  The copyright holders
            disclaim any liability to any recipient for claims brought against
            recipient by any third party for infringement of that parties
            intellectual property rights.
-         
+
            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
            "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
            LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -28966,86 +28966,86 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
            THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
            OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-         
-         
+
+
          Name: GCC runtime library
          Files: scipy/.dylibs/libgfortran*, scipy/.dylibs/libgcc*
          Description: dynamically linked to files compiled with gcc
          Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
          License: GPL-3.0-or-later WITH GCC-exception-3.1
            Copyright (C) 2002-2017 Free Software Foundation, Inc.
-           
+
            Libgfortran is free software; you can redistribute it and/or modify
            it under the terms of the GNU General Public License as published by
            the Free Software Foundation; either version 3, or (at your option)
            any later version.
-           
+
            Libgfortran is distributed in the hope that it will be useful,
            but WITHOUT ANY WARRANTY; without even the implied warranty of
            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
            GNU General Public License for more details.
-           
+
            Under Section 7 of GPL version 3, you are granted additional
            permissions described in the GCC Runtime Library Exception, version
            3.1, as published by the Free Software Foundation.
-           
+
            You should have received a copy of the GNU General Public License and
            a copy of the GCC Runtime Library Exception along with this program;
            see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
            <http://www.gnu.org/licenses/>.
-         
+
          ----
-         
+
          Full text of license texts referred to above follows (that they are
          listed below does not necessarily imply the conditions apply to the
          present binary release):
-         
+
          ----
-         
+
          GCC RUNTIME LIBRARY EXCEPTION
-         
+
          Version 3.1, 31 March 2009
-         
+
          Copyright (C) 2009 Free Software Foundation, Inc. <http://fsf.org/>
-         
+
          Everyone is permitted to copy and distribute verbatim copies of this
          license document, but changing it is not allowed.
-         
+
          This GCC Runtime Library Exception ("Exception") is an additional
          permission under section 7 of the GNU General Public License, version
          3 ("GPLv3"). It applies to a given file (the "Runtime Library") that
          bears a notice placed by the copyright holder of the file stating that
          the file is governed by GPLv3 along with this Exception.
-         
+
          When you use GCC to compile a program, GCC may combine portions of
          certain GCC header files and runtime libraries with the compiled
          program. The purpose of this Exception is to allow compilation of
          non-GPL (including proprietary) programs to use, in this way, the
          header files and runtime libraries covered by this Exception.
-         
+
          0. Definitions.
-         
+
          A file is an "Independent Module" if it either requires the Runtime
          Library for execution after a Compilation Process, or makes use of an
          interface provided by the Runtime Library, but is not otherwise based
          on the Runtime Library.
-         
+
          "GCC" means a version of the GNU Compiler Collection, with or without
          modifications, governed by version 3 (or a specified later version) of
          the GNU General Public License (GPL) with the option of using any
          subsequent versions published by the FSF.
-         
+
          "GPL-compatible Software" is software whose conditions of propagation,
          modification and use would permit combination with GCC in accord with
          the license of GCC.
-         
+
          "Target Code" refers to output from any compiler for a real or virtual
          target processor architecture, in executable form or suitable for
          input to an assembler, loader, linker and/or execution
          phase. Notwithstanding that, Target Code does not include data in any
          format that is used as a compiler intermediate representation, or used
          for producing a compiler intermediate representation.
-         
+
          The "Compilation Process" transforms code entirely represented in
          non-intermediate languages designed for human-written code, and/or in
          Java Virtual Machine byte code, into Target Code. Thus, for example,
@@ -29053,42 +29053,42 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          part of the Compilation Process, since the Compilation Process can be
          understood as starting with the output of the generators or
          preprocessors.
-         
+
          A Compilation Process is "Eligible" if it is done using GCC, alone or
          with other GPL-compatible software, or if it is done without using any
          work based on GCC. For example, using non-GPL-compatible Software to
          optimize any GCC intermediate representations would not qualify as an
          Eligible Compilation Process.
-         
+
          1. Grant of Additional Permission.
-         
+
          You have permission to propagate a work of Target Code formed by
          combining the Runtime Library with Independent Modules, even if such
          propagation would otherwise violate the terms of GPLv3, provided that
          all Target Code was generated by Eligible Compilation Processes. You
          may then convey such a combination under terms of your choice,
          consistent with the licensing of the Independent Modules.
-         
+
          2. No Weakening of GCC Copyleft.
-         
+
          The availability of this Exception does not imply any general
          presumption that third-party software is unaffected by the copyleft
          requirements of the license of GCC.
-         
+
          ----
-         
+
                              GNU GENERAL PUBLIC LICENSE
                                 Version 3, 29 June 2007
-         
+
           Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
           Everyone is permitted to copy and distribute verbatim copies
           of this license document, but changing it is not allowed.
-         
+
                                      Preamble
-         
+
            The GNU General Public License is a free, copyleft license for
          software and other kinds of works.
-         
+
            The licenses for most software and other practical works are designed
          to take away your freedom to share and change the works.  By contrast,
          the GNU General Public License is intended to guarantee your freedom to
@@ -29097,35 +29097,35 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          GNU General Public License for most of our software; it applies also to
          any other work released this way by its authors.  You can apply it to
          your programs, too.
-         
+
            When we speak of free software, we are referring to freedom, not
          price.  Our General Public Licenses are designed to make sure that you
          have the freedom to distribute copies of free software (and charge for
          them if you wish), that you receive source code or can get it if you
          want it, that you can change the software or use pieces of it in new
          free programs, and that you know you can do these things.
-         
+
            To protect your rights, we need to prevent others from denying you
          these rights or asking you to surrender the rights.  Therefore, you have
          certain responsibilities if you distribute copies of the software, or if
          you modify it: responsibilities to respect the freedom of others.
-         
+
            For example, if you distribute copies of such a program, whether
          gratis or for a fee, you must pass on to the recipients the same
          freedoms that you received.  You must make sure that they, too, receive
          or can get the source code.  And you must show them these terms so they
          know their rights.
-         
+
            Developers that use the GNU GPL protect your rights with two steps:
          (1) assert copyright on the software, and (2) offer you this License
          giving you legal permission to copy, distribute and/or modify it.
-         
+
            For the developers' and authors' protection, the GPL clearly explains
          that there is no warranty for this free software.  For both users' and
          authors' sake, the GPL requires that modified versions be marked as
          changed, so that their problems will not be attributed erroneously to
          authors of previous versions.
-         
+
            Some devices are designed to deny users access to install or run
          modified versions of the software inside them, although the manufacturer
          can do so.  This is fundamentally incompatible with the aim of
@@ -29136,49 +29136,49 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          products.  If such problems arise substantially in other domains, we
          stand ready to extend this provision to those domains in future versions
          of the GPL, as needed to protect the freedom of users.
-         
+
            Finally, every program is threatened constantly by software patents.
          States should not allow patents to restrict development and use of
          software on general-purpose computers, but in those that do, we wish to
          avoid the special danger that patents applied to a free program could
          make it effectively proprietary.  To prevent this, the GPL assures that
          patents cannot be used to render the program non-free.
-         
+
            The precise terms and conditions for copying, distribution and
          modification follow.
-         
+
                                 TERMS AND CONDITIONS
-         
+
            0. Definitions.
-         
+
            "This License" refers to version 3 of the GNU General Public License.
-         
+
            "Copyright" also means copyright-like laws that apply to other kinds of
          works, such as semiconductor masks.
-         
+
            "The Program" refers to any copyrightable work licensed under this
          License.  Each licensee is addressed as "you".  "Licensees" and
          "recipients" may be individuals or organizations.
-         
+
            To "modify" a work means to copy from or adapt all or part of the work
          in a fashion requiring copyright permission, other than the making of an
          exact copy.  The resulting work is called a "modified version" of the
          earlier work or a work "based on" the earlier work.
-         
+
            A "covered work" means either the unmodified Program or a work based
          on the Program.
-         
+
            To "propagate" a work means to do anything with it that, without
          permission, would make you directly or secondarily liable for
          infringement under applicable copyright law, except executing it on a
          computer or modifying a private copy.  Propagation includes copying,
          distribution (with or without modification), making available to the
          public, and in some countries other activities as well.
-         
+
            To "convey" a work means any kind of propagation that enables other
          parties to make or receive copies.  Mere interaction with a user through
          a computer network, with no transfer of a copy, is not conveying.
-         
+
            An interactive user interface displays "Appropriate Legal Notices"
          to the extent that it includes a convenient and prominently visible
          feature that (1) displays an appropriate copyright notice, and (2)
@@ -29187,18 +29187,18 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          work under this License, and how to view a copy of this License.  If
          the interface presents a list of user commands or options, such as a
          menu, a prominent item in the list meets this criterion.
-         
+
            1. Source Code.
-         
+
            The "source code" for a work means the preferred form of the work
          for making modifications to it.  "Object code" means any non-source
          form of a work.
-         
+
            A "Standard Interface" means an interface that either is an official
          standard defined by a recognized standards body, or, in the case of
          interfaces specified for a particular programming language, one that
          is widely used among developers working in that language.
-         
+
            The "System Libraries" of an executable work include anything, other
          than the work as a whole, that (a) is included in the normal form of
          packaging a Major Component, but which is not part of that Major
@@ -29209,7 +29209,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          (kernel, window system, and so on) of the specific operating system
          (if any) on which the executable work runs, or a compiler used to
          produce the work, or an object code interpreter used to run it.
-         
+
            The "Corresponding Source" for a work in object code form means all
          the source code needed to generate, install, and (for an executable
          work) run the object code and to modify the work, including scripts to
@@ -29222,16 +29222,16 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          linked subprograms that the work is specifically designed to require,
          such as by intimate data communication or control flow between those
          subprograms and other parts of the work.
-         
+
            The Corresponding Source need not include anything that users
          can regenerate automatically from other parts of the Corresponding
          Source.
-         
+
            The Corresponding Source for a work in source code form is that
          same work.
-         
+
            2. Basic Permissions.
-         
+
            All rights granted under this License are granted for the term of
          copyright on the Program, and are irrevocable provided the stated
          conditions are met.  This License explicitly affirms your unlimited
@@ -29239,7 +29239,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          covered work is covered by this License only if the output, given its
          content, constitutes a covered work.  This License acknowledges your
          rights of fair use or other equivalent, as provided by copyright law.
-         
+
            You may make, run and propagate covered works that you do not
          convey, without conditions so long as your license otherwise remains
          in force.  You may convey covered works to others for the sole purpose
@@ -29250,19 +29250,19 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          for you must do so exclusively on your behalf, under your direction
          and control, on terms that prohibit them from making any copies of
          your copyrighted material outside their relationship with you.
-         
+
            Conveying under any other circumstances is permitted solely under
          the conditions stated below.  Sublicensing is not allowed; section 10
          makes it unnecessary.
-         
+
            3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-         
+
            No covered work shall be deemed part of an effective technological
          measure under any applicable law fulfilling obligations under article
          11 of the WIPO copyright treaty adopted on 20 December 1996, or
          similar laws prohibiting or restricting circumvention of such
          measures.
-         
+
            When you convey a covered work, you waive any legal power to forbid
          circumvention of technological measures to the extent such circumvention
          is effected by exercising rights under this License with respect to
@@ -29270,9 +29270,9 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          modification of the work as a means of enforcing, against the work's
          users, your or third parties' legal rights to forbid circumvention of
          technological measures.
-         
+
            4. Conveying Verbatim Copies.
-         
+
            You may convey verbatim copies of the Program's source code as you
          receive it, in any medium, provided that you conspicuously and
          appropriately publish on each copy an appropriate copyright notice;
@@ -29280,24 +29280,24 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          non-permissive terms added in accord with section 7 apply to the code;
          keep intact all notices of the absence of any warranty; and give all
          recipients a copy of this License along with the Program.
-         
+
            You may charge any price or no price for each copy that you convey,
          and you may offer support or warranty protection for a fee.
-         
+
            5. Conveying Modified Source Versions.
-         
+
            You may convey a work based on the Program, or the modifications to
          produce it from the Program, in the form of source code under the
          terms of section 4, provided that you also meet all of these conditions:
-         
+
              a) The work must carry prominent notices stating that you modified
              it, and giving a relevant date.
-         
+
              b) The work must carry prominent notices stating that it is
              released under this License and any conditions added under section
              7.  This requirement modifies the requirement in section 4 to
              "keep intact all notices".
-         
+
              c) You must license the entire work, as a whole, under this
              License to anyone who comes into possession of a copy.  This
              License will therefore apply, along with any applicable section 7
@@ -29305,12 +29305,12 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
              regardless of how they are packaged.  This License gives no
              permission to license the work in any other way, but it does not
              invalidate such permission if you have separately received it.
-         
+
              d) If the work has interactive user interfaces, each must display
              Appropriate Legal Notices; however, if the Program has interactive
              interfaces that do not display Appropriate Legal Notices, your
              work need not make them do so.
-         
+
            A compilation of a covered work with other separate and independent
          works, which are not by their nature extensions of the covered work,
          and which are not combined with it such as to form a larger program,
@@ -29320,19 +29320,19 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          beyond what the individual works permit.  Inclusion of a covered work
          in an aggregate does not cause this License to apply to the other
          parts of the aggregate.
-         
+
            6. Conveying Non-Source Forms.
-         
+
            You may convey a covered work in object code form under the terms
          of sections 4 and 5, provided that you also convey the
          machine-readable Corresponding Source under the terms of this License,
          in one of these ways:
-         
+
              a) Convey the object code in, or embodied in, a physical product
              (including a physical distribution medium), accompanied by the
              Corresponding Source fixed on a durable physical medium
              customarily used for software interchange.
-         
+
              b) Convey the object code in, or embodied in, a physical product
              (including a physical distribution medium), accompanied by a
              written offer, valid for at least three years and valid for as
@@ -29344,13 +29344,13 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
              more than your reasonable cost of physically performing this
              conveying of source, or (2) access to copy the
              Corresponding Source from a network server at no charge.
-         
+
              c) Convey individual copies of the object code with a copy of the
              written offer to provide the Corresponding Source.  This
              alternative is allowed only occasionally and noncommercially, and
              only if you received the object code with such an offer, in accord
              with subsection 6b.
-         
+
              d) Convey the object code by offering access from a designated
              place (gratis or for a charge), and offer equivalent access to the
              Corresponding Source in the same way through the same place at no
@@ -29363,16 +29363,16 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
              Corresponding Source.  Regardless of what server hosts the
              Corresponding Source, you remain obligated to ensure that it is
              available for as long as needed to satisfy these requirements.
-         
+
              e) Convey the object code using peer-to-peer transmission, provided
              you inform other peers where the object code and Corresponding
              Source of the work are being offered to the general public at no
              charge under subsection 6d.
-         
+
            A separable portion of the object code, whose source code is excluded
          from the Corresponding Source as a System Library, need not be
          included in conveying the object code work.
-         
+
            A "User Product" is either (1) a "consumer product", which means any
          tangible personal property which is normally used for personal, family,
          or household purposes, or (2) anything designed or sold for incorporation
@@ -29385,7 +29385,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          is a consumer product regardless of whether the product has substantial
          commercial, industrial or non-consumer uses, unless such uses represent
          the only significant mode of use of the product.
-         
+
            "Installation Information" for a User Product means any methods,
          procedures, authorization keys, or other information required to install
          and execute modified versions of a covered work in that User Product from
@@ -29393,7 +29393,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          suffice to ensure that the continued functioning of the modified object
          code is in no case prevented or interfered with solely because
          modification has been made.
-         
+
            If you convey an object code work under this section in, or with, or
          specifically for use in, a User Product, and the conveying occurs as
          part of a transaction in which the right of possession and use of the
@@ -29404,7 +29404,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          if neither you nor any third party retains the ability to install
          modified object code on the User Product (for example, the work has
          been installed in ROM).
-         
+
            The requirement to provide Installation Information does not include a
          requirement to continue to provide support service, warranty, or updates
          for a work that has been modified or installed by the recipient, or for
@@ -29412,15 +29412,15 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          network may be denied when the modification itself materially and
          adversely affects the operation of the network or violates the rules and
          protocols for communication across the network.
-         
+
            Corresponding Source conveyed, and Installation Information provided,
          in accord with this section must be in a format that is publicly
          documented (and with an implementation available to the public in
          source code form), and must require no special password or key for
          unpacking, reading or copying.
-         
+
            7. Additional Terms.
-         
+
            "Additional permissions" are terms that supplement the terms of this
          License by making exceptions from one or more of its conditions.
          Additional permissions that are applicable to the entire Program shall
@@ -29429,41 +29429,41 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          apply only to part of the Program, that part may be used separately
          under those permissions, but the entire Program remains governed by
          this License without regard to the additional permissions.
-         
+
            When you convey a copy of a covered work, you may at your option
          remove any additional permissions from that copy, or from any part of
          it.  (Additional permissions may be written to require their own
          removal in certain cases when you modify the work.)  You may place
          additional permissions on material, added by you to a covered work,
          for which you have or can give appropriate copyright permission.
-         
+
            Notwithstanding any other provision of this License, for material you
          add to a covered work, you may (if authorized by the copyright holders of
          that material) supplement the terms of this License with terms:
-         
+
              a) Disclaiming warranty or limiting liability differently from the
              terms of sections 15 and 16 of this License; or
-         
+
              b) Requiring preservation of specified reasonable legal notices or
              author attributions in that material or in the Appropriate Legal
              Notices displayed by works containing it; or
-         
+
              c) Prohibiting misrepresentation of the origin of that material, or
              requiring that modified versions of such material be marked in
              reasonable ways as different from the original version; or
-         
+
              d) Limiting the use for publicity purposes of names of licensors or
              authors of the material; or
-         
+
              e) Declining to grant rights under trademark law for use of some
              trade names, trademarks, or service marks; or
-         
+
              f) Requiring indemnification of licensors and authors of that
              material by anyone who conveys the material (or modified versions of
              it) with contractual assumptions of liability to the recipient, for
              any liability that these contractual assumptions directly impose on
              those licensors and authors.
-         
+
            All other non-permissive additional terms are considered "further
          restrictions" within the meaning of section 10.  If the Program as you
          received it, or any part of it, contains a notice stating that it is
@@ -29473,46 +29473,46 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          License, you may add to a covered work material governed by the terms
          of that license document, provided that the further restriction does
          not survive such relicensing or conveying.
-         
+
            If you add terms to a covered work in accord with this section, you
          must place, in the relevant source files, a statement of the
          additional terms that apply to those files, or a notice indicating
          where to find the applicable terms.
-         
+
            Additional terms, permissive or non-permissive, may be stated in the
          form of a separately written license, or stated as exceptions;
          the above requirements apply either way.
-         
+
            8. Termination.
-         
+
            You may not propagate or modify a covered work except as expressly
          provided under this License.  Any attempt otherwise to propagate or
          modify it is void, and will automatically terminate your rights under
          this License (including any patent licenses granted under the third
          paragraph of section 11).
-         
+
            However, if you cease all violation of this License, then your
          license from a particular copyright holder is reinstated (a)
          provisionally, unless and until the copyright holder explicitly and
          finally terminates your license, and (b) permanently, if the copyright
          holder fails to notify you of the violation by some reasonable means
          prior to 60 days after the cessation.
-         
+
            Moreover, your license from a particular copyright holder is
          reinstated permanently if the copyright holder notifies you of the
          violation by some reasonable means, this is the first time you have
          received notice of violation of this License (for any work) from that
          copyright holder, and you cure the violation prior to 30 days after
          your receipt of the notice.
-         
+
            Termination of your rights under this section does not terminate the
          licenses of parties who have received copies or rights from you under
          this License.  If your rights have been terminated and not permanently
          reinstated, you do not qualify to receive new licenses for the same
          material under section 10.
-         
+
            9. Acceptance Not Required for Having Copies.
-         
+
            You are not required to accept this License in order to receive or
          run a copy of the Program.  Ancillary propagation of a covered work
          occurring solely as a consequence of using peer-to-peer transmission
@@ -29521,14 +29521,14 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          modify any covered work.  These actions infringe copyright if you do
          not accept this License.  Therefore, by modifying or propagating a
          covered work, you indicate your acceptance of this License to do so.
-         
+
            10. Automatic Licensing of Downstream Recipients.
-         
+
            Each time you convey a covered work, the recipient automatically
          receives a license from the original licensors, to run, modify and
          propagate that work, subject to this License.  You are not responsible
          for enforcing compliance by third parties with this License.
-         
+
            An "entity transaction" is a transaction transferring control of an
          organization, or substantially all assets of one, or subdividing an
          organization, or merging organizations.  If propagation of a covered
@@ -29538,7 +29538,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          give under the previous paragraph, plus a right to possession of the
          Corresponding Source of the work from the predecessor in interest, if
          the predecessor has it or can get it with reasonable efforts.
-         
+
            You may not impose any further restrictions on the exercise of the
          rights granted or affirmed under this License.  For example, you may
          not impose a license fee, royalty, or other charge for exercise of
@@ -29546,13 +29546,13 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          (including a cross-claim or counterclaim in a lawsuit) alleging that
          any patent claim is infringed by making, using, selling, offering for
          sale, or importing the Program or any portion of it.
-         
+
            11. Patents.
-         
+
            A "contributor" is a copyright holder who authorizes use under this
          License of the Program or a work on which the Program is based.  The
          work thus licensed is called the contributor's "contributor version".
-         
+
            A contributor's "essential patent claims" are all patent claims
          owned or controlled by the contributor, whether already acquired or
          hereafter acquired, that would be infringed by some manner, permitted
@@ -29562,19 +29562,19 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          purposes of this definition, "control" includes the right to grant
          patent sublicenses in a manner consistent with the requirements of
          this License.
-         
+
            Each contributor grants you a non-exclusive, worldwide, royalty-free
          patent license under the contributor's essential patent claims, to
          make, use, sell, offer for sale, import and otherwise run, modify and
          propagate the contents of its contributor version.
-         
+
            In the following three paragraphs, a "patent license" is any express
          agreement or commitment, however denominated, not to enforce a patent
          (such as an express permission to practice a patent or covenant not to
          sue for patent infringement).  To "grant" such a patent license to a
          party means to make such an agreement or commitment not to enforce a
          patent against the party.
-         
+
            If you convey a covered work, knowingly relying on a patent license,
          and the Corresponding Source of the work is not available for anyone
          to copy, free of charge and under the terms of this License, through a
@@ -29588,7 +29588,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          covered work in a country, or your recipient's use of the covered work
          in a country, would infringe one or more identifiable patents in that
          country that you have reason to believe are valid.
-         
+
            If, pursuant to or in connection with a single transaction or
          arrangement, you convey, or propagate by procuring conveyance of, a
          covered work, and grant a patent license to some of the parties
@@ -29596,7 +29596,7 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          or convey a specific copy of the covered work, then the patent license
          you grant is automatically extended to all recipients of the covered
          work and works based on it.
-         
+
            A patent license is "discriminatory" if it does not include within
          the scope of its coverage, prohibits the exercise of, or is
          conditioned on the non-exercise of one or more of the rights that are
@@ -29611,13 +29611,13 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          for and in connection with specific products or compilations that
          contain the covered work, unless you entered into that arrangement,
          or that patent license was granted, prior to 28 March 2007.
-         
+
            Nothing in this License shall be construed as excluding or limiting
          any implied license or other defenses to infringement that may
          otherwise be available to you under applicable patent law.
-         
+
            12. No Surrender of Others' Freedom.
-         
+
            If conditions are imposed on you (whether by court order, agreement or
          otherwise) that contradict the conditions of this License, they do not
          excuse you from the conditions of this License.  If you cannot convey a
@@ -29627,9 +29627,9 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          to collect a royalty for further conveying from those to whom you convey
          the Program, the only way you could satisfy both those terms and this
          License would be to refrain entirely from conveying the Program.
-         
+
            13. Use with the GNU Affero General Public License.
-         
+
            Notwithstanding any other provision of this License, you have
          permission to link or combine any covered work with a work licensed
          under version 3 of the GNU Affero General Public License into a single
@@ -29638,14 +29638,14 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          but the special requirements of the GNU Affero General Public License,
          section 13, concerning interaction through a network will apply to the
          combination as such.
-         
+
            14. Revised Versions of this License.
-         
+
            The Free Software Foundation may publish revised and/or new versions of
          the GNU General Public License from time to time.  Such new versions will
          be similar in spirit to the present version, but may differ in detail to
          address new problems or concerns.
-         
+
            Each version is given a distinguishing version number.  If the
          Program specifies that a certain numbered version of the GNU General
          Public License "or any later version" applies to it, you have the
@@ -29654,19 +29654,19 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          Foundation.  If the Program does not specify a version number of the
          GNU General Public License, you may choose any version ever published
          by the Free Software Foundation.
-         
+
            If the Program specifies that a proxy can decide which future
          versions of the GNU General Public License can be used, that proxy's
          public statement of acceptance of a version permanently authorizes you
          to choose that version for the Program.
-         
+
            Later license versions may give you additional or different
          permissions.  However, no additional obligations are imposed on any
          author or copyright holder as a result of your choosing to follow a
          later version.
-         
+
            15. Disclaimer of Warranty.
-         
+
            THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
          APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
          HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
@@ -29675,9 +29675,9 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
          IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
          ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-         
+
            16. Limitation of Liability.
-         
+
            IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
          WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
          THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
@@ -29687,88 +29687,88 @@ License: `Copyright (c) 2001-2002 Enthought, Inc. 2003, SciPy Developers.
          PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
          EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
          SUCH DAMAGES.
-         
+
            17. Interpretation of Sections 15 and 16.
-         
+
            If the disclaimer of warranty and limitation of liability provided
          above cannot be given local legal effect according to their terms,
          reviewing courts shall apply local law that most closely approximates
          an absolute waiver of all civil liability in connection with the
          Program, unless a warranty or assumption of liability accompanies a
          copy of the Program in return for a fee.
-         
+
                               END OF TERMS AND CONDITIONS
-         
+
                      How to Apply These Terms to Your New Programs
-         
+
            If you develop a new program, and you want it to be of the greatest
          possible use to the public, the best way to achieve this is to make it
          free software which everyone can redistribute and change under these terms.
-         
+
            To do so, attach the following notices to the program.  It is safest
          to attach them to the start of each source file to most effectively
          state the exclusion of warranty; and each file should have at least
          the "copyright" line and a pointer to where the full notice is found.
-         
+
              <one line to give the program's name and a brief idea of what it does.>
              Copyright (C) <year>  <name of author>
-         
+
              This program is free software: you can redistribute it and/or modify
              it under the terms of the GNU General Public License as published by
              the Free Software Foundation, either version 3 of the License, or
              (at your option) any later version.
-         
+
              This program is distributed in the hope that it will be useful,
              but WITHOUT ANY WARRANTY; without even the implied warranty of
              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
              GNU General Public License for more details.
-         
+
              You should have received a copy of the GNU General Public License
              along with this program.  If not, see <http://www.gnu.org/licenses/>.
-         
+
          Also add information on how to contact you by electronic and paper mail.
-         
+
            If the program does terminal interaction, make it output a short
          notice like this when it starts in an interactive mode:
-         
+
              <program>  Copyright (C) <year>  <name of author>
              This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
              This is free software, and you are welcome to redistribute it
              under certain conditions; type `show c' for details.
-         
+
          The hypothetical commands `show w' and `show c' should show the appropriate
          parts of the General Public License.  Of course, your program's commands
          might be different; for a GUI interface, you would use an "about box".
-         
+
            You should also get your employer (if you work as a programmer) or school,
          if any, to sign a "copyright disclaimer" for the program, if necessary.
          For more information on this, and how to apply and follow the GNU GPL, see
          <http://www.gnu.org/licenses/>.
-         
+
            The GNU General Public License does not permit incorporating your program
          into proprietary programs.  If your program is a subroutine library, you
          may consider it more useful to permit linking proprietary applications with
          the library.  If this is what you want to do, use the GNU Lesser General
          Public License instead of this License.  But first, please read
          <http://www.gnu.org/philosophy/why-not-lgpl.html>.
-         
-         
+
+
          Name: libquadmath
          Files: scipy/.dylibs/libquadmath*.so
          Description: dynamically linked to files compiled with gcc
          Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libquadmath
          License: LGPL-2.1-or-later
-         
+
              GCC Quad-Precision Math Library
              Copyright (C) 2010-2019 Free Software Foundation, Inc.
              Written by Francois-Xavier Coudert  <fxcoudert@gcc.gnu.org>
-         
+
              This file is part of the libquadmath library.
              Libquadmath is free software; you can redistribute it and/or
              modify it under the terms of the GNU Library General Public
              License as published by the Free Software Foundation; either
              version 2.1 of the License, or (at your option) any later version.
-         
+
              Libquadmath is distributed in the hope that it will be useful,
              but WITHOUT ANY WARRANTY; without even the implied warranty of
              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -29824,23 +29824,23 @@ Availability: https://github.com/OpenMathLib/OpenBLAS/
 License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
-  
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-  
+
      1. Redistributions of source code must retain the above copyright
         notice, this list of conditions and the following disclaimer.
-  
+
      2. Redistributions in binary form must reproduce the above copyright
         notice, this list of conditions and the following disclaimer in
         the documentation and/or other materials provided with the
         distribution.
-     3. Neither the name of the OpenBLAS project nor the names of 
-        its contributors may be used to endorse or promote products 
-        derived from this software without specific prior written 
+     3. Neither the name of the OpenBLAS project nor the names of
+        its contributors may be used to endorse or promote products
+        derived from this software without specific prior written
         permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29865,36 +29865,36 @@ License: BSD-3-Clause-Open-MPI
                           rights reserved.
   Copyright (c) 2006-2013 The University of Colorado Denver.  All rights
                           reserved.
-  
+
   $COPYRIGHT$
-  
+
   Additional copyrights may follow
-  
+
   $HEADER$
-  
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-  
+
   - Redistributions of source code must retain the above copyright
     notice, this list of conditions and the following disclaimer.
-  
+
   - Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer listed
     in this license in the documentation and/or other materials
     provided with the distribution.
-  
+
   - Neither the name of the copyright holders nor the names of its
     contributors may be used to endorse or promote products derived from
     this software without specific prior written permission.
-  
+
   The copyright holders provide no reassurances that the source code
   provided does not infringe any patent, copyright, or any other
   intellectual property rights of third parties.  The copyright holders
   disclaim any liability to any recipient for claims brought against
   recipient by any third party for infringement of that parties
   intellectual property rights.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -29914,21 +29914,21 @@ Description: dynamically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
 License: GPL-3.0-or-later WITH GCC-exception-3.1
   Copyright (C) 2002-2017 Free Software Foundation, Inc.
-  
+
   Libgfortran is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 3, or (at your option)
   any later version.
-  
+
   Libgfortran is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   Under Section 7 of GPL version 3, you are granted additional
   permissions described in the GCC Runtime Library Exception, version
   3.1, as published by the Free Software Foundation.
-  
+
   You should have received a copy of the GNU General Public License and
   a copy of the GCC Runtime Library Exception along with this program;
   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
@@ -32685,7 +32685,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-The files under the directory sympy/parsing/latex 
+The files under the directory sympy/parsing/latex
 are directly copied from latex2sympy project and are licensed as:
 
 Copyright 2016, latex2sympy
@@ -32751,19 +32751,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### Licenses
 License: `MIT License
-        
+
         Copyright (c) 2022 OpenAI, Shantanu Jain
-        
+
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
         to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
         copies of the Software, and to permit persons to whom the Software is
         furnished to do so, subject to the following conditions:
-        
+
         The above copyright notice and this permission notice shall be included in all
         copies or substantial portions of the Software.
-        
+
         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
         FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33271,19 +33271,19 @@ License: `Apache-2.0`
 
 ### Licenses
 License: `MIT License
-        
+
         Copyright (c) 2026 LightSeek Foundation <contact@lightseek.org>
-        
+
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
         to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
         copies of the Software, and to permit persons to whom the Software is
         furnished to do so, subject to the following conditions:
-        
+
         The above copyright notice and this permission notice shall be included in all
         copies or substantial portions of the Software.
-        
+
         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
         FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33643,17 +33643,17 @@ SOFTWARE.
 License: `Apache License
                                    Version 2.0, January 2004
                                 http://www.apache.org/licenses/
-        
+
            TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-        
+
            1. Definitions.
-        
+
               "License" shall mean the terms and conditions for use, reproduction,
               and distribution as defined by Sections 1 through 9 of this document.
-        
+
               "Licensor" shall mean the copyright owner or entity authorized by
               the copyright owner that is granting the License.
-        
+
               "Legal Entity" shall mean the union of the acting entity and all
               other entities that control, are controlled by, or are under common
               control with that entity. For the purposes of this definition,
@@ -33661,24 +33661,24 @@ License: `Apache License
               direction or management of such entity, whether by contract or
               otherwise, or (ii) ownership of fifty percent (50%) or more of the
               outstanding shares, or (iii) beneficial ownership of such entity.
-        
+
               "You" (or "Your") shall mean an individual or Legal Entity
               exercising permissions granted by this License.
-        
+
               "Source" form shall mean the preferred form for making modifications,
               including but not limited to software source code, documentation
               source, and configuration files.
-        
+
               "Object" form shall mean any form resulting from mechanical
               transformation or translation of a Source form, including but
               not limited to compiled object code, generated documentation,
               and conversions to other media types.
-        
+
               "Work" shall mean the work of authorship, whether in Source or
               Object form, made available under the License, as indicated by a
               copyright notice that is included in or attached to the work
               (an example is provided in the Appendix below).
-        
+
               "Derivative Works" shall mean any work, whether in Source or Object
               form, that is based on (or derived from) the Work and for which the
               editorial revisions, annotations, elaborations, or other modifications
@@ -33686,7 +33686,7 @@ License: `Apache License
               of this License, Derivative Works shall not include works that remain
               separable from, or merely link (or bind by name) to the interfaces of,
               the Work and Derivative Works thereof.
-        
+
               "Contribution" shall mean any work of authorship, including
               the original version of the Work and any modifications or additions
               to that Work or Derivative Works thereof, that is intentionally
@@ -33700,18 +33700,18 @@ License: `Apache License
               Licensor for the purpose of discussing and improving the Work, but
               excluding communication that is conspicuously marked or otherwise
               designated in writing by the copyright owner as "Not a Contribution."
-        
+
               "Contributor" shall mean Licensor and any individual or Legal Entity
               on behalf of whom a Contribution has been received by Licensor and
               subsequently incorporated within the Work.
-        
+
            2. Grant of Copyright License. Subject to the terms and conditions of
               this License, each Contributor hereby grants to You a perpetual,
               worldwide, non-exclusive, no-charge, royalty-free, irrevocable
               copyright license to reproduce, prepare Derivative Works of,
               publicly display, publicly perform, sublicense, and distribute the
               Work and such Derivative Works in Source or Object form.
-        
+
            3. Grant of Patent License. Subject to the terms and conditions of
               this License, each Contributor hereby grants to You a perpetual,
               worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -33727,24 +33727,24 @@ License: `Apache License
               or contributory patent infringement, then any patent licenses
               granted to You under this License for that Work shall terminate
               as of the date such litigation is filed.
-        
+
            4. Redistribution. You may reproduce and distribute copies of the
               Work or Derivative Works thereof in any medium, with or without
               modifications, and in Source or Object form, provided that You
               meet the following conditions:
-        
+
               (a) You must give any other recipients of the Work or
                   Derivative Works a copy of this License; and
-        
+
               (b) You must cause any modified files to carry prominent notices
                   stating that You changed the files; and
-        
+
               (c) You must retain, in the Source form of any Derivative Works
                   that You distribute, all copyright, patent, trademark, and
                   attribution notices from the Source form of the Work,
                   excluding those notices that do not pertain to any part of
                   the Derivative Works; and
-        
+
               (d) If the Work includes a "NOTICE" text file as part of its
                   distribution, then any Derivative Works that You distribute must
                   include a readable copy of the attribution notices contained
@@ -33761,14 +33761,14 @@ License: `Apache License
                   or as an addendum to the NOTICE text from the Work, provided
                   that such additional attribution notices cannot be construed
                   as modifying the License.
-        
+
               You may add Your own copyright statement to Your modifications and
               may provide additional or different license terms and conditions
               for use, reproduction, or distribution of Your modifications, or
               for any such Derivative Works as a whole, provided Your use,
               reproduction, and distribution of the Work otherwise complies with
               the conditions stated in this License.
-        
+
            5. Submission of Contributions. Unless You explicitly state otherwise,
               any Contribution intentionally submitted for inclusion in the Work
               by You to the Licensor shall be under the terms and conditions of
@@ -33776,12 +33776,12 @@ License: `Apache License
               Notwithstanding the above, nothing herein shall supersede or modify
               the terms of any separate license agreement you may have executed
               with Licensor regarding such Contributions.
-        
+
            6. Trademarks. This License does not grant permission to use the trade
               names, trademarks, service marks, or product names of the Licensor,
               except as required for reasonable and customary use in describing the
               origin of the Work and reproducing the content of the NOTICE file.
-        
+
            7. Disclaimer of Warranty. Unless required by applicable law or
               agreed to in writing, Licensor provides the Work (and each
               Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -33791,7 +33791,7 @@ License: `Apache License
               PARTICULAR PURPOSE. You are solely responsible for determining the
               appropriateness of using or redistributing the Work and assume any
               risks associated with Your exercise of permissions under this License.
-        
+
            8. Limitation of Liability. In no event and under no legal theory,
               whether in tort (including negligence), contract, or otherwise,
               unless required by applicable law (such as deliberate and grossly
@@ -33803,7 +33803,7 @@ License: `Apache License
               work stoppage, computer failure or malfunction, or any and all
               other commercial damages or losses), even if such Contributor
               has been advised of the possibility of such damages.
-        
+
            9. Accepting Warranty or Additional Liability. While redistributing
               the Work or Derivative Works thereof, You may choose to offer,
               and charge a fee for, acceptance of support, warranty, indemnity,
@@ -33814,11 +33814,11 @@ License: `Apache License
               defend, and hold each Contributor harmless for any liability
               incurred by, or claims asserted against, such Contributor by reason
               of your accepting any such warranty or additional liability.
-        
+
            END OF TERMS AND CONDITIONS
-        
+
            APPENDIX: How to apply the Apache License to your work.
-        
+
               To apply the Apache License to your work, attach the following
               boilerplate notice, with the fields enclosed by brackets "{}"
               replaced with your own identifying information. (Don't include
@@ -33827,15 +33827,15 @@ License: `Apache License
               file or class name and description of purpose be included on the
               same "printed page" as the copyright notice for easier
               identification within third-party archives.
-        
+
            Copyright {yyyy} {name of copyright owner}
-        
+
            Licensed under the Apache License, Version 2.0 (the "License");
            you may not use this file except in compliance with the License.
            You may obtain a copy of the License at
-        
+
                http://www.apache.org/licenses/LICENSE-2.0
-        
+
            Unless required by applicable law or agreed to in writing, software
            distributed under the License is distributed on an "AS IS" BASIS,
            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34065,7 +34065,7 @@ License: `BSD-3-Clause`
 ```
 BSD 2-Clause License
 
-Copyright (c) 2017 Facebook Inc. (Soumith Chintala), 
+Copyright (c) 2017 Facebook Inc. (Soumith Chintala),
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34318,7 +34318,7 @@ License: `BSD`
 ```
 BSD 3-Clause License
 
-Copyright (c) Soumith Chintala 2016, 
+Copyright (c) Soumith Chintala 2016,
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36061,7 +36061,7 @@ License: `LGPL v3`
 the terms and conditions of version 3 of the GNU General Public
 License, supplemented by the additional permissions listed below.
 
-  0. Additional Definitions. 
+  0. Additional Definitions.
 
   As used herein, "this License" refers to version 3 of the GNU Lesser
 General Public License, and the "GNU GPL" refers to version 3 of the GNU
@@ -36162,7 +36162,7 @@ the following:
        a copy of the Library already present on the user's computer
        system, and (b) will operate properly with a modified version
        of the Library that is interface-compatible with the Linked
-       Version. 
+       Version.
 
    e) Provide Installation Information, but only if you would otherwise
    be required to provide such information under section 6 of the
@@ -36845,7 +36845,7 @@ License: `MIT License`
 ```
 Z3
 Copyright (c) Microsoft Corporation
-All rights reserved. 
+All rights reserved.
 MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/ATTRIBUTIONS-Rust.md
+++ b/ATTRIBUTIONS-Rust.md
@@ -6654,7 +6654,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -8041,7 +8041,7 @@ DEALINGS IN THE SOFTWARE.
 **License Type(s)**: BSD-3-Clause
 ### License: https://raw.githubusercontent.com/dalek-cryptography/curve25519-dalek/HEAD/curve25519-dalek/LICENSE-BSD
 ```
-Copyright (c) <year> <owner>. 
+Copyright (c) <year> <owner>.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -9245,7 +9245,7 @@ limitations under the License.
 ```
 
 ## dynamo-codegen - 0.1.0
-**Repository URL**: 
+**Repository URL**:
 **License Type(s)**: Apache-2.0
 ### License: Apache-2.0
 ```
@@ -10508,7 +10508,7 @@ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
 PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 ## educe - 0.6.0
@@ -11171,7 +11171,7 @@ DEALINGS IN THE SOFTWARE.
 **License Type(s)**: BSD-3-Clause
 ### License: https://raw.githubusercontent.com/johannesvollmer/exrs/HEAD/LICENSE-BSD
 ```
-Copyright (c) <year> <owner>. 
+Copyright (c) <year> <owner>.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -21788,7 +21788,7 @@ For these and/or other purposes and motivations, and without any expectation of 
 
      c. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
 
-     d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work. 
+     d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
 ```
 
 ## nu-ansi-term - 0.50.3
@@ -22875,20 +22875,20 @@ remains the property of the original authors and is re-distributed
 under the original license.
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2015 Will Speak <will@willspeak.me>, Ivan Ivashchenko
 > <defuz@me.com>, and contributors.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22912,20 +22912,20 @@ under the original license, see [COPYING](oniguruma/COPYING) for more
 information.
 
 > The MIT License (MIT)
-> 
+>
 > Copyright (c) 2015 Will Speak <will@willspeak.me>, Ivan Ivashchenko
 > <defuz@me.com>, and contributors.
-> 
+>
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
 > in the Software without restriction, including without limitation the rights
 > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 > copies of the Software, and to permit persons to whom the Software is
 > furnished to do so, subject to the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be included in all
 > copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23758,7 +23758,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -29496,7 +29496,7 @@ DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29509,7 +29509,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29521,7 +29521,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29534,7 +29534,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29546,7 +29546,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29559,7 +29559,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29571,7 +29571,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29584,7 +29584,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29596,7 +29596,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29609,7 +29609,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29621,7 +29621,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29634,7 +29634,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29646,7 +29646,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29659,7 +29659,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29671,7 +29671,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29684,7 +29684,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -29696,7 +29696,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright 2018-19 Michele d'Amico
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), 
+of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation the
 rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 sell copies of the Software, and to permit persons to whom the Software is
@@ -29709,7 +29709,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
 HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -33055,7 +33055,7 @@ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
 PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 ## syn - 1.0.109
@@ -34090,7 +34090,7 @@ SOFTWARE.
 ```
 
 ## tiny-keccak - 2.0.2
-**Repository URL**: 
+**Repository URL**:
 **License Type(s)**: CC0-1.0
 ### License: CC0-1.0
 ```
@@ -40519,7 +40519,7 @@ licences; see files named LICENSE.*.txt for details.
 **License Type(s)**: Zlib
 ### License: https://raw.githubusercontent.com/trifectatechfoundation/zlib-rs/HEAD/LICENSE
 ```
-(C) 2024 Trifecta Tech Foundation 
+(C) 2024 Trifecta Tech Foundation
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages
@@ -40864,7 +40864,7 @@ SOFTWARE.
 ```
 
 ## zune-inflate - 0.2.54
-**Repository URL**: 
+**Repository URL**:
 **License Type(s)**: MIT OR Apache-2.0 OR Zlib
 ### License: MIT OR Apache-2.0 OR Zlib
 ```

--- a/components/src/dynamo/common/tests/test_video_utils.py
+++ b/components/src/dynamo/common/tests/test_video_utils.py
@@ -26,134 +26,83 @@ def make_frames(n=3, h=8, w=8) -> np.ndarray:
 
 
 class TestEncodeToVideoBytes:
-    """Tests for encode_to_video_bytes()."""
+    """Tests for encode_to_video_bytes().
 
-    def _mock_iio_v3(self):
-        """Return a mock that looks like imageio.v3 (has imwrite)."""
-        iio = MagicMock()
-        iio.imwrite = MagicMock()
-        return iio
+    encode_to_video_bytes pre-converts RGB->YUV420p in numpy and shells out to
+    ffmpeg (feeding planar YUV on stdin) to sidestep the in-tree LGPL ffmpeg's
+    broken libswscale RGB->YUV path. These tests mock subprocess.run + the temp
+    file so no real ffmpeg is invoked.
+    """
 
-    def _mock_iio_v2(self):
-        """Return a mock that looks like imageio v2 (no imwrite, has get_writer)."""
-        iio = MagicMock(spec=[])  # no attributes by default
-        writer = MagicMock()
-        iio.get_writer = MagicMock(return_value=writer)
-        return iio, writer
+    def _patch_ffmpeg(self, read_bytes=b"video-bytes"):
+        """Patch subprocess.run (success) and the output tempfile.
 
-    def test_mp4_selects_h264_nvenc_codec(self):
+        Returns (run_patch, tempfile_patch); the run_patch's mock is what tests
+        assert against.
+        """
+        run_patch = patch("subprocess.run", MagicMock())
+        tmp = MagicMock()
+        tmp.read.return_value = read_bytes
+        ntf_cm = MagicMock()
+        ntf_cm.__enter__.return_value = tmp
+        tempfile_patch = patch(
+            "tempfile.NamedTemporaryFile", MagicMock(return_value=ntf_cm)
+        )
+        return run_patch, tempfile_patch
+
+    def test_mp4_uses_h264_nvenc(self):
         from dynamo.common.utils.video_utils import encode_to_video_bytes
 
-        iio = self._mock_iio_v3()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio}):
-            buf = MagicMock()
-            buf.getvalue.return_value = b"fake-mp4"
-            mock_io.BytesIO.return_value = buf
-
+        run_patch, tempfile_patch = self._patch_ffmpeg()
+        with run_patch as mock_run, tempfile_patch:
             encode_to_video_bytes(make_frames(), fps=8, output_format="mp4")
 
-            iio.imwrite.assert_called_once()
-            _, kwargs = iio.imwrite.call_args
-            assert kwargs.get("codec") == "h264_nvenc"
-            assert kwargs.get("fps") == 8
+            cmd = mock_run.call_args[0][0]
+            assert "h264_nvenc" in cmd
+            assert mock_run.call_args[1]["check"] is True
 
-    def test_webm_selects_libvpx_vp9_codec(self):
+    def test_webm_uses_libvpx_vp9(self):
         from dynamo.common.utils.video_utils import encode_to_video_bytes
 
-        iio = self._mock_iio_v3()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio}):
-            buf = MagicMock()
-            buf.getvalue.return_value = b"fake-webm"
-            mock_io.BytesIO.return_value = buf
-
+        run_patch, tempfile_patch = self._patch_ffmpeg()
+        with run_patch as mock_run, tempfile_patch:
             encode_to_video_bytes(make_frames(), fps=16, output_format="webm")
 
-            iio.imwrite.assert_called_once()
-            _, kwargs = iio.imwrite.call_args
-            assert kwargs.get("codec") == "libvpx-vp9"
-
-    def test_mp4_passes_extension_to_imwrite(self):
-        from dynamo.common.utils.video_utils import encode_to_video_bytes
-
-        iio = self._mock_iio_v3()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio}):
-            buf = MagicMock()
-            buf.getvalue.return_value = b"bytes"
-            mock_io.BytesIO.return_value = buf
-
-            encode_to_video_bytes(make_frames(), output_format="mp4")
-
-            _, kwargs = iio.imwrite.call_args
-            assert kwargs.get("extension") == ".mp4"
-
-    def test_webm_passes_extension_to_imwrite(self):
-        from dynamo.common.utils.video_utils import encode_to_video_bytes
-
-        iio = self._mock_iio_v3()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio}):
-            buf = MagicMock()
-            buf.getvalue.return_value = b"bytes"
-            mock_io.BytesIO.return_value = buf
-
-            encode_to_video_bytes(make_frames(), output_format="webm")
-
-            _, kwargs = iio.imwrite.call_args
-            assert kwargs.get("extension") == ".webm"
+            assert "libvpx-vp9" in mock_run.call_args[0][0]
 
     def test_unsupported_format_raises_value_error(self):
         from dynamo.common.utils.video_utils import encode_to_video_bytes
 
-        iio = self._mock_iio_v3()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio}):
-            mock_io.BytesIO.return_value = MagicMock()
+        with pytest.raises(ValueError, match="No codec"):
+            encode_to_video_bytes(make_frames(), output_format="avi")
 
-            # ValueError is wrapped into RuntimeError by the except block
-            with pytest.raises(RuntimeError, match="Video encoding to bytes failed"):
-                encode_to_video_bytes(make_frames(), output_format="avi")
-
-    def test_returns_bytes_from_buffer(self):
+    def test_bad_shape_raises_value_error(self):
         from dynamo.common.utils.video_utils import encode_to_video_bytes
 
-        expected = b"\x00\x01\x02"
-        iio = self._mock_iio_v3()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio}):
-            buf = MagicMock()
-            buf.getvalue.return_value = expected
-            mock_io.BytesIO.return_value = buf
+        with pytest.raises(ValueError, match="Expected frames of shape"):
+            encode_to_video_bytes(
+                np.zeros((3, 8, 8), dtype=np.uint8), output_format="mp4"
+            )
 
+    def test_subprocess_failure_raises_runtime_error(self):
+        import subprocess
+
+        from dynamo.common.utils.video_utils import encode_to_video_bytes
+
+        err = subprocess.CalledProcessError(1, "ffmpeg", stderr=b"boom")
+        _, tempfile_patch = self._patch_ffmpeg()
+        with patch("subprocess.run", MagicMock(side_effect=err)), tempfile_patch:
+            with pytest.raises(RuntimeError, match="Video encoding to bytes failed"):
+                encode_to_video_bytes(make_frames(), output_format="mp4")
+
+    def test_returns_file_bytes(self):
+        from dynamo.common.utils.video_utils import encode_to_video_bytes
+
+        run_patch, tempfile_patch = self._patch_ffmpeg(read_bytes=b"\x00\x01\x02")
+        with run_patch, tempfile_patch:
             result = encode_to_video_bytes(make_frames(), output_format="mp4")
 
-        assert result == expected
-
-    def test_v2_api_fallback_writes_all_frames(self):
-        """When imageio.v3.imwrite is absent, falls back to get_writer loop."""
-        from dynamo.common.utils.video_utils import encode_to_video_bytes
-
-        iio_v2, writer = self._mock_iio_v2()
-        with patch("dynamo.common.utils.video_utils.io") as mock_io, patch(
-            "imageio.v3", iio_v2, create=True
-        ), patch.dict("sys.modules", {"imageio.v3": iio_v2}):
-            buf = MagicMock()
-            buf.getvalue.return_value = b"v2-bytes"
-            mock_io.BytesIO.return_value = buf
-
-            frames = make_frames(n=4)
-            encode_to_video_bytes(frames, output_format="mp4")
-
-            assert writer.append_data.call_count == 4
-            writer.close.assert_called_once()
+        assert result == b"\x00\x01\x02"
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/common/utils/video_utils.py
+++ b/components/src/dynamo/common/utils/video_utils.py
@@ -7,7 +7,6 @@ Provides helpers for parsing video request parameters and encoding numpy
 video frames to MP4 format.
 """
 
-import io
 import logging
 import os
 from typing import Tuple
@@ -205,6 +204,29 @@ def encode_to_mp4(
         raise RuntimeError(f"Video encoding failed: {e}") from e
 
 
+def _rgb_to_yuv420p(frames: np.ndarray) -> bytes:
+    """Convert RGB frames (N, H, W, 3) uint8 to planar YUV420p bytes.
+
+    Done in numpy (BT.601, full range) so ffmpeg never performs the RGB->YUV
+    conversion itself: the in-tree LGPL ffmpeg's libswscale RGB->YUV path is
+    broken and collapses chroma (greens render as magenta). H and W must be even.
+    """
+    rgb = frames.astype(np.float32)
+    r, g, b = rgb[..., 0], rgb[..., 1], rgb[..., 2]
+    y = 0.299 * r + 0.587 * g + 0.114 * b
+    u = -0.168736 * r - 0.331264 * g + 0.5 * b + 128.0
+    v = 0.5 * r - 0.418688 * g - 0.081312 * b + 128.0
+    n, h, w = y.shape
+    y = y.round().clip(0, 255).astype(np.uint8)
+    # 4:2:0 -- box-average each 2x2 chroma block
+    u = u.reshape(n, h // 2, 2, w // 2, 2).mean((2, 4)).round().clip(0, 255).astype(np.uint8)
+    v = v.reshape(n, h // 2, 2, w // 2, 2).mean((2, 4)).round().clip(0, 255).astype(np.uint8)
+    out = bytearray()
+    for i in range(n):
+        out += y[i].tobytes() + u[i].tobytes() + v[i].tobytes()
+    return bytes(out)
+
+
 def encode_to_video_bytes(
     frames: np.ndarray,
     fps: int = 16,
@@ -222,51 +244,43 @@ def encode_to_video_bytes(
         Encoded video as bytes.
 
     Raises:
-        ImportError: If imageio is not available.
         RuntimeError: If encoding fails.
     """
-    try:
-        import imageio.v3 as iio
-    except ImportError:
+    import subprocess
+    import tempfile
+
+    codec = {"mp4": "h264_nvenc", "webm": "libvpx-vp9"}.get(output_format)
+    if codec is None:
+        raise ValueError(f"No codec specified for response format: {output_format}")
+
+    frames = np.asarray(frames)
+    if frames.ndim != 4 or frames.shape[-1] != 3:
+        raise ValueError(f"Expected frames of shape (N, H, W, 3), got {frames.shape}")
+    n, h, w, _ = frames.shape
+    h, w = h & ~1, w & ~1  # yuv420p needs even dimensions
+    frames = frames[:, :h, :w, :]
+
+    logger.info(f"Encoding {n} frames to {output_format} bytes at {fps} fps")
+
+    # Pre-convert RGB->YUV420p in numpy and feed planar YUV directly, bypassing
+    # the in-tree ffmpeg's broken libswscale RGB->YUV path.
+    yuv = _rgb_to_yuv420p(frames)
+    ffmpeg = os.environ.get("IMAGEIO_FFMPEG_EXE", "ffmpeg")
+    cmd = [
+        ffmpeg, "-y", "-v", "error",
+        "-f", "rawvideo", "-pix_fmt", "yuv420p", "-s", f"{w}x{h}",
+        "-r", str(fps), "-color_range", "pc", "-i", "-",
+        "-c:v", codec, "-pix_fmt", "yuv420p", "-color_range", "pc",
+    ]
+    with tempfile.NamedTemporaryFile(suffix=f".{output_format}") as tmp:
         try:
-            import imageio as iio  # type: ignore[no-redef]
-        except ImportError:
-            raise ImportError(
-                "imageio is required for video encoding. "
-                "Install with: pip install imageio[ffmpeg]"
-            )
+            subprocess.run(cmd + [tmp.name], input=yuv, check=True, capture_output=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Video encoding to bytes failed: {e.stderr.decode(errors='replace')}"
+            ) from e
+        tmp.seek(0)
+        video_bytes = tmp.read()
 
-    logger.info(f"Encoding {len(frames)} frames to {output_format} bytes at {fps} fps")
-
-    try:
-        buffer = io.BytesIO()
-
-        kwargs: dict = {"fps": fps}
-        if output_format == "webm":
-            kwargs["codec"] = "libvpx-vp9"
-        elif output_format == "mp4":
-            kwargs["codec"] = "h264_nvenc"
-        else:
-            raise ValueError(f"No codec specified for response format: {output_format}")
-
-        if hasattr(iio, "imwrite"):
-            # v3 API
-            iio.imwrite(buffer, frames, extension=f".{output_format}", **kwargs)
-        else:
-            # v2 API
-            writer = iio.get_writer(  # type: ignore[attr-defined]
-                buffer, format="FFMPEG", mode="I", **kwargs
-            )
-            try:
-                for frame in frames:
-                    writer.append_data(frame)
-            finally:
-                writer.close()
-
-        video_bytes = buffer.getvalue()
-        logger.info(f"Encoded video to {len(video_bytes)} bytes")
-        return video_bytes
-
-    except Exception as e:
-        logger.error(f"Failed to encode video to bytes: {e}")
-        raise RuntimeError(f"Video encoding to bytes failed: {e}") from e
+    logger.info(f"Encoded video to {len(video_bytes)} bytes")
+    return video_bytes


### PR DESCRIPTION
## Root cause (corrected)

Video MP4 output had **corrupted colors** (e.g. greens rendering as magenta). The earlier theory (nvenc / encoder choice) was wrong — the real bug is that **the in-tree LGPL ffmpeg's `libswscale` RGB→YUV conversion is broken** and collapses chroma. Because that conversion runs *before* the encoder, swapping encoders (libx264 → `h264_nvenc` → OpenH264) made no difference, which is why the OpenH264 build (the previous version of this PR) was validated **not** to fix it.

## Fix

Bypass `libswscale` entirely: `encode_to_video_bytes` now converts RGB `(N,H,W,3)` uint8 → **planar YUV420p in numpy** (BT.601, full range) and feeds the planar YUV directly to ffmpeg over stdin:

```
ffmpeg -f rawvideo -pix_fmt yuv420p -s WxH -r FPS -color_range pc -i - \
       -c:v <codec> -pix_fmt yuv420p -color_range pc out.<ext>
```

So ffmpeg never performs the RGB→YUV step. It shells out to the in-tree ffmpeg (`IMAGEIO_FFMPEG_EXE`) instead of going through imageio. Dimensions are cropped to even (yuv420p requirement). Codecs unchanged: **`h264_nvenc`** for MP4, **`libvpx-vp9`** for WebM.

This **replaces the OpenH264 build approach** that was previously on this branch (force-pushed) — that fix targeted the wrong layer.

### Changed files
- `components/src/dynamo/common/utils/video_utils.py` — `encode_to_video_bytes` rewritten to the numpy-YUV + ffmpeg-subprocess path (adds `_rgb_to_yuv420p`). Consumed by vLLM-Omni (`output_formatter`) and the TRT-LLM video handler.
- `components/src/dynamo/common/tests/test_video_utils.py` — `encode_to_video_bytes` tests rewritten for the subprocess path (mock `subprocess.run` + tempfile).
- `ATTRIBUTIONS-Python.md`, `ATTRIBUTIONS-Rust.md` — strip pre-existing trailing whitespace so the repo-wide (`--all-files`) `trailing-whitespace` pre-commit hook passes.

## Verification
- `ruff==0.5.2` (pre-commit pin): **All checks passed** on the changed Python.
- `test_video_utils.py`: **10 passed** in-container.
- Trailing-whitespace: the only file group the `--all-files` hook was fixing; now 0 trailing-ws lines.
- Color correctness was validated by the author's own container testing of this patched `video_utils.py`.

## Caveats (unchanged by this PR, worth noting)
- MP4 still uses **`h264_nvenc`** → requires a GPU + NVIDIA driver ≥ 570; it will still fail on CPU/older-driver boxes (`Cannot load libnvidia-encode.so.1`). Color and GPU-dependency are independent now (the numpy bypass produces finished YUV), so an encoder swap could be layered later if CPU encoding is needed.
- The **sglang** inline video encoder (`_frames_to_video`) still goes through imageio/swscale and is **not** covered by this change (it doesn't use `dynamo.common.utils.video_utils`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
