### PR TITLE
test(fix): flaky router e2e `test_disagg_topology_required_prefill_pin_match_and_mismatch`

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -2417,6 +2417,20 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
                     "prefill_worker_id": prefill_zone_a_id,
                 },
             }
+            topology_ready_payload = {
+                **zone_a_payload,
+                "messages": [{"role": "user", "content": "test"}],
+                "max_tokens": 1,
+                "stream": False,
+            }
+            logger.info("Waiting for topology-valid frontend readiness...")
+            await wait_for_frontend_ready(
+                frontend_url=frontend_url,
+                expected_num_workers=decode_workers.num_workers,
+                timeout=120,
+                test_payload=topology_ready_payload,
+            )
+
             async with aiohttp.ClientSession() as session:
                 async with session.post(chat_url, json=zone_a_payload) as response:
                     response_body = await response.text()

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -162,7 +162,10 @@ def verify_response_timing(timing_info: dict[str, Any], disagg: bool = False) ->
 
 
 async def wait_for_frontend_ready(
-    frontend_url: str, expected_num_workers: int = 2, timeout: int = 120
+    frontend_url: str,
+    expected_num_workers: int = 2,
+    timeout: int = 120,
+    test_payload: dict[str, Any] | None = None,
 ):
     """Wait for backend worker(s) to be ready via the HTTP frontend (OpenAI API).
 
@@ -177,6 +180,8 @@ async def wait_for_frontend_ready(
         frontend_url: Base URL of the frontend HTTP server (e.g., "http://localhost:8000")
         expected_num_workers: Number of workers to wait for (currently logs but doesn't enforce)
         timeout: Maximum time to wait in seconds for both phases combined
+        test_payload: Optional chat completions payload for the phase 2 readiness probe.
+            Use this when readiness must satisfy the same routing constraints as the test.
 
     Raises:
         TimeoutError: If workers don't register or pipeline doesn't become ready within timeout
@@ -225,12 +230,16 @@ async def wait_for_frontend_ready(
 
     # Phase 2: Wait for chat completions pipeline to be ready
     logger.info("Waiting for chat completions pipeline to be built...")
-    test_payload = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "test"}],
-        "max_tokens": 1,
-        "stream": False,
-    }
+    if test_payload is None:
+        test_payload = {
+            "model": model_name,
+            "messages": [{"role": "user", "content": "test"}],
+            "max_tokens": 1,
+            "stream": False,
+        }
+    else:
+        test_payload = {**test_payload}
+        test_payload.setdefault("model", model_name)
 
     while True:
         elapsed = asyncio.get_event_loop().time() - start_time


### PR DESCRIPTION
## Summary
- Let `wait_for_frontend_ready` probe `/v1/chat/completions` with a caller-provided payload.
- Use a zone-a pinned, non-streaming warmup before the topology-required prefill pin assertions.

## Root Cause
The failing job showed the frontend process health check accepted `/v1/models` while it returned `data: []`. The test then separately observed both decode workers and both prefill workers through endpoint clients, but the first pinned HTTP chat request still returned `404` with an empty body. This left a race between worker discovery visibility and the frontend model/pipeline becoming routable.

Failed job: https://github.com/ai-dynamo/dynamo/actions/runs/26757971066/job/78865886747

## Testing
- `ruff check tests/router/helper.py tests/router/common.py`
- `python -m py_compile tests/router/helper.py tests/router/common.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced frontend readiness check to support custom payload configuration for more flexible test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->