### PR TITLE
fix(parser): DeepSeek V3 incomplete tool call markup for batch.5.b and stream.4.c

### DIFF
--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1607,4 +1607,105 @@ mod tests {
             "finish_reason should pass through as Stop when no tool calls are emitted"
         );
     }
+
+    // TOOLCALLING.stream.4.c — recover complete bare inner calls without
+    // leaking protocol markup, matching DeepSeek V3.2/V4 behavior.
+
+    #[tokio::test]
+    async fn test_deepseek_v3_streaming_orphan_call_recovered() {
+        let chunks = vec![
+            make_chunk(
+                "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{\"location\": \"NYC\"}\n```\n<｜tool▁call▁end｜>\n<｜tool▁call▁end｜>\n<｜tool▁call▁end｜>",
+                None,
+            ),
+            make_chunk("", Some(FinishReason::Length)),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let output_chunks = parse_response_stream(
+            input_stream,
+            true,
+            false,
+            Some("deepseek_v3".to_string()),
+            None,
+        )
+        .await;
+
+        let aggregated = aggregate_content_from_chunks(&output_chunks);
+
+        assert!(
+            aggregated.has_tool_calls,
+            "Bare DeepSeek V3 inner call (no outer wrapper) should be recovered"
+        );
+        assert_eq!(aggregated.tool_calls.len(), 1);
+        assert_eq!(
+            aggregated.tool_calls[0]["function"]["name"].as_str(),
+            Some("get_weather")
+        );
+        let args: serde_json::Value = serde_json::from_str(
+            aggregated.tool_calls[0]["function"]["arguments"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(args["location"], "NYC");
+        assert!(
+            aggregated.normal_content.is_empty(),
+            "Orphan tool-call markup must not leak into normal_content. Got: {:?}",
+            aggregated.normal_content
+        );
+        assert!(
+            validate_finish_reason(&output_chunks, FinishReason::Length),
+            "finish_reason validation failed for recovered orphan DeepSeek V3 call"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deepseek_v3_1_streaming_orphan_call_recovered() {
+        let chunks = vec![
+            make_chunk(
+                "<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{\"location\":\"NYC\"}<｜tool▁call▁end｜><｜tool▁call▁end｜><｜tool▁call▁end｜>",
+                None,
+            ),
+            make_chunk("", Some(FinishReason::Length)),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let output_chunks = parse_response_stream(
+            input_stream,
+            true,
+            false,
+            Some("deepseek_v3_1".to_string()),
+            None,
+        )
+        .await;
+
+        let aggregated = aggregate_content_from_chunks(&output_chunks);
+
+        assert!(
+            aggregated.has_tool_calls,
+            "Bare DeepSeek V3.1 inner call (no outer wrapper) should be recovered"
+        );
+        assert_eq!(aggregated.tool_calls.len(), 1);
+        assert_eq!(
+            aggregated.tool_calls[0]["function"]["name"].as_str(),
+            Some("get_weather")
+        );
+        let args: serde_json::Value = serde_json::from_str(
+            aggregated.tool_calls[0]["function"]["arguments"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(args["location"], "NYC");
+        assert!(
+            aggregated.normal_content.is_empty(),
+            "Orphan tool-call markup must not leak into normal_content. Got: {:?}",
+            aggregated.normal_content
+        );
+        assert!(
+            validate_finish_reason(&output_chunks, FinishReason::Length),
+            "finish_reason validation failed for recovered orphan DeepSeek V3.1 call"
+        );
+    }
 }

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -2934,8 +2934,8 @@ mod detect_parser_tests {
     }
 
     // DeepSeek V3
-    #[test]
-    fn test_e2e_detect_incomplete_tool_call_start_deepseek_v3() {
+    #[test] // A bare inner call (no outer wrapper) is jailed so it can be recovered, matching deepseek_v3_2/v4.
+    fn test_e2e_detect_bare_tool_call_start_deepseek_v3() {
         let text = r#"<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_current_weather
 ```json
 {"location": "Tokyo"}
@@ -2955,8 +2955,8 @@ mod detect_parser_tests {
     }
 
     // DeepSeek V3.1
-    #[test]
-    fn test_e2e_detect_incomplete_tool_call_start_deepseek_v3_1() {
+    #[test] // A bare inner call (no outer wrapper) is jailed so it can be recovered, matching deepseek_v3_2/v4.
+    fn test_e2e_detect_bare_tool_call_start_deepseek_v3_1() {
         let text = r#"<｜tool▁call▁begin｜>get_current_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜>"#;
         let result = detect_tool_call_start(text, Some("deepseek_v3_1")).unwrap();
         assert!(result);


### PR DESCRIPTION
#### Overview:

This PR fixes DeepSeek V3 and DeepSeek V3.1 tool-call parsing for complete bare/orphan inner tool calls, covering `TOOLCALLING.batch.5.b` and `TOOLCALLING.stream.4.c`.

When the model emits a complete inner DeepSeek tool-call block without the outer `<｜tool▁calls▁begin｜>` wrapper, Dynamo now recovers the structured tool call instead of leaking protocol markup into `normal_text`. This aligns V3/V3.1 with the existing DeepSeek V3.2 / V4 behavior.

#### Details:

Before this fix, Dynamo preserved complete orphan inner tool-call markup as visible assistant text.

```text
calls=[]
normal_text='<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
```

After this fix, Dynamo recovers the complete bare inner call and keeps protocol markup out of `normal_text`.

```text
calls=[get_weather({"location": "NYC"})]
normal_text=''
```


#### Where should the reviewer start?
- `lib/parsers/src/tool_calling/json/deepseek_v3_parser.rs`
- `lib/parsers/src/tool_calling/json/deepseek_v3_1_parser.rs`
- `lib/parsers/src/tool_calling/parsers.rs`
- `lib/llm/tests/test_streaming_tool_parsers.rs`
- `tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.batch.5.yaml`
- `tests/parity/toolcalling/fixtures/deepseek_v3/TOOLCALLING.stream.4.yaml`
- `tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.batch.5.yaml`
- `tests/parity/toolcalling/fixtures/deepseek_v3_1/TOOLCALLING.stream.4.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool-call recovery for DeepSeek V3 and V3.1, handling cases where outer wrapper markers are absent.

* **Bug Fixes**
  * Improved detection and processing of incomplete tool-call markup in streaming scenarios.

* **Tests**
  * Added regression tests for streaming tool-call parsing and recovery.
  * Extended coverage for bare tool-call detection and validation.
  * Updated test fixtures to reflect refined parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->