### PR TITLE
feat(sglang): add require_reasoning param to control SGLang behavior

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -158,6 +158,7 @@ def _preprocess_worker(
         eos_token_id,
         pre.guided_decoding,
         pre.tool_call_parser,
+        pre.force_reasoning,
     )
 
     effective_reasoning_parser_name = (
@@ -180,6 +181,7 @@ def _build_dynamo_preproc(
     eos_token_id: int | None,
     guided_decoding: dict[str, Any] | None = None,
     tool_call_parser: ToolCallParserType | None = None,
+    require_reasoning: bool = False,
 ) -> dict[str, Any]:
     """Build the Dynamo preprocessed request dict from request fields."""
     max_tokens = request.get("max_completion_tokens") or request.get("max_tokens")
@@ -240,6 +242,7 @@ def _build_dynamo_preproc(
             "skip_special_tokens": tool_call_parser is None,
             "return_tokens_as_token_ids": request.get("return_tokens_as_token_ids"),
         },
+        "require_reasoning": require_reasoning,
         "eos_token_ids": [eos_token_id] if eos_token_id is not None else [],
         "annotations": [],
         "routing": request.get("routing"),
@@ -368,6 +371,7 @@ class SglangProcessor:
                 self.eos_token_id,
                 pre.guided_decoding,
                 pre.tool_call_parser,
+                pre.force_reasoning,
             )
         except InvalidArgument:
             raise

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -432,6 +432,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         sampling_params = self._build_sampling_params(request)
         input_param = self._get_input_param(request)
         priority = (request.get("routing") or {}).get("priority")
+        require_reasoning = request.get("require_reasoning", False)
         logprob_kwargs = self._build_logprob_kwargs(request)
 
         output_options = request.get("output_options", {})
@@ -469,6 +470,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             decode = await self.engine.async_generate(
                 **input_param,
                 sampling_params=sampling_params,
+                require_reasoning=require_reasoning,
                 stream=True,
                 **self._routed_experts_kwargs,
                 bootstrap_host=bootstrap_info["bootstrap_host"],
@@ -529,6 +531,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 **input_param,
                 image_data=image_data,
                 video_data=video_data,
+                require_reasoning=require_reasoning,
                 sampling_params=sampling_params,
                 stream=True,
                 **self._routed_experts_kwargs,

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -218,6 +218,11 @@ pub struct PreprocessedRequest {
     #[serde(default)]
     pub annotations: Vec<String>,
 
+    /// Whether to require reasoning for the request
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_reasoning: Option<bool>,
+
     /// Routing hints for worker targeting (backend_instance_id, prefill/decode worker IDs, dp_rank)
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
#### Overview:

SGLang needs a require_reasoning field to control reasoning grammar and enable tracking of reasoning tokens.

#### Details:

This change simply adds the require_reasoning API. It depends on sgl-project/sglang#27019, which has been merged.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-request reasoning requirement control in the generation pipeline, enabling dynamic reasoning configuration throughout the preprocessing and generation stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->