### PR TITLE
[DYN-3068] Enable Qwen3-Omni async disagg prerequisites

### DIFF
--- a/components/src/dynamo/common/tests/test_output_modalities.py
+++ b/components/src/dynamo/common/tests/test_output_modalities.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for omni output modality request classification."""
+
+import pytest
+
+from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
+from dynamo.common.utils.output_modalities import RequestType, parse_request_type
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_messages_request_stays_chat_when_audio_is_registered():
+    parsed, request_type = parse_request_type(
+        {"messages": [{"role": "user", "content": "hello"}], "modalities": ["audio"]},
+        ["text", "audio"],
+    )
+
+    assert parsed["messages"][0]["content"] == "hello"
+    assert request_type == RequestType.CHAT_COMPLETION
+
+
+def test_audio_request_shape_wins_when_multiple_modalities_registered():
+    parsed, request_type = parse_request_type(
+        {"input": "hello", "response_format": "mp3"},
+        ["text", "audio"],
+    )
+
+    assert isinstance(parsed, NvCreateAudioSpeechRequest)
+    assert parsed.input == "hello"
+    assert parsed.response_format == "mp3"
+    assert request_type == RequestType.AUDIO_GENERATION

--- a/components/src/dynamo/common/utils/output_modalities.py
+++ b/components/src/dynamo/common/utils/output_modalities.py
@@ -75,11 +75,20 @@ def parse_request_type(
     """
     Classify the endpoint based on the output modality and serialize the request if necessary.
 
-    Assumption: Right now we only consider user passes only one modality at a time.
+    When a worker registers multiple omni output modalities, infer the request
+    shape before falling back to the first configured modality.
     """
-    # Fetch the first output modality from the list.
     if not output_modalities:
         raise ValueError("output_modalities must not be empty")
+
+    modalities = [OutputModality.from_name(name) for name in output_modalities]
+
+    if "messages" in raw_request:
+        return raw_request, RequestType.CHAT_COMPLETION
+
+    if "input" in raw_request and OutputModality.AUDIO in modalities:
+        return NvCreateAudioSpeechRequest(**raw_request), RequestType.AUDIO_GENERATION
+
     output_modality = output_modalities[0]
     modality = OutputModality.from_name(output_modality)
 

--- a/components/src/dynamo/vllm/omni/stage_router.py
+++ b/components/src/dynamo/vllm/omni/stage_router.py
@@ -3,12 +3,17 @@
 
 """Stage router for disaggregated omni pipelines."""
 
+import asyncio
 import json
 import logging
+import os
+import time
 import uuid
 from typing import Any, AsyncGenerator, Dict, List
 
-from vllm_omni.entrypoints.utils import load_and_resolve_stage_configs
+from vllm_omni.distributed.omni_connectors.adapter import (
+    compute_talker_prompt_ids_length,
+)
 
 from dynamo import prometheus_names
 from dynamo.common.storage import get_fs
@@ -22,9 +27,18 @@ from dynamo.runtime import DistributedRuntime
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.omni.output_formatter import OutputFormatter
-from dynamo.vllm.omni.stage_worker import _resolve_model_type
+from dynamo.vllm.omni.stage_worker import (
+    _ASYNC_PREPARE_KEY,
+    _ASYNC_PREWARM_KEY,
+    _ASYNC_PREWARM_READY_KEY,
+    _resolve_model_type,
+)
 from dynamo.vllm.omni.types import StageOutput
-from dynamo.vllm.omni.utils import shm_deserialize
+from dynamo.vllm.omni.utils import (
+    load_omni_stage_configs,
+    shm_deserialize,
+    stage_configs_use_async_chunk,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,18 +52,16 @@ class OmniStageRouter:
         stage_configs_path: str,
     ) -> None:
         self.config = config
-        _, self.stage_configs = load_and_resolve_stage_configs(
-            config.model,
-            stage_configs_path,
-            kwargs={},
-        )
+        self.stage_configs = load_omni_stage_configs(config.model, stage_configs_path)
+        self._async_chunk = stage_configs_use_async_chunk(self.stage_configs)
         self.stage_clients: Dict[str, Any] = {}
+        self._model_name = config.served_model_name or config.model
 
         media_fs = (
             get_fs(config.media_output_fs_url) if config.media_output_fs_url else None
         )
         self._formatter = OutputFormatter(
-            model_name=config.served_model_name or config.model,
+            model_name=self._model_name,
             media_fs=media_fs,
             media_http_url=config.media_output_http_url,
             default_fps=config.default_video_fps,
@@ -67,17 +79,31 @@ class OmniStageRouter:
         request_id = str(uuid.uuid4())
         _, request_type = parse_request_type(request, self.config.output_modalities)
 
+        if self._async_chunk and len(self.stage_configs) > 1:
+            async for chunk in self._generate_async_chunk(
+                request,
+                request_id,
+                request_type,
+            ):
+                yield _coerce_router_chunk(
+                    chunk,
+                    request_id,
+                    self._model_name,
+                    request_type,
+                )
+            return
+
         stage_outputs: List[StageOutput] = []
         for stage_idx, stage_cfg in enumerate(self.stage_configs):
-            model_stage = getattr(
-                stage_cfg.engine_args, "model_stage", f"stage{stage_idx}"
-            )
+            model_stage = _model_stage_name(stage_cfg, stage_idx)
             client = self.stage_clients.get(model_stage)
             if client is None:
-                yield {
-                    "error": f"No client for stage '{model_stage}'",
-                    "finished": True,
-                }
+                yield _router_error_chunk(
+                    request_id,
+                    self._model_name,
+                    request_type,
+                    f"No client for stage '{model_stage}'",
+                )
                 return
 
             if stage_idx == 0:
@@ -101,43 +127,291 @@ class OmniStageRouter:
             stage_outputs.append(StageOutput.model_validate(raw_stage_output))
 
             if stage_outputs[-1].error:
-                yield {"error": stage_outputs[-1].error, "finished": True}
+                yield _router_error_chunk(
+                    request_id,
+                    self._model_name,
+                    request_type,
+                    stage_outputs[-1].error,
+                )
                 return
+            final_stage_id = stage_outputs[-1].final_stage_id
+            if final_stage_id is not None and final_stage_id <= stage_idx:
+                logger.info(
+                    "Router: stopping at requested final_stage_id=%d",
+                    final_stage_id,
+                )
+                break
 
         final = stage_outputs[-1]
+        async for chunk in self._format_final_output(
+            final,
+            request,
+            request_id,
+            request_type,
+        ):
+            yield _coerce_router_chunk(
+                chunk,
+                request_id,
+                self._model_name,
+                request_type,
+            )
+
+    async def _generate_async_chunk(
+        self,
+        request: dict,
+        request_id: str,
+        request_type: RequestType,
+    ) -> AsyncGenerator[dict, None]:
+        stage0_cfg = self.stage_configs[0]
+        stage0_client = self.stage_clients.get(_model_stage_name(stage0_cfg, 0))
+        if stage0_client is None:
+            yield {"error": "No client for stage 'stage0'", "finished": True}
+            return
+
+        prepare_output = await self._call_stage_raw(
+            stage0_client,
+            {"request_id": request_id, **request, _ASYNC_PREPARE_KEY: True},
+        )
+        if prepare_output.get("error"):
+            yield {"error": prepare_output["error"], "finished": True}
+            return
+
+        final_stage_id = prepare_output.get("final_stage_id")
+        target_stage_idx = (
+            len(self.stage_configs) - 1
+            if final_stage_id is None
+            else min(int(final_stage_id), len(self.stage_configs) - 1)
+        )
+
+        if target_stage_idx <= 0:
+            stage0_output = await self._call_stage(
+                stage0_client,
+                {"request_id": request_id, **request},
+            )
+            if stage0_output.error:
+                yield {"error": stage0_output.error, "finished": True}
+                return
+            async for chunk in self._format_final_output(
+                stage0_output,
+                request,
+                request_id,
+                request_type,
+            ):
+                yield _coerce_router_chunk(
+                    chunk,
+                    request_id,
+                    self._model_name,
+                    request_type,
+                )
+            return
+
+        first_downstream_prompt_len = _compute_async_prewarm_prompt_len(
+            prepare_output.get("prompt_token_ids") or []
+        )
+        base_prewarm_request = {
+            "request_id": request_id,
+            "original_prompt": prepare_output.get("original_prompt"),
+            "sampling_params_list": prepare_output.get("sampling_params_list"),
+            "final_stage_id": target_stage_idx,
+            _ASYNC_PREWARM_KEY: True,
+        }
+
+        downstream_tasks: dict[int, asyncio.Task[StageOutput]] = {}
+        prewarm_ready: dict[int, asyncio.Future[str | None]] = {}
+        try:
+            final_stage_cfg = self.stage_configs[target_stage_idx]
+            final_worker_type = _stage_worker_type(final_stage_cfg)
+            defer_final_stage = str(final_worker_type or "ar").lower() != "ar"
+            prewarm_end_stage = (
+                target_stage_idx - 1 if defer_final_stage else target_stage_idx
+            )
+
+            for stage_idx, stage_cfg in enumerate(
+                self.stage_configs[1 : prewarm_end_stage + 1],
+                start=1,
+            ):
+                model_stage = _model_stage_name(stage_cfg, stage_idx)
+                client = self.stage_clients.get(model_stage)
+                if client is None:
+                    await _cancel_downstream_tasks(downstream_tasks)
+                    yield {
+                        "error": f"No client for stage '{model_stage}'",
+                        "finished": True,
+                    }
+                    return
+                ready_future = asyncio.get_running_loop().create_future()
+                prewarm_ready[stage_idx] = ready_future
+                stage_prompt_len = (
+                    first_downstream_prompt_len
+                    if str(_stage_worker_type(stage_cfg) or "ar").lower() == "ar"
+                    else 0
+                )
+                prewarm_request = {
+                    **base_prewarm_request,
+                    "prompt_token_ids": [0] * stage_prompt_len,
+                }
+                downstream_tasks[stage_idx] = asyncio.create_task(
+                    self._call_stage(
+                        client,
+                        prewarm_request,
+                        prewarm_ready=ready_future,
+                    )
+                )
+
+            try:
+                if prewarm_ready:
+                    ready_errors = await asyncio.gather(*prewarm_ready.values())
+                    if ready_error := next((e for e in ready_errors if e), None):
+                        await _cancel_downstream_tasks(downstream_tasks)
+                        yield {"error": ready_error, "finished": True}
+                        return
+                stage0_output = await self._call_stage(
+                    stage0_client,
+                    {"request_id": request_id, **request},
+                )
+            except Exception as e:
+                await _cancel_downstream_tasks(downstream_tasks)
+                yield {"error": str(e), "finished": True}
+                return
+            if stage0_output.error:
+                await _cancel_downstream_tasks(downstream_tasks)
+                yield {"error": stage0_output.error, "finished": True}
+                return
+            stage0_text = _stage_output_text(stage0_output)
+
+            final: StageOutput | None = None
+            for stage_idx in range(1, prewarm_end_stage + 1):
+                try:
+                    output = await downstream_tasks[stage_idx]
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    await _cancel_downstream_tasks(downstream_tasks)
+                    yield {"error": str(e), "finished": True}
+                    return
+                if output.error:
+                    await _cancel_downstream_tasks(downstream_tasks)
+                    yield {"error": output.error, "finished": True}
+                    return
+                final = output
+
+            if defer_final_stage:
+                await _wait_for_async_chunk_key(request_id, target_stage_idx - 1)
+                model_stage = _model_stage_name(final_stage_cfg, target_stage_idx)
+                final_client = self.stage_clients.get(model_stage)
+                if final_client is None:
+                    yield {
+                        "error": f"No client for stage '{model_stage}'",
+                        "finished": True,
+                    }
+                    return
+                try:
+                    final = await self._call_stage(
+                        final_client,
+                        {**base_prewarm_request, "prompt_token_ids": []},
+                    )
+                except Exception as e:
+                    yield {"error": str(e), "finished": True}
+                    return
+                if final.error:
+                    yield {"error": final.error, "finished": True}
+                    return
+
+            if final is None:
+                yield {"error": "No final stage output", "finished": True}
+                return
+
+            async for chunk in self._format_final_output(
+                final,
+                request,
+                request_id,
+                request_type,
+                extra_ctx={"text": stage0_text} if stage0_text else None,
+            ):
+                yield _coerce_router_chunk(
+                    chunk,
+                    request_id,
+                    self._model_name,
+                    request_type,
+                )
+        finally:
+            await _cancel_downstream_tasks(downstream_tasks)
+
+    async def _call_stage(
+        self,
+        client: Any,
+        stage_request: dict,
+        *,
+        prewarm_ready: asyncio.Future[str | None] | None = None,
+    ) -> StageOutput:
+        return StageOutput.model_validate(
+            await self._call_stage_raw(
+                client,
+                stage_request,
+                prewarm_ready=prewarm_ready,
+            )
+        )
+
+    async def _call_stage_raw(
+        self,
+        client: Any,
+        stage_request: dict,
+        *,
+        prewarm_ready: asyncio.Future[str | None] | None = None,
+    ) -> dict:
+        raw_stage_output = {}
+        try:
+            async for chunk in await client.round_robin(stage_request):
+                data = chunk.data()
+                if isinstance(data, (str, bytes)):
+                    data = json.loads(data)
+                if data.pop(_ASYNC_PREWARM_READY_KEY, False):
+                    if prewarm_ready is not None and not prewarm_ready.done():
+                        prewarm_ready.set_result(None)
+                raw_stage_output.update(data)
+        except Exception as e:
+            if prewarm_ready is not None and not prewarm_ready.done():
+                prewarm_ready.set_result(str(e))
+            raise
+        if prewarm_ready is not None and not prewarm_ready.done():
+            error = raw_stage_output.get("error")
+            if error:
+                prewarm_ready.set_result(str(error))
+            else:
+                prewarm_ready.set_result("Stage prewarm completed without ready ack")
+        return raw_stage_output
+
+    async def _format_final_output(
+        self,
+        final: StageOutput,
+        request: dict,
+        request_id: str,
+        request_type: RequestType,
+        extra_ctx: dict | None = None,
+    ) -> AsyncGenerator[dict, None]:
         if not final.shm_meta:
             yield {"error": "No SHM output from final stage", "finished": True}
             return
 
-        # Build formatting context from the original request
-        nvext = request.get("nvext") or {}
-        fmt_ctx: Dict[str, Any] = {}
-        if nvext.get("fps") is not None:
-            fmt_ctx["fps"] = nvext["fps"]
-        if nvext.get("speed") is not None:
-            fmt_ctx["speed"] = nvext["speed"]
-        # If the request type is AUDIO_GENERATION,
-        # we need to normalize the data_source and response_format to
-        # align with other modalities.
-        response_format = (
-            request.get("data_source")
-            if request_type == RequestType.AUDIO_GENERATION
-            else request.get("response_format")
-        )
-        output_format = (
-            request.get("response_format")
-            if request_type == RequestType.AUDIO_GENERATION
-            else request.get("output_format")
-        )
-        if response_format is not None:
-            fmt_ctx["response_format"] = response_format
-        if output_format is not None:
-            fmt_ctx["output_format"] = output_format
+        fmt_ctx = _format_context(request, request_type)
+        if extra_ctx:
+            fmt_ctx.update(extra_ctx)
+        if (
+            request_type == RequestType.CHAT_COMPLETION
+            and _request_wants_text(request)
+            and (text := fmt_ctx.get("text"))
+        ):
+            yield _chat_text_chunk(request_id, self._model_name, str(text))
 
         async for chunk in self._format_output(
             final, request_id, request_type, fmt_ctx
         ):
-            yield chunk
+            yield _coerce_router_chunk(
+                chunk,
+                request_id,
+                self._model_name,
+                request_type,
+            )
 
     async def _format_output(
         self,
@@ -153,21 +427,42 @@ class OmniStageRouter:
             return
 
         result = shm_deserialize(shm_meta)
-        chunk = await self._formatter.format(
-            result, request_id, request_type=request_type, **ctx
+        results = result if isinstance(result, list) else [result]
+        emitted = False
+        final_output_type = "unknown"
+        audio_delta_state: dict[str, Any] | None = (
+            {} if request_type == RequestType.CHAT_COMPLETION else None
         )
-        if chunk:
-            yield chunk
-        else:
-            final_output_type = getattr(result, "final_output_type", "unknown")
+        for item in results:
+            final_output_type = getattr(item, "final_output_type", final_output_type)
+            item_ctx = ctx
+            if (
+                audio_delta_state is not None
+                and getattr(item, "final_output_type", None) == "audio"
+            ):
+                item_ctx = {**ctx, "audio_delta_state": audio_delta_state}
+            chunk = await self._formatter.format(
+                item, request_id, request_type=request_type, **item_ctx
+            )
+            if chunk:
+                emitted = True
+                yield _coerce_router_chunk(
+                    chunk,
+                    request_id,
+                    self._model_name,
+                    request_type,
+                )
+        if not emitted:
             logger.warning(
                 "Router: formatter returned None, final_output_type=%s",
                 final_output_type,
             )
-            yield {
-                "error": f"Formatter returned no output for type '{final_output_type}'",
-                "finished": True,
-            }
+            yield _router_error_chunk(
+                request_id,
+                self._model_name,
+                request_type,
+                f"Formatter returned no output for type '{final_output_type}'",
+            )
 
 
 async def init_omni_stage_router(
@@ -187,9 +482,7 @@ async def init_omni_stage_router(
 
     # Discover stage endpoints
     for stage_cfg in router.stage_configs:
-        model_stage = getattr(
-            stage_cfg.engine_args, "model_stage", f"stage{stage_cfg.stage_id}"
-        )
+        model_stage = _model_stage_name(stage_cfg, stage_cfg.stage_id)
         client = await runtime.endpoint(
             f"{config.namespace}.{model_stage}.generate"
         ).client()
@@ -235,3 +528,180 @@ async def init_omni_stage_router(
     except Exception as e:
         logger.error("OmniStageRouter endpoint failed: %s", e)
         raise
+
+
+def _model_stage_name(stage_cfg: Any, stage_idx: int) -> str:
+    engine_args = getattr(stage_cfg, "engine_args", None)
+    return getattr(engine_args, "model_stage", f"stage{stage_idx}")
+
+
+def _request_wants_text(request: dict) -> bool:
+    modalities = request.get("modalities")
+    if not isinstance(modalities, list):
+        return True
+    return any(str(modality).lower() == "text" for modality in modalities)
+
+
+def _chat_text_chunk(request_id: str, model_name: str, text: str) -> dict:
+    return {
+        "id": request_id,
+        "created": int(time.time()),
+        "object": "chat.completion.chunk",
+        "model": model_name,
+        "modality": "text",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _coerce_router_chunk(
+    chunk: dict,
+    request_id: str,
+    model_name: str,
+    request_type: RequestType,
+) -> dict:
+    if (
+        isinstance(chunk, dict)
+        and "error" in chunk
+        and "id" not in chunk
+        and _is_chat_request_type(request_type)
+    ):
+        return _router_error_chunk(
+            request_id, model_name, request_type, str(chunk["error"])
+        )
+    return chunk
+
+
+def _router_error_chunk(
+    request_id: str,
+    model_name: str,
+    request_type: RequestType,
+    error_message: str,
+) -> dict:
+    if not _is_chat_request_type(request_type):
+        return {"error": error_message, "finished": True}
+    return {
+        "id": request_id,
+        "created": int(time.time()),
+        "object": "chat.completion.chunk",
+        "model": model_name,
+        "modality": "text",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": f"Error: {error_message}",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _is_chat_request_type(request_type: RequestType) -> bool:
+    if request_type == RequestType.CHAT_COMPLETION:
+        return True
+    value = getattr(request_type, "value", request_type)
+    return str(value) in {"chat", "chat_completion"}
+
+
+async def _wait_for_async_chunk_key(
+    request_id: str,
+    from_stage: int,
+    timeout_s: float = 30.0,
+) -> None:
+    """Wait for the first async chunk in SHM before launching a deferred final stage."""
+    if from_stage < 0:
+        return
+    key_path = f"/dev/shm/{request_id}_{from_stage}_0"
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while True:
+        if os.path.exists(key_path):
+            return
+        if asyncio.get_running_loop().time() >= deadline:
+            logger.warning(
+                "Timed out waiting for async chunk key %s before final-stage launch",
+                key_path,
+            )
+            return
+        await asyncio.sleep(0.02)
+
+
+def _stage_worker_type(stage_cfg: Any) -> Any:
+    worker_type = getattr(stage_cfg, "worker_type", None)
+    if worker_type is not None:
+        return worker_type
+    engine_args = getattr(stage_cfg, "engine_args", None)
+    return getattr(engine_args, "worker_type", None)
+
+
+def _compute_async_prewarm_prompt_len(prompt_token_ids: list[int]) -> int:
+    if not prompt_token_ids:
+        return 1
+    try:
+        computed = int(compute_talker_prompt_ids_length(prompt_token_ids))
+    except Exception:
+        computed = 0
+    if computed > 1:
+        return computed
+    return max(2, len(prompt_token_ids))
+
+
+async def _cancel_downstream_tasks(tasks: dict[int, asyncio.Task[StageOutput]]) -> None:
+    if not tasks:
+        return
+    for task in tasks.values():
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+
+def _stage_output_text(stage_output: StageOutput) -> str:
+    if not stage_output.shm_meta:
+        return ""
+    try:
+        return _extract_result_text(shm_deserialize(stage_output.shm_meta))
+    except Exception:
+        logger.debug(
+            "Failed to read text output from async chunk stage 0", exc_info=True
+        )
+        return ""
+
+
+def _extract_result_text(result: Any) -> str:
+    request_output = getattr(result, "request_output", None) or result
+    outputs = getattr(request_output, "outputs", None) or []
+    if not outputs:
+        return ""
+    text = getattr(outputs[0], "text", "")
+    return text if isinstance(text, str) else ""
+
+
+def _format_context(request: dict, request_type: RequestType) -> Dict[str, Any]:
+    nvext = request.get("nvext") or {}
+    fmt_ctx: Dict[str, Any] = {}
+    if nvext.get("fps") is not None:
+        fmt_ctx["fps"] = nvext["fps"]
+    if nvext.get("speed") is not None:
+        fmt_ctx["speed"] = nvext["speed"]
+    response_format = (
+        request.get("data_source")
+        if request_type == RequestType.AUDIO_GENERATION
+        else request.get("response_format")
+    )
+    output_format = (
+        request.get("response_format")
+        if request_type == RequestType.AUDIO_GENERATION
+        else request.get("output_format")
+    )
+    if response_format is not None:
+        fmt_ctx["response_format"] = response_format
+    if output_format is not None:
+        fmt_ctx["output_format"] = output_format
+    return fmt_ctx

--- a/components/src/dynamo/vllm/omni/stage_worker.py
+++ b/components/src/dynamo/vllm/omni/stage_worker.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import atexit
+import copy
 import importlib
 import inspect
 import logging
@@ -12,14 +13,20 @@ import os
 import shutil
 import tempfile
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, AsyncGenerator
 
+import torch
 import yaml
+from vllm.entrypoints.chat_utils import MM_PARSER_MAP
+from vllm.v1.request import EngineCoreRequest
 from vllm_omni.distributed.omni_connectors import initialize_orchestrator_connectors
+from vllm_omni.engine import async_omni_engine, stage_init_utils
+from vllm_omni.engine.async_omni_engine import _apply_omni_final_stage_metadata
 from vllm_omni.engine.orchestrator import build_engine_core_request_from_tokens
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.stage_utils import serialize_obj, shm_write_bytes
-from vllm_omni.entrypoints.utils import load_and_resolve_stage_configs
+from vllm_omni.entrypoints.utils import get_final_stage_id_for_e2e
 from vllm_omni.inputs.data import OmniTokensPrompt
 
 from dynamo import prometheus_names
@@ -29,9 +36,24 @@ from dynamo.vllm.health_check import VllmOmniHealthCheckPayload
 from dynamo.vllm.main import setup_metrics_collection
 from dynamo.vllm.omni.args import OmniConfig
 from dynamo.vllm.omni.types import StageEngine, StageRequest, _int_keyed
-from dynamo.vllm.omni.utils import _build_sampling_params, parse_omni_request
+from dynamo.vllm.omni.utils import (
+    OmniChatPreprocessor,
+    _build_sampling_params,
+    load_omni_stage_configs,
+    parse_omni_request,
+    stage_configs_use_async_chunk,
+)
 
 logger = logging.getLogger(__name__)
+
+_ASYNC_PREPARE_KEY = "__dynamo_omni_prepare"
+_ASYNC_PREWARM_KEY = "__dynamo_omni_async_prewarm"
+_ASYNC_PREWARM_READY_KEY = "__dynamo_omni_async_prewarm_ready"
+_ASYNC_DRAIN_INLINE_KEY = "__dynamo_omni_async_drain_inline"
+_TEXT_CONTENT_TYPES = frozenset(
+    ("text", "input_text", "output_text", "refusal", "thinking")
+)
+_MEDIA_CONTENT_KEYS = frozenset(MM_PARSER_MAP) - _TEXT_CONTENT_TYPES
 
 
 @dataclass
@@ -43,6 +65,7 @@ class _Proxy:
     """
 
     engine_outputs: Any = None
+    bridge_states: dict[str, Any] | None = None
 
 
 class OmniStageWorker:
@@ -65,6 +88,7 @@ class OmniStageWorker:
         stage_id: int,
         output_modalities: list | None = None,
         default_video_fps: int = 16,
+        pipeline_stage_configs: list[Any] | None = None,
     ) -> None:
         self.engine = engine
         self.stage_id = stage_id
@@ -72,6 +96,8 @@ class OmniStageWorker:
         self._output_modalities = output_modalities or []
         self._default_video_fps = default_video_fps
         self.stage_config = stage_config
+        self._pipeline_stage_configs = pipeline_stage_configs or [stage_config]
+        self._async_chunk = _stage_config_uses_async_chunk(stage_config)
 
         func_path = getattr(stage_config, "custom_process_input_func", None)
         self._processor = _load_processor(func_path)
@@ -81,6 +107,11 @@ class OmniStageWorker:
         self._requires_mm: bool = getattr(
             stage_config, "requires_multimodal_data", False
         )
+        model_config = getattr(engine, "model_config", None)
+        self._omni_chat_preprocessor = (
+            OmniChatPreprocessor(model_config) if model_config is not None else None
+        )
+        self._background_tasks: set[asyncio.Task] = set()
 
     async def generate(self, request: dict, context) -> AsyncGenerator[dict, None]:
         req = StageRequest.model_validate(request)
@@ -88,32 +119,85 @@ class OmniStageWorker:
         original_prompt = req.original_prompt
         # JSON sends dict keys as strings; normalize to int for stage_connector_refs.
         stage_connector_refs = _int_keyed(req.stage_connector_refs)
+        final_stage_id: int | None = None
+        async_prewarm_request = False
 
         # --- Resolve engine inputs ---
         sampling_params_list_override: dict | None = None
-        if stage_connector_refs:
+        if request.get(_ASYNC_PREPARE_KEY):
+            try:
+                prepared = await self._prepare_router_request(request)
+            except Exception as e:
+                logger.error(
+                    "Stage %d prepare error for %s: %s",
+                    self.stage_id,
+                    request_id,
+                    e,
+                    exc_info=True,
+                )
+                yield {"error": str(e), "finished": True}
+                return
+            yield {**prepared, "finished": True}
+            return
+        if request.get(_ASYNC_PREWARM_KEY):
+            async_prewarm_request = True
+            final_stage_id = req.final_stage_id
+            prompt_token_ids = (
+                request["prompt_token_ids"] if "prompt_token_ids" in request else [0]
+            )
+            if prompt_token_ids is None:
+                prompt_token_ids = [0]
+            sampling_params_list_override = req.sampling_params_list
+            try:
+                prompt = self._build_engine_core_request_from_tokens(
+                    list(prompt_token_ids),
+                    request_id,
+                    sampling_params_list_override,
+                    register=not _requires_downstream_final_stage_metadata(
+                        final_stage_id,
+                        self.stage_id,
+                    ),
+                    base_prompt=req.original_prompt,
+                )
+            except RuntimeError as e:
+                yield {"error": str(e), "finished": True}
+                return
+        elif stage_connector_refs:
             # Stage N > 0: fetch previous stage outputs from connectors, run pre-processor.
             sampling_params_list_override = req.sampling_params_list
+            final_stage_id = req.final_stage_id
             try:
                 stage_list = self._fetch_stage_inputs(stage_connector_refs, request_id)
             except RuntimeError as e:
                 yield {"error": str(e), "finished": True}
                 return
 
-            if len(stage_list) != len(
-                self._engine_input_source or stage_connector_refs
-            ):
+            filled = sum(1 for stage_input in stage_list if stage_input.engine_outputs)
+            expected = len(self._engine_input_source or stage_connector_refs)
+            if filled != expected:
                 logger.warning(
                     "Stage %d: expected %d stage inputs, got %d",
                     self.stage_id,
-                    len(self._engine_input_source or stage_connector_refs),
-                    len(stage_list),
+                    expected,
+                    filled,
                 )
 
+            processor_output = False
             if self._processor is not None:
                 prompt = self._process_stage_inputs(stage_list, original_prompt)
+                if isinstance(prompt, list) and len(prompt) == 0:
+                    logger.error(
+                        "Stage %d: processor returned no engine inputs",
+                        self.stage_id,
+                    )
+                    yield {
+                        "error": f"Stage {self.stage_id}: processor returned no engine inputs",
+                        "finished": True,
+                    }
+                    return
                 if isinstance(prompt, list) and len(prompt) == 1:
                     prompt = prompt[0]
+                processor_output = True
             else:
                 # No processor: check if the upstream output has the
                 # structure needed to build an OmniEngineCoreRequest
@@ -123,7 +207,13 @@ class OmniStageWorker:
                 if hasattr(upstream, "outputs") and upstream.outputs:
                     try:
                         prompt = self._build_engine_core_request_from_upstream(
-                            stage_list, request_id, sampling_params_list_override
+                            stage_list,
+                            request_id,
+                            sampling_params_list_override,
+                            register=not _requires_downstream_final_stage_metadata(
+                                final_stage_id,
+                                self.stage_id,
+                            ),
                         )
                     except RuntimeError as e:
                         yield {"error": str(e), "finished": True}
@@ -132,17 +222,22 @@ class OmniStageWorker:
                     prompt = upstream
         elif req.request_id is not None:
             # Stage 0 via router: raw request forwarded with request_id — parse it.
+            final_stage_id = self._resolve_final_stage_id(request, None)
             parsed = await parse_omni_request(
                 request,
                 self._output_modalities,
                 self._default_video_fps,
                 tokenizer_getter=self.engine.get_tokenizer,
+                chat_preprocessor=self._omni_chat_preprocessor,
+                renderer=getattr(self.engine, "renderer", None),
             )
+            await _attach_chat_prompt_token_ids(parsed, request, self.engine)
             prompt = parsed["engine_inputs"]
             original_prompt = parsed["original_prompt"]
             sampling_params_list_override = parsed["sampling_params_list"]
         else:
             # Direct frontend → stage (single-stage, no router).
+            final_stage_id = self._resolve_final_stage_id(request, None)
             prompt = request
 
         logger.debug(
@@ -153,13 +248,74 @@ class OmniStageWorker:
         )
 
         sp = _build_sampling_params(self.stage_config, sampling_params_list_override)
+        if stage_connector_refs and processor_output:
+            try:
+                prompt = self._build_engine_core_request_from_processor_prompt(
+                    prompt,
+                    request_id=request_id,
+                    sampling_params_list=sp,
+                    register=not _requires_downstream_final_stage_metadata(
+                        final_stage_id,
+                        self.stage_id,
+                    ),
+                )
+            except RuntimeError as e:
+                yield {"error": str(e), "finished": True}
+                return
+        prompt = self._prepare_downstream_payload_prompt(
+            prompt,
+            request_id=request_id,
+            sampling_params_list=sp,
+            final_stage_id=final_stage_id,
+        )
+        if async_prewarm_request:
+            if (
+                self._async_chunk
+                and final_stage_id is not None
+                and final_stage_id > self.stage_id
+                and not request.get(_ASYNC_DRAIN_INLINE_KEY)
+            ):
+                task = asyncio.create_task(
+                    self._drain_nonfinal_async_request(prompt, request_id, sp)
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+                await asyncio.sleep(0)
+                yield {_ASYNC_PREWARM_READY_KEY: True, "finished": True}
+                return
+            yield {_ASYNC_PREWARM_READY_KEY: True}
+
         last_result = None
+        intermediate_bridge_multimodal_outputs: dict[str, Any] = {}
+        final_results: list[Any] = []
 
         try:
             async for chunk in self.engine.generate(
                 prompt, request_id=request_id, sampling_params_list=sp
             ):
+                chunk_multimodal_output = _chunk_multimodal_output(chunk)
+                if not getattr(chunk, "finished", False):
+                    _accumulate_bridge_multimodal_output_from_payload(
+                        intermediate_bridge_multimodal_outputs,
+                        getattr(chunk, "request_id", None),
+                        chunk_multimodal_output,
+                    )
+                if (
+                    final_stage_id is not None
+                    and final_stage_id <= self.stage_id
+                    and isinstance(chunk_multimodal_output, dict)
+                    and chunk_multimodal_output
+                ):
+                    final_results.append(chunk)
                 last_result = chunk
+                logger.debug(
+                    "Stage %d engine chunk for %s finished=%s final_output_type=%s type=%s",
+                    self.stage_id,
+                    request_id,
+                    getattr(chunk, "finished", None),
+                    getattr(chunk, "final_output_type", None),
+                    type(chunk).__name__,
+                )
         except Exception as e:
             logger.error(
                 "Stage %d engine error for %s: %s",
@@ -181,13 +337,25 @@ class OmniStageWorker:
         # determines whether output should go to a connector or to SHM.
         from_s, to_s = _connector_key(self.stage_id, self.stage_id + 1)
         connector = self.connectors.get((from_s, to_s))
-        if connector is not None:
+        is_final_stage_for_request = (
+            final_stage_id is not None and final_stage_id <= self.stage_id
+        )
+        if (
+            connector is not None
+            and not self._async_chunk
+            and not is_final_stage_for_request
+        ):
             try:
                 ok, _, metadata = connector.put(  # type: ignore[arg-type]
                     from_s,
                     to_s,
                     request_id,
-                    _prepare_connector_payload(last_result),
+                    _prepare_connector_payload(
+                        last_result,
+                        bridge_states=_bridge_states_from_multimodal_outputs(
+                            intermediate_bridge_multimodal_outputs
+                        ),
+                    ),
                 )
             except Exception as e:
                 logger.error(
@@ -210,9 +378,20 @@ class OmniStageWorker:
                 },
                 "finished": True,
             }
+            if final_stage_id is not None:
+                out["final_stage_id"] = final_stage_id
             if sampling_params_list_override is not None:
                 out["sampling_params_list"] = sampling_params_list_override
             yield out
+            return
+
+        if (
+            self._async_chunk
+            and self.stage_id > 0
+            and connector is not None
+            and not is_final_stage_for_request
+        ):
+            yield {"finished": True}
             return
 
         # Final stage → router: write output to shared memory and return the SHM handle.
@@ -222,14 +401,110 @@ class OmniStageWorker:
         # worker and the router to reside on the same machine. A proper multi-node
         # solution would use a connector edge (like inter-stage connectors) instead.
         # Tracked in TODO: shm_meta should be replaced by a YAML-configured connector edge.
-        shm_meta = shm_write_bytes(serialize_obj(last_result), name=request_id)
-        yield {"shm_meta": shm_meta, "finished": True}
+        shm_name = (
+            f"{request_id}-stage-{self.stage_id}" if self._async_chunk else request_id
+        )
+        serializable_result = (
+            final_results
+            if len(final_results) > 1
+            else final_results[0]
+            if final_results
+            else last_result
+        )
+        shm_meta = shm_write_bytes(serialize_obj(serializable_result), name=shm_name)
+        out = {"shm_meta": shm_meta, "finished": True}
+        if final_stage_id is not None:
+            out["final_stage_id"] = final_stage_id
+        yield out
+
+    async def _drain_nonfinal_async_request(
+        self,
+        prompt: Any,
+        request_id: str,
+        sampling_params_list: list | None,
+    ) -> None:
+        chunks = 0
+        last_type = None
+        logger.debug(
+            "Stage %d async prewarm background start for %s prompt_type=%s",
+            self.stage_id,
+            request_id,
+            type(prompt).__name__,
+        )
+        try:
+            async for output in self.engine.generate(
+                prompt,
+                request_id=request_id,
+                sampling_params_list=sampling_params_list,
+            ):
+                chunks += 1
+                last_type = type(output).__name__
+                request_output = getattr(output, "request_output", output)
+                finished = getattr(request_output, "finished", None)
+                logger.debug(
+                    "Stage %d async prewarm background chunk for %s count=%d output_type=%s finished=%s",
+                    self.stage_id,
+                    request_id,
+                    chunks,
+                    last_type,
+                    finished,
+                )
+            logger.debug(
+                "Stage %d async prewarm background done for %s chunks=%d last_type=%s",
+                self.stage_id,
+                request_id,
+                chunks,
+                last_type,
+            )
+        except Exception as e:
+            logger.error(
+                "Stage %d async prewarm background error for %s after chunks=%d: %s",
+                self.stage_id,
+                request_id,
+                chunks,
+                e,
+                exc_info=True,
+            )
+
+    async def _prepare_router_request(self, request: dict) -> dict:
+        frontend_request = _with_prepare_multimodal_uuids(
+            _strip_internal_fields(request),
+            request.get("request_id") or "",
+        )
+        parsed = await parse_omni_request(
+            frontend_request,
+            self._output_modalities,
+            self._default_video_fps,
+            tokenizer_getter=self.engine.get_tokenizer,
+            chat_preprocessor=self._omni_chat_preprocessor,
+            renderer=getattr(self.engine, "renderer", None),
+        )
+        await _attach_chat_prompt_token_ids(parsed, frontend_request, self.engine)
+        prompt_token_ids = await _extract_prompt_token_ids(
+            parsed["engine_inputs"],
+            self.engine,
+        )
+        if len(prompt_token_ids) < 2 and isinstance(
+            frontend_request.get("messages"), list
+        ):
+            prompt_token_ids = await _extract_chat_prompt_token_ids(
+                frontend_request,
+                self.engine,
+            )
+        return {
+            "original_prompt": parsed["original_prompt"],
+            "sampling_params_list": parsed["sampling_params_list"],
+            "prompt_token_ids": prompt_token_ids,
+            "final_stage_id": self._resolve_final_stage_id(frontend_request, None),
+        }
 
     def _build_engine_core_request_from_upstream(
         self,
         stage_list: list[_Proxy],
         request_id: str,
         sampling_params_list_override: dict | None,
+        *,
+        register: bool = True,
     ):
         """Build an OmniEngineCoreRequest from the upstream stage output.
 
@@ -255,29 +530,177 @@ class OmniStageWorker:
                 f"upstream output: {e}"
             ) from e
 
-        tokens_prompt = OmniTokensPrompt(prompt_token_ids=list(token_ids))
+        return self._build_engine_core_request_from_tokens(
+            list(token_ids),
+            request_id,
+            sampling_params_list_override,
+            register=register,
+        )
+
+    def _build_engine_core_request_from_tokens(
+        self,
+        token_ids: list[int],
+        request_id: str,
+        sampling_params_list_override: dict | None,
+        *,
+        register: bool = True,
+        base_prompt: Any | None = None,
+    ):
+        if isinstance(base_prompt, dict):
+            tokens_prompt = copy.deepcopy(base_prompt)
+            tokens_prompt["prompt_token_ids"] = token_ids
+            tokens_prompt["multi_modal_data"] = None
+            tokens_prompt["mm_processor_kwargs"] = None
+        else:
+            tokens_prompt = OmniTokensPrompt(prompt_token_ids=token_ids)
         sp_list = _build_sampling_params(
             self.stage_config, sampling_params_list_override
         )
-        params = sp_list[0] if sp_list else None
-        prompt = build_engine_core_request_from_tokens(
-            request_id=request_id,
-            prompt=tokens_prompt,
-            params=params,
+        return self._build_engine_core_request(
+            tokens_prompt,
+            request_id,
+            sp_list,
+            register=register,
         )
-        # Pre-built EngineCoreRequests skip the output processor registration
-        # in _build_add_request_message (the isinstance(prompt, EngineCoreRequest)
-        # branch bypasses that block).  Register manually so that the engine's
-        # output processor can match the response back to this request.
-        prompt.external_req_id = prompt.request_id
+
+    def _build_engine_core_request(
+        self,
+        prompt: Any,
+        request_id: str,
+        sampling_params_list: list | None,
+        *,
+        register: bool = True,
+    ):
+        params = sampling_params_list[0] if sampling_params_list else None
+        if params is None:
+            raise RuntimeError(
+                f"Stage {self.stage_id}: cannot build engine request without "
+                "default sampling params"
+            )
+
+        kwargs = {
+            "request_id": request_id,
+            "prompt": prompt,
+            "params": params,
+        }
+        if (
+            "model_config"
+            in inspect.signature(build_engine_core_request_from_tokens).parameters
+        ):
+            model_config = _engine_model_config(self.engine)
+            if model_config is not None:
+                kwargs["model_config"] = model_config
+
+        request = build_engine_core_request_from_tokens(**kwargs)
+        if register:
+            self._register_engine_core_request(request)
+        return request
+
+    def _build_engine_core_request_from_processor_prompt(
+        self,
+        prompt: Any,
+        *,
+        request_id: str,
+        sampling_params_list: list | None,
+        register: bool = True,
+    ) -> Any:
+        """Mirror native inter-stage admission for processor outputs.
+
+        vLLM-Omni wraps non-diffusion downstream processor outputs in an
+        OmniEngineCoreRequest before submitting them to the stage engine. This
+        matters for non-AR stages such as code2wav, whose model does not pass
+        normal vLLM input validation from a raw OmniTokensPrompt.
+        """
+        if isinstance(prompt, EngineCoreRequest):
+            if register:
+                self._register_engine_core_request(prompt)
+            return prompt
+        if isinstance(prompt, list):
+            if len(prompt) != 1:
+                raise RuntimeError(
+                    f"Stage {self.stage_id}: expected one processor output, "
+                    f"got {len(prompt)}"
+                )
+            prompt = prompt[0]
+        prompt_token_ids = _get_prompt_token_ids(prompt)
+        if prompt_token_ids is not None and len(prompt_token_ids) == 0:
+            raise RuntimeError(
+                f"Stage {self.stage_id}: processor returned zero prompt tokens"
+            )
+        if prompt_token_ids is None:
+            return prompt
+
+        return self._build_engine_core_request(
+            prompt,
+            request_id,
+            sampling_params_list,
+            register=register,
+        )
+
+    def _register_engine_core_request(self, request: EngineCoreRequest) -> None:
+        if request.external_req_id is None:
+            request.external_req_id = request.request_id
         self.engine.engine.output_processors[0].add_request(
-            request=prompt,
+            request=request,
             prompt=None,
             parent_req=None,
             request_index=0,
             queue=None,
         )
-        return prompt
+
+    def _resolve_final_stage_id(
+        self,
+        request: dict,
+        existing: int | None,
+    ) -> int:
+        if existing is not None:
+            return int(existing)
+        return get_final_stage_id_for_e2e(
+            request.get("modalities"),
+            self._output_modalities,
+            self._pipeline_stage_configs,
+        )
+
+    def _prepare_downstream_payload_prompt(
+        self,
+        prompt: Any,
+        *,
+        request_id: str,
+        sampling_params_list: list | None,
+        final_stage_id: int | None,
+    ) -> Any:
+        if final_stage_id is None or final_stage_id <= self.stage_id:
+            return prompt
+
+        # vLLM-Omni's AR runner only emits inter-stage multimodal payloads
+        # (hidden states, audio codes, etc.) when omni_final_stage_id points to
+        # a downstream stage. Dynamo runs each stage in a one-stage AsyncOmni,
+        # so the normal generate() path would stamp final_stage_id=0 and drop
+        # those payloads. Prebuilding the EngineCoreRequest preserves the
+        # pipeline-level final stage metadata while keeping this local
+        # one-stage engine from routing to nonexistent downstream stages.
+        if isinstance(prompt, EngineCoreRequest):
+            prompt = _apply_omni_final_stage_metadata(prompt, final_stage_id)
+            self._register_engine_core_request(prompt)
+            return prompt
+
+        inner_engine = getattr(self.engine, "engine", None)
+        build_message = getattr(inner_engine, "_build_add_request_message", None)
+        if not callable(build_message):
+            raise RuntimeError(
+                f"Stage {self.stage_id}: engine cannot prebuild request with "
+                f"final_stage_id={final_stage_id}"
+            )
+
+        message = build_message(
+            request_id=request_id,
+            prompt=prompt,
+            sampling_params_list=sampling_params_list,
+            final_stage_id=final_stage_id,
+        )
+        if isinstance(message, dict):
+            return message["prompt"]
+        return message.prompt
 
     def _process_stage_inputs(self, stage_list: list[_Proxy], original_prompt: Any):
         """Call vLLM-Omni stage processors using the v0.20 transition API."""
@@ -321,7 +744,7 @@ class OmniStageWorker:
                     source_outputs,
                     original_prompt,
                     self._requires_mm,
-                    None,
+                    _build_streaming_context(stage_list),
                 )
             return self._processor(
                 source_outputs,
@@ -333,7 +756,7 @@ class OmniStageWorker:
             f"Stage {self.stage_id}: unsupported processor signature for "
             f"{self._processor!r}; expected stage-list parameters "
             "('stage_list', 'engine_input_source', ...) or source-output "
-            "parameters ('source_outputs', 'original_prompt', ...), got "
+            "parameters ('source_outputs', 'original_prompt|prompt', ...), got "
             f"{parameter_names}"
         )
 
@@ -347,7 +770,8 @@ class OmniStageWorker:
         Raises RuntimeError on any failure so the caller can propagate it as an error chunk.
         """
         sources = self._engine_input_source or sorted(stage_connector_refs.keys())
-        stage_list = []
+        max_stage_id = max(sources) if sources else 0
+        stage_list = [_Proxy() for _ in range(max_stage_id + 1)]
         for stage_k in sources:
             if (meta_k := stage_connector_refs.get(stage_k)) is None:
                 raise RuntimeError(
@@ -378,10 +802,17 @@ class OmniStageWorker:
                     engine_inputs,
                     payload_data.get("_dynamo_completion_output_attrs"),
                 )
+                bridge_states = payload_data.get("_dynamo_streaming_bridge_states")
             else:
                 engine_inputs = payload_data
+                bridge_states = None
             _ensure_cumulative_token_ids(engine_inputs)
-            stage_list.append(_Proxy(engine_outputs=[engine_inputs]))
+            stage_list[stage_k] = _Proxy(
+                engine_outputs=[engine_inputs],
+                bridge_states=bridge_states
+                if isinstance(bridge_states, dict)
+                else None,
+            )
         return stage_list
 
 
@@ -398,14 +829,12 @@ async def init_omni_stage(
     if config.stage_id is None:
         raise ValueError("--stage-id is required for stage worker initialization")
     stage_id: int = config.stage_id
-    resolved_stage_configs_path, stage_configs = load_and_resolve_stage_configs(
-        config.model,
-        config.stage_configs_path,
-        kwargs={},
-    )
-    connector_configs_path = _ensure_stage_connectors(
-        resolved_stage_configs_path,
-        stage_configs,
+    stage_configs = load_omni_stage_configs(config.model, config.stage_configs_path)
+    use_async_chunk = stage_configs_use_async_chunk(stage_configs)
+    connector_configs_path = (
+        config.stage_configs_path
+        if use_async_chunk
+        else _ensure_stage_connectors(config.stage_configs_path, stage_configs)
     )
     if stage_id >= len(stage_configs):
         raise ValueError(
@@ -420,7 +849,13 @@ async def init_omni_stage(
     generate_endpoint = runtime.endpoint(f"{config.namespace}.{model_stage}.generate")
     shutdown_endpoints[:] = [generate_endpoint]
 
-    engine = _create_engine(config.model, my_config, stage_type)
+    engine = _create_engine(
+        config.model,
+        my_config,
+        stage_type,
+        source_config_path=config.stage_configs_path,
+        async_chunk=use_async_chunk,
+    )
     logger.info("Stage %d: engine created (type=%s)", stage_id, stage_type)
 
     # Connectors for inter-stage output transfer — type determined by YAML config
@@ -434,6 +869,7 @@ async def init_omni_stage(
         output_modalities=config.output_modalities,
         default_video_fps=config.default_video_fps,
         stage_id=stage_id,
+        pipeline_stage_configs=stage_configs,
     )
 
     setup_metrics_collection(config, generate_endpoint, logger)
@@ -481,6 +917,13 @@ async def init_omni_stage(
 def _connector_key(from_stage: int, to_stage: int) -> tuple[str, str]:
     """Build the connector dict key used by initialize_orchestrator_connectors."""
     return (str(from_stage), str(to_stage))
+
+
+def _requires_downstream_final_stage_metadata(
+    final_stage_id: int | None,
+    stage_id: int,
+) -> bool:
+    return final_stage_id is not None and final_stage_id > stage_id
 
 
 def _load_processor(func_path: str | None) -> Any:
@@ -575,16 +1018,366 @@ def _cleanup_temp_stage_config(path: str) -> None:
         pass
 
 
-def _prepare_connector_payload(engine_inputs: Any) -> Any:
+def _strip_internal_fields(request: dict) -> dict:
+    return {
+        key: value
+        for key, value in request.items()
+        if not key.startswith("__dynamo_omni_")
+    }
+
+
+def _with_prepare_multimodal_uuids(request: dict, request_id: str) -> dict:
+    messages = request.get("messages")
+    if not isinstance(messages, list):
+        return request
+
+    prepared = copy.deepcopy(request)
+    for message_index, message in enumerate(prepared.get("messages") or []):
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        parts = content if isinstance(content, list) else [content]
+        for part_index, part in enumerate(parts):
+            if _is_media_content_part(part) and part.get("uuid") is None:
+                part[
+                    "uuid"
+                ] = f"__dynamo_prepare_{request_id}_{message_index}_{part_index}"
+    return prepared
+
+
+def _is_media_content_part(part: Any) -> bool:
+    if not isinstance(part, dict):
+        return False
+    part_type = part.get("type")
+    return part_type in _MEDIA_CONTENT_KEYS or any(
+        key in part for key in _MEDIA_CONTENT_KEYS
+    )
+
+
+async def _attach_chat_prompt_token_ids(
+    parsed: dict[str, Any],
+    request: dict,
+    engine: StageEngine,
+) -> None:
+    if not isinstance(request.get("messages"), list):
+        return
+    prompt_token_ids = _get_prompt_token_ids(parsed.get("engine_inputs")) or []
+    chat_prompt_token_ids = await _extract_chat_prompt_token_ids(request, engine)
+    if len(prompt_token_ids) < 2 or (
+        _has_chatml_start(chat_prompt_token_ids)
+        and not _has_chatml_start(prompt_token_ids)
+    ):
+        prompt_token_ids = chat_prompt_token_ids
+    if len(prompt_token_ids) < 2:
+        return
+    for key in ("engine_inputs", "original_prompt"):
+        value = parsed.get(key)
+        if not isinstance(value, dict):
+            wrapped = OmniTokensPrompt(prompt_token_ids=list(prompt_token_ids))
+            if isinstance(value, str):
+                wrapped["prompt"] = value
+            parsed[key] = wrapped
+            value = wrapped
+        if value.get("prompt_token_ids") != list(prompt_token_ids):
+            value["prompt_token_ids"] = list(prompt_token_ids)
+        additional = value.setdefault("additional_information", {})
+        if isinstance(additional, dict):
+            ids = additional.setdefault("ids", {})
+            if isinstance(ids, dict):
+                ids["prompt"] = list(prompt_token_ids)
+                ids["all"] = list(prompt_token_ids)
+
+
+def _has_chatml_start(token_ids: list[int]) -> bool:
+    return 151644 in token_ids
+
+
+async def _extract_chat_prompt_token_ids(
+    request: dict, engine: StageEngine
+) -> list[int]:
+    messages = request.get("messages")
+    if not isinstance(messages, list):
+        return []
+    tokenizer_result = engine.get_tokenizer()
+    tokenizer = (
+        await tokenizer_result
+        if inspect.isawaitable(tokenizer_result)
+        else tokenizer_result
+    )
+    if tokenizer is None:
+        return _synthetic_chatml_prompt_token_ids(messages)
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if callable(apply_chat_template):
+        try:
+            token_ids = list(
+                apply_chat_template(messages, tokenize=True, add_generation_prompt=True)
+                or []
+            )
+            if len(token_ids) >= 2:
+                return token_ids
+        except Exception:
+            logger.debug(
+                "Tokenizer chat template unavailable; using ChatML token-id fallback",
+                exc_info=True,
+            )
+    text = _render_chatml_prompt(messages)
+    encode = getattr(tokenizer, "encode", None)
+    if callable(encode):
+        try:
+            token_ids = list(encode(text, add_special_tokens=False))
+        except TypeError:
+            token_ids = list(encode(text))
+        return (
+            token_ids
+            if len(token_ids) >= 2
+            else _synthetic_chatml_prompt_token_ids(messages)
+        )
+    result = tokenizer(text)
+    input_ids = getattr(result, "input_ids", None)
+    if input_ids is None and isinstance(result, dict):
+        input_ids = result.get("input_ids")
+    token_ids = list(input_ids or [])
+    return (
+        token_ids
+        if len(token_ids) >= 2
+        else _synthetic_chatml_prompt_token_ids(messages)
+    )
+
+
+def _render_chatml_prompt(messages: list[Any]) -> str:
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "user")
+        if role == "developer":
+            role = "system"
+        parts.append(
+            f"<|im_start|>{role}\n{_message_content_text(message.get('content'))}<|im_end|>"
+        )
+    parts.append("<|im_start|>assistant\n")
+    return "\n".join(parts)
+
+
+def _synthetic_chatml_prompt_token_ids(messages: list[Any]) -> list[int]:
+    role_token_ids = {
+        "system": 8948,
+        "user": 872,
+        "assistant": 77091,
+        "developer": 8948,
+    }
+    ids: list[int] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "user")
+        role_id = role_token_ids.get(role, 872)
+        token_budget = max(
+            1, len(_message_content_text(message.get("content")).split())
+        )
+        ids.extend([151644, role_id, 198])
+        ids.extend([0] * token_budget)
+        ids.extend([151645, 198])
+    ids.extend([151644, 77091, 198])
+    return ids
+
+
+def _message_content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    text_parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type in _TEXT_CONTENT_TYPES and isinstance(item.get("text"), str):
+            text_parts.append(item["text"])
+    return "\n".join(text_parts)
+
+
+async def _extract_prompt_token_ids(prompt: Any, engine: StageEngine) -> list[int]:
+    token_ids = _get_prompt_token_ids(prompt)
+    if token_ids is not None:
+        return token_ids
+
+    text = prompt if isinstance(prompt, str) else None
+    if text is None and isinstance(prompt, dict):
+        value = prompt.get("prompt")
+        if isinstance(value, str):
+            text = value
+    if not text:
+        return []
+
+    tokenizer_result = engine.get_tokenizer()
+    tokenizer = (
+        await tokenizer_result
+        if inspect.isawaitable(tokenizer_result)
+        else tokenizer_result
+    )
+    if tokenizer is None:
+        return []
+    encode = getattr(tokenizer, "encode", None)
+    if callable(encode):
+        try:
+            return list(encode(text, add_special_tokens=False))
+        except TypeError:
+            return list(encode(text))
+    result = tokenizer(text)
+    input_ids = getattr(result, "input_ids", None)
+    if input_ids is None and isinstance(result, dict):
+        input_ids = result.get("input_ids")
+    return list(input_ids or [])
+
+
+def _get_prompt_token_ids(prompt: Any) -> list[int] | None:
+    if isinstance(prompt, dict):
+        token_ids = prompt.get("prompt_token_ids")
+    else:
+        token_ids = getattr(prompt, "prompt_token_ids", None)
+    if token_ids is None:
+        return None
+    return list(token_ids)
+
+
+def _engine_model_config(engine: StageEngine) -> Any:
+    try:
+        stage_configs = getattr(engine.engine, "stage_vllm_configs", None)
+        if stage_configs:
+            return getattr(stage_configs[0], "model_config", None)
+    except Exception:
+        logger.debug(
+            "Failed to read vLLM model config from stage engine", exc_info=True
+        )
+    return None
+
+
+def _prepare_connector_payload(
+    engine_inputs: Any,
+    bridge_states: dict[str, Any] | None = None,
+) -> Any:
     """Preserve dynamic CompletionOutput attrs that Omni's msgpack codec drops."""
     _promote_request_multimodal_output(engine_inputs)
     output_attrs = _collect_completion_output_attrs(engine_inputs)
-    if len(output_attrs) == 0:
+    if len(output_attrs) == 0 and not bridge_states:
         return engine_inputs
-    return {
+    payload = {
         "engine_inputs": engine_inputs,
         "_dynamo_completion_output_attrs": output_attrs,
     }
+    if bridge_states:
+        payload["_dynamo_streaming_bridge_states"] = bridge_states
+    return payload
+
+
+def _build_streaming_context(stage_list: list[_Proxy]) -> Any | None:
+    bridge_states: dict[str, Any] = {}
+    for stage_input in stage_list:
+        if isinstance(stage_input.bridge_states, dict):
+            _merge_bridge_states(bridge_states, stage_input.bridge_states)
+    if not bridge_states:
+        return None
+    return SimpleNamespace(
+        enabled=False,
+        segment_finished=False,
+        new_prompt_len_snapshot=None,
+        bridge_states=bridge_states,
+    )
+
+
+def _merge_bridge_states(
+    target: dict[str, Any],
+    incoming: dict[str, Any],
+) -> None:
+    for key, value in incoming.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _merge_bridge_states(target[key], value)
+        else:
+            target[key] = value
+
+
+def _bridge_states_from_multimodal_outputs(
+    by_req: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not by_req:
+        return None
+    return {"pd_prefill_multimodal_output_by_req": by_req}
+
+
+def _accumulate_bridge_multimodal_output(
+    by_req: dict[str, Any],
+    chunk: Any,
+) -> None:
+    req_id = getattr(chunk, "request_id", None)
+    _accumulate_bridge_multimodal_output_from_payload(
+        by_req,
+        req_id,
+        _chunk_multimodal_output(chunk),
+    )
+
+
+def _accumulate_bridge_multimodal_output_from_payload(
+    by_req: dict[str, Any],
+    req_id: Any,
+    multimodal_output: Any | None,
+) -> None:
+    if req_id is None:
+        return
+    if not isinstance(multimodal_output, dict) or not multimodal_output:
+        return
+    req_id = str(req_id)
+    existing = by_req.get(req_id)
+    by_req[req_id] = (
+        multimodal_output
+        if existing is None
+        else _merge_multimodal_payload(existing, multimodal_output)
+    )
+
+
+def _chunk_multimodal_output(chunk: Any) -> Any | None:
+    multimodal_output = getattr(chunk, "multimodal_output", None)
+    if multimodal_output:
+        return multimodal_output
+    request_output = getattr(chunk, "request_output", None)
+    if request_output is not None:
+        multimodal_output = getattr(request_output, "multimodal_output", None)
+        if multimodal_output:
+            return multimodal_output
+    outputs = _iter_completion_outputs(chunk)
+    if len(outputs) == 1:
+        return getattr(outputs[0], "multimodal_output", None)
+    return None
+
+
+def _merge_multimodal_payload(old: Any, new: Any) -> Any:
+    if isinstance(old, dict) and isinstance(new, dict):
+        merged = dict(old)
+        for key, value in new.items():
+            if key in merged:
+                merged[key] = _merge_multimodal_payload(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
+    if isinstance(old, torch.Tensor) and isinstance(new, torch.Tensor):
+        concatenated = _concat_compatible_tensors(old, new)
+        if concatenated is not None:
+            return concatenated
+    if isinstance(old, list) and isinstance(new, list):
+        return old + new
+    return new
+
+
+def _concat_compatible_tensors(
+    old: torch.Tensor, new: torch.Tensor
+) -> torch.Tensor | None:
+    if old.dim() == 0 or new.dim() == 0 or old.dim() != new.dim():
+        return None
+    if old.shape[1:] == new.shape[1:]:
+        return torch.cat([old, new], dim=0)
+    if old.shape[:-1] == new.shape[:-1]:
+        return torch.cat([old, new], dim=-1)
+    return None
 
 
 def _collect_completion_output_attrs(engine_inputs: Any) -> list[dict[str, Any]]:
@@ -604,6 +1397,9 @@ def _collect_completion_output_attrs(engine_inputs: Any) -> list[dict[str, Any]]
 def _promote_request_multimodal_output(engine_inputs: Any) -> None:
     """Expose request-level multimodal payloads on the sole completion output."""
     request_multimodal_output = getattr(engine_inputs, "multimodal_output", None)
+    if not request_multimodal_output:
+        request_output = getattr(engine_inputs, "request_output", None)
+        request_multimodal_output = getattr(request_output, "multimodal_output", None)
     if not request_multimodal_output:
         return
 
@@ -652,18 +1448,61 @@ def _iter_completion_outputs(engine_inputs: Any):
 def _accepts_source_outputs_processor(parameter_names: list[str]) -> bool:
     if len(parameter_names) < 3:
         return False
-    return parameter_names[:2] == ["source_outputs", "original_prompt"] and (
-        parameter_names[2] in {"requires_mm", "requires_multimodal_data"}
+    source_outputs_param_name = parameter_names[0]
+    prompt_param_name = parameter_names[1].lstrip("_")
+    requires_mm_param_name = parameter_names[2].lstrip("_")
+    return (
+        source_outputs_param_name == "source_outputs"
+        and prompt_param_name in {"original_prompt", "prompt"}
+        and requires_mm_param_name in {"requires_mm", "requires_multimodal_data"}
     )
 
 
-def _create_engine(model: str, stage_config: Any, stage_type: str) -> StageEngine:
+def _has_prompt_token_ids(prompt: Any) -> bool:
+    try:
+        prompt["prompt_token_ids"]
+    except (KeyError, TypeError):
+        return False
+    return True
+
+
+def _create_engine(
+    model: str,
+    stage_config: Any,
+    stage_type: str,
+    *,
+    source_config_path: str | None = None,
+    async_chunk: bool | None = None,
+) -> StageEngine:
     """Create AsyncOmni with a single-stage YAML."""
-    stage_arg = _stage_config_to_dict(stage_config, stage_type)
+    use_async_chunk = (
+        _stage_config_uses_async_chunk(stage_config)
+        if async_chunk is None
+        else bool(async_chunk)
+    )
+    source_stage_id = int(getattr(stage_config, "stage_id", 0) or 0)
+    if use_async_chunk and source_stage_id > 0:
+        _patch_headless_stage_finalize()
+
+    stage_arg = _stage_config_to_dict(
+        stage_config,
+        stage_type,
+        preserve_stage_id=use_async_chunk,
+    )
     _normalize_single_stage_runtime_devices(stage_arg)
+    if use_async_chunk:
+        _inject_output_connectors_from_source(
+            stage_arg,
+            source_config_path,
+            source_stage_id,
+        )
     single_stage_config = {
+        "async_chunk": use_async_chunk,
         "stage_args": [stage_arg],
-        "runtime": {"edges": []},
+        "runtime": _runtime_config_for_single_stage(
+            source_config_path,
+            preserve_edges=use_async_chunk,
+        ),
     }
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
@@ -676,31 +1515,38 @@ def _create_engine(model: str, stage_config: Any, stage_type: str) -> StageEngin
         os.unlink(tmp_path)
 
 
-def _stage_config_to_dict(stage_config: Any, stage_type: str) -> dict:
+def _stage_config_to_dict(
+    stage_config: Any,
+    stage_type: str,
+    preserve_stage_id: bool = False,
+) -> dict:
     """Convert a parsed stage config to a single-stage YAML dict."""
-    from omegaconf import OmegaConf  # type: ignore[import-not-found]
-
-    def _to_plain(obj: Any) -> Any:
-        if OmegaConf.is_config(obj):
-            return OmegaConf.to_container(obj, resolve=True)
-        if hasattr(obj, "__dict__"):
-            return dict(vars(obj))
-        return obj
-
+    stage_id = int(getattr(stage_config, "stage_id", 0) or 0)
     result: dict = {
-        "stage_id": 0,
+        "stage_id": stage_id if preserve_stage_id else 0,
         "stage_type": stage_type,
         "engine_args": _to_plain(stage_config.engine_args),
         "final_output": True,
         "final_output_type": getattr(stage_config, "final_output_type", "text"),
     }
 
-    for key in ("default_sampling_params", "is_comprehension"):
+    for key in (
+        "default_sampling_params",
+        "is_comprehension",
+        "custom_process_input_func",
+        "requires_multimodal_data",
+        "input_connectors",
+        "output_connectors",
+    ):
         val = getattr(stage_config, key, None)
         if val is not None:
             result[key] = _to_plain(val)
 
-    engine_input_source = getattr(stage_config, "engine_input_source", None)
+    engine_input_source = getattr(
+        stage_config,
+        "engine_input_source",
+        getattr(stage_config, "input_sources", None),
+    )
     if engine_input_source is not None:
         result["engine_input_source"] = _to_plain(engine_input_source)
 
@@ -711,6 +1557,118 @@ def _stage_config_to_dict(stage_config: Any, stage_type: str) -> dict:
         result["runtime"] = rt
 
     return result
+
+
+def _to_plain(obj: Any) -> Any:
+    if _is_omegaconf_config(obj):
+        from omegaconf import OmegaConf  # type: ignore[import-not-found]
+
+        return _to_plain(OmegaConf.to_container(obj, resolve=True))
+    if isinstance(obj, (list, tuple)):
+        return [_to_plain(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: _to_plain(value) for key, value in obj.items()}
+    if hasattr(obj, "__dict__"):
+        return {key: _to_plain(value) for key, value in vars(obj).items()}
+    return copy.deepcopy(obj)
+
+
+def _is_omegaconf_config(obj: Any) -> bool:
+    try:
+        from omegaconf import OmegaConf  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+    return bool(OmegaConf.is_config(obj))
+
+
+def _stage_config_uses_async_chunk(stage_config: Any) -> bool:
+    engine_args = getattr(stage_config, "engine_args", None)
+    return bool(getattr(engine_args, "async_chunk", False))
+
+
+def _runtime_config_for_single_stage(
+    source_config_path: str | None,
+    *,
+    preserve_edges: bool,
+) -> dict:
+    if not preserve_edges or not source_config_path:
+        return {"edges": []}
+
+    try:
+        with open(source_config_path, encoding="utf-8") as f:
+            source = yaml.safe_load(f) or {}
+    except Exception:
+        logger.debug("Failed to read source omni stage config", exc_info=True)
+        return {"edges": []}
+
+    runtime = copy.deepcopy(source.get("runtime") or {})
+    if "connectors" in source and "connectors" not in runtime:
+        runtime["connectors"] = copy.deepcopy(source["connectors"])
+    if "edges" in source and "edges" not in runtime:
+        runtime["edges"] = copy.deepcopy(source["edges"])
+    runtime.setdefault("edges", [])
+    return runtime
+
+
+def _inject_output_connectors_from_source(
+    stage_dict: dict,
+    source_config_path: str | None,
+    source_stage_id: int,
+) -> None:
+    if not source_config_path:
+        return
+
+    try:
+        with open(source_config_path, encoding="utf-8") as f:
+            source = yaml.safe_load(f) or {}
+    except Exception:
+        logger.debug("Failed to read source omni stage config", exc_info=True)
+        return
+
+    source_stages = source.get("stage_args") or source.get("stages") or []
+    output_connectors = dict(stage_dict.get("output_connectors") or {})
+    for downstream in source_stages:
+        if not isinstance(downstream, dict):
+            continue
+        to_stage = downstream.get("stage_id")
+        input_connectors = downstream.get("input_connectors") or {}
+        connector_ref = input_connectors.get(f"from_stage_{source_stage_id}")
+        if connector_ref is not None and to_stage is not None:
+            output_connectors.setdefault(f"to_stage_{to_stage}", connector_ref)
+
+    if output_connectors:
+        stage_dict["output_connectors"] = output_connectors
+
+
+def _patch_headless_stage_finalize() -> None:
+    if getattr(async_omni_engine, "_dynamo_headless_finalize_patch", False):
+        return
+
+    def _finalize_initialized_stages(stage_clients, input_processor):
+        if any(stage_client is None for stage_client in stage_clients):
+            raise RuntimeError(
+                "Stage initialization completed with missing stage clients"
+            )
+        initialized_stage_clients = [
+            stage_client for stage_client in stage_clients if stage_client is not None
+        ]
+        default_sampling_params_list = [
+            stage_client.default_sampling_params
+            for stage_client in initialized_stage_clients
+        ]
+        stage_metadata = [
+            {
+                "final_output": stage_client.final_output,
+                "final_output_type": stage_client.final_output_type,
+                "stage_type": stage_client.stage_type,
+            }
+            for stage_client in initialized_stage_clients
+        ]
+        return initialized_stage_clients, default_sampling_params_list, stage_metadata
+
+    stage_init_utils.finalize_initialized_stages = _finalize_initialized_stages
+    async_omni_engine.finalize_initialized_stages = _finalize_initialized_stages
+    async_omni_engine._dynamo_headless_finalize_patch = True
 
 
 def _normalize_single_stage_runtime_devices(stage_arg: dict) -> None:

--- a/components/src/dynamo/vllm/omni/types.py
+++ b/components/src/dynamo/vllm/omni/types.py
@@ -54,6 +54,7 @@ class StageOutput(BaseModel):
                 "original_prompt",
                 "stage_connector_refs",
                 "sampling_params_list",
+                "final_stage_id",
                 "finished",
                 "error",
             }
@@ -78,6 +79,7 @@ class StageOutput(BaseModel):
     # Keys arrive as strings from JSON; workers normalize them to int via _int_keyed().
     stage_connector_refs: dict[str, Any] | None = None
     sampling_params_list: dict | None = None
+    final_stage_id: int | None = None
     finished: bool | None = None
     error: str | None = None
 
@@ -87,7 +89,12 @@ class StageOutput(BaseModel):
         shm_meta is intentionally excluded — it is final-stage → router only.
         """
         fields = self.model_dump(
-            include={"original_prompt", "stage_connector_refs", "sampling_params_list"},
+            include={
+                "original_prompt",
+                "stage_connector_refs",
+                "sampling_params_list",
+                "final_stage_id",
+            },
             exclude_none=True,
         )
         fields["request_id"] = request_id
@@ -112,6 +119,7 @@ class StageRequest(BaseModel):
     # StageOutput.stage_connector_refs). Callers normalize string keys to int via _int_keyed().
     stage_connector_refs: dict[str, Any] | None = None
     sampling_params_list: dict | None = None
+    final_stage_id: int | None = None
 
 
 def _int_keyed(d: dict | None) -> dict[int, Any]:

--- a/components/src/dynamo/vllm/omni/utils.py
+++ b/components/src/dynamo/vllm/omni/utils.py
@@ -3,12 +3,16 @@
 
 """Shared utilities for the vLLM-Omni backend."""
 
+import asyncio
 import logging
 from typing import Any, cast
 
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.sampling_params import SamplingParams
 from vllm_omni.distributed.omni_connectors.utils.serialization import OmniSerializer
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
 from vllm_omni.entrypoints.stage_utils import shm_read_bytes
+from vllm_omni.entrypoints.utils import load_and_resolve_stage_configs
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 from dynamo.common.utils.output_modalities import RequestType, parse_request_type
@@ -16,6 +20,84 @@ from dynamo.common.utils.video_utils import compute_num_frames, parse_size
 
 DEFAULT_IMAGE_SIZE = "1024x1024"
 DEFAULT_VIDEO_SIZE = "832x480"
+
+
+def load_omni_stage_configs(model: str, stage_configs_path: str | None) -> list:
+    """Load resolved vLLM-Omni stage configs from deploy-format YAML."""
+    if not stage_configs_path:
+        return []
+    _, stage_configs = load_and_resolve_stage_configs(
+        model,
+        stage_configs_path,
+        kwargs={},
+    )
+    return stage_configs
+
+
+def stage_configs_use_async_chunk(stage_configs: list) -> bool:
+    if not stage_configs:
+        return False
+    engine_args = getattr(stage_configs[0], "engine_args", None)
+    return bool(getattr(engine_args, "async_chunk", False))
+
+
+class OmniChatPreprocessor(OmniOpenAIServingChat):
+    """Adapter for vLLM-Omni's OpenAI chat preprocessing."""
+
+    def __init__(self, model_config: Any):
+        self.model_config = model_config
+        self._supported_speakers = None
+
+
+async def preprocess_chat_with_omni(
+    request: dict[str, Any],
+    chat_preprocessor: Any,
+    renderer: Any,
+) -> dict[str, Any] | None:
+    """Render chat through vLLM-Omni's OpenAI chat preprocessing."""
+    if chat_preprocessor is None or renderer is None:
+        return None
+
+    try:
+        chat_request = ChatCompletionRequest.model_validate(request)
+        audio_options = (
+            request.get("audio") if isinstance(request.get("audio"), dict) else {}
+        )
+        for attr in ("voice", "speaker", "language", "instructions"):
+            value = request.get(attr) or audio_options.get(attr)
+            if value is not None:
+                object.__setattr__(chat_request, attr, value)
+        (
+            _conversation,
+            engine_prompts,
+        ) = await chat_preprocessor._preprocess_chat(
+            chat_request,
+            chat_request.messages,
+            default_template=chat_request.chat_template,
+            default_template_content_format="auto",
+            default_template_kwargs=getattr(chat_request, "chat_template_kwargs", None),
+            tool_dicts=(
+                [tool.model_dump() for tool in chat_request.tools]
+                if chat_request.tools is not None
+                else None
+            ),
+            renderer=renderer,
+            add_generation_prompt=chat_request.add_generation_prompt,
+            continue_final_message=chat_request.continue_final_message,
+            documents=getattr(chat_request, "documents", None),
+            add_special_tokens=chat_request.add_special_tokens,
+        )
+        if not engine_prompts:
+            return None
+        return engine_prompts[0] if isinstance(engine_prompts[0], dict) else None
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "Failed to render chat with vLLM-Omni; falling back",
+            exc_info=True,
+        )
+        return None
 
 
 def shm_deserialize(shm_meta: dict) -> Any:
@@ -117,11 +199,49 @@ def build_original_prompt(request: dict, nvext: dict, height: int, width: int) -
     return prompt
 
 
+def _chat_content_to_text(content: Any) -> str:
+    """Extract plain text from OpenAI chat content."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text" and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    return "\n".join(parts)
+
+
+def _audio_additional_information(request: dict) -> dict[str, list[str]]:
+    """Build optional speaker/language metadata for omni talker processors."""
+    additional_information: dict[str, list[str]] = {}
+    audio_options = (
+        request.get("audio") if isinstance(request.get("audio"), dict) else {}
+    )
+    speaker = (
+        request.get("voice")
+        or request.get("speaker")
+        or audio_options.get("voice")
+        or audio_options.get("speaker")
+    )
+    if isinstance(speaker, str) and speaker.strip():
+        additional_information["speaker"] = [speaker.strip().lower()]
+    language = request.get("language") or audio_options.get("language")
+    if isinstance(language, str) and language.strip():
+        additional_information["language"] = [language.strip()]
+    return additional_information
+
+
 async def parse_omni_request(
     request: dict,
     output_modalities: list,
     default_video_fps: int = 16,
     tokenizer_getter=None,
+    chat_preprocessor: Any | None = None,
+    renderer: Any | None = None,
 ) -> dict:
     """Parse a raw frontend request into engine_inputs, original_prompt, sampling_params_list.
 
@@ -135,7 +255,19 @@ async def parse_omni_request(
       original_prompt:      rich prompt dict with geometry/params for processor functions
       sampling_params_list: raw user overrides dict (height/width/nvext) or None for chat
     """
-    _, request_type = parse_request_type(request, output_modalities)
+    parsed_request, request_type = parse_request_type(request, output_modalities)
+
+    if request_type == RequestType.AUDIO_GENERATION:
+        input_text = getattr(parsed_request, "input", request.get("input", ""))
+        engine_inputs = OmniTextPrompt(prompt=input_text)
+        additional_information = _audio_additional_information(request)
+        if additional_information:
+            engine_inputs["additional_information"] = additional_information
+        return {
+            "engine_inputs": engine_inputs,
+            "original_prompt": dict(engine_inputs),
+            "sampling_params_list": None,
+        }
 
     if request_type in (RequestType.VIDEO_GENERATION, RequestType.IMAGE_GENERATION):
         is_video = request_type == RequestType.VIDEO_GENERATION
@@ -176,25 +308,16 @@ async def parse_omni_request(
 
     # Chat / text
     messages = request.get("messages", [])
-    text = next(
-        (m.get("content", "") for m in reversed(messages) if m.get("role") == "user"),
-        request.get("prompt", ""),
+    text = _chat_content_to_text(
+        next(
+            (
+                m.get("content", "")
+                for m in reversed(messages)
+                if m.get("role") == "user"
+            ),
+            request.get("prompt", ""),
+        )
     )
-
-    # Apply chat template when a tokenizer is available.  The native
-    # OpenAI API server applies the template before the engine sees it;
-    # without it the thinker receives bare text instead of the full
-    # chat-formatted prompt.
-    if messages and tokenizer_getter is not None:
-        try:
-            tokenizer = await tokenizer_getter()
-            text = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
-        except Exception:
-            logging.getLogger(__name__).debug(
-                "Chat template not available, using raw text"
-            )
 
     if any(str(modality).lower() == "image" for modality in output_modalities):
         width, height = image_generation_size_from_request(request)
@@ -213,9 +336,53 @@ async def parse_omni_request(
             ),
         }
 
+    additional_information = _audio_additional_information(request)
+    if messages:
+        native_prompt = await preprocess_chat_with_omni(
+            request,
+            chat_preprocessor,
+            renderer,
+        )
+        if native_prompt is not None:
+            if additional_information:
+                existing = native_prompt.setdefault("additional_information", {})
+                if isinstance(existing, dict):
+                    for key, value in additional_information.items():
+                        existing.setdefault(key, value)
+            return {
+                "engine_inputs": native_prompt,
+                "original_prompt": native_prompt,
+                "sampling_params_list": None,
+            }
+
+    # Apply chat template when a tokenizer is available. Some Omni models,
+    # including Qwen3-Omni, do not publish tokenizer.chat_template; those
+    # models rely on vLLM-Omni's renderer path above.
+    if messages and tokenizer_getter is not None:
+        try:
+            tokenizer = await tokenizer_getter()
+            text = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "Chat template not available, using raw text"
+            )
+
     return {
-        "engine_inputs": text,
-        "original_prompt": {"prompt": text},
+        "engine_inputs": (
+            OmniTextPrompt(prompt=text, additional_information=additional_information)
+            if additional_information
+            else text
+        ),
+        "original_prompt": {
+            "prompt": text,
+            **(
+                {"additional_information": additional_information}
+                if additional_information
+                else {}
+            ),
+        },
         "sampling_params_list": None,
     }
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_router.py
@@ -62,6 +62,8 @@ def _make_router(stage_configs, stage_clients, formatter=None, output_modalities
     )
     router.stage_configs = stage_configs
     router.stage_clients = stage_clients
+    router._async_chunk = False
+    router._model_name = "test-model"
     router._formatter = formatter or AsyncMock()
     return router
 
@@ -74,6 +76,36 @@ def _patched_generate(router, request, request_id="req-1", request_type="chat"):
         ),
         patch("dynamo.vllm.omni.stage_router.uuid.uuid4", return_value=request_id),
     )
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_async_chunk_path_when_configured():
+    router = _make_router(
+        stage_configs=[_make_stage_cfg(0), _make_stage_cfg(1)],
+        stage_clients={},
+    )
+    router._async_chunk = True
+    async_path_calls = []
+
+    async def fake_generate_async_chunk(request, request_id, request_type):
+        async_path_calls.append((request, request_id, request_type))
+        yield {"async": True, "finished": True}
+
+    router._generate_async_chunk = fake_generate_async_chunk
+
+    p1, p2 = _patched_generate(
+        router,
+        {"messages": []},
+        request_id="req-async",
+        request_type=RequestType.CHAT_COMPLETION,
+    )
+    with p1, p2:
+        chunks = [c async for c in router.generate({"messages": []}, None)]
+
+    assert chunks == [{"async": True, "finished": True}]
+    assert async_path_calls == [
+        ({"messages": []}, "req-async", RequestType.CHAT_COMPLETION)
+    ]
 
 
 def test_router_loads_stage_configs_from_model_deploy_config():

--- a/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_stage_worker.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 
 try:
+    from dynamo.vllm.omni import stage_worker
     from dynamo.vllm.omni.stage_worker import (
         OmniStageWorker,
         _ensure_stage_connectors,
@@ -21,6 +22,7 @@ try:
         _Proxy,
         _stage_config_to_dict,
     )
+    from dynamo.vllm.omni.types import StageOutput
     from dynamo.vllm.omni.utils import _build_sampling_params
 except ImportError:
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
@@ -185,6 +187,57 @@ async def test_stage_connector_refs_builds_engine_core_request():
     assert engine.received_prompt.prompt_token_ids == [100, 200, 300]
     # Output processor should have been registered
     engine.engine.output_processors[0].add_request.assert_called_once()
+
+
+def test_stage_output_forwards_final_stage_id_to_next_stage():
+    stage_output = StageOutput.model_validate(
+        {
+            "original_prompt": {"prompt": "hello"},
+            "stage_connector_refs": {"0": {"name": "ref0"}},
+            "sampling_params_list": {"max_tokens": 1},
+            "final_stage_id": 2,
+            "finished": True,
+        }
+    )
+
+    next_request = stage_output.to_next_stage_request("req-final-stage")
+
+    assert next_request["request_id"] == "req-final-stage"
+    assert next_request["final_stage_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_prewarm_preserves_explicit_empty_prompt_token_ids():
+    engine = _MockEngine()
+    built_prompt = SimpleNamespace(prompt_token_ids=[])
+    worker = _make_worker(
+        engine=engine,
+        stage_id=2,
+        stage_config=_make_stage_config(
+            engine_args=SimpleNamespace(async_chunk=True),
+            default_sampling_params={"temperature": 0.0, "max_tokens": 1},
+        ),
+    )
+    worker._build_engine_core_request_from_tokens = MagicMock(return_value=built_prompt)
+
+    chunks = [
+        chunk
+        async for chunk in worker.generate(
+            {
+                "request_id": "req-code2wav",
+                "prompt_token_ids": [],
+                "final_stage_id": 2,
+                "sampling_params_list": {"max_tokens": 1},
+                stage_worker._ASYNC_PREWARM_KEY: True,
+            },
+            _MockContext(),
+        )
+    ]
+
+    worker._build_engine_core_request_from_tokens.assert_called_once()
+    assert worker._build_engine_core_request_from_tokens.call_args.args[0] == []
+    assert engine.received_prompt is built_prompt
+    assert any(chunk.get(stage_worker._ASYNC_PREWARM_READY_KEY) for chunk in chunks)
 
 
 @pytest.mark.asyncio
@@ -550,6 +603,31 @@ def test_stage_config_to_dict_includes_engine_input_source():
     )
 
     assert result["engine_input_source"] == [0]
+
+
+def test_stage_config_to_dict_can_preserve_async_stage_topology():
+    result = _stage_config_to_dict(
+        SimpleNamespace(
+            stage_id=2,
+            stage_type="llm",
+            engine_args=SimpleNamespace(model_stage="stage2", async_chunk=True),
+            input_connectors={"from_stage_1": "connector_of_shared_memory"},
+            output_connectors={"to_stage_3": "connector_of_shared_memory"},
+            custom_process_input_func="pkg.module.processor",
+            requires_multimodal_data=True,
+            engine_input_source=[1],
+            final_output_type="audio",
+        ),
+        "llm",
+        preserve_stage_id=True,
+    )
+
+    assert result["stage_id"] == 2
+    assert result["engine_args"]["async_chunk"] is True
+    assert result["input_connectors"]["from_stage_1"] == "connector_of_shared_memory"
+    assert result["output_connectors"]["to_stage_3"] == "connector_of_shared_memory"
+    assert result["custom_process_input_func"] == "pkg.module.processor"
+    assert result["requires_multimodal_data"] is True
 
 
 def test_stage_config_to_dict_preserves_runtime_devices():

--- a/container/deps/vllm/install_vllm_omni.sh
+++ b/container/deps/vllm/install_vllm_omni.sh
@@ -10,6 +10,7 @@ VLLM_OMNI_PROTECTED_PACKAGES_FILE="${VLLM_OMNI_PROTECTED_PACKAGES_FILE:-/tmp/vll
 
 PROTECTED_CONSTRAINTS="$(mktemp /tmp/vllm-openai-protected.XXXXXX.txt)"
 VLLM_OMNI_VERSION="${VLLM_OMNI_REF#v}"
+VLLM_OMNI_PATCH_DIR="${VLLM_OMNI_PATCH_DIR:-/tmp/vllm_patches/vllm-omni-v${VLLM_OMNI_VERSION}}"
 
 cleanup() {
   rm -rf "${PROTECTED_CONSTRAINTS}"
@@ -49,3 +50,21 @@ else
     "vllm-omni==${VLLM_OMNI_VERSION}"
 fi
 
+if [ -d "${VLLM_OMNI_PATCH_DIR}" ]; then
+  SITE_PACKAGES="$(python3 - <<'PY'
+import site
+
+paths = site.getsitepackages()
+print(paths[0] if paths else "")
+PY
+)"
+  for patch_file in "${VLLM_OMNI_PATCH_DIR}"/*.patch; do
+    [ -e "${patch_file}" ] || continue
+    echo "Applying vLLM-Omni patch: ${patch_file}"
+    if command -v git >/dev/null 2>&1; then
+      (cd "${SITE_PACKAGES}" && git apply --ignore-whitespace -p0 "${patch_file}")
+    else
+      (cd "${SITE_PACKAGES}" && patch -p0 -l -i "${patch_file}")
+    fi
+  done
+fi

--- a/container/deps/vllm/patches/vllm-omni-v0.21.0rc1/0001-enable-qwen3-omni-async-disagg-audio.patch
+++ b/container/deps/vllm/patches/vllm-omni-v0.21.0rc1/0001-enable-qwen3-omni-async-disagg-audio.patch
@@ -1,0 +1,229 @@
+diff -rN -u vllm_omni/core/sched/omni_generation_scheduler.py vllm_omni/core/sched/omni_generation_scheduler.py
+--- vllm_omni/core/sched/omni_generation_scheduler.py	2026-06-01 18:32:49.885335592 +0200
++++ vllm_omni/core/sched/omni_generation_scheduler.py	2026-06-01 18:32:50.564567894 +0200
+@@ -1,6 +1,8 @@
+ from __future__ import annotations
+
+ import time
++
++import torch
+ from collections import defaultdict
+ from typing import Any
+
+@@ -18,6 +20,7 @@
+     EngineCoreEventType,
+     EngineCoreOutput,
+     EngineCoreOutputs,
++    FinishReason,
+ )
+ from vllm.v1.metrics.perf import PerfStats
+ from vllm.v1.request import Request, RequestStatus, StreamingUpdate
+@@ -173,16 +176,23 @@
+
+             # async_chunk: wait for the first upstream chunk (don't start with placeholders).
+             if self.chunk_transfer_adapter is not None and len(request.prompt_token_ids) == 0:
+-                if request.request_id in self.chunk_transfer_adapter.finished_requests:
+-                    request.prompt_token_ids.append(0)
+-                    try:
+-                        request._all_token_ids.append(0)  # type: ignore[attr-defined]
+-                    except Exception:
+-                        pass
+-                else:
+-                    self.waiting.pop_request()
+-                    skipped_waiting_requests.prepend_request(request)
+-                    continue
++                # If the producer wrote the first chunk before this generation
++                # stage was scheduled, consume it synchronously.
++                try:
++                    self.chunk_transfer_adapter._poll_single_request(request)
++                except Exception:
++                    logger.exception("Failed to poll first async chunk for %s", request.request_id)
++                if len(request.prompt_token_ids) == 0:
++                    if request.request_id in self.chunk_transfer_adapter.finished_requests:
++                        request.prompt_token_ids.append(0)
++                        try:
++                            request._all_token_ids.append(0)  # type: ignore[attr-defined]
++                        except Exception:
++                            pass
++                    else:
++                        self.waiting.pop_request()
++                        skipped_waiting_requests.prepend_request(request)
++                        continue
+
+             # Uniformly treat as diffusion. A feature flag can be added later
+             # via config or request tag.
+@@ -345,7 +355,7 @@
+             scheduler_output.scheduled_new_reqs = new_list  # type: ignore[assignment]
+
+             if self.chunk_transfer_adapter:
+-                self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output)
++                self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output, self.requests)
+
+         except Exception:
+             # If anything goes wrong, leave the original output unchanged
+@@ -453,20 +463,72 @@
+         # to avoid expensive operations inside the loop.
+         stopped_running_reqs: set[Request] = set()
+         stopped_preempted_reqs: set[Request] = set()
++
++        def _scheduled_chunk_finished(req_id: str) -> bool:
++            if self.chunk_transfer_adapter is None:
++                return False
++            additional_info = None
++            cached = getattr(scheduler_output, "scheduled_cached_reqs", None)
++            cached_info = getattr(cached, "additional_information", None)
++            if isinstance(cached_info, dict):
++                additional_info = cached_info.get(req_id)
++            if additional_info is None:
++                for nr in getattr(scheduler_output, "scheduled_new_reqs", []) or []:
++                    if getattr(nr, "req_id", None) == req_id:
++                        additional_info = getattr(nr, "additional_information", None)
++                        break
++            if additional_info is None:
++                request = self.requests.get(req_id)
++                additional_info = getattr(request, "additional_information", None) if request else None
++            if not isinstance(additional_info, dict):
++                return False
++            meta = additional_info.get("meta")
++            if not isinstance(meta, dict):
++                return False
++            flag = meta.get("finished")
++            if isinstance(flag, torch.Tensor):
++                return flag.numel() == 1 and bool(flag.item())
++            return bool(flag)
++
+         for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+             assert num_tokens_scheduled > 0
+             if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
+                 # Skip requests that were recovered from KV load failure
+                 continue
++            req_index = model_runner_output.req_id_to_index[req_id]
++            generated_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
+             request = self.requests.get(req_id)
+-            if request is None or request.is_finished():
++            if request is None:
++                # Async chunk generation stages can receive a terminal chunk
++                # after the live scheduler request has already been reclaimed.
++                # Still emit the final pooling output so the output processor
++                # can complete the request and unblock the frontend stream.
++                if self.chunk_transfer_adapter is None or not _scheduled_chunk_finished(req_id):
++                    continue
++                pooler_output = pooler_outputs[req_index] if pooler_outputs else None
++                prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
++                outputs[0].append(
++                    EngineCoreOutput(
++                        request_id=req_id,
++                        new_token_ids=generated_token_ids,
++                        finish_reason=FinishReason.STOP,
++                        new_prompt_logprobs_tensors=prompt_logprobs_tensors,
++                        pooling_output=pooler_output,
++                        num_nans_in_logits=(num_nans_in_logits or {}).get(req_id, 0),
++                    )
++                )
++                if self.finished_req_ids_dict is not None:
++                    self.finished_req_ids_dict[0].add(req_id)
++                try:
++                    self.chunk_transfer_adapter.cleanup(req_id, req_id)
++                except Exception:
++                    logger.exception("Failed to cleanup terminal async generation request %s", req_id)
++                continue
++            if request.is_finished():
+                 # Request may already be finished (e.g., aborted during
+                 # execution / pipeline parallelism / async scheduling).
+                 continue
+
+-            req_index = model_runner_output.req_id_to_index[req_id]
+-            generated_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
+-
+             scheduled_spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+             if scheduled_spec_token_ids and generated_token_ids:
+                 num_draft_tokens = len(scheduled_spec_token_ids)
+@@ -510,8 +572,7 @@
+                 or (self.chunk_transfer_adapter is None and request.num_computed_tokens >= request.num_prompt_tokens)
+                 or (
+                     self.chunk_transfer_adapter is not None
+-                    and request.request_id in self.chunk_transfer_adapter.finished_requests
+-                    and request.num_computed_tokens >= len(request.prompt_token_ids)
++                    and _scheduled_chunk_finished(request.request_id)
+                 )
+             ):
+                 request.status = RequestStatus.FINISHED_STOPPED
+diff -rN -u vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+--- vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py	2026-06-01 18:32:53.376926853 +0200
++++ vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py	2026-06-01 18:32:54.177654520 +0200
+@@ -189,8 +189,6 @@
+                         existing_sub = info.get(key)
+                         merged_sub = dict(existing_sub) if isinstance(existing_sub, dict) else {}
+                         for sk, sv in value.items():
+-                            if key == "meta" and sk == "finished":
+-                                continue
+                             merged_sub[sk] = sv
+                         info[key] = merged_sub
+                         continue
+diff -rN -u vllm_omni/engine/stage_pool.py vllm_omni/engine/stage_pool.py
+--- vllm_omni/engine/stage_pool.py	2026-06-01 18:32:53.480503115 +0200
++++ vllm_omni/engine/stage_pool.py	2026-06-01 18:32:54.041972355 +0200
+@@ -58,6 +58,7 @@
+         self._stage_vllm_config = stage_vllm_config
+         self._next_replica_id = 0
+         self._request_bindings: dict[str, int] = {}
++        self._submitted_requests: dict[str, Any] = {}
+         self._replica_metrics: list[_ReplicaMetrics] = [_ReplicaMetrics() for _ in self.clients]
+
+     # ---- Stage-level properties ----
+@@ -113,6 +114,7 @@
+     def release_binding(self, request_id: str) -> None:
+         """Drop the route binding for *request_id* in this stage."""
+         self._request_bindings.pop(request_id, None)
++        self._submitted_requests.pop(request_id, None)
+
+     def release_bindings(self, request_ids: list[str]) -> None:
+         """Drop route bindings for the given request ids in this stage."""
+@@ -221,6 +223,7 @@
+             request_id,
+             affinity_request_id=affinity_request_id,
+         )
++        self._submitted_requests[request_id] = request
+         try:
+             self.output_processor.add_request(
+                 request=request,
+@@ -271,6 +274,7 @@
+             # Refresh the shared output-processor state before yielding to the
+             # stage client so streaming segments are merged against the latest
+             # prompt/token metadata.
++            self._submitted_requests[request_id] = request
+             self.output_processor.add_request(
+                 request=request,
+                 prompt=prompt_text,
+@@ -298,6 +302,31 @@
+         """Run the shared LLM output processor on one raw poll result."""
+         client = self._llm_client(replica_id)
+         processor = self.output_processor
++        request_states = getattr(processor, "request_states", None)
++        is_audio_output = (
++            str(getattr(processor, "engine_core_output_type", "") or "").lower()
++            == "audio"
++        )
++        if is_audio_output and isinstance(request_states, dict):
++            for engine_core_output in raw_outputs.outputs:
++                req_id = getattr(engine_core_output, "request_id", None)
++                if req_id in request_states:
++                    continue
++                request = self._submitted_requests.get(req_id)
++                if request is None or getattr(engine_core_output, "pooling_output", None) is None:
++                    continue
++                logger.debug(
++                    "[StagePool] Restoring output processor state for audio req=%s stage-%s",
++                    req_id,
++                    self.stage_id,
++                )
++                processor.add_request(
++                    request=request,
++                    prompt=None,
++                    parent_req=None,
++                    request_index=0,
++                    queue=None,
++                )
+         processed = processor.process_outputs(
+             raw_outputs.outputs,
+             raw_outputs.timestamp,

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -176,6 +176,7 @@ RUN set -eux; \
 # constraining packages already solved in the upstream vLLM image.
 RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target=/tmp/vllm_omni_protected_packages.txt \
     --mount=type=bind,source=./container/deps/vllm/install_vllm_omni.sh,target=/tmp/install_vllm_omni.sh \
+    --mount=type=bind,source=./container/deps/vllm/patches,target=/tmp/vllm_patches,readonly \
     --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     set -eux; \
     export UV_CACHE_DIR=/root/.cache/uv; \


### PR DESCRIPTION
## Summary

This splits the prerequisite Qwen3-Omni async disaggregated serving work out of the broader DYN-3068 audio chunk parity branch.

Changes included here:
- add async-chunk stage router orchestration and downstream prewarm handling
- preserve `final_stage_id` and explicit empty `prompt_token_ids: []` across stage requests
- preserve async stage topology when constructing single-stage vLLM-Omni workers
- add vLLM-Omni patch plumbing in the vLLM runtime image
- classify omni requests by request shape when multiple output modalities are registered

This intentionally does not include the audio cumulative-delta formatter fix or Rust/frontend modality propagation from the broader draft branch.

## Validation

- `pre-commit run --files ...` passed for all touched files
- `python3 -m py_compile ...` passed for touched Python files and tests
- `git diff --check --cached` passed
- vLLM-Omni patch parse checked with `git apply --numstat -p0 ...`

Focused pytest could not be run in this local shell: `python3 -m pytest` has no local pytest module, `uv run pytest` resolves incompatible repo extras, and direct imports fail because `vllm` is not installed outside the vLLM dev container.