### PR TITLE
feat(mocker): add TensorRT-LLM scheduler simulation [DYN-2664]

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -208,7 +208,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--block-size",
         type=int,
         default=None,
-        help="Token block size for KV cache blocks (default: 64)",
+        help="Token block size for KV cache blocks. When unset, the default "
+        "depends on engine: vLLM 64, SGLang 1, TRTLLM 32.",
     )
     parser.add_argument(
         "--max-num-seqs",
@@ -315,6 +316,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "(default: 0.88).",
     )
     parser.add_argument(
+        "--free-gpu-memory-fraction",
+        type=float,
+        default=None,
+        help="Fraction of free GPU memory (after model load) for the KV cache, "
+        "for AIC KV capacity estimation with TRT-LLM (default: 0.9).",
+    )
+    parser.add_argument(
         "--aic-system",
         type=str,
         default=None,
@@ -334,8 +342,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--aic-backend-version",
         type=str,
         default=None,
-        help="AIC backend engine version (e.g., '0.14.0' for vLLM, '0.5.6.post2' for SGLang). "
-        "If not set, uses the default version for the backend.",
+        help="AIC backend engine version (e.g., '0.19.0' for vLLM, '0.5.10' for SGLang, "
+        "'1.3.0rc10' for TRT-LLM). If not set, uses the default version for the backend.",
     )
     parser.add_argument(
         "--aic-tp-size",
@@ -388,8 +396,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--engine-type",
         type=str,
         default="vllm",
-        choices=["vllm", "sglang"],
-        help="Engine simulation type: 'vllm' (default) or 'sglang'.",
+        choices=["vllm", "sglang", "trtllm"],
+        help="Engine simulation type: 'vllm' (default), 'sglang', or 'trtllm'.",
     )
 
     # SGLang-specific configuration
@@ -429,6 +437,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=None,
         help="SGLang schedule conservativeness factor 0.0-1.0 (default: 1.0).",
+    )
+
+    # TensorRT-LLM-specific configuration
+    parser.add_argument(
+        "--trtllm-capacity-scheduler-policy",
+        type=str,
+        default=None,
+        choices=["guaranteed_no_evict"],
+        help="TRT-LLM capacity scheduler policy. v1 supports only "
+        "'guaranteed_no_evict' (default).",
     )
 
     # Legacy support - allow direct JSON file specification

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -12,7 +12,13 @@ from dynamo._internal.aic import (
     estimate_num_gpu_blocks,
 )
 from dynamo.common.utils.topology import apply_topology_config
-from dynamo.llm import MockEngineArgs, ModelRuntimeConfig, ReasoningConfig, SglangArgs
+from dynamo.llm import (
+    MockEngineArgs,
+    ModelRuntimeConfig,
+    ReasoningConfig,
+    SglangArgs,
+    TrtllmArgs,
+)
 
 _DEFAULT_NUM_GPU_BLOCKS = 16384
 _DEFAULT_MAX_NUM_SEQS = 256
@@ -20,6 +26,8 @@ _DEFAULT_MAX_NUM_BATCHED_TOKENS = 8192
 _DEFAULT_AIC_SYSTEM = "h200_sxm"
 _DEFAULT_VLLM_BLOCK_SIZE = 64
 _DEFAULT_SGLANG_BLOCK_SIZE = 1
+# Recent TRT-LLM PyTorch backend default tokens_per_block (older builds use 64).
+_DEFAULT_TRTLLM_BLOCK_SIZE = 32
 
 
 def _parse_reasoning_config(reasoning_json: str | None) -> ReasoningConfig | None:
@@ -50,6 +58,17 @@ def _build_sglang_args(args: argparse.Namespace) -> SglangArgs | None:
     return SglangArgs(**sglang_args)
 
 
+def _build_trtllm_args(args: argparse.Namespace) -> TrtllmArgs | None:
+    trtllm_args = {
+        "capacity_scheduler_policy": getattr(
+            args, "trtllm_capacity_scheduler_policy", None
+        ),
+    }
+    if not any(value is not None for value in trtllm_args.values()):
+        return None
+    return TrtllmArgs(**trtllm_args)
+
+
 def _resolve_block_size_for_capacity(
     engine_type: str,
     block_size: int | None,
@@ -61,6 +80,8 @@ def _resolve_block_size_for_capacity(
         if sglang_page_size is not None:
             return sglang_page_size
         return _DEFAULT_SGLANG_BLOCK_SIZE
+    if engine_type == "trtllm":
+        return _DEFAULT_TRTLLM_BLOCK_SIZE
     return _DEFAULT_VLLM_BLOCK_SIZE
 
 
@@ -79,6 +100,7 @@ def _estimate_aic_num_gpu_blocks(
     aic_attention_dp_size: int | None,
     gpu_memory_utilization: float | None,
     mem_fraction_static: float | None,
+    free_gpu_memory_fraction: float | None,
     sglang_page_size: int | None,
 ) -> int:
     if not aic_model_path:
@@ -110,6 +132,8 @@ def _estimate_aic_num_gpu_blocks(
             if mem_fraction_static is not None
             else DEFAULT_MEM_FRACTION_STATIC
         ),
+        # None -> aic.py applies the TRT-LLM default (0.9).
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
         backend_version=aic_backend_version,
         moe_tp_size=aic_moe_tp_size,
         moe_ep_size=aic_moe_ep_size,
@@ -133,6 +157,7 @@ def _resolve_num_gpu_blocks(
     aic_attention_dp_size: int | None,
     gpu_memory_utilization: float | None,
     mem_fraction_static: float | None,
+    free_gpu_memory_fraction: float | None,
     sglang_page_size: int | None,
 ) -> int:
     if explicit_num_gpu_blocks is not None:
@@ -153,6 +178,7 @@ def _resolve_num_gpu_blocks(
         aic_attention_dp_size=aic_attention_dp_size,
         gpu_memory_utilization=gpu_memory_utilization,
         mem_fraction_static=mem_fraction_static,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
         sglang_page_size=sglang_page_size,
     )
 
@@ -186,6 +212,7 @@ def _resolve_raw_engine_args(
         aic_attention_dp_size=raw.get("aic_attention_dp_size"),
         gpu_memory_utilization=raw.get("gpu_memory_utilization"),
         mem_fraction_static=raw.get("mem_fraction_static"),
+        free_gpu_memory_fraction=raw.get("free_gpu_memory_fraction"),
         sglang_page_size=sglang_page_size,
     )
     return raw
@@ -238,6 +265,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         aic_attention_dp_size=aic_attention_dp_size,
         gpu_memory_utilization=getattr(args, "gpu_memory_utilization", None),
         mem_fraction_static=getattr(args, "mem_fraction_static", None),
+        free_gpu_memory_fraction=getattr(args, "free_gpu_memory_fraction", None),
         sglang_page_size=getattr(args, "sglang_page_size", None),
     )
     return MockEngineArgs(
@@ -266,6 +294,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         aic_attention_dp_size=aic_attention_dp_size,
         gpu_memory_utilization=getattr(args, "gpu_memory_utilization", None),
         mem_fraction_static=getattr(args, "mem_fraction_static", None),
+        free_gpu_memory_fraction=getattr(args, "free_gpu_memory_fraction", None),
         enable_local_indexer=not getattr(args, "durable_kv_events", False),
         kv_bytes_per_token=getattr(args, "kv_bytes_per_token", None),
         kv_transfer_bandwidth=getattr(args, "kv_transfer_bandwidth", None),
@@ -281,6 +310,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         bandwidth_g4_to_g2_gbps=getattr(args, "bandwidth_g4_to_g2_gbps", None),
         reasoning=_parse_reasoning_config(getattr(args, "reasoning", None)),
         sglang=_build_sglang_args(args),
+        trtllm=_build_trtllm_args(args),
         preemption_mode=getattr(args, "preemption_mode", "lifo"),
     )
 

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -51,6 +51,7 @@ def make_args(**overrides):
         "sglang_chunked_prefill_size": None,
         "sglang_clip_max_new_tokens": None,
         "sglang_schedule_conservativeness": None,
+        "trtllm_capacity_scheduler_policy": None,
         "aic_perf_model": False,
         "aic_system": None,
         "aic_backend": None,
@@ -61,6 +62,7 @@ def make_args(**overrides):
         "aic_attention_dp_size": None,
         "gpu_memory_utilization": None,
         "mem_fraction_static": None,
+        "free_gpu_memory_fraction": None,
         "model_path": None,
         "is_prefill_worker": False,
         "is_decode_worker": False,
@@ -101,6 +103,53 @@ def test_load_mocker_engine_args_from_json_file_normalizes_page_size(tmp_path):
 
     assert engine_args.block_size == 32
     assert engine_args.num_gpu_blocks == 1024
+
+
+def test_build_mocker_engine_args_trtllm_defaults_block_size():
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(engine_type="trtllm", block_size=None)
+    )
+
+    # TRT-LLM PyTorch backend default tokens_per_block.
+    assert engine_args.block_size == 32
+
+
+def test_build_mocker_engine_args_trtllm_accepts_guaranteed_no_evict():
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(
+            engine_type="trtllm",
+            trtllm_capacity_scheduler_policy="guaranteed_no_evict",
+        )
+    )
+
+    assert engine_args.block_size == 32
+
+
+def test_build_mocker_engine_args_trtllm_rejects_unsupported_policy():
+    with pytest.raises(Exception, match="guaranteed_no_evict"):
+        CONFIG.build_mocker_engine_args(
+            make_args(
+                engine_type="trtllm",
+                trtllm_capacity_scheduler_policy="max_utilization",
+            )
+        )
+
+
+def test_load_mocker_engine_args_from_json_file_accepts_trtllm(tmp_path):
+    config_path = tmp_path / "engine_args.json"
+    config_path.write_text(
+        '{"engine_type":"trtllm",'
+        '"trtllm":{"capacity_scheduler_policy":"guaranteed_no_evict"},'
+        '"num_gpu_blocks":1024}'
+    )
+
+    engine_args = CONFIG.load_mocker_engine_args(
+        make_args(extra_engine_args=config_path)
+    )
+
+    assert engine_args.num_gpu_blocks == 1024
+    # block_size omitted from JSON -> normalized to the TRT-LLM default.
+    assert engine_args.block_size == 32
 
 
 def test_worker_overrides_drive_runtime_config_for_prefill_worker():
@@ -383,6 +432,7 @@ def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):
             "max_num_batched_tokens": 4096,
             "gpu_memory_utilization": 0.8,
             "mem_fraction_static": 0.7,
+            "free_gpu_memory_fraction": None,
             "backend_version": None,
             "moe_tp_size": None,
             "moe_ep_size": None,
@@ -414,6 +464,7 @@ def test_aic_capacity_estimation_preserves_explicit_zero_inputs(monkeypatch):
         aic_attention_dp_size=None,
         gpu_memory_utilization=0.0,
         mem_fraction_static=0.0,
+        free_gpu_memory_fraction=0.0,
         sglang_page_size=0,
     )
 

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -474,6 +474,7 @@ def test_aic_capacity_estimation_preserves_explicit_zero_inputs(monkeypatch):
     assert calls[0]["max_num_batched_tokens"] == 0
     assert calls[0]["gpu_memory_utilization"] == 0.0
     assert calls[0]["mem_fraction_static"] == 0.0
+    assert calls[0]["free_gpu_memory_fraction"] == 0.0
 
 
 def test_build_mocker_engine_args_estimates_sglang_blocks_with_static_fraction(

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -183,6 +183,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<llm::entrypoint::KvRouterConfig>()?;
     m.add_class::<llm::replay::ReasoningConfig>()?;
     m.add_class::<llm::replay::SglangArgs>()?;
+    m.add_class::<llm::replay::TrtllmArgs>()?;
     m.add_class::<llm::replay::MockEngineArgs>()?;
     #[cfg(feature = "aic-forward-pass")]
     {

--- a/lib/bindings/python/rust/llm/aic_callback.rs
+++ b/lib/bindings/python/rust/llm/aic_callback.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 use dynamo_kv_router::PrefillLoadEstimator;
 use dynamo_mocker::common::perf_model::AicCallback;
@@ -156,28 +157,27 @@ pub(super) fn estimate_aic_num_gpu_blocks(
     max_num_batched_tokens: usize,
     gpu_memory_utilization: f64,
     mem_fraction_static: Option<f64>,
+    free_gpu_memory_fraction: Option<f64>,
     backend_version: Option<&str>,
     moe_tp_size: Option<usize>,
     moe_ep_size: Option<usize>,
     attention_dp_size: Option<usize>,
 ) -> PyResult<usize> {
     let module = py.import("dynamo._internal.aic")?;
-    let blocks = module.call_method1(
-        "estimate_num_gpu_blocks",
-        (
-            backend_name,
-            system,
-            model_path,
-            tp_size,
-            block_size,
-            max_num_batched_tokens,
-            gpu_memory_utilization,
-            mem_fraction_static,
-            backend_version,
-            moe_tp_size,
-            moe_ep_size,
-            attention_dp_size,
-        ),
-    )?;
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("backend_name", backend_name)?;
+    kwargs.set_item("system", system)?;
+    kwargs.set_item("model_path", model_path)?;
+    kwargs.set_item("tp_size", tp_size)?;
+    kwargs.set_item("block_size", block_size)?;
+    kwargs.set_item("max_num_batched_tokens", max_num_batched_tokens)?;
+    kwargs.set_item("gpu_memory_utilization", gpu_memory_utilization)?;
+    kwargs.set_item("mem_fraction_static", mem_fraction_static)?;
+    kwargs.set_item("free_gpu_memory_fraction", free_gpu_memory_fraction)?;
+    kwargs.set_item("backend_version", backend_version)?;
+    kwargs.set_item("moe_tp_size", moe_tp_size)?;
+    kwargs.set_item("moe_ep_size", moe_ep_size)?;
+    kwargs.set_item("attention_dp_size", attention_dp_size)?;
+    let blocks = module.call_method("estimate_num_gpu_blocks", (), Some(&kwargs))?;
     blocks.extract()
 }

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -8,7 +8,7 @@ use dynamo_mocker::common::perf_model::PerfModel;
 use dynamo_mocker::common::protocols::{
     DirectRequest, EngineType as RsMockerEngineType, MockEngineArgs as RsMockEngineArgs,
     PreemptionMode as RsPreemptionMode, ReasoningConfig as RsReasoningConfig,
-    SglangArgs as RsSglangArgs, WorkerType as RsWorkerType,
+    SglangArgs as RsSglangArgs, TrtllmArgs as RsTrtllmArgs, WorkerType as RsWorkerType,
 };
 use dynamo_mocker::loadgen::{
     ArrivalSpec, DelaySpec, LengthSpec, SyntheticTraceSpec, Trace as RsTrace,
@@ -34,8 +34,9 @@ fn parse_mocker_engine_type(engine_type: &str) -> PyResult<RsMockerEngineType> {
     match engine_type {
         "vllm" => Ok(RsMockerEngineType::Vllm),
         "sglang" => Ok(RsMockerEngineType::Sglang),
+        "trtllm" => Ok(RsMockerEngineType::Trtllm),
         other => Err(PyException::new_err(format!(
-            "engine_type must be either 'vllm' or 'sglang', got '{other}'"
+            "engine_type must be one of 'vllm', 'sglang', or 'trtllm', got '{other}'"
         ))),
     }
 }
@@ -128,6 +129,30 @@ impl SglangArgs {
 
 #[pyclass]
 #[derive(Clone, Debug, Default)]
+pub struct TrtllmArgs {
+    inner: RsTrtllmArgs,
+}
+
+impl TrtllmArgs {
+    pub fn inner(&self) -> RsTrtllmArgs {
+        self.inner.clone()
+    }
+}
+
+#[pymethods]
+impl TrtllmArgs {
+    #[new]
+    #[pyo3(signature = (capacity_scheduler_policy=None))]
+    fn new(capacity_scheduler_policy: Option<String>) -> PyResult<Self> {
+        let inner = RsTrtllmArgs {
+            capacity_scheduler_policy,
+        };
+        Ok(Self { inner })
+    }
+}
+
+#[pyclass]
+#[derive(Clone, Debug, Default)]
 pub struct MockEngineArgs {
     inner: RsMockEngineArgs,
     num_gpu_blocks_explicit: bool,
@@ -146,7 +171,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -174,6 +199,7 @@ impl MockEngineArgs {
         aic_nextn_accept_rates: Option<String>,
         gpu_memory_utilization: Option<f64>,
         mem_fraction_static: Option<f64>,
+        free_gpu_memory_fraction: Option<f64>,
         enable_local_indexer: bool,
         bootstrap_port: Option<u16>,
         kv_bytes_per_token: Option<usize>,
@@ -184,6 +210,7 @@ impl MockEngineArgs {
         preemption_mode: &str,
         router_queue_policy: Option<&str>,
         sglang: Option<SglangArgs>,
+        trtllm: Option<TrtllmArgs>,
         num_g2_blocks: Option<usize>,
         num_g3_blocks: Option<usize>,
         offload_batch_size: Option<usize>,
@@ -231,6 +258,7 @@ impl MockEngineArgs {
             .aic_nextn_accept_rates(aic_nextn_accept_rates)
             .gpu_memory_utilization(gpu_memory_utilization)
             .mem_fraction_static(mem_fraction_static)
+            .free_gpu_memory_fraction(free_gpu_memory_fraction)
             .enable_local_indexer(enable_local_indexer)
             .bootstrap_port(bootstrap_port)
             .kv_bytes_per_token(kv_bytes_per_token)
@@ -250,7 +278,8 @@ impl MockEngineArgs {
             .zmq_replay_port(zmq_replay_port)
             .preemption_mode(preemption_mode)
             .router_queue_policy(router_queue_policy)
-            .sglang(sglang.map(|config| config.inner()));
+            .sglang(sglang.map(|config| config.inner()))
+            .trtllm(trtllm.map(|config| config.inner()));
         let num_gpu_blocks_explicit = num_gpu_blocks.is_some();
         if let Some(num_gpu_blocks) = num_gpu_blocks {
             builder = builder.num_gpu_blocks(num_gpu_blocks);
@@ -542,6 +571,24 @@ impl MockEngineArgs {
     }
 
     #[getter]
+    fn free_gpu_memory_fraction(&self) -> Option<f64> {
+        self.inner.free_gpu_memory_fraction
+    }
+
+    #[setter]
+    fn set_free_gpu_memory_fraction(&mut self, value: Option<f64>) -> PyResult<()> {
+        if let Some(value) = value
+            && !(0.0..=1.0).contains(&value)
+        {
+            return Err(PyValueError::new_err(format!(
+                "free_gpu_memory_fraction must be in [0, 1], got {value}"
+            )));
+        }
+        self.inner.free_gpu_memory_fraction = value;
+        Ok(())
+    }
+
+    #[getter]
     fn worker_type(&self) -> &'static str {
         match self.inner.worker_type {
             RsWorkerType::Aggregated => "aggregated",
@@ -571,7 +618,7 @@ impl MockEngineArgs {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (bootstrap_port=None, zmq_kv_events_port=None, zmq_replay_port=None, kv_bytes_per_token=None, num_gpu_blocks=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, enable_prefix_caching=None, worker_type=None))]
+    #[pyo3(signature = (bootstrap_port=None, zmq_kv_events_port=None, zmq_replay_port=None, kv_bytes_per_token=None, num_gpu_blocks=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_prefix_caching=None, worker_type=None))]
     fn with_overrides(
         &self,
         bootstrap_port: Option<u16>,
@@ -591,6 +638,7 @@ impl MockEngineArgs {
         aic_nextn_accept_rates: Option<String>,
         gpu_memory_utilization: Option<f64>,
         mem_fraction_static: Option<f64>,
+        free_gpu_memory_fraction: Option<f64>,
         enable_prefix_caching: Option<bool>,
         worker_type: Option<String>,
     ) -> PyResult<Self> {
@@ -647,6 +695,9 @@ impl MockEngineArgs {
         }
         if let Some(mem_fraction_static) = mem_fraction_static {
             inner.mem_fraction_static = Some(mem_fraction_static);
+        }
+        if let Some(free_gpu_memory_fraction) = free_gpu_memory_fraction {
+            inner.free_gpu_memory_fraction = Some(free_gpu_memory_fraction);
         }
         if let Some(enable_prefix_caching) = enable_prefix_caching {
             inner.enable_prefix_caching = enable_prefix_caching;

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1271,6 +1271,7 @@ fn materialize_replay_mocker_args(
                     .unwrap_or(DEFAULT_GPU_MEMORY_UTILIZATION),
                 args.mem_fraction_static
                     .or(Some(DEFAULT_MEM_FRACTION_STATIC)),
+                args.free_gpu_memory_fraction,
                 backend_version.as_deref(),
                 moe_tp_size,
                 moe_ep_size,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1790,6 +1790,13 @@ class SglangArgs:
     ) -> None:
         ...
 
+class TrtllmArgs:
+    def __init__(
+        self,
+        capacity_scheduler_policy: Optional[str] = None,
+    ) -> None:
+        ...
+
 class MockEngineArgs:
     def __init__(
         self,
@@ -1818,6 +1825,7 @@ class MockEngineArgs:
         aic_nextn_accept_rates: Optional[str] = None,
         gpu_memory_utilization: Optional[float] = None,
         mem_fraction_static: Optional[float] = None,
+        free_gpu_memory_fraction: Optional[float] = None,
         enable_local_indexer: bool = False,
         bootstrap_port: Optional[int] = None,
         kv_bytes_per_token: Optional[int] = None,
@@ -1828,6 +1836,7 @@ class MockEngineArgs:
         preemption_mode: str = "lifo",
         router_queue_policy: Optional[str] = None,
         sglang: Optional[SglangArgs] = None,
+        trtllm: Optional[TrtllmArgs] = None,
         num_g2_blocks: Optional[int] = None,
         num_g3_blocks: Optional[int] = None,
         offload_batch_size: Optional[int] = None,
@@ -1980,6 +1989,12 @@ class MockEngineArgs:
     def mem_fraction_static(self, value: Optional[float]) -> None: ...
 
     @property
+    def free_gpu_memory_fraction(self) -> Optional[float]: ...
+
+    @free_gpu_memory_fraction.setter
+    def free_gpu_memory_fraction(self, value: Optional[float]) -> None: ...
+
+    @property
     def worker_type(self) -> str: ...
 
     @worker_type.setter
@@ -2008,6 +2023,7 @@ class MockEngineArgs:
         aic_nextn_accept_rates: Optional[str] = None,
         gpu_memory_utilization: Optional[float] = None,
         mem_fraction_static: Optional[float] = None,
+        free_gpu_memory_fraction: Optional[float] = None,
         enable_prefix_caching: Optional[bool] = None,
         worker_type: Optional[str] = None,
     ) -> "MockEngineArgs": ...

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -14,6 +14,7 @@ _NEXTN_ACCEPT_RATES_LEN = 5
 # AIC CLI default when accept-rates are omitted (``cli/main.py:795``).
 _DEFAULT_NEXTN_ACCEPT_RATES = [0.85, 0.3, 0.0, 0.0, 0.0]
 
+# Default backend versions match the AIC v0.9.0 perf DB.
 DEFAULT_BACKEND_VERSIONS = {
     "vllm": "0.19.0",
     "sglang": "0.5.10",

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -15,13 +15,15 @@ _NEXTN_ACCEPT_RATES_LEN = 5
 _DEFAULT_NEXTN_ACCEPT_RATES = [0.85, 0.3, 0.0, 0.0, 0.0]
 
 DEFAULT_BACKEND_VERSIONS = {
-    "vllm": "0.14.0",
-    "sglang": "0.5.6.post2",
+    "vllm": "0.19.0",
+    "sglang": "0.5.10",
+    "trtllm": "1.3.0rc10",
 }
 _KV_CAPACITY_BACKENDS = frozenset(DEFAULT_BACKEND_VERSIONS)
 DEFAULT_STATIC_STRIDE = 32
 DEFAULT_GPU_MEMORY_UTILIZATION = 0.9
 DEFAULT_MEM_FRACTION_STATIC = 0.88
+DEFAULT_FREE_GPU_MEMORY_FRACTION = 0.9
 _BYTES_PER_GIB = 1 << 30
 
 
@@ -248,6 +250,7 @@ class AicSession:
         max_num_batched_tokens: int,
         gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION,
         mem_fraction_static: float | None = None,
+        free_gpu_memory_fraction: float | None = None,
     ) -> int:
         """Estimate rank-local KV cache blocks from AIC's per-GPU memory model."""
         _validate_kv_capacity_backend(self._backend_name)
@@ -274,6 +277,14 @@ class AicSession:
                 f"got mem_fraction_static={mem_fraction_static}"
             )
 
+        if free_gpu_memory_fraction is None:
+            free_gpu_memory_fraction = DEFAULT_FREE_GPU_MEMORY_FRACTION
+        if not 0 < free_gpu_memory_fraction <= 1:
+            raise ValueError(
+                "free_gpu_memory_fraction must be in (0, 1], "
+                f"got free_gpu_memory_fraction={free_gpu_memory_fraction}"
+            )
+
         # AIC's memory model is already rank-local for the configured TP/DP shape.
         # The returned weight/KV numbers have been sharded, so mocker should not
         # multiply the resulting block count by TP or DP.
@@ -295,6 +306,14 @@ class AicSession:
                 f"AIC returned non-positive KV block size: block_bytes={block_bytes}"
             )
 
+        # Non-KV memory footprint AIC models for this rank (everything resident
+        # besides the KV pool: weights, activations, runtime). The vLLM and
+        # TRT-LLM budgets below both derive from it; SGLang uses its own static
+        # figure instead.
+        non_kv_bytes = (
+            float(memory["total"]) - float(memory.get("kvcache", 0.0))
+        ) * _BYTES_PER_GIB
+
         if self._backend_name == "sglang":
             # SGLang's knob reserves a static fraction of HBM for weights,
             # runtime allocations, and the KV pool. AIC reports those static
@@ -309,12 +328,17 @@ class AicSession:
             )
             fraction_name = "mem_fraction_static"
             fraction_value = mem_fraction_static
+        elif self._backend_name == "trtllm":
+            # TRT-LLM allocates `free_gpu_memory_fraction` of the memory that
+            # remains *after* the model is loaded — unlike vLLM's
+            # `gpu_memory_utilization`, which is a fraction of *total* memory.
+            free_bytes = gpu_capacity_bytes - non_kv_bytes
+            kv_budget_bytes = free_bytes * free_gpu_memory_fraction
+            fraction_name = "free_gpu_memory_fraction"
+            fraction_value = free_gpu_memory_fraction
         else:
             # vLLM's knob caps total engine memory. Subtract AIC's modeled
             # non-KV footprint from that cap to get the KV budget.
-            non_kv_bytes = (
-                float(memory["total"]) - float(memory.get("kvcache", 0.0))
-            ) * _BYTES_PER_GIB
             kv_budget_bytes = gpu_capacity_bytes * gpu_memory_utilization - non_kv_bytes
             fraction_name = "gpu_memory_utilization"
             fraction_value = gpu_memory_utilization
@@ -373,6 +397,7 @@ def estimate_num_gpu_blocks(
     max_num_batched_tokens: int,
     gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION,
     mem_fraction_static: float | None = None,
+    free_gpu_memory_fraction: float | None = None,
     backend_version: str | None = None,
     moe_tp_size: int | None = None,
     moe_ep_size: int | None = None,
@@ -398,4 +423,5 @@ def estimate_num_gpu_blocks(
         max_num_batched_tokens=max_num_batched_tokens,
         gpu_memory_utilization=gpu_memory_utilization,
         mem_fraction_static=mem_fraction_static,
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
     )

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -36,6 +36,7 @@ from dynamo._core import RouterConfig as RouterConfig
 from dynamo._core import RouterMode as RouterMode
 from dynamo._core import RoutingConstraints as RoutingConstraints
 from dynamo._core import SglangArgs as SglangArgs
+from dynamo._core import TrtllmArgs as TrtllmArgs
 from dynamo._core import WorkerMetricsPublisher as WorkerMetricsPublisher
 from dynamo._core import WorkerType as WorkerType
 from dynamo._core import compute_block_hash_for_seq as compute_block_hash_for_seq

--- a/lib/bindings/python/src/dynamo/replay/main.py
+++ b/lib/bindings/python/src/dynamo/replay/main.py
@@ -38,6 +38,7 @@ _DEFAULT_AIC_SYSTEM = "h200_sxm"
 _DEFAULT_MAX_NUM_BATCHED_TOKENS = 8192
 _DEFAULT_VLLM_BLOCK_SIZE = 64
 _DEFAULT_SGLANG_BLOCK_SIZE = 1
+_DEFAULT_TRTLLM_BLOCK_SIZE = 32
 
 
 def resolve_planner_profile_data(
@@ -67,6 +68,8 @@ def _resolve_block_size_for_capacity(raw: dict) -> int:
         if isinstance(sglang, dict) and sglang.get("page_size") is not None:
             return cast(int, sglang["page_size"])
         return _DEFAULT_SGLANG_BLOCK_SIZE
+    if raw.get("engine_type") == "trtllm":
+        return _DEFAULT_TRTLLM_BLOCK_SIZE
     return _DEFAULT_VLLM_BLOCK_SIZE
 
 
@@ -88,6 +91,7 @@ def _resolve_aic_num_gpu_blocks(raw: dict) -> None:
     max_num_batched_tokens = raw.get("max_num_batched_tokens")
     gpu_memory_utilization = raw.get("gpu_memory_utilization")
     mem_fraction_static = raw.get("mem_fraction_static")
+    free_gpu_memory_fraction = raw.get("free_gpu_memory_fraction")
 
     raw["num_gpu_blocks"] = estimate_num_gpu_blocks(
         backend_name=aic_backend,
@@ -113,6 +117,8 @@ def _resolve_aic_num_gpu_blocks(raw: dict) -> None:
             if mem_fraction_static is not None
             else DEFAULT_MEM_FRACTION_STATIC,
         ),
+        # None -> aic.py applies the TRT-LLM default (0.9).
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
         backend_version=raw.get("aic_backend_version"),
         moe_tp_size=raw.get("aic_moe_tp_size"),
         moe_ep_size=raw.get("aic_moe_ep_size"),

--- a/lib/bindings/python/tests/replay/test_replay_aic_capacity.py
+++ b/lib/bindings/python/tests/replay/test_replay_aic_capacity.py
@@ -56,6 +56,7 @@ def test_load_engine_args_estimates_aic_blocks(monkeypatch):
             "max_num_batched_tokens": 4096,
             "gpu_memory_utilization": 0.8,
             "mem_fraction_static": 0.88,
+            "free_gpu_memory_fraction": None,
             "backend_version": None,
             "moe_tp_size": None,
             "moe_ep_size": None,
@@ -84,6 +85,7 @@ def test_resolve_aic_blocks_preserves_explicit_zero_inputs(monkeypatch):
         "max_num_batched_tokens": 0,
         "gpu_memory_utilization": 0.0,
         "mem_fraction_static": 0.0,
+        "free_gpu_memory_fraction": 0.0,
         "sglang": {"page_size": 0},
     }
 
@@ -95,6 +97,7 @@ def test_resolve_aic_blocks_preserves_explicit_zero_inputs(monkeypatch):
     assert calls[0]["max_num_batched_tokens"] == 0
     assert calls[0]["gpu_memory_utilization"] == 0.0
     assert calls[0]["mem_fraction_static"] == 0.0
+    assert calls[0]["free_gpu_memory_fraction"] == 0.0
 
 
 def test_programmatic_replay_estimates_unset_aic_blocks(monkeypatch):
@@ -107,8 +110,8 @@ def test_programmatic_replay_estimates_unset_aic_blocks(monkeypatch):
         def predict_decode(self, batch_size, isl, osl):
             return float(batch_size + isl + osl)
 
-    def fake_estimate_num_gpu_blocks(*args):
-        calls.append(args)
+    def fake_estimate_num_gpu_blocks(**kwargs):
+        calls.append(kwargs)
         return 100
 
     def fake_create_session(*_args):
@@ -139,20 +142,21 @@ def test_programmatic_replay_estimates_unset_aic_blocks(monkeypatch):
 
     assert report["num_requests"] == 1
     assert calls == [
-        (
-            "vllm",
-            "h200_sxm",
-            "/models/mock",
-            2,
-            2,
-            16,
-            0.9,
-            0.88,
-            None,
-            None,
-            None,
-            None,
-        )
+        {
+            "backend_name": "vllm",
+            "system": "h200_sxm",
+            "model_path": "/models/mock",
+            "tp_size": 2,
+            "block_size": 2,
+            "max_num_batched_tokens": 16,
+            "gpu_memory_utilization": 0.9,
+            "mem_fraction_static": 0.88,
+            "free_gpu_memory_fraction": None,
+            "backend_version": None,
+            "moe_tp_size": None,
+            "moe_ep_size": None,
+            "attention_dp_size": None,
+        }
     ]
 
 
@@ -166,8 +170,8 @@ def test_planner_bridge_materializes_unset_aic_blocks(tmp_path, monkeypatch):
         def predict_decode(self, batch_size, isl, osl):
             return float(batch_size + isl + osl)
 
-    def fake_estimate_num_gpu_blocks(*args):
-        calls.append(args)
+    def fake_estimate_num_gpu_blocks(**kwargs):
+        calls.append(kwargs)
         return 100
 
     def fake_create_session(*_args):
@@ -222,49 +226,27 @@ def test_planner_bridge_materializes_unset_aic_blocks(tmp_path, monkeypatch):
         num_decode_workers=1,
     )
 
+    def expected(model_path):
+        return {
+            "backend_name": "vllm",
+            "system": "h200_sxm",
+            "model_path": model_path,
+            "tp_size": 2,
+            "block_size": 2,
+            "max_num_batched_tokens": 16,
+            "gpu_memory_utilization": 0.9,
+            "mem_fraction_static": 0.88,
+            "free_gpu_memory_fraction": None,
+            "backend_version": None,
+            "moe_tp_size": None,
+            "moe_ep_size": None,
+            "attention_dp_size": None,
+        }
+
     assert calls == [
-        (
-            "vllm",
-            "h200_sxm",
-            "/models/agg",
-            2,
-            2,
-            16,
-            0.9,
-            0.88,
-            None,
-            None,
-            None,
-            None,
-        ),
-        (
-            "vllm",
-            "h200_sxm",
-            "/models/prefill",
-            2,
-            2,
-            16,
-            0.9,
-            0.88,
-            None,
-            None,
-            None,
-            None,
-        ),
-        (
-            "vllm",
-            "h200_sxm",
-            "/models/decode",
-            2,
-            2,
-            16,
-            0.9,
-            0.88,
-            None,
-            None,
-            None,
-            None,
-        ),
+        expected("/models/agg"),
+        expected("/models/prefill"),
+        expected("/models/decode"),
     ]
 
 

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -93,9 +93,17 @@ def test_estimate_num_gpu_blocks_uses_sglang_static_memory_fraction():
     assert blocks == 37
 
 
-def test_trtllm_version_resolution_still_supports_latency_configs():
+def test_trtllm_version_resolution():
     assert resolve_backend_version("trtllm", "0.20.0") == "0.20.0"
 
+
+def test_estimate_num_gpu_blocks_uses_trtllm_free_memory_fraction():
+    # TRT-LLM now supports KV capacity estimation (it previously raised). It
+    # applies free_gpu_memory_fraction to the memory left *after* the model
+    # footprint, unlike vLLM's gpu_memory_utilization (a fraction of total):
+    #   non_kv = total - kvcache       = 400 - 50   = 350 GiB
+    #   free   = capacity - non_kv     = 1000 - 350  = 650 GiB
+    #   blocks = floor(free * fraction / block_bytes)
     session = make_session(
         "trtllm",
         {
@@ -108,12 +116,26 @@ def test_trtllm_version_resolution_still_supports_latency_configs():
         },
     )
 
-    with pytest.raises(ValueError, match="KV cache capacity estimation"):
+    # Default free_gpu_memory_fraction (0.9): floor(650 * 0.9 / 10) = 58.
+    # gpu_memory_utilization is accepted for signature parity but ignored here.
+    assert (
         session.estimate_num_gpu_blocks(
             block_size=10,
             max_num_batched_tokens=128,
             gpu_memory_utilization=0.8,
         )
+        == 58
+    )
+
+    # Explicit free_gpu_memory_fraction drives the budget: floor(650 * 0.8 / 10) = 52.
+    assert (
+        session.estimate_num_gpu_blocks(
+            block_size=10,
+            max_num_batched_tokens=128,
+            free_gpu_memory_fraction=0.8,
+        )
+        == 52
+    )
 
 
 def test_pad_nextn_accept_rates_defaults_when_omitted():

--- a/lib/llm/src/mocker/metrics.rs
+++ b/lib/llm/src/mocker/metrics.rs
@@ -43,10 +43,25 @@ struct NativeMockerMetricsState {
 
 enum NativeCollectors {
     Vllm(VllmCollectors),
+    Trtllm(TrtllmCollectors),
     Sglang(SglangCollectors),
 }
 
 struct VllmCollectors {
+    num_requests_running: IntGaugeVec,
+    num_requests_waiting: IntGaugeVec,
+    kv_cache_usage_perc: GaugeVec,
+    gpu_cache_usage_perc: GaugeVec,
+    num_preemptions_total: IntCounterVec,
+    time_to_first_token_seconds: HistogramVec,
+    inter_token_latency_seconds: HistogramVec,
+    e2e_request_latency_seconds: HistogramVec,
+}
+
+/// TRT-LLM runs on the vLLM scheduler core, so it exposes the same metric
+/// shape as [`VllmCollectors`] but under the `trtllm:` native name prefix. It
+/// binds into the same [`NativeMetricHandles::Vllm`] update path.
+struct TrtllmCollectors {
     num_requests_running: IntGaugeVec,
     num_requests_waiting: IntGaugeVec,
     kv_cache_usage_perc: GaugeVec,
@@ -257,6 +272,47 @@ impl NativeMockerMetrics {
                 }
                 Some(NativeMetricHandles::Vllm(handles))
             }
+            NativeCollectors::Trtllm(collectors) => {
+                // Identical shape to the vLLM path; bind into the same handles
+                // so the snapshot-application logic is shared.
+                let mut handles = HashMap::with_capacity(self.dp_size as usize);
+                for dp_rank in 0..self.dp_size {
+                    let engine = dp_rank.to_string();
+                    let label_values = [model_name, engine.as_str()];
+                    handles.insert(
+                        dp_rank,
+                        VllmDpHandles {
+                            num_requests_running: collectors
+                                .num_requests_running
+                                .with_label_values(&label_values),
+                            num_requests_waiting: collectors
+                                .num_requests_waiting
+                                .with_label_values(&label_values),
+                            kv_cache_usage_perc: collectors
+                                .kv_cache_usage_perc
+                                .with_label_values(&label_values),
+                            gpu_cache_usage_perc: collectors
+                                .gpu_cache_usage_perc
+                                .with_label_values(&label_values),
+                            num_preemptions_total: collectors
+                                .num_preemptions_total
+                                .with_label_values(&label_values),
+                            request_metrics: NativeRequestMetricHandles::Vllm {
+                                time_to_first_token_seconds: collectors
+                                    .time_to_first_token_seconds
+                                    .with_label_values(&label_values),
+                                inter_token_latency_seconds: collectors
+                                    .inter_token_latency_seconds
+                                    .with_label_values(&label_values),
+                                e2e_request_latency_seconds: collectors
+                                    .e2e_request_latency_seconds
+                                    .with_label_values(&label_values),
+                            },
+                        },
+                    );
+                }
+                Some(NativeMetricHandles::Vllm(handles))
+            }
             NativeCollectors::Sglang(collectors) => {
                 let scheduler_label_values = [model_name, "sglang", "0", "0", "0"];
                 let request_label_values = [model_name, "sglang"];
@@ -363,6 +419,7 @@ impl NativeCollectors {
     fn new(engine_type: EngineType) -> Result<Self> {
         match engine_type {
             EngineType::Vllm => Ok(Self::Vllm(VllmCollectors::new()?)),
+            EngineType::Trtllm => Ok(Self::Trtllm(TrtllmCollectors::new()?)),
             EngineType::Sglang => Ok(Self::Sglang(SglangCollectors::new()?)),
         }
     }
@@ -370,6 +427,7 @@ impl NativeCollectors {
     fn register(&self, registry: &MetricsRegistry) -> Result<()> {
         match self {
             Self::Vllm(collectors) => collectors.register(registry),
+            Self::Trtllm(collectors) => collectors.register(registry),
             Self::Sglang(collectors) => collectors.register(registry),
         }
     }
@@ -432,6 +490,84 @@ impl VllmCollectors {
             e2e_request_latency_seconds: HistogramVec::new(
                 HistogramOpts::new(
                     "vllm:e2e_request_latency_seconds",
+                    "Histogram of e2e request latency in seconds.",
+                )
+                .buckets(vllm_e2e_buckets()),
+                VLLM_LABELS,
+            )?,
+        })
+    }
+
+    fn register(&self, registry: &MetricsRegistry) -> Result<()> {
+        registry.add_metric(Box::new(self.num_requests_running.clone()))?;
+        registry.add_metric(Box::new(self.num_requests_waiting.clone()))?;
+        registry.add_metric(Box::new(self.kv_cache_usage_perc.clone()))?;
+        registry.add_metric(Box::new(self.gpu_cache_usage_perc.clone()))?;
+        registry.add_metric(Box::new(self.num_preemptions_total.clone()))?;
+        registry.add_metric(Box::new(self.time_to_first_token_seconds.clone()))?;
+        registry.add_metric(Box::new(self.inter_token_latency_seconds.clone()))?;
+        registry.add_metric(Box::new(self.e2e_request_latency_seconds.clone()))?;
+        Ok(())
+    }
+}
+
+impl TrtllmCollectors {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            num_requests_running: IntGaugeVec::new(
+                Opts::new(
+                    "trtllm:num_requests_running",
+                    "Number of requests currently running on GPU.",
+                ),
+                VLLM_LABELS,
+            )?,
+            num_requests_waiting: IntGaugeVec::new(
+                Opts::new(
+                    "trtllm:num_requests_waiting",
+                    "Number of requests waiting to be processed.",
+                ),
+                VLLM_LABELS,
+            )?,
+            kv_cache_usage_perc: GaugeVec::new(
+                Opts::new(
+                    "trtllm:kv_cache_usage_perc",
+                    "KV-cache usage as a fraction of available cache blocks.",
+                ),
+                VLLM_LABELS,
+            )?,
+            gpu_cache_usage_perc: GaugeVec::new(
+                Opts::new(
+                    "trtllm:gpu_cache_usage_perc",
+                    "Compatibility alias for KV-cache usage as a fraction of available cache blocks.",
+                ),
+                VLLM_LABELS,
+            )?,
+            num_preemptions_total: IntCounterVec::new(
+                Opts::new(
+                    "trtllm:num_preemptions_total",
+                    "Cumulative number of request preemptions (always 0 under GUARANTEED_NO_EVICT).",
+                ),
+                VLLM_LABELS,
+            )?,
+            time_to_first_token_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "trtllm:time_to_first_token_seconds",
+                    "Histogram of time to first token in seconds.",
+                )
+                .buckets(vllm_ttft_buckets()),
+                VLLM_LABELS,
+            )?,
+            inter_token_latency_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "trtllm:inter_token_latency_seconds",
+                    "Histogram of inter-token latency in seconds.",
+                )
+                .buckets(vllm_itl_buckets()),
+                VLLM_LABELS,
+            )?,
+            e2e_request_latency_seconds: HistogramVec::new(
+                HistogramOpts::new(
+                    "trtllm:e2e_request_latency_seconds",
                     "Histogram of e2e request latency in seconds.",
                 )
                 .buckets(vllm_e2e_buckets()),

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -264,6 +264,23 @@ pub enum EngineType {
     Vllm,
     /// SGLang-style scheduling with radix-tree KV cache
     Sglang,
+    /// TensorRT-LLM-style scheduling. Reuses the vLLM scheduler
+    /// core with a TensorRT-LLM-style admission policy.
+    Trtllm,
+}
+
+/// Scheduling policy applied by the shared vLLM scheduler core.
+///
+/// Derived from [`EngineType`] (+ engine-specific args) so the core reads a
+/// single discriminant instead of re-deriving engine behavior per pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SchedulingPolicy {
+    /// vLLM semantics: optimistic admission, preempt under KV pressure.
+    #[default]
+    Vllm,
+    /// TRT-LLM `GUARANTEED_NO_EVICT`: reserve `prompt + max_output` per
+    /// admitted request up front; never preempt.
+    TrtllmGuaranteedNoEvict,
 }
 
 /// Worker type for disaggregated serving configurations
@@ -335,6 +352,17 @@ pub struct SglangArgs {
     pub schedule_conservativeness: Option<f64>,
 }
 
+/// TensorRT-LLM-specific configuration parameters.
+///
+/// Grouped into a nested struct to keep the `MockEngineArgs` namespace clean,
+/// following the same pattern as [`SglangArgs`].
+#[derive(Debug, Clone, Serialize, Deserialize, Validate, Default)]
+pub struct TrtllmArgs {
+    /// Capacity scheduler policy, supported only `"guaranteed_no_evict"`
+    /// (TensorRT-LLM's default). Default: `"guaranteed_no_evict"`.
+    pub capacity_scheduler_policy: Option<String>,
+}
+
 /// Keeps omitted JSON fields distinct from explicit `null` so serde can replace
 /// the old hand-written parser without losing input-config semantics.
 #[derive(Debug, Clone, Default)]
@@ -403,6 +431,7 @@ struct MockEngineArgsSerde {
     aic_nextn_accept_rates: OptionalConfigValue<String>,
     gpu_memory_utilization: OptionalConfigValue<f64>,
     mem_fraction_static: OptionalConfigValue<f64>,
+    free_gpu_memory_fraction: OptionalConfigValue<f64>,
     enable_local_indexer: OptionalConfigValue<bool>,
     bootstrap_port: OptionalConfigValue<u16>,
     kv_bytes_per_token: OptionalConfigValue<usize>,
@@ -423,6 +452,7 @@ struct MockEngineArgsSerde {
     preemption_mode: OptionalConfigValue<String>,
     router_queue_policy: OptionalConfigValue<String>,
     sglang: OptionalConfigValue<SglangArgs>,
+    trtllm: OptionalConfigValue<TrtllmArgs>,
     #[serde(rename = "has_perf_model")]
     _has_perf_model: OptionalConfigValue<serde_json::Value>,
 }
@@ -431,8 +461,9 @@ fn parse_engine_type(value: &str) -> Result<EngineType, String> {
     match value {
         "vllm" => Ok(EngineType::Vllm),
         "sglang" => Ok(EngineType::Sglang),
+        "trtllm" => Ok(EngineType::Trtllm),
         other => Err(format!(
-            "Invalid engine_type '{other}'. Must be 'vllm' or 'sglang'."
+            "Invalid engine_type '{other}'. Must be 'vllm', 'sglang', or 'trtllm'."
         )),
     }
 }
@@ -615,6 +646,15 @@ pub struct MockEngineArgs {
     #[validate(range(min = 0.0, max = 1.0))]
     pub mem_fraction_static: Option<f64>,
 
+    /// Fraction of *free* GPU memory (after weights/buffers) allocated to the KV
+    /// cache, for AIC KV capacity estimation with TRT-LLM. Mirrors TRT-LLM's
+    /// `KvCacheConfig.free_gpu_memory_fraction`. Unlike vLLM's
+    /// `gpu_memory_utilization` (a fraction of *total* memory), this is a
+    /// fraction of what remains after the model is loaded.
+    #[builder(default = "None")]
+    #[validate(range(min = 0.0, max = 1.0))]
+    pub free_gpu_memory_fraction: Option<f64>,
+
     /// Enable worker-local KV indexer for tracking this worker's own KV cache state
     #[builder(default = "false")]
     pub enable_local_indexer: bool,
@@ -729,6 +769,10 @@ pub struct MockEngineArgs {
     /// SGLang-specific configuration. Only used when `engine_type == Sglang`.
     #[builder(default = "None")]
     pub sglang: Option<SglangArgs>,
+
+    /// TensorRT-LLM-specific configuration. Only used when `engine_type == Trtllm`.
+    #[builder(default = "None")]
+    pub trtllm: Option<TrtllmArgs>,
 }
 
 fn mock_engine_args_validation_error(code: &'static str, message: String) -> ValidationError {
@@ -756,6 +800,20 @@ fn validate_mock_engine_args(args: &MockEngineArgs) -> Result<(), ValidationErro
             "g4_requires_g2",
             "enable_g4_storage requires num_g2_blocks because mocker stages G4 through G2"
                 .to_string(),
+        ));
+    }
+
+    if let Some(policy) = args
+        .trtllm
+        .as_ref()
+        .and_then(|trtllm| trtllm.capacity_scheduler_policy.as_deref())
+        && policy != "guaranteed_no_evict"
+    {
+        return Err(mock_engine_args_validation_error(
+            "trtllm_unsupported_capacity_scheduler_policy",
+            format!(
+                "engine_type=trtllm v1 supports only capacity_scheduler_policy='guaranteed_no_evict', got '{policy}'",
+            ),
         ));
     }
 
@@ -913,6 +971,9 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         if let Some(mem_fraction_static) = compat.mem_fraction_static.into_nullable() {
             builder = builder.mem_fraction_static(mem_fraction_static);
         }
+        if let Some(free_gpu_memory_fraction) = compat.free_gpu_memory_fraction.into_nullable() {
+            builder = builder.free_gpu_memory_fraction(free_gpu_memory_fraction);
+        }
         if let Some(enable_local_indexer) = compat
             .enable_local_indexer
             .into_non_null("enable_local_indexer")?
@@ -982,6 +1043,9 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         if let Some(sglang) = compat.sglang.into_nullable() {
             builder = builder.sglang(sglang);
         }
+        if let Some(trtllm) = compat.trtllm.into_nullable() {
+            builder = builder.trtllm(trtllm);
+        }
 
         builder
             .build()
@@ -1004,6 +1068,7 @@ impl Default for MockEngineArgs {
 impl MockEngineArgs {
     const DEFAULT_VLLM_BLOCK_SIZE: usize = 64;
     const DEFAULT_SGLANG_BLOCK_SIZE: usize = 1;
+    const DEFAULT_TRTLLM_BLOCK_SIZE: usize = 32;
 
     pub fn builder() -> MockEngineArgsBuilder {
         MockEngineArgsBuilder::default()
@@ -1035,6 +1100,11 @@ impl MockEngineArgs {
                     (_, None) => {}
                 }
             }
+            EngineType::Trtllm => {
+                if self.block_size == 0 {
+                    self.block_size = Self::DEFAULT_TRTLLM_BLOCK_SIZE;
+                }
+            }
         }
 
         if self.num_g2_blocks == Some(0) {
@@ -1052,6 +1122,15 @@ impl MockEngineArgs {
         self.validate()
             .map_err(|error| anyhow::anyhow!("Failed to validate MockEngineArgs: {error}"))?;
         Ok(())
+    }
+
+    /// Scheduling policy applied by the shared vLLM scheduler core, derived
+    /// from the engine type. TRT-LLM uses `GUARANTEED_NO_EVICT`.
+    pub fn scheduling_policy(&self) -> SchedulingPolicy {
+        match self.engine_type {
+            EngineType::Trtllm => SchedulingPolicy::TrtllmGuaranteedNoEvict,
+            EngineType::Vllm | EngineType::Sglang => SchedulingPolicy::Vllm,
+        }
     }
 
     pub fn is_prefill(&self) -> bool {

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -223,6 +223,9 @@ pub struct PrefillCost {
     /// Number of tokens already cached (prefix hit).
     /// isl = cached_tokens + new_tokens
     pub cached_tokens: usize,
+    /// Subset of `cached_tokens` backed by active blocks; TRT-LLM no-evict
+    /// capacity reservation discounts only these (inactive reuse is re-consumed).
+    pub active_cached_tokens: usize,
 }
 
 impl PrefillCost {
@@ -512,7 +515,7 @@ fn load_perf_model(path: &Path) -> Arc<PerfModel> {
 #[validate(schema(function = "validate_mock_engine_args"))]
 #[builder(pattern = "owned", build_fn(public))]
 pub struct MockEngineArgs {
-    /// Engine type: vLLM or SGLang simulation
+    /// Engine type: vLLM, SGLang, or TensorRT-LLM simulation
     #[builder(default = "EngineType::Vllm")]
     pub engine_type: EngineType,
 

--- a/lib/mocker/src/engine.rs
+++ b/lib/mocker/src/engine.rs
@@ -24,7 +24,9 @@ pub fn create_engine(
     fpm_publisher: FpmPublisher,
 ) -> Box<dyn SchedulerHandle> {
     match args.engine_type {
-        EngineType::Vllm => Box::new(Scheduler::new(
+        // TRT-LLM reuses the vLLM scheduler core; the GUARANTEED_NO_EVICT
+        // policy is carried in `args` and read by the core per pass.
+        EngineType::Vllm | EngineType::Trtllm => Box::new(Scheduler::new(
             args,
             dp_rank,
             output_tx,

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -1237,14 +1237,18 @@ impl KvManager {
         // randomised hash that can't possibly be in the cache across requests
         // — skip the PLH lookup (PLH is deterministic from tokens) to stay
         // consistent with that no-reuse contract.
-        let overlap_blocks = if sequence.enable_prefix_caching() {
+        // overlap = all reusable prefix blocks (compute); active_overlap = only
+        // those backed by an active block (capacity — inactive reuse is re-consumed).
+        let (overlap_blocks, active_overlap_blocks) = if sequence.enable_prefix_caching() {
             let plhs = sequence.positional_lineage_hashes();
             let mut overlap = 0;
+            let mut active_overlap = 0;
             for (i, block) in seq_blocks.iter().enumerate() {
                 match block {
                     UniqueBlock::FullBlock(seq_hash) => {
                         if self.active_full.contains_key(seq_hash) {
                             overlap += 1;
+                            active_overlap += 1;
                             continue;
                         }
                         let Some(plh) = plhs.get(i) else {
@@ -1259,19 +1263,22 @@ impl KvManager {
                     UniqueBlock::PartialBlock(_) => break,
                 }
             }
-            overlap
+            (overlap, active_overlap)
         } else {
-            0
+            (0, 0)
         };
 
         let new_blocks = seq_blocks.len() - overlap_blocks;
         let cached_tokens = (overlap_blocks * self.block_size).min(sequence.num_input_tokens());
+        let active_cached_tokens =
+            (active_overlap_blocks * self.block_size).min(sequence.num_input_tokens());
         let new_tokens = sequence.num_input_tokens() - cached_tokens;
 
         PrefillCost {
             new_blocks,
             new_tokens,
             cached_tokens,
+            active_cached_tokens,
         }
     }
 }
@@ -1378,6 +1385,36 @@ mod tests {
         let mut mgr = make_mgr(10, 16);
         assert_eq!(use_full(&mut mgr, 1, plh(100)), 1);
         assert_eq!(mgr.num_active_blocks(), 1);
+    }
+
+    /// `get_prefill_cost` must report an inactive cached prefix as reusable for
+    /// compute (`cached_tokens`) but NOT for no-evict capacity reservation
+    /// (`active_cached_tokens`), since reactivation re-consumes the block.
+    #[test]
+    fn prefill_cost_splits_active_and_inactive_cached_reuse() {
+        let mut mgr = make_mgr(10, 4);
+        // 2 full blocks (8 tokens, block_size 4), prefix caching on.
+        let seq = ActiveSequence::new((0u32..8).collect(), 4, Some(4), true, false);
+        let blocks = seq.unique_blocks();
+        let plhs = seq.positional_lineage_hashes();
+        let h0 = match &blocks[0] {
+            UniqueBlock::FullBlock(h) => *h,
+            other => panic!("expected a full block, got {other:?}"),
+        };
+        // Register block 0, then deref so it falls inactive (still registered;
+        // only eviction prunes registered_blocks).
+        use_full(&mut mgr, h0, plhs[0]);
+        deref_full(&mut mgr, h0);
+
+        let cost = mgr.get_prefill_cost(&seq);
+        assert!(
+            cost.cached_tokens >= 4,
+            "inactive prefix should count for compute reuse: {cost:?}"
+        );
+        assert_eq!(
+            cost.active_cached_tokens, 0,
+            "inactive reuse must not be discounted for capacity: {cost:?}"
+        );
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/core.rs
+++ b/lib/mocker/src/replay/offline/core.rs
@@ -13,7 +13,8 @@ pub(crate) struct ReplayWorkerCore {
 impl ReplayWorkerCore {
     pub(crate) fn new(args: MockEngineArgs) -> Self {
         let core = match args.engine_type {
-            crate::common::protocols::EngineType::Vllm => {
+            crate::common::protocols::EngineType::Vllm
+            | crate::common::protocols::EngineType::Trtllm => {
                 let mut core = VllmCore::new(args);
                 Self::init_offload_vllm(&mut core);
                 EngineCore::Vllm(core)
@@ -27,7 +28,8 @@ impl ReplayWorkerCore {
 
     pub(crate) fn new_with_kv_capture(args: MockEngineArgs, worker_id: WorkerId) -> Self {
         let core = match args.engine_type {
-            crate::common::protocols::EngineType::Vllm => {
+            crate::common::protocols::EngineType::Vllm
+            | crate::common::protocols::EngineType::Trtllm => {
                 let mut core = VllmCore::new_with_kv_capture(args, worker_id);
                 Self::init_offload_vllm(&mut core);
                 EngineCore::Vllm(core)

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -162,7 +162,8 @@ pub(crate) struct OfflineWorkerSnapshot {
 impl OfflineWorkerState {
     pub(crate) fn new(worker_idx: usize, args: MockEngineArgs, capture_kv_events: bool) -> Self {
         let core = match args.engine_type {
-            crate::common::protocols::EngineType::Vllm => {
+            crate::common::protocols::EngineType::Vllm
+            | crate::common::protocols::EngineType::Trtllm => {
                 #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
                 let mut core = if capture_kv_events {
                     crate::scheduler::VllmCore::new_with_kv_capture(args, worker_idx as u64)

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -6,6 +6,7 @@
 mod kv_event_sink;
 #[path = "sglang/mod.rs"]
 pub mod sglang;
+mod trtllm;
 pub mod vllm;
 
 pub use crate::common::protocols::ForwardPassSnapshot;
@@ -224,7 +225,10 @@ impl EngineScheduler {
         fpm_publisher: FpmPublisher,
     ) -> Self {
         match args.engine_type {
-            crate::common::protocols::EngineType::Vllm => {
+            // TRT-LLM reuses the vLLM scheduler; the GUARANTEED_NO_EVICT
+            // policy is carried in `args` and read by `VllmCore` per pass.
+            crate::common::protocols::EngineType::Vllm
+            | crate::common::protocols::EngineType::Trtllm => {
                 Self::Vllm(Scheduler::new_with_admission(
                     args,
                     dp_rank,

--- a/lib/mocker/src/scheduler/trtllm/mod.rs
+++ b/lib/mocker/src/scheduler/trtllm/mod.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! TRT-LLM scheduler simulation.
+//!
+//! TRT-LLM is not a separate engine in the mocker: `EngineType::Trtllm` routes
+//! to the vLLM `Scheduler` / `VllmCore` (see [`crate::scheduler::vllm`]), which
+//! switches behavior on `MockEngineArgs::scheduling_policy`. This module owns the
+//! pieces that differ from vLLM.
+//!
+//! - **Reservation-based admission** — [`blocks_needed_to_finish`] and
+//!   [`available_blocks`]: a waiting request is admitted only if its
+//!   `prompt + max_output` footprint still fits after every running request's
+//!   to-completion reservation.
+//! - **No-preemption invariant** — [`is_no_evict`] gates the policy and
+//!   [`report_no_evict_violation`] fails loudly if a preemption is ever required.
+
+mod policy;
+
+pub(crate) use policy::{
+    available_blocks, blocks_needed_to_finish, is_no_evict, report_no_evict_violation,
+};
+
+#[cfg(test)]
+mod tests;

--- a/lib/mocker/src/scheduler/trtllm/mod.rs
+++ b/lib/mocker/src/scheduler/trtllm/mod.rs
@@ -18,7 +18,8 @@
 mod policy;
 
 pub(crate) use policy::{
-    available_blocks, blocks_needed_to_finish, is_no_evict, report_no_evict_violation,
+    available_blocks, blocks_needed_to_finish, is_no_evict, normalize_max_output_tokens,
+    report_no_evict_violation,
 };
 
 #[cfg(test)]

--- a/lib/mocker/src/scheduler/trtllm/policy.rs
+++ b/lib/mocker/src/scheduler/trtllm/policy.rs
@@ -15,13 +15,13 @@ use crate::kv_manager::KvManager;
 /// ```text
 /// needed = ceil((prompt_len + max_output_tokens) / block_size)
 ///          - blocks_already_held
-///          - reusable_cached_prefix_blocks   (waiting candidates only)
+///          - active_cached_prefix_blocks   (waiting candidates only)
 /// ```
 ///
 /// For a running request, the blocks it already holds are physical (counted in
 /// the KV manager's active blocks), so only the remaining footprint is reserved.
-/// For a waiting candidate (nothing allocated yet) the prefix it can reuse from
-/// the cache is discounted instead.
+/// For a waiting candidate, only the active cached prefix is discounted
+/// (`active_cached_tokens`).
 pub(crate) fn blocks_needed_to_finish(
     sequence: &ActiveSequence,
     block_size: usize,
@@ -30,7 +30,8 @@ pub(crate) fn blocks_needed_to_finish(
     let full_blocks =
         (sequence.num_input_tokens() + sequence.max_output_tokens()).div_ceil(block_size);
     if sequence.num_allocated_tokens() == 0 {
-        let reusable_blocks = kv_manager.get_prefill_cost(sequence).cached_tokens / block_size;
+        let reusable_blocks =
+            kv_manager.get_prefill_cost(sequence).active_cached_tokens / block_size;
         full_blocks.saturating_sub(reusable_blocks)
     } else {
         let allocated_blocks = sequence.num_allocated_tokens().div_ceil(block_size);
@@ -62,6 +63,23 @@ pub(crate) fn available_blocks<'a>(
 /// reservation-gates admission and forbids preemption.
 pub(crate) fn is_no_evict(policy: SchedulingPolicy) -> bool {
     policy == SchedulingPolicy::TrtllmGuaranteedNoEvict
+}
+
+/// TRT-LLM enqueue normalization: a no-evict request's `prompt + output` can
+/// reserve at most the whole KV pool. Returns `max_output_tokens` clamped to the
+/// room left after the prompt, or `None` if the prompt alone leaves no decode
+/// room (the request can never run and should be rejected).
+pub(crate) fn normalize_max_output_tokens(
+    prompt_len: usize,
+    max_output_tokens: usize,
+    num_gpu_blocks: usize,
+    block_size: usize,
+) -> Option<usize> {
+    let capacity_tokens = num_gpu_blocks.saturating_mul(block_size);
+    if prompt_len >= capacity_tokens {
+        return None;
+    }
+    Some(max_output_tokens.min(capacity_tokens - prompt_len))
 }
 
 /// Fail loudly when the no-evict invariant is violated.

--- a/lib/mocker/src/scheduler/trtllm/policy.rs
+++ b/lib/mocker/src/scheduler/trtllm/policy.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! TRT-LLM `GUARANTEED_NO_EVICT` capacity policy: the scheduling decisions that
+//! differ from vLLM, expressed as free functions over public scheduler types so
+//! they need none of the vLLM core's internals.
+
+use crate::common::protocols::SchedulingPolicy;
+use crate::common::sequence::ActiveSequence;
+use crate::kv_manager::KvManager;
+
+/// Blocks a request still needs to reserve to run to completion under the
+/// TRT-LLM `GUARANTEED_NO_EVICT` policy.
+///
+/// ```text
+/// needed = ceil((prompt_len + max_output_tokens) / block_size)
+///          - blocks_already_held
+///          - reusable_cached_prefix_blocks   (waiting candidates only)
+/// ```
+///
+/// For a running request, the blocks it already holds are physical (counted in
+/// the KV manager's active blocks), so only the remaining footprint is reserved.
+/// For a waiting candidate (nothing allocated yet) the prefix it can reuse from
+/// the cache is discounted instead.
+pub(crate) fn blocks_needed_to_finish(
+    sequence: &ActiveSequence,
+    block_size: usize,
+    kv_manager: &KvManager,
+) -> usize {
+    let full_blocks =
+        (sequence.num_input_tokens() + sequence.max_output_tokens()).div_ceil(block_size);
+    if sequence.num_allocated_tokens() == 0 {
+        let reusable_blocks = kv_manager.get_prefill_cost(sequence).cached_tokens / block_size;
+        full_blocks.saturating_sub(reusable_blocks)
+    } else {
+        let allocated_blocks = sequence.num_allocated_tokens().div_ceil(block_size);
+        full_blocks.saturating_sub(allocated_blocks)
+    }
+}
+
+/// Free blocks remaining after reserving every running request's to-completion
+/// footprint. A waiting candidate may be admitted iff its
+/// [`blocks_needed_to_finish`] is `<=` this value.
+///
+/// `running` yields the active sequence of each currently-running request;
+/// `num_gpu_blocks` is the KV pool size and `kv_manager` supplies the count of
+/// physically allocated blocks.
+pub(crate) fn available_blocks<'a>(
+    running: impl Iterator<Item = &'a ActiveSequence>,
+    num_gpu_blocks: usize,
+    block_size: usize,
+    kv_manager: &KvManager,
+) -> usize {
+    let reserved: usize = running
+        .map(|sequence| blocks_needed_to_finish(sequence, block_size, kv_manager))
+        .sum();
+    let free = num_gpu_blocks.saturating_sub(kv_manager.num_active_blocks());
+    free.saturating_sub(reserved)
+}
+
+/// Whether the policy is TRT-LLM `GUARANTEED_NO_EVICT` — the mode that both
+/// reservation-gates admission and forbids preemption.
+pub(crate) fn is_no_evict(policy: SchedulingPolicy) -> bool {
+    policy == SchedulingPolicy::TrtllmGuaranteedNoEvict
+}
+
+/// Fail loudly when the no-evict invariant is violated.
+///
+/// Under `GUARANTEED_NO_EVICT` the capacity gate reserves blocks for every
+/// admitted request up front, so a preemption should never be required.
+/// Reaching the preemption path means the reservation under-counted physical
+/// KV demand (e.g. a reusable prefix block was evicted before the request
+/// claimed it). A silent preempt would still produce output but no longer
+/// represent TRT-LLM, degrading timing fidelity undetectably — so debug builds
+/// assert and release builds log and decline to preempt.
+pub(crate) fn report_no_evict_violation() {
+    debug_assert!(
+        false,
+        "no-evict invariant violated: trtllm GUARANTEED_NO_EVICT required preemption"
+    );
+    tracing::error!(
+        "trtllm GUARANTEED_NO_EVICT required preemption; reservation under-counted physical KV demand"
+    );
+}

--- a/lib/mocker/src/scheduler/trtllm/tests.rs
+++ b/lib/mocker/src/scheduler/trtllm/tests.rs
@@ -199,3 +199,76 @@ fn no_evict_admission_cap_matches_hardware() {
         "the rest must stay queued, not dropped"
     );
 }
+
+fn drain(core: &mut VllmCore) -> usize {
+    let mut collector = crate::replay::TraceCollector::default();
+    let mut now_ms = 0.0;
+    let mut completed = 0usize;
+    for _ in 0..100 {
+        if core.state().requests.is_empty() {
+            break;
+        }
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms.max(now_ms + 1.0);
+        completed += pass
+            .output_signals
+            .iter()
+            .filter(|signal| signal.completed)
+            .count();
+    }
+    completed
+}
+
+fn capacity_args() -> MockEngineArgs {
+    // 4 GPU blocks * block_size 4 = 16-token per-request capacity.
+    MockEngineArgs::builder()
+        .engine_type(EngineType::Trtllm)
+        .block_size(4)
+        .num_gpu_blocks(4)
+        .max_num_batched_tokens(Some(64))
+        .max_num_seqs(Some(4))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(false)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap()
+}
+
+/// Enqueue normalization rejects a prompt that leaves no decode room (prompt
+/// alone exceeds the KV pool): it never enters the scheduler, so a following
+/// valid request still runs and the queue drains (no FIFO-head stall).
+#[test]
+fn enqueue_rejects_prompt_with_no_decode_room() {
+    let mut core = VllmCore::new(capacity_args());
+    let r1 = Uuid::from_u128(1);
+    let r2 = Uuid::from_u128(2);
+    receive(&mut core, r1, 0..20, 4); // 20-token prompt > 16-token pool -> rejected
+    receive(&mut core, r2, 100..104, 4); // fits
+
+    assert!(
+        !core.state().requests.contains_key(&r1),
+        "no-decode-room r1 must be rejected at enqueue, never entering the scheduler"
+    );
+    let completed = drain(&mut core);
+    assert_eq!(completed, 1, "valid r2 still completes");
+    assert!(core.state().requests.is_empty(), "queue fully drains");
+}
+
+/// Enqueue normalization clamps an over-long output to the room left in the KV
+/// pool, so a request asking for more than fits still runs to the clamped
+/// length instead of being dropped. (Without clamping, r1's 4+40=44 tokens =
+/// 11 blocks exceed the 4-block pool and it could never run.)
+#[test]
+fn enqueue_clamps_excess_output_to_capacity() {
+    let mut core = VllmCore::new(capacity_args());
+    let r1 = Uuid::from_u128(1);
+    receive(&mut core, r1, 0..4, 40); // clamped to 4 + (16-4)=12 = 16 tokens (4 blocks)
+
+    assert!(
+        core.state().requests.contains_key(&r1),
+        "r1 fits after clamping and is admitted, not rejected"
+    );
+    let completed = drain(&mut core);
+    assert_eq!(completed, 1, "clamped r1 runs to completion");
+    assert!(core.state().requests.is_empty(), "queue fully drains");
+}

--- a/lib/mocker/src/scheduler/trtllm/tests.rs
+++ b/lib/mocker/src/scheduler/trtllm/tests.rs
@@ -234,26 +234,6 @@ fn capacity_args() -> MockEngineArgs {
         .unwrap()
 }
 
-/// Enqueue normalization rejects a prompt that leaves no decode room (prompt
-/// alone exceeds the KV pool): it never enters the scheduler, so a following
-/// valid request still runs and the queue drains (no FIFO-head stall).
-#[test]
-fn enqueue_rejects_prompt_with_no_decode_room() {
-    let mut core = VllmCore::new(capacity_args());
-    let r1 = Uuid::from_u128(1);
-    let r2 = Uuid::from_u128(2);
-    receive(&mut core, r1, 0..20, 4); // 20-token prompt > 16-token pool -> rejected
-    receive(&mut core, r2, 100..104, 4); // fits
-
-    assert!(
-        !core.state().requests.contains_key(&r1),
-        "no-decode-room r1 must be rejected at enqueue, never entering the scheduler"
-    );
-    let completed = drain(&mut core);
-    assert_eq!(completed, 1, "valid r2 still completes");
-    assert!(core.state().requests.is_empty(), "queue fully drains");
-}
-
 /// Enqueue normalization clamps an over-long output to the room left in the KV
 /// pool, so a request asking for more than fits still runs to the clamped
 /// length instead of being dropped. (Without clamping, r1's 4+40=44 tokens =
@@ -271,4 +251,78 @@ fn enqueue_clamps_excess_output_to_capacity() {
     let completed = drain(&mut core);
     assert_eq!(completed, 1, "clamped r1 runs to completion");
     assert!(core.state().requests.is_empty(), "queue fully drains");
+}
+
+/// Scheduler-level regression for the active-vs-inactive cached-prefix split:
+/// a request reusing an INACTIVE cached prefix must NOT discount it from the
+/// no-evict reservation, so it stays waiting while a holder occupies capacity
+/// and is admitted only once that capacity frees. (With the old all-cached
+/// discount it would be over-admitted into a pool that cannot hold it.)
+#[test]
+fn inactive_cached_prefix_not_discounted_keeps_request_waiting() {
+    // 8 blocks * block_size 4, prefix caching on so reuse is modeled.
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Trtllm)
+        .block_size(4)
+        .num_gpu_blocks(8)
+        .max_num_batched_tokens(Some(64))
+        .max_num_seqs(Some(8))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(true)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    let holder = Uuid::from_u128(1);
+    let seeder = Uuid::from_u128(2);
+    let reuser = Uuid::from_u128(3);
+    // holder: full = ceil((4+12)/4) = 4 blocks, long output -> holds capacity;
+    //   while it runs, free-for-others = 8 - 4 = 4 blocks.
+    receive(&mut core, holder, 0..4, 12);
+    // seeder: a 2-block prefix (100..108), short output -> completes and leaves
+    //   that prefix INACTIVE-but-registered.
+    receive(&mut core, seeder, 100..108, 4);
+    // reuser: SAME 2-block prefix + output -> full = ceil((8+12)/4) = 5 blocks.
+    //   Discounting the inactive prefix (the bug) -> needs 5-2=3 <= 4 -> admitted;
+    //   discounting only ACTIVE reuse -> needs 5 > 4 -> must wait for the holder.
+    receive(&mut core, reuser, 100..108, 12);
+
+    let mut collector = crate::replay::TraceCollector::default();
+    let mut now_ms = 0.0;
+    let mut max_preemptions = 0u64;
+    let mut checked = false;
+    for _ in 0..400 {
+        if core.state().requests.is_empty() {
+            break;
+        }
+        // Once the seeder has completed (prefix now inactive) but the holder is
+        // still running, the reuser must remain waiting.
+        if !checked
+            && !core.state().requests.contains_key(&seeder)
+            && core.state().requests.contains_key(&holder)
+        {
+            assert!(
+                !core.state().running.contains(&reuser),
+                "reuser hits the seeder's INACTIVE prefix; un-discounted it needs 5 > 4 free, \
+                 so it must wait while the holder holds capacity"
+            );
+            assert_eq!(
+                core.state().requests.get(&reuser).map(|r| r.status),
+                Some(RequestStatus::Waiting),
+            );
+            checked = true;
+        }
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms.max(now_ms + 1.0);
+        max_preemptions = max_preemptions.max(pass.mocker_metrics.vllm_preemptions_total);
+    }
+    assert!(
+        checked,
+        "test must observe the seeder-done / holder-running window"
+    );
+    assert!(
+        core.state().requests.is_empty(),
+        "reuser is admitted once the holder frees capacity; all requests drain"
+    );
+    assert_eq!(max_preemptions, 0, "GUARANTEED_NO_EVICT must never preempt");
 }

--- a/lib/mocker/src/scheduler/trtllm/tests.rs
+++ b/lib/mocker/src/scheduler/trtllm/tests.rs
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the TRT-LLM `GUARANTEED_NO_EVICT` policy carried on the shared
+//! vLLM scheduler core: reservation-gated admission and the no-preemption
+//! invariant. See [`super::policy`].
+//!
+//! These drive the vLLM [`VllmCore`] directly (TRT-LLM routes to it) and read
+//! its scheduler state through the test-only [`VllmCore::state`] accessor.
+
+use uuid::Uuid;
+
+use crate::common::protocols::{DirectRequest, EngineType, MockEngineArgs};
+use crate::scheduler::vllm::{RequestStatus, VllmCore};
+
+/// block_size 4, 6 GPU blocks (24 tokens). Each request below reserves
+/// `ceil((prompt + max_output) / 4)` blocks to completion.
+fn engine_args(engine_type: EngineType) -> MockEngineArgs {
+    MockEngineArgs::builder()
+        .engine_type(engine_type)
+        .block_size(4)
+        .num_gpu_blocks(6)
+        // High enough that both prompts (8 + 8) fit in one pass, so the
+        // capacity gate — not the token budget — is what limits admission.
+        .max_num_batched_tokens(Some(16))
+        .max_num_seqs(Some(4))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(false)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap()
+}
+
+fn receive(core: &mut VllmCore, uuid: Uuid, tokens: std::ops::Range<u32>, max_output: usize) {
+    core.receive(DirectRequest {
+        tokens: tokens.collect(),
+        max_output_tokens: max_output,
+        uuid: Some(uuid),
+        dp_rank: 0,
+        arrival_timestamp_ms: None,
+    });
+}
+
+/// Under GUARANTEED_NO_EVICT only the first request — whose
+/// `prompt + max_output` footprint fits after reserving for running
+/// requests — is admitted; the second halts at the gate and stays waiting.
+#[test]
+fn admits_only_what_fits_to_completion() {
+    let mut core = VllmCore::new(engine_args(EngineType::Trtllm));
+    let r1 = Uuid::from_u128(1);
+    let r2 = Uuid::from_u128(2);
+    // Each: 8 prompt + 8 output = 16 tokens = 4 blocks. Two need 8 > 6.
+    receive(&mut core, r1, 0..8, 8);
+    receive(&mut core, r2, 100..108, 8);
+
+    let mut collector = crate::replay::TraceCollector::default();
+    let pass = core.execute_pass(&mut collector, 0.0);
+
+    assert_eq!(
+        core.state().running.iter().copied().collect::<Vec<_>>(),
+        vec![r1],
+        "only r1 fits its to-completion reservation under no-evict"
+    );
+    assert!(
+        core.state().waiting.contains(&r2),
+        "r2 must remain waiting (no skip-ahead admission)"
+    );
+    assert_eq!(
+        core.state().requests.get(&r2).unwrap().status,
+        RequestStatus::Waiting,
+    );
+    assert_eq!(
+        pass.mocker_metrics.vllm_preemptions_total, 0,
+        "no-evict policy must never preempt"
+    );
+}
+
+/// Contrast: with identical args, vLLM admits optimistically and runs both
+/// requests concurrently (their prompts physically fit; only the reserved
+/// to-completion footprint exceeds capacity, which vLLM ignores).
+#[test]
+fn vllm_admits_optimistically_unlike_trtllm() {
+    let mut core = VllmCore::new(engine_args(EngineType::Vllm));
+    let r1 = Uuid::from_u128(1);
+    let r2 = Uuid::from_u128(2);
+    receive(&mut core, r1, 0..8, 8);
+    receive(&mut core, r2, 100..108, 8);
+
+    let mut collector = crate::replay::TraceCollector::default();
+    core.execute_pass(&mut collector, 0.0);
+
+    let running: Vec<_> = core.state().running.iter().copied().collect();
+    assert!(
+        running.contains(&r1) && running.contains(&r2),
+        "vLLM admits both requests optimistically, got {running:?}"
+    );
+}
+
+/// A workload that over-commits KV during decode would preempt under vLLM.
+/// Under no-evict the gate prevents over-admission, so the run completes
+/// every request without ever calling the (hard-error) preemption path.
+#[test]
+fn preemption_inducing_workload_never_preempts() {
+    // 4 GPU blocks (16 tokens). Each request reserves all 4 blocks to
+    // completion (4 prompt + 12 output = 16 tokens), so only one can run
+    // at a time.
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Trtllm)
+        .block_size(4)
+        .num_gpu_blocks(4)
+        .max_num_batched_tokens(Some(8))
+        .max_num_seqs(Some(4))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(false)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    let r1 = Uuid::from_u128(1);
+    let r2 = Uuid::from_u128(2);
+    receive(&mut core, r1, 0..4, 12);
+    receive(&mut core, r2, 100..104, 12);
+
+    let mut collector = crate::replay::TraceCollector::default();
+    let mut completed = 0usize;
+    let mut now_ms = 0.0;
+    let mut max_preemptions = 0u64;
+    for _ in 0..300 {
+        if core.state().requests.is_empty() {
+            break;
+        }
+        // Would panic via debug_assert in `trtllm::report_no_evict_violation`
+        // if the no-evict gate ever let the core over-admit.
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms.max(now_ms + 1.0);
+        completed += pass
+            .output_signals
+            .iter()
+            .filter(|signal| signal.completed)
+            .count();
+        max_preemptions = max_preemptions.max(pass.mocker_metrics.vllm_preemptions_total);
+    }
+
+    assert!(
+        core.state().requests.is_empty(),
+        "both requests should complete; {} left",
+        core.state().requests.len()
+    );
+    assert_eq!(completed, 2, "both requests should finish");
+    assert_eq!(max_preemptions, 0, "GUARANTEED_NO_EVICT must never preempt");
+}
+
+/// Hardware-parity test: reproduces a real `trtllm-serve` no-evict saturation
+/// run (B200, MiniMax-M2.5-NVFP4, TP4). KV pool 7319 blocks (block_size 32),
+/// 64 offered requests of ISL 1096 + max_output 7000 → each reserves
+/// `ceil((1096+7000)/32) = 253` blocks → admission cap `floor(7319/253) = 28`.
+/// Real engine measured a steady `num_scheduled_requests = 28` with the rest
+/// queued and zero evictions; the mocker must match: running caps at 28, the
+/// remainder stays waiting, and preemption never fires.
+#[test]
+fn no_evict_admission_cap_matches_hardware() {
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Trtllm)
+        .block_size(32)
+        .num_gpu_blocks(7319)
+        .max_num_seqs(Some(256)) // batch-size cap is NOT the limiter; KV is
+        .max_num_batched_tokens(Some(8192))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(false)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    for i in 0..64u128 {
+        // 1096 unique input tokens (no prefix reuse), max_output 7000
+        let base = (i as u32 + 1) * 100_000;
+        receive(&mut core, Uuid::from_u128(i + 1), base..(base + 1096), 7000);
+    }
+    let mut collector = crate::replay::TraceCollector::default();
+    let mut now_ms = 0.0;
+    let mut max_preemptions = 0u64;
+    // Run enough passes to finish all prefills; long OSL means none complete,
+    // so the running set fills to the KV cap and then holds.
+    for _ in 0..40 {
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms.max(now_ms + 1.0);
+        max_preemptions = max_preemptions.max(pass.mocker_metrics.vllm_preemptions_total);
+    }
+    let running = core.state().running.len();
+    let waiting = core.state().waiting.len();
+    eprintln!(
+        "no-evict cap: running={running} waiting={waiting} max_preemptions={max_preemptions} (hardware=28)"
+    );
+    assert_eq!(max_preemptions, 0, "GUARANTEED_NO_EVICT must never preempt");
+    assert_eq!(running, 28, "mocker admission cap must match hardware (28)");
+    assert_eq!(
+        running + waiting,
+        64,
+        "the rest must stay queued, not dropped"
+    );
+}

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -331,29 +331,28 @@ impl VllmCore {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         let mut max_output_tokens = request.max_output_tokens;
         if trtllm::is_no_evict(self.args.scheduling_policy()) {
-            // TRT-LLM enqueue normalization: clamp output to KV-pool capacity, or
-            // reject a prompt with no decode room (never enqueue). The admission
-            // gate keeps a defensive terminal-drop for any oversized leftover.
-            match trtllm::normalize_max_output_tokens(
+            // TRT-LLM enqueue normalization: clamp the output so prompt + output
+            // fits the KV pool (keeps the request valid and admittable).
+            if let Some(clamped) = trtllm::normalize_max_output_tokens(
                 request.tokens.len(),
                 max_output_tokens,
                 self.args.num_gpu_blocks,
                 self.args.block_size,
             ) {
-                Some(clamped) => {
-                    if clamped != max_output_tokens {
-                        tracing::warn!(%uuid, requested = max_output_tokens, clamped,
-                            "clamped TRT-LLM max_output_tokens to KV-pool capacity");
-                        max_output_tokens = clamped;
-                    }
+                if clamped != max_output_tokens {
+                    tracing::warn!(%uuid, requested = max_output_tokens, clamped,
+                        "clamped TRT-LLM max_output_tokens to KV-pool capacity");
                 }
-                None => {
-                    tracing::warn!(%uuid, prompt_len = request.tokens.len(),
-                        capacity_blocks = self.args.num_gpu_blocks,
-                        "rejecting TRT-LLM request: prompt leaves no room for decode");
-                    return uuid;
-                }
+                max_output_tokens = clamped;
             }
+            // TODO(trtllm-reject-propagation): reject a prompt that leaves no decode
+            // room (prompt_len >= pool capacity — the `None` case above). DISABLED as
+            // a NO-OP: any in-PR handling (silent reject via `return uuid`, or clamping
+            // output to 0) emits no terminal signal, dead-ending aggregated offline
+            // replay (in_flight) and live replay (waiter) — verified to hang. MUST NOT
+            // be enabled until offline + live replay propagate an explicit terminal-
+            // rejection outcome. Until then the request is left unchanged and stalls at
+            // the FIFO head like any oversized request (also deferred).
         }
         let sequence = ActiveSequence::new(
             request.tokens,
@@ -732,19 +731,19 @@ impl VllmCore {
                         &self.kv_manager,
                     )
                 {
-                    // Normal TRT-LLM receive() normalizes requests before enqueue, so this should
-                    // only catch bypassed/malformed scheduler state. Keep it as a terminal fallback
-                    // so an impossible FIFO head cannot stall replay.
-                    if needed > self.args.num_gpu_blocks {
-                        tracing::warn!(
-                            %uuid,
-                            needed_blocks = needed,
-                            capacity_blocks = self.args.num_gpu_blocks,
-                            "rejecting TRT-LLM request: prompt + max_output exceeds the entire KV pool"
-                        );
-                        self.drop_request(uuid);
-                        continue;
-                    }
+                    // TODO(trtllm-reject-propagation): terminal-reject a request
+                    // whose footprint exceeds the whole pool — it can never be
+                    // admitted, so an oversized FIFO head stalls replay. DISABLED —
+                    // drop_request here removes the request without a terminal
+                    // signal, which dead-ends offline (in_flight) and live (waiter)
+                    // replay the same way a silent enqueue-reject would. MUST NOT be
+                    // enabled until both propagate an explicit terminal-rejection
+                    // outcome. For now, break (FIFO) as before:
+                    //     if needed > self.args.num_gpu_blocks {
+                    //         tracing::warn!(%uuid, "exceeds entire KV pool");
+                    //         self.drop_request(uuid);
+                    //         continue;
+                    //     }
                     break;
                 }
             }

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -329,9 +329,35 @@ impl VllmCore {
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+        let mut max_output_tokens = request.max_output_tokens;
+        if trtllm::is_no_evict(self.args.scheduling_policy()) {
+            // TRT-LLM enqueue normalization: clamp output to KV-pool capacity, or
+            // reject a prompt with no decode room (never enqueue). The admission
+            // gate keeps a defensive terminal-drop for any oversized leftover.
+            match trtllm::normalize_max_output_tokens(
+                request.tokens.len(),
+                max_output_tokens,
+                self.args.num_gpu_blocks,
+                self.args.block_size,
+            ) {
+                Some(clamped) => {
+                    if clamped != max_output_tokens {
+                        tracing::warn!(%uuid, requested = max_output_tokens, clamped,
+                            "clamped TRT-LLM max_output_tokens to KV-pool capacity");
+                        max_output_tokens = clamped;
+                    }
+                }
+                None => {
+                    tracing::warn!(%uuid, prompt_len = request.tokens.len(),
+                        capacity_blocks = self.args.num_gpu_blocks,
+                        "rejecting TRT-LLM request: prompt leaves no room for decode");
+                    return uuid;
+                }
+            }
+        }
         let sequence = ActiveSequence::new(
             request.tokens,
-            request.max_output_tokens,
+            max_output_tokens,
             Some(self.args.block_size),
             self.args.enable_prefix_caching,
             self.args.zmq_kv_events_port.is_some(),
@@ -706,6 +732,19 @@ impl VllmCore {
                         &self.kv_manager,
                     )
                 {
+                    // Normal TRT-LLM receive() normalizes requests before enqueue, so this should
+                    // only catch bypassed/malformed scheduler state. Keep it as a terminal fallback
+                    // so an impossible FIFO head cannot stall replay.
+                    if needed > self.args.num_gpu_blocks {
+                        tracing::warn!(
+                            %uuid,
+                            needed_blocks = needed,
+                            capacity_blocks = self.args.num_gpu_blocks,
+                            "rejecting TRT-LLM request: prompt + max_output exceeds the entire KV pool"
+                        );
+                        self.drop_request(uuid);
+                        continue;
+                    }
                     break;
                 }
             }

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -26,6 +26,7 @@ use crate::kv_manager::KvManager;
 #[cfg(feature = "kvbm-offload")]
 use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
 use crate::replay::TraceCollector;
+use crate::scheduler::trtllm;
 use crate::scheduler::{
     AdmissionEvent, CapturedRouterEventBuffer, EnginePassResult, ForwardPassSnapshot,
     MockerMetrics, RouterEventVisibility, build_fpm_snapshot, capture_router_event_sink,
@@ -55,7 +56,7 @@ pub(crate) struct SchedulerState {
     pub(crate) preemptions_total: u64,
 }
 
-struct PreemptedRequest {
+pub(super) struct PreemptedRequest {
     uuid: Uuid,
     signals: Vec<MoveBlock>,
 }
@@ -172,7 +173,7 @@ impl SchedulerState {
             .map(|request| &mut request.sequence)
     }
 
-    fn preempt(&mut self, mode: PreemptionMode) -> Option<PreemptedRequest> {
+    pub(super) fn preempt(&mut self, mode: PreemptionMode) -> Option<PreemptedRequest> {
         let uuid = loop {
             let candidate = match mode {
                 PreemptionMode::Lifo => self.running.pop_back(),
@@ -243,7 +244,7 @@ enum SwapInAdmissionAttempt {
 }
 
 pub(crate) struct VllmCore {
-    args: MockEngineArgs,
+    pub(super) args: MockEngineArgs,
     dp_rank: u32,
     pub(super) state: SchedulerState,
     pub(super) kv_manager: KvManager,
@@ -357,6 +358,13 @@ impl VllmCore {
 
     pub(crate) fn num_requests(&self) -> usize {
         self.state.requests.len()
+    }
+
+    /// Read-only view of the scheduler state, for tests in sibling modules
+    /// (e.g. `crate::scheduler::trtllm`) that assert on queue membership.
+    #[cfg(test)]
+    pub(crate) fn state(&self) -> &SchedulerState {
+        &self.state
     }
 
     pub(super) fn mocker_metrics(&self) -> MockerMetrics {
@@ -661,10 +669,46 @@ impl VllmCore {
         }
 
         let max_num_running = self.args.max_num_seqs.unwrap_or(usize::MAX);
+        let trtllm_no_evict = trtllm::is_no_evict(self.args.scheduling_policy());
         while !preempted_any && self.state.running.len() < max_num_running {
             let Some(uuid) = self.state.next_waiting_uuid() else {
                 break;
             };
+            // TRT-LLM GUARANTEED_NO_EVICT capacity gate: only admit a waiting
+            // request if its prompt + max_output footprint fits after the
+            // to-completion reservations of all running requests. Halt at the
+            // first non-fitting candidate (no skip-ahead) to preserve FIFO
+            // fairness, matching TRT-LLM's `capacityScheduler.cpp`.
+            if trtllm_no_evict {
+                let needed = self
+                    .state
+                    .requests
+                    .get(&uuid)
+                    .map(|request| {
+                        trtllm::blocks_needed_to_finish(
+                            &request.sequence,
+                            self.args.block_size,
+                            &self.kv_manager,
+                        )
+                    })
+                    .unwrap_or(0);
+                let running_seqs = self
+                    .state
+                    .running
+                    .iter()
+                    .filter_map(|running_uuid| self.state.requests.get(running_uuid))
+                    .map(|request| &request.sequence);
+                if needed
+                    > trtllm::available_blocks(
+                        running_seqs,
+                        self.args.num_gpu_blocks,
+                        self.args.block_size,
+                        &self.kv_manager,
+                    )
+                {
+                    break;
+                }
+            }
             #[cfg(feature = "kvbm-offload")]
             match self.try_park_for_swap_in(uuid, now_ms) {
                 SwapInAdmissionAttempt::Parked => continue,
@@ -754,6 +798,21 @@ impl VllmCore {
             self.kv_manager.process(&signal);
         }
         self.state.complete(&uuid);
+    }
+
+    /// Preempt a running request under the active scheduling policy.
+    ///
+    /// Under vLLM semantics this evicts a running request on KV pressure. Under
+    /// TRT-LLM `GUARANTEED_NO_EVICT` preemption must never happen — the capacity
+    /// gate reserves blocks for every admitted request up front — so reaching
+    /// this path is reported as a hard error (see
+    /// [`trtllm::report_no_evict_violation`]) and nothing is evicted.
+    pub(super) fn policy_preempt(&mut self) -> Option<PreemptedRequest> {
+        if trtllm::is_no_evict(self.args.scheduling_policy()) {
+            trtllm::report_no_evict_violation();
+            return None;
+        }
+        self.state.preempt(self.args.preemption_mode)
     }
 
     /// Compute a forward pass metrics snapshot from the just-completed pass.
@@ -906,7 +965,7 @@ impl VllmCore {
                 break;
             }
 
-            let Some(preempted) = self.state.preempt(self.args.preemption_mode) else {
+            let Some(preempted) = self.policy_preempt() else {
                 actual_computed_after = current_computed_tokens;
                 break;
             };
@@ -1046,7 +1105,7 @@ impl VllmCore {
                 }
                 sequence.pop();
 
-                let Some(preempted) = self.state.preempt(self.args.preemption_mode) else {
+                let Some(preempted) = self.policy_preempt() else {
                     break;
                 };
                 running_changed = true;

--- a/lib/mocker/src/scheduler/vllm/mod.rs
+++ b/lib/mocker/src/scheduler/vllm/mod.rs
@@ -11,5 +11,10 @@ mod live;
 pub(crate) use core::VllmCore;
 pub use live::{MockerMetrics, Scheduler};
 
+/// Re-exported for the sibling `crate::scheduler::trtllm` tests, which assert on
+/// request status through [`VllmCore::state`]; only needed in test builds.
+#[cfg(test)]
+pub(crate) use core::RequestStatus;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
#### Overview:

Adds TensorRT-LLM scheduler simulation to the mocker via `engine_type=trtllm`, implements the DEP #10093 .

#### Details:

- TRT-LLM is modeled as a **scheduling-policy variant of the existing vLLM scheduler core**, not a separate engine. `EngineType::Trtllm` routes to the vLLM `Scheduler`/`VllmCore`, which switches behavior on a new `SchedulingPolicy`.
- All TRT-LLM-specific logic lives in a dedicated `lib/mocker/src/scheduler/trtllm/` module, the only TRT-LLM code on the vLLM core is the thin admission-gate / preemption-hook glue.
- GUARANTEED_NO_EVICT policy: reserves `ceil((prompt + max_output) / block_size)` blocks per request up front, admits
  FCFS until the next request won't fit, queues the rest, and never preempts.
- AIC perf-model integration: for the trtllm backend, using `free_gpu_memory_fraction` to calculate
  *free* memory (after weights), unlike vLLM's `gpu_memory_utilization`
- Default backend versions bumped: vLLM `0.19.0`, SGLang `0.5.10`,  TRT-LLM `1.3.0rc10`.

**Tests:** Rust unit/invariant tests in `scheduler/trtllm/tests.rs` (including a hardware-parity `no_evict_admission_cap_matches_hardware`, pinned to cap = 28, see details in test comments);

#### Where should the reviewer start?

- `lib/mocker/src/scheduler/trtllm/policy.rs` — reservation / no-evict logic (free functions over public types).
- `lib/mocker/src/scheduler/vllm/core.rs` — the admission-gate + `policy_preempt` glue that calls it.
- `lib/bindings/python/src/dynamo/_internal/aic.py` — the `free_gpu_memory_fraction` KV-budget formula for the trtllm backend.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #10093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TensorRT-LLM (TRT-LLM) as a supported engine type.
  * Added `--free-gpu-memory-fraction` parameter for optimizing KV cache capacity estimation.
  * Added TRT-LLM-specific scheduling policy (`guaranteed_no_evict`) to control preemption behavior.

* **Documentation**
  * Updated CLI help text for `--block-size` and backend version options to reflect TRT-LLM defaults.

* **Tests**
  * Added comprehensive test coverage for TRT-LLM configuration, scheduling policies, and capacity estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->