### PR TITLE
fix(ci): key per-test COVERAGE_FILE on w_id only to avoid ENAMETOOLONG 

### DIFF
--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -534,9 +534,18 @@ def run_parallel(
         # (pytest-cov collapses data_suffix=True shards into the unsuffixed
         # path) doesn't clobber siblings. Harmless when pytest-cov is not
         # active — the env var is just unread.
+        #
+        # Key only on w_id, which is a permanent, globally-unique per-test index
+        # (assigned via enumerate() above), so it already guarantees uniqueness.
+        # Do NOT append the test node-id: pytest-cov adds its own
+        # ".<hostname>.<pid>.<random>" parallel suffix (plus a temp suffix during
+        # the atomic save), so a long node-id here can push the filename past the
+        # filesystem's 255-byte NAME_MAX and crash the run with
+        # "OSError: [Errno 36] File name too long". The w_id->test mapping stays
+        # recoverable from the orchestrator log and the per-test JUnit filenames.
         parent_cov_file = env.get("COVERAGE_FILE")
         if parent_cov_file:
-            env["COVERAGE_FILE"] = f"{parent_cov_file}.w{test.w_id}.{safe_name}"
+            env["COVERAGE_FILE"] = f"{parent_cov_file}.w{test.w_id}"
         junit_path = os.path.join(_JUNIT_DIR, f"{safe_name}.xml")
         has_tb = extra_pytest_args and any(
             a.startswith("--tb") for a in extra_pytest_args


### PR DESCRIPTION
## Overview

The parallel GPU test runner (`tests/utils/pytest_parallel_gpu.py`) gives each child process a unique `COVERAGE_FILE` so siblings don't clobber each other's session-end coverage data. It did so by appending the **full pytest node-id** to the parent path. `pytest-cov` then appends its own `.<hostname>.<pid>.<random>` parallel suffix (plus a temp suffix during coverage's atomic save). On the AMD `-v2` runners (long hostname like `prod-tester-amd-gpu-v2-kz4c5-runner-78k8x-workflow`), the combination pushes the basename past the filesystem's 255-byte `NAME_MAX`, crashing the session at coverage teardown:

```
INTERNALERROR> OSError: [Errno 36] File name too long:
'.../test-results/.coverage.w62.components_src_dynamo_frontend_tests_test_sglang_processor_unit.py__...signature.prod-tester-amd-gpu-v2-kz4c5-runner-78k8x-workflow.pid4077.Xwg3E9Cx'
```

The tests themselves pass — they only fail because pytest-cov can't write the per-test coverage shard. This surfaced as ~12 spurious failures in the `sglang-runtime / Test cuda13.0` job ([example run](https://github.com/ai-dynamo/dynamo/actions/runs/26565847339/job/78264264450)).

Introduced in #9559 (the per-test `COVERAGE_FILE` only exists when `enable_coverage=true`).

## Fix

Key the per-child `COVERAGE_FILE` only on `w_id`, dropping the node-id entirely:

```python
env["COVERAGE_FILE"] = f"{parent_cov_file}.w{test.w_id}"
```

`w_id` is already a **permanent, globally-unique per-test index** — it's assigned once via `enumerate()` over all tests (`run_parallel`, ~L411), which is also why the run loop can key `running[w_id]` by it. So `w_id` alone guarantees uniqueness; the full node-id was only ever there for readability. This makes the filename independent of test-name length, so neither long node-ids nor long runner hostnames can reach `NAME_MAX`. The `w_id -> test` mapping stays recoverable from the orchestrator's `[w{id}] {name}` log lines and the per-test JUnit filenames.

## Verification

- **Reproduced + fixed on the real filesystem:** the old construction + the exact pytest-cov/temp suffixes from the CI log = 264 bytes -> `OSError errno 36`; the new `.coverage.w{id}` form = 97 bytes worst-case (even with a 5-digit index and max-length hostname) -> 158 bytes of headroom under the 255 limit.
- **Real pytest-cov round-trip** (coverage 7.13.4, pytest-cov, xdist `-n 2`): ran `pytest --cov` with the new `COVERAGE_FILE`, then `coverage combine` — shard written and combined, no ENAMETOOLONG.
- **End-to-end collection unaffected:** simulated the exact nightly `find -name ".coverage*" | cp | coverage combine --keep` flow (`.github/workflows/nightly-ci.yml`) on new-style shards — all found, combined into a final `.coverage`, report generated. The collector matches by the `.coverage*` glob and merges by file content; it never parsed the test-id out of the filename, so the rename is transparent.
- `py_compile` + pre-commit (black, ruff, flake8, isort) pass.

## Scope / follow-up

- This only fixes the coverage-file crash. The same job also has unrelated, real GPU-level failures (sglang request-migration assertions, a multimodal-vision deployment readiness timeout) that are **not** addressed here.
- Confirmed this is the **only** place that builds a per-test coverage filename — the CI actions (`pytest/action.yml`, `pytest-local/action.yml`) set a fixed `COVERAGE_FILE=.../.coverage`, and `scripts/coverage.sh` / `conftest.py` only forward `--cov` flags.
- The same unbounded-node-id pattern still exists for the JUnit XML filename and the per-test basetemp dir in this function (more headroom today, no pytest-cov suffix appended). Not crashing now; can be hardened the same way as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
