### PR TITLE
feat: improve BSI by removing scheduler hop

### DIFF
--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -331,9 +331,6 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
         depth: usize,
     ) {
         let score = depth as u32;
-        scores
-            .scores
-            .reserve(active.len().saturating_sub(scores.scores.len()));
         for &worker in active {
             let entry = scores.scores.entry(worker).or_insert(0);
             *entry = (*entry).max(score);
@@ -341,10 +338,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
     }
 
     fn collect_live_workers(node: &RoutingNode) -> FxHashSet<WorkerWithDpRank> {
-        let mut workers =
-            FxHashSet::with_capacity_and_hasher(node.live_workers.len(), FxBuildHasher);
-        workers.extend(node.live_workers.iter().map(|worker| *worker));
-        workers
+        node.live_workers.iter().map(|worker| *worker).collect()
     }
 
     fn reconcile_active_workers(
@@ -360,9 +354,6 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             return;
         }
         let score = drop_depth as u32;
-        scores
-            .scores
-            .reserve(active.len().saturating_sub(scores.scores.len()));
         active.retain(|worker| {
             if node.live_workers.contains(worker) {
                 true

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -331,6 +331,9 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
         depth: usize,
     ) {
         let score = depth as u32;
+        scores
+            .scores
+            .reserve(active.len().saturating_sub(scores.scores.len()));
         for &worker in active {
             let entry = scores.scores.entry(worker).or_insert(0);
             *entry = (*entry).max(score);
@@ -338,7 +341,10 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
     }
 
     fn collect_live_workers(node: &RoutingNode) -> FxHashSet<WorkerWithDpRank> {
-        node.live_workers.iter().map(|worker| *worker).collect()
+        let mut workers =
+            FxHashSet::with_capacity_and_hasher(node.live_workers.len(), FxBuildHasher);
+        workers.extend(node.live_workers.iter().map(|worker| *worker));
+        workers
     }
 
     fn reconcile_active_workers(
@@ -354,6 +360,9 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             return;
         }
         let score = drop_depth as u32;
+        scores
+            .scores
+            .reserve(active.len().saturating_sub(scores.scores.len()));
         active.retain(|worker| {
             if node.live_workers.contains(worker) {
                 true

--- a/lib/kv-router/src/indexer/shard_handle.rs
+++ b/lib/kv-router/src/indexer/shard_handle.rs
@@ -100,8 +100,9 @@ pub trait AsyncShardHandle: Send + Sync + 'static {
 /// running in the same process.
 ///
 /// * Writes are channel sends (sync, wrapped in async).
-/// * `find_matches_from_anchor` runs on a `spawn_blocking` thread since the
-///   underlying trie `find_matches_from_anchor` is synchronous.
+/// * `find_matches_from_anchor` runs inline on the caller's task, matching
+///   `ThreadPoolIndexer::find_matches` and avoiding scheduler overhead in the
+///   in-process branch-sharded hot path.
 impl<T: AnchorCapableSyncIndexer> AsyncShardHandle for ThreadPoolIndexer<T> {
     async fn apply_event(&self, event: RouterEvent) {
         KvIndexerInterface::apply_event(self, event).await;
@@ -120,10 +121,7 @@ impl<T: AnchorCapableSyncIndexer> AsyncShardHandle for ThreadPoolIndexer<T> {
         anchor: AnchorRef,
         suffix: Vec<LocalBlockHash>,
     ) -> Result<OverlapScores, KvRouterError> {
-        let backend = self.backend_arc();
-        tokio::task::spawn_blocking(move || backend.find_matches_from_anchor(anchor, &suffix))
-            .await
-            .map_err(|_| KvRouterError::IndexerOffline)?
+        self.backend().find_matches_from_anchor(anchor, &suffix)
     }
 
     async fn remove_worker(&self, worker_id: WorkerId) {


### PR DESCRIPTION
#### Overview:

Removes unnecessary blocking-pool dispatch from in-process BSI anchored reads.

#### Details:

The main fix is to remove a `spawn_blocking` hop from `ThreadPoolIndexer<T>::find_matches_from_anchor`. Normal `ThreadPoolIndexer::find_matches` already runs inline on the caller, but BSI anchored reads were dispatching every shard lookup through Tokio’s blocking pool. On the Mooncake benchmark, most BSI lookups cross the shard boundary, so this scheduler hop dominated p99.

Mooncake trace: 23,608 rows, sha256 `b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711`

Command shape: `branch-sharded-crtc --num-shards 8 --num-event-workers-per-shard 4 --prefix-depth 2`, `--benchmark-duration-ms 60000`, `--benchmark-runs 5`, `--num-unique-inference-workers 1000`, `--trace-duplication-factor 5`, `--inference-worker-duplication-factor 4`.

| Local run | Version | p99 p50 | achieved ops/s p50 | Note |
|---|---|---:|---:|---|
| A | pre-change | 7,590µs | 24,651.6 | no saturation |
| A | spawn-only change | 890µs | 24,653.4 | no saturation |
| B | pre-change | 27,173µs | 24,649.2 | one run saturated |
| B | spawn-only change | 1,758µs | 24,653.8 | no saturation |

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized router indexer score aggregation with improved memory pre-allocation, reducing unnecessary reallocations and improving matching throughput.
  * Enhanced matcher operation performance through streamlined task execution, eliminating thread pool overhead.

* **Documentation**
  * Updated internal documentation for matcher operations to reflect current execution model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->