### PR TITLE
feat: add prompt-enhanced text-to-video client

### DIFF
--- a/components/src/dynamo/common/clients/__init__.py
+++ b/components/src/dynamo/common/clients/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dynamo.common.clients.t2v_enhanced import (
+    EnhancerMode,
+    T2VEnhancedClient,
+    T2VEnhancedClientError,
+)
+
+__all__ = [
+    "EnhancerMode",
+    "T2VEnhancedClient",
+    "T2VEnhancedClientError",
+]

--- a/components/src/dynamo/common/clients/t2v_enhanced.py
+++ b/components/src/dynamo/common/clients/t2v_enhanced.py
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Async client for the prompt-enhanced text-to-video pipeline.
+
+Chains a small LLM rewriter (OpenAI chat-completions API) and a diffusion
+text-to-video backend (OpenAI /v1/videos API) behind a single ``generate``
+call. Supports a per-request ``enhancer`` override that skips the LLM hop
+entirely, which is the cheapest way to honor empirical findings that
+larger T2V backbones do not benefit from short-prompt rewriting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional
+
+import aiohttp
+
+
+class EnhancerMode(str, Enum):
+    AUTO = "auto"
+    OFF = "off"
+
+
+class T2VEnhancedClientError(RuntimeError):
+    """Raised when either the LLM or T2V endpoint returns a non-2xx status."""
+
+
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are a cinematographer. Given a short user idea, rewrite it as ONE "
+    "rich, vivid English sentence (no more than 40 words) suitable as a "
+    "text-to-video prompt. Include camera framing, lighting, mood, and "
+    "motion. Output the rewritten prompt only - no preamble, no quotes, no "
+    "thinking tags."
+)
+
+
+@dataclass
+class T2VTimings:
+    """Per-request timing breakdown in milliseconds (monotonic clock)."""
+
+    submit_ms: float = 0.0
+    enhance_start_ms: float = 0.0
+    enhance_end_ms: float = 0.0
+    t2v_start_ms: float = 0.0
+    t2v_end_ms: float = 0.0
+    response_ms: float = 0.0
+
+    @property
+    def enhance_ms(self) -> float:
+        if not self.enhance_end_ms:
+            return 0.0
+        return self.enhance_end_ms - self.enhance_start_ms
+
+    @property
+    def t2v_ms(self) -> float:
+        return self.t2v_end_ms - self.t2v_start_ms
+
+    @property
+    def e2e_ms(self) -> float:
+        return self.response_ms - self.submit_ms
+
+
+@dataclass
+class T2VResult:
+    """Returned by ``T2VEnhancedClient.generate``."""
+
+    url: str
+    rewritten_prompt: Optional[str]
+    timings: T2VTimings
+    raw_t2v_response: Mapping[str, Any] = field(default_factory=dict)
+
+
+class T2VEnhancedClient:
+    """Two-endpoint async client: LLM enhancer -> T2V backend.
+
+    The two endpoints are two independent Dynamo deployments. This client
+    chains them request-by-request and provides:
+      * a single ``.generate(prompt, ...)`` entrypoint;
+      * a per-request ``enhancer`` knob ("auto" or "off") so callers can
+        skip the LLM hop when the diffusion backbone is large enough that
+        prompt rewriting hurts quality;
+      * a chained timing record so the caller can correlate LLM and T2V
+        latencies under a single request id.
+
+    Parameters
+    ----------
+    llm_url : str
+        Base URL of the Dynamo HTTP frontend serving the enhancer model.
+    t2v_url : str
+        Base URL of the Dynamo HTTP frontend serving the diffusion model.
+    llm_model : str
+        Model name registered against ``llm_url``, e.g. ``Qwen/Qwen3-0.6B``.
+    t2v_model : str
+        Model name registered against ``t2v_url``.
+    default_enhancer : EnhancerMode | str
+        Mode used when ``generate`` is called without an explicit
+        ``enhancer`` argument. ``"auto"`` runs the LLM enhancer; ``"off"``
+        skips it and forwards the user prompt verbatim.
+    system_prompt : Optional[str]
+        Override the built-in cinematographer system prompt.
+    enhancer_max_tokens : int
+        Cap on rewritten-prompt length.
+    enhancer_temperature : float
+        Sampling temperature for the enhancer. Defaults to 0 for
+        determinism.
+    timeout_s : float
+        Per-request timeout applied to both legs.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm_url: str,
+        t2v_url: str,
+        llm_model: str,
+        t2v_model: str,
+        default_enhancer: EnhancerMode | str = EnhancerMode.AUTO,
+        system_prompt: Optional[str] = None,
+        enhancer_max_tokens: int = 80,
+        enhancer_temperature: float = 0.0,
+        timeout_s: float = 120.0,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> None:
+        self._llm_url = llm_url.rstrip("/")
+        self._t2v_url = t2v_url.rstrip("/")
+        self._llm_model = llm_model
+        self._t2v_model = t2v_model
+        self._default_enhancer = EnhancerMode(default_enhancer)
+        self._system_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT
+        self._enhancer_max_tokens = int(enhancer_max_tokens)
+        self._enhancer_temperature = float(enhancer_temperature)
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._owns_session = session is None
+        self._session = session
+
+    async def __aenter__(self) -> "T2VEnhancedClient":
+        if self._session is None:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+            self._owns_session = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def close(self) -> None:
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    def _resolve_enhancer(self, override: Optional[EnhancerMode | str]) -> EnhancerMode:
+        if override is None:
+            return self._default_enhancer
+        return EnhancerMode(override)
+
+    def _session_or_raise(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            raise T2VEnhancedClientError(
+                "T2VEnhancedClient is not entered: use 'async with client:' "
+                "or pass an external aiohttp.ClientSession to the constructor."
+            )
+        return self._session
+
+    async def _enhance(self, prompt: str) -> str:
+        session = self._session_or_raise()
+        payload = {
+            "model": self._llm_model,
+            "messages": [
+                {"role": "system", "content": self._system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": self._enhancer_max_tokens,
+            "temperature": self._enhancer_temperature,
+        }
+        async with session.post(
+            f"{self._llm_url}/v1/chat/completions", json=payload
+        ) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise T2VEnhancedClientError(
+                    f"LLM enhancer returned HTTP {resp.status}: {body!r}"
+                )
+            data = await resp.json()
+        try:
+            return data["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError, AttributeError) as exc:
+            raise T2VEnhancedClientError(
+                f"Unexpected enhancer response shape: {data!r}"
+            ) from exc
+
+    async def _t2v(self, prompt: str, t2v_params: Mapping[str, Any]) -> Mapping[str, Any]:
+        session = self._session_or_raise()
+        payload = {"model": self._t2v_model, "prompt": prompt, **t2v_params}
+        async with session.post(f"{self._t2v_url}/v1/videos", json=payload) as resp:
+            if resp.status >= 400:
+                body = await resp.text()
+                raise T2VEnhancedClientError(
+                    f"T2V backend returned HTTP {resp.status}: {body!r}"
+                )
+            return await resp.json()
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        enhancer: Optional[EnhancerMode | str] = None,
+        **t2v_params: Any,
+    ) -> T2VResult:
+        """Run the chained enhancer + T2V pipeline.
+
+        When ``enhancer`` resolves to ``EnhancerMode.OFF`` the LLM hop is
+        skipped entirely and ``rewritten_prompt`` in the result is
+        ``None``. Otherwise the LLM enhancer is invoked first and its
+        output replaces the ``prompt`` field passed to the T2V backend.
+        Any additional ``t2v_params`` are forwarded verbatim to the T2V
+        endpoint (for example ``size``, ``num_inference_steps``,
+        ``num_frames``, ``nvext``).
+        """
+        loop = asyncio.get_event_loop()
+        now = loop.time
+
+        timings = T2VTimings(submit_ms=now() * 1000.0)
+        rewritten: Optional[str] = None
+        mode = self._resolve_enhancer(enhancer)
+
+        if mode is EnhancerMode.OFF:
+            text_prompt = prompt
+        else:
+            timings.enhance_start_ms = now() * 1000.0
+            rewritten = await self._enhance(prompt)
+            timings.enhance_end_ms = now() * 1000.0
+            text_prompt = rewritten
+
+        timings.t2v_start_ms = now() * 1000.0
+        raw = await self._t2v(text_prompt, t2v_params)
+        timings.t2v_end_ms = now() * 1000.0
+        timings.response_ms = timings.t2v_end_ms
+
+        try:
+            url = raw["data"][0]["url"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise T2VEnhancedClientError(
+                f"Unexpected T2V response shape: {raw!r}"
+            ) from exc
+
+        return T2VResult(
+            url=url,
+            rewritten_prompt=rewritten,
+            timings=timings,
+            raw_t2v_response=raw,
+        )

--- a/components/src/dynamo/common/clients/t2v_enhanced.py
+++ b/components/src/dynamo/common/clients/t2v_enhanced.py
@@ -193,7 +193,9 @@ class T2VEnhancedClient:
                 f"Unexpected enhancer response shape: {data!r}"
             ) from exc
 
-    async def _t2v(self, prompt: str, t2v_params: Mapping[str, Any]) -> Mapping[str, Any]:
+    async def _t2v(
+        self, prompt: str, t2v_params: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
         session = self._session_or_raise()
         payload = {"model": self._t2v_model, "prompt": prompt, **t2v_params}
         async with session.post(f"{self._t2v_url}/v1/videos", json=payload) as resp:

--- a/components/src/dynamo/common/clients/tests/__init__.py
+++ b/components/src/dynamo/common/clients/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/components/src/dynamo/common/clients/tests/test_t2v_enhanced.py
+++ b/components/src/dynamo/common/clients/tests/test_t2v_enhanced.py
@@ -1,17 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for T2VEnhancedClient.
-
-The tests use ``aioresponses`` to mock both the LLM and T2V HTTP endpoints
-so the chained orchestration logic can be exercised without launching any
-Dynamo workers.
-"""
+"""Unit tests for T2VEnhancedClient."""
 
 from __future__ import annotations
 
+from collections import defaultdict, deque
+from typing import Any
+
+from aiohttp import web
 import pytest
-from aioresponses import aioresponses
 
 from dynamo.common.clients import (
     EnhancerMode,
@@ -24,6 +22,8 @@ LLM_URL = "http://llm.test"
 T2V_URL = "http://t2v.test"
 LLM_MODEL = "Qwen/Qwen3-0.6B"
 T2V_MODEL = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+LLM_PATH = "/v1/chat/completions"
+T2V_PATH = "/v1/videos"
 
 
 def _llm_ok_payload(rewritten: str) -> dict:
@@ -40,159 +40,197 @@ def _t2v_ok_payload(url: str) -> dict:
     return {"data": [{"url": url}]}
 
 
+class _MockOpenAIServer:
+    def __init__(self) -> None:
+        self._app = web.Application()
+        self._app.router.add_route("*", "/{tail:.*}", self._handle)
+        self._runner = web.AppRunner(self._app)
+        self._site: web.TCPSite | None = None
+        self._responses: dict[str, deque[tuple[int, Any, str | None]]] = defaultdict(
+            deque
+        )
+        self.requests: list[dict[str, Any]] = []
+        self.url: str | None = None
+
+    async def __aenter__(self) -> "_MockOpenAIServer":
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await self._site.start()
+        assert self._site._server is not None
+        sock = self._site._server.sockets[0]
+        self.url = f"http://127.0.0.1:{sock.getsockname()[1]}"
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self._runner.cleanup()
+
+    def respond_json(self, path: str, payload: Any, status: int = 200) -> None:
+        self._responses[path].append((status, payload, None))
+
+    def respond_text(self, path: str, body: str, status: int = 200) -> None:
+        self._responses[path].append((status, None, body))
+
+    def requests_for(self, path: str) -> list[dict[str, Any]]:
+        return [request for request in self.requests if request["path"] == path]
+
+    async def _handle(self, request: web.Request) -> web.Response:
+        try:
+            request_json = await request.json()
+        except Exception:
+            request_json = None
+
+        self.requests.append(
+            {
+                "method": request.method,
+                "path": request.path,
+                "json": request_json,
+            }
+        )
+
+        if not self._responses[request.path]:
+            return web.Response(status=404, text=f"unexpected request: {request.path}")
+
+        status, payload, body = self._responses[request.path].popleft()
+        if payload is not None:
+            return web.json_response(payload, status=status)
+        return web.Response(status=status, text=body)
+
+
 @pytest.mark.asyncio
 async def test_generate_runs_enhancer_then_t2v():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{LLM_URL}/v1/chat/completions",
-                payload=_llm_ok_payload("a cinematic bear by a campfire"),
-            )
-            mock.post(
-                f"{T2V_URL}/v1/videos",
-                payload=_t2v_ok_payload("file:///tmp/result.mp4"),
-            )
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_json(
+            LLM_PATH,
+            _llm_ok_payload("a cinematic skyline at golden hour"),
+        )
+        server.respond_json(T2V_PATH, _t2v_ok_payload("file:///tmp/result.mp4"))
 
-            result = await client.generate("a bear by a campfire")
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+        ) as client:
+            result = await client.generate("a skyline at golden hour")
 
-            assert result.url == "file:///tmp/result.mp4"
-            assert result.rewritten_prompt == "a cinematic bear by a campfire"
-            assert result.timings.enhance_ms > 0
-            assert result.timings.t2v_ms > 0
-            assert result.timings.e2e_ms >= result.timings.enhance_ms
+        assert result.url == "file:///tmp/result.mp4"
+        assert result.rewritten_prompt == "a cinematic skyline at golden hour"
+        assert result.timings.enhance_ms > 0
+        assert result.timings.t2v_ms > 0
+        assert result.timings.e2e_ms >= result.timings.enhance_ms
 
-            # T2V was called with the rewritten prompt, not the user input.
-            requests = mock.requests
-            t2v_calls = [k for k in requests if k[1].path == "/v1/videos"]
-            assert t2v_calls, "expected /v1/videos call"
-            body = requests[t2v_calls[0]][0].kwargs["json"]
-            assert body["prompt"] == "a cinematic bear by a campfire"
+        # T2V was called with the rewritten prompt, not the user input.
+        t2v_calls = server.requests_for(T2V_PATH)
+        assert t2v_calls, "expected /v1/videos call"
+        assert t2v_calls[0]["json"]["prompt"] == "a cinematic skyline at golden hour"
 
 
 @pytest.mark.asyncio
 async def test_enhancer_off_skips_llm_call():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{T2V_URL}/v1/videos",
-                payload=_t2v_ok_payload("file:///tmp/skipped.mp4"),
-            )
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_json(T2V_PATH, _t2v_ok_payload("file:///tmp/skipped.mp4"))
 
-            result = await client.generate(
-                "raw user prompt", enhancer=EnhancerMode.OFF
-            )
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+        ) as client:
+            result = await client.generate("raw user prompt", enhancer=EnhancerMode.OFF)
 
-            assert result.url == "file:///tmp/skipped.mp4"
-            assert result.rewritten_prompt is None
-            assert result.timings.enhance_ms == 0
+        assert result.url == "file:///tmp/skipped.mp4"
+        assert result.rewritten_prompt is None
+        assert result.timings.enhance_ms == 0
 
-            calls = list(mock.requests.keys())
-            paths = [c[1].path for c in calls]
-            assert "/v1/chat/completions" not in paths
+        assert not server.requests_for(LLM_PATH)
 
 
 @pytest.mark.asyncio
 async def test_enhancer_off_string_alias():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{T2V_URL}/v1/videos",
-                payload=_t2v_ok_payload("file:///tmp/off.mp4"),
-            )
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_json(T2V_PATH, _t2v_ok_payload("file:///tmp/off.mp4"))
 
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+        ) as client:
             result = await client.generate("anything", enhancer="off")
-            assert result.rewritten_prompt is None
+
+        assert result.rewritten_prompt is None
 
 
 @pytest.mark.asyncio
 async def test_default_enhancer_off_applies_when_no_override():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-        default_enhancer=EnhancerMode.OFF,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{T2V_URL}/v1/videos",
-                payload=_t2v_ok_payload("file:///tmp/default-off.mp4"),
-            )
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_json(T2V_PATH, _t2v_ok_payload("file:///tmp/default-off.mp4"))
 
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+            default_enhancer=EnhancerMode.OFF,
+        ) as client:
             result = await client.generate("anything")
-            assert result.rewritten_prompt is None
+
+        assert result.rewritten_prompt is None
 
 
 @pytest.mark.asyncio
 async def test_llm_5xx_raises_client_error():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{LLM_URL}/v1/chat/completions",
-                status=500,
-                body="internal error",
-            )
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_text(LLM_PATH, "internal error", status=500)
 
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+        ) as client:
             with pytest.raises(T2VEnhancedClientError) as exc_info:
                 await client.generate("anything")
 
-            assert "HTTP 500" in str(exc_info.value)
+        assert "HTTP 500" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 async def test_t2v_5xx_raises_client_error():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{LLM_URL}/v1/chat/completions",
-                payload=_llm_ok_payload("rewritten"),
-            )
-            mock.post(f"{T2V_URL}/v1/videos", status=502, body="bad gateway")
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_json(LLM_PATH, _llm_ok_payload("rewritten"))
+        server.respond_text(T2V_PATH, "bad gateway", status=502)
 
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+        ) as client:
             with pytest.raises(T2VEnhancedClientError) as exc_info:
                 await client.generate("anything")
 
-            assert "HTTP 502" in str(exc_info.value)
+        assert "HTTP 502" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 async def test_t2v_extra_kwargs_are_forwarded():
-    async with T2VEnhancedClient(
-        llm_url=LLM_URL,
-        t2v_url=T2V_URL,
-        llm_model=LLM_MODEL,
-        t2v_model=T2V_MODEL,
-    ) as client:
-        with aioresponses() as mock:
-            mock.post(
-                f"{T2V_URL}/v1/videos",
-                payload=_t2v_ok_payload("file:///tmp/forward.mp4"),
-            )
+    async with _MockOpenAIServer() as server:
+        assert server.url is not None
+        server.respond_json(T2V_PATH, _t2v_ok_payload("file:///tmp/forward.mp4"))
+
+        async with T2VEnhancedClient(
+            llm_url=server.url,
+            t2v_url=server.url,
+            llm_model=LLM_MODEL,
+            t2v_model=T2V_MODEL,
+        ) as client:
             await client.generate(
                 "anything",
                 enhancer=EnhancerMode.OFF,
@@ -201,12 +239,11 @@ async def test_t2v_extra_kwargs_are_forwarded():
                 num_frames=33,
             )
 
-            requests = mock.requests
-            t2v_calls = [k for k in requests if k[1].path == "/v1/videos"]
-            body = requests[t2v_calls[0]][0].kwargs["json"]
-            assert body["size"] == "832x480"
-            assert body["num_inference_steps"] == 50
-            assert body["num_frames"] == 33
+        t2v_calls = server.requests_for(T2V_PATH)
+        body = t2v_calls[0]["json"]
+        assert body["size"] == "832x480"
+        assert body["num_inference_steps"] == 50
+        assert body["num_frames"] == 33
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/common/clients/tests/test_t2v_enhanced.py
+++ b/components/src/dynamo/common/clients/tests/test_t2v_enhanced.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for T2VEnhancedClient.
+
+The tests use ``aioresponses`` to mock both the LLM and T2V HTTP endpoints
+so the chained orchestration logic can be exercised without launching any
+Dynamo workers.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aioresponses import aioresponses
+
+from dynamo.common.clients import (
+    EnhancerMode,
+    T2VEnhancedClient,
+    T2VEnhancedClientError,
+)
+
+
+LLM_URL = "http://llm.test"
+T2V_URL = "http://t2v.test"
+LLM_MODEL = "Qwen/Qwen3-0.6B"
+T2V_MODEL = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+
+
+def _llm_ok_payload(rewritten: str) -> dict:
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": rewritten}}
+        ],
+    }
+
+
+def _t2v_ok_payload(url: str) -> dict:
+    return {"data": [{"url": url}]}
+
+
+@pytest.mark.asyncio
+async def test_generate_runs_enhancer_then_t2v():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{LLM_URL}/v1/chat/completions",
+                payload=_llm_ok_payload("a cinematic bear by a campfire"),
+            )
+            mock.post(
+                f"{T2V_URL}/v1/videos",
+                payload=_t2v_ok_payload("file:///tmp/result.mp4"),
+            )
+
+            result = await client.generate("a bear by a campfire")
+
+            assert result.url == "file:///tmp/result.mp4"
+            assert result.rewritten_prompt == "a cinematic bear by a campfire"
+            assert result.timings.enhance_ms > 0
+            assert result.timings.t2v_ms > 0
+            assert result.timings.e2e_ms >= result.timings.enhance_ms
+
+            # T2V was called with the rewritten prompt, not the user input.
+            requests = mock.requests
+            t2v_calls = [k for k in requests if k[1].path == "/v1/videos"]
+            assert t2v_calls, "expected /v1/videos call"
+            body = requests[t2v_calls[0]][0].kwargs["json"]
+            assert body["prompt"] == "a cinematic bear by a campfire"
+
+
+@pytest.mark.asyncio
+async def test_enhancer_off_skips_llm_call():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{T2V_URL}/v1/videos",
+                payload=_t2v_ok_payload("file:///tmp/skipped.mp4"),
+            )
+
+            result = await client.generate(
+                "raw user prompt", enhancer=EnhancerMode.OFF
+            )
+
+            assert result.url == "file:///tmp/skipped.mp4"
+            assert result.rewritten_prompt is None
+            assert result.timings.enhance_ms == 0
+
+            calls = list(mock.requests.keys())
+            paths = [c[1].path for c in calls]
+            assert "/v1/chat/completions" not in paths
+
+
+@pytest.mark.asyncio
+async def test_enhancer_off_string_alias():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{T2V_URL}/v1/videos",
+                payload=_t2v_ok_payload("file:///tmp/off.mp4"),
+            )
+
+            result = await client.generate("anything", enhancer="off")
+            assert result.rewritten_prompt is None
+
+
+@pytest.mark.asyncio
+async def test_default_enhancer_off_applies_when_no_override():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+        default_enhancer=EnhancerMode.OFF,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{T2V_URL}/v1/videos",
+                payload=_t2v_ok_payload("file:///tmp/default-off.mp4"),
+            )
+
+            result = await client.generate("anything")
+            assert result.rewritten_prompt is None
+
+
+@pytest.mark.asyncio
+async def test_llm_5xx_raises_client_error():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{LLM_URL}/v1/chat/completions",
+                status=500,
+                body="internal error",
+            )
+
+            with pytest.raises(T2VEnhancedClientError) as exc_info:
+                await client.generate("anything")
+
+            assert "HTTP 500" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_t2v_5xx_raises_client_error():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{LLM_URL}/v1/chat/completions",
+                payload=_llm_ok_payload("rewritten"),
+            )
+            mock.post(f"{T2V_URL}/v1/videos", status=502, body="bad gateway")
+
+            with pytest.raises(T2VEnhancedClientError) as exc_info:
+                await client.generate("anything")
+
+            assert "HTTP 502" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_t2v_extra_kwargs_are_forwarded():
+    async with T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    ) as client:
+        with aioresponses() as mock:
+            mock.post(
+                f"{T2V_URL}/v1/videos",
+                payload=_t2v_ok_payload("file:///tmp/forward.mp4"),
+            )
+            await client.generate(
+                "anything",
+                enhancer=EnhancerMode.OFF,
+                size="832x480",
+                num_inference_steps=50,
+                num_frames=33,
+            )
+
+            requests = mock.requests
+            t2v_calls = [k for k in requests if k[1].path == "/v1/videos"]
+            body = requests[t2v_calls[0]][0].kwargs["json"]
+            assert body["size"] == "832x480"
+            assert body["num_inference_steps"] == 50
+            assert body["num_frames"] == 33
+
+
+@pytest.mark.asyncio
+async def test_client_must_be_entered_when_session_not_provided():
+    client = T2VEnhancedClient(
+        llm_url=LLM_URL,
+        t2v_url=T2V_URL,
+        llm_model=LLM_MODEL,
+        t2v_model=T2V_MODEL,
+    )
+    with pytest.raises(T2VEnhancedClientError):
+        await client.generate("anything", enhancer=EnhancerMode.OFF)

--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -146,12 +146,19 @@ async def init_image_diffusion(
 
     dist_timeout = getattr(server_args, "dist_timeout", None)
 
+    # Forward master_port when explicitly set on server_args so multiple
+    # diffusion replicas can coexist on one node. sglang's default of
+    # 30005 collides when more than one worker is launched per host.
+    master_port = getattr(server_args, "master_port", None)
+    extra_kwargs = {"master_port": master_port} if master_port is not None else {}
+
     generator = DiffGenerator.from_pretrained(
         model_path=server_args.model_path,
         num_gpus=num_gpus,
         tp_size=tp_size,
         dp_size=dp_size,
         dist_timeout=dist_timeout,
+        **extra_kwargs,
     )
 
     fs_url = dynamo_args.media_output_fs_url
@@ -232,12 +239,19 @@ async def init_video_diffusion(
 
     dist_timeout = getattr(server_args, "dist_timeout", None)
 
+    # Forward master_port when explicitly set on server_args so multiple
+    # diffusion replicas can coexist on one node. sglang's default of
+    # 30005 collides when more than one worker is launched per host.
+    master_port = getattr(server_args, "master_port", None)
+    extra_kwargs = {"master_port": master_port} if master_port is not None else {}
+
     generator = DiffGenerator.from_pretrained(
         model_path=server_args.model_path,
         num_gpus=num_gpus,
         tp_size=tp_size,
         dp_size=dp_size,
         dist_timeout=dist_timeout,
+        **extra_kwargs,
     )
 
     fs_url = dynamo_args.media_output_fs_url

--- a/examples/diffusers/prompt_enhanced_t2v/client_example.py
+++ b/examples/diffusers/prompt_enhanced_t2v/client_example.py
@@ -48,9 +48,7 @@ def _parse_args() -> argparse.Namespace:
         help="Bypass the LLM enhancer when set to 'off'.",
     )
     p.add_argument("--steps", type=int, default=25, help="num_inference_steps.")
-    p.add_argument(
-        "--size", default="832x480", help="Output resolution, e.g. 832x480."
-    )
+    p.add_argument("--size", default="832x480", help="Output resolution, e.g. 832x480.")
     p.add_argument("--frames", type=int, default=33, help="num_frames.")
     return p.parse_args()
 

--- a/examples/diffusers/prompt_enhanced_t2v/client_example.py
+++ b/examples/diffusers/prompt_enhanced_t2v/client_example.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal demo of T2VEnhancedClient against the launched topology.
+
+Assumes ``container.sh`` is already running: enhancer LLM on
+:8000 and diffusion backend on :8001.
+
+Usage::
+
+    python client_example.py "a bear by a campfire under starlight"
+    python client_example.py --enhancer off "an astronaut on a black sand beach"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from dynamo.common.clients import EnhancerMode, T2VEnhancedClient
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("prompt", help="User-facing prompt for the video.")
+    p.add_argument(
+        "--llm-url", default="http://127.0.0.1:8000", help="Enhancer frontend URL."
+    )
+    p.add_argument(
+        "--t2v-url", default="http://127.0.0.1:8001", help="T2V frontend URL."
+    )
+    p.add_argument(
+        "--llm-model",
+        default="Qwen/Qwen3-0.6B",
+        help="Model name registered against the enhancer frontend.",
+    )
+    p.add_argument(
+        "--t2v-model",
+        default="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        help="Model name registered against the T2V frontend.",
+    )
+    p.add_argument(
+        "--enhancer",
+        choices=[m.value for m in EnhancerMode],
+        default=EnhancerMode.AUTO.value,
+        help="Bypass the LLM enhancer when set to 'off'.",
+    )
+    p.add_argument("--steps", type=int, default=25, help="num_inference_steps.")
+    p.add_argument(
+        "--size", default="832x480", help="Output resolution, e.g. 832x480."
+    )
+    p.add_argument("--frames", type=int, default=33, help="num_frames.")
+    return p.parse_args()
+
+
+async def _main() -> int:
+    args = _parse_args()
+    async with T2VEnhancedClient(
+        llm_url=args.llm_url,
+        t2v_url=args.t2v_url,
+        llm_model=args.llm_model,
+        t2v_model=args.t2v_model,
+    ) as client:
+        result = await client.generate(
+            args.prompt,
+            enhancer=args.enhancer,
+            size=args.size,
+            num_inference_steps=args.steps,
+            num_frames=args.frames,
+        )
+    print(f"video_url      : {result.url}")
+    print(f"rewritten      : {result.rewritten_prompt!r}")
+    t = result.timings
+    print(
+        f"timings_ms     : enhance={t.enhance_ms:.1f}  "
+        f"t2v={t.t2v_ms:.1f}  e2e={t.e2e_ms:.1f}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/examples/diffusers/prompt_enhanced_t2v/container.sh
+++ b/examples/diffusers/prompt_enhanced_t2v/container.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# In-container bring-up for the prompt-enhanced text-to-video example.
+# Starts:
+#   * one dynamo.frontend on FE_LLM_PORT serving the enhancer LLM
+#   * one dynamo.frontend on FE_T2V_PORT serving the diffusion backend
+#   * one enhancer worker on GPU 0
+#   * N diffusion replicas on GPUs 1..N (default N=3 for the GB200 layout)
+#
+# Each diffusion replica is launched with a distinct --master-port so
+# sglang's multimodal_gen does not collide on 30005.
+
+set -euo pipefail
+
+JOB_ID="${SLURM_JOB_ID:-manual}"
+NS="${NS:-prompt-enhanced-t2v}"
+
+LLM_MODEL="${LLM_MODEL:-Qwen/Qwen3-0.6B}"
+T2V_MODEL="${T2V_MODEL:-Wan-AI/Wan2.1-T2V-1.3B-Diffusers}"
+
+FE_LLM_PORT="${FE_LLM_PORT:-8000}"
+FE_T2V_PORT="${FE_T2V_PORT:-8001}"
+
+T2V_REPLICAS="${T2V_REPLICAS:-3}"
+T2V_MASTER_PORT_BASE="${T2V_MASTER_PORT_BASE:-30110}"
+T2V_MASTER_PORT_STRIDE="${T2V_MASTER_PORT_STRIDE:-10}"
+
+LOG_DIR="${LOG_DIR:-/scratch/exp-prompt-enhanced-t2v/logs/${JOB_ID}}"
+MEDIA_DIR="${MEDIA_DIR:-/scratch/exp-prompt-enhanced-t2v/media/${JOB_ID}}"
+mkdir -p "${LOG_DIR}" "${MEDIA_DIR}"
+
+DYN_KV_LLM="/tmp/dyn-kv-llm-${JOB_ID}"
+DYN_KV_T2V="/tmp/dyn-kv-t2v-${JOB_ID}"
+rm -rf "${DYN_KV_LLM}" "${DYN_KV_T2V}"
+mkdir -p "${DYN_KV_LLM}" "${DYN_KV_T2V}"
+
+pids=()
+cleanup() {
+  set +e
+  for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null || true; done
+  sleep 3
+  for p in "${pids[@]:-}"; do kill -9 "$p" 2>/dev/null || true; done
+}
+trap cleanup EXIT
+
+DYN_FILE_KV="${DYN_KV_LLM}" python3 -m dynamo.frontend \
+  --http-port "${FE_LLM_PORT}" --namespace "${NS}-llm" \
+  --discovery-backend file --request-plane tcp --event-plane zmq \
+  > "${LOG_DIR}/frontend_llm.log" 2>&1 &
+pids+=($!)
+
+DYN_FILE_KV="${DYN_KV_T2V}" python3 -m dynamo.frontend \
+  --http-port "${FE_T2V_PORT}" --namespace "${NS}-t2v" \
+  --discovery-backend file --request-plane tcp --event-plane zmq \
+  > "${LOG_DIR}/frontend_t2v.log" 2>&1 &
+pids+=($!)
+
+sleep 5
+
+CUDA_VISIBLE_DEVICES=0 DYN_FILE_KV="${DYN_KV_LLM}" \
+python3 -m dynamo.sglang \
+  --model "${LLM_MODEL}" --served-model-name "${LLM_MODEL}" \
+  --namespace "${NS}-llm" \
+  --discovery-backend file --request-plane tcp --event-plane zmq \
+  > "${LOG_DIR}/enhancer.log" 2>&1 &
+pids+=($!)
+
+for ((g=1; g<=T2V_REPLICAS; g++)); do
+  port=$((T2V_MASTER_PORT_BASE + (g - 1) * T2V_MASTER_PORT_STRIDE))
+  CUDA_VISIBLE_DEVICES="${g}" DYN_FILE_KV="${DYN_KV_T2V}" \
+  python3 -m dynamo.sglang \
+    --video-generation-worker \
+    --model "${T2V_MODEL}" --served-model-name "${T2V_MODEL}" \
+    --namespace "${NS}-t2v" \
+    --media-output-fs-url "file://${MEDIA_DIR}" \
+    --master-port "${port}" \
+    --discovery-backend file --request-plane tcp --event-plane zmq \
+    > "${LOG_DIR}/t2v_g${g}.log" 2>&1 &
+  pids+=($!)
+done
+
+wait

--- a/examples/diffusers/prompt_enhanced_t2v/launch.sh
+++ b/examples/diffusers/prompt_enhanced_t2v/launch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Slurm wrapper for the prompt-enhanced text-to-video example.
+#
+# Launches one enhancer LLM (Qwen3-0.6B by default) and N video generation
+# replicas (Wan2.1-T2V-1.3B-Diffusers by default) on a single node. Each
+# replica gets a distinct --master-port to avoid the sglang multimodal_gen
+# 30005 default collision.
+
+set -euo pipefail
+
+PARTITION="${PARTITION:-gb200nvl72_cx8}"
+WALLTIME="${WALLTIME:-04:00:00}"
+IMAGE="${IMAGE:-nvcr.io#nvidia/ai-dynamo/sglang-runtime:1.1.1}"
+HOST_MOUNT="${HOST_MOUNT:-${HOME}}"
+GUEST_MOUNT="${GUEST_MOUNT:-/scratch}"
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_ROOT="${LOG_ROOT:-${HOST_MOUNT}/exp-prompt-enhanced-t2v/logs}"
+MEDIA_ROOT="${MEDIA_ROOT:-${HOST_MOUNT}/exp-prompt-enhanced-t2v/media}"
+mkdir -p "${LOG_ROOT}" "${MEDIA_ROOT}"
+
+sbatch --wait \
+  --job-name=prompt-enhanced-t2v \
+  --partition="${PARTITION}" \
+  --nodes=1 \
+  --gres=gpu:4 \
+  --time="${WALLTIME}" \
+  --output="${LOG_ROOT}/slurm-%j.out" \
+  --container-image="${IMAGE}" \
+  --container-mounts="${HOST_MOUNT}:${GUEST_MOUNT},${THIS_DIR}:/example" \
+  --container-workdir=/example \
+  --wrap 'bash /example/container.sh'


### PR DESCRIPTION
#### Overview:

Port prompt-enhanced text-to-video support from `Chokoyo/dynamo:prompt-enhanced-t2v` onto latest `main`.

#### Details:

- Add `T2VEnhancedClient` for chaining an OpenAI-compatible chat prompt enhancer with the `/v1/videos` text-to-video backend.
- Add focused tests for enhancer-on, enhancer-off, forwarded T2V params, and upstream error handling.
- Forward `master_port` to SGLang diffusion generators so multiple diffusion replicas can coexist on one host.
- Add an end-to-end diffusers example under `examples/diffusers/prompt_enhanced_t2v`.

#### Where should the reviewer start?

- `components/src/dynamo/common/clients/t2v_enhanced.py`
- `components/src/dynamo/common/clients/tests/test_t2v_enhanced.py`
- `components/src/dynamo/sglang/init_diffusion.py`
- `examples/diffusers/prompt_enhanced_t2v/`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to prompt-enhanced text-to-video deployment work.
