### PR TITLE
feat(mocker): eagle plumbing for replay

### DIFF
--- a/components/src/dynamo/common/configuration/groups/aic_perf_args.py
+++ b/components/src/dynamo/common/configuration/groups/aic_perf_args.py
@@ -18,6 +18,8 @@ _AIC_PERF_FIELDS: tuple[str, ...] = (
     "aic_moe_tp_size",
     "aic_moe_ep_size",
     "aic_attention_dp_size",
+    "aic_nextn",
+    "aic_nextn_accept_rates",
 )
 
 
@@ -30,6 +32,8 @@ class AicPerfConfigBase(ConfigBase):
     aic_moe_tp_size: Optional[int]
     aic_moe_ep_size: Optional[int]
     aic_attention_dp_size: Optional[int]
+    aic_nextn: Optional[int]
+    aic_nextn_accept_rates: Optional[str]
 
     def aic_perf_kwargs(self) -> dict:
         return {field: getattr(self, field) for field in _AIC_PERF_FIELDS}
@@ -113,4 +117,25 @@ class AicPerfArgGroup(ArgGroup):
             default=None,
             help="[EXPERIMENTAL] Attention data-parallel size to model in AIC.",
             arg_type=int,
+        )
+        add_argument(
+            g,
+            flag_name="--aic-nextn",
+            env_var="DYN_AIC_NEXTN",
+            default=None,
+            help=(
+                "[EXPERIMENTAL] MTP/Eagle speculative-decoding draft-token count "
+                "for AIC latency modeling (max 5). Omit to disable spec dec."
+            ),
+            arg_type=int,
+        )
+        add_argument(
+            g,
+            flag_name="--aic-nextn-accept-rates",
+            env_var="DYN_AIC_NEXTN_ACCEPT_RATES",
+            default=None,
+            help=(
+                "[EXPERIMENTAL] Comma-separated per-position accept rates for MTP "
+                "draft tokens (e.g. '0.85,0.3,0,0,0'). Padded to length 5."
+            ),
         )

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -63,6 +63,8 @@ def test_aic_perf_moe_cli_flows_to_binding_kwargs() -> None:
         "aic_moe_tp_size": 2,
         "aic_moe_ep_size": 1,
         "aic_attention_dp_size": 1,
+        "aic_nextn": None,
+        "aic_nextn_accept_rates": None,
     }
 
 

--- a/container/README.md
+++ b/container/README.md
@@ -5,6 +5,7 @@
 The NVIDIA Dynamo project uses containerized development and deployment to maintain consistent environments across different AI inference frameworks and deployment scenarios. This directory contains the tools for building and running Dynamo containers:
 
 ### Rendering Requirements:
+
 - Python
 - Python Packages:
   - pyyaml
@@ -12,63 +13,61 @@ The NVIDIA Dynamo project uses containerized development and deployment to maint
 
 ### Core Components
 
-- **`render.py`** - A render script used to generate Dockerfiles for AI inference frameworks (vLLM, TensorRT-LLM, SGLang) and the frontend image. The generated Dockerfile includes the needed multi-stage steps for development vs production configurations.
-
-- **`run.sh`** - A container runtime manager that launches Docker containers with proper GPU access, volume mounts, and environment configurations. It supports different development workflows from root-based legacy setups to user-based development environments.
+- `**render.py**` - A render script used to generate Dockerfiles for AI inference frameworks (vLLM, TensorRT-LLM, SGLang) and the frontend image. The generated Dockerfile includes the needed multi-stage steps for development vs production configurations.
+- `**run.sh**` - A container runtime manager that launches Docker containers with proper GPU access, volume mounts, and environment configurations. It supports different development workflows from root-based legacy setups to user-based development environments.
 
 ### Stage Summary for Frameworks
 
-<details>
-<summary>Show Stage Summary Table</summary>
-Dockerfile General Structure
+Show Stage Summary Table Dockerfile General Structure
 
 Below is a summary of the general file structure for the framework Dockerfile stages. Some exceptions exist.
 
-| Stage/Filepath | Target |
-| --- | --- |
-| **STAGE dynamo_base** | **FROM ${BASE_IMAGE}** |
-| /bin/uv, /bin/uvx | COPY from ghcr.io/astral-sh/uv:latest (→ framework, runtime) |
-|  /usr/bin/nats-server | Downloaded from GitHub (→ runtime) |
-|  /usr/local/bin/etcd/ | Downloaded from GitHub (→ runtime) |
-|  /usr/local/rustup/ | Installed via rustup-init (→ wheel_builder, dev) |
-|  /usr/local/cargo/ | Installed via rustup-init (→ wheel_builder, dev) |
-|  /usr/local/cuda/ | Inherited from BASE_IMAGE (→ wheel_builder, runtime) |
-| **STAGE: wheel_builder** | **FROM quay.io/pypa/manylinux_2_28_${ARCH_ALT}** |
-|  /usr/local/ucx/ | Built from source (→ runtime)
-|  /opt/nvidia/nvda_nixl/ | Built from source (→ runtime)
-|  /opt/nvidia/nvda_nixl/lib64/ | Built from source (→ runtime)
-|  /opt/dynamo/target/ | Cargo build output (→ runtime)
-|  /opt/dynamo/dist/*.whl | Built wheels (→ runtime)
-|  /opt/dynamo/dist/nixl/ | Built nixl wheels (→ runtime)
-| **STAGE: runtime** | **FROM ${RUNTIME_IMAGE} (multi-arch upstream runtime image)** |
-|  /usr/bin/nats-server | COPY from dynamo_base |
-|  /usr/local/bin/etcd/ | COPY from dynamo_base |
-|  /opt/dynamo/wheelhouse/ | COPY from wheel_builder |
-|  upstream Python/site-packages | inherited from the upstream runtime image — `vllm/vllm-openai` (vLLM; multi-arch amd64/arm64, separate tag per CUDA family), `lmsysorg/sglang` (SGLang; multi-arch amd64/arm64), or `nvcr.io/nvidia/tensorrt-llm/release` (TRT-LLM; multi-arch amd64/arm64) |
-|  /workspace/ | COPY from build context — subset varies by framework (see note below) |
-| **STAGE: dev** | **FROM runtime (via dev/Dockerfile.dev)** |
-|  /usr/bin/, /usr/lib/, etc. | COPY from dynamo_tools (dev utilities, git, sudo, etc.) |
-|  /usr/local/rustup/ | COPY from dynamo_tools |
-|  /usr/local/cargo/ | COPY from dynamo_tools |
-|  /usr/local/bin/maturin | COPY from dynamo_tools |
-|  /opt/dynamo/venv/ | For SGLang: created with --system-site-packages, includes uv and maturin |
-|  /workspace/ | Full source code copied from build context with editable install |
-|  **💡 Recommendation** | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code) |
-|  PATH | Includes /opt/dynamo/venv/bin:/usr/local/cargo/bin |
-|  umask 002 | Login shell sources /etc/profile.d/00-umask.sh for group-writable files |
-| **STAGE: local-dev** | **FROM dev (via dev/Dockerfile.dev)** |
-|  /home/dynamo/.rustup/ | COPY from /usr/local/rustup (user-writable) |
-|  USER | dynamo (UID/GID remapped to match host user) |
-|  **💡 Recommendation** | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code) |
-|  RUSTUP_HOME | /home/dynamo/.rustup |
-|  CARGO_HOME | /home/dynamo/.cargo |
+
+| Stage/Filepath                | Target                                                                                                                                                                                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **STAGE dynamo_base**         | **FROM ${BASE_IMAGE}**                                                                                                                                                                                                                                      |
+| /bin/uv, /bin/uvx             | COPY from ghcr.io/astral-sh/uv:latest (→ framework, runtime)                                                                                                                                                                                                |
+| /usr/bin/nats-server          | Downloaded from GitHub (→ runtime)                                                                                                                                                                                                                          |
+| /usr/local/bin/etcd/          | Downloaded from GitHub (→ runtime)                                                                                                                                                                                                                          |
+| /usr/local/rustup/            | Installed via rustup-init (→ wheel_builder, dev)                                                                                                                                                                                                            |
+| /usr/local/cargo/             | Installed via rustup-init (→ wheel_builder, dev)                                                                                                                                                                                                            |
+| /usr/local/cuda/              | Inherited from BASE_IMAGE (→ wheel_builder, runtime)                                                                                                                                                                                                        |
+| **STAGE: wheel_builder**      | **FROM quay.io/pypa/manylinux_2_28_${ARCH_ALT}**                                                                                                                                                                                                            |
+| /usr/local/ucx/               | Built from source (→ runtime)                                                                                                                                                                                                                               |
+| /opt/nvidia/nvda_nixl/        | Built from source (→ runtime)                                                                                                                                                                                                                               |
+| /opt/nvidia/nvda_nixl/lib64/  | Built from source (→ runtime)                                                                                                                                                                                                                               |
+| /opt/dynamo/target/           | Cargo build output (→ runtime)                                                                                                                                                                                                                              |
+| /opt/dynamo/dist/*.whl        | Built wheels (→ runtime)                                                                                                                                                                                                                                    |
+| /opt/dynamo/dist/nixl/        | Built nixl wheels (→ runtime)                                                                                                                                                                                                                               |
+| **STAGE: runtime**            | **FROM ${RUNTIME_IMAGE} (multi-arch upstream runtime image)**                                                                                                                                                                                               |
+| /usr/bin/nats-server          | COPY from dynamo_base                                                                                                                                                                                                                                       |
+| /usr/local/bin/etcd/          | COPY from dynamo_base                                                                                                                                                                                                                                       |
+| /opt/dynamo/wheelhouse/       | COPY from wheel_builder                                                                                                                                                                                                                                     |
+| upstream Python/site-packages | inherited from the upstream runtime image — `vllm/vllm-openai` (vLLM; multi-arch amd64/arm64, separate tag per CUDA family), `lmsysorg/sglang` (SGLang; multi-arch amd64/arm64), or `nvcr.io/nvidia/tensorrt-llm/release` (TRT-LLM; multi-arch amd64/arm64) |
+| /workspace/                   | COPY from build context — subset varies by framework (see note below)                                                                                                                                                                                       |
+| **STAGE: dev**                | **FROM runtime (via dev/Dockerfile.dev)**                                                                                                                                                                                                                   |
+| /usr/bin/, /usr/lib/, etc.    | COPY from dynamo_tools (dev utilities, git, sudo, etc.)                                                                                                                                                                                                     |
+| /usr/local/rustup/            | COPY from dynamo_tools                                                                                                                                                                                                                                      |
+| /usr/local/cargo/             | COPY from dynamo_tools                                                                                                                                                                                                                                      |
+| /usr/local/bin/maturin        | COPY from dynamo_tools                                                                                                                                                                                                                                      |
+| /opt/dynamo/venv/             | For SGLang: created with --system-site-packages, includes uv and maturin                                                                                                                                                                                    |
+| /workspace/                   | Full source code copied from build context with editable install                                                                                                                                                                                            |
+| **💡 Recommendation**         | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code)                                                                                                                                                                 |
+| PATH                          | Includes /opt/dynamo/venv/bin:/usr/local/cargo/bin                                                                                                                                                                                                          |
+| umask 002                     | Login shell sources /etc/profile.d/00-umask.sh for group-writable files                                                                                                                                                                                     |
+| **STAGE: local-dev**          | **FROM dev (via dev/Dockerfile.dev)**                                                                                                                                                                                                                       |
+| /home/dynamo/.rustup/         | COPY from /usr/local/rustup (user-writable)                                                                                                                                                                                                                 |
+| USER                          | dynamo (UID/GID remapped to match host user)                                                                                                                                                                                                                |
+| **💡 Recommendation**         | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code)                                                                                                                                                                 |
+| RUSTUP_HOME                   | /home/dynamo/.rustup                                                                                                                                                                                                                                        |
+| CARGO_HOME                    | /home/dynamo/.cargo                                                                                                                                                                                                                                         |
+
 
 **Note on `/workspace/` COPY set:**
 
 - Common to all three frameworks: `tests`, `examples`, `dev`, `components/src/dynamo/{common,frontend,<framework>}`
 - vLLM and TRT-LLM additionally copy `lib`; SGLang and TRT-LLM additionally copy `deploy` and `components/src/dynamo/mocker`; SGLang additionally copies `recipes`.
 - See each framework's `templates/<framework>_runtime.Dockerfile` for the exact list.
-</details>
 
 ### Why Containerization?
 
@@ -79,6 +78,7 @@ The scripts in this directory abstract away the complexity of Docker commands wh
 ### Convenience Scripts vs Direct Docker Commands
 
 The `run.sh` script and rendering scripts are conveniences that simplify common Docker operations. They automatically handle:
+
 - GPU access configuration and runtime selection
 - Volume mount setup for development workflows
 - Environment variable management
@@ -90,15 +90,17 @@ The `run.sh` script and rendering scripts are conveniences that simplify common 
 
 **Note**: In Dynamo, "targets" and "Docker stages" are synonymous. Each target corresponds to a stage in the multi-stage Docker build. Similarly, "frameworks" and "engines" are synonymous (vLLM, TensorRT-LLM, SGLang).
 
-| Feature | **runtime + `run.sh`** | **local-dev (`run.sh` or Dev Container)** | **dev + `run.sh`** (legacy) |
-|---------|----------------------|-------------------------------------------|--------------------------|
-| **Usage** | Benchmarking inference and deployments, non-root | Development, compilation, testing locally | Legacy workflows, root user, use with caution |
-| **User** | dynamo (UID 1000) | dynamo (UID=host user) with sudo | root (UID 0, use with caution) |
-| **Home Directory** | `/home/dynamo` | `/home/dynamo` | `/root` |
-| **Working Directory** | `/workspace` (in-container or mounted) | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`) | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`) |
-| **Rust Toolchain** | None (uses pre-built wheels) | System install (`/usr/local/rustup`, `/usr/local/cargo`) | System install (`/usr/local/rustup`, `/usr/local/cargo`) |
-| **Cargo Target** | None | `/workspace/target` | `/workspace/target` |
-| **Python Env** | system site-packages for vllm/sglang; venv (`/opt/dynamo/venv` with `--system-site-packages`) for trtllm | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) |
+
+| Feature               | **runtime + `run.sh`**                                                                                   | **local-dev (`run.sh` or Dev Container)**                                                                             | **dev + `run.sh`** (legacy)                                                                                           |
+| --------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Usage**             | Benchmarking inference and deployments, non-root                                                         | Development, compilation, testing locally                                                                             | Legacy workflows, root user, use with caution                                                                         |
+| **User**              | dynamo (UID 1000)                                                                                        | dynamo (UID=host user) with sudo                                                                                      | root (UID 0, use with caution)                                                                                        |
+| **Home Directory**    | `/home/dynamo`                                                                                           | `/home/dynamo`                                                                                                        | `/root`                                                                                                               |
+| **Working Directory** | `/workspace` (in-container or mounted)                                                                   | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`)                                                    | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`)                                                    |
+| **Rust Toolchain**    | None (uses pre-built wheels)                                                                             | System install (`/usr/local/rustup`, `/usr/local/cargo`)                                                              | System install (`/usr/local/rustup`, `/usr/local/cargo`)                                                              |
+| **Cargo Target**      | None                                                                                                     | `/workspace/target`                                                                                                   | `/workspace/target`                                                                                                   |
+| **Python Env**        | system site-packages for vllm/sglang; venv (`/opt/dynamo/venv` with `--system-site-packages`) for trtllm | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) |
+
 
 **Note (vLLM/TRT-LLM/SGLang)**: All three runtime images inherit upstream Python solves. vLLM and SGLang install Dynamo wheels into the upstream system site-packages with `--system --no-deps`; the TRT-LLM runtime creates `/opt/dynamo/venv` with `--system-site-packages` and installs Dynamo wheels into that venv with `uv pip install --no-deps`, so upstream packages stay importable but Dynamo's wheels live in their own namespace. The `dev`/`local-dev` images also create `/opt/dynamo/venv` (with `--system-site-packages` where the runtime image uses system Python) so build tooling like `maturin` and `uv` is available without re-solving the framework Python stack.
 
@@ -112,27 +114,33 @@ The `run.sh` script and rendering scripts are conveniences that simplify common 
 ## Example Commands
 
 ### 1. runtime target (runs as non-root dynamo user):
+
 ```bash
 # Build runtime image
-container/render.py --framework vllm --target runtime --output-short-filename
-docker build -t dynamo:latest-vllm-runtime -f container/rendered.Dockerfile .
+container/render.py --framework trtllm --target runtime --output-short-filename --platform arm64 --cuda-version 13.1
+docker build -t dynamo:latest-trtllm-runtime-condp -f container/rendered.Dockerfile .
+docker tag dynamo:latest-trtllm-runtime-condp nvcr.io/nvidian/dynamo-dev/karenc:dynamo-1.2.1-rc16-condp-v1-6ef4f183a-arm
+docker push nvcr.io/nvidian/dynamo-dev/karenc:dynamo-1.2.1-rc16-condp-v1-6ef4f183a-arm
 
 # Run runtime container
 container/run.sh --image dynamo:latest-vllm-runtime -it
 ```
 
 ### 2. test image (layers test deps on top of runtime):
+
 ```bash
 # Build test image from a runtime image (for running tests locally)
 docker build -f container/Dockerfile.test --build-arg BASE_IMAGE=dynamo:latest-vllm-runtime -t dynamo:latest-vllm-test .
 ```
 
 ### 3. local-dev + `run.sh` (runs as dynamo user with matched host UID/GID):
+
 ```bash
 run.sh --mount-workspace -it --image dynamo:latest-vllm-local-dev ...
 ```
 
 ### 3. local-dev + Dev Container Extension:
+
 Use VS Code/Cursor Dev Container Extension with devcontainer.json configuration. The `dynamo` user UID is automatically matched to your local user.
 
 ## Build and Run Scripts Overview
@@ -142,12 +150,14 @@ Use VS Code/Cursor Dev Container Extension with devcontainer.json configuration.
 The `render.py` script is responsible for generating Dockerfiles for different AI inference frameworks. It supports multiple frameworks and configurations:
 
 **Purpose:**
+
 - Generates Dockerfiles for NVIDIA Dynamo with support for vLLM, TensorRT-LLM, SGLang, or standalone configurations
 - Handles framework-specific dependencies and optimizations
 - Manages build contexts, caching, and multi-stage builds
 - Configures development vs production targets
 
 **Key Features:**
+
 - **Framework Support**: vLLM (default when --framework not specified), TensorRT-LLM, SGLang, or NONE (standalone Dynamo)
 - **Multi-stage Builds**: Build process with base images
 - **Development Targets**: Supports `dev`, `runtime`, and `local-dev` targets via `render.py`.
@@ -159,12 +169,14 @@ The `render.py` script is responsible for generating Dockerfiles for different A
 The framework Dockerfiles use BuildKit cache mounts (`RUN --mount=type=cache,...`) to reduce repeated downloads across builds. These caches are stored in Docker/BuildKit’s cache storage on the host (not in your host `~/.cache`), and are shared across builds that use the same builder.
 
 Common cache mount targets:
+
 - `--mount=type=cache,target=/root/.cache/uv`: `uv` download cache (wheels/sdists, git checkouts used by `uv`, etc.)
 - `--mount=type=cache,target=/var/cache/apt,sharing=locked`: apt download cache (`sharing=locked` avoids apt/dpkg races with concurrent builds)
 - `--mount=type=cache,target=/var/cache/{yum,dnf},sharing=locked`: yum/dnf metadata cache (`sharing=locked` avoids corruption with concurrent builds)
 - `--mount=type=cache,target=/root/.cargo/{registry,git}`: Cargo crate/git download caches (Cargo has its own locking; no `sharing=locked` needed)
 
 To inspect cache usage:
+
 ```bash
 docker buildx du
 docker info --format 'DockerRootDir: {{.DockerRootDir}}'
@@ -173,23 +185,27 @@ docker info --format 'DockerRootDir: {{.DockerRootDir}}'
 ##### Inspecting BuildKit cache on the host (quick checklist)
 
 1. Quick summary:
+
 ```bash
 docker buildx du | tail -5
 ```
 
-2. Find Docker root:
+1. Find Docker root:
+
 ```bash
 docker info | grep "Docker Root Dir"
 # Output example: Docker Root Dir: /var/lib/docker
 ```
 
-3. Check executor storage size:
+1. Check executor storage size:
+
 ```bash
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 sudo du -sh "${DOCKER_ROOT}/buildkit/executor" 2>/dev/null || true
 ```
 
-4. Find specific caches (example: uv cache under BuildKit executor rootfs):
+1. Find specific caches (example: uv cache under BuildKit executor rootfs):
+
 ```bash
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 sudo sh -c 'find '"${DOCKER_ROOT}"'/buildkit/executor/*/rootfs/root/.cache/uv -type d 2>/dev/null | while read -r dir; do
@@ -198,13 +214,15 @@ sudo sh -c 'find '"${DOCKER_ROOT}"'/buildkit/executor/*/rootfs/root/.cache/uv -t
 done'
 ```
 
-5. List all large cache directories:
+1. List all large cache directories:
+
 ```bash
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 sudo sh -c 'du -sh '"${DOCKER_ROOT}"'/buildkit/executor/* 2>/dev/null | sort -h | tail -10'
 ```
 
 Cleanup commands:
+
 ```bash
 # Safe: clean only reclaimable cache
 docker buildx prune
@@ -217,6 +235,7 @@ docker buildx prune --filter until=72h
 ```
 
 Current cache types (as mounted in various Dockerfiles):
+
 1. `/root/.cache/uv` and `/home/dynamo/.cache/uv` - Python packages (uv; match the current `USER`)
 2. `/root/.cargo/registry` - Rust crates
 3. `/root/.cargo/git` - Rust git deps
@@ -241,6 +260,7 @@ docker build -t dynamo:latest-trtllm-runtime -f container/rendered.Dockerfile .
 ```
 
 After building, use `run.sh` to launch the container (see [run.sh - Container Runtime Manager](#runsh---container-runtime-manager) below for full options):
+
 ```bash
 # Launch local-dev container with workspace mounted for live editing
 container/run.sh --image dynamo:latest-vllm-local-dev --mount-workspace -it
@@ -251,6 +271,7 @@ container/run.sh --image dynamo:latest-vllm-local-dev --mount-workspace -it
 The frontend image is a specialized container that includes the Dynamo components (Dynamo, NIXL, etc) along with the Endpoint Picker (EPP) for Kubernetes Gateway API Inference Extension integration. This image is primarily used for inference gateway deployments.
 
 **Build EPP Image**
+
 ```bash
 sudo apt-get update && sudo apt-get install -y git build-essential protobuf-compiler libclang-dev
 curl --retry 5 --retry-delay 3 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
@@ -266,6 +287,7 @@ EPP_IMAGE="dynamo/dynamo-epp:${EPP_GIT_TAG}"
 ```
 
 **Build Frontend Image**
+
 ```bash
 # Build the frontend image (automatically builds EPP image as a dependency)
 container/render.py --framework=dynamo --target=frontend --output-short-filename
@@ -273,15 +295,17 @@ docker build -t dynamo:frontend --build-arg EPP_IMAGE=${EPP_IMAGE} -f container/
 ```
 
 The build process automatically:
+
 1. Builds the Dynamo static library for EPP KV-aware routing
 2. Builds the custom EPP Docker image using `make all` from `deploy/inference-gateway/epp/Makefile`
 3. Builds the frontend image with the EPP binary and Dynamo runtime components
 
-For more details, see [`deploy/inference-gateway/README.md`](../deploy/inference-gateway/README.md).
+For more details, see `[deploy/inference-gateway/README.md](../deploy/inference-gateway/README.md)`.
 
 #### Frontend Image Contents
 
 The frontend image includes:
+
 - **EPP (Endpoint Picker)**: Handles request routing and load balancing for inference gateway
 - **Dynamo Runtime**: Core platform components and routing logic
 - **NIXL**: NVIDIA InfiniBand Library for high-performance network communication
@@ -290,19 +314,21 @@ The frontend image includes:
 
 #### Deployment
 
-The frontend image is designed for Kubernetes deployment with the Gateway API Inference Extension. See [`deploy/inference-gateway/README.md`](../deploy/inference-gateway/README.md) for complete deployment instructions using Helm charts.
+The frontend image is designed for Kubernetes deployment with the Gateway API Inference Extension. See `[deploy/inference-gateway/README.md](../deploy/inference-gateway/README.md)` for complete deployment instructions using Helm charts.
 
 ### run.sh - Container Runtime Manager
 
 The `run.sh` script launches Docker containers with the appropriate configuration for development and inference workloads.
 
 **Purpose:**
+
 - Runs pre-built Dynamo Docker images with proper GPU access
 - Configures volume mounts, networking, and environment variables
 - Supports different development workflows (root vs user-based)
 - Manages container lifecycle and resource allocation
 
 **Key Features:**
+
 - **GPU Management**: Automatic GPU detection and allocation
 - **Volume Mounting**: Workspace and HuggingFace cache mounting
 - **User Management**: Non-root `dynamo` user execution (UID 1000, GID 0), with optional `--user` flag to override
@@ -349,12 +375,15 @@ container/run.sh --image dynamo:latest-vllm --user dynamo -v $HOME/.cache:/home/
 The `run.sh` script supports different networking modes via the `--network` flag (defaults to `host`):
 
 #### Host Networking (Default)
+
 ```bash
 # Examples with dynamo user
 container/run.sh --image dynamo:latest-vllm-local-dev --network host -v $HOME/.cache:/home/dynamo/.cache
 container/run.sh --image dynamo:latest-vllm-local-dev -v $HOME/.cache:/home/dynamo/.cache
 ```
+
 **Use cases:**
+
 - High-performance ML inference (default for GPU workloads)
 - Services that need direct host port access
 - Maximum network performance with minimal overhead
@@ -363,11 +392,14 @@ container/run.sh --image dynamo:latest-vllm-local-dev -v $HOME/.cache:/home/dyna
 **⚠️ Port Sharing Limitation:** Host networking shares all ports with the host machine, which means you can only run **one instance** of services like NATS (port 4222) or etcd (port 2379) across all containers and the host.
 
 #### Bridge Networking (Isolated)
+
 ```bash
 # CI/testing with isolated bridge networking and host cache sharing (no -it for automated CI)
 container/run.sh --image dynamo:latest-vllm --mount-workspace --network bridge -v $HOME/.cache:/home/dynamo/.cache
 ```
+
 **Use cases:**
+
 - Secure isolation from host network
 - CI/CD pipelines requiring complete isolation
 - When you need absolute control of ports
@@ -376,6 +408,7 @@ container/run.sh --image dynamo:latest-vllm --mount-workspace --network bridge -
 **Note:** For port sharing with the host, use the `--port` or `-p` option with format `host_port:container_port` (e.g., `--port 8000:8000` or `-p 9081:8081`) to expose specific container ports to the host.
 
 #### No Networking ⚠️ **LIMITED FUNCTIONALITY**
+
 ```bash
 # Complete network isolation - no external connectivity
 container/run.sh --image dynamo:latest-vllm --network none --mount-workspace -it -v $HOME/.cache:/home/dynamo/.cache
@@ -383,7 +416,9 @@ container/run.sh --image dynamo:latest-vllm --network none --mount-workspace -it
 # Same with local-dev image (dynamo user with matched host UID/GID)
 container/run.sh --image dynamo:latest-vllm-local-dev --network none --mount-workspace -it -v $HOME/.cache:/home/dynamo/.cache
 ```
+
 **⚠️ WARNING: `--network none` severely limits Dynamo functionality:**
+
 - **No model downloads** - HuggingFace models cannot be downloaded
 - **No API access** - Cannot reach external APIs or services
 - **No distributed inference** - Multi-node setups won't work
@@ -391,13 +426,16 @@ container/run.sh --image dynamo:latest-vllm-local-dev --network none --mount-wor
 - **Limited debugging** - Cannot access external debugging tools
 
 **Very limited use cases:**
+
 - Pre-downloaded models with purely local processing
 - Air-gapped security environments (models must be pre-staged)
 
 #### Container Network Sharing
+
 Use `--network container:name` to share the network namespace with another container.
 
 **Use cases:**
+
 - Sidecar patterns (logging, monitoring, caching)
 - Service mesh architectures
 - Sharing network namespaces between related containers
@@ -405,9 +443,11 @@ Use `--network container:name` to share the network namespace with another conta
 See Docker documentation for `--network container:name` usage.
 
 #### Custom Networks
+
 Use custom Docker networks for multi-container applications. Create with `docker network create` and specify with `--network network-name`.
 
 **Use cases:**
+
 - Multi-container applications
 - Service discovery by container name
 
@@ -415,17 +455,20 @@ See Docker documentation for custom network creation and management.
 
 #### Network Mode Comparison
 
-| Mode | Performance | Security | Use Case | Dynamo Compatibility | Port Sharing | Port Publishing |
-|------|-------------|----------|----------|---------------------|---------------|-----------------|
-| `host` | Highest | Lower | ML/GPU workloads, high-performance services | ✅ Full | ⚠️ **Shared with host** (one NATS/etcd only) | ❌ Not needed |
-| `bridge` | Good | Higher | General web services, controlled port exposure | ✅ Full | ✅ Isolated ports | ✅ `-p host:container` |
-| `none` | N/A | Highest | Air-gapped environments only | ⚠️ **Very Limited** | ✅ No network | ❌ No network |
-| `container:name` | Good | Medium | Sidecar patterns, shared network stacks | ✅ Full | ⚠️ Shared with target container | ❌ Use target's ports |
-| Custom networks | Good | Medium | Multi-container applications | ✅ Full | ✅ Isolated ports | ✅ `-p host:container` |
+
+| Mode             | Performance | Security | Use Case                                       | Dynamo Compatibility | Port Sharing                                 | Port Publishing       |
+| ---------------- | ----------- | -------- | ---------------------------------------------- | -------------------- | -------------------------------------------- | --------------------- |
+| `host`           | Highest     | Lower    | ML/GPU workloads, high-performance services    | ✅ Full               | ⚠️ **Shared with host** (one NATS/etcd only) | ❌ Not needed          |
+| `bridge`         | Good        | Higher   | General web services, controlled port exposure | ✅ Full               | ✅ Isolated ports                             | ✅ `-p host:container` |
+| `none`           | N/A         | Highest  | Air-gapped environments only                   | ⚠️ **Very Limited**  | ✅ No network                                 | ❌ No network          |
+| `container:name` | Good        | Medium   | Sidecar patterns, shared network stacks        | ✅ Full               | ⚠️ Shared with target container              | ❌ Use target's ports  |
+| Custom networks  | Good        | Medium   | Multi-container applications                   | ✅ Full               | ✅ Isolated ports                             | ✅ `-p host:container` |
+
 
 ## Workflow Examples
 
 ### Development Workflow
+
 ```bash
 # 1. Build local-dev image (builds runtime, then dev as intermediate, then local-dev as final image)
 container/render.py --framework=vllm --target=local-dev --output-short-filename
@@ -449,6 +492,7 @@ python -m dynamo.vllm --model Qwen/Qwen3-0.6B --gpu-memory-utilization 0.20 &
 ```
 
 ### Production Workflow
+
 ```bash
 # 1. Build production runtime image (runs as non-root dynamo user)
 container/render.py --framework=vllm --target=runtime --output-short-filename
@@ -459,6 +503,7 @@ container/run.sh --image dynamo:latest-vllm-runtime --gpus all -v $HOME/.cache:/
 ```
 
 ### Testing Workflow
+
 ```bash
 # 1. Build dev image
 container/render.py --framework=vllm --target=dev --output-short-filename
@@ -501,6 +546,8 @@ DYN_SYSTEM_PORT=8081 python -m dynamo.trtllm --model Qwen/Qwen3-0.6B --free-gpu-
 ```
 
 **Framework-Specific GPU Memory Arguments:**
+
 - **vLLM**: `--gpu-memory-utilization 0.20` (use 20% GPU memory), `--enforce-eager` (disable CUDA graphs), `--no-enable-prefix-caching` (save memory), `--max-num-seqs 64` (max concurrent sequences)
 - **SGLang**: `--mem-fraction-static 0.20` (20% GPU memory for static allocation), `--max-running-requests 64` (max concurrent requests)
 - **TensorRT-LLM**: `--free-gpu-memory-fraction 0.20` (reserve 20% GPU memory), `--max-num-tokens 8192` (max tokens in batch), `--max-batch-size 64` (max batch size)
+

--- a/container/README.md
+++ b/container/README.md
@@ -5,7 +5,6 @@
 The NVIDIA Dynamo project uses containerized development and deployment to maintain consistent environments across different AI inference frameworks and deployment scenarios. This directory contains the tools for building and running Dynamo containers:
 
 ### Rendering Requirements:
-
 - Python
 - Python Packages:
   - pyyaml
@@ -13,61 +12,63 @@ The NVIDIA Dynamo project uses containerized development and deployment to maint
 
 ### Core Components
 
-- `**render.py**` - A render script used to generate Dockerfiles for AI inference frameworks (vLLM, TensorRT-LLM, SGLang) and the frontend image. The generated Dockerfile includes the needed multi-stage steps for development vs production configurations.
-- `**run.sh**` - A container runtime manager that launches Docker containers with proper GPU access, volume mounts, and environment configurations. It supports different development workflows from root-based legacy setups to user-based development environments.
+- **`render.py`** - A render script used to generate Dockerfiles for AI inference frameworks (vLLM, TensorRT-LLM, SGLang) and the frontend image. The generated Dockerfile includes the needed multi-stage steps for development vs production configurations.
+
+- **`run.sh`** - A container runtime manager that launches Docker containers with proper GPU access, volume mounts, and environment configurations. It supports different development workflows from root-based legacy setups to user-based development environments.
 
 ### Stage Summary for Frameworks
 
-Show Stage Summary Table Dockerfile General Structure
+<details>
+<summary>Show Stage Summary Table</summary>
+Dockerfile General Structure
 
 Below is a summary of the general file structure for the framework Dockerfile stages. Some exceptions exist.
 
-
-| Stage/Filepath                | Target                                                                                                                                                                                                                                                      |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **STAGE dynamo_base**         | **FROM ${BASE_IMAGE}**                                                                                                                                                                                                                                      |
-| /bin/uv, /bin/uvx             | COPY from ghcr.io/astral-sh/uv:latest (→ framework, runtime)                                                                                                                                                                                                |
-| /usr/bin/nats-server          | Downloaded from GitHub (→ runtime)                                                                                                                                                                                                                          |
-| /usr/local/bin/etcd/          | Downloaded from GitHub (→ runtime)                                                                                                                                                                                                                          |
-| /usr/local/rustup/            | Installed via rustup-init (→ wheel_builder, dev)                                                                                                                                                                                                            |
-| /usr/local/cargo/             | Installed via rustup-init (→ wheel_builder, dev)                                                                                                                                                                                                            |
-| /usr/local/cuda/              | Inherited from BASE_IMAGE (→ wheel_builder, runtime)                                                                                                                                                                                                        |
-| **STAGE: wheel_builder**      | **FROM quay.io/pypa/manylinux_2_28_${ARCH_ALT}**                                                                                                                                                                                                            |
-| /usr/local/ucx/               | Built from source (→ runtime)                                                                                                                                                                                                                               |
-| /opt/nvidia/nvda_nixl/        | Built from source (→ runtime)                                                                                                                                                                                                                               |
-| /opt/nvidia/nvda_nixl/lib64/  | Built from source (→ runtime)                                                                                                                                                                                                                               |
-| /opt/dynamo/target/           | Cargo build output (→ runtime)                                                                                                                                                                                                                              |
-| /opt/dynamo/dist/*.whl        | Built wheels (→ runtime)                                                                                                                                                                                                                                    |
-| /opt/dynamo/dist/nixl/        | Built nixl wheels (→ runtime)                                                                                                                                                                                                                               |
-| **STAGE: runtime**            | **FROM ${RUNTIME_IMAGE} (multi-arch upstream runtime image)**                                                                                                                                                                                               |
-| /usr/bin/nats-server          | COPY from dynamo_base                                                                                                                                                                                                                                       |
-| /usr/local/bin/etcd/          | COPY from dynamo_base                                                                                                                                                                                                                                       |
-| /opt/dynamo/wheelhouse/       | COPY from wheel_builder                                                                                                                                                                                                                                     |
-| upstream Python/site-packages | inherited from the upstream runtime image — `vllm/vllm-openai` (vLLM; multi-arch amd64/arm64, separate tag per CUDA family), `lmsysorg/sglang` (SGLang; multi-arch amd64/arm64), or `nvcr.io/nvidia/tensorrt-llm/release` (TRT-LLM; multi-arch amd64/arm64) |
-| /workspace/                   | COPY from build context — subset varies by framework (see note below)                                                                                                                                                                                       |
-| **STAGE: dev**                | **FROM runtime (via dev/Dockerfile.dev)**                                                                                                                                                                                                                   |
-| /usr/bin/, /usr/lib/, etc.    | COPY from dynamo_tools (dev utilities, git, sudo, etc.)                                                                                                                                                                                                     |
-| /usr/local/rustup/            | COPY from dynamo_tools                                                                                                                                                                                                                                      |
-| /usr/local/cargo/             | COPY from dynamo_tools                                                                                                                                                                                                                                      |
-| /usr/local/bin/maturin        | COPY from dynamo_tools                                                                                                                                                                                                                                      |
-| /opt/dynamo/venv/             | For SGLang: created with --system-site-packages, includes uv and maturin                                                                                                                                                                                    |
-| /workspace/                   | Full source code copied from build context with editable install                                                                                                                                                                                            |
-| **💡 Recommendation**         | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code)                                                                                                                                                                 |
-| PATH                          | Includes /opt/dynamo/venv/bin:/usr/local/cargo/bin                                                                                                                                                                                                          |
-| umask 002                     | Login shell sources /etc/profile.d/00-umask.sh for group-writable files                                                                                                                                                                                     |
-| **STAGE: local-dev**          | **FROM dev (via dev/Dockerfile.dev)**                                                                                                                                                                                                                       |
-| /home/dynamo/.rustup/         | COPY from /usr/local/rustup (user-writable)                                                                                                                                                                                                                 |
-| USER                          | dynamo (UID/GID remapped to match host user)                                                                                                                                                                                                                |
-| **💡 Recommendation**         | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code)                                                                                                                                                                 |
-| RUSTUP_HOME                   | /home/dynamo/.rustup                                                                                                                                                                                                                                        |
-| CARGO_HOME                    | /home/dynamo/.cargo                                                                                                                                                                                                                                         |
-
+| Stage/Filepath | Target |
+| --- | --- |
+| **STAGE dynamo_base** | **FROM ${BASE_IMAGE}** |
+| /bin/uv, /bin/uvx | COPY from ghcr.io/astral-sh/uv:latest (→ framework, runtime) |
+|  /usr/bin/nats-server | Downloaded from GitHub (→ runtime) |
+|  /usr/local/bin/etcd/ | Downloaded from GitHub (→ runtime) |
+|  /usr/local/rustup/ | Installed via rustup-init (→ wheel_builder, dev) |
+|  /usr/local/cargo/ | Installed via rustup-init (→ wheel_builder, dev) |
+|  /usr/local/cuda/ | Inherited from BASE_IMAGE (→ wheel_builder, runtime) |
+| **STAGE: wheel_builder** | **FROM quay.io/pypa/manylinux_2_28_${ARCH_ALT}** |
+|  /usr/local/ucx/ | Built from source (→ runtime)
+|  /opt/nvidia/nvda_nixl/ | Built from source (→ runtime)
+|  /opt/nvidia/nvda_nixl/lib64/ | Built from source (→ runtime)
+|  /opt/dynamo/target/ | Cargo build output (→ runtime)
+|  /opt/dynamo/dist/*.whl | Built wheels (→ runtime)
+|  /opt/dynamo/dist/nixl/ | Built nixl wheels (→ runtime)
+| **STAGE: runtime** | **FROM ${RUNTIME_IMAGE} (multi-arch upstream runtime image)** |
+|  /usr/bin/nats-server | COPY from dynamo_base |
+|  /usr/local/bin/etcd/ | COPY from dynamo_base |
+|  /opt/dynamo/wheelhouse/ | COPY from wheel_builder |
+|  upstream Python/site-packages | inherited from the upstream runtime image — `vllm/vllm-openai` (vLLM; multi-arch amd64/arm64, separate tag per CUDA family), `lmsysorg/sglang` (SGLang; multi-arch amd64/arm64), or `nvcr.io/nvidia/tensorrt-llm/release` (TRT-LLM; multi-arch amd64/arm64) |
+|  /workspace/ | COPY from build context — subset varies by framework (see note below) |
+| **STAGE: dev** | **FROM runtime (via dev/Dockerfile.dev)** |
+|  /usr/bin/, /usr/lib/, etc. | COPY from dynamo_tools (dev utilities, git, sudo, etc.) |
+|  /usr/local/rustup/ | COPY from dynamo_tools |
+|  /usr/local/cargo/ | COPY from dynamo_tools |
+|  /usr/local/bin/maturin | COPY from dynamo_tools |
+|  /opt/dynamo/venv/ | For SGLang: created with --system-site-packages, includes uv and maturin |
+|  /workspace/ | Full source code copied from build context with editable install |
+|  **💡 Recommendation** | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code) |
+|  PATH | Includes /opt/dynamo/venv/bin:/usr/local/cargo/bin |
+|  umask 002 | Login shell sources /etc/profile.d/00-umask.sh for group-writable files |
+| **STAGE: local-dev** | **FROM dev (via dev/Dockerfile.dev)** |
+|  /home/dynamo/.rustup/ | COPY from /usr/local/rustup (user-writable) |
+|  USER | dynamo (UID/GID remapped to match host user) |
+|  **💡 Recommendation** | **Use --mount-workspace with run.sh** for live editing (bind mount overrides baked-in code) |
+|  RUSTUP_HOME | /home/dynamo/.rustup |
+|  CARGO_HOME | /home/dynamo/.cargo |
 
 **Note on `/workspace/` COPY set:**
 
 - Common to all three frameworks: `tests`, `examples`, `dev`, `components/src/dynamo/{common,frontend,<framework>}`
 - vLLM and TRT-LLM additionally copy `lib`; SGLang and TRT-LLM additionally copy `deploy` and `components/src/dynamo/mocker`; SGLang additionally copies `recipes`.
 - See each framework's `templates/<framework>_runtime.Dockerfile` for the exact list.
+</details>
 
 ### Why Containerization?
 
@@ -78,7 +79,6 @@ The scripts in this directory abstract away the complexity of Docker commands wh
 ### Convenience Scripts vs Direct Docker Commands
 
 The `run.sh` script and rendering scripts are conveniences that simplify common Docker operations. They automatically handle:
-
 - GPU access configuration and runtime selection
 - Volume mount setup for development workflows
 - Environment variable management
@@ -90,17 +90,15 @@ The `run.sh` script and rendering scripts are conveniences that simplify common 
 
 **Note**: In Dynamo, "targets" and "Docker stages" are synonymous. Each target corresponds to a stage in the multi-stage Docker build. Similarly, "frameworks" and "engines" are synonymous (vLLM, TensorRT-LLM, SGLang).
 
-
-| Feature               | **runtime + `run.sh`**                                                                                   | **local-dev (`run.sh` or Dev Container)**                                                                             | **dev + `run.sh`** (legacy)                                                                                           |
-| --------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Usage**             | Benchmarking inference and deployments, non-root                                                         | Development, compilation, testing locally                                                                             | Legacy workflows, root user, use with caution                                                                         |
-| **User**              | dynamo (UID 1000)                                                                                        | dynamo (UID=host user) with sudo                                                                                      | root (UID 0, use with caution)                                                                                        |
-| **Home Directory**    | `/home/dynamo`                                                                                           | `/home/dynamo`                                                                                                        | `/root`                                                                                                               |
-| **Working Directory** | `/workspace` (in-container or mounted)                                                                   | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`)                                                    | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`)                                                    |
-| **Rust Toolchain**    | None (uses pre-built wheels)                                                                             | System install (`/usr/local/rustup`, `/usr/local/cargo`)                                                              | System install (`/usr/local/rustup`, `/usr/local/cargo`)                                                              |
-| **Cargo Target**      | None                                                                                                     | `/workspace/target`                                                                                                   | `/workspace/target`                                                                                                   |
-| **Python Env**        | system site-packages for vllm/sglang; venv (`/opt/dynamo/venv` with `--system-site-packages`) for trtllm | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) |
-
+| Feature | **runtime + `run.sh`** | **local-dev (`run.sh` or Dev Container)** | **dev + `run.sh`** (legacy) |
+|---------|----------------------|-------------------------------------------|--------------------------|
+| **Usage** | Benchmarking inference and deployments, non-root | Development, compilation, testing locally | Legacy workflows, root user, use with caution |
+| **User** | dynamo (UID 1000) | dynamo (UID=host user) with sudo | root (UID 0, use with caution) |
+| **Home Directory** | `/home/dynamo` | `/home/dynamo` | `/root` |
+| **Working Directory** | `/workspace` (in-container or mounted) | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`) | `/workspace` (baked-in, optionally mounted w/ `--mount-workspace`) |
+| **Rust Toolchain** | None (uses pre-built wheels) | System install (`/usr/local/rustup`, `/usr/local/cargo`) | System install (`/usr/local/rustup`, `/usr/local/cargo`) |
+| **Cargo Target** | None | `/workspace/target` | `/workspace/target` |
+| **Python Env** | system site-packages for vllm/sglang; venv (`/opt/dynamo/venv` with `--system-site-packages`) for trtllm | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) | venv (`/opt/dynamo/venv`) for all frameworks (with --system-site-packages where the runtime image uses system Python) |
 
 **Note (vLLM/TRT-LLM/SGLang)**: All three runtime images inherit upstream Python solves. vLLM and SGLang install Dynamo wheels into the upstream system site-packages with `--system --no-deps`; the TRT-LLM runtime creates `/opt/dynamo/venv` with `--system-site-packages` and installs Dynamo wheels into that venv with `uv pip install --no-deps`, so upstream packages stay importable but Dynamo's wheels live in their own namespace. The `dev`/`local-dev` images also create `/opt/dynamo/venv` (with `--system-site-packages` where the runtime image uses system Python) so build tooling like `maturin` and `uv` is available without re-solving the framework Python stack.
 
@@ -114,33 +112,27 @@ The `run.sh` script and rendering scripts are conveniences that simplify common 
 ## Example Commands
 
 ### 1. runtime target (runs as non-root dynamo user):
-
 ```bash
 # Build runtime image
-container/render.py --framework trtllm --target runtime --output-short-filename --platform arm64 --cuda-version 13.1
-docker build -t dynamo:latest-trtllm-runtime-condp -f container/rendered.Dockerfile .
-docker tag dynamo:latest-trtllm-runtime-condp nvcr.io/nvidian/dynamo-dev/karenc:dynamo-1.2.1-rc16-condp-v1-6ef4f183a-arm
-docker push nvcr.io/nvidian/dynamo-dev/karenc:dynamo-1.2.1-rc16-condp-v1-6ef4f183a-arm
+container/render.py --framework vllm --target runtime --output-short-filename
+docker build -t dynamo:latest-vllm-runtime -f container/rendered.Dockerfile .
 
 # Run runtime container
 container/run.sh --image dynamo:latest-vllm-runtime -it
 ```
 
 ### 2. test image (layers test deps on top of runtime):
-
 ```bash
 # Build test image from a runtime image (for running tests locally)
 docker build -f container/Dockerfile.test --build-arg BASE_IMAGE=dynamo:latest-vllm-runtime -t dynamo:latest-vllm-test .
 ```
 
 ### 3. local-dev + `run.sh` (runs as dynamo user with matched host UID/GID):
-
 ```bash
 run.sh --mount-workspace -it --image dynamo:latest-vllm-local-dev ...
 ```
 
 ### 3. local-dev + Dev Container Extension:
-
 Use VS Code/Cursor Dev Container Extension with devcontainer.json configuration. The `dynamo` user UID is automatically matched to your local user.
 
 ## Build and Run Scripts Overview
@@ -150,14 +142,12 @@ Use VS Code/Cursor Dev Container Extension with devcontainer.json configuration.
 The `render.py` script is responsible for generating Dockerfiles for different AI inference frameworks. It supports multiple frameworks and configurations:
 
 **Purpose:**
-
 - Generates Dockerfiles for NVIDIA Dynamo with support for vLLM, TensorRT-LLM, SGLang, or standalone configurations
 - Handles framework-specific dependencies and optimizations
 - Manages build contexts, caching, and multi-stage builds
 - Configures development vs production targets
 
 **Key Features:**
-
 - **Framework Support**: vLLM (default when --framework not specified), TensorRT-LLM, SGLang, or NONE (standalone Dynamo)
 - **Multi-stage Builds**: Build process with base images
 - **Development Targets**: Supports `dev`, `runtime`, and `local-dev` targets via `render.py`.
@@ -169,14 +159,12 @@ The `render.py` script is responsible for generating Dockerfiles for different A
 The framework Dockerfiles use BuildKit cache mounts (`RUN --mount=type=cache,...`) to reduce repeated downloads across builds. These caches are stored in Docker/BuildKit’s cache storage on the host (not in your host `~/.cache`), and are shared across builds that use the same builder.
 
 Common cache mount targets:
-
 - `--mount=type=cache,target=/root/.cache/uv`: `uv` download cache (wheels/sdists, git checkouts used by `uv`, etc.)
 - `--mount=type=cache,target=/var/cache/apt,sharing=locked`: apt download cache (`sharing=locked` avoids apt/dpkg races with concurrent builds)
 - `--mount=type=cache,target=/var/cache/{yum,dnf},sharing=locked`: yum/dnf metadata cache (`sharing=locked` avoids corruption with concurrent builds)
 - `--mount=type=cache,target=/root/.cargo/{registry,git}`: Cargo crate/git download caches (Cargo has its own locking; no `sharing=locked` needed)
 
 To inspect cache usage:
-
 ```bash
 docker buildx du
 docker info --format 'DockerRootDir: {{.DockerRootDir}}'
@@ -185,27 +173,23 @@ docker info --format 'DockerRootDir: {{.DockerRootDir}}'
 ##### Inspecting BuildKit cache on the host (quick checklist)
 
 1. Quick summary:
-
 ```bash
 docker buildx du | tail -5
 ```
 
-1. Find Docker root:
-
+2. Find Docker root:
 ```bash
 docker info | grep "Docker Root Dir"
 # Output example: Docker Root Dir: /var/lib/docker
 ```
 
-1. Check executor storage size:
-
+3. Check executor storage size:
 ```bash
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 sudo du -sh "${DOCKER_ROOT}/buildkit/executor" 2>/dev/null || true
 ```
 
-1. Find specific caches (example: uv cache under BuildKit executor rootfs):
-
+4. Find specific caches (example: uv cache under BuildKit executor rootfs):
 ```bash
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 sudo sh -c 'find '"${DOCKER_ROOT}"'/buildkit/executor/*/rootfs/root/.cache/uv -type d 2>/dev/null | while read -r dir; do
@@ -214,15 +198,13 @@ sudo sh -c 'find '"${DOCKER_ROOT}"'/buildkit/executor/*/rootfs/root/.cache/uv -t
 done'
 ```
 
-1. List all large cache directories:
-
+5. List all large cache directories:
 ```bash
 DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}')"
 sudo sh -c 'du -sh '"${DOCKER_ROOT}"'/buildkit/executor/* 2>/dev/null | sort -h | tail -10'
 ```
 
 Cleanup commands:
-
 ```bash
 # Safe: clean only reclaimable cache
 docker buildx prune
@@ -235,7 +217,6 @@ docker buildx prune --filter until=72h
 ```
 
 Current cache types (as mounted in various Dockerfiles):
-
 1. `/root/.cache/uv` and `/home/dynamo/.cache/uv` - Python packages (uv; match the current `USER`)
 2. `/root/.cargo/registry` - Rust crates
 3. `/root/.cargo/git` - Rust git deps
@@ -260,7 +241,6 @@ docker build -t dynamo:latest-trtllm-runtime -f container/rendered.Dockerfile .
 ```
 
 After building, use `run.sh` to launch the container (see [run.sh - Container Runtime Manager](#runsh---container-runtime-manager) below for full options):
-
 ```bash
 # Launch local-dev container with workspace mounted for live editing
 container/run.sh --image dynamo:latest-vllm-local-dev --mount-workspace -it
@@ -271,7 +251,6 @@ container/run.sh --image dynamo:latest-vllm-local-dev --mount-workspace -it
 The frontend image is a specialized container that includes the Dynamo components (Dynamo, NIXL, etc) along with the Endpoint Picker (EPP) for Kubernetes Gateway API Inference Extension integration. This image is primarily used for inference gateway deployments.
 
 **Build EPP Image**
-
 ```bash
 sudo apt-get update && sudo apt-get install -y git build-essential protobuf-compiler libclang-dev
 curl --retry 5 --retry-delay 3 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
@@ -287,7 +266,6 @@ EPP_IMAGE="dynamo/dynamo-epp:${EPP_GIT_TAG}"
 ```
 
 **Build Frontend Image**
-
 ```bash
 # Build the frontend image (automatically builds EPP image as a dependency)
 container/render.py --framework=dynamo --target=frontend --output-short-filename
@@ -295,17 +273,15 @@ docker build -t dynamo:frontend --build-arg EPP_IMAGE=${EPP_IMAGE} -f container/
 ```
 
 The build process automatically:
-
 1. Builds the Dynamo static library for EPP KV-aware routing
 2. Builds the custom EPP Docker image using `make all` from `deploy/inference-gateway/epp/Makefile`
 3. Builds the frontend image with the EPP binary and Dynamo runtime components
 
-For more details, see `[deploy/inference-gateway/README.md](../deploy/inference-gateway/README.md)`.
+For more details, see [`deploy/inference-gateway/README.md`](../deploy/inference-gateway/README.md).
 
 #### Frontend Image Contents
 
 The frontend image includes:
-
 - **EPP (Endpoint Picker)**: Handles request routing and load balancing for inference gateway
 - **Dynamo Runtime**: Core platform components and routing logic
 - **NIXL**: NVIDIA InfiniBand Library for high-performance network communication
@@ -314,21 +290,19 @@ The frontend image includes:
 
 #### Deployment
 
-The frontend image is designed for Kubernetes deployment with the Gateway API Inference Extension. See `[deploy/inference-gateway/README.md](../deploy/inference-gateway/README.md)` for complete deployment instructions using Helm charts.
+The frontend image is designed for Kubernetes deployment with the Gateway API Inference Extension. See [`deploy/inference-gateway/README.md`](../deploy/inference-gateway/README.md) for complete deployment instructions using Helm charts.
 
 ### run.sh - Container Runtime Manager
 
 The `run.sh` script launches Docker containers with the appropriate configuration for development and inference workloads.
 
 **Purpose:**
-
 - Runs pre-built Dynamo Docker images with proper GPU access
 - Configures volume mounts, networking, and environment variables
 - Supports different development workflows (root vs user-based)
 - Manages container lifecycle and resource allocation
 
 **Key Features:**
-
 - **GPU Management**: Automatic GPU detection and allocation
 - **Volume Mounting**: Workspace and HuggingFace cache mounting
 - **User Management**: Non-root `dynamo` user execution (UID 1000, GID 0), with optional `--user` flag to override
@@ -375,15 +349,12 @@ container/run.sh --image dynamo:latest-vllm --user dynamo -v $HOME/.cache:/home/
 The `run.sh` script supports different networking modes via the `--network` flag (defaults to `host`):
 
 #### Host Networking (Default)
-
 ```bash
 # Examples with dynamo user
 container/run.sh --image dynamo:latest-vllm-local-dev --network host -v $HOME/.cache:/home/dynamo/.cache
 container/run.sh --image dynamo:latest-vllm-local-dev -v $HOME/.cache:/home/dynamo/.cache
 ```
-
 **Use cases:**
-
 - High-performance ML inference (default for GPU workloads)
 - Services that need direct host port access
 - Maximum network performance with minimal overhead
@@ -392,14 +363,11 @@ container/run.sh --image dynamo:latest-vllm-local-dev -v $HOME/.cache:/home/dyna
 **⚠️ Port Sharing Limitation:** Host networking shares all ports with the host machine, which means you can only run **one instance** of services like NATS (port 4222) or etcd (port 2379) across all containers and the host.
 
 #### Bridge Networking (Isolated)
-
 ```bash
 # CI/testing with isolated bridge networking and host cache sharing (no -it for automated CI)
 container/run.sh --image dynamo:latest-vllm --mount-workspace --network bridge -v $HOME/.cache:/home/dynamo/.cache
 ```
-
 **Use cases:**
-
 - Secure isolation from host network
 - CI/CD pipelines requiring complete isolation
 - When you need absolute control of ports
@@ -408,7 +376,6 @@ container/run.sh --image dynamo:latest-vllm --mount-workspace --network bridge -
 **Note:** For port sharing with the host, use the `--port` or `-p` option with format `host_port:container_port` (e.g., `--port 8000:8000` or `-p 9081:8081`) to expose specific container ports to the host.
 
 #### No Networking ⚠️ **LIMITED FUNCTIONALITY**
-
 ```bash
 # Complete network isolation - no external connectivity
 container/run.sh --image dynamo:latest-vllm --network none --mount-workspace -it -v $HOME/.cache:/home/dynamo/.cache
@@ -416,9 +383,7 @@ container/run.sh --image dynamo:latest-vllm --network none --mount-workspace -it
 # Same with local-dev image (dynamo user with matched host UID/GID)
 container/run.sh --image dynamo:latest-vllm-local-dev --network none --mount-workspace -it -v $HOME/.cache:/home/dynamo/.cache
 ```
-
 **⚠️ WARNING: `--network none` severely limits Dynamo functionality:**
-
 - **No model downloads** - HuggingFace models cannot be downloaded
 - **No API access** - Cannot reach external APIs or services
 - **No distributed inference** - Multi-node setups won't work
@@ -426,16 +391,13 @@ container/run.sh --image dynamo:latest-vllm-local-dev --network none --mount-wor
 - **Limited debugging** - Cannot access external debugging tools
 
 **Very limited use cases:**
-
 - Pre-downloaded models with purely local processing
 - Air-gapped security environments (models must be pre-staged)
 
 #### Container Network Sharing
-
 Use `--network container:name` to share the network namespace with another container.
 
 **Use cases:**
-
 - Sidecar patterns (logging, monitoring, caching)
 - Service mesh architectures
 - Sharing network namespaces between related containers
@@ -443,11 +405,9 @@ Use `--network container:name` to share the network namespace with another conta
 See Docker documentation for `--network container:name` usage.
 
 #### Custom Networks
-
 Use custom Docker networks for multi-container applications. Create with `docker network create` and specify with `--network network-name`.
 
 **Use cases:**
-
 - Multi-container applications
 - Service discovery by container name
 
@@ -455,20 +415,17 @@ See Docker documentation for custom network creation and management.
 
 #### Network Mode Comparison
 
-
-| Mode             | Performance | Security | Use Case                                       | Dynamo Compatibility | Port Sharing                                 | Port Publishing       |
-| ---------------- | ----------- | -------- | ---------------------------------------------- | -------------------- | -------------------------------------------- | --------------------- |
-| `host`           | Highest     | Lower    | ML/GPU workloads, high-performance services    | ✅ Full               | ⚠️ **Shared with host** (one NATS/etcd only) | ❌ Not needed          |
-| `bridge`         | Good        | Higher   | General web services, controlled port exposure | ✅ Full               | ✅ Isolated ports                             | ✅ `-p host:container` |
-| `none`           | N/A         | Highest  | Air-gapped environments only                   | ⚠️ **Very Limited**  | ✅ No network                                 | ❌ No network          |
-| `container:name` | Good        | Medium   | Sidecar patterns, shared network stacks        | ✅ Full               | ⚠️ Shared with target container              | ❌ Use target's ports  |
-| Custom networks  | Good        | Medium   | Multi-container applications                   | ✅ Full               | ✅ Isolated ports                             | ✅ `-p host:container` |
-
+| Mode | Performance | Security | Use Case | Dynamo Compatibility | Port Sharing | Port Publishing |
+|------|-------------|----------|----------|---------------------|---------------|-----------------|
+| `host` | Highest | Lower | ML/GPU workloads, high-performance services | ✅ Full | ⚠️ **Shared with host** (one NATS/etcd only) | ❌ Not needed |
+| `bridge` | Good | Higher | General web services, controlled port exposure | ✅ Full | ✅ Isolated ports | ✅ `-p host:container` |
+| `none` | N/A | Highest | Air-gapped environments only | ⚠️ **Very Limited** | ✅ No network | ❌ No network |
+| `container:name` | Good | Medium | Sidecar patterns, shared network stacks | ✅ Full | ⚠️ Shared with target container | ❌ Use target's ports |
+| Custom networks | Good | Medium | Multi-container applications | ✅ Full | ✅ Isolated ports | ✅ `-p host:container` |
 
 ## Workflow Examples
 
 ### Development Workflow
-
 ```bash
 # 1. Build local-dev image (builds runtime, then dev as intermediate, then local-dev as final image)
 container/render.py --framework=vllm --target=local-dev --output-short-filename
@@ -492,7 +449,6 @@ python -m dynamo.vllm --model Qwen/Qwen3-0.6B --gpu-memory-utilization 0.20 &
 ```
 
 ### Production Workflow
-
 ```bash
 # 1. Build production runtime image (runs as non-root dynamo user)
 container/render.py --framework=vllm --target=runtime --output-short-filename
@@ -503,7 +459,6 @@ container/run.sh --image dynamo:latest-vllm-runtime --gpus all -v $HOME/.cache:/
 ```
 
 ### Testing Workflow
-
 ```bash
 # 1. Build dev image
 container/render.py --framework=vllm --target=dev --output-short-filename
@@ -546,8 +501,6 @@ DYN_SYSTEM_PORT=8081 python -m dynamo.trtllm --model Qwen/Qwen3-0.6B --free-gpu-
 ```
 
 **Framework-Specific GPU Memory Arguments:**
-
 - **vLLM**: `--gpu-memory-utilization 0.20` (use 20% GPU memory), `--enforce-eager` (disable CUDA graphs), `--no-enable-prefix-caching` (save memory), `--max-num-seqs 64` (max concurrent sequences)
 - **SGLang**: `--mem-fraction-static 0.20` (20% GPU memory for static allocation), `--max-running-requests 64` (max concurrent requests)
 - **TensorRT-LLM**: `--free-gpu-memory-fraction 0.20` (reserve 20% GPU memory), `--max-num-tokens 8192` (max tokens in batch), `--max-batch-size 64` (max batch size)
-

--- a/lib/bindings/python/rust/llm/aic_callback.rs
+++ b/lib/bindings/python/rust/llm/aic_callback.rs
@@ -85,6 +85,8 @@ pub(super) fn create_aic_callback(
     moe_tp_size: Option<usize>,
     moe_ep_size: Option<usize>,
     attention_dp_size: Option<usize>,
+    nextn: Option<usize>,
+    nextn_accept_rates: Option<&str>,
 ) -> PyResult<Arc<dyn AicCallback>> {
     let module = py.import("dynamo._internal.aic")?;
     let session = module.call_method1(
@@ -98,6 +100,8 @@ pub(super) fn create_aic_callback(
             moe_tp_size,
             moe_ep_size,
             attention_dp_size,
+            nextn,
+            nextn_accept_rates,
         ),
     )?;
     Ok(Arc::new(PyAicCallback {
@@ -116,6 +120,8 @@ pub(super) fn create_aic_prefill_load_estimator(
     moe_tp_size: Option<usize>,
     moe_ep_size: Option<usize>,
     attention_dp_size: Option<usize>,
+    nextn: Option<usize>,
+    nextn_accept_rates: Option<&str>,
 ) -> PyResult<Arc<dyn PrefillLoadEstimator>> {
     let module = py.import("dynamo._internal.aic")?;
     let session = module.call_method1(
@@ -129,6 +135,8 @@ pub(super) fn create_aic_prefill_load_estimator(
             moe_tp_size,
             moe_ep_size,
             attention_dp_size,
+            nextn,
+            nextn_accept_rates,
         ),
     )?;
     Ok(Arc::new(PyAicCallback {
@@ -136,6 +144,14 @@ pub(super) fn create_aic_prefill_load_estimator(
     }))
 }
 
+/// Estimate the KV block pool size from AIC's base-model memory model.
+///
+/// Intentionally does NOT take ``nextn``/``nextn_accept_rates``: AIC's
+/// spec-dec memory scaling (``trtllm_backend._get_memory_usage`` applies
+/// ``activations * (nextn + 1)``) inflates non-KV bytes enough to push the
+/// KV budget negative on tight configs. The block pool should reflect the
+/// base model's footprint; spec-dec speedup is applied separately by the
+/// latency callback (``create_aic_callback``).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn estimate_aic_num_gpu_blocks(
     py: Python<'_>,

--- a/lib/bindings/python/rust/llm/aic_callback.rs
+++ b/lib/bindings/python/rust/llm/aic_callback.rs
@@ -145,13 +145,6 @@ pub(super) fn create_aic_prefill_load_estimator(
 }
 
 /// Estimate the KV block pool size from AIC's base-model memory model.
-///
-/// Intentionally does NOT take ``nextn``/``nextn_accept_rates``: AIC's
-/// spec-dec memory scaling (``trtllm_backend._get_memory_usage`` applies
-/// ``activations * (nextn + 1)``) inflates non-KV bytes enough to push the
-/// KV budget negative on tight configs. The block pool should reflect the
-/// base model's footprint; spec-dec speedup is applied separately by the
-/// latency callback (``create_aic_callback``).
 #[allow(clippy::too_many_arguments)]
 pub(super) fn estimate_aic_num_gpu_blocks(
     py: Python<'_>,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -86,6 +86,8 @@ pub struct AicPerfConfig {
     aic_moe_tp_size: Option<usize>,
     aic_moe_ep_size: Option<usize>,
     aic_attention_dp_size: Option<usize>,
+    aic_nextn: Option<usize>,
+    aic_nextn_accept_rates: Option<String>,
 }
 
 impl AicPerfConfig {
@@ -120,12 +122,20 @@ impl AicPerfConfig {
     pub(crate) fn attention_dp_size(&self) -> Option<usize> {
         self.aic_attention_dp_size
     }
+
+    pub(crate) fn nextn(&self) -> Option<usize> {
+        self.aic_nextn
+    }
+
+    pub(crate) fn nextn_accept_rates(&self) -> Option<&str> {
+        self.aic_nextn_accept_rates.as_deref()
+    }
 }
 
 #[pymethods]
 impl AicPerfConfig {
     #[new]
-    #[pyo3(signature = (aic_backend, aic_system, aic_model_path, aic_tp_size=1, aic_backend_version=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None))]
+    #[pyo3(signature = (aic_backend, aic_system, aic_model_path, aic_tp_size=1, aic_backend_version=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         aic_backend: String,
@@ -136,6 +146,8 @@ impl AicPerfConfig {
         aic_moe_tp_size: Option<usize>,
         aic_moe_ep_size: Option<usize>,
         aic_attention_dp_size: Option<usize>,
+        aic_nextn: Option<usize>,
+        aic_nextn_accept_rates: Option<String>,
     ) -> PyResult<Self> {
         if aic_backend.is_empty() {
             return Err(PyValueError::new_err("aic_backend must be non-empty"));
@@ -158,6 +170,11 @@ impl AicPerfConfig {
                 return Err(PyValueError::new_err(format!("{name} must be >= 1")));
             }
         }
+        if matches!(aic_nextn, Some(0)) {
+            return Err(PyValueError::new_err(
+                "aic_nextn must be >= 1 when set (omit to disable spec dec)",
+            ));
+        }
 
         Ok(Self {
             aic_backend,
@@ -168,6 +185,8 @@ impl AicPerfConfig {
             aic_moe_tp_size,
             aic_moe_ep_size,
             aic_attention_dp_size,
+            aic_nextn,
+            aic_nextn_accept_rates,
         })
     }
 }
@@ -681,6 +700,8 @@ async fn select_engine(
                             config.moe_tp_size(),
                             config.moe_ep_size(),
                             config.attention_dp_size(),
+                            config.nextn(),
+                            config.nextn_accept_rates(),
                         )
                     })
                 })
@@ -722,6 +743,8 @@ async fn select_engine(
                 let moe_tp_size = mocker_args.aic_moe_tp_size;
                 let moe_ep_size = mocker_args.aic_moe_ep_size;
                 let attention_dp_size = mocker_args.aic_attention_dp_size;
+                let nextn = mocker_args.aic_nextn;
+                let nextn_accept_rates = mocker_args.aic_nextn_accept_rates.as_deref();
                 match Python::with_gil(|py| {
                     create_aic_callback(
                         py,
@@ -733,6 +756,8 @@ async fn select_engine(
                         moe_tp_size,
                         moe_ep_size,
                         attention_dp_size,
+                        nextn,
+                        nextn_accept_rates,
                     )
                 }) {
                     Ok(callback) => {

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -170,9 +170,12 @@ impl AicPerfConfig {
                 return Err(PyValueError::new_err(format!("{name} must be >= 1")));
             }
         }
-        if matches!(aic_nextn, Some(0)) {
+        // AIC caps MTP draft tokens at 5; >5 would IndexError in calc_expectation.
+        if let Some(nextn) = aic_nextn
+            && !(1..=5).contains(&nextn)
+        {
             return Err(PyValueError::new_err(
-                "aic_nextn must be >= 1 when set (omit to disable spec dec)",
+                "aic_nextn must be 1..=5 when set (omit to disable spec dec)",
             ));
         }
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -921,6 +921,8 @@ impl KvRouter {
                         config.moe_tp_size(),
                         config.moe_ep_size(),
                         config.attention_dp_size(),
+                        config.nextn(),
+                        config.nextn_accept_rates(),
                     )
                 })
             })

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -146,7 +146,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, gpu_memory_utilization=None, mem_fraction_static=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, enable_local_indexer=false, bootstrap_port=None, kv_bytes_per_token=None, kv_transfer_bandwidth=None, reasoning=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -170,6 +170,8 @@ impl MockEngineArgs {
         aic_moe_tp_size: Option<usize>,
         aic_moe_ep_size: Option<usize>,
         aic_attention_dp_size: Option<usize>,
+        aic_nextn: Option<usize>,
+        aic_nextn_accept_rates: Option<String>,
         gpu_memory_utilization: Option<f64>,
         mem_fraction_static: Option<f64>,
         enable_local_indexer: bool,
@@ -225,6 +227,8 @@ impl MockEngineArgs {
             .aic_moe_tp_size(aic_moe_tp_size)
             .aic_moe_ep_size(aic_moe_ep_size)
             .aic_attention_dp_size(aic_attention_dp_size)
+            .aic_nextn(aic_nextn)
+            .aic_nextn_accept_rates(aic_nextn_accept_rates)
             .gpu_memory_utilization(gpu_memory_utilization)
             .mem_fraction_static(mem_fraction_static)
             .enable_local_indexer(enable_local_indexer)
@@ -482,6 +486,26 @@ impl MockEngineArgs {
     }
 
     #[getter]
+    fn aic_nextn(&self) -> Option<usize> {
+        self.inner.aic_nextn
+    }
+
+    #[setter]
+    fn set_aic_nextn(&mut self, value: Option<usize>) {
+        self.inner.aic_nextn = value;
+    }
+
+    #[getter]
+    fn aic_nextn_accept_rates(&self) -> Option<String> {
+        self.inner.aic_nextn_accept_rates.clone()
+    }
+
+    #[setter]
+    fn set_aic_nextn_accept_rates(&mut self, value: Option<String>) {
+        self.inner.aic_nextn_accept_rates = value;
+    }
+
+    #[getter]
     fn gpu_memory_utilization(&self) -> Option<f64> {
         self.inner.gpu_memory_utilization
     }
@@ -547,7 +571,7 @@ impl MockEngineArgs {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (bootstrap_port=None, zmq_kv_events_port=None, zmq_replay_port=None, kv_bytes_per_token=None, num_gpu_blocks=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, gpu_memory_utilization=None, mem_fraction_static=None, enable_prefix_caching=None, worker_type=None))]
+    #[pyo3(signature = (bootstrap_port=None, zmq_kv_events_port=None, zmq_replay_port=None, kv_bytes_per_token=None, num_gpu_blocks=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, gpu_memory_utilization=None, mem_fraction_static=None, enable_prefix_caching=None, worker_type=None))]
     fn with_overrides(
         &self,
         bootstrap_port: Option<u16>,
@@ -563,6 +587,8 @@ impl MockEngineArgs {
         aic_moe_tp_size: Option<usize>,
         aic_moe_ep_size: Option<usize>,
         aic_attention_dp_size: Option<usize>,
+        aic_nextn: Option<usize>,
+        aic_nextn_accept_rates: Option<String>,
         gpu_memory_utilization: Option<f64>,
         mem_fraction_static: Option<f64>,
         enable_prefix_caching: Option<bool>,
@@ -609,6 +635,12 @@ impl MockEngineArgs {
         }
         if let Some(attention_dp_size) = aic_attention_dp_size {
             inner.aic_attention_dp_size = Some(attention_dp_size);
+        }
+        if let Some(nextn) = aic_nextn {
+            inner.aic_nextn = Some(nextn);
+        }
+        if let Some(rates) = aic_nextn_accept_rates {
+            inner.aic_nextn_accept_rates = Some(rates);
         }
         if let Some(gpu_memory_utilization) = gpu_memory_utilization {
             inner.gpu_memory_utilization = Some(gpu_memory_utilization);
@@ -1171,6 +1203,8 @@ fn materialize_replay_mocker_args(
         let moe_tp_size = args.aic_moe_tp_size;
         let moe_ep_size = args.aic_moe_ep_size;
         let attention_dp_size = args.aic_attention_dp_size;
+        let nextn = args.aic_nextn;
+        let nextn_accept_rates = args.aic_nextn_accept_rates.clone();
         // AIC-backed config may intentionally omit num_gpu_blocks. Estimate it
         // here, after candidate TP/backend/model overrides have been applied.
         if !extra_args.num_gpu_blocks_explicit() {
@@ -1208,6 +1242,8 @@ fn materialize_replay_mocker_args(
             moe_tp_size,
             moe_ep_size,
             attention_dp_size,
+            nextn,
+            nextn_accept_rates.as_deref(),
         )
         .map_err(|e| {
             PyException::new_err(format!(
@@ -1312,6 +1348,8 @@ fn load_replay_prefill_load_estimator(
         aic_perf_config.moe_tp_size(),
         aic_perf_config.moe_ep_size(),
         aic_perf_config.attention_dp_size(),
+        aic_perf_config.nextn(),
+        aic_perf_config.nextn_accept_rates(),
     )
     .map(Some)
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1481,6 +1481,8 @@ class AicPerfConfig:
         aic_moe_tp_size: Optional[int] = None,
         aic_moe_ep_size: Optional[int] = None,
         aic_attention_dp_size: Optional[int] = None,
+        aic_nextn: Optional[int] = None,
+        aic_nextn_accept_rates: Optional[str] = None,
     ) -> None:
         ...
 
@@ -1812,6 +1814,8 @@ class MockEngineArgs:
         aic_moe_tp_size: Optional[int] = None,
         aic_moe_ep_size: Optional[int] = None,
         aic_attention_dp_size: Optional[int] = None,
+        aic_nextn: Optional[int] = None,
+        aic_nextn_accept_rates: Optional[str] = None,
         gpu_memory_utilization: Optional[float] = None,
         mem_fraction_static: Optional[float] = None,
         enable_local_indexer: bool = False,
@@ -1952,6 +1956,18 @@ class MockEngineArgs:
     def aic_attention_dp_size(self, value: Optional[int]) -> None: ...
 
     @property
+    def aic_nextn(self) -> Optional[int]: ...
+
+    @aic_nextn.setter
+    def aic_nextn(self, value: Optional[int]) -> None: ...
+
+    @property
+    def aic_nextn_accept_rates(self) -> Optional[str]: ...
+
+    @aic_nextn_accept_rates.setter
+    def aic_nextn_accept_rates(self, value: Optional[str]) -> None: ...
+
+    @property
     def gpu_memory_utilization(self) -> Optional[float]: ...
 
     @gpu_memory_utilization.setter
@@ -1988,6 +2004,8 @@ class MockEngineArgs:
         aic_moe_tp_size: Optional[int] = None,
         aic_moe_ep_size: Optional[int] = None,
         aic_attention_dp_size: Optional[int] = None,
+        aic_nextn: Optional[int] = None,
+        aic_nextn_accept_rates: Optional[str] = None,
         gpu_memory_utilization: Optional[float] = None,
         mem_fraction_static: Optional[float] = None,
         enable_prefix_caching: Optional[bool] = None,

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -66,6 +66,12 @@ def _pad_nextn_accept_rates(
     if not nextn_accept_rates:
         return list(_DEFAULT_NEXTN_ACCEPT_RATES)
     rates = list(nextn_accept_rates)
+    # Rates are acceptance probabilities; out-of-range or non-finite values
+    # would silently skew calc_expectation rather than surface a config error.
+    if any(not math.isfinite(r) or not 0.0 <= r <= 1.0 for r in rates):
+        raise ValueError(
+            f"aic_nextn_accept_rates must be finite floats in [0, 1], got {rates}"
+        )
     if len(rates) < _NEXTN_ACCEPT_RATES_LEN:
         rates = rates + [0.0] * (_NEXTN_ACCEPT_RATES_LEN - len(rates))
     elif len(rates) > _NEXTN_ACCEPT_RATES_LEN:
@@ -140,10 +146,11 @@ class AicSession:
             attention_dp_size=attention_dp_size or 1,
         )
         if nextn:
-            if nextn > _NEXTN_ACCEPT_RATES_LEN:
-                # AIC indexes accept_rates up to nextn; >5 would IndexError.
+            # Mirror the Rust 1..=5 contract; AIC indexes accept_rates up to
+            # nextn, so >5 would IndexError in calc_expectation.
+            if not 1 <= nextn <= _NEXTN_ACCEPT_RATES_LEN:
                 raise ValueError(
-                    f"nextn must be <= {_NEXTN_ACCEPT_RATES_LEN} when set, got {nextn}"
+                    f"nextn must be 1..={_NEXTN_ACCEPT_RATES_LEN} when set, got {nextn}"
                 )
             model_config_kwargs["nextn"] = nextn
             model_config_kwargs["nextn_accept_rates"] = _pad_nextn_accept_rates(

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -371,15 +371,11 @@ def estimate_num_gpu_blocks(
     moe_ep_size: int | None = None,
     attention_dp_size: int | None = None,
 ) -> int:
-    """Estimate rank-local KV cache blocks for mocker/replay AIC configs.
-
-    Intentionally spec-dec-blind: the session is constructed without ``nextn``,
-    so AIC's draft-token activation/weight inflation (over-counted in
-    ``trtllm_backend._get_memory_usage``) doesn't drag the KV budget negative.
-    Spec-dec speedup is applied separately on the latency path via
-    :class:`AicSession` constructed with ``nextn`` / ``nextn_accept_rates``.
-    """
+    """Estimate rank-local KV cache blocks for mocker/replay AIC configs."""
     _validate_kv_capacity_backend(backend_name)
+    # TODO: account for whether specdec is enabled, (i.e. pass in `nextn=...`
+    #   to `create_session``). Currently omitted to downstream AIC calculation
+    #   bug causing `_get_memory_usage` to predict negative KV capacity w/ Eagle.
     session = create_session(
         backend_name=backend_name,
         system=system,

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -11,6 +11,8 @@ import math
 logger = logging.getLogger(__name__)
 
 _NEXTN_ACCEPT_RATES_LEN = 5
+# AIC CLI default when accept-rates are omitted (``cli/main.py:795``).
+_DEFAULT_NEXTN_ACCEPT_RATES = [0.85, 0.3, 0.0, 0.0, 0.0]
 
 DEFAULT_BACKEND_VERSIONS = {
     "vllm": "0.14.0",
@@ -47,16 +49,23 @@ def _pad_nextn_accept_rates(
 
     AIC caps MTP draft tokens at 5 (``ModelConfig.nextn`` "at most mtp5",
     ``sdk/config.py:28``) and ``calc_expectation`` indexes into the list up
-    to ``nextn``. AIC's own CLI normalizes to length 5 with trailing zeros
-    (``cli/main.py:795``); we mirror that so callers can pass a shorter list
-    or a comma-separated string without tripping over IndexError or
-    schema-mismatch downstream.
+    to ``nextn``. When rates are omitted entirely we fall back to AIC's CLI
+    default (``cli/main.py:795``); an explicit shorter list is zero-padded and
+    a longer one is truncated, so callers never trip over IndexError downstream.
     """
     if isinstance(nextn_accept_rates, str):
-        nextn_accept_rates = [
-            float(x) for x in nextn_accept_rates.split(",") if x.strip()
-        ]
-    rates = list(nextn_accept_rates) if nextn_accept_rates else []
+        try:
+            nextn_accept_rates = [
+                float(x) for x in nextn_accept_rates.split(",") if x.strip()
+            ]
+        except ValueError as exc:
+            raise ValueError(
+                "aic_nextn_accept_rates must be comma-separated floats, got "
+                f"{nextn_accept_rates!r}"
+            ) from exc
+    if not nextn_accept_rates:
+        return list(_DEFAULT_NEXTN_ACCEPT_RATES)
+    rates = list(nextn_accept_rates)
     if len(rates) < _NEXTN_ACCEPT_RATES_LEN:
         rates = rates + [0.0] * (_NEXTN_ACCEPT_RATES_LEN - len(rates))
     elif len(rates) > _NEXTN_ACCEPT_RATES_LEN:
@@ -131,6 +140,11 @@ class AicSession:
             attention_dp_size=attention_dp_size or 1,
         )
         if nextn:
+            if nextn > _NEXTN_ACCEPT_RATES_LEN:
+                # AIC indexes accept_rates up to nextn; >5 would IndexError.
+                raise ValueError(
+                    f"nextn must be <= {_NEXTN_ACCEPT_RATES_LEN} when set, got {nextn}"
+                )
             model_config_kwargs["nextn"] = nextn
             model_config_kwargs["nextn_accept_rates"] = _pad_nextn_accept_rates(
                 nextn_accept_rates

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -10,6 +10,8 @@ import math
 
 logger = logging.getLogger(__name__)
 
+_NEXTN_ACCEPT_RATES_LEN = 5
+
 DEFAULT_BACKEND_VERSIONS = {
     "vllm": "0.14.0",
     "sglang": "0.5.6.post2",
@@ -36,6 +38,30 @@ def resolve_backend_version(backend_name: str, backend_version: str | None) -> s
     if backend_version is not None:
         return backend_version
     return DEFAULT_BACKEND_VERSIONS.get(backend_name, DEFAULT_BACKEND_VERSIONS["vllm"])
+
+
+def _pad_nextn_accept_rates(
+    nextn_accept_rates: list[float] | str | None,
+) -> list[float]:
+    """Normalize accept-rates to AIC's fixed length-5 slot.
+
+    AIC caps MTP draft tokens at 5 (``ModelConfig.nextn`` "at most mtp5",
+    ``sdk/config.py:28``) and ``calc_expectation`` indexes into the list up
+    to ``nextn``. AIC's own CLI normalizes to length 5 with trailing zeros
+    (``cli/main.py:795``); we mirror that so callers can pass a shorter list
+    or a comma-separated string without tripping over IndexError or
+    schema-mismatch downstream.
+    """
+    if isinstance(nextn_accept_rates, str):
+        nextn_accept_rates = [
+            float(x) for x in nextn_accept_rates.split(",") if x.strip()
+        ]
+    rates = list(nextn_accept_rates) if nextn_accept_rates else []
+    if len(rates) < _NEXTN_ACCEPT_RATES_LEN:
+        rates = rates + [0.0] * (_NEXTN_ACCEPT_RATES_LEN - len(rates))
+    elif len(rates) > _NEXTN_ACCEPT_RATES_LEN:
+        rates = rates[:_NEXTN_ACCEPT_RATES_LEN]
+    return rates
 
 
 def _load_aiconfigurator():
@@ -78,6 +104,8 @@ class AicSession:
         moe_tp_size: int | None = None,
         moe_ep_size: int | None = None,
         attention_dp_size: int | None = None,
+        nextn: int | None = None,
+        nextn_accept_rates: list[float] | str | None = None,
     ):
         aic = _load_aiconfigurator()
         version = resolve_backend_version(backend_name, backend_version)
@@ -96,12 +124,18 @@ class AicSession:
                 f"Supported versions for this system/backend: {supported_versions}"
             )
 
-        model_config = aic["config"].ModelConfig(
+        model_config_kwargs: dict = dict(
             tp_size=tp_size,
             moe_tp_size=moe_tp_size,
             moe_ep_size=moe_ep_size,
             attention_dp_size=attention_dp_size or 1,
         )
+        if nextn:
+            model_config_kwargs["nextn"] = nextn
+            model_config_kwargs["nextn_accept_rates"] = _pad_nextn_accept_rates(
+                nextn_accept_rates
+            )
+        model_config = aic["config"].ModelConfig(**model_config_kwargs)
         model = aic["get_model"](
             model_path=model_path,
             model_config=model_config,
@@ -291,6 +325,8 @@ def create_session(
     moe_tp_size: int | None = None,
     moe_ep_size: int | None = None,
     attention_dp_size: int | None = None,
+    nextn: int | None = None,
+    nextn_accept_rates: list[float] | str | None = None,
 ) -> AicSession:
     """Factory function called from Rust via PyO3."""
     return AicSession(
@@ -302,6 +338,8 @@ def create_session(
         moe_tp_size,
         moe_ep_size,
         attention_dp_size,
+        nextn=nextn,
+        nextn_accept_rates=nextn_accept_rates,
     )
 
 
@@ -319,7 +357,14 @@ def estimate_num_gpu_blocks(
     moe_ep_size: int | None = None,
     attention_dp_size: int | None = None,
 ) -> int:
-    """Estimate rank-local KV cache blocks for mocker/replay AIC configs."""
+    """Estimate rank-local KV cache blocks for mocker/replay AIC configs.
+
+    Intentionally spec-dec-blind: the session is constructed without ``nextn``,
+    so AIC's draft-token activation/weight inflation (over-counted in
+    ``trtllm_backend._get_memory_usage``) doesn't drag the KV budget negative.
+    Spec-dec speedup is applied separately on the latency path via
+    :class:`AicSession` constructed with ``nextn`` / ``nextn_accept_rates``.
+    """
     _validate_kv_capacity_backend(backend_name)
     session = create_session(
         backend_name=backend_name,

--- a/lib/bindings/python/src/dynamo/replay/main.py
+++ b/lib/bindings/python/src/dynamo/replay/main.py
@@ -190,6 +190,8 @@ def _load_aic_perf_config(args: argparse.Namespace):
         "aic_moe_tp_size": args.aic_moe_tp_size,
         "aic_moe_ep_size": args.aic_moe_ep_size,
         "aic_attention_dp_size": args.aic_attention_dp_size,
+        "aic_nextn": args.aic_nextn,
+        "aic_nextn_accept_rates": args.aic_nextn_accept_rates,
     }
     if not any(value is not None for value in values.values()):
         return None
@@ -212,6 +214,8 @@ def _load_aic_perf_config(args: argparse.Namespace):
         aic_moe_tp_size=values["aic_moe_tp_size"],
         aic_moe_ep_size=values["aic_moe_ep_size"],
         aic_attention_dp_size=values["aic_attention_dp_size"],
+        aic_nextn=values["aic_nextn"],
+        aic_nextn_accept_rates=values["aic_nextn_accept_rates"],
     )
 
 
@@ -499,6 +503,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--aic-moe-tp-size", type=int)
     parser.add_argument("--aic-moe-ep-size", type=int)
     parser.add_argument("--aic-attention-dp-size", type=int)
+    parser.add_argument("--aic-nextn", type=int)
+    parser.add_argument("--aic-nextn-accept-rates")
     parser.add_argument("--input-tokens", type=int)
     parser.add_argument("--output-tokens", type=int)
     parser.add_argument(

--- a/lib/bindings/python/tests/replay/test_replay_cli.py
+++ b/lib/bindings/python/tests/replay/test_replay_cli.py
@@ -46,6 +46,8 @@ def test_replay_cli_aic_perf_config_includes_moe_kwargs(monkeypatch):
             aic_moe_tp_size=2,
             aic_moe_ep_size=1,
             aic_attention_dp_size=1,
+            aic_nextn=None,
+            aic_nextn_accept_rates=None,
         )
     )
 
@@ -59,6 +61,8 @@ def test_replay_cli_aic_perf_config_includes_moe_kwargs(monkeypatch):
         "aic_moe_tp_size": 2,
         "aic_moe_ep_size": 1,
         "aic_attention_dp_size": 1,
+        "aic_nextn": None,
+        "aic_nextn_accept_rates": None,
     }
 
 

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -3,7 +3,13 @@
 
 import pytest
 
-from dynamo._internal.aic import AicSession, resolve_backend_version
+from dynamo._internal.aic import (
+    _DEFAULT_NEXTN_ACCEPT_RATES,
+    _NEXTN_ACCEPT_RATES_LEN,
+    AicSession,
+    _pad_nextn_accept_rates,
+    resolve_backend_version,
+)
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -108,3 +114,25 @@ def test_trtllm_version_resolution_still_supports_latency_configs():
             max_num_batched_tokens=128,
             gpu_memory_utilization=0.8,
         )
+
+
+def test_pad_nextn_accept_rates_defaults_when_omitted():
+    # Omitted/empty input falls back to AIC's CLI default, not all zeros.
+    assert _pad_nextn_accept_rates(None) == _DEFAULT_NEXTN_ACCEPT_RATES
+    assert _pad_nextn_accept_rates("") == _DEFAULT_NEXTN_ACCEPT_RATES
+    assert _pad_nextn_accept_rates([]) == _DEFAULT_NEXTN_ACCEPT_RATES
+
+
+def test_pad_nextn_accept_rates_pads_and_truncates():
+    assert _pad_nextn_accept_rates([0.9, 0.4]) == [0.9, 0.4, 0.0, 0.0, 0.0]
+    assert _pad_nextn_accept_rates("0.9,0.4") == [0.9, 0.4, 0.0, 0.0, 0.0]
+    assert _pad_nextn_accept_rates([0.1] * 7) == [0.1] * _NEXTN_ACCEPT_RATES_LEN
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["0.85,abc,0", [1.5, 0.0], [-0.1, 0.0], [float("nan")], [float("inf")]],
+)
+def test_pad_nextn_accept_rates_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        _pad_nextn_accept_rates(bad)

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -399,6 +399,8 @@ struct MockEngineArgsSerde {
     aic_moe_tp_size: OptionalConfigValue<usize>,
     aic_moe_ep_size: OptionalConfigValue<usize>,
     aic_attention_dp_size: OptionalConfigValue<usize>,
+    aic_nextn: OptionalConfigValue<usize>,
+    aic_nextn_accept_rates: OptionalConfigValue<String>,
     gpu_memory_utilization: OptionalConfigValue<f64>,
     mem_fraction_static: OptionalConfigValue<f64>,
     enable_local_indexer: OptionalConfigValue<bool>,
@@ -587,6 +589,18 @@ pub struct MockEngineArgs {
     #[serde(skip)]
     #[builder(default = "None")]
     pub aic_attention_dp_size: Option<usize>,
+
+    /// MTP/Eagle speculative-decoding draft-token count (max 5). When set,
+    /// AIC's perf model applies the spec-dec speedup to decode latency.
+    #[serde(skip)]
+    #[builder(default = "None")]
+    pub aic_nextn: Option<usize>,
+
+    /// Per-position accept rates for MTP draft tokens, comma-separated
+    /// (e.g. "0.85,0.3,0,0,0"). Padded to length 5 by the Python layer.
+    #[serde(skip)]
+    #[builder(default = "None")]
+    pub aic_nextn_accept_rates: Option<String>,
 
     /// GPU memory fraction for AIC KV capacity estimation with vLLM.
     #[builder(default = "None")]
@@ -883,6 +897,12 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         }
         if let Some(aic_attention_dp_size) = compat.aic_attention_dp_size.into_nullable() {
             builder = builder.aic_attention_dp_size(aic_attention_dp_size);
+        }
+        if let Some(aic_nextn) = compat.aic_nextn.into_nullable() {
+            builder = builder.aic_nextn(aic_nextn);
+        }
+        if let Some(aic_nextn_accept_rates) = compat.aic_nextn_accept_rates.into_nullable() {
+            builder = builder.aic_nextn_accept_rates(aic_nextn_accept_rates);
         }
         if let Some(gpu_memory_utilization) = compat.gpu_memory_utilization.into_nullable() {
             builder = builder.gpu_memory_utilization(gpu_memory_utilization);

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -590,10 +590,13 @@ pub struct MockEngineArgs {
     #[builder(default = "None")]
     pub aic_attention_dp_size: Option<usize>,
 
-    /// MTP/Eagle speculative-decoding draft-token count (max 5). When set,
+    /// MTP/Eagle speculative-decoding draft-token count (1..=5). When set,
     /// AIC's perf model applies the spec-dec speedup to decode latency.
+    /// Validated here so the mocker/replay JSON path shares the same 1..=5
+    /// contract as `AicPerfConfig` (omit to disable spec dec).
     #[serde(skip)]
     #[builder(default = "None")]
+    #[validate(range(min = 1, max = 5))]
     pub aic_nextn: Option<usize>,
 
     /// Per-position accept rates for MTP draft tokens, comma-separated
@@ -1281,6 +1284,29 @@ mod tests {
             missing_g2.to_string().contains("requires num_g2_blocks"),
             "unexpected error: {missing_g2}",
         );
+    }
+
+    #[test]
+    fn test_normalized_rejects_out_of_range_aic_nextn() {
+        // The mocker/replay JSON path must share AicPerfConfig's 1..=5 contract.
+        for bad in [0_usize, 6] {
+            let err = MockEngineArgs::builder()
+                .aic_nextn(Some(bad))
+                .build()
+                .unwrap()
+                .normalized()
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("aic_nextn"),
+                "unexpected error for nextn={bad}: {err}",
+            );
+        }
+        MockEngineArgs::builder()
+            .aic_nextn(Some(3))
+            .build()
+            .unwrap()
+            .normalized()
+            .expect("in-range aic_nextn should validate");
     }
 
     #[test]


### PR DESCRIPTION
### Overview:

Adds MTP/Eagle speculative-decoding support to the AIC perf model used by mocker/replay. Exposes `aic_nextn` (draft-token count) and `aic_nextn_accept_rates` (per-position accept rates) and plumbs them through the CLI, PyO3 bindings, and mocker serde so AIC applies the spec-dec decode speedup during latency modeling.

### Details:

- New params `aic_nextn` / `aic_nextn_accept_rates` threaded through: CLI args (`aic_perf_args.py`, `replay/main.py`), `AicPerfConfig` + `MockEngineArgs` (PyO3 `entrypoint.rs`, `replay.rs`, `kv.rs`), .pyi stubs, and mocker serde (`protocols.rs`, `#[serde(skip)`] consistent with sibling AIC fields).
- Applied to the latency path only (`create_aic_callback`). 
- Note: The KV-block estimator (`estimate_num_gpu_blocks`) is intentionally constructed without `nextn`: AIC's `activations * (nextn + 1)` correction over-counts non-KV bytes and seems to drive the computed KV capacity negative on tight configs which are known to be valid on silicon (I don't think it counts for draft head weights either? Need to check.). Left as a TODO in `aic.py`.
- `_pad_nextn_accept_rates` normalizes rates to AIC's fixed length-5 slot: omitted → AIC's default `[0.85, 0.3, 0, 0, 0]`; shorter → zero-padded; longer → truncated; malformed string → clear error.
- Validation: `aic_nextn` bounded to `1..=5` in `AicPerfConfig::new` and re-checked in `AicSession` to also cover the mocker `MockEngineArgs` path (AIC indexes accept-rates up to `nextn`, so >5 would IndexError in `calc_expectation`).

### Where should the reviewer start?

- `lib/bindings/python/src/dynamo/_internal/aic.py` — the only non-mechanical logic: `_pad_nextn_accept_rates`, the `nextn` guard in `AicSession.__init__`, and the spec-dec-blind `estimate_num_gpu_blocks`.
- `lib/bindings/python/rust/llm/entrypoint.rs` — the 1..=5 validation in `AicPerfConfig::new`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for two new AIC configuration parameters: `aic_nextn` and `aic_nextn_accept_rates`
  * Parameters can be configured via CLI arguments, Python API, and replay mode
  * Includes automatic validation of parameter values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->