### PR TITLE
feat(kv-router): expose modeled prefill time reads

### DIFF
--- a/lib/kv-router/src/sequences/README.md
+++ b/lib/kv-router/src/sequences/README.md
@@ -72,10 +72,15 @@ This value is computed from admission-time prefill duration hints already stored
 then projected through `PromptRegistry` with the same advisory read semantics as token load.
 
 This read is not a routing input, protocol payload, metric, or authoritative engine timing signal.
-It returns signed milliseconds because negative values are meaningful: if the oldest active prefill
-has exceeded its singleton modeled duration, the negative spillover reduces later modeled backlog.
-That behavior is intentional because engines may batch or overlap multiple prefills faster than the
-per-request model represents.
+It returns non-negative milliseconds. Elapsed time from the oldest active prefill is applied to the
+aggregate modeled backlog, so spillover can reduce later modeled prefills before the final worker
+backlog clips at zero. That behavior is intentional because engines may batch or overlap multiple
+prefills faster than the per-request model represents.
+
+The active-token load view uses the same aggregate spillover only when all active prefills have
+modeled durations. If any active prefill lacks an expected duration, token load falls back to
+anchor-only decay so unmodeled no-AIC/default requests do not decay. A zero-duration anchor is treated
+as completing its own tokens immediately without inventing token spillover into later requests.
 
 When any active prefill for a worker lacks an expected duration, the modeled-time read returns
 `Err(MissingExpectedDuration)`. That is the normal default/no-AIC or prediction-failed state, and the

--- a/lib/kv-router/src/sequences/README.md
+++ b/lib/kv-router/src/sequences/README.md
@@ -64,3 +64,19 @@ So a stale or torn read can lead to a suboptimal routing choice, but it should n
 - The system accepts this lag because the read side is advisory.
 
 This is the core design: a strict local write DAG with an eventually consistent read projection.
+
+## Modeled remaining prefill time
+
+The slot tracker also exposes an internal derived read for modeled remaining prefill time per worker.
+This value is computed from admission-time prefill duration hints already stored in `ActiveSequences`,
+then projected through `PromptRegistry` with the same advisory read semantics as token load.
+
+This read is not a routing input, protocol payload, metric, or authoritative engine timing signal.
+It returns signed milliseconds because negative values are meaningful: if the oldest active prefill
+has exceeded its singleton modeled duration, the negative spillover reduces later modeled backlog.
+That behavior is intentional because engines may batch or overlap multiple prefills faster than the
+per-request model represents.
+
+When any active prefill for a worker lacks an expected duration, the modeled-time read returns
+`Err(MissingExpectedDuration)`. That is the normal default/no-AIC or prediction-failed state, and the
+tracker fast-returns from the derived snapshot without summing active prefills in that case.

--- a/lib/kv-router/src/sequences/README.md
+++ b/lib/kv-router/src/sequences/README.md
@@ -81,6 +81,14 @@ The active-token load view uses the same aggregate spillover only when all activ
 modeled durations. If any active prefill lacks an expected duration, token load falls back to
 anchor-only decay so unmodeled no-AIC/default requests do not decay. A zero-duration anchor is treated
 as completing its own tokens immediately without inventing token spillover into later requests.
+This token-load approximation assumes active modeled prefills have roughly uniform tokens/sec.
+
+If a modeled non-anchor prefill is removed before the anchor, the tracker credits that completed work
+by shifting the effective anchor forward by the removed request's modeled duration, capped at the
+removal time. This keeps completed non-anchor work from also counting as elapsed progress against the
+remaining modeled backlog. `Free` keeps its existing implicit prefill-completion cleanup behavior and
+applies the same credit when the prefill is still tracked. Replica-synced state remains advisory and
+receive-time anchored.
 
 When any active prefill for a worker lacks an expected duration, the modeled-time read returns
 `Err(MissingExpectedDuration)`. That is the normal default/no-AIC or prediction-failed state, and the

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -615,14 +615,13 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 
     /// Return modeled remaining prefill time by worker from the derived read model.
     ///
-    /// Values are signed milliseconds. For workers whose active prefills all have
-    /// modeled durations, the formula is:
-    /// `oldest_expected_ms - elapsed_since_oldest_anchor_ms + sum(non_oldest_expected_ms)`.
+    /// Values are non-negative milliseconds. For workers whose active prefills
+    /// all have modeled durations, the formula is:
+    /// `total_modeled_prefill_ms.saturating_sub(elapsed_since_oldest_anchor_ms)`.
     ///
-    /// The oldest term is intentionally not clipped at zero. Negative values are
-    /// advisory spillover for singleton predictions that have run past their
-    /// modeled duration; this allows elapsed time to reduce later modeled backlog
-    /// and accounts for engines that batch or overlap multiple prefills.
+    /// Elapsed time from the oldest active prefill can reduce later modeled
+    /// backlog, then the final worker backlog is clipped at zero. This accounts
+    /// for engines that batch or overlap multiple prefills.
     ///
     /// `Err(MissingExpectedDuration)` is expected for workers with any active
     /// prefill that lacks an AIC prediction, including the default no-AIC path or
@@ -1066,7 +1065,7 @@ mod tests {
     fn modeled_time_loads_by_worker(
         sequences: &ActiveSequencesMultiWorker<NoopSequencePublisher>,
         now: Instant,
-    ) -> HashMap<WorkerWithDpRank, Result<i64, PrefillTimeLoadError>> {
+    ) -> HashMap<WorkerWithDpRank, Result<u64, PrefillTimeLoadError>> {
         sequences
             .modeled_remaining_prefill_time_loads_at(now)
             .into_iter()

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -20,6 +20,7 @@ use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use super::PrefillTokenDeltas;
+use super::prefill_tracker::PrefillTimeLoad;
 #[cfg(any(test, feature = "bench"))]
 use super::prompt_membership_trie::lookup_live_hashes;
 use super::prompt_registry::{PromptRegistry, WorkerLoadSnapshot};
@@ -612,6 +613,38 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.prompt_registry.active_tokens(decay_now)
     }
 
+    /// Return modeled remaining prefill time by worker from the derived read model.
+    ///
+    /// Values are signed milliseconds. For workers whose active prefills all have
+    /// modeled durations, the formula is:
+    /// `oldest_expected_ms - elapsed_since_oldest_anchor_ms + sum(non_oldest_expected_ms)`.
+    ///
+    /// The oldest term is intentionally not clipped at zero. Negative values are
+    /// advisory spillover for singleton predictions that have run past their
+    /// modeled duration; this allows elapsed time to reduce later modeled backlog
+    /// and accounts for engines that batch or overlap multiple prefills.
+    ///
+    /// `Err(MissingExpectedDuration)` is expected for workers with any active
+    /// prefill that lacks an AIC prediction, including the default no-AIC path or
+    /// failed predictions. Replica-synced remote values are receive-time anchored
+    /// advisory reads, not producer-time truth.
+    #[allow(dead_code)]
+    pub(crate) fn modeled_remaining_prefill_time_loads_at(
+        &self,
+        now: Instant,
+    ) -> Vec<PrefillTimeLoad> {
+        self.prompt_registry
+            .modeled_remaining_prefill_times_ms(now)
+            .into_iter()
+            .map(
+                |(worker, modeled_remaining_prefill_time_ms)| PrefillTimeLoad {
+                    worker,
+                    modeled_remaining_prefill_time_ms,
+                },
+            )
+            .collect()
+    }
+
     /// Return true if any worker satisfies the provided predicate on active token count.
     pub fn any_worker_matches_active_tokens(
         &self,
@@ -928,6 +961,7 @@ mod tests {
         ActiveSequenceEvent, ActiveSequenceEventData, BlockHashOptions, PrefillLoadHint,
         compute_block_hash_for_seq, compute_seq_hash_for_block,
     };
+    use crate::sequences::prefill_tracker::PrefillTimeLoadError;
     use crate::test_utils::NoopSequencePublisher;
 
     fn make_sequences() -> ActiveSequencesMultiWorker<NoopSequencePublisher> {
@@ -1022,6 +1056,24 @@ mod tests {
         })
     }
 
+    fn modeled_hint(tokens: usize, duration_secs: u64) -> Option<PrefillLoadHint> {
+        Some(PrefillLoadHint {
+            initial_effective_prefill_tokens: tokens,
+            expected_prefill_duration: Some(Duration::from_secs(duration_secs)),
+        })
+    }
+
+    fn modeled_time_loads_by_worker(
+        sequences: &ActiveSequencesMultiWorker<NoopSequencePublisher>,
+        now: Instant,
+    ) -> HashMap<WorkerWithDpRank, Result<i64, PrefillTimeLoadError>> {
+        sequences
+            .modeled_remaining_prefill_time_loads_at(now)
+            .into_iter()
+            .map(|load| (load.worker, load.modeled_remaining_prefill_time_ms))
+            .collect()
+    }
+
     struct VecSubscriber {
         events: VecDeque<anyhow::Result<ActiveSequenceEvent>>,
     }
@@ -1058,6 +1110,75 @@ mod tests {
         assert_eq!(
             sequences.active_tokens(decay_now).get(&worker).copied(),
             Some(0)
+        );
+    }
+
+    #[test]
+    fn modeled_remaining_prefill_time_loads_follow_multi_worker_projection() {
+        let sequences = make_multi_sequences();
+        let worker_a = WorkerWithDpRank::new(1, 0);
+        let worker_b = WorkerWithDpRank::new(2, 0);
+        let start = Instant::now();
+        let a_oldest = "a-oldest".to_string();
+
+        sequences
+            .add_request(
+                SequenceRequest {
+                    request_id: a_oldest.clone(),
+                    token_sequence: Some(vec![1, 2, 3]),
+                    track_prefill_tokens: true,
+                    expected_output_tokens: None,
+                    prefill_load_hint: modeled_hint(100, 10),
+                    worker: worker_a,
+                    lora_name: None,
+                },
+                start,
+            )
+            .unwrap();
+        sequences
+            .add_request(
+                SequenceRequest {
+                    request_id: "a-later".to_string(),
+                    token_sequence: Some(vec![4, 5, 6]),
+                    track_prefill_tokens: true,
+                    expected_output_tokens: None,
+                    prefill_load_hint: modeled_hint(60, 4),
+                    worker: worker_a,
+                    lora_name: None,
+                },
+                start + Duration::from_secs(1),
+            )
+            .unwrap();
+        sequences
+            .add_request(
+                SequenceRequest {
+                    request_id: "b-unmodeled".to_string(),
+                    token_sequence: Some(vec![7, 8, 9]),
+                    track_prefill_tokens: true,
+                    expected_output_tokens: None,
+                    prefill_load_hint: tracking_hint(12),
+                    worker: worker_b,
+                    lora_name: None,
+                },
+                start,
+            )
+            .unwrap();
+
+        let query = start + Duration::from_secs(3);
+        let loads = modeled_time_loads_by_worker(&sequences, query);
+        assert_eq!(loads.get(&worker_a).copied(), Some(Ok(11_000)));
+        assert_eq!(
+            loads.get(&worker_b).copied(),
+            Some(Err(PrefillTimeLoadError::MissingExpectedDuration))
+        );
+
+        sequences.mark_prefill_completed(&a_oldest, query).unwrap();
+
+        let loads = modeled_time_loads_by_worker(&sequences, query + Duration::from_secs(2));
+        assert_eq!(loads.get(&worker_a).copied(), Some(Ok(2_000)));
+        assert_eq!(
+            loads.get(&worker_b).copied(),
+            Some(Err(PrefillTimeLoadError::MissingExpectedDuration))
         );
     }
 
@@ -1414,6 +1535,105 @@ mod tests {
         assert!(sequences.request_index.is_empty());
         assert!(sequences.prompt_registry.is_block_index_empty());
         assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_modeled_remaining_prefill_time_uses_receive_time_and_clears() {
+        let sequences = ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+        );
+        let worker = WorkerWithDpRank::new(1, 0);
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(ActiveSequenceEvent {
+                        request_id: "req-1".to_string(),
+                        worker,
+                        data: ActiveSequenceEventData::AddRequest {
+                            token_sequence: Some(vec![1, 2, 3]),
+                            track_prefill_tokens: true,
+                            expected_output_tokens: None,
+                            prefill_load_hint: modeled_hint(12, 10),
+                        },
+                        router_id: 99,
+                        lora_name: None,
+                    })]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let loads = modeled_time_loads_by_worker(&sequences, Instant::now());
+        assert_eq!(loads.get(&worker).copied(), Some(Ok(10_000)));
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(ActiveSequenceEvent {
+                        request_id: "req-1".to_string(),
+                        worker,
+                        data: ActiveSequenceEventData::MarkPrefillCompleted,
+                        router_id: 99,
+                        lora_name: None,
+                    })]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let loads = modeled_time_loads_by_worker(&sequences, Instant::now());
+        assert_eq!(loads.get(&worker).copied(), Some(Ok(0)));
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(ActiveSequenceEvent {
+                        request_id: "req-2".to_string(),
+                        worker,
+                        data: ActiveSequenceEventData::AddRequest {
+                            token_sequence: Some(vec![4, 5, 6]),
+                            track_prefill_tokens: true,
+                            expected_output_tokens: None,
+                            prefill_load_hint: modeled_hint(12, 6),
+                        },
+                        router_id: 99,
+                        lora_name: None,
+                    })]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let loads = modeled_time_loads_by_worker(&sequences, Instant::now());
+        assert_eq!(loads.get(&worker).copied(), Some(Ok(6_000)));
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(ActiveSequenceEvent {
+                        request_id: "req-2".to_string(),
+                        worker,
+                        data: ActiveSequenceEventData::Free,
+                        router_id: 99,
+                        lora_name: None,
+                    })]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let loads = modeled_time_loads_by_worker(&sequences, Instant::now());
+        assert_eq!(loads.get(&worker).copied(), Some(Ok(0)));
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -1182,6 +1182,74 @@ mod tests {
     }
 
     #[test]
+    fn free_nonanchor_modeled_prefill_applies_anchor_credit() {
+        let sequences = make_sequences();
+        let worker = WorkerWithDpRank::new(1, 0);
+        let start = Instant::now();
+        let later = "later".to_string();
+
+        sequences
+            .add_request(
+                SequenceRequest {
+                    request_id: "oldest".to_string(),
+                    token_sequence: Some(vec![1, 2, 3]),
+                    track_prefill_tokens: true,
+                    expected_output_tokens: None,
+                    prefill_load_hint: modeled_hint(100, 10),
+                    worker,
+                    lora_name: None,
+                },
+                start,
+            )
+            .unwrap();
+        sequences
+            .add_request(
+                SequenceRequest {
+                    request_id: later.clone(),
+                    token_sequence: Some(vec![4, 5, 6]),
+                    track_prefill_tokens: true,
+                    expected_output_tokens: None,
+                    prefill_load_hint: modeled_hint(40, 4),
+                    worker,
+                    lora_name: None,
+                },
+                start,
+            )
+            .unwrap();
+
+        let completion_time = start + Duration::from_secs(5);
+        assert_eq!(
+            sequences
+                .active_tokens(completion_time)
+                .get(&worker)
+                .copied(),
+            Some(90)
+        );
+        assert_eq!(
+            modeled_time_loads_by_worker(&sequences, completion_time)
+                .get(&worker)
+                .copied(),
+            Some(Ok(9_000))
+        );
+
+        sequences.free(&later, completion_time).unwrap();
+
+        assert_eq!(
+            sequences
+                .active_tokens(completion_time)
+                .get(&worker)
+                .copied(),
+            Some(90)
+        );
+        assert_eq!(
+            modeled_time_loads_by_worker(&sequences, completion_time)
+                .get(&worker)
+                .copied(),
+            Some(Ok(9_000))
+        );
+    }
+
+    #[test]
     fn block_membership_index_matches_naive_loads_with_output_blocks_and_prefill_updates() {
         let sequences = make_multi_sequences();
         let worker_a = WorkerWithDpRank::new(1, 0);
@@ -1633,6 +1701,87 @@ mod tests {
 
         let loads = modeled_time_loads_by_worker(&sequences, Instant::now());
         assert_eq!(loads.get(&worker).copied(), Some(Ok(0)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_nonanchor_free_applies_receive_time_anchor_credit() {
+        let sequences = ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+        );
+        let worker = WorkerWithDpRank::new(1, 0);
+        let later = "later".to_string();
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![
+                        Ok(ActiveSequenceEvent {
+                            request_id: "oldest".to_string(),
+                            worker,
+                            data: ActiveSequenceEventData::AddRequest {
+                                token_sequence: Some(vec![1, 2, 3]),
+                                track_prefill_tokens: true,
+                                expected_output_tokens: None,
+                                prefill_load_hint: modeled_hint(100, 10),
+                            },
+                            router_id: 99,
+                            lora_name: None,
+                        }),
+                        Ok(ActiveSequenceEvent {
+                            request_id: later.clone(),
+                            worker,
+                            data: ActiveSequenceEventData::AddRequest {
+                                token_sequence: Some(vec![4, 5, 6]),
+                                track_prefill_tokens: true,
+                                expected_output_tokens: None,
+                                prefill_load_hint: modeled_hint(40, 4),
+                            },
+                            router_id: 99,
+                            lora_name: None,
+                        }),
+                    ]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let completion_time = Instant::now();
+        assert_eq!(
+            modeled_time_loads_by_worker(&sequences, completion_time)
+                .get(&worker)
+                .copied(),
+            Some(Ok(9_000))
+        );
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(ActiveSequenceEvent {
+                        request_id: later,
+                        worker,
+                        data: ActiveSequenceEventData::Free,
+                        router_id: 99,
+                        lora_name: None,
+                    })]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            modeled_time_loads_by_worker(&sequences, completion_time)
+                .get(&worker)
+                .copied(),
+            Some(Ok(9_000))
+        );
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/sequences/prefill_tracker.rs
+++ b/lib/kv-router/src/sequences/prefill_tracker.rs
@@ -20,10 +20,12 @@ pub(super) struct PrefillLoadState {
 pub(super) struct AnchoredPrefillSnapshot {
     pub(super) initial_effective_prefill_tokens: usize,
     pub(super) expected_prefill_duration: Option<Duration>,
-    /// When the oldest active prefill became the decay anchor.
+    /// Effective decay anchor time for the oldest active prefill.
     ///
-    /// The elapsed time from this front request is applied to the aggregate
-    /// all-modeled backlog, allowing spillover into later prefills.
+    /// This usually starts as the router time when the request became oldest,
+    /// but it may be shifted forward when modeled non-anchor prefills complete
+    /// out of order. The elapsed time from this effective anchor is applied to
+    /// the aggregate all-modeled backlog.
     pub(super) anchored_since: Instant,
 }
 
@@ -201,10 +203,11 @@ pub(super) struct PrefillLoadTracker {
     pub(super) prefill_order: VecDeque<RequestId>,
     pub(super) prefill_full_tokens_sum: usize,
     pub(super) unmodeled_prefill_count: usize,
-    /// The front of `prefill_order` plus the local time it became front.
+    /// The front of `prefill_order` plus its effective decay anchor time.
     ///
-    /// This anchors both token decay and modeled-time decay. When the anchor is
-    /// removed, the next queued prefill is re-anchored at that removal time.
+    /// This anchors both token decay and modeled-time decay. It starts as the
+    /// local time the front request became oldest, may shift forward when a
+    /// modeled non-front prefill is removed, and is capped at that removal time.
     pub(super) anchored_prefill: Option<(RequestId, Instant)>,
 }
 
@@ -250,6 +253,9 @@ impl PrefillLoadTracker {
         } else {
             self.prefill_order
                 .retain(|queued_request_id| queued_request_id != request_id);
+            if let Some(expected_prefill_duration) = prefill.expected_prefill_duration {
+                self.shift_anchor_forward(expected_prefill_duration, decay_now);
+            }
         }
         if self
             .anchored_prefill
@@ -259,6 +265,16 @@ impl PrefillLoadTracker {
             self.set_anchor_to_front(decay_now);
         }
         Some(prefill)
+    }
+
+    fn shift_anchor_forward(&mut self, duration: Duration, max_anchor_time: Instant) {
+        let Some((_, anchored_since)) = self.anchored_prefill.as_mut() else {
+            return;
+        };
+        let shifted = anchored_since
+            .checked_add(duration)
+            .unwrap_or(max_anchor_time);
+        *anchored_since = shifted.min(max_anchor_time);
     }
 
     pub(super) fn set_anchor_to_front(&mut self, now: Instant) {
@@ -576,6 +592,119 @@ mod tests {
     }
 
     #[test]
+    fn nonfront_modeled_removal_preserves_time_and_token_continuity() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        let p1 = prefill_state(100, 10);
+        let p2 = prefill_state(40, 4);
+        tracker.insert(&r1, p1, epoch);
+        tracker.insert(&r2, p2, epoch);
+
+        let completion_time = epoch + Duration::from_secs(5);
+        let before = tracker.snapshot();
+        assert_eq!(before.active_tokens_at(completion_time), 90);
+        assert_eq!(
+            before.modeled_remaining_prefill_time_ms_at(completion_time),
+            Ok(9_000)
+        );
+
+        assert_eq!(tracker.remove(&r2, completion_time), Some(p2));
+
+        assert_eq!(tracker.prefill_order, VecDeque::from([r1.clone()]));
+        assert!(
+            tracker
+                .anchored_prefill
+                .as_ref()
+                .is_some_and(|(request_id, anchored_since)| {
+                    request_id == &r1 && *anchored_since == epoch + Duration::from_secs(4)
+                })
+        );
+
+        let after = tracker.snapshot();
+        assert_eq!(after.active_tokens_at(completion_time), 90);
+        assert_eq!(
+            after.modeled_remaining_prefill_time_ms_at(completion_time),
+            Ok(9_000)
+        );
+    }
+
+    #[test]
+    fn nonfront_modeled_removal_caps_anchor_shift_at_removal_time() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        let p1 = prefill_state(100, 10);
+        let p2 = prefill_state(40, 4);
+        tracker.insert(&r1, p1, epoch);
+        tracker.insert(&r2, p2, epoch);
+
+        let completion_time = epoch + Duration::from_secs(2);
+        assert_eq!(tracker.remove(&r2, completion_time), Some(p2));
+
+        assert!(
+            tracker
+                .anchored_prefill
+                .as_ref()
+                .is_some_and(|(request_id, anchored_since)| {
+                    request_id == &r1 && *anchored_since == completion_time
+                })
+        );
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(snapshot.active_tokens_at(completion_time), 100);
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(completion_time),
+            Ok(10_000)
+        );
+        assert_eq!(
+            snapshot.active_tokens_at(completion_time + Duration::from_secs(1)),
+            90
+        );
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(completion_time + Duration::from_secs(1)),
+            Ok(9_000)
+        );
+    }
+
+    #[test]
+    fn nonfront_unmodeled_removal_does_not_shift_anchor() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        let p1 = prefill_state(100, 10);
+        let p2 = unmodeled_prefill_state(40);
+        tracker.insert(&r1, p1, epoch);
+        tracker.insert(&r2, p2, epoch);
+
+        assert_eq!(
+            tracker.remove(&r2, epoch + Duration::from_secs(5)),
+            Some(p2)
+        );
+
+        assert!(
+            tracker
+                .anchored_prefill
+                .as_ref()
+                .is_some_and(|(request_id, anchored_since)| {
+                    request_id == &r1 && *anchored_since == epoch
+                })
+        );
+        assert_eq!(
+            tracker
+                .snapshot()
+                .active_tokens_at(epoch + Duration::from_secs(5)),
+            50
+        );
+    }
+
+    #[test]
     fn removing_anchored_prefill_reanchors_front_and_resets_decay() {
         let epoch = Instant::now();
         let mut tracker = PrefillLoadTracker::default();
@@ -616,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    fn removing_nonfront_prefill_preserves_existing_anchor() {
+    fn removing_nonfront_modeled_prefill_shifts_existing_anchor() {
         let epoch = Instant::now();
         let mut tracker = PrefillLoadTracker::default();
         let r1 = "r1".to_string();
@@ -638,13 +767,17 @@ mod tests {
                 .anchored_prefill
                 .as_ref()
                 .is_some_and(|(request_id, anchored_since)| {
-                    request_id == &r1 && *anchored_since == epoch
+                    request_id == &r1 && *anchored_since == epoch + Duration::from_secs(2)
                 })
         );
 
         let snapshot = tracker.snapshot();
         assert_eq!(
             snapshot.active_tokens_at(epoch + Duration::from_secs(2)),
+            30
+        );
+        assert_eq!(
+            snapshot.active_tokens_at(epoch + Duration::from_secs(4)),
             20
         );
     }

--- a/lib/kv-router/src/sequences/prefill_tracker.rs
+++ b/lib/kv-router/src/sequences/prefill_tracker.rs
@@ -20,6 +20,10 @@ pub(super) struct PrefillLoadState {
 pub(super) struct AnchoredPrefillSnapshot {
     pub(super) initial_effective_prefill_tokens: usize,
     pub(super) expected_prefill_duration: Option<Duration>,
+    /// When the oldest active prefill became the decay anchor.
+    ///
+    /// Only this front request decays with elapsed time; later active prefills
+    /// remain at full modeled load until they are promoted to the front.
     pub(super) anchored_since: Instant,
 }
 
@@ -168,6 +172,10 @@ pub(super) struct PrefillLoadTracker {
     pub(super) prefill_order: VecDeque<RequestId>,
     pub(super) prefill_full_tokens_sum: usize,
     pub(super) unmodeled_prefill_count: usize,
+    /// The front of `prefill_order` plus the local time it became front.
+    ///
+    /// This anchors both token decay and modeled-time decay. When the anchor is
+    /// removed, the next queued prefill is re-anchored at that removal time.
     pub(super) anchored_prefill: Option<(RequestId, Instant)>,
 }
 
@@ -240,6 +248,9 @@ impl PrefillLoadTracker {
         let modeled_non_anchored_prefill_time_ms = if self.unmodeled_prefill_count > 0 {
             None
         } else {
+            // TODO: This all-modeled path walks active prefills on snapshot refresh even if the
+            // modeled-time diagnostic read is never consumed. Consider moving this to an on-demand
+            // worker-slot read if snapshot-time O(active_prefills) work becomes undesirable.
             let sum = self
                 .prefill_order
                 .iter()

--- a/lib/kv-router/src/sequences/prefill_tracker.rs
+++ b/lib/kv-router/src/sequences/prefill_tracker.rs
@@ -22,8 +22,8 @@ pub(super) struct AnchoredPrefillSnapshot {
     pub(super) expected_prefill_duration: Option<Duration>,
     /// When the oldest active prefill became the decay anchor.
     ///
-    /// Only this front request decays with elapsed time; later active prefills
-    /// remain at full modeled load until they are promoted to the front.
+    /// The elapsed time from this front request is applied to the aggregate
+    /// all-modeled backlog, allowing spillover into later prefills.
     pub(super) anchored_since: Instant,
 }
 
@@ -35,14 +35,14 @@ pub(crate) enum PrefillTimeLoadError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PrefillTimeLoad {
     pub(crate) worker: WorkerWithDpRank,
-    pub(crate) modeled_remaining_prefill_time_ms: Result<i64, PrefillTimeLoadError>,
+    pub(crate) modeled_remaining_prefill_time_ms: Result<u64, PrefillTimeLoadError>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct PrefillLoadSnapshot {
     pub(super) prefill_full_tokens_sum: usize,
     pub(super) anchored_prefill: Option<AnchoredPrefillSnapshot>,
-    pub(super) modeled_non_anchored_prefill_time_ms: Option<i64>,
+    pub(super) total_modeled_prefill_time_ms: Option<u64>,
 }
 
 impl Default for PrefillLoadSnapshot {
@@ -50,7 +50,7 @@ impl Default for PrefillLoadSnapshot {
         Self {
             prefill_full_tokens_sum: 0,
             anchored_prefill: None,
-            modeled_non_anchored_prefill_time_ms: Some(0),
+            total_modeled_prefill_time_ms: Some(0),
         }
     }
 }
@@ -60,6 +60,25 @@ impl PrefillLoadSnapshot {
         let Some(anchored_prefill) = self.anchored_prefill else {
             return 0;
         };
+
+        if self.total_modeled_prefill_time_ms.is_none() {
+            return self.anchor_only_active_tokens_at(anchored_prefill, now);
+        }
+
+        let completed_tokens = completed_prefill_tokens(
+            anchored_prefill.initial_effective_prefill_tokens,
+            anchored_prefill.expected_prefill_duration,
+            now.saturating_duration_since(anchored_prefill.anchored_since),
+        );
+        self.prefill_full_tokens_sum
+            .saturating_sub(completed_tokens)
+    }
+
+    fn anchor_only_active_tokens_at(
+        &self,
+        anchored_prefill: AnchoredPrefillSnapshot,
+        now: Instant,
+    ) -> usize {
         let anchored_full = anchored_prefill.initial_effective_prefill_tokens;
         let anchored_remaining = match anchored_prefill.expected_prefill_duration {
             None => anchored_full,
@@ -79,15 +98,14 @@ impl PrefillLoadSnapshot {
             + anchored_remaining
     }
 
-    /// Return modeled remaining prefill time in signed milliseconds.
+    /// Return modeled remaining prefill time in non-negative milliseconds.
     ///
     /// Formula:
-    /// `oldest_expected_ms - elapsed_since_oldest_anchor_ms + sum(non_oldest_expected_ms)`.
+    /// `total_modeled_prefill_ms.saturating_sub(elapsed_since_oldest_anchor_ms)`.
     ///
-    /// The oldest term is intentionally not clipped at zero. Negative results are
-    /// advisory spillover: they represent that the front prefill has exceeded its
-    /// singleton model and allow elapsed time to reduce later modeled backlog,
-    /// acknowledging that engines may batch or overlap multiple prefills.
+    /// Elapsed time from the oldest active prefill is intentionally applied to the
+    /// aggregate modeled backlog, so work can spill past the front request and
+    /// reduce later modeled prefills. The final worker backlog is clipped at zero.
     ///
     /// `Err(MissingExpectedDuration)` means at least one active prefill was added
     /// without a modeled duration, which is expected when AIC is absent or
@@ -96,33 +114,44 @@ impl PrefillLoadSnapshot {
     pub(super) fn modeled_remaining_prefill_time_ms_at(
         &self,
         now: Instant,
-    ) -> Result<i64, PrefillTimeLoadError> {
-        let modeled_non_anchored_ms = self
-            .modeled_non_anchored_prefill_time_ms
+    ) -> Result<u64, PrefillTimeLoadError> {
+        let total_modeled_ms = self
+            .total_modeled_prefill_time_ms
             .ok_or(PrefillTimeLoadError::MissingExpectedDuration)?;
 
         let Some(anchored_prefill) = self.anchored_prefill else {
-            return Ok(modeled_non_anchored_ms);
+            return Ok(total_modeled_ms);
         };
 
-        let expected_prefill_duration = anchored_prefill
+        anchored_prefill
             .expected_prefill_duration
             .ok_or(PrefillTimeLoadError::MissingExpectedDuration)?;
-        let expected_ms = duration_millis_i128(expected_prefill_duration);
         let elapsed_ms =
-            duration_millis_i128(now.saturating_duration_since(anchored_prefill.anchored_since));
-        let remaining_ms = modeled_non_anchored_ms as i128 + expected_ms - elapsed_ms;
-        Ok(remaining_ms.clamp(i64::MIN as i128, i64::MAX as i128) as i64)
+            duration_millis_u64(now.saturating_duration_since(anchored_prefill.anchored_since));
+        Ok(total_modeled_ms.saturating_sub(elapsed_ms))
     }
 }
 
-fn duration_millis_i128(duration: Duration) -> i128 {
+fn duration_millis_u64(duration: Duration) -> u64 {
     let millis = duration.as_millis();
-    if millis > i128::MAX as u128 {
-        i128::MAX
-    } else {
-        millis as i128
+    millis.min(u64::MAX as u128) as u64
+}
+
+fn completed_prefill_tokens(
+    initial_effective_prefill_tokens: usize,
+    expected_prefill_duration: Option<Duration>,
+    elapsed: Duration,
+) -> usize {
+    let Some(expected_prefill_duration) = expected_prefill_duration else {
+        return 0;
+    };
+    if expected_prefill_duration.is_zero() {
+        return initial_effective_prefill_tokens;
     }
+
+    let completed = (initial_effective_prefill_tokens as u128).saturating_mul(elapsed.as_nanos())
+        / expected_prefill_duration.as_nanos();
+    completed.min(usize::MAX as u128) as usize
 }
 
 /// Per-worker prefill token deltas already projected by the scheduler.
@@ -241,11 +270,7 @@ impl PrefillLoadTracker {
     }
 
     pub(super) fn snapshot(&self) -> PrefillLoadSnapshot {
-        let anchored_request_id = self
-            .anchored_prefill
-            .as_ref()
-            .map(|(request_id, _)| request_id);
-        let modeled_non_anchored_prefill_time_ms = if self.unmodeled_prefill_count > 0 {
+        let total_modeled_prefill_time_ms = if self.unmodeled_prefill_count > 0 {
             None
         } else {
             // TODO: This all-modeled path walks active prefills on snapshot refresh even if the
@@ -254,20 +279,19 @@ impl PrefillLoadTracker {
             let sum = self
                 .prefill_order
                 .iter()
-                .filter(|request_id| Some(*request_id) != anchored_request_id)
                 .map(|request_id| {
                     let prefill = self
                         .prefills
                         .get(request_id)
                         .expect("prefill_order references missing request state");
-                    duration_millis_i128(
+                    duration_millis_u64(
                         prefill
                             .expected_prefill_duration
                             .expect("modeled snapshot saw unmodeled prefill after zero count"),
                     )
                 })
-                .fold(0_i128, |acc, millis| acc.saturating_add(millis));
-            Some(sum.clamp(i64::MIN as i128, i64::MAX as i128) as i64)
+                .fold(0_u64, |acc, millis| acc.saturating_add(millis));
+            Some(sum)
         };
 
         PrefillLoadSnapshot {
@@ -287,7 +311,7 @@ impl PrefillLoadTracker {
                         anchored_since: *anchored_since,
                     }
                 }),
-            modeled_non_anchored_prefill_time_ms,
+            total_modeled_prefill_time_ms,
         }
     }
 
@@ -425,7 +449,7 @@ mod tests {
     }
 
     #[test]
-    fn modeled_remaining_single_prefill_can_go_negative() {
+    fn modeled_remaining_single_prefill_clips_at_zero() {
         let epoch = Instant::now();
         let mut tracker = PrefillLoadTracker::default();
         let r1 = "r1".to_string();
@@ -435,12 +459,12 @@ mod tests {
         let snapshot = tracker.snapshot();
         assert_eq!(
             snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(15)),
-            Ok(-5_000)
+            Ok(0)
         );
     }
 
     #[test]
-    fn modeled_remaining_sums_oldest_signed_remaining_and_later_full_durations() {
+    fn modeled_remaining_subtracts_elapsed_from_total_modeled_duration() {
         let epoch = Instant::now();
         let mut tracker = PrefillLoadTracker::default();
         let r1 = "r1".to_string();
@@ -458,20 +482,34 @@ mod tests {
             snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(12)),
             Ok(4_000)
         );
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(17)),
+            Ok(0)
+        );
     }
 
     #[test]
-    fn modeled_remaining_zero_duration_anchor_spills_negative() {
+    fn modeled_remaining_zero_duration_prefill_contributes_no_time() {
         let epoch = Instant::now();
         let mut tracker = PrefillLoadTracker::default();
         let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
 
         tracker.insert(&r1, prefill_state_ms(100, 0), epoch);
+        tracker.insert(&r2, prefill_state(60, 6), epoch);
 
         let snapshot = tracker.snapshot();
         assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch),
+            Ok(6_000)
+        );
+        assert_eq!(
             snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(3)),
-            Ok(-3_000)
+            Ok(3_000)
+        );
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(7)),
+            Ok(0)
         );
     }
 
@@ -495,6 +533,45 @@ mod tests {
         assert_eq!(
             snapshot.active_tokens_at(epoch + Duration::from_secs(5)),
             110
+        );
+        assert_eq!(
+            snapshot.active_tokens_at(epoch + Duration::from_secs(12)),
+            40
+        );
+    }
+
+    #[test]
+    fn active_tokens_with_unmodeled_prefills_use_anchor_only_decay() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        tracker.insert(&r1, prefill_state(100, 10), epoch);
+        tracker.insert(&r2, unmodeled_prefill_state(60), epoch);
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(
+            snapshot.active_tokens_at(epoch + Duration::from_secs(12)),
+            60
+        );
+    }
+
+    #[test]
+    fn active_tokens_zero_duration_anchor_only_completes_anchor() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        tracker.insert(&r1, prefill_state_ms(100, 0), epoch);
+        tracker.insert(&r2, prefill_state(60, 6), epoch);
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(snapshot.active_tokens_at(epoch), 60);
+        assert_eq!(
+            snapshot.active_tokens_at(epoch + Duration::from_secs(3)),
+            60
         );
     }
 
@@ -568,7 +645,7 @@ mod tests {
         let snapshot = tracker.snapshot();
         assert_eq!(
             snapshot.active_tokens_at(epoch + Duration::from_secs(2)),
-            21
+            20
         );
     }
 

--- a/lib/kv-router/src/sequences/prefill_tracker.rs
+++ b/lib/kv-router/src/sequences/prefill_tracker.rs
@@ -23,10 +23,32 @@ pub(super) struct AnchoredPrefillSnapshot {
     pub(super) anchored_since: Instant,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrefillTimeLoadError {
+    MissingExpectedDuration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PrefillTimeLoad {
+    pub(crate) worker: WorkerWithDpRank,
+    pub(crate) modeled_remaining_prefill_time_ms: Result<i64, PrefillTimeLoadError>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct PrefillLoadSnapshot {
     pub(super) prefill_full_tokens_sum: usize,
     pub(super) anchored_prefill: Option<AnchoredPrefillSnapshot>,
+    pub(super) modeled_non_anchored_prefill_time_ms: Option<i64>,
+}
+
+impl Default for PrefillLoadSnapshot {
+    fn default() -> Self {
+        Self {
+            prefill_full_tokens_sum: 0,
+            anchored_prefill: None,
+            modeled_non_anchored_prefill_time_ms: Some(0),
+        }
+    }
 }
 
 impl PrefillLoadSnapshot {
@@ -51,6 +73,51 @@ impl PrefillLoadSnapshot {
             .checked_sub(anchored_full)
             .expect("prefill_full_tokens_sum smaller than anchored load")
             + anchored_remaining
+    }
+
+    /// Return modeled remaining prefill time in signed milliseconds.
+    ///
+    /// Formula:
+    /// `oldest_expected_ms - elapsed_since_oldest_anchor_ms + sum(non_oldest_expected_ms)`.
+    ///
+    /// The oldest term is intentionally not clipped at zero. Negative results are
+    /// advisory spillover: they represent that the front prefill has exceeded its
+    /// singleton model and allow elapsed time to reduce later modeled backlog,
+    /// acknowledging that engines may batch or overlap multiple prefills.
+    ///
+    /// `Err(MissingExpectedDuration)` means at least one active prefill was added
+    /// without a modeled duration, which is expected when AIC is absent or
+    /// prediction failed. In that case the snapshot was created via the fast path
+    /// and did not scan active prefills to sum modeled time.
+    pub(super) fn modeled_remaining_prefill_time_ms_at(
+        &self,
+        now: Instant,
+    ) -> Result<i64, PrefillTimeLoadError> {
+        let modeled_non_anchored_ms = self
+            .modeled_non_anchored_prefill_time_ms
+            .ok_or(PrefillTimeLoadError::MissingExpectedDuration)?;
+
+        let Some(anchored_prefill) = self.anchored_prefill else {
+            return Ok(modeled_non_anchored_ms);
+        };
+
+        let expected_prefill_duration = anchored_prefill
+            .expected_prefill_duration
+            .ok_or(PrefillTimeLoadError::MissingExpectedDuration)?;
+        let expected_ms = duration_millis_i128(expected_prefill_duration);
+        let elapsed_ms =
+            duration_millis_i128(now.saturating_duration_since(anchored_prefill.anchored_since));
+        let remaining_ms = modeled_non_anchored_ms as i128 + expected_ms - elapsed_ms;
+        Ok(remaining_ms.clamp(i64::MIN as i128, i64::MAX as i128) as i64)
+    }
+}
+
+fn duration_millis_i128(duration: Duration) -> i128 {
+    let millis = duration.as_millis();
+    if millis > i128::MAX as u128 {
+        i128::MAX
+    } else {
+        millis as i128
     }
 }
 
@@ -100,6 +167,7 @@ pub(super) struct PrefillLoadTracker {
     pub(super) prefills: HashMap<RequestId, PrefillLoadState>,
     pub(super) prefill_order: VecDeque<RequestId>,
     pub(super) prefill_full_tokens_sum: usize,
+    pub(super) unmodeled_prefill_count: usize,
     pub(super) anchored_prefill: Option<(RequestId, Instant)>,
 }
 
@@ -112,6 +180,9 @@ impl PrefillLoadTracker {
     ) {
         self.prefills.insert(request_id.clone(), prefill);
         self.prefill_full_tokens_sum += prefill.initial_effective_prefill_tokens;
+        if prefill.expected_prefill_duration.is_none() {
+            self.unmodeled_prefill_count += 1;
+        }
         let should_anchor = self.anchored_prefill.is_none();
         self.prefill_order.push_back(request_id.clone());
         if should_anchor {
@@ -129,6 +200,12 @@ impl PrefillLoadTracker {
             .prefill_full_tokens_sum
             .checked_sub(prefill.initial_effective_prefill_tokens)
             .expect("prefill_full_tokens_sum underflow");
+        if prefill.expected_prefill_duration.is_none() {
+            self.unmodeled_prefill_count = self
+                .unmodeled_prefill_count
+                .checked_sub(1)
+                .expect("unmodeled_prefill_count underflow");
+        }
         let removed_front = self.prefill_order.front() == Some(request_id);
         if removed_front {
             let removed = self.prefill_order.pop_front();
@@ -156,6 +233,32 @@ impl PrefillLoadTracker {
     }
 
     pub(super) fn snapshot(&self) -> PrefillLoadSnapshot {
+        let anchored_request_id = self
+            .anchored_prefill
+            .as_ref()
+            .map(|(request_id, _)| request_id);
+        let modeled_non_anchored_prefill_time_ms = if self.unmodeled_prefill_count > 0 {
+            None
+        } else {
+            let sum = self
+                .prefill_order
+                .iter()
+                .filter(|request_id| Some(*request_id) != anchored_request_id)
+                .map(|request_id| {
+                    let prefill = self
+                        .prefills
+                        .get(request_id)
+                        .expect("prefill_order references missing request state");
+                    duration_millis_i128(
+                        prefill
+                            .expected_prefill_duration
+                            .expect("modeled snapshot saw unmodeled prefill after zero count"),
+                    )
+                })
+                .fold(0_i128, |acc, millis| acc.saturating_add(millis));
+            Some(sum.clamp(i64::MIN as i128, i64::MAX as i128) as i64)
+        };
+
         PrefillLoadSnapshot {
             prefill_full_tokens_sum: self.prefill_full_tokens_sum,
             anchored_prefill: self
@@ -173,6 +276,7 @@ impl PrefillLoadTracker {
                         anchored_since: *anchored_since,
                     }
                 }),
+            modeled_non_anchored_prefill_time_ms,
         }
     }
 
@@ -187,6 +291,11 @@ impl PrefillLoadTracker {
             .values()
             .map(|prefill| prefill.initial_effective_prefill_tokens)
             .sum();
+        let recomputed_unmodeled_prefill_count = self
+            .prefills
+            .values()
+            .filter(|prefill| prefill.expected_prefill_duration.is_none())
+            .count();
 
         assert_eq!(
             ordered_prefills.len(),
@@ -200,6 +309,10 @@ impl PrefillLoadTracker {
         assert_eq!(
             self.prefill_full_tokens_sum, recomputed_prefill_sum,
             "prefill_full_tokens_sum drifted from tracker state",
+        );
+        assert_eq!(
+            self.unmodeled_prefill_count, recomputed_unmodeled_prefill_count,
+            "unmodeled_prefill_count drifted from tracker state",
         );
         if let Some(oldest_request_id) = self.prefill_order.front() {
             let Some((anchored_request_id, _)) = self.anchored_prefill.as_ref() else {
@@ -233,12 +346,122 @@ mod tests {
         }
     }
 
+    fn prefill_state_ms(tokens: usize, duration_ms: u64) -> PrefillLoadState {
+        PrefillLoadState {
+            initial_effective_prefill_tokens: tokens,
+            expected_prefill_duration: Some(Duration::from_millis(duration_ms)),
+        }
+    }
+
+    fn unmodeled_prefill_state(tokens: usize) -> PrefillLoadState {
+        PrefillLoadState {
+            initial_effective_prefill_tokens: tokens,
+            expected_prefill_duration: None,
+        }
+    }
+
     #[test]
     fn snapshot_without_anchor_reports_zero_active_tokens() {
         let tracker = PrefillLoadTracker::default();
         let snapshot = tracker.snapshot();
 
         assert_eq!(snapshot.active_tokens_at(Instant::now()), 0);
+    }
+
+    #[test]
+    fn modeled_remaining_snapshot_without_anchor_reports_zero() {
+        let tracker = PrefillLoadTracker::default();
+        let snapshot = tracker.snapshot();
+
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(Instant::now()),
+            Ok(0)
+        );
+    }
+
+    #[test]
+    fn modeled_remaining_no_aic_prefill_returns_missing_duration_error() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+
+        tracker.insert(&r1, unmodeled_prefill_state(100), epoch);
+        tracker.assert_consistent();
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch),
+            Err(PrefillTimeLoadError::MissingExpectedDuration)
+        );
+    }
+
+    #[test]
+    fn modeled_remaining_mixed_modeled_and_unmodeled_prefills_return_error() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        tracker.insert(&r1, prefill_state(100, 10), epoch);
+        tracker.insert(&r2, unmodeled_prefill_state(60), epoch);
+        tracker.assert_consistent();
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(2)),
+            Err(PrefillTimeLoadError::MissingExpectedDuration)
+        );
+    }
+
+    #[test]
+    fn modeled_remaining_single_prefill_can_go_negative() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+
+        tracker.insert(&r1, prefill_state(100, 10), epoch);
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(15)),
+            Ok(-5_000)
+        );
+    }
+
+    #[test]
+    fn modeled_remaining_sums_oldest_signed_remaining_and_later_full_durations() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
+
+        tracker.insert(&r1, prefill_state(100, 10), epoch);
+        tracker.insert(&r2, prefill_state(60, 6), epoch + Duration::from_secs(2));
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(2)),
+            Ok(14_000)
+        );
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(12)),
+            Ok(4_000)
+        );
+    }
+
+    #[test]
+    fn modeled_remaining_zero_duration_anchor_spills_negative() {
+        let epoch = Instant::now();
+        let mut tracker = PrefillLoadTracker::default();
+        let r1 = "r1".to_string();
+
+        tracker.insert(&r1, prefill_state_ms(100, 0), epoch);
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(3)),
+            Ok(-3_000)
+        );
     }
 
     #[test]
@@ -297,6 +520,10 @@ mod tests {
         assert_eq!(
             snapshot.active_tokens_at(epoch + Duration::from_secs(5)),
             30
+        );
+        assert_eq!(
+            snapshot.modeled_remaining_prefill_time_ms_at(epoch + Duration::from_secs(5)),
+            Ok(6_000)
         );
     }
 

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use tokio::time::Instant;
 
 use super::PrefillTokenDeltas;
-use super::prefill_tracker::PrefillLoadSnapshot;
+use super::prefill_tracker::{PrefillLoadSnapshot, PrefillTimeLoadError};
 use super::prompt_membership_trie::{PromptMembershipTrie, WorkerLookup};
 use super::single::PromptMembershipDelta;
 use super::topology::WorkerTopologyChange;
@@ -26,6 +26,13 @@ pub(super) struct WorkerLoadSnapshot {
 impl WorkerLoadSnapshot {
     pub(super) fn active_tokens(&self, decay_now: Instant) -> usize {
         self.prefill.active_tokens_at(decay_now)
+    }
+
+    pub(super) fn modeled_remaining_prefill_time_ms(
+        &self,
+        now: Instant,
+    ) -> Result<i64, PrefillTimeLoadError> {
+        self.prefill.modeled_remaining_prefill_time_ms_at(now)
     }
 }
 
@@ -160,6 +167,21 @@ impl PromptRegistry {
             .collect()
     }
 
+    pub(super) fn modeled_remaining_prefill_times_ms(
+        &self,
+        now: Instant,
+    ) -> HashMap<WorkerWithDpRank, Result<i64, PrefillTimeLoadError>> {
+        self.loads
+            .iter()
+            .map(|entry| {
+                (
+                    *entry.key(),
+                    entry.value().modeled_remaining_prefill_time_ms(now),
+                )
+            })
+            .collect()
+    }
+
     pub(super) fn any_worker_matches_active_tokens(
         &self,
         decay_now: Instant,
@@ -251,6 +273,7 @@ mod tests {
                     expected_prefill_duration,
                     anchored_since,
                 }),
+                modeled_non_anchored_prefill_time_ms: expected_prefill_duration.map(|_| 0),
             },
         }
     }

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -31,7 +31,7 @@ impl WorkerLoadSnapshot {
     pub(super) fn modeled_remaining_prefill_time_ms(
         &self,
         now: Instant,
-    ) -> Result<i64, PrefillTimeLoadError> {
+    ) -> Result<u64, PrefillTimeLoadError> {
         self.prefill.modeled_remaining_prefill_time_ms_at(now)
     }
 }
@@ -170,7 +170,7 @@ impl PromptRegistry {
     pub(super) fn modeled_remaining_prefill_times_ms(
         &self,
         now: Instant,
-    ) -> HashMap<WorkerWithDpRank, Result<i64, PrefillTimeLoadError>> {
+    ) -> HashMap<WorkerWithDpRank, Result<u64, PrefillTimeLoadError>> {
         self.loads
             .iter()
             .map(|entry| {
@@ -273,7 +273,8 @@ mod tests {
                     expected_prefill_duration,
                     anchored_since,
                 }),
-                modeled_non_anchored_prefill_time_ms: expected_prefill_duration.map(|_| 0),
+                total_modeled_prefill_time_ms: expected_prefill_duration
+                    .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64),
             },
         }
     }


### PR DESCRIPTION
Adds a Rust-internal slot-tracker read for modeled remaining prefill time from existing admission hints. Documents signed negative spillover semantics and keeps unmodeled/no-AIC workers on the fast error path.

## Benchmarks

Post-merge router sweep on commit `fa707453edb4` using the existing `benchmarks/router/prefix_ratio_benchmark.py` workload.

Setup:
- Model: `Qwen/Qwen3-32B`
- Hardware: 4x GB200, one vLLM worker per GPU, TP=1
- Router comparison: KV router vs. KV router + AIC prefill model
- Traffic: prefix ratios `0.1, 0.3, 0.5, 0.7, 0.9`, `200` requests per ratio, concurrency `64`, ISL `14000`, OSL `200`, `20` prefix prompts, expected OSL hints enabled
- Router flags: `--router-mode kv`, `--router-kv-overlap-score-credit 1.0`; vLLM KV events enabled
- AIC flags: `--router-prefill-load-model aic`, `--aic-backend vllm`, `--aic-system gb200_sxm`, `--aic-backend-version 0.14.0`, `--aic-model-path Qwen/Qwen3-32B`, `--aic-tp-size 1`
- Lifecycle: baseline and AIC variants used fresh engine/frontend launches; no service reuse between variants

![KV router vs KV router + AIC p50 TTFT prefix-ratio sweep](https://gist.githubusercontent.com/PeaBrane/cea2b562fb3897ce33ef75c62c30367c/raw/5eeeef52dafb4065adbb1f3e980432a47890a2c1/kv_vs_kv_aic_ttft.svg)

Results, p50 TTFT:

| Prefix ratio | KV router | KV router + AIC | Delta |
| ---: | ---: | ---: | ---: |
| 0.1 | 1141 ms | 1117 ms | -25 ms |
| 0.3 | 1100 ms | 1082 ms | -18 ms |
| 0.5 | 943 ms | 871 ms | -73 ms |
| 0.7 | 673 ms | 570 ms | -103 ms |
| 0.9 | 241 ms | 262 ms | +21 ms |

Median TTFT decreases with prefix ratio in the no-AIC baseline. AIC gives modest median wins through prefix ratio `0.7`, with a small regression at `0.9`; p75/p90 were noisy under this concurrency, so this run should not be read as a robust tail-latency win. All benchmark points completed with 200 requests and 0 request errors.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added modeled remaining prefill time diagnostic, providing per-worker projected prefill time consumption in signed milliseconds for improved load visibility.

* **Documentation**
  * Updated documentation on modeled remaining prefill time metric and its behavior.

* **Tests**
  * Enhanced test coverage for modeled prefill time projection and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
