### PR TITLE
chore(deps): bump vLLM to 0.22.0

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -777,6 +777,12 @@ class InstrumentedScheduler(AsyncScheduler):
                     block_ids=block_ids,
                     num_computed_tokens=ctx_len,
                     lora_request=None,
+                    # vLLM >=0.22's v2 GPU model runner requires `prefill_token_ids`
+                    # (asserted non-None in gpu/model_runner.add_requests, used as the
+                    # request's `all_token_ids`). vLLM's own scheduler passes
+                    # `req._all_token_ids` for new requests; mirror that here for the
+                    # synthetic decode requests we build directly. Older runners ignore it.
+                    prefill_token_ids=req._all_token_ids,
                 )
             )
             num_scheduled_tokens[req_id] = 1

--- a/components/src/dynamo/vllm/tests/test_vllm_api_contract.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_api_contract.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for the deep, *non-public* vLLM internals dynamo's vLLM backend
+relies on.
+
+The ``InstrumentedScheduler`` (self-benchmark mode, ``--benchmark-mode``) subclasses
+vLLM's V1 ``AsyncScheduler`` and constructs ``NewRequestData`` / ``SchedulerOutput``
+objects directly. vLLM even warns at runtime that this scheduler interface "is not
+public and compatibility may not be maintained." Because the coupling is to internal
+classes/fields rather than imports alone, a vLLM version bump can break a benchmark
+worker *at runtime* (e.g. an ``AssertionError`` deep in the GPU model runner) with no
+import or compile error — and only on GPU CI.
+
+These tests assert the contract up front so such breaks surface in fast unit CI.
+
+Concrete motivating break (vLLM 0.21 -> 0.22): vLLM added the now-required
+``NewRequestData.prefill_token_ids`` field — the v2 GPU model runner asserts it is not
+None and uses it as the request's ``all_token_ids``. ``InstrumentedScheduler``'s
+hand-built ``NewRequestData`` for synthetic decode requests had to start populating it
+(``_bench_inject_fake_decode``). The first test below guards exactly that field.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import inspect
+
+import pytest
+
+# Module-level vLLM import so the real site-packages ``vllm`` loads (matches the
+# pattern in test_vllm_instrumented_scheduler.py / test_vllm_unit.py).
+import vllm  # noqa: F401,E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_instrumented_scheduler_internal_imports_resolve():
+    """Every deep vLLM symbol ``instrumented_scheduler`` imports must still exist.
+
+    Catches vLLM renames/moves (the ImportError class of breakage) in unit CI.
+    """
+    required = {
+        "vllm.sampling_params": ["SamplingParams"],
+        "vllm.utils.hashing": ["get_hash_fn_by_name"],
+        "vllm.v1.core.kv_cache_utils": ["get_request_block_hasher", "init_none_hash"],
+        "vllm.v1.core.sched.async_scheduler": ["AsyncScheduler"],
+        "vllm.v1.core.sched.output": [
+            "CachedRequestData",
+            "NewRequestData",
+            "SchedulerOutput",
+        ],
+        "vllm.v1.request": ["Request", "RequestStatus"],
+    }
+    missing = []
+    for mod_name, symbols in required.items():
+        module = importlib.import_module(mod_name)
+        missing += [f"{mod_name}.{s}" for s in symbols if not hasattr(module, s)]
+    assert not missing, (
+        "vLLM internal symbols the InstrumentedScheduler imports are gone "
+        f"(likely a vLLM rename/move): {missing}"
+    )
+
+
+def test_new_request_data_has_fields_instrumented_scheduler_sets():
+    """``InstrumentedScheduler._bench_inject_fake_decode`` builds ``NewRequestData``
+    directly. Guard the fields it sets — notably ``prefill_token_ids``, which vLLM
+    >=0.22's v2 GPU model runner requires (asserted non-None, used as all_token_ids).
+    """
+    from vllm.v1.core.sched.output import NewRequestData
+
+    field_names = {f.name for f in dataclasses.fields(NewRequestData)}
+    needed = {
+        "req_id",
+        "prompt_token_ids",
+        "mm_features",
+        "sampling_params",
+        "pooling_params",
+        "block_ids",
+        "num_computed_tokens",
+        "lora_request",
+        "prefill_token_ids",
+    }
+    missing = needed - field_names
+    assert not missing, (
+        "vLLM NewRequestData no longer has fields InstrumentedScheduler sets "
+        f"{sorted(missing)} — update _bench_inject_fake_decode."
+    )
+
+
+def test_async_scheduler_has_methods_instrumented_scheduler_overrides():
+    """Guard the ``AsyncScheduler`` methods ``InstrumentedScheduler`` overrides /
+    calls via ``super()``."""
+    from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+
+    for method in (
+        "schedule",
+        "update_from_output",
+        "has_requests",
+        "shutdown",
+        "add_request",
+    ):
+        assert hasattr(AsyncScheduler, method), (
+            f"vLLM AsyncScheduler.{method} is gone — the InstrumentedScheduler "
+            "override/super() call is stale."
+        )
+
+
+def test_kv_cache_manager_has_methods_instrumented_scheduler_uses():
+    """Guard the ``KVCacheManager`` methods the InstrumentedScheduler calls through
+    ``self.kv_cache_manager`` while building synthetic benchmark batches."""
+    from vllm.v1.core.kv_cache_manager import KVCacheManager
+
+    for method in ("allocate_slots", "new_step_starts", "take_new_block_ids"):
+        assert hasattr(
+            KVCacheManager, method
+        ), f"vLLM KVCacheManager.{method} is gone — InstrumentedScheduler relies on it."
+
+
+def test_request_exposes_all_token_ids():
+    """``InstrumentedScheduler`` passes ``req._all_token_ids`` as
+    ``NewRequestData.prefill_token_ids`` (mirroring vLLM's own scheduler). Guard that
+    private attribute so a rename is caught here, not at runtime."""
+    from vllm.v1.request import Request
+
+    assert "_all_token_ids" in inspect.getsource(Request), (
+        "vllm.v1.request.Request no longer exposes `_all_token_ids` — "
+        "InstrumentedScheduler relies on it for NewRequestData.prefill_token_ids."
+    )

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -50,12 +50,12 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.06-cuda12.9-devel-ubuntu24.04
-    runtime_image_tag: v0.21.0-cu129-ubuntu2404
+    runtime_image_tag: v0.22.0-cu129-ubuntu2404
   cuda13.0:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.21.0-ubuntu2404
+    runtime_image_tag: v0.22.0-ubuntu2404
   xpu:
     base_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
     runtime_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
@@ -65,7 +65,7 @@ vllm:
     base_image: ubuntu
     runtime_image: vllm/vllm-openai-cpu
     base_image_tag: 22.04
-    runtime_image_tag: v0.21.0
+    runtime_image_tag: v0.22.0
   flashinf_ref: v0.6.8.post1
   vllm_omni_ref: "v0.21.0rc1"
   nixl_ref: v1.1.0

--- a/container/deps/vllm/protected_packages.txt
+++ b/container/deps/vllm/protected_packages.txt
@@ -10,8 +10,8 @@ triton
 vllm
 transformers
 tokenizers
-# vLLM-Omni 0.21.0rc1 requires safetensors>=0.8.0rc0, while the upstream
-# vLLM 0.21.0 image currently ships safetensors 0.7.0.
+# vLLM-Omni (v0.21.0rc1) may require a newer safetensors than the upstream
+# vLLM 0.22.0 image ships, so safetensors is intentionally left unfrozen here.
 # safetensors
 msgspec
 flashinfer-python

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -71,9 +71,12 @@ COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
 COPY --from=dynamo_base /bin/uv /bin/uvx /bin/
 
-# Create dynamo user with group 0 for OpenShift compatibility
+# Create dynamo user with group 0 for OpenShift compatibility.
+# Pin -u 1000 explicitly: the vllm/vllm-openai >=0.22 image ships a `vllm` user at
+# UID 2000, so after freeing 1000 (ubuntu) useradd would otherwise auto-assign the
+# next-highest UID (2001) and fail the `id -u dynamo` == 1000 assertion below.
 RUN userdel -r ubuntu > /dev/null 2>&1 || true \
-    && useradd -m -s /bin/bash -g 0 dynamo \
+    && useradd -u 1000 -m -s /bin/bash -g 0 dynamo \
     && [ `id -u dynamo` -eq 1000 ] \
     && mkdir -p /home/dynamo/.cache /opt/dynamo \
     && ln -sf /usr/bin/python3 /usr/local/bin/python \

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -631,14 +631,31 @@ impl OpenAIPreprocessor {
         builder.model(request.model());
 
         let mut stop_conditions = request.extract_stop_conditions()?;
+        // Harmony's `<|call|>` is BOTH the tool-call terminator the parser needs in the
+        // decoded text AND a gpt-oss EOS token. Hiding it like other EOS tokens strips the
+        // terminator before the harmony parser sees it, so tool calls are silently dropped
+        // (vLLM >=0.22 correctly stops on `<|call|>`, which is when this surfaces). Keep it
+        // visible — out of the hidden stop set — when the harmony tool-call parser is active.
+        // Generation still stops on it via the worker's own EOS; we only avoid *hiding* it.
+        let visible_eos: Vec<u32> = if matches!(self.tool_call_parser.as_deref(), Some("harmony")) {
+            dynamo_parsers::harmony_terminator_token_ids()
+        } else {
+            Vec::new()
+        };
         if let Some(stop_tokens) = &mut stop_conditions.stop_token_ids_hidden {
             for eos_token in self.model_info.eos_token_ids() {
-                if !stop_tokens.contains(&eos_token) {
+                if !visible_eos.contains(&eos_token) && !stop_tokens.contains(&eos_token) {
                     stop_tokens.push(eos_token);
                 }
             }
         } else {
-            stop_conditions.stop_token_ids_hidden = Some(self.model_info.eos_token_ids());
+            stop_conditions.stop_token_ids_hidden = Some(
+                self.model_info
+                    .eos_token_ids()
+                    .into_iter()
+                    .filter(|t| !visible_eos.contains(t))
+                    .collect(),
+            );
         }
 
         // apply ignore eos if not already set

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -117,6 +117,20 @@ fn harmony_call_token_ids() -> Option<&'static [u32]> {
     }
 }
 
+/// Token id(s) for the harmony `<|call|>` terminator.
+///
+/// `<|call|>` is simultaneously the harmony tool-call terminator the parser
+/// requires AND a gpt-oss EOS token. Pipelines that hide EOS tokens from the
+/// decoded output (e.g. the preprocessor's stop-condition handling) must keep
+/// these ids visible when the harmony tool-call parser is active — otherwise the
+/// terminator is stripped before the parser sees it and tool calls are silently
+/// dropped. Empty if the harmony encoding is unavailable.
+pub fn harmony_terminator_token_ids() -> Vec<u32> {
+    harmony_call_token_ids()
+        .map(|ids| ids.to_vec())
+        .unwrap_or_default()
+}
+
 fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
     !marker_ids.is_empty()
         && marker_ids.len() <= token_ids.len()

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -12,7 +12,7 @@ mod minimax_append_think_parser;
 // Re-export main types and functions for convenience
 pub use base_parser::BasicReasoningParser;
 pub use gemma4_parser::Gemma4ReasoningParser;
-pub use gpt_oss_parser::GptOssReasoningParser;
+pub use gpt_oss_parser::{GptOssReasoningParser, harmony_terminator_token_ids};
 pub use granite_parser::GraniteReasoningParser;
 pub use minimax_append_think_parser::MiniMaxAppendThinkParser;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]==1.1.0",
-    "vllm[flashinfer,runai,otel]==0.21.0",
+    "vllm[flashinfer,runai,otel]==0.22.0",
     # vllm-omni is not part of ai-dynamo[vllm]: container builds inherit the
     # framework stack from vllm/vllm-openai, and pip/uv dependency resolution
     # for omni can override the vLLM torch stack.


### PR DESCRIPTION
## Summary

Bumps Dynamo from vLLM **0.21.0 → 0.22.0** — repins the prebuilt `vllm/vllm-openai` runtime container (cu130/cu129/cpu) + the Python dep, plus the compatibility fixes the 0.22 base surfaced.

## Changes

**Version pins**
- `container/context.yaml`: `runtime_image_tag` → `v0.22.0-ubuntu2404` / `v0.22.0-cu129-ubuntu2404` / `v0.22.0`. `vllm_omni_ref` stays `v0.21.0rc1` (no 0.22 omni; rc2 is a GitHub tag, not on PyPI).
- `pyproject.toml`: `vllm[flashinfer,runai,otel]==0.22.0`.

**Fix 1 — container UID (`vllm_runtime.Dockerfile`)**
0.22 image ships a `vllm` user at UID 2000; after deleting `ubuntu`, bare `useradd dynamo` picks 2001 and fails the `id -u dynamo == 1000` assertion. Pinned `useradd -u 1000`.

**Fix 2 — gpt-oss harmony tool calling (`preprocessor.rs` + `lib/parsers`)**
vLLM 0.22 correctly stops on `<|call|>` (200012), a gpt-oss EOS token. dynamo hides all EOS tokens from the detokenized output (`stop_token_ids_hidden`), so the terminating `<|call|>` was stripped before the harmony parser saw it → tool calls silently dropped. Fix (decode layer, not the parser): when the harmony tool parser is active, keep `<|call|>` out of the hidden-EOS set so it survives detokenization. Generation still stops via the worker EOS. Gated to harmony; parser + parity fixtures unchanged.

**Fix 3 — self-benchmark scheduler (`instrumented_scheduler.py`) + API guard tests**
vLLM 0.22's v2 GPU model runner requires `NewRequestData.prefill_token_ids` (asserts non-None). dynamo's `InstrumentedScheduler` (`--benchmark-mode`) hand-builds `NewRequestData` for synthetic decode requests and didn't set it → benchmark worker crashed at startup (`AssertionError` in the model runner) → both `test_self_benchmark_{agg,disagg}_serves_after_bench` failed. Fix: pass `prefill_token_ids=req._all_token_ids` (mirroring vLLM's own scheduler). Added `tests/.../test_vllm_api_contract.py` to guard the non-public vLLM internals the InstrumentedScheduler couples to, so future bumps catch such breaks in unit CI.

## Validation (local, cu130 vLLM 0.22 dev image)
- ✅ `test_tool_calling` e2e (harmony) — correct call, no leak
- ✅ `test_self_benchmark_agg_serves_after_bench` (was crashing)
- ✅ 5 new vLLM API-contract tests; harmony (27) + gpt_oss (14) parser unit + zero-call aggregator
- ✅ 328 unit/component; serve 26/30 (4 fails = single-GPU resource + LoRA-needs-MinIO, not 0.22)
- ✅ `cargo fmt` + `clippy -D warnings`; pre-commit (black/isort/ruff/flake8) clean

## Notes
- Only **cu130** validated locally; cu129/cpu bumped, not run. disagg self-benchmark shares the agg fix (not runnable on a single local GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)