### PR TITLE
fix(sglang): advertise global DP ranks for routing

### DIFF
--- a/components/src/dynamo/sglang/CLAUDE.md
+++ b/components/src/dynamo/sglang/CLAUDE.md
@@ -141,6 +141,23 @@ BaseGenerativeHandler (handler_base.py)
 3. **Video generation** (`register_video_generation_model`): Same fast path with
    `ModelType.Videos`.
 
+### Multinode DP Rank Visibility
+
+SGLang multinode LLM workers have two different DP-rank views:
+
+- **Model registration / router scheduling** is global. In the legacy
+  `python -m dynamo.sglang` path, only the leader process (`node_rank == 0`)
+  serves the Dynamo endpoint and registers the model card. That single routable
+  worker must advertise `[0, dp_size)` via `ModelRuntimeConfig`; otherwise the
+  router cannot schedule remote DP ranks.
+- **KV events, FPM, and component metrics** are local. Each node subscribes only
+  to its own rank slice from `local_dp_rank_bounds(server_args)`, and non-leader
+  nodes publish those events using the leader worker id so the router-visible KV
+  trees remain keyed as `(leader_worker_id, dp_rank)`.
+
+Do not reuse the local per-node rank slice for model registration. Keep
+registration on the global range and local publishers on the local range.
+
 ## Init Flow (typical LLM decode)
 
 ```

--- a/components/src/dynamo/sglang/capacity.py
+++ b/components/src/dynamo/sglang/capacity.py
@@ -30,6 +30,11 @@ def local_dp_rank_bounds(server_args: Any) -> tuple[int, int]:
     return 0, 1
 
 
+def model_card_dp_rank_bounds(server_args: Any) -> tuple[int, int]:
+    dp_size = getattr(server_args, "dp_size", 1) or 1
+    return 0, dp_size
+
+
 def per_rank_max_running_requests(server_args: Any) -> int | None:
     max_running_requests = getattr(server_args, "max_running_requests", None)
     if max_running_requests is None:

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -27,7 +27,7 @@ from dynamo.llm import (
 from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import DynamoConfig
-from dynamo.sglang.capacity import local_dp_rank_bounds, runtime_capacity
+from dynamo.sglang.capacity import model_card_dp_rank_bounds, runtime_capacity
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
 
@@ -291,13 +291,13 @@ async def _get_runtime_config(
         dynamo_args.enable_local_indexer and not is_decode_worker
     )
 
-    start_dp_rank, end_dp_rank = local_dp_rank_bounds(server_args)
-    local_dp_size = end_dp_rank - start_dp_rank
+    start_dp_rank, end_dp_rank = model_card_dp_rank_bounds(server_args)
+    registered_dp_size = end_dp_rank - start_dp_rank
     runtime_config.data_parallel_start_rank = start_dp_rank
-    runtime_config.data_parallel_size = local_dp_size
-    if local_dp_size > 1:
+    runtime_config.data_parallel_size = registered_dp_size
+    if registered_dp_size > 1:
         logging.info(
-            "Registering with local data_parallel rank range [%s, %s)",
+            "Registering with routable data_parallel rank range [%s, %s)",
             start_dp_rank,
             end_dp_rank,
         )

--- a/components/src/dynamo/sglang/tests/test_sglang_local_dp_ranks.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_local_dp_ranks.py
@@ -44,6 +44,19 @@ def test_dp_attention_multi_node_slices_ranks_by_node_index():
     assert _slice(dp_size=8, enable_dp_attention=True, nnodes=2, node_rank=1) == (4, 8)
 
 
+def test_model_card_registration_keeps_global_dp_range():
+    from dynamo.sglang.capacity import model_card_dp_rank_bounds
+
+    server_args = SimpleNamespace(
+        dp_size=16,
+        enable_dp_attention=True,
+        nnodes=4,
+        node_rank=0,
+    )
+
+    assert model_card_dp_rank_bounds(server_args) == (0, 16)
+
+
 def test_missing_attributes_use_safe_defaults():
     from dynamo.sglang.llm_engine import _local_dp_rank_range as helper
 


### PR DESCRIPTION
Restore SGLang leader model-card DP visibility to the global DP range while keeping local rank slices for KV/FPM publishers. Documents and tests the registration vs local-publishing invariant.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance on multinode data-parallel rank visibility for distributed training configurations.

* **Bug Fixes**
  * Updated model registration to correctly compute global data-parallel rank ranges for distributed deployments.

* **Tests**
  * Added test coverage for model card registration with data-parallel rank ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->