### PR TITLE
[codex] add DisaggregatedSet LWS fallback

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -405,6 +405,8 @@ func main() {
 
 	setupLog.Info("Detecting LWS availability...")
 	lwsDetected := commonController.DetectLWSAvailability(mainCtx, mgr)
+	setupLog.Info("Detecting DisaggregatedSet availability...")
+	runtimeConfig.DisaggregatedSetEnabled = commonController.DetectDisaggregatedSetAvailability(mainCtx, mgr)
 	setupLog.Info("Detecting Volcano availability...")
 	volcanoDetected := commonController.DetectVolcanoAvailability(mainCtx, mgr)
 	// LWS for multinode deployment usage depends on both LWS and Volcano availability
@@ -470,6 +472,7 @@ func main() {
 	setupLog.Info("Detected orchestrators availability",
 		"grove", runtimeConfig.GroveEnabled,
 		"lws", runtimeConfig.LWSEnabled,
+		"disaggregatedset", runtimeConfig.DisaggregatedSetEnabled,
 		"volcano", volcanoDetected,
 		"kai-scheduler", runtimeConfig.KaiSchedulerEnabled,
 		"dra", runtimeConfig.DRAEnabled,

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -118,6 +118,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - disaggregatedset.x-k8s.io
+  resources:
+  - disaggregatedsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -41,6 +41,12 @@ const (
 	KubeLabelDynamoSelector = "nvidia.com/selector"
 
 	KubeAnnotationEnableGrove = "nvidia.com/enable-grove"
+	// KubeAnnotationEnableDisaggregatedSet opts a non-Grove DGD into rendering
+	// one DisaggregatedSet for multinode worker roles instead of independent
+	// DynamoComponentDeployment-backed LeaderWorkerSets. The path is guarded by
+	// runtime CRD detection because DisaggregatedSet is not in the stable LWS
+	// release used by the operator yet.
+	KubeAnnotationEnableDisaggregatedSet = "nvidia.com/enable-disaggregatedset"
 
 	// KubeAnnotationIstioSidecarInject is the standard Istio annotation that
 	// controls whether the mutating webhook injects an istio-proxy sidecar into

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -542,11 +542,6 @@ func (r *DynamoComponentDeploymentReconciler) generateWorkerPodTemplateSpec(ctx 
 		return nil, errors.Wrap(err, "generateWorkerPodTemplateSpec: failed to check LWS worker main container")
 	}
 
-	resources := dynamo.GetMainContainerResources(&opt.dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec)
-	if gpu, ok := resources.Limits[corev1.ResourceName("nvidia.com/gpu")]; !ok || gpu.IsZero() {
-		return nil, fmt.Errorf("generateWorkerPodTemplateSpec: GPU limit is not set for LWS worker pod")
-	}
-
 	return workerPodTemplateSpec, nil
 }
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -100,6 +100,7 @@ type DynamoGraphDeploymentReconciler struct {
 // +kubebuilder:rbac:groups=grove.io,resources=podcliquescalinggroups,verbs=get;list;watch
 // +kubebuilder:rbac:groups=grove.io,resources=podcliquescalinggroups/scale,verbs=get;update;patch
 // +kubebuilder:rbac:groups=grove.io,resources=clustertopologies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=disaggregatedset.x-k8s.io,resources=disaggregatedsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=scheduling.run.ai,resources=queues,verbs=get;list
 // +kubebuilder:rbac:groups=inference.networking.k8s.io,resources=inferencepools,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;patch;delete
@@ -426,17 +427,38 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 		return ReconcileResult{}, err
 	}
 
+	useDisaggregatedSet, disaggregatedSetFallbackReason := r.shouldUseDisaggregatedSet(dynamoDeployment)
+
 	var result ReconcileResult
 	if r.isGrovePathway(dynamoDeployment) {
 		logger.Info("Reconciling Grove resources", "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.LWSEnabled)
+		if r.RuntimeConfig.DisaggregatedSetEnabled {
+			if err := r.deleteDisaggregatedSetIfExists(ctx, dynamoDeployment); err != nil {
+				return ReconcileResult{}, err
+			}
+		}
 		result, err = r.reconcileGroveResources(ctx, dynamoDeployment, restartState, checkpointInfos)
+	} else if useDisaggregatedSet {
+		logger.Info("Reconciling DisaggregatedSet resources", "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.LWSEnabled)
+		result, err = r.reconcileDisaggregatedSetResources(ctx, dynamoDeployment, restartState)
 	} else {
+		if r.RuntimeConfig.DisaggregatedSetEnabled {
+			if err := r.deleteDisaggregatedSetIfExists(ctx, dynamoDeployment); err != nil {
+				return ReconcileResult{}, err
+			}
+		}
+		if r.wantsDisaggregatedSet(dynamoDeployment) && disaggregatedSetFallbackReason != "" {
+			logger.Info("DisaggregatedSet requested but falling back to DynamoComponentDeployment resources", "reason", disaggregatedSetFallbackReason)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(dynamoDeployment, corev1.EventTypeWarning, "DisaggregatedSetFallback", "DisaggregatedSet requested but falling back to DynamoComponentDeployments: %s", disaggregatedSetFallbackReason)
+			}
+		}
 		logger.Info("Reconciling Dynamo components deployments", "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.LWSEnabled)
 		result, err = r.reconcileDynamoComponentsDeployments(ctx, dynamoDeployment, restartState)
 	}
 	if err != nil {
-		logger.Error(err, "Failed to reconcile Dynamo components deployments")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		logger.Error(err, "Failed to reconcile workload resources")
+		return ReconcileResult{}, fmt.Errorf("failed to reconcile workload resources: %w", err)
 	}
 	result.RestartStatus = restartStatus
 	return result, nil
@@ -457,6 +479,9 @@ func (r *DynamoGraphDeploymentReconciler) isGrovePathway(dgd *nvidiacomv1beta1.D
 func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgress(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment, inProgress []string) []string {
 	if r.isGrovePathway(dgd) {
 		return r.getUpdatedInProgressForGrove(ctx, dgd, inProgress)
+	}
+	if useDisaggregatedSet, _ := r.shouldUseDisaggregatedSet(dgd); useDisaggregatedSet {
+		return r.getUpdatedInProgressForDisaggregatedSet(ctx, dgd, inProgress)
 	}
 	return r.getUpdatedInProgressForComponent(ctx, dgd, inProgress)
 }
@@ -1396,6 +1421,54 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForComponent(ctx c
 	return updatedInProgress
 }
 
+// getUpdatedInProgressForDisaggregatedSet checks selected components against
+// DisaggregatedSet role status and falls back to DCD readiness for components
+// still reconciled outside the DisaggregatedSet.
+func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForDisaggregatedSet(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment, inProgress []string) []string {
+	logger := log.FromContext(ctx)
+
+	selection, reason := selectDisaggregatedSetComponents(dgd)
+	if reason != "" {
+		logger.V(1).Info("failed to select DisaggregatedSet components for restart progress", "reason", reason)
+		return inProgress
+	}
+
+	ds := newDisaggregatedSetObject()
+	dsErr := r.Get(ctx, types.NamespacedName{Name: disaggregatedSetName(dgd), Namespace: dgd.Namespace}, ds)
+	if dsErr != nil && !errors.IsNotFound(dsErr) {
+		logger.V(1).Info("failed to get DisaggregatedSet for restart progress", "error", dsErr)
+	}
+
+	updatedInProgress := make([]string, 0, len(inProgress))
+	for _, componentName := range inProgress {
+		if _, selected := selection.componentToRole[componentName]; !selected {
+			isFullyUpdated, reason := r.checkComponentFullyUpdated(ctx, dgd, componentName)
+			if !isFullyUpdated {
+				logger.V(1).Info("component not fully updated", "componentName", componentName, "reason", reason)
+				updatedInProgress = append(updatedInProgress, componentName)
+			}
+			continue
+		}
+
+		if dsErr != nil {
+			reason := "resource not found"
+			if !errors.IsNotFound(dsErr) {
+				reason = dsErr.Error()
+			}
+			logger.V(1).Info("DisaggregatedSet component not fully updated", "componentName", componentName, "reason", reason)
+			updatedInProgress = append(updatedInProgress, componentName)
+			continue
+		}
+
+		isFullyUpdated, reason := checkDisaggregatedSetComponentReady(ds, selection, componentName)
+		if !isFullyUpdated {
+			logger.V(1).Info("DisaggregatedSet component not fully updated", "componentName", componentName, "reason", reason)
+			updatedInProgress = append(updatedInProgress, componentName)
+		}
+	}
+	return updatedInProgress
+}
+
 func (r *DynamoGraphDeploymentReconciler) checkResourcesReadiness(resources []Resource) ReconcileResult {
 	// Sort resources by name to ensure deterministic ordering
 	sort.Slice(resources, func(i, j int) bool {
@@ -2152,6 +2225,14 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
 			UpdateFunc:  func(de event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return false },
+		}))
+	}
+	if r.RuntimeConfig.DisaggregatedSetEnabled {
+		ctrlBuilder = ctrlBuilder.Owns(newDisaggregatedSetObject(), builder.WithPredicates(predicate.Funcs{
+			CreateFunc:  func(ce event.CreateEvent) bool { return false },
+			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
+			UpdateFunc:  func(ue event.UpdateEvent) bool { return disaggregatedSetStatusChanged(ue.ObjectOld, ue.ObjectNew) },
+			GenericFunc: func(ge event.GenericEvent) bool { return true },
 		}))
 	}
 	if r.RuntimeConfig.GroveEnabled {

--- a/deploy/operator/internal/controller/dynamographdeployment_disaggregatedset.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_disaggregatedset.go
@@ -1,0 +1,871 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var disaggregatedSetGVK = schema.GroupVersionKind{
+	Group:   "disaggregatedset.x-k8s.io",
+	Version: "v1",
+	Kind:    "DisaggregatedSet",
+}
+
+type disaggregatedSetSelection struct {
+	componentToRole map[string]string
+	desiredReplicas map[string]int32
+}
+
+func newDisaggregatedSetObject() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(disaggregatedSetGVK)
+	return obj
+}
+
+func (r *DynamoGraphDeploymentReconciler) wantsDisaggregatedSet(dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
+	if dgd == nil || dgd.Annotations == nil {
+		return false
+	}
+	return strings.ToLower(dgd.Annotations[consts.KubeAnnotationEnableDisaggregatedSet]) == consts.KubeLabelValueTrue
+}
+
+func (r *DynamoGraphDeploymentReconciler) shouldUseDisaggregatedSet(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (bool, string) {
+	if !r.wantsDisaggregatedSet(dgd) {
+		return false, ""
+	}
+	if r.RuntimeConfig == nil {
+		return false, "runtime config is not initialized"
+	}
+	if !r.RuntimeConfig.DisaggregatedSetEnabled {
+		return false, "DisaggregatedSet API is not available"
+	}
+	if !r.RuntimeConfig.LWSEnabled {
+		return false, "LeaderWorkerSet is not available"
+	}
+	selection, reason := selectDisaggregatedSetComponents(dgd)
+	if reason != "" {
+		return false, reason
+	}
+	if len(selection.componentToRole) < 2 {
+		return false, "DisaggregatedSet requires at least two eligible multinode worker roles"
+	}
+	return true, ""
+}
+
+func selectDisaggregatedSetComponents(dgd *nvidiacomv1beta1.DynamoGraphDeployment) (disaggregatedSetSelection, string) {
+	selection := disaggregatedSetSelection{
+		componentToRole: make(map[string]string),
+		desiredReplicas: make(map[string]int32),
+	}
+	usedRoles := make(map[string]struct{})
+	zeroReplicas := 0
+	positiveReplicas := 0
+
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if !isDisaggregatedSetEligibleComponent(component) {
+			continue
+		}
+		if component.ScalingAdapter != nil {
+			return selection, fmt.Sprintf("component %q uses scalingAdapter, but DisaggregatedSet has no scale subresource", component.ComponentName)
+		}
+
+		roleName := disaggregatedSetRoleName(component, usedRoles)
+		usedRoles[roleName] = struct{}{}
+		selection.componentToRole[component.ComponentName] = roleName
+
+		desiredReplicas := desiredComponentReplicas(component)
+		selection.desiredReplicas[component.ComponentName] = desiredReplicas
+		if desiredReplicas == 0 {
+			zeroReplicas++
+		} else {
+			positiveReplicas++
+		}
+	}
+
+	if len(selection.componentToRole) == 0 {
+		return selection, "no eligible multinode worker roles found"
+	}
+	if zeroReplicas > 0 && positiveReplicas > 0 {
+		return selection, "DisaggregatedSet requires replicas to be zero for all roles or positive for all roles"
+	}
+	return selection, ""
+}
+
+func isDisaggregatedSetEligibleComponent(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) bool {
+	return component.GetNumberOfNodes() > 1 && dynamo.IsWorkerComponent(string(component.ComponentType))
+}
+
+func desiredComponentReplicas(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) int32 {
+	if component.Replicas == nil {
+		return 1
+	}
+	return *component.Replicas
+}
+
+func disaggregatedSetRoleName(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec, used map[string]struct{}) string {
+	preferred := strings.ToLower(string(component.ComponentType))
+	if preferred != consts.ComponentTypePrefill && preferred != consts.ComponentTypeDecode {
+		preferred = ""
+	}
+	if preferred == "" || roleNameUsed(preferred, used) {
+		preferred = dynamo.NormalizeKubeResourceName(component.ComponentName)
+	}
+	roleName := preferred
+	for i := 2; roleNameUsed(roleName, used); i++ {
+		roleName = fmt.Sprintf("%s-%d", truncateDNSLabel(preferred, 61), i)
+	}
+	return roleName
+}
+
+func roleNameUsed(roleName string, used map[string]struct{}) bool {
+	_, ok := used[roleName]
+	return ok
+}
+
+func truncateDNSLabel(value string, maxLength int) string {
+	if len(value) <= maxLength {
+		return value
+	}
+	return strings.TrimRight(value[:maxLength], "-")
+}
+
+func disaggregatedSetName(dgd *nvidiacomv1beta1.DynamoGraphDeployment) string {
+	return dynamo.NormalizeKubeResourceName(dgd.Name)
+}
+
+func (r *DynamoGraphDeploymentReconciler) reconcileDisaggregatedSetResources(
+	ctx context.Context,
+	dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment,
+	restartState *dynamo.RestartState,
+) (ReconcileResult, error) {
+	resources := []Resource{}
+	logger := log.FromContext(ctx)
+
+	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dynamoDeployment)
+	if err != nil {
+		return ReconcileResult{}, fmt.Errorf("failed to build rolling update context: %w", err)
+	}
+
+	existingRestartAnnotations, err := r.getExistingRestartAnnotationsDCD(ctx, dynamoDeployment)
+	if err != nil {
+		logger.Error(err, "failed to get existing restart annotations")
+		return ReconcileResult{}, fmt.Errorf("failed to get existing restart annotations: %w", err)
+	}
+
+	dynamoComponentsDeployments, err := dynamo.GenerateDynamoComponentsDeployments(
+		dynamoDeployment,
+		restartState,
+		existingRestartAnnotations,
+		disaggregatedSetRenderRollingUpdateContext(rollingUpdateCtx, dynamoDeployment),
+	)
+	if err != nil {
+		logger.Error(err, "failed to generate the DynamoComponentsDeployments")
+		return ReconcileResult{}, fmt.Errorf("failed to generate the DynamoComponentsDeployments: %w", err)
+	}
+
+	selection, reason := selectDisaggregatedSetComponents(dynamoDeployment)
+	if reason != "" {
+		return ReconcileResult{}, fmt.Errorf("failed to select DisaggregatedSet roles: %s", reason)
+	}
+
+	desiredDS, err := r.generateDisaggregatedSet(ctx, dynamoDeployment, dynamoComponentsDeployments, selection)
+	if err != nil {
+		return ReconcileResult{}, err
+	}
+	dsModified, syncedDS, err := r.syncDisaggregatedSet(ctx, dynamoDeployment, desiredDS)
+	if err != nil {
+		return ReconcileResult{}, err
+	}
+
+	if err := r.reconcileDisaggregatedSetSideResources(ctx, dynamoDeployment, dynamoComponentsDeployments, selection); err != nil {
+		return ReconcileResult{}, err
+	}
+
+	syncedDSResource, err := commoncontroller.NewResourceWithComponentStatuses(
+		syncedDS,
+		func() (bool, string, map[string]nvidiacomv1beta1.ComponentReplicaStatus) {
+			if dsModified {
+				_, _, statuses := checkDisaggregatedSetReadiness(syncedDS, selection)
+				return false, "DisaggregatedSet spec was updated; waiting for controller status", statuses
+			}
+			return checkDisaggregatedSetReadiness(syncedDS, selection)
+		},
+	)
+	if err != nil {
+		return ReconcileResult{}, err
+	}
+	resources = append(resources, syncedDSResource)
+
+	dsReady, _, _ := checkDisaggregatedSetReadiness(syncedDS, selection)
+	keys := sortedDCDKeys(dynamoComponentsDeployments)
+	for _, key := range keys {
+		dcd := dynamoComponentsDeployments[key]
+		if _, selected := selection.componentToRole[key]; selected {
+			continue
+		}
+		logger.Info("Reconciling non-DisaggregatedSet DynamoComponentDeployment", "key", key, "name", dcd.Name)
+		if err := r.preserveExistingDCDBackendFramework(ctx, dcd); err != nil {
+			logger.Error(err, "failed to preserve existing DynamoComponentDeployment backendFramework", "name", dcd.Name)
+			return ReconcileResult{}, fmt.Errorf("failed to preserve existing DynamoComponentDeployment backendFramework: %w", err)
+		}
+		_, syncedDCD, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*nvidiacomv1beta1.DynamoComponentDeployment, bool, error) {
+			return dcd, false, nil
+		})
+		if err != nil {
+			logger.Error(err, "failed to sync the DynamoComponentDeployment", "name", dcd.Name)
+			return ReconcileResult{}, fmt.Errorf("failed to sync the DynamoComponentDeployment: %w", err)
+		}
+		resources = append(resources, syncedDCD)
+	}
+
+	if !dsModified && dsReady {
+		if err := r.deleteOwnedSelectedDCDs(ctx, dynamoDeployment, selection); err != nil {
+			return ReconcileResult{}, err
+		}
+	}
+
+	return r.checkResourcesReadiness(resources), nil
+}
+
+func disaggregatedSetRenderRollingUpdateContext(
+	rollingUpdateCtx dynamo.RollingUpdateContext,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) dynamo.RollingUpdateContext {
+	renderCtx := dynamo.RollingUpdateContext{
+		NewWorkerHash:     rollingUpdateCtx.NewWorkerHash,
+		OldWorkerReplicas: cloneInt32Map(rollingUpdateCtx.OldWorkerReplicas),
+		NewWorkerReplicas: cloneInt32Map(rollingUpdateCtx.NewWorkerReplicas),
+	}
+	if !renderCtx.InProgress() {
+		return renderCtx
+	}
+
+	selection, reason := selectDisaggregatedSetComponents(dgd)
+	if reason != "" {
+		return renderCtx
+	}
+	if renderCtx.NewWorkerReplicas == nil {
+		renderCtx.NewWorkerReplicas = map[string]int32{}
+	}
+	for componentName, desiredReplicas := range selection.desiredReplicas {
+		renderCtx.NewWorkerReplicas[componentName] = desiredReplicas
+	}
+	return renderCtx
+}
+
+func cloneInt32Map(in map[string]int32) map[string]int32 {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]int32, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func (r *DynamoGraphDeploymentReconciler) generateDisaggregatedSet(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	dcds map[string]*nvidiacomv1beta1.DynamoComponentDeployment,
+	selection disaggregatedSetSelection,
+) (*unstructured.Unstructured, error) {
+	ds := newDisaggregatedSetObject()
+	ds.SetName(disaggregatedSetName(dgd))
+	ds.SetNamespace(dgd.Namespace)
+	ds.SetLabels(map[string]string{
+		consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+		consts.KubeLabelDynamoSelector:            disaggregatedSetName(dgd),
+	})
+	if ownerRef := dgdControllerOwnerReference(dgd); ownerRef != nil {
+		ds.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
+	}
+
+	dcdReconciler := &DynamoComponentDeploymentReconciler{
+		Client:                r.Client,
+		Recorder:              r.Recorder,
+		Config:                r.Config,
+		RuntimeConfig:         r.RuntimeConfig,
+		DockerSecretRetriever: r.DockerSecretRetriever,
+	}
+
+	roles := make([]any, 0, len(selection.componentToRole))
+	for i := range dgd.Spec.Components {
+		componentName := dgd.Spec.Components[i].ComponentName
+		roleName, ok := selection.componentToRole[componentName]
+		if !ok {
+			continue
+		}
+		dcd := dcds[componentName]
+		if dcd == nil {
+			return nil, fmt.Errorf("generated DynamoComponentDeployment missing for selected component %q", componentName)
+		}
+		lws, _, err := dcdReconciler.generateLeaderWorkerSet(ctx, generateResourceOption{dynamoComponentDeployment: dcd})
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate LeaderWorkerSet template for DisaggregatedSet role %q: %w", roleName, err)
+		}
+		lwsSpec, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&lws.Spec)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert LeaderWorkerSet spec for DisaggregatedSet role %q: %w", roleName, err)
+		}
+
+		roleMetadata := map[string]any{}
+		if len(lws.Labels) > 0 {
+			roleMetadata["labels"] = stringMapToAny(lws.Labels)
+		}
+		if len(lws.Annotations) > 0 {
+			roleMetadata["annotations"] = stringMapToAny(lws.Annotations)
+		}
+		roles = append(roles, map[string]any{
+			"name":     roleName,
+			"metadata": roleMetadata,
+			"spec":     lwsSpec,
+		})
+	}
+	if len(roles) < 2 {
+		return nil, fmt.Errorf("DisaggregatedSet requires at least two roles, got %d", len(roles))
+	}
+	ds.Object["spec"] = map[string]any{"roles": roles}
+	return ds, nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) reconcileDisaggregatedSetSideResources(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	dcds map[string]*nvidiacomv1beta1.DynamoComponentDeployment,
+	selection disaggregatedSetSelection,
+) error {
+	if err := dynamo.ReconcileModelServicesForComponents(
+		ctx,
+		r,
+		dgd,
+		selectedComponentsByName(dgd, selection),
+		dgd.Namespace,
+	); err != nil {
+		return fmt.Errorf("failed to reconcile DisaggregatedSet model services: %w", err)
+	}
+	if err := r.adoptSelectedModelServices(ctx, dgd, selection); err != nil {
+		return err
+	}
+
+	dcdReconciler := &DynamoComponentDeploymentReconciler{
+		Client:                r.Client,
+		Recorder:              r.Recorder,
+		Config:                r.Config,
+		RuntimeConfig:         r.RuntimeConfig,
+		DockerSecretRetriever: r.DockerSecretRetriever,
+	}
+
+	for _, componentName := range sortedSelectionComponentNames(selection) {
+		dcd := dcds[componentName]
+		if dcd == nil {
+			return fmt.Errorf("generated DynamoComponentDeployment missing for selected component %q", componentName)
+		}
+		_, syncedService, err := commoncontroller.SyncResource(ctx, r, dgd, func(ctx context.Context) (*corev1.Service, bool, error) {
+			return dcdReconciler.generateService(ctx, generateResourceOption{dynamoComponentDeployment: dcd})
+		})
+		if err != nil {
+			return fmt.Errorf("failed to reconcile DisaggregatedSet component service for %q: %w", componentName, err)
+		}
+		if syncedService != nil {
+			if err := r.ensureControlledByDGD(ctx, dgd, syncedService); err != nil {
+				return fmt.Errorf("failed to adopt DisaggregatedSet component service %s/%s: %w", syncedService.Namespace, syncedService.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func selectedComponentsByName(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	selection disaggregatedSetSelection,
+) map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	components := map[string]*nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{}
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if _, selected := selection.componentToRole[component.ComponentName]; selected {
+			components[component.ComponentName] = component
+		}
+	}
+	return components
+}
+
+func sortedSelectionComponentNames(selection disaggregatedSetSelection) []string {
+	names := make([]string, 0, len(selection.componentToRole))
+	for componentName := range selection.componentToRole {
+		names = append(names, componentName)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (r *DynamoGraphDeploymentReconciler) adoptSelectedModelServices(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	selection disaggregatedSetSelection,
+) error {
+	seen := map[string]struct{}{}
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		if _, selected := selection.componentToRole[component.ComponentName]; !selected {
+			continue
+		}
+		if component.ModelRef == nil || component.ModelRef.Name == "" {
+			continue
+		}
+		serviceName := dynamo.GenerateServiceName(component.ModelRef.Name)
+		if _, ok := seen[serviceName]; ok {
+			continue
+		}
+		seen[serviceName] = struct{}{}
+
+		service := &corev1.Service{}
+		err := r.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: dgd.Namespace}, service)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get DisaggregatedSet model service %s/%s: %w", dgd.Namespace, serviceName, err)
+		}
+		if err := r.ensureControlledByDGD(ctx, dgd, service); err != nil {
+			return fmt.Errorf("failed to adopt DisaggregatedSet model service %s/%s: %w", service.Namespace, service.Name, err)
+		}
+	}
+	return nil
+}
+
+func stringMapToAny(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func sortedDCDKeys(dcds map[string]*nvidiacomv1beta1.DynamoComponentDeployment) []string {
+	keys := make([]string, 0, len(dcds))
+	for key := range dcds {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (r *DynamoGraphDeploymentReconciler) syncDisaggregatedSet(
+	ctx context.Context,
+	parent *nvidiacomv1beta1.DynamoGraphDeployment,
+	desired *unstructured.Unstructured,
+) (bool, *unstructured.Unstructured, error) {
+	logger := log.FromContext(ctx).WithValues("namespace", desired.GetNamespace(), "resourceName", desired.GetName(), "resourceType", "DisaggregatedSet")
+	current := newDisaggregatedSetObject()
+	err := r.Get(ctx, types.NamespacedName{Name: desired.GetName(), Namespace: desired.GetNamespace()}, current)
+	if apierrors.IsNotFound(err) {
+		if err := withDisaggregatedSetSyncAnnotations(desired, 1); err != nil {
+			return false, nil, err
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			return false, nil, fmt.Errorf("failed to create DisaggregatedSet %s/%s: %w", desired.GetNamespace(), desired.GetName(), err)
+		}
+		if r.Recorder != nil {
+			r.Recorder.Eventf(parent, corev1.EventTypeNormal, "CreateDisaggregatedSet", "Created DisaggregatedSet %s/%s", desired.GetNamespace(), desired.GetName())
+		}
+		return true, desired, nil
+	}
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to get DisaggregatedSet %s/%s: %w", desired.GetNamespace(), desired.GetName(), err)
+	}
+
+	if disaggregatedSetMatches(current, desired) {
+		logger.Info("DisaggregatedSet spec is the same. Skipping update.")
+		return false, current, nil
+	}
+
+	updated := current.DeepCopy()
+	updated.Object["spec"] = desired.Object["spec"]
+	updated.SetLabels(desired.GetLabels())
+	updated.SetOwnerReferences(desired.GetOwnerReferences())
+	updated.SetAnnotations(filteredSyncAnnotations(desired.GetAnnotations()))
+	if err := withDisaggregatedSetSyncAnnotations(updated, current.GetGeneration()+1); err != nil {
+		return false, nil, err
+	}
+
+	patch := client.MergeFrom(current.DeepCopy())
+	if err := r.Patch(ctx, updated, patch); err != nil {
+		return false, nil, fmt.Errorf("failed to update DisaggregatedSet %s/%s: %w", desired.GetNamespace(), desired.GetName(), err)
+	}
+	if r.Recorder != nil {
+		r.Recorder.Eventf(parent, corev1.EventTypeNormal, "UpdateDisaggregatedSet", "Updated DisaggregatedSet %s/%s", desired.GetNamespace(), desired.GetName())
+	}
+	return true, updated, nil
+}
+
+func withDisaggregatedSetSyncAnnotations(obj *unstructured.Unstructured, generation int64) error {
+	hash, err := commoncontroller.GetResourceHash(obj.Object["spec"])
+	if err != nil {
+		return fmt.Errorf("failed to calculate DisaggregatedSet spec hash: %w", err)
+	}
+	annotations := filteredSyncAnnotations(obj.GetAnnotations())
+	annotations[commoncontroller.NvidiaAnnotationHashKey] = hash
+	annotations[commoncontroller.NvidiaAnnotationGenerationKey] = strconv.FormatInt(generation, 10)
+	obj.SetAnnotations(annotations)
+	return nil
+}
+
+func disaggregatedSetMatches(current, desired *unstructured.Unstructured) bool {
+	return equality.Semantic.DeepEqual(current.Object["spec"], desired.Object["spec"]) &&
+		equality.Semantic.DeepEqual(current.GetLabels(), desired.GetLabels()) &&
+		equality.Semantic.DeepEqual(filteredSyncAnnotations(current.GetAnnotations()), filteredSyncAnnotations(desired.GetAnnotations())) &&
+		equality.Semantic.DeepEqual(current.GetOwnerReferences(), desired.GetOwnerReferences())
+}
+
+func filteredSyncAnnotations(annotations map[string]string) map[string]string {
+	out := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		if k == commoncontroller.NvidiaAnnotationHashKey || k == commoncontroller.NvidiaAnnotationGenerationKey {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func (r *DynamoGraphDeploymentReconciler) deleteDisaggregatedSetIfExists(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment) error {
+	ds := newDisaggregatedSetObject()
+	key := types.NamespacedName{Name: disaggregatedSetName(dgd), Namespace: dgd.Namespace}
+	if err := r.Get(ctx, key, ds); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get stale DisaggregatedSet %s/%s: %w", dgd.Namespace, disaggregatedSetName(dgd), err)
+	}
+	if !isControlledByBetaDGD(ds, dgd) {
+		return fmt.Errorf("refusing to delete DisaggregatedSet %s/%s because it is not controlled by DynamoGraphDeployment %s/%s", dgd.Namespace, disaggregatedSetName(dgd), dgd.Namespace, dgd.Name)
+	}
+	if err := r.Delete(ctx, ds); err != nil {
+		return fmt.Errorf("failed to delete stale DisaggregatedSet %s/%s: %w", dgd.Namespace, disaggregatedSetName(dgd), err)
+	}
+	return nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) deleteOwnedSelectedDCDs(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	selection disaggregatedSetSelection,
+) error {
+	dcds, err := r.listOwnedSelectedDCDs(ctx, dgd, selection)
+	if err != nil {
+		return err
+	}
+	for i := range dcds {
+		dcd := &dcds[i]
+		if err := r.Delete(ctx, dcd); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete selected DynamoComponentDeployment %s/%s: %w", dcd.Namespace, dcd.Name, err)
+		}
+	}
+	return nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) listOwnedSelectedDCDs(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	selection disaggregatedSetSelection,
+) ([]nvidiacomv1beta1.DynamoComponentDeployment, error) {
+	dcdList := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	if err := r.List(ctx, dcdList, client.InNamespace(dgd.Namespace), client.MatchingLabels{
+		consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list DynamoComponentDeployments for DisaggregatedSet cleanup: %w", err)
+	}
+
+	selectedDCDs := []nvidiacomv1beta1.DynamoComponentDeployment{}
+	for _, dcd := range dcdList.Items {
+		if !isControlledByBetaDGD(&dcd, dgd) {
+			continue
+		}
+		componentName := dynamo.GetDCDComponentName(&dcd)
+		if _, selected := selection.componentToRole[componentName]; selected {
+			selectedDCDs = append(selectedDCDs, dcd)
+		}
+	}
+	return selectedDCDs, nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) ensureControlledByDGD(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	obj client.Object,
+) error {
+	if dgdControllerOwnerReference(dgd) == nil || isControlledByBetaDGD(obj, dgd) {
+		return nil
+	}
+
+	controllerOwner := metav1.GetControllerOf(obj)
+	if controllerOwner != nil {
+		if controllerOwner.APIVersion != nvidiacomv1beta1.GroupVersion.String() || controllerOwner.Kind != "DynamoComponentDeployment" {
+			return fmt.Errorf("resource is controlled by %s/%s %q", controllerOwner.APIVersion, controllerOwner.Kind, controllerOwner.Name)
+		}
+		dcd := &nvidiacomv1beta1.DynamoComponentDeployment{}
+		if err := r.Get(ctx, types.NamespacedName{Name: controllerOwner.Name, Namespace: obj.GetNamespace()}, dcd); err != nil {
+			return fmt.Errorf("failed to verify current DynamoComponentDeployment owner %s/%s: %w", obj.GetNamespace(), controllerOwner.Name, err)
+		}
+		if !isControlledByBetaDGD(dcd, dgd) {
+			return fmt.Errorf("current DynamoComponentDeployment owner %s/%s is not controlled by DynamoGraphDeployment %s/%s", dcd.Namespace, dcd.Name, dgd.Namespace, dgd.Name)
+		}
+	}
+
+	original := obj.DeepCopyObject().(client.Object)
+	setDGDControllerOwnerReference(dgd, obj)
+	if equality.Semantic.DeepEqual(original.GetOwnerReferences(), obj.GetOwnerReferences()) {
+		return nil
+	}
+	if err := r.Patch(ctx, obj, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("failed to update owner references: %w", err)
+	}
+	return nil
+}
+
+func dgdControllerOwnerReference(dgd *nvidiacomv1beta1.DynamoGraphDeployment) *metav1.OwnerReference {
+	if dgd == nil || dgd.UID == "" {
+		return nil
+	}
+	return &metav1.OwnerReference{
+		APIVersion:         nvidiacomv1beta1.GroupVersion.String(),
+		Kind:               "DynamoGraphDeployment",
+		Name:               dgd.Name,
+		UID:                dgd.UID,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+}
+
+func setDGDControllerOwnerReference(dgd *nvidiacomv1beta1.DynamoGraphDeployment, obj client.Object) {
+	ownerRef := dgdControllerOwnerReference(dgd)
+	if ownerRef == nil {
+		return
+	}
+	ownerRefs := make([]metav1.OwnerReference, 0, len(obj.GetOwnerReferences())+1)
+	for _, ref := range obj.GetOwnerReferences() {
+		if ptr.Deref(ref.Controller, false) {
+			continue
+		}
+		if ref.APIVersion == ownerRef.APIVersion && ref.Kind == ownerRef.Kind && ref.Name == ownerRef.Name {
+			continue
+		}
+		ownerRefs = append(ownerRefs, ref)
+	}
+	ownerRefs = append(ownerRefs, *ownerRef)
+	obj.SetOwnerReferences(ownerRefs)
+}
+
+func isControlledByBetaDGD(obj client.Object, dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
+	if obj == nil || dgd == nil {
+		return false
+	}
+	if dgd.UID != "" {
+		return metav1.IsControlledBy(obj, dgd)
+	}
+	controllerOwner := metav1.GetControllerOf(obj)
+	return controllerOwner != nil &&
+		controllerOwner.APIVersion == nvidiacomv1beta1.GroupVersion.String() &&
+		controllerOwner.Kind == "DynamoGraphDeployment" &&
+		controllerOwner.Name == dgd.Name
+}
+
+func checkDisaggregatedSetReadiness(
+	ds *unstructured.Unstructured,
+	selection disaggregatedSetSelection,
+) (bool, string, map[string]nvidiacomv1beta1.ComponentReplicaStatus) {
+	statuses := make(map[string]nvidiacomv1beta1.ComponentReplicaStatus, len(selection.componentToRole))
+	roleStatuses := disaggregatedSetRoleStatuses(ds)
+	notReadyReasons := []string{}
+
+	for componentName, roleName := range selection.componentToRole {
+		desiredReplicas := selection.desiredReplicas[componentName]
+		componentStatus := nvidiacomv1beta1.ComponentReplicaStatus{
+			ComponentKind:  nvidiacomv1beta1.ComponentKindLeaderWorkerSet,
+			ComponentNames: []string{fmt.Sprintf("%s/%s", ds.GetName(), roleName)},
+		}
+
+		roleStatus, found := roleStatuses[roleName]
+		if found {
+			componentStatus.Replicas = nestedInt32(roleStatus, "replicas")
+			componentStatus.UpdatedReplicas = nestedInt32(roleStatus, "updatedReplicas")
+			readyReplicas := nestedInt32(roleStatus, "readyReplicas")
+			componentStatus.ReadyReplicas = &readyReplicas
+		}
+		statuses[componentName] = componentStatus
+
+		if desiredReplicas == 0 {
+			continue
+		}
+		if !found {
+			notReadyReasons = append(notReadyReasons, fmt.Sprintf("%s role %q has no status yet", componentName, roleName))
+			continue
+		}
+		if componentStatus.Replicas < desiredReplicas ||
+			componentStatus.UpdatedReplicas < desiredReplicas ||
+			componentStatus.ReadyReplicas == nil ||
+			*componentStatus.ReadyReplicas < desiredReplicas {
+			notReadyReasons = append(notReadyReasons, fmt.Sprintf(
+				"%s role %q replicas not ready (desired=%d replicas=%d updated=%d ready=%d)",
+				componentName,
+				roleName,
+				desiredReplicas,
+				componentStatus.Replicas,
+				componentStatus.UpdatedReplicas,
+				ptr.Deref(componentStatus.ReadyReplicas, 0),
+			))
+		}
+	}
+
+	if current, reason := disaggregatedSetStatusObserved(ds); !current {
+		return false, reason, statuses
+	}
+	if len(notReadyReasons) > 0 {
+		sort.Strings(notReadyReasons)
+		return false, strings.Join(notReadyReasons, "; "), statuses
+	}
+	return true, "All DisaggregatedSet roles are ready", statuses
+}
+
+func checkDisaggregatedSetComponentReady(
+	ds *unstructured.Unstructured,
+	selection disaggregatedSetSelection,
+	componentName string,
+) (bool, string) {
+	roleName, selected := selection.componentToRole[componentName]
+	if !selected {
+		return false, fmt.Sprintf("component %q is not managed by DisaggregatedSet", componentName)
+	}
+	desiredReplicas := selection.desiredReplicas[componentName]
+	componentSelection := disaggregatedSetSelection{
+		componentToRole: map[string]string{componentName: roleName},
+		desiredReplicas: map[string]int32{componentName: desiredReplicas},
+	}
+	ready, reason, _ := checkDisaggregatedSetReadiness(ds, componentSelection)
+	return ready, reason
+}
+
+func disaggregatedSetStatusObserved(ds *unstructured.Unstructured) (bool, string) {
+	if ds == nil || ds.GetGeneration() == 0 {
+		return true, ""
+	}
+	if observedGeneration, found := nestedInt64FromObject(ds.Object, "status", "observedGeneration"); found && observedGeneration < ds.GetGeneration() {
+		return false, fmt.Sprintf("DisaggregatedSet status has not observed generation %d (observedGeneration=%d)", ds.GetGeneration(), observedGeneration)
+	}
+	conditions, found, _ := unstructured.NestedSlice(ds.Object, "status", "conditions")
+	if !found {
+		return true, ""
+	}
+	for _, item := range conditions {
+		condition, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		observedGeneration, ok := nestedInt64(condition, "observedGeneration")
+		if !ok || observedGeneration >= ds.GetGeneration() {
+			continue
+		}
+		conditionType, _ := condition["type"].(string)
+		return false, fmt.Sprintf("DisaggregatedSet condition %q has not observed generation %d (observedGeneration=%d)", conditionType, ds.GetGeneration(), observedGeneration)
+	}
+	return true, ""
+}
+
+func disaggregatedSetRoleStatuses(ds *unstructured.Unstructured) map[string]map[string]any {
+	out := map[string]map[string]any{}
+	roleStatuses, found, _ := unstructured.NestedSlice(ds.Object, "status", "roleStatuses")
+	if !found {
+		return out
+	}
+	for _, item := range roleStatuses {
+		roleStatus, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := roleStatus["name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+		out[name] = roleStatus
+	}
+	return out
+}
+
+func nestedInt32(obj map[string]any, key string) int32 {
+	value, _ := nestedInt64(obj, key)
+	return int32(value)
+}
+
+func nestedInt64FromObject(obj map[string]any, fields ...string) (int64, bool) {
+	value, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil || !found {
+		return 0, false
+	}
+	return int64Value(value)
+}
+
+func nestedInt64(obj map[string]any, key string) (int64, bool) {
+	return int64Value(obj[key])
+}
+
+func int64Value(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func disaggregatedSetStatusChanged(oldObj, newObj client.Object) bool {
+	oldDS, okOld := oldObj.(*unstructured.Unstructured)
+	newDS, okNew := newObj.(*unstructured.Unstructured)
+	if !okOld || !okNew {
+		return false
+	}
+	return oldDS.GetGeneration() != newDS.GetGeneration() ||
+		!equality.Semantic.DeepEqual(oldDS.Object["status"], newDS.Object["status"])
+}

--- a/deploy/operator/internal/controller/dynamographdeployment_disaggregatedset_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_disaggregatedset_envtest_test.go
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("DisaggregatedSet sync", func() {
+	It("creates and updates DisaggregatedSets through the Kubernetes API", func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "ds-sync-"}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ns))).To(Succeed())
+		})
+
+		parent := &nvidiacomv1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ds-envtest",
+				Namespace: ns.Name,
+			},
+		}
+
+		reconciler := &DynamoGraphDeploymentReconciler{Client: k8sClient}
+		desired := envtestDisaggregatedSet(ns.Name, "ds-envtest", 0, 0)
+		modified, synced, err := reconciler.syncDisaggregatedSet(ctx, parent, desired)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(modified).To(BeTrue())
+		Expect(synced.GetName()).To(Equal("ds-envtest"))
+
+		fetched := newDisaggregatedSetObject()
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "ds-envtest", Namespace: ns.Name}, fetched)).To(Succeed())
+		roles, found, err := unstructured.NestedSlice(fetched.Object, "spec", "roles")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(roles).To(HaveLen(2))
+		Expect(fetched.GetAnnotations()).To(HaveKey(commoncontroller.NvidiaAnnotationHashKey))
+		Expect(fetched.GetAnnotations()).To(HaveKey(commoncontroller.NvidiaAnnotationGenerationKey))
+
+		modified, _, err = reconciler.syncDisaggregatedSet(ctx, parent, envtestDisaggregatedSet(ns.Name, "ds-envtest", 1, 1))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(modified).To(BeTrue())
+
+		invalid := envtestDisaggregatedSet(ns.Name, "ds-envtest-invalid", 0, 1)
+		err = k8sClient.Create(ctx, invalid)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("replicas must be zero"))
+	})
+})
+
+func envtestDisaggregatedSet(namespace, name string, prefillReplicas, decodeReplicas int64) *unstructured.Unstructured {
+	ds := newDisaggregatedSetObject()
+	ds.SetNamespace(namespace)
+	ds.SetName(name)
+	ds.SetLabels(map[string]string{
+		consts.KubeLabelDynamoGraphDeploymentName: name,
+	})
+	ds.Object["spec"] = map[string]any{
+		"roles": []any{
+			envtestDisaggregatedSetRole("prefill", prefillReplicas),
+			envtestDisaggregatedSetRole("decode", decodeReplicas),
+		},
+	}
+	return ds
+}
+
+func envtestDisaggregatedSetRole(name string, replicas int64) map[string]any {
+	return map[string]any{
+		"name":     name,
+		"metadata": map[string]any{"labels": map[string]any{"role": name}},
+		"spec": map[string]any{
+			"replicas": replicas,
+			"leaderWorkerTemplate": map[string]any{
+				"size": int64(2),
+			},
+		},
+	}
+}

--- a/deploy/operator/internal/controller/dynamographdeployment_disaggregatedset_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_disaggregatedset_test.go
@@ -1,0 +1,397 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDynamoGraphDeploymentReconciler_shouldUseDisaggregatedSet(t *testing.T) {
+	tests := []struct {
+		name       string
+		runtime    *commoncontroller.RuntimeConfig
+		dgd        *nvidiacomv1beta1.DynamoGraphDeployment
+		wantUse    bool
+		wantReason string
+	}{
+		{
+			name: "enabled with two eligible roles",
+			runtime: &commoncontroller.RuntimeConfig{
+				LWSEnabled:              true,
+				DisaggregatedSetEnabled: true,
+			},
+			dgd:     disaggregatedSetTestDGD(disaggregatedSetComponent("Prefill", nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(1))), disaggregatedSetComponent("Decode", nvidiacomv1beta1.ComponentTypeDecode, ptr.To(int32(1)))),
+			wantUse: true,
+		},
+		{
+			name: "falls back when API is unavailable",
+			runtime: &commoncontroller.RuntimeConfig{
+				LWSEnabled:              true,
+				DisaggregatedSetEnabled: false,
+			},
+			dgd:        disaggregatedSetTestDGD(disaggregatedSetComponent("Prefill", nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(1))), disaggregatedSetComponent("Decode", nvidiacomv1beta1.ComponentTypeDecode, ptr.To(int32(1)))),
+			wantReason: "DisaggregatedSet API is not available",
+		},
+		{
+			name: "falls back on mixed zero and positive replicas",
+			runtime: &commoncontroller.RuntimeConfig{
+				LWSEnabled:              true,
+				DisaggregatedSetEnabled: true,
+			},
+			dgd:        disaggregatedSetTestDGD(disaggregatedSetComponent("Prefill", nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(0))), disaggregatedSetComponent("Decode", nvidiacomv1beta1.ComponentTypeDecode, ptr.To(int32(1)))),
+			wantReason: "replicas to be zero for all roles or positive for all roles",
+		},
+		{
+			name: "falls back with only one eligible role",
+			runtime: &commoncontroller.RuntimeConfig{
+				LWSEnabled:              true,
+				DisaggregatedSetEnabled: true,
+			},
+			dgd:        disaggregatedSetTestDGD(disaggregatedSetComponent("Prefill", nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(1))), singleNodeComponent("Frontend", nvidiacomv1beta1.ComponentTypeFrontend)),
+			wantReason: "requires at least two eligible",
+		},
+		{
+			name: "falls back for scaling adapter roles",
+			runtime: &commoncontroller.RuntimeConfig{
+				LWSEnabled:              true,
+				DisaggregatedSetEnabled: true,
+			},
+			dgd:        disaggregatedSetTestDGD(scalingAdapterDisaggregatedSetComponent("Prefill"), disaggregatedSetComponent("Decode", nvidiacomv1beta1.ComponentTypeDecode, ptr.To(int32(1)))),
+			wantReason: "no scale subresource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := &DynamoGraphDeploymentReconciler{RuntimeConfig: tt.runtime}
+			gotUse, gotReason := reconciler.shouldUseDisaggregatedSet(tt.dgd)
+			if gotUse != tt.wantUse {
+				t.Fatalf("shouldUseDisaggregatedSet() use = %v, want %v", gotUse, tt.wantUse)
+			}
+			if tt.wantReason != "" && !strings.Contains(gotReason, tt.wantReason) {
+				t.Fatalf("shouldUseDisaggregatedSet() reason = %q, want to contain %q", gotReason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestSelectDisaggregatedSetComponentsAssignsStableRoleNames(t *testing.T) {
+	dgd := disaggregatedSetTestDGD(
+		disaggregatedSetComponent("PrefillWorker", nvidiacomv1beta1.ComponentTypePrefill, nil),
+		disaggregatedSetComponent("DecodeWorker", nvidiacomv1beta1.ComponentTypeDecode, nil),
+		disaggregatedSetComponent("GenericWorker", nvidiacomv1beta1.ComponentTypeWorker, nil),
+		singleNodeComponent("Frontend", nvidiacomv1beta1.ComponentTypeFrontend),
+	)
+
+	selection, reason := selectDisaggregatedSetComponents(dgd)
+	if reason != "" {
+		t.Fatalf("selectDisaggregatedSetComponents() reason = %q, want empty", reason)
+	}
+	wantRoles := map[string]string{
+		"PrefillWorker": "prefill",
+		"DecodeWorker":  "decode",
+		"GenericWorker": "genericworker",
+	}
+	for component, wantRole := range wantRoles {
+		if gotRole := selection.componentToRole[component]; gotRole != wantRole {
+			t.Fatalf("role for %s = %q, want %q", component, gotRole, wantRole)
+		}
+	}
+	if _, selected := selection.componentToRole["Frontend"]; selected {
+		t.Fatalf("single-node frontend should not be selected for DisaggregatedSet")
+	}
+}
+
+func TestCheckDisaggregatedSetReadiness(t *testing.T) {
+	ds := newDisaggregatedSetObject()
+	ds.SetName("test-dgd")
+	ds.Object["status"] = map[string]any{
+		"roleStatuses": []any{
+			map[string]any{"name": "prefill", "replicas": int64(2), "updatedReplicas": int64(2), "readyReplicas": int64(2)},
+			map[string]any{"name": "decode", "replicas": int64(2), "updatedReplicas": int64(2), "readyReplicas": int64(1)},
+		},
+	}
+	selection := disaggregatedSetSelection{
+		componentToRole: map[string]string{"Prefill": "prefill", "Decode": "decode"},
+		desiredReplicas: map[string]int32{"Prefill": 2, "Decode": 2},
+	}
+
+	ready, reason, statuses := checkDisaggregatedSetReadiness(ds, selection)
+	if ready {
+		t.Fatalf("checkDisaggregatedSetReadiness() ready = true, want false")
+	}
+	if !strings.Contains(reason, "Decode") || !strings.Contains(reason, "ready=1") {
+		t.Fatalf("checkDisaggregatedSetReadiness() reason = %q, want Decode ready=1 detail", reason)
+	}
+	if gotReady := ptr.Deref(statuses["Prefill"].ReadyReplicas, 0); gotReady != 2 {
+		t.Fatalf("Prefill ready replicas = %d, want 2", gotReady)
+	}
+	if gotReady := ptr.Deref(statuses["Decode"].ReadyReplicas, 0); gotReady != 1 {
+		t.Fatalf("Decode ready replicas = %d, want 1", gotReady)
+	}
+}
+
+func TestCheckDisaggregatedSetReadinessZeroReplicas(t *testing.T) {
+	ds := newDisaggregatedSetObject()
+	ds.SetName("test-dgd")
+	selection := disaggregatedSetSelection{
+		componentToRole: map[string]string{"Prefill": "prefill", "Decode": "decode"},
+		desiredReplicas: map[string]int32{"Prefill": 0, "Decode": 0},
+	}
+
+	ready, reason, statuses := checkDisaggregatedSetReadiness(ds, selection)
+	if !ready {
+		t.Fatalf("checkDisaggregatedSetReadiness() ready = false, reason = %q", reason)
+	}
+	if statuses["Prefill"].Replicas != 0 || statuses["Decode"].Replicas != 0 {
+		t.Fatalf("zero-replica DisaggregatedSet statuses = %#v, want zero replicas", statuses)
+	}
+}
+
+func TestCheckDisaggregatedSetReadinessWaitsForObservedGeneration(t *testing.T) {
+	ds := readyDisaggregatedSetStatus()
+	ds.SetGeneration(3)
+	ds.Object["status"].(map[string]any)["observedGeneration"] = int64(2)
+	selection := disaggregatedSetSelection{
+		componentToRole: map[string]string{"Prefill": "prefill", "Decode": "decode"},
+		desiredReplicas: map[string]int32{"Prefill": 2, "Decode": 2},
+	}
+
+	ready, reason, _ := checkDisaggregatedSetReadiness(ds, selection)
+	if ready {
+		t.Fatalf("checkDisaggregatedSetReadiness() ready = true, want false")
+	}
+	if !strings.Contains(reason, "observedGeneration=2") {
+		t.Fatalf("checkDisaggregatedSetReadiness() reason = %q, want observedGeneration detail", reason)
+	}
+
+	ds.Object["status"].(map[string]any)["observedGeneration"] = int64(3)
+	ready, reason, _ = checkDisaggregatedSetReadiness(ds, selection)
+	if !ready {
+		t.Fatalf("checkDisaggregatedSetReadiness() ready = false, reason = %q", reason)
+	}
+}
+
+func TestDisaggregatedSetRenderRollingUpdateContextUsesFullDesiredReplicas(t *testing.T) {
+	dgd := disaggregatedSetTestDGD(
+		disaggregatedSetComponent("Prefill", nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(4))),
+		disaggregatedSetComponent("Decode", nvidiacomv1beta1.ComponentTypeDecode, ptr.To(int32(5))),
+	)
+	rollingCtx := dynamo.RollingUpdateContext{
+		NewWorkerHash:     "abcd1234",
+		OldWorkerReplicas: map[string]int32{"Prefill": 4, "Decode": 5},
+		NewWorkerReplicas: map[string]int32{"Prefill": 1, "Decode": 1},
+	}
+
+	got := disaggregatedSetRenderRollingUpdateContext(rollingCtx, dgd)
+	if got.NewWorkerHash != "abcd1234" {
+		t.Fatalf("NewWorkerHash = %q, want abcd1234", got.NewWorkerHash)
+	}
+	if got.NewWorkerReplicas["Prefill"] != 4 || got.NewWorkerReplicas["Decode"] != 5 {
+		t.Fatalf("NewWorkerReplicas = %#v, want full desired replicas", got.NewWorkerReplicas)
+	}
+	if rollingCtx.NewWorkerReplicas["Prefill"] != 1 {
+		t.Fatalf("input rolling context was mutated: %#v", rollingCtx.NewWorkerReplicas)
+	}
+}
+
+func TestEnsureControlledByDGDAdoptsDCDOwnedService(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1) error = %v", err)
+	}
+	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(nvidia) error = %v", err)
+	}
+
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default", UID: types.UID("dgd-uid")},
+	}
+	dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "graph-prefill-abcd1234",
+			Namespace: "default",
+			UID:       types.UID("dcd-uid"),
+			OwnerReferences: []metav1.OwnerReference{
+				*dgdControllerOwnerReference(dgd),
+			},
+		},
+	}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "graph-prefill-abcd1234",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         nvidiacomv1beta1.GroupVersion.String(),
+				Kind:               "DynamoComponentDeployment",
+				Name:               dcd.Name,
+				UID:                dcd.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+	}
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(dcd, service).Build(),
+	}
+
+	if err := reconciler.ensureControlledByDGD(t.Context(), dgd, service); err != nil {
+		t.Fatalf("ensureControlledByDGD() error = %v", err)
+	}
+
+	got := &corev1.Service{}
+	if err := reconciler.Get(t.Context(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, got); err != nil {
+		t.Fatalf("Get(service) error = %v", err)
+	}
+	if !metav1.IsControlledBy(got, dgd) {
+		t.Fatalf("service ownerReferences = %#v, want DGD controller owner", got.OwnerReferences)
+	}
+}
+
+func TestListOwnedSelectedDCDsSkipsUserManagedDCDs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(nvidia) error = %v", err)
+	}
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default", UID: types.UID("dgd-uid")},
+	}
+	owned := selectedDCDForCleanup("graph-prefill-abcd1234", "Prefill", dgd, true)
+	userManaged := selectedDCDForCleanup("graph-decode-abcd1234", "Decode", dgd, false)
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(owned, userManaged).Build(),
+	}
+	selection := disaggregatedSetSelection{
+		componentToRole: map[string]string{"Prefill": "prefill", "Decode": "decode"},
+	}
+
+	got, err := reconciler.listOwnedSelectedDCDs(t.Context(), dgd, selection)
+	if err != nil {
+		t.Fatalf("listOwnedSelectedDCDs() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Name != owned.Name {
+		t.Fatalf("listOwnedSelectedDCDs() = %#v, want only %q", got, owned.Name)
+	}
+}
+
+func TestGetUpdatedInProgressForDisaggregatedSetUsesRoleStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(disaggregatedSetGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(disaggregatedSetGVK.GroupVersion().WithKind("DisaggregatedSetList"), &unstructured.UnstructuredList{})
+
+	dgd := disaggregatedSetTestDGD(
+		disaggregatedSetComponent("Prefill", nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(2))),
+		disaggregatedSetComponent("Decode", nvidiacomv1beta1.ComponentTypeDecode, ptr.To(int32(2))),
+	)
+	ds := readyDisaggregatedSetStatus()
+	ds.SetName(disaggregatedSetName(dgd))
+	ds.SetNamespace(dgd.Namespace)
+	ds.Object["status"].(map[string]any)["roleStatuses"].([]any)[1].(map[string]any)["readyReplicas"] = int64(1)
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(ds).Build(),
+	}
+
+	got := reconciler.getUpdatedInProgressForDisaggregatedSet(t.Context(), dgd, []string{"Prefill", "Decode"})
+	if len(got) != 1 || got[0] != "Decode" {
+		t.Fatalf("getUpdatedInProgressForDisaggregatedSet() = %#v, want Decode only", got)
+	}
+}
+
+func readyDisaggregatedSetStatus() *unstructured.Unstructured {
+	ds := newDisaggregatedSetObject()
+	ds.SetName("test-dgd")
+	ds.Object["status"] = map[string]any{
+		"roleStatuses": []any{
+			map[string]any{"name": "prefill", "replicas": int64(2), "updatedReplicas": int64(2), "readyReplicas": int64(2)},
+			map[string]any{"name": "decode", "replicas": int64(2), "updatedReplicas": int64(2), "readyReplicas": int64(2)},
+		},
+	}
+	return ds
+}
+
+func selectedDCDForCleanup(name, componentName string, dgd *nvidiacomv1beta1.DynamoGraphDeployment, owned bool) *nvidiacomv1beta1.DynamoComponentDeployment {
+	dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: dgd.Namespace,
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: dgd.Name,
+			},
+		},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: componentName,
+				ComponentType: nvidiacomv1beta1.ComponentTypePrefill,
+			},
+		},
+	}
+	if owned {
+		dcd.OwnerReferences = []metav1.OwnerReference{*dgdControllerOwnerReference(dgd)}
+	}
+	return dcd
+}
+
+func disaggregatedSetTestDGD(components ...nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) *nvidiacomv1beta1.DynamoGraphDeployment {
+	return &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+			Annotations: map[string]string{
+				consts.KubeAnnotationEnableGrove:            consts.KubeLabelValueFalse,
+				consts.KubeAnnotationEnableDisaggregatedSet: consts.KubeLabelValueTrue,
+			},
+		},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+			Components: components,
+		},
+	}
+}
+
+func disaggregatedSetComponent(name string, componentType nvidiacomv1beta1.ComponentType, replicas *int32) nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	return nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+		ComponentName: name,
+		ComponentType: componentType,
+		Replicas:      replicas,
+		Multinode:     &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2},
+	}
+}
+
+func scalingAdapterDisaggregatedSetComponent(name string) nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	component := disaggregatedSetComponent(name, nvidiacomv1beta1.ComponentTypePrefill, ptr.To(int32(1)))
+	component.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
+	return component
+}
+
+func singleNodeComponent(name string, componentType nvidiacomv1beta1.ComponentType) nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	return nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+		ComponentName: name,
+		ComponentType: componentType,
+	}
+}

--- a/deploy/operator/internal/controller/suite_test.go
+++ b/deploy/operator/internal/controller/suite_test.go
@@ -81,6 +81,7 @@ var _ = BeforeSuite(func() {
 			filepath.Join(".", "testing", "volcano.sh"),
 			filepath.Join(".", "testing", "run.ai"),
 			filepath.Join(".", "testing", "nvidia"),
+			filepath.Join(".", "testing", "disaggregatedset"),
 		},
 		ErrorIfCRDPathMissing: false,
 

--- a/deploy/operator/internal/controller/testing/disaggregatedset/disaggregatedsets.yaml
+++ b/deploy/operator/internal/controller/testing/disaggregatedset/disaggregatedsets.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: disaggregatedsets.disaggregatedset.x-k8s.io
+spec:
+  group: disaggregatedset.x-k8s.io
+  names:
+    kind: DisaggregatedSet
+    listKind: DisaggregatedSetList
+    plural: disaggregatedsets
+    singular: disaggregatedset
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            required:
+            - roles
+            x-kubernetes-validations:
+            - message: replicas must be zero for all roles or non-zero for all roles
+              rule: self.roles.all(r, !has(r.spec.replicas) || r.spec.replicas == 0) || self.roles.all(r, has(r.spec.replicas) && r.spec.replicas > 0)
+            properties:
+              roles:
+                type: array
+                minItems: 2
+                x-kubernetes-list-type: map
+                x-kubernetes-list-map-keys:
+                - name
+                items:
+                  type: object
+                  required:
+                  - name
+                  - spec
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    metadata:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        replicas:
+                          type: integer
+                          format: int32
+          status:
+            type: object
+            properties:
+              roleStatuses:
+                type: array
+                x-kubernetes-list-type: map
+                x-kubernetes-list-map-keys:
+                - name
+                items:
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    name:
+                      type: string
+                    replicas:
+                      type: integer
+                      format: int32
+                    updatedReplicas:
+                      type: integer
+                      format: int32
+                    readyReplicas:
+                      type: integer
+                      format: int32
+    subresources:
+      status: {}

--- a/deploy/operator/internal/controller_common/predicate.go
+++ b/deploy/operator/internal/controller_common/predicate.go
@@ -48,6 +48,14 @@ func DetectLWSAvailability(ctx context.Context, mgr ctrl.Manager) bool {
 	return detectAPIGroupAvailability(ctx, mgr, "leaderworkerset.x-k8s.io", nil)
 }
 
+// DetectDisaggregatedSetAvailability checks if the LWS DisaggregatedSet API is
+// available. Dynamo targets v1 because older standalone DisaggregatedSet code
+// used v1alpha1 while the integrated LWS mainline API uses v1.
+func DetectDisaggregatedSetAvailability(ctx context.Context, mgr ctrl.Manager) bool {
+	version := "v1"
+	return detectAPIGroupAvailability(ctx, mgr, "disaggregatedset.x-k8s.io", &version)
+}
+
 // DetectVolcanoAvailability checks if Volcano is available by checking if the Volcano API group is registered
 func DetectVolcanoAvailability(ctx context.Context, mgr ctrl.Manager) bool {
 	return detectAPIGroupAvailability(ctx, mgr, "scheduling.volcano.sh", nil)

--- a/deploy/operator/internal/controller_common/runtime.go
+++ b/deploy/operator/internal/controller_common/runtime.go
@@ -24,6 +24,10 @@ type RuntimeConfig struct {
 	GroveEnabled bool
 	// LWSEnabled is the resolved LWS availability (config override merged with auto-detection)
 	LWSEnabled bool
+	// DisaggregatedSetEnabled is true when the LWS DisaggregatedSet API is available.
+	// It is independent from LWSEnabled because current Dynamo depends on a stable
+	// LWS release while DisaggregatedSet is only available in newer LWS installs.
+	DisaggregatedSetEnabled bool
 	// KaiSchedulerEnabled is the resolved Kai-scheduler availability (config override merged with auto-detection)
 	KaiSchedulerEnabled bool
 	// DRAEnabled indicates whether Dynamic Resource Allocation (resource.k8s.io/v1) is available


### PR DESCRIPTION
## Summary

Adds an opt-in DisaggregatedSet path for non-Grove DynamoGraphDeployment reconciliation using the annotation `nvidia.com/enable-disaggregatedset: "true"`.

The implementation keeps the current stable LWS dependency and renders DisaggregatedSet roles by converting the existing generated LeaderWorkerSet specs to unstructured role specs. It detects the DisaggregatedSet API at operator startup, watches owned DisaggregatedSets when available, and falls back to the existing DynamoComponentDeployment path when gates fail.

## What changed

- Adds runtime DisaggregatedSet API detection and RBAC for `disaggregatedsets.disaggregatedset.x-k8s.io`.
- Adds DS selection/gating for multinode worker roles: prefill, decode, or generic worker components.
- Renders one DisaggregatedSet per DGD with role specs derived from existing LWS generation.
- Keeps selected DCDs as fallback capacity during DS migration and deletes only DGD-owned selected DCDs after DS is ready.
- Reconciles DS side resources for selected roles: k8s-discovery component Services and modelRef headless Services.
- Carries worker rolling-update hash context into DS pod templates while targeting full desired replicas for selected DS roles.
- Adds DS-aware restart progress checks for sequential and parallel restarts.
- Prevents stale DS status from being treated as ready immediately after create/update, and respects observedGeneration when the DS status exposes it.
- Removes the hard LWS worker GPU-limit validation so CPU-only/mock multinode validation remains possible.

## Gates and limitations

- Requires `nvidia.com/enable-disaggregatedset: "true"` on the DGD.
- Requires the DisaggregatedSet CRD/API to be installed.
- Requires LWS to be enabled.
- Requires at least two eligible multinode worker roles.
- Rejects selected components with `scalingAdapter`, because current DisaggregatedSet has no scale subresource.
- Rejects mixed zero and positive role replicas to match DS CRD validation.
- Reports DS role status using `ComponentKindLeaderWorkerSet` until the Dynamo API has a first-class DisaggregatedSet component kind.

## Review pass fixes

I ran a Graham-style review pass and a Cursor-style maintainability review pass before opening this draft. Their actionable findings were addressed in this branch:

- DS rendering now uses the graph rolling-update context so worker hash labels/env are preserved.
- Selected DS roles render full desired replicas during migration, rather than using DCD rolling-update surge budgeting for the new DS workload.
- Selected DCDs are no longer deleted before DS readiness.
- Component/model Services are reconciled and adopted by the DGD before selected DCD cleanup.
- Cleanup is owner-filtered and refuses to delete a same-name DS not controlled by the current DGD.
- Restart completion checks selected components through DS role status and non-selected components through existing DCD readiness.
- DS readiness waits after spec updates and honors observedGeneration when exposed by status.

## Validation

- `go test ./internal/controller -run 'DisaggregatedSet|shouldUseDisaggregatedSet|SelectDisaggregatedSet|CheckDisaggregatedSet|EnsureControlledByDGD|ListOwnedSelectedDCDs'`
- `KUBEBUILDER_ASSETS=/Users/amaddipoti/repos/dynamo/deploy/operator/bin/k8s/1.29.0-darwin-arm64 go test ./internal/controller ./internal/controller_common ./cmd`
- `PATH="$HOME/Library/Python/3.9/bin:$PATH" PROMETHEUS_EXTRA_QUERY_PARAMS='noop=1' make test`
- `git diff --check`

Kubernetes footprint note: the active shared NScale cluster has DGD and LWS APIs but does not currently have the DisaggregatedSet CRD installed. I avoided installing cluster-wide CRDs or creating shared-cluster workloads, and used envtest with a minimal DisaggregatedSet CRD to validate the Kubernetes API create/update path.
