### PR TITLE
feat(operator): pass DGD priority class to Grove

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
@@ -294,6 +294,11 @@ spec:
                     Labels to propagate to all child resources (PCS, DCD, Deployments, and pod templates).
                     Service-level labels take precedence over these values.
                   type: object
+                priorityClassName:
+                  description: |-
+                    PriorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.
+                    Requires the Grove pathway.
+                  type: string
                 pvcs:
                   description: |-
                     PVCs defines a list of persistent volume claims that can be referenced by components.
@@ -20851,6 +20856,11 @@ spec:
                     type: string
                   description: labels to propagate to all child resources. Same precedence rules as `annotations`.
                   type: object
+                priorityClassName:
+                  description: |-
+                    priorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.
+                    Requires the Grove pathway.
+                  type: string
                 restart:
                   description: restart specifies the restart policy for the graph deployment.
                   properties:

--- a/deploy/operator/api/v1alpha1/conversion_field_coverage_test.go
+++ b/deploy/operator/api/v1alpha1/conversion_field_coverage_test.go
@@ -125,6 +125,7 @@ DynamoGraphDeploymentSpec.experimental.kvTransferPolicy.enforcement
 DynamoGraphDeploymentSpec.experimental.kvTransferPolicy.labelKey
 DynamoGraphDeploymentSpec.experimental.kvTransferPolicy.preferredWeight
 DynamoGraphDeploymentSpec.labels
+DynamoGraphDeploymentSpec.priorityClassName
 DynamoGraphDeploymentSpec.restart.id
 DynamoGraphDeploymentSpec.restart.strategy.order
 DynamoGraphDeploymentSpec.restart.strategy.type

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -101,6 +101,7 @@ func ConvertFromDynamoGraphDeploymentSpec(src *DynamoGraphDeploymentSpec, dst *v
 	// Convert fields represented by both versions from the live source.
 	dst.Annotations = src.Annotations
 	dst.Labels = src.Labels
+	dst.PriorityClassName = src.PriorityClassName
 	dst.BackendFramework = src.BackendFramework
 
 	if src.Restart != nil {
@@ -407,6 +408,7 @@ func ConvertToDynamoGraphDeploymentSpec(src *v1beta1.DynamoGraphDeploymentSpec, 
 	// Convert fields represented by both versions from the live source.
 	dst.Annotations = src.Annotations
 	dst.Labels = src.Labels
+	dst.PriorityClassName = src.PriorityClassName
 	dst.BackendFramework = src.BackendFramework
 
 	if src.Restart != nil {

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -446,9 +446,10 @@ func TestDGD_RoundTrip_SpecLevelFields(t *testing.T) {
 	src := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "spec", Namespace: "ns"},
 		Spec: v1beta1.DynamoGraphDeploymentSpec{
-			Annotations:      map[string]string{"a": "1"},
-			Labels:           map[string]string{"l": "v"},
-			BackendFramework: backendFrameworkSGLang,
+			Annotations:       map[string]string{"a": "1"},
+			Labels:            map[string]string{"l": "v"},
+			PriorityClassName: "high-priority",
+			BackendFramework:  backendFrameworkSGLang,
 			Env: []corev1.EnvVar{
 				{Name: "FOO", Value: "bar"},
 			},

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
@@ -64,6 +64,10 @@ type DynamoGraphDeploymentSpec struct {
 	// Service-level labels take precedence over these values.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+	// PriorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.
+	// Requires the Grove pathway.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// PVCs defines a list of persistent volume claims that can be referenced by components.
 	// Each PVC must have a unique name that can be referenced in component specifications.
 	// +kubebuilder:validation:Optional

--- a/deploy/operator/api/v1beta1/dynamographdeployment_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeployment_types.go
@@ -35,6 +35,11 @@ type DynamoGraphDeploymentSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// priorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.
+	// Requires the Grove pathway.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// components are the components deployed as part of this graph. Each entry
 	// carries its own stable logical `name`, and names must be unique within
 	// the list. Component types are generally repeatable, except `type: epp`

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -294,6 +294,11 @@ spec:
                     Labels to propagate to all child resources (PCS, DCD, Deployments, and pod templates).
                     Service-level labels take precedence over these values.
                   type: object
+                priorityClassName:
+                  description: |-
+                    PriorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.
+                    Requires the Grove pathway.
+                  type: string
                 pvcs:
                   description: |-
                     PVCs defines a list of persistent volume claims that can be referenced by components.
@@ -20851,6 +20856,11 @@ spec:
                     type: string
                   description: labels to propagate to all child resources. Same precedence rules as `annotations`.
                   type: object
+                priorityClassName:
+                  description: |-
+                    priorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.
+                    Requires the Grove pathway.
+                  type: string
                 restart:
                   description: restart specifies the restart policy for the graph deployment.
                   properties:

--- a/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeployment.yaml
+++ b/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamographdeployment.yaml
@@ -21,5 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: dynamographdeployment-sample
 spec:
+  # Optional Grove-only pass-through to PodCliqueSet.spec.template.priorityClassName.
+  # priorityClassName: high-priority
   # TODO(user): Add fields here
   # EXAMPLE: dynamoComponent: basic:dev

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2128,6 +2128,7 @@ func GenerateGrovePodCliqueSet(
 		PublishNotReadyAddresses: true,
 	}
 	gangSet.Spec.Template.StartupType = ptr.To(grovev1alpha1.CliqueStartupTypeAnyOrder)
+	gangSet.Spec.Template.PriorityClassName = dynamoDeployment.Spec.PriorityClassName
 	if operatorConfig.Orchestrators.Grove.TerminationDelay.Duration > 0 {
 		gangSet.Spec.Template.TerminationDelay = &operatorConfig.Orchestrators.Grove.TerminationDelay
 	}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -8998,6 +8998,29 @@ func TestGenerateGrovePodCliqueSet_SpecMetadataPropagation(t *testing.T) {
 		"service-level annotation should take precedence over spec.metadata")
 }
 
+func TestGenerateGrovePodCliqueSet_PriorityClassName(t *testing.T) {
+	dgd := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "ns",
+		},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			PriorityClassName: "high-priority",
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(1)),
+				},
+			},
+		},
+	}
+
+	pcs, err := GenerateGrovePodCliqueSet(context.Background(), betaDGD(t, dgd), &configv1alpha1.OperatorConfiguration{}, &controller_common.RuntimeConfig{}, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "high-priority", pcs.Spec.Template.PriorityClassName)
+}
+
 func TestGenerateDynamoComponentsDeployments_SpecMetadataPropagation(t *testing.T) {
 	dgd := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -99,6 +99,11 @@ func (v *DynamoGraphDeploymentValidator) Validate(ctx context.Context) (admissio
 		return nil, err
 	}
 
+	// Validate priority class pass-through
+	if err := v.validatePriorityClassName(); err != nil {
+		return nil, err
+	}
+
 	// Validate topology constraints
 	if err := v.validateTopologyConstraints(ctx); err != nil {
 		return nil, err
@@ -558,6 +563,17 @@ func (v *DynamoGraphDeploymentValidator) validateRestartStrategyOrder() error {
 	}
 
 	return err
+}
+
+func (v *DynamoGraphDeploymentValidator) validatePriorityClassName() error {
+	if v.deployment.Spec.PriorityClassName == "" || v.isGrovePathway() {
+		return nil
+	}
+	if !v.groveEnabled {
+		return fmt.Errorf("spec.priorityClassName requires the Grove pathway, but Grove is disabled at the operator level (global.grove.enabled=false)")
+	}
+	return fmt.Errorf("spec.priorityClassName requires the Grove pathway; remove or unset the %q annotation (currently %q)",
+		consts.KubeAnnotationEnableGrove, v.deployment.Annotations[consts.KubeAnnotationEnableGrove])
 }
 
 // validateAnnotations validates known DGD annotations have valid values.

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -57,7 +57,7 @@ type DynamoGraphDeploymentValidator struct {
 }
 
 // NewDynamoGraphDeploymentValidator creates a new validator for DynamoGraphDeployment.
-// groveEnabled should reflect the operator's runtime config (global.grove.enabled).
+// groveEnabled should reflect the operator's runtime Grove configuration.
 func NewDynamoGraphDeploymentValidator(deployment *nvidiacomv1alpha1.DynamoGraphDeployment, groveEnabled bool) *DynamoGraphDeploymentValidator {
 	return &DynamoGraphDeploymentValidator{
 		deployment:   deployment,
@@ -338,15 +338,9 @@ func (v *DynamoGraphDeploymentValidator) validateService(ctx context.Context, se
 	// templates are all wired at the PodCliqueScalingGroup level, which only
 	// the Grove renderer produces.
 	if service.IsInterPodGMSEnabled() && !v.isGrovePathway() {
-		if !v.groveEnabled {
-			return nil, fmt.Errorf(
-				"spec.services[%s]: gpuMemoryService.mode=%q requires the Grove pathway, but Grove is disabled at the operator level (global.grove.enabled=false)",
-				serviceName, nvidiacomv1alpha1.GMSModeInterPod)
-		}
-		return nil, fmt.Errorf(
-			"spec.services[%s]: gpuMemoryService.mode=%q requires the Grove pathway; remove or unset the %q annotation (currently %q)",
-			serviceName, nvidiacomv1alpha1.GMSModeInterPod,
-			consts.KubeAnnotationEnableGrove, v.deployment.Annotations[consts.KubeAnnotationEnableGrove])
+		return nil, v.grovePathwayRequiredError(fmt.Sprintf(
+			"spec.services[%s]: gpuMemoryService.mode=%q",
+			serviceName, nvidiacomv1alpha1.GMSModeInterPod))
 	}
 
 	// The inter-pod GMS layout is currently implemented only for vLLM (the
@@ -471,8 +465,8 @@ func (v *DynamoGraphDeploymentValidator) validateServiceNameLength(serviceName s
 }
 
 // isGrovePathway determines if Grove pathway may be used for this deployment.
-// Grove requires both operator-level enablement (global.grove.enabled) and the
-// per-DGD annotation not being explicitly set to "false".
+// Grove requires both operator-level enablement and the per-DGD annotation not
+// being explicitly set to "false".
 func (v *DynamoGraphDeploymentValidator) isGrovePathway() bool {
 	if !v.groveEnabled {
 		return false
@@ -569,11 +563,15 @@ func (v *DynamoGraphDeploymentValidator) validatePriorityClassName() error {
 	if v.deployment.Spec.PriorityClassName == "" || v.isGrovePathway() {
 		return nil
 	}
+	return v.grovePathwayRequiredError("spec.priorityClassName")
+}
+
+func (v *DynamoGraphDeploymentValidator) grovePathwayRequiredError(subject string) error {
 	if !v.groveEnabled {
-		return fmt.Errorf("spec.priorityClassName requires the Grove pathway, but Grove is disabled at the operator level (global.grove.enabled=false)")
+		return fmt.Errorf("%s requires the Grove pathway, but Grove is disabled in the operator configuration", subject)
 	}
-	return fmt.Errorf("spec.priorityClassName requires the Grove pathway; remove or unset the %q annotation (currently %q)",
-		consts.KubeAnnotationEnableGrove, v.deployment.Annotations[consts.KubeAnnotationEnableGrove])
+	return fmt.Errorf("%s requires the Grove pathway; remove or unset the %q annotation (currently %q)",
+		subject, consts.KubeAnnotationEnableGrove, v.deployment.Annotations[consts.KubeAnnotationEnableGrove])
 }
 
 // validateAnnotations validates known DGD annotations have valid values.

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -49,7 +49,7 @@ type DynamoGraphDeploymentHandler struct {
 // NewDynamoGraphDeploymentHandler creates a new handler for DynamoGraphDeployment Webhook.
 // operatorPrincipal is the full Kubernetes SA username of the operator, used to authorize
 // replica changes on scaling-adapter-enabled services (#7656).
-// groveEnabled reflects the operator's runtime config (global.grove.enabled).
+// groveEnabled reflects the operator's runtime Grove configuration.
 func NewDynamoGraphDeploymentHandler(mgr manager.Manager, operatorPrincipal string, groveEnabled bool) *DynamoGraphDeploymentHandler {
 	return &DynamoGraphDeploymentHandler{
 		mgr:               mgr,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -106,8 +106,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			groveEnabled: true,
 			wantErr:      true,
-			errContains:  true,
-			errMsg:       "spec.priorityClassName requires the Grove pathway",
+			errMsg:       "spec.priorityClassName requires the Grove pathway; remove or unset the \"nvidia.com/enable-grove\" annotation (currently \"false\")",
 		},
 		{
 			name: "priorityClassName requires Grove pathway when operator disables Grove",
@@ -127,8 +126,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			groveEnabled: false,
 			wantErr:      true,
-			errContains:  true,
-			errMsg:       "spec.priorityClassName requires the Grove pathway",
+			errMsg:       "spec.priorityClassName requires the Grove pathway, but Grove is disabled in the operator configuration",
 		},
 		{
 			name: "no services",
@@ -922,7 +920,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: true,
-			errMsg:      "requires the Grove pathway",
+			errMsg:      "remove or unset the \"nvidia.com/enable-grove\" annotation",
 		},
 		{
 			name:         "GMS failover requires Grove pathway - operator grove disabled",
@@ -955,7 +953,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: true,
-			errMsg:      "requires the Grove pathway",
+			errMsg:      "Grove is disabled in the operator configuration",
 		},
 		{
 			name:         "inter-pod GMS rejected on non-vLLM backend",

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -67,6 +67,70 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:         "priorityClassName is valid on Grove pathway",
+			groveEnabled: true,
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-graph",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					PriorityClassName: "high-priority",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"main": {
+							Replicas: &validReplicas,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "priorityClassName requires Grove pathway when DGD opts out",
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-graph",
+					Namespace: "default",
+					Annotations: map[string]string{
+						consts.KubeAnnotationEnableGrove: "false",
+					},
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					PriorityClassName: "high-priority",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"main": {
+							Replicas: &validReplicas,
+						},
+					},
+				},
+			},
+			groveEnabled: true,
+			wantErr:      true,
+			errContains:  true,
+			errMsg:       "spec.priorityClassName requires the Grove pathway",
+		},
+		{
+			name: "priorityClassName requires Grove pathway when operator disables Grove",
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-graph",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					PriorityClassName: "high-priority",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"main": {
+							Replicas: &validReplicas,
+						},
+					},
+				},
+			},
+			groveEnabled: false,
+			wantErr:      true,
+			errContains:  true,
+			errMsg:       "spec.priorityClassName requires the Grove pathway",
+		},
+		{
 			name: "no services",
 			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -662,6 +662,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `annotations` _object (keys:string, values:string)_ | Annotations to propagate to all child resources (PCS, DCD, Deployments, and pod templates).<br />Service-level annotations take precedence over these values. |  | Optional: \{\} <br /> |
 | `labels` _object (keys:string, values:string)_ | Labels to propagate to all child resources (PCS, DCD, Deployments, and pod templates).<br />Service-level labels take precedence over these values. |  | Optional: \{\} <br /> |
+| `priorityClassName` _string_ | PriorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.<br />Requires the Grove pathway. |  | Optional: \{\} <br /> |
 | `pvcs` _[PVC](#pvc) array_ | PVCs defines a list of persistent volume claims that can be referenced by components.<br />Each PVC must have a unique name that can be referenced in component specifications. |  | MaxItems: 100 <br />Optional: \{\} <br /> |
 | `services` _object (keys:string, values:[DynamoComponentDeploymentSharedSpec](#dynamocomponentdeploymentsharedspec))_ | Services are the services to deploy as part of this deployment. |  | MaxProperties: 25 <br />Optional: \{\} <br /> |
 | `envs` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | Envs are environment variables applied to all services in the deployment unless<br />overridden by service-specific configuration. |  | Optional: \{\} <br /> |
@@ -2064,6 +2065,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `annotations` _object (keys:string, values:string)_ | annotations to propagate to all child resources (PCS, DCD, Deployments,<br />and pod templates). Component-level (`podTemplate`) values take precedence<br />on conflict. |  | Optional: \{\} <br /> |
 | `labels` _object (keys:string, values:string)_ | labels to propagate to all child resources. Same precedence rules as `annotations`. |  | Optional: \{\} <br /> |
+| `priorityClassName` _string_ | priorityClassName is the name of the PriorityClass to use for Grove PodCliqueSets.<br />Requires the Grove pathway. |  | Optional: \{\} <br /> |
 | `components` _[DynamoComponentDeploymentSharedSpec](#dynamocomponentdeploymentsharedspec) array_ | components are the components deployed as part of this graph. Each entry<br />carries its own stable logical `name`, and names must be unique within<br />the list. Component types are generally repeatable, except `type: epp`<br />which may appear at most once. |  | MaxItems: 25 <br />Optional: \{\} <br /> |
 | `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ | env is prepended to every component's environment. Component-specific<br />env entries with the same name take precedence and may reference values<br />from this list. |  | Optional: \{\} <br /> |
 | `backendFramework` _string_ | backendFramework specifies the backend framework (e.g. "sglang", "vllm", "trtllm"). |  | Enum: [sglang vllm trtllm] <br /> |


### PR DESCRIPTION
## Summary
- add optional DynamoGraphDeployment spec.priorityClassName in v1alpha1 and v1beta1
- pass it through to Grove PodCliqueSet.spec.template.priorityClassName
- reject priorityClassName through the DGD webhook unless the Grove pathway is active

Refs #8172.

## Testing
- go test ./api/v1alpha1 -run 'TestDGD_RoundTrip_SpecLevelFields|TestV1Beta1ConversionFieldSetIsAcknowledged'
- go test ./internal/dynamo -run TestGenerateGrovePodCliqueSet_PriorityClassName
- go test ./internal/webhook/validation -run TestDynamoGraphDeploymentValidator_Validate
- make lint
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a PriorityClass name (`priorityClassName`) for Grove PodCliqueSets in DynamoGraphDeployment configurations.

* **Bug Fixes**
  * Improved validation to ensure `priorityClassName` is only set when the Grove pathway is enabled.

* **Documentation**
  * Updated API reference and sample manifests to document the new `priorityClassName` field and its usage requirements.

* **Tests**
  * Added and updated tests to verify correct behavior of `priorityClassName` handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->