### PR TITLE
fix(tests): add DYN_MM_ALLOW_INTERNAL=1 to aggregated_toolcalling_xpu config

### DIFF
--- a/tests/serve/test_vllm_xpu.py
+++ b/tests/serve/test_vllm_xpu.py
@@ -374,6 +374,7 @@ vllm_configs = {
             "--dyn-tool-call-parser",
             "hermes",
         ],
+        env={"DYN_MM_ALLOW_INTERNAL": "1"},
         delayed_start=0,
         timeout=600,
         request_payloads=[


### PR DESCRIPTION
#### Overview:

Add missing `DYN_MM_ALLOW_INTERNAL=1` environment variable to the `aggregated_toolcalling_xpu` test configuration, fixing the 500 error caused by the mm_routing security policy blocking `http://` image URLs.

#### Details:

The `aggregated_toolcalling_xpu` test in `tests/serve/test_vllm_xpu.py` sends a tool-calling request containing an `http://localhost:8780/llm-graphic.png` image URL. The dynamo mm_routing layer blocks direct HTTP URL access by default for security. The CUDA equivalent (`tests/serve/test_vllm.py`) already sets `env={"DYN_MM_ALLOW_INTERNAL": "1"}` but the XPU config was missing this flag.

This caused consistent CI failures:
```
Failed to load image from http://localhost:8780/llm-graphic.png...:
http:// URLs are not allowed; set DYN_MM_ALLOW_INTERNAL=1 to enable
```

#### Where should the reviewer start?

- [tests/serve/test_vllm_xpu.py](tests/serve/test_vllm_xpu.py) — the one-line fix adding `env={"DYN_MM_ALLOW_INTERNAL": "1"}` to match the CUDA config.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #9611
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for vLLM deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->