### PR TITLE
fix(operator): preserve available old rollout generations

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1452,7 +1452,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileDynamoComponentsDeployments(c
 	if rollingUpdateCtx.InProgress() {
 		logger.Info("Rolling update in progress",
 			"newWorkerHash", rollingUpdateCtx.NewWorkerHash,
-			"oldWorkerReplicas", rollingUpdateCtx.OldWorkerReplicas)
+			"oldWorkerComponentReplicas", rollingUpdateCtx.OldWorkerComponentReplicas)
 	}
 
 	// Generate all DCDs (handles both normal and rolling update cases)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1452,7 +1452,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileDynamoComponentsDeployments(c
 	if rollingUpdateCtx.InProgress() {
 		logger.Info("Rolling update in progress",
 			"newWorkerHash", rollingUpdateCtx.NewWorkerHash,
-			"oldWorkerComponentReplicas", rollingUpdateCtx.OldWorkerComponentReplicas)
+			"oldWorkerComponentReplicas", rollingUpdateCtx.OldWorkerReplicaTargetsByComponent)
 	}
 
 	// Generate all DCDs (handles both normal and rolling update cases)

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -830,8 +830,8 @@ func (r *DynamoGraphDeploymentReconciler) getDesiredWorkerReplicas(
 type oldWorkerReplicaPlan struct {
 	name      string
 	createdAt metav1.Time
-	spec      int32
-	target    int32
+	spec      int32 // declared intent for this DCD
+	target    int32 // desired replica count for this DCD
 }
 
 func allocateOldWorkerDCDReplicas(
@@ -839,10 +839,15 @@ func allocateOldWorkerDCDReplicas(
 	oldTarget int32,
 ) map[string]int32 {
 	plans := buildOldWorkerReplicaPlans(dcds)
-	servingTarget := sumTargetReplicas(plans)
+	var servingTarget int32
+	for i := range plans {
+		servingTarget += plans[i].target
+	}
 
+	// if we have more available replicas currently than total desired replicas, remove the oldest DCD replicas first
 	if servingTarget > oldTarget {
-		removeServingReplicasOldestFirst(plans, servingTarget-oldTarget)
+		removeAvailableReplicasOldestFirst(plans, servingTarget-oldTarget)
+		// if we have less available replicas currently than total desired replicas, add the newest DCD replicas first
 	} else if servingTarget < oldTarget {
 		addUnavailableReplicasNewestFirst(plans, oldTarget-servingTarget)
 	}
@@ -850,6 +855,7 @@ func allocateOldWorkerDCDReplicas(
 	return replicaTargetsByDCDName(plans)
 }
 
+// initializes DCD replicas to available replicas
 func buildOldWorkerReplicaPlans(
 	dcds []*nvidiacomv1beta1.DynamoComponentDeployment,
 ) []oldWorkerReplicaPlan {
@@ -857,7 +863,6 @@ func buildOldWorkerReplicaPlans(
 
 	for _, dcd := range dcds {
 		state := dcdComponentStateFromDCD(dcd)
-		// Start by preserving replicas that are currently serving traffic.
 		target := min(state.Spec, state.Available)
 		plans = append(plans, oldWorkerReplicaPlan{
 			name:      dcd.Name,
@@ -870,17 +875,12 @@ func buildOldWorkerReplicaPlans(
 	return plans
 }
 
-func sumTargetReplicas(plans []oldWorkerReplicaPlan) int32 {
-	var total int32
-	for i := range plans {
-		total += plans[i].target
-	}
-	return total
-}
-
-func removeServingReplicasOldestFirst(plans []oldWorkerReplicaPlan, replicasToRemove int32) {
+func removeAvailableReplicasOldestFirst(plans []oldWorkerReplicaPlan, replicasToRemove int32) {
 	sort.Slice(plans, func(i, j int) bool {
-		return olderOldWorkerReplicaPlanFirst(plans[i], plans[j])
+		if plans[i].createdAt.Time.Equal(plans[j].createdAt.Time) {
+			return plans[i].name < plans[j].name
+		}
+		return plans[i].createdAt.Time.Before(plans[j].createdAt.Time)
 	})
 
 	for i := range plans {
@@ -895,7 +895,10 @@ func removeServingReplicasOldestFirst(plans []oldWorkerReplicaPlan, replicasToRe
 
 func addUnavailableReplicasNewestFirst(plans []oldWorkerReplicaPlan, replicasToAdd int32) {
 	sort.Slice(plans, func(i, j int) bool {
-		return newerOldWorkerReplicaPlanFirst(plans[i], plans[j])
+		if plans[i].createdAt.Time.Equal(plans[j].createdAt.Time) {
+			return plans[i].name < plans[j].name
+		}
+		return plans[i].createdAt.Time.After(plans[j].createdAt.Time)
 	})
 
 	for i := range plans {
@@ -907,20 +910,6 @@ func addUnavailableReplicasNewestFirst(plans []oldWorkerReplicaPlan, replicasToA
 		plans[i].target += added
 		replicasToAdd -= added
 	}
-}
-
-func olderOldWorkerReplicaPlanFirst(a, b oldWorkerReplicaPlan) bool {
-	if a.createdAt.Time.Equal(b.createdAt.Time) {
-		return a.name < b.name
-	}
-	return a.createdAt.Time.Before(b.createdAt.Time)
-}
-
-func newerOldWorkerReplicaPlanFirst(a, b oldWorkerReplicaPlan) bool {
-	if a.createdAt.Time.Equal(b.createdAt.Time) {
-		return a.name < b.name
-	}
-	return a.createdAt.Time.After(b.createdAt.Time)
 }
 
 func replicaTargetsByDCDName(plans []oldWorkerReplicaPlan) map[string]int32 {

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -827,64 +827,106 @@ func (r *DynamoGraphDeploymentReconciler) getDesiredWorkerReplicas(
 	return total
 }
 
-type oldWorkerDCDAllocation struct {
-	dcd         *nvidiacomv1beta1.DynamoComponentDeployment
-	currentSpec int32
-	target      int32
+type oldWorkerReplicaPlan struct {
+	name      string
+	createdAt metav1.Time
+	spec      int32
+	target    int32
 }
 
 func allocateOldWorkerDCDReplicas(
 	dcds []*nvidiacomv1beta1.DynamoComponentDeployment,
-	oldNeeded int32,
-) map[*nvidiacomv1beta1.DynamoComponentDeployment]int32 {
-	allocations := make([]oldWorkerDCDAllocation, 0, len(dcds))
-	allocated := int32(0)
+	oldTarget int32,
+) map[string]int32 {
+	plans := buildOldWorkerReplicaPlans(dcds)
+	servingTarget := sumTargetReplicas(plans)
+
+	if servingTarget > oldTarget {
+		removeServingReplicasOldestFirst(plans, servingTarget-oldTarget)
+	} else if servingTarget < oldTarget {
+		addUnavailableReplicasNewestFirst(plans, oldTarget-servingTarget)
+	}
+
+	return replicaTargetsByDCDName(plans)
+}
+
+func buildOldWorkerReplicaPlans(
+	dcds []*nvidiacomv1beta1.DynamoComponentDeployment,
+) []oldWorkerReplicaPlan {
+	plans := make([]oldWorkerReplicaPlan, 0, len(dcds))
 
 	for _, dcd := range dcds {
 		state := dcdComponentStateFromDCD(dcd)
+		// Start by preserving replicas that are currently serving traffic.
 		target := min(state.Spec, state.Available)
-		allocations = append(allocations, oldWorkerDCDAllocation{
-			dcd:         dcd,
-			currentSpec: state.Spec,
-			target:      target,
+		plans = append(plans, oldWorkerReplicaPlan{
+			name:      dcd.Name,
+			createdAt: dcd.CreationTimestamp,
+			spec:      state.Spec,
+			target:    target,
 		})
-		allocated += target
 	}
 
-	if surplus := allocated - oldNeeded; surplus > 0 {
-		// Once serving availability exceeds the old target, drain older healthy
-		// generations first, matching Kubernetes Deployment behavior.
-		sort.SliceStable(allocations, func(i, j int) bool {
-			return allocations[i].dcd.CreationTimestamp.Time.Before(allocations[j].dcd.CreationTimestamp.Time)
-		})
-		for i := range allocations {
-			if surplus <= 0 {
-				break
-			}
-			reduced := min(allocations[i].target, surplus)
-			allocations[i].target -= reduced
-			surplus -= reduced
-		}
-	} else if remaining := oldNeeded - allocated; remaining > 0 {
-		// Preserve existing newest-first behavior for non-serving capacity after
-		// all currently available old replicas have been retained.
-		sort.SliceStable(allocations, func(i, j int) bool {
-			return allocations[i].dcd.CreationTimestamp.After(allocations[j].dcd.CreationTimestamp.Time)
-		})
-		for i := range allocations {
-			if remaining <= 0 {
-				break
-			}
-			extraCapacity := allocations[i].currentSpec - allocations[i].target
-			added := min(extraCapacity, remaining)
-			allocations[i].target += added
-			remaining -= added
-		}
-	}
+	return plans
+}
 
-	targets := make(map[*nvidiacomv1beta1.DynamoComponentDeployment]int32, len(allocations))
-	for i := range allocations {
-		targets[allocations[i].dcd] = allocations[i].target
+func sumTargetReplicas(plans []oldWorkerReplicaPlan) int32 {
+	var total int32
+	for i := range plans {
+		total += plans[i].target
+	}
+	return total
+}
+
+func removeServingReplicasOldestFirst(plans []oldWorkerReplicaPlan, replicasToRemove int32) {
+	sort.Slice(plans, func(i, j int) bool {
+		return olderOldWorkerReplicaPlanFirst(plans[i], plans[j])
+	})
+
+	for i := range plans {
+		if replicasToRemove <= 0 {
+			break
+		}
+		removed := min(plans[i].target, replicasToRemove)
+		plans[i].target -= removed
+		replicasToRemove -= removed
+	}
+}
+
+func addUnavailableReplicasNewestFirst(plans []oldWorkerReplicaPlan, replicasToAdd int32) {
+	sort.Slice(plans, func(i, j int) bool {
+		return newerOldWorkerReplicaPlanFirst(plans[i], plans[j])
+	})
+
+	for i := range plans {
+		if replicasToAdd <= 0 {
+			break
+		}
+		unavailable := plans[i].spec - plans[i].target
+		added := min(unavailable, replicasToAdd)
+		plans[i].target += added
+		replicasToAdd -= added
+	}
+}
+
+func olderOldWorkerReplicaPlanFirst(a, b oldWorkerReplicaPlan) bool {
+	if a.createdAt.Time.Equal(b.createdAt.Time) {
+		return a.name < b.name
+	}
+	return a.createdAt.Time.Before(b.createdAt.Time)
+}
+
+func newerOldWorkerReplicaPlanFirst(a, b oldWorkerReplicaPlan) bool {
+	if a.createdAt.Time.Equal(b.createdAt.Time) {
+		return a.name < b.name
+	}
+	return a.createdAt.Time.After(b.createdAt.Time)
+}
+
+func replicaTargetsByDCDName(plans []oldWorkerReplicaPlan) map[string]int32 {
+	targets := make(map[string]int32, len(plans))
+	for i := range plans {
+		targets[plans[i].name] = plans[i].target
 	}
 	return targets
 }
@@ -1161,8 +1203,8 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		oldWorkerComponentReplicas[componentName] = oldTarget
 		newWorkerReplicas[componentName] = newTarget
 
-		for dcd, target := range allocateOldWorkerDCDReplicas(oldDCDsByComponent[componentName], oldTarget) {
-			oldWorkerDCDReplicas[dcd.Name] = target
+		for dcdName, target := range allocateOldWorkerDCDReplicas(oldDCDsByComponent[componentName], oldTarget) {
+			oldWorkerDCDReplicas[dcdName] = target
 		}
 
 		logger.V(1).Info("Rolling update replica calculation",

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -781,20 +781,23 @@ func (r *DynamoGraphDeploymentReconciler) getOldWorkerInfo(
 	return status, nil
 }
 
-// getOldWorkerComponentStates returns per-component old DCD state aggregated across all old generations.
-func (r *DynamoGraphDeploymentReconciler) getOldWorkerComponentStates(
+// getOldWorkerDCDsByComponent returns old DCDs grouped by component and per-component state
+// aggregated across all old generations.
+func (r *DynamoGraphDeploymentReconciler) getOldWorkerDCDsByComponent(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 	newWorkerHash string,
-) (map[string]dcdComponentState, error) {
+) (map[string][]*nvidiacomv1beta1.DynamoComponentDeployment, map[string]dcdComponentState, error) {
 	oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	dcdsByComponent := make(map[string][]*nvidiacomv1beta1.DynamoComponentDeployment)
 	states := make(map[string]dcdComponentState)
 	for i := range oldDCDs {
 		componentName := dynamo.GetDCDComponentName(&oldDCDs[i])
+		dcdsByComponent[componentName] = append(dcdsByComponent[componentName], &oldDCDs[i])
 		s := dcdComponentStateFromDCD(&oldDCDs[i])
 		agg := states[componentName]
 		agg.Spec += s.Spec
@@ -803,7 +806,7 @@ func (r *DynamoGraphDeploymentReconciler) getOldWorkerComponentStates(
 		states[componentName] = agg
 	}
 
-	return states, nil
+	return dcdsByComponent, states, nil
 }
 
 // getDesiredWorkerReplicas returns the total desired replicas across all worker components.
@@ -824,9 +827,71 @@ func (r *DynamoGraphDeploymentReconciler) getDesiredWorkerReplicas(
 	return total
 }
 
+type oldWorkerDCDAllocation struct {
+	dcd         *nvidiacomv1beta1.DynamoComponentDeployment
+	currentSpec int32
+	target      int32
+}
+
+func allocateOldWorkerDCDReplicas(
+	dcds []*nvidiacomv1beta1.DynamoComponentDeployment,
+	oldNeeded int32,
+) map[*nvidiacomv1beta1.DynamoComponentDeployment]int32 {
+	allocations := make([]oldWorkerDCDAllocation, 0, len(dcds))
+	allocated := int32(0)
+
+	for _, dcd := range dcds {
+		state := dcdComponentStateFromDCD(dcd)
+		target := min(state.Spec, state.Available)
+		allocations = append(allocations, oldWorkerDCDAllocation{
+			dcd:         dcd,
+			currentSpec: state.Spec,
+			target:      target,
+		})
+		allocated += target
+	}
+
+	if surplus := allocated - oldNeeded; surplus > 0 {
+		// Once serving availability exceeds the old target, drain older healthy
+		// generations first, matching Kubernetes Deployment behavior.
+		sort.SliceStable(allocations, func(i, j int) bool {
+			return allocations[i].dcd.CreationTimestamp.Time.Before(allocations[j].dcd.CreationTimestamp.Time)
+		})
+		for i := range allocations {
+			if surplus <= 0 {
+				break
+			}
+			reduced := min(allocations[i].target, surplus)
+			allocations[i].target -= reduced
+			surplus -= reduced
+		}
+	} else if remaining := oldNeeded - allocated; remaining > 0 {
+		// Preserve existing newest-first behavior for non-serving capacity after
+		// all currently available old replicas have been retained.
+		sort.SliceStable(allocations, func(i, j int) bool {
+			return allocations[i].dcd.CreationTimestamp.After(allocations[j].dcd.CreationTimestamp.Time)
+		})
+		for i := range allocations {
+			if remaining <= 0 {
+				break
+			}
+			extraCapacity := allocations[i].currentSpec - allocations[i].target
+			added := min(extraCapacity, remaining)
+			allocations[i].target += added
+			remaining -= added
+		}
+	}
+
+	targets := make(map[*nvidiacomv1beta1.DynamoComponentDeployment]int32, len(allocations))
+	for i := range allocations {
+		targets[allocations[i].dcd] = allocations[i].target
+	}
+	return targets
+}
+
 // scaleOldWorkerDCDs patches the replicas field on old worker DCDs during a rolling update.
-// When multiple old generations exist for the same component, replicas are distributed to the
-// newest old DCD first, with older DCDs drained to 0 (matching K8s Deployment controller behavior).
+// When multiple old generations exist for the same component, unavailable replicas are removed
+// before reducing old generations that are still serving traffic.
 func (r *DynamoGraphDeploymentReconciler) scaleOldWorkerDCDs(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
@@ -843,61 +908,41 @@ func (r *DynamoGraphDeploymentReconciler) scaleOldWorkerDCDs(
 		return fmt.Errorf("failed to list old worker DCDs: %w", err)
 	}
 
-	// Group old DCDs by logical component name.
-	dcdsByComponent := make(map[string][]*nvidiacomv1beta1.DynamoComponentDeployment)
 	for i := range oldDCDs {
-		componentName := dynamo.GetDCDComponentName(&oldDCDs[i])
-		dcdsByComponent[componentName] = append(dcdsByComponent[componentName], &oldDCDs[i])
-	}
-
-	for componentName, dcds := range dcdsByComponent {
-		oldNeeded, ok := rollingUpdateCtx.OldWorkerReplicas[componentName]
-		if !ok {
+		dcd := &oldDCDs[i]
+		componentName := dynamo.GetDCDComponentName(dcd)
+		if _, ok := rollingUpdateCtx.OldWorkerComponentReplicas[componentName]; !ok {
 			continue
 		}
 
-		// Sort by creation time descending (newest first) so newest old DCDs get replicas first
-		sort.Slice(dcds, func(i, j int) bool {
-			return dcds[i].CreationTimestamp.After(dcds[j].CreationTimestamp.Time)
-		})
-
-		remaining := oldNeeded
-		for _, dcd := range dcds {
-			var desiredReplicas int32
-			if remaining > 0 {
-				currentSpec := int32(1)
-				if dcd.Spec.Replicas != nil {
-					currentSpec = *dcd.Spec.Replicas
-				}
-				// Give this DCD up to its current spec count, but no more than remaining
-				desiredReplicas = min(remaining, currentSpec)
-				remaining -= desiredReplicas
-			}
-
-			currentReplicas := int32(1)
-			if dcd.Spec.Replicas != nil {
-				currentReplicas = *dcd.Spec.Replicas
-			}
-
-			if currentReplicas == desiredReplicas {
-				logger.V(1).Info("Old worker DCD replicas already at desired value",
-					"dcdName", dcd.Name, "replicas", desiredReplicas)
-				continue
-			}
-
-			patch := client.MergeFrom(dcd.DeepCopy())
-			dcd.Spec.Replicas = &desiredReplicas
-
-			if err := r.Patch(ctx, dcd, patch); err != nil {
-				return fmt.Errorf("failed to patch old worker DCD %s replicas: %w", dcd.Name, err)
-			}
-
-			logger.Info("Scaled old worker DCD",
-				"dcdName", dcd.Name,
-				"component", componentName,
-				"oldReplicas", currentReplicas,
-				"newReplicas", desiredReplicas)
+		desiredReplicas, ok := rollingUpdateCtx.OldWorkerDCDReplicas[dcd.Name]
+		if !ok {
+			return fmt.Errorf("missing old worker DCD replica target for %s", dcd.Name)
 		}
+
+		currentReplicas := int32(1)
+		if dcd.Spec.Replicas != nil {
+			currentReplicas = *dcd.Spec.Replicas
+		}
+
+		if currentReplicas == desiredReplicas {
+			logger.V(1).Info("Old worker DCD replicas already at desired value",
+				"dcdName", dcd.Name, "replicas", desiredReplicas)
+			continue
+		}
+
+		patch := client.MergeFrom(dcd.DeepCopy())
+		dcd.Spec.Replicas = &desiredReplicas
+
+		if err := r.Patch(ctx, dcd, patch); err != nil {
+			return fmt.Errorf("failed to patch old worker DCD %s replicas: %w", dcd.Name, err)
+		}
+
+		logger.Info("Scaled old worker DCD",
+			"dcdName", dcd.Name,
+			"component", componentName,
+			"oldReplicas", currentReplicas,
+			"newReplicas", desiredReplicas)
 	}
 
 	return nil
@@ -990,7 +1035,7 @@ func (r *DynamoGraphDeploymentReconciler) aggregateOldWorkerComponentStatuses(
 
 	for _, dcd := range oldDCDs {
 		componentName := dynamo.GetDCDComponentName(&dcd)
-		if _, inRollout := rollingUpdateCtx.OldWorkerReplicas[componentName]; !inRollout {
+		if _, inRollout := rollingUpdateCtx.OldWorkerComponentReplicas[componentName]; !inRollout {
 			continue
 		}
 		if dcd.Status.Component == nil {
@@ -1059,18 +1104,20 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 
 	if currentHashes.contains(newWorkerHash) {
 		return dynamo.RollingUpdateContext{
-			NewWorkerHash:     newWorkerHash,
-			OldWorkerReplicas: make(map[string]int32),
-			NewWorkerReplicas: make(map[string]int32),
+			NewWorkerHash:              newWorkerHash,
+			OldWorkerComponentReplicas: make(map[string]int32),
+			OldWorkerDCDReplicas:       make(map[string]int32),
+			NewWorkerReplicas:          make(map[string]int32),
 		}, nil
 	}
 
-	oldStates, err := r.getOldWorkerComponentStates(ctx, dgd, newWorkerHash)
+	oldDCDsByComponent, oldStates, err := r.getOldWorkerDCDsByComponent(ctx, dgd, newWorkerHash)
 	if err != nil {
 		return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get old worker component states: %w", err)
 	}
 
-	oldWorkerReplicas := make(map[string]int32)
+	oldWorkerComponentReplicas := make(map[string]int32)
+	oldWorkerDCDReplicas := make(map[string]int32)
 	newWorkerReplicas := make(map[string]int32)
 
 	for i := range dgd.Spec.Components {
@@ -1111,8 +1158,12 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		scaleUpBudget := max(int32(0), desired+maxSurge-oldState.Spec-newState.Spec)
 		newTarget := min(desired, newState.Spec+scaleUpBudget)
 
-		oldWorkerReplicas[componentName] = oldTarget
+		oldWorkerComponentReplicas[componentName] = oldTarget
 		newWorkerReplicas[componentName] = newTarget
+
+		for dcd, target := range allocateOldWorkerDCDReplicas(oldDCDsByComponent[componentName], oldTarget) {
+			oldWorkerDCDReplicas[dcd.Name] = target
+		}
 
 		logger.V(1).Info("Rolling update replica calculation",
 			"component", componentName,
@@ -1127,9 +1178,10 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 	}
 
 	return dynamo.RollingUpdateContext{
-		NewWorkerHash:     newWorkerHash,
-		OldWorkerReplicas: oldWorkerReplicas,
-		NewWorkerReplicas: newWorkerReplicas,
+		NewWorkerHash:              newWorkerHash,
+		OldWorkerComponentReplicas: oldWorkerComponentReplicas,
+		OldWorkerDCDReplicas:       oldWorkerDCDReplicas,
+		NewWorkerReplicas:          newWorkerReplicas,
 	}, nil
 }
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -942,11 +942,11 @@ func (r *DynamoGraphDeploymentReconciler) scaleOldWorkerDCDs(
 	for i := range oldDCDs {
 		dcd := &oldDCDs[i]
 		componentName := dynamo.GetDCDComponentName(dcd)
-		if _, ok := rollingUpdateCtx.OldWorkerComponentReplicas[componentName]; !ok {
+		if _, ok := rollingUpdateCtx.OldWorkerReplicaTargetsByComponent[componentName]; !ok {
 			continue
 		}
 
-		desiredReplicas, ok := rollingUpdateCtx.OldWorkerDCDReplicas[dcd.Name]
+		desiredReplicas, ok := rollingUpdateCtx.OldWorkerReplicaTargetsByDCD[dcd.Name]
 		if !ok {
 			return fmt.Errorf("missing old worker DCD replica target for %s", dcd.Name)
 		}
@@ -1066,7 +1066,7 @@ func (r *DynamoGraphDeploymentReconciler) aggregateOldWorkerComponentStatuses(
 
 	for _, dcd := range oldDCDs {
 		componentName := dynamo.GetDCDComponentName(&dcd)
-		if _, inRollout := rollingUpdateCtx.OldWorkerComponentReplicas[componentName]; !inRollout {
+		if _, inRollout := rollingUpdateCtx.OldWorkerReplicaTargetsByComponent[componentName]; !inRollout {
 			continue
 		}
 		if dcd.Status.Component == nil {
@@ -1135,10 +1135,10 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 
 	if currentHashes.contains(newWorkerHash) {
 		return dynamo.RollingUpdateContext{
-			NewWorkerHash:              newWorkerHash,
-			OldWorkerComponentReplicas: make(map[string]int32),
-			OldWorkerDCDReplicas:       make(map[string]int32),
-			NewWorkerReplicas:          make(map[string]int32),
+			NewWorkerHash:                      newWorkerHash,
+			OldWorkerReplicaTargetsByComponent: make(map[string]int32),
+			OldWorkerReplicaTargetsByDCD:       make(map[string]int32),
+			NewWorkerReplicaTargetsByComponent: make(map[string]int32),
 		}, nil
 	}
 
@@ -1209,10 +1209,10 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 	}
 
 	return dynamo.RollingUpdateContext{
-		NewWorkerHash:              newWorkerHash,
-		OldWorkerComponentReplicas: oldWorkerComponentReplicas,
-		OldWorkerDCDReplicas:       oldWorkerDCDReplicas,
-		NewWorkerReplicas:          newWorkerReplicas,
+		NewWorkerHash:                      newWorkerHash,
+		OldWorkerReplicaTargetsByComponent: oldWorkerComponentReplicas,
+		OldWorkerReplicaTargetsByDCD:       oldWorkerDCDReplicas,
+		NewWorkerReplicaTargetsByComponent: newWorkerReplicas,
 	}, nil
 }
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -1452,9 +1452,9 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     testNewWorkerHash,
-			OldWorkerReplicas: map[string]int32{"prefill": 1},
-			NewWorkerReplicas: map[string]int32{"prefill": 2},
+			NewWorkerHash:              testNewWorkerHash,
+			OldWorkerComponentReplicas: map[string]int32{"prefill": 1},
+			NewWorkerReplicas:          map[string]int32{"prefill": 2},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -1478,9 +1478,9 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     testNewWorkerHash,
-			OldWorkerReplicas: map[string]int32{"prefill": 1},
-			NewWorkerReplicas: map[string]int32{"prefill": 2},
+			NewWorkerHash:              testNewWorkerHash,
+			OldWorkerComponentReplicas: map[string]int32{"prefill": 1},
+			NewWorkerReplicas:          map[string]int32{"prefill": 2},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -2202,9 +2202,10 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     "newhash1",
-			OldWorkerReplicas: map[string]int32{"worker": 1},
-			NewWorkerReplicas: map[string]int32{"worker": 3},
+			NewWorkerHash:              "newhash1",
+			OldWorkerComponentReplicas: map[string]int32{"worker": 1},
+			OldWorkerDCDReplicas:       map[string]int32{"test-dgd-worker": 1},
+			NewWorkerReplicas:          map[string]int32{"worker": 3},
 		}
 
 		err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2225,11 +2226,12 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		r := createTestReconcilerWithStatus(dgd)
 		ctx := context.Background()
 
-		// Empty OldWorkerReplicas = not in progress
+		// Empty OldWorkerComponentReplicas = not in progress
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     "samehash",
-			OldWorkerReplicas: map[string]int32{},
-			NewWorkerReplicas: map[string]int32{},
+			NewWorkerHash:              "samehash",
+			OldWorkerComponentReplicas: map[string]int32{},
+			OldWorkerDCDReplicas:       map[string]int32{},
+			NewWorkerReplicas:          map[string]int32{},
 		}
 
 		err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2266,9 +2268,10 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     "newhash1",
-			OldWorkerReplicas: map[string]int32{"worker": 1},
-			NewWorkerReplicas: map[string]int32{"worker": 3},
+			NewWorkerHash:              "newhash1",
+			OldWorkerComponentReplicas: map[string]int32{"worker": 1},
+			OldWorkerDCDReplicas:       map[string]int32{"test-dgd-worker": 1},
+			NewWorkerReplicas:          map[string]int32{"worker": 3},
 		}
 
 		err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2322,9 +2325,9 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     "newhash1",
-			OldWorkerReplicas: map[string]int32{"worker": 2},
-			NewWorkerReplicas: map[string]int32{"worker": 3},
+			NewWorkerHash:              "newhash1",
+			OldWorkerComponentReplicas: map[string]int32{"worker": 2},
+			NewWorkerReplicas:          map[string]int32{"worker": 3},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -2347,9 +2350,9 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:     "newhash1",
-			OldWorkerReplicas: map[string]int32{"worker": 1},
-			NewWorkerReplicas: map[string]int32{"worker": 1},
+			NewWorkerHash:              "newhash1",
+			OldWorkerComponentReplicas: map[string]int32{"worker": 1},
+			NewWorkerReplicas:          map[string]int32{"worker": 1},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -2610,8 +2613,12 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 
 	// oldNeeded = 2: newest old (B) should get 2, oldest (A) should get 0
 	rollingUpdateCtx := dynamo.RollingUpdateContext{
-		NewWorkerHash:     "hashcccc",
-		OldWorkerReplicas: map[string]int32{"worker": 2},
+		NewWorkerHash:              "hashcccc",
+		OldWorkerComponentReplicas: map[string]int32{"worker": 2},
+		OldWorkerDCDReplicas: map[string]int32{
+			"test-dgd-worker-hashaaaa": 0,
+			"test-dgd-worker-hashbbbb": 2,
+		},
 		NewWorkerReplicas: map[string]int32{"worker": 4},
 	}
 
@@ -2629,6 +2636,97 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 	err = r.Get(ctx, types.NamespacedName{Name: "test-dgd-worker-hashaaaa", Namespace: "default"}, updatedA)
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), *updatedA.Spec.Replicas, "Oldest old DCD should be drained to 0")
+}
+
+func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Replicas:      ptr.To(int32(20)),
+		},
+	})
+
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-1 * 60 * 1e9)) // 1 minute earlier
+
+	// Generation A (oldest): healthy and serving the minAvailable budget.
+	genADCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-dgd-worker-hashaaaa",
+			Namespace:         "default",
+			CreationTimestamp: earlier,
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          "hashaaaa",
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+				Replicas:      ptr.To(int32(15)),
+			},
+		},
+		Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+			Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+				Replicas:          15,
+				AvailableReplicas: ptr.To(int32(15)),
+			},
+		},
+	})
+
+	// Generation B (newer old): spec consumes rollout budget but has no serving replicas.
+	genBDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-dgd-worker-hashbbbb",
+			Namespace:         "default",
+			CreationTimestamp: now,
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          "hashbbbb",
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+				Replicas:      ptr.To(int32(10)),
+			},
+		},
+		Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+			Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+				Replicas:          10,
+				AvailableReplicas: ptr.To(int32(0)),
+			},
+		},
+	})
+
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash: "hashbbbb",
+	}
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(genADCD, genBDCD))
+	ctx := context.Background()
+
+	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dgd)
+	require.NoError(t, err)
+	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerComponentReplicas["worker"])
+	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerDCDReplicas["test-dgd-worker-hashaaaa"])
+	assert.Equal(t, int32(0), rollingUpdateCtx.OldWorkerDCDReplicas["test-dgd-worker-hashbbbb"])
+	assert.Equal(t, int32(0), rollingUpdateCtx.NewWorkerReplicas["worker"])
+
+	err = r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
+	require.NoError(t, err)
+
+	updatedA := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{})
+	err = r.Get(ctx, types.NamespacedName{Name: "test-dgd-worker-hashaaaa", Namespace: "default"}, updatedA)
+	require.NoError(t, err)
+	assert.Equal(t, int32(15), *updatedA.Spec.Replicas, "Healthy old DCD should continue serving minAvailable")
+
+	updatedB := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{})
+	err = r.Get(ctx, types.NamespacedName{Name: "test-dgd-worker-hashbbbb", Namespace: "default"}, updatedB)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), *updatedB.Spec.Replicas, "Unavailable newer old DCD should be drained first")
 }
 
 func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) {
@@ -2697,9 +2795,9 @@ func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) 
 	ctx := context.Background()
 
 	rollingUpdateCtx := dynamo.RollingUpdateContext{
-		NewWorkerHash:     "hashcccc",
-		OldWorkerReplicas: map[string]int32{"worker": 3},
-		NewWorkerReplicas: map[string]int32{"worker": 4},
+		NewWorkerHash:              "hashcccc",
+		OldWorkerComponentReplicas: map[string]int32{"worker": 3},
+		NewWorkerReplicas:          map[string]int32{"worker": 4},
 	}
 
 	statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -3499,7 +3597,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 
 			assert.Equal(t, newHash, result.NewWorkerHash)
 			for svc, expectedOld := range tt.expectedOld {
-				assert.Equal(t, expectedOld, result.OldWorkerReplicas[svc],
+				assert.Equal(t, expectedOld, result.OldWorkerComponentReplicas[svc],
 					"old replicas for service %s", svc)
 			}
 			for svc, expectedNew := range tt.expectedNew {
@@ -3556,7 +3654,7 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 	assert.NoError(t, err, "IsNotFound on the new-hash DCD must not produce an error")
 	assert.Equal(t, newHash, result.NewWorkerHash)
 	// Math runs with newState={0,0,0}: drain old to minAvailable, surge new from zero.
-	assert.Equal(t, int32(8), result.OldWorkerReplicas["worker"])
+	assert.Equal(t, int32(8), result.OldWorkerComponentReplicas["worker"])
 	assert.Equal(t, int32(3), result.NewWorkerReplicas["worker"])
 }
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2669,63 +2669,39 @@ func TestAllocateOldWorkerDCDReplicas(t *testing.T) {
 		want      map[string]int32
 	}{
 		{
-			name:      "preserves healthy old DCD before unavailable newer old DCD",
+			name:      "overlapping update keeps healthy original and drops unavailable intermediate",
 			oldTarget: 15,
 			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
-				dcd("oldest-healthy", earlier, 15, 15),
-				dcd("newer-unavailable", now, 10, 0),
+				dcd("test-dgd-worker-hashaaaa", earlier, 15, 15),
+				dcd("test-dgd-worker-hashbbbb", now, 10, 0),
 			},
 			want: map[string]int32{
-				"oldest-healthy":    15,
-				"newer-unavailable": 0,
+				"test-dgd-worker-hashaaaa": 15,
+				"test-dgd-worker-hashbbbb": 0,
 			},
 		},
 		{
-			name:      "removes serving surplus oldest first",
-			oldTarget: 2,
+			name:      "available surplus removes replicas from oldest generation first",
+			oldTarget: 3,
 			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
-				dcd("oldest-healthy", earlier, 3, 3),
-				dcd("newer-healthy", now, 2, 2),
+				dcd("test-dgd-worker-hashaaaa", earlier, 3, 3),
+				dcd("test-dgd-worker-hashbbbb", now, 1, 1),
 			},
 			want: map[string]int32{
-				"oldest-healthy": 0,
-				"newer-healthy":  2,
+				"test-dgd-worker-hashaaaa": 2,
+				"test-dgd-worker-hashbbbb": 1,
 			},
 		},
 		{
-			name:      "adds unavailable capacity newest first when serving replicas are below target",
+			name:      "degraded original fills remaining target from newest old generation",
 			oldTarget: 15,
 			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
-				dcd("oldest-partially-available", earlier, 15, 12),
-				dcd("newer-unavailable", now, 10, 0),
+				dcd("test-dgd-worker-hashaaaa", earlier, 15, 12),
+				dcd("test-dgd-worker-hashbbbb", now, 10, 0),
 			},
 			want: map[string]int32{
-				"oldest-partially-available": 12,
-				"newer-unavailable":          3,
-			},
-		},
-		{
-			name:      "keeps serving targets when already at old target",
-			oldTarget: 2,
-			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
-				dcd("oldest-healthy", earlier, 2, 2),
-				dcd("newer-unavailable", now, 2, 0),
-			},
-			want: map[string]int32{
-				"oldest-healthy":    2,
-				"newer-unavailable": 0,
-			},
-		},
-		{
-			name:      "caps targets at total old DCD spec",
-			oldTarget: 5,
-			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
-				dcd("oldest-healthy", earlier, 1, 1),
-				dcd("newer-unavailable", now, 1, 0),
-			},
-			want: map[string]int32{
-				"oldest-healthy":    1,
-				"newer-unavailable": 1,
+				"test-dgd-worker-hashaaaa": 12,
+				"test-dgd-worker-hashbbbb": 3,
 			},
 		},
 	}

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2638,6 +2638,106 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 	assert.Equal(t, int32(0), *updatedA.Spec.Replicas, "Oldest old DCD should be drained to 0")
 }
 
+func TestAllocateOldWorkerDCDReplicas(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-1 * 60 * 1e9))
+
+	dcd := func(name string, createdAt metav1.Time, spec, available int32) *nvidiacomv1beta1.DynamoComponentDeployment {
+		return &nvidiacomv1beta1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: createdAt,
+			},
+			Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					Replicas: ptr.To(spec),
+				},
+			},
+			Status: nvidiacomv1beta1.DynamoComponentDeploymentStatus{
+				Component: &nvidiacomv1beta1.ComponentReplicaStatus{
+					Replicas:          spec,
+					AvailableReplicas: ptr.To(available),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		oldTarget int32
+		dcds      []*nvidiacomv1beta1.DynamoComponentDeployment
+		want      map[string]int32
+	}{
+		{
+			name:      "preserves healthy old DCD before unavailable newer old DCD",
+			oldTarget: 15,
+			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("oldest-healthy", earlier, 15, 15),
+				dcd("newer-unavailable", now, 10, 0),
+			},
+			want: map[string]int32{
+				"oldest-healthy":    15,
+				"newer-unavailable": 0,
+			},
+		},
+		{
+			name:      "removes serving surplus oldest first",
+			oldTarget: 2,
+			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("oldest-healthy", earlier, 3, 3),
+				dcd("newer-healthy", now, 2, 2),
+			},
+			want: map[string]int32{
+				"oldest-healthy": 0,
+				"newer-healthy":  2,
+			},
+		},
+		{
+			name:      "adds unavailable capacity newest first when serving replicas are below target",
+			oldTarget: 15,
+			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("oldest-partially-available", earlier, 15, 12),
+				dcd("newer-unavailable", now, 10, 0),
+			},
+			want: map[string]int32{
+				"oldest-partially-available": 12,
+				"newer-unavailable":          3,
+			},
+		},
+		{
+			name:      "keeps serving targets when already at old target",
+			oldTarget: 2,
+			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("oldest-healthy", earlier, 2, 2),
+				dcd("newer-unavailable", now, 2, 0),
+			},
+			want: map[string]int32{
+				"oldest-healthy":    2,
+				"newer-unavailable": 0,
+			},
+		},
+		{
+			name:      "caps targets at total old DCD spec",
+			oldTarget: 5,
+			dcds: []*nvidiacomv1beta1.DynamoComponentDeployment{
+				dcd("oldest-healthy", earlier, 1, 1),
+				dcd("newer-unavailable", now, 1, 0),
+			},
+			want: map[string]int32{
+				"oldest-healthy":    1,
+				"newer-unavailable": 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allocateOldWorkerDCDReplicas(tt.dcds, tt.oldTarget)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -1452,9 +1452,9 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              testNewWorkerHash,
-			OldWorkerComponentReplicas: map[string]int32{"prefill": 1},
-			NewWorkerReplicas:          map[string]int32{"prefill": 2},
+			NewWorkerHash:                      testNewWorkerHash,
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 1},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 2},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -1478,9 +1478,9 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              testNewWorkerHash,
-			OldWorkerComponentReplicas: map[string]int32{"prefill": 1},
-			NewWorkerReplicas:          map[string]int32{"prefill": 2},
+			NewWorkerHash:                      testNewWorkerHash,
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 1},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 2},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -2202,10 +2202,10 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              "newhash1",
-			OldWorkerComponentReplicas: map[string]int32{"worker": 1},
-			OldWorkerDCDReplicas:       map[string]int32{"test-dgd-worker": 1},
-			NewWorkerReplicas:          map[string]int32{"worker": 3},
+			NewWorkerHash:                      "newhash1",
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"worker": 1},
+			OldWorkerReplicaTargetsByDCD:       map[string]int32{"test-dgd-worker": 1},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"worker": 3},
 		}
 
 		err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2228,10 +2228,10 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 
 		// Empty OldWorkerComponentReplicas = not in progress
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              "samehash",
-			OldWorkerComponentReplicas: map[string]int32{},
-			OldWorkerDCDReplicas:       map[string]int32{},
-			NewWorkerReplicas:          map[string]int32{},
+			NewWorkerHash:                      "samehash",
+			OldWorkerReplicaTargetsByComponent: map[string]int32{},
+			OldWorkerReplicaTargetsByDCD:       map[string]int32{},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{},
 		}
 
 		err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2268,10 +2268,10 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              "newhash1",
-			OldWorkerComponentReplicas: map[string]int32{"worker": 1},
-			OldWorkerDCDReplicas:       map[string]int32{"test-dgd-worker": 1},
-			NewWorkerReplicas:          map[string]int32{"worker": 3},
+			NewWorkerHash:                      "newhash1",
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"worker": 1},
+			OldWorkerReplicaTargetsByDCD:       map[string]int32{"test-dgd-worker": 1},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"worker": 3},
 		}
 
 		err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2325,9 +2325,9 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              "newhash1",
-			OldWorkerComponentReplicas: map[string]int32{"worker": 2},
-			NewWorkerReplicas:          map[string]int32{"worker": 3},
+			NewWorkerHash:                      "newhash1",
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"worker": 2},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"worker": 3},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -2350,9 +2350,9 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
-			NewWorkerHash:              "newhash1",
-			OldWorkerComponentReplicas: map[string]int32{"worker": 1},
-			NewWorkerReplicas:          map[string]int32{"worker": 1},
+			NewWorkerHash:                      "newhash1",
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"worker": 1},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"worker": 1},
 		}
 
 		statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -2613,13 +2613,13 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 
 	// oldNeeded = 2: newest old (B) should get 2, oldest (A) should get 0
 	rollingUpdateCtx := dynamo.RollingUpdateContext{
-		NewWorkerHash:              "hashcccc",
-		OldWorkerComponentReplicas: map[string]int32{"worker": 2},
-		OldWorkerDCDReplicas: map[string]int32{
+		NewWorkerHash:                      "hashcccc",
+		OldWorkerReplicaTargetsByComponent: map[string]int32{"worker": 2},
+		OldWorkerReplicaTargetsByDCD: map[string]int32{
 			"test-dgd-worker-hashaaaa": 0,
 			"test-dgd-worker-hashbbbb": 2,
 		},
-		NewWorkerReplicas: map[string]int32{"worker": 4},
+		NewWorkerReplicaTargetsByComponent: map[string]int32{"worker": 4},
 	}
 
 	err := r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
@@ -2786,10 +2786,10 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerationsPreservesAvailableReplicas(t *
 
 	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dgd)
 	require.NoError(t, err)
-	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerComponentReplicas["worker"])
-	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerDCDReplicas["test-dgd-worker-hashaaaa"])
-	assert.Equal(t, int32(0), rollingUpdateCtx.OldWorkerDCDReplicas["test-dgd-worker-hashbbbb"])
-	assert.Equal(t, int32(0), rollingUpdateCtx.NewWorkerReplicas["worker"])
+	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerReplicaTargetsByComponent["worker"])
+	assert.Equal(t, int32(15), rollingUpdateCtx.OldWorkerReplicaTargetsByDCD["test-dgd-worker-hashaaaa"])
+	assert.Equal(t, int32(0), rollingUpdateCtx.OldWorkerReplicaTargetsByDCD["test-dgd-worker-hashbbbb"])
+	assert.Equal(t, int32(0), rollingUpdateCtx.NewWorkerReplicaTargetsByComponent["worker"])
 
 	err = r.scaleOldWorkerDCDs(ctx, dgd, rollingUpdateCtx)
 	require.NoError(t, err)
@@ -2871,9 +2871,9 @@ func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) 
 	ctx := context.Background()
 
 	rollingUpdateCtx := dynamo.RollingUpdateContext{
-		NewWorkerHash:              "hashcccc",
-		OldWorkerComponentReplicas: map[string]int32{"worker": 3},
-		NewWorkerReplicas:          map[string]int32{"worker": 4},
+		NewWorkerHash:                      "hashcccc",
+		OldWorkerReplicaTargetsByComponent: map[string]int32{"worker": 3},
+		NewWorkerReplicaTargetsByComponent: map[string]int32{"worker": 4},
 	}
 
 	statuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dgd, rollingUpdateCtx)
@@ -3673,11 +3673,11 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 
 			assert.Equal(t, newHash, result.NewWorkerHash)
 			for svc, expectedOld := range tt.expectedOld {
-				assert.Equal(t, expectedOld, result.OldWorkerComponentReplicas[svc],
+				assert.Equal(t, expectedOld, result.OldWorkerReplicaTargetsByComponent[svc],
 					"old replicas for service %s", svc)
 			}
 			for svc, expectedNew := range tt.expectedNew {
-				assert.Equal(t, expectedNew, result.NewWorkerReplicas[svc],
+				assert.Equal(t, expectedNew, result.NewWorkerReplicaTargetsByComponent[svc],
 					"new replicas for service %s", svc)
 			}
 		})
@@ -3730,8 +3730,8 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 	assert.NoError(t, err, "IsNotFound on the new-hash DCD must not produce an error")
 	assert.Equal(t, newHash, result.NewWorkerHash)
 	// Math runs with newState={0,0,0}: drain old to minAvailable, surge new from zero.
-	assert.Equal(t, int32(8), result.OldWorkerComponentReplicas["worker"])
-	assert.Equal(t, int32(3), result.NewWorkerReplicas["worker"])
+	assert.Equal(t, int32(8), result.OldWorkerReplicaTargetsByComponent["worker"])
+	assert.Equal(t, int32(3), result.NewWorkerReplicaTargetsByComponent["worker"])
 }
 
 func TestBuildRollingUpdateContext_ListOldDCDsError(t *testing.T) {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -262,16 +262,20 @@ func ParseDynDeploymentConfig(jsonContent []byte) (DynDeploymentConfig, error) {
 }
 
 func (r RollingUpdateContext) InProgress() bool {
-	return len(r.OldWorkerReplicas) > 0
+	return len(r.OldWorkerComponentReplicas) > 0
 }
 
 // RollingUpdateContext provides information about an in-progress rolling update.
 type RollingUpdateContext struct {
 	// NewWorkerHash is the short hash (8 chars) for the new worker spec, used for DCD naming
 	NewWorkerHash string
-	// OldWorkerReplicas maps service name to the desired replica count for old workers.
-	// Used by the controller to patch old worker DCDs directly.
-	OldWorkerReplicas map[string]int32
+	// OldWorkerComponentReplicas maps component name to the aggregate old-worker replica target.
+	// It preserves the component-level rollout decision used for rollout state and status aggregation.
+	OldWorkerComponentReplicas map[string]int32
+	// OldWorkerDCDReplicas maps old worker DCD name to the concrete replica target.
+	// It is derived from OldWorkerComponentReplicas after accounting for availability across old generations,
+	// and is used by the controller to patch each old worker DCD without recomputing allocation.
+	OldWorkerDCDReplicas map[string]int32
 	// NewWorkerReplicas maps service name to the desired replica count for new workers.
 	NewWorkerReplicas map[string]int32
 }

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -262,7 +262,7 @@ func ParseDynDeploymentConfig(jsonContent []byte) (DynDeploymentConfig, error) {
 }
 
 func (r RollingUpdateContext) InProgress() bool {
-	return len(r.OldWorkerComponentReplicas) > 0
+	return len(r.OldWorkerReplicaTargetsByComponent) > 0
 }
 
 // RollingUpdateContext provides information about an in-progress rolling update.
@@ -272,14 +272,14 @@ type RollingUpdateContext struct {
 
 	// Aggregate desired replica targets for old worker generations, keyed by logical component name.
 	// Example: worker -> 3 means all old DCDs for component "worker" should sum to 3 replicas.
-	OldWorkerComponentReplicas map[string]int32
+	OldWorkerReplicaTargetsByComponent map[string]int32
 
 	// Concrete desired replica targets for each old worker DCD, keyed by DCD object name.
 	// Example: dgd-worker-a -> 3, dgd-worker-b -> 0.
-	OldWorkerDCDReplicas map[string]int32
+	OldWorkerReplicaTargetsByDCD map[string]int32
 
 	// Desired replica targets for the new worker generation, keyed by logical component name.
-	NewWorkerReplicas map[string]int32
+	NewWorkerReplicaTargetsByComponent map[string]int32
 }
 
 // GenerateDynamoComponentsDeployments generates a map of DynamoComponentDeployments from a DynamoGraphConfig.
@@ -433,7 +433,7 @@ func generateSingleDCD(
 	}
 
 	// during a rolling update, the replica count is determined by the rollingUpdateCtx instead of the component spec
-	if newReplicas, ok := rollingUpdateCtx.NewWorkerReplicas[componentName]; rollingUpdateCtx.InProgress() && IsWorkerComponent(string(component.ComponentType)) && ok {
+	if newReplicas, ok := rollingUpdateCtx.NewWorkerReplicaTargetsByComponent[componentName]; rollingUpdateCtx.InProgress() && IsWorkerComponent(string(component.ComponentType)) && ok {
 		deployment.Spec.Replicas = ptr.To(newReplicas)
 	} else if component.Replicas != nil {
 		deployment.Spec.Replicas = component.Replicas

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -269,14 +269,16 @@ func (r RollingUpdateContext) InProgress() bool {
 type RollingUpdateContext struct {
 	// NewWorkerHash is the short hash (8 chars) for the new worker spec, used for DCD naming
 	NewWorkerHash string
-	// OldWorkerComponentReplicas maps component name to the aggregate old-worker replica target.
-	// It preserves the component-level rollout decision used for rollout state and status aggregation.
+
+	// Aggregate desired replica targets for old worker generations, keyed by logical component name.
+	// Example: worker -> 3 means all old DCDs for component "worker" should sum to 3 replicas.
 	OldWorkerComponentReplicas map[string]int32
-	// OldWorkerDCDReplicas maps old worker DCD name to the concrete replica target.
-	// It is derived from OldWorkerComponentReplicas after accounting for availability across old generations,
-	// and is used by the controller to patch each old worker DCD without recomputing allocation.
+
+	// Concrete desired replica targets for each old worker DCD, keyed by DCD object name.
+	// Example: dgd-worker-a -> 3, dgd-worker-b -> 0.
 	OldWorkerDCDReplicas map[string]int32
-	// NewWorkerReplicas maps service name to the desired replica count for new workers.
+
+	// Desired replica targets for the new worker generation, keyed by logical component name.
 	NewWorkerReplicas map[string]int32
 }
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -8102,7 +8102,7 @@ func TestIsWorkerComponent(t *testing.T) {
 func TestRollingUpdateContext_InProgress(t *testing.T) {
 	assert.False(t, RollingUpdateContext{}.InProgress())
 	assert.False(t, RollingUpdateContext{NewWorkerHash: "abc"}.InProgress())
-	assert.True(t, RollingUpdateContext{OldWorkerReplicas: map[string]int32{"w": 1}}.InProgress())
+	assert.True(t, RollingUpdateContext{OldWorkerComponentReplicas: map[string]int32{"w": 1}}.InProgress())
 }
 
 func TestGetDCDResourceName(t *testing.T) {
@@ -8204,9 +8204,9 @@ func TestGenerateSingleDCD_RollingUpdateContext(t *testing.T) {
 	}
 
 	ruCtx := RollingUpdateContext{
-		NewWorkerHash:     "aabb1122",
-		OldWorkerReplicas: map[string]int32{"prefill": 2},
-		NewWorkerReplicas: map[string]int32{"prefill": 2},
+		NewWorkerHash:              "aabb1122",
+		OldWorkerComponentReplicas: map[string]int32{"prefill": 2},
+		NewWorkerReplicas:          map[string]int32{"prefill": 2},
 	}
 
 	dcds, err := GenerateDynamoComponentsDeployments(betaDGD(t, dgd), &RestartState{}, nil, ruCtx)
@@ -8267,9 +8267,9 @@ func TestGenerateDynamoComponentsDeploymentsDoesNotMutateParentDGD(t *testing.T)
 		&RestartState{},
 		map[string]string{"prefill": "2026-05-12T13:00:00Z"},
 		RollingUpdateContext{
-			NewWorkerHash:     "aabb1122",
-			OldWorkerReplicas: map[string]int32{"prefill": 1},
-			NewWorkerReplicas: map[string]int32{"prefill": 2},
+			NewWorkerHash:              "aabb1122",
+			OldWorkerComponentReplicas: map[string]int32{"prefill": 1},
+			NewWorkerReplicas:          map[string]int32{"prefill": 2},
 		},
 	)
 	require.NoError(t, err)
@@ -8367,9 +8367,9 @@ func TestGenerateSingleDCD_RollingUpdateZeroReplicas(t *testing.T) {
 	}
 
 	ruCtx := RollingUpdateContext{
-		NewWorkerHash:     "aabb1122",
-		OldWorkerReplicas: map[string]int32{"decode": 3},
-		NewWorkerReplicas: map[string]int32{"decode": 0},
+		NewWorkerHash:              "aabb1122",
+		OldWorkerComponentReplicas: map[string]int32{"decode": 3},
+		NewWorkerReplicas:          map[string]int32{"decode": 0},
 	}
 
 	dcds, err := GenerateDynamoComponentsDeployments(betaDGD(t, dgd), &RestartState{}, nil, ruCtx)

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -8102,7 +8102,7 @@ func TestIsWorkerComponent(t *testing.T) {
 func TestRollingUpdateContext_InProgress(t *testing.T) {
 	assert.False(t, RollingUpdateContext{}.InProgress())
 	assert.False(t, RollingUpdateContext{NewWorkerHash: "abc"}.InProgress())
-	assert.True(t, RollingUpdateContext{OldWorkerComponentReplicas: map[string]int32{"w": 1}}.InProgress())
+	assert.True(t, RollingUpdateContext{OldWorkerReplicaTargetsByComponent: map[string]int32{"w": 1}}.InProgress())
 }
 
 func TestGetDCDResourceName(t *testing.T) {
@@ -8204,9 +8204,9 @@ func TestGenerateSingleDCD_RollingUpdateContext(t *testing.T) {
 	}
 
 	ruCtx := RollingUpdateContext{
-		NewWorkerHash:              "aabb1122",
-		OldWorkerComponentReplicas: map[string]int32{"prefill": 2},
-		NewWorkerReplicas:          map[string]int32{"prefill": 2},
+		NewWorkerHash:                      "aabb1122",
+		OldWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 2},
+		NewWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 2},
 	}
 
 	dcds, err := GenerateDynamoComponentsDeployments(betaDGD(t, dgd), &RestartState{}, nil, ruCtx)
@@ -8267,9 +8267,9 @@ func TestGenerateDynamoComponentsDeploymentsDoesNotMutateParentDGD(t *testing.T)
 		&RestartState{},
 		map[string]string{"prefill": "2026-05-12T13:00:00Z"},
 		RollingUpdateContext{
-			NewWorkerHash:              "aabb1122",
-			OldWorkerComponentReplicas: map[string]int32{"prefill": 1},
-			NewWorkerReplicas:          map[string]int32{"prefill": 2},
+			NewWorkerHash:                      "aabb1122",
+			OldWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 1},
+			NewWorkerReplicaTargetsByComponent: map[string]int32{"prefill": 2},
 		},
 	)
 	require.NoError(t, err)
@@ -8367,9 +8367,9 @@ func TestGenerateSingleDCD_RollingUpdateZeroReplicas(t *testing.T) {
 	}
 
 	ruCtx := RollingUpdateContext{
-		NewWorkerHash:              "aabb1122",
-		OldWorkerComponentReplicas: map[string]int32{"decode": 3},
-		NewWorkerReplicas:          map[string]int32{"decode": 0},
+		NewWorkerHash:                      "aabb1122",
+		OldWorkerReplicaTargetsByComponent: map[string]int32{"decode": 3},
+		NewWorkerReplicaTargetsByComponent: map[string]int32{"decode": 0},
 	}
 
 	dcds, err := GenerateDynamoComponentsDeployments(betaDGD(t, dgd), &RestartState{}, nil, ruCtx)


### PR DESCRIPTION
Linear: DEP-990

## Summary
This PR fixes an availability gap in overlapping worker rollouts.

When multiple old worker generations exist, an unavailable intermediate generation could still consume rollout budget. The operator could then scale down an older healthy generation and reduce total serving capacity below the intended `minAvailable` floor.

The rollout planner now treats old generations as a shared availability pool, matching how the Kubernetes Deployment controller handles multiple ReplicaSets during a rollout: preserve replicas that are currently serving traffic first, drain unavailable old-generation capacity before healthy capacity, and only reduce serving replicas when there is actual availability surplus.

## Repro / Behavior
- Fresh minikube + Helm platform install with a 3-replica CPU stub DGD reproduced the failure on the CI main operator image `dynamoci.azurecr.io/ai-dynamo/dynamo:5da7cda5440f289503e340714ee11aae10fcd126-operator`:
  - A original: `spec=2 available=2`
  - B intermediate unavailable: `spec=1 available=0`
  - C latest unavailable: `spec=1 available=0`
  - total available settled at `2` despite desired `3` and default `maxUnavailable=0`
- Same scenario with this PR's operator image preserved availability:
  - A original: `spec=3 available=3`
  - B intermediate unavailable: `spec=0 available=0`
  - C latest unavailable: `spec=1 available=0`
  - total available stayed at `3`

## Testing
- `go test ./internal/controller -run 'Test(AllocateOldWorkerDCDReplicas|.*RollingUpdate|ScaleOldWorkerDCDs|BuildRollingUpdateContext|AggregateOldWorkerServiceStatuses|ListOldWorkerDCDs)' -count=1`
- `go test ./internal/controller -run 'TestScaleOldWorkerDCDs_MultipleOldGenerations' -count=1`
- `go test ./internal/dynamo -count=1`
- `go test ./internal/controller -count=1` fails locally because envtest cannot find `../../bin/k8s/1.29.0-linux-amd64/etcd`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced rolling-update logic with granular per-deployment replica allocation for old worker components.

* **Bug Fixes**
  * Improved operator's old worker replica tracking and scaling precision during rolling updates, including better multi-generation handling while preserving available capacity.

* **Tests**
  * Added test coverage for replica allocation and multi-generation scaling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->