### PR TITLE
docs: fix lmcache launch links

### DIFF
--- a/docs/backends/vllm/vllm-kv-offloading.md
+++ b/docs/backends/vllm/vllm-kv-offloading.md
@@ -40,10 +40,10 @@ For configuration details, see the [KVBM Guide](../../components/kvbm/kvbm-guide
 
 | Deployment                                | Launch Script                                                                                                                       |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Aggregated (MP sidecar — recommended)     | [`agg_lmcache_mp.sh`](/examples/backends/vllm/launch/agg_lmcache_mp.sh)                 |
-| Aggregated (legacy, in-process)           | [`agg_lmcache.sh`](/examples/backends/vllm/launch/agg_lmcache.sh)                       |
-| Aggregated (legacy, multiprocess metrics) | [`agg_lmcache_multiproc.sh`](/examples/backends/vllm/launch/agg_lmcache_multiproc.sh)   |
-| Disaggregated                             | [`disagg_lmcache.sh`](/examples/backends/vllm/launch/disagg_lmcache.sh)                 |
+| Aggregated (MP sidecar — recommended)     | [`agg_lmcache_mp.sh`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/agg_lmcache_mp.sh)                 |
+| Aggregated (legacy, in-process)           | [`agg_lmcache.sh`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/agg_lmcache.sh)                       |
+| Aggregated (legacy, multiprocess metrics) | [`agg_lmcache_multiproc.sh`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/agg_lmcache_multiproc.sh)   |
+| Disaggregated                             | [`disagg_lmcache.sh`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/disagg_lmcache.sh)                 |
 
 
 For configuration details, see the [LMCache Integration Guide](../../integrations/lmcache-integration.md).


### PR DESCRIPTION
## Summary
- point LMCache launch-script references at the GitHub source files so Fern broken-link checks can resolve them

## Validation
- git diff --check origin/main..HEAD
- NPM_CONFIG_CACHE=/Users/sschimanski/Library/Caches/npm npx --yes fern-api check
- NPM_CONFIG_CACHE=/Users/sschimanski/Library/Caches/npm npx --yes fern-api docs broken-links

## Prompt trail
- While rebasing PR #9821, Fern broken-link validation failed on existing LMCache launch-script links.
- Split that inherited docs issue into this standalone PR so the priority scheduling docs PR stays focused.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vLLM KV offloading backend documentation links to reference the correct deployment and launch script resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->