### PR TITLE
docs(kubernetes): show API reference in sidebar

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -153,6 +153,8 @@ navigation:
             contents:
               - page: GKE Setup
                 path: kubernetes/cloud-providers/gke/gke.md
+      - page: API Reference
+        path: kubernetes/api-reference.md
 
   # ==================== User Guides ====================
   - section: User Guides
@@ -460,8 +462,6 @@ navigation:
           - page: RDMA Metadata
             path: api/nixl-connect/rdma-metadata.md
       # -- Kubernetes (hidden sub-pages) --
-      - page: API Reference (K8s)
-        path: kubernetes/api-reference.md
       - page: Creating Deployments
         path: kubernetes/deployment/create-deployment.md
       - page: FluxCD


### PR DESCRIPTION
## Summary
- move the Kubernetes API Reference nav entry into the visible Kubernetes Deployment section
- remove the historical hidden API Reference (K8s) entry from Additional Resources

## Validation
- ruby YAML parse and visible path duplicate check
- git diff --check -- docs/index.yml
- pre-commit hook: check yaml passed

Note: fern check was not run because fern is not available on PATH.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized API Reference navigation item in documentation for improved discoverability, positioning it alongside Kubernetes Cloud Provider Guides.
  * Updated API Reference label for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->