### PR TITLE
perf(embedding): same-node shared-memory fast path for the embedding response

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -13,7 +13,9 @@ import struct
 import tempfile
 import threading
 import time
+import uuid
 from abc import ABC, abstractmethod
+from multiprocessing import resource_tracker, shared_memory
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, Final, Generic, Optional, TypeVar
 
@@ -2986,8 +2988,34 @@ class EmbeddingWorkerHandler:
             if pending:
                 await asyncio.gather(*pending, return_exceptions=True)
 
-        embedding_objects: list[Dict[str, Any]] = []
         prompt_tokens = 0
+        for final_output in outputs:
+            token_ids = getattr(final_output, "prompt_token_ids", None) or []
+            prompt_tokens += len(token_ids)
+        usage = {"prompt_tokens": prompt_tokens, "total_tokens": prompt_tokens}
+
+        # Same-node SHM fast path (opt-in via DYN_EMBEDDING_SHM=1): stage all
+        # vectors as one contiguous [count, dim] f32 buffer in POSIX shared
+        # memory and send only a small handle. The Rust frontend reads
+        # /dev/shm/<name> directly and unlinks it, skipping base64 + JSON on the
+        # worker->frontend hop entirely.
+        if os.environ.get("DYN_EMBEDDING_SHM", "0").lower() in ("1", "true", "yes"):
+            yield {
+                "object": "list",
+                "data": [],
+                "data_shm": _write_embeddings_to_shm(outputs, dimensions),
+                "model": model_name,
+                "usage": usage,
+            }
+            return
+
+        # Default wire format: always base64 (the Rust frontend decodes back to
+        # float when the client's ``encoding_format`` is float or unset).
+        # 15x1024-float JSON arrays cost ~110 ms in Python json.dumps + Rust
+        # serde parse; base64 bytes are ~3x smaller and ~10x faster to
+        # (de)serialize. Client-visible wire format is preserved because Rust
+        # converts at the HTTP boundary.
+        embedding_objects: list[Dict[str, Any]] = []
         for idx, final_output in enumerate(outputs):
             embedding = _pooling_output_to_list(final_output.outputs.data)
             if dimensions is not None:
@@ -2997,14 +3025,6 @@ class EmbeddingWorkerHandler:
                         f"dimension {len(embedding)}"
                     )
                 embedding = embedding[:dimensions]
-
-            # Always emit base64 over the worker->frontend wire format. The
-            # Rust frontend decodes back to float when the client's
-            # ``encoding_format`` is float (or unset). 15x1024-float responses
-            # serialized as JSON arrays cost ~110 ms in Python json.dumps +
-            # Rust serde parse; base64 bytes are ~3x smaller and ~10x faster
-            # to (de)serialize. Client-visible wire format is preserved
-            # because Rust converts at the HTTP boundary.
             embedding_objects.append(
                 {
                     "object": "embedding",
@@ -3012,17 +3032,12 @@ class EmbeddingWorkerHandler:
                     "index": idx,
                 }
             )
-            token_ids = getattr(final_output, "prompt_token_ids", None) or []
-            prompt_tokens += len(token_ids)
 
         yield {
             "object": "list",
             "data": embedding_objects,
             "model": model_name,
-            "usage": {
-                "prompt_tokens": prompt_tokens,
-                "total_tokens": prompt_tokens,
-            },
+            "usage": usage,
         }
 
 
@@ -3133,3 +3148,41 @@ def _encode_floats_to_base64(floats: list[float]) -> str:
     """
     packed = struct.pack(f"<{len(floats)}f", *floats)
     return base64.b64encode(packed).decode("ascii")
+
+
+def _write_embeddings_to_shm(outputs: list[Any], dimensions: int | None) -> dict[str, Any]:
+    """Stage all embedding vectors as one contiguous ``[count, dim]``
+    little-endian f32 buffer in a POSIX shared-memory segment; return the
+    ``{name, count, dim}`` handle.
+
+    Same-node fast path: the Rust frontend opens ``/dev/shm/<name>`` directly,
+    copies the bytes out, and unlinks the segment. The worker creates the
+    segment but unregisters it from multiprocessing's ``resource_tracker`` so
+    the worker and frontend don't both try to unlink it (the frontend owns
+    cleanup). ``torch -> numpy.tobytes`` keeps the heavy copy in C; bytes are
+    little-endian f32, matching the frontend's ``f32::from_le_bytes`` read.
+    """
+    vecs = []
+    for final_output in outputs:
+        vec = final_output.outputs.data.detach().cpu().flatten().to(torch.float32)
+        if dimensions is not None:
+            if dimensions > vec.numel():
+                raise ValueError(
+                    f"dimensions={dimensions} exceeds model embedding "
+                    f"dimension {vec.numel()}"
+                )
+            vec = vec[:dimensions]
+        vecs.append(vec)
+
+    matrix = torch.stack(vecs).contiguous()  # [count, dim], float32
+    count, dim = int(matrix.shape[0]), int(matrix.shape[1])
+    data_bytes = matrix.numpy().tobytes()
+
+    name = f"emb_{os.getpid()}_{uuid.uuid4().hex[:12]}"
+    sm = shared_memory.SharedMemory(name=name, create=True, size=len(data_bytes))
+    sm.buf[: len(data_bytes)] = data_bytes
+    sm.close()
+    # Frontend reads + unlinks; detach from this process's resource_tracker so
+    # the two don't race to unlink at worker exit.
+    resource_tracker.unregister(sm._name, "shared_memory")
+    return {"name": name, "count": count, "dim": dim}

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1008,6 +1008,24 @@ async fn embeddings(
             err_response
         })?;
 
+    // Same-node SHM fast path: if the worker staged the vectors in shared
+    // memory, read them straight from /dev/shm, populate `data`, and unlink
+    // the segment. Skips base64 + JSON serialization on the worker->frontend
+    // hop. read_shm_embeddings produces the client's requested encoding
+    // directly, so the base64->float block below is a no-op for this path.
+    if let Some(handle) = response.data_shm.take() {
+        match read_shm_embeddings(&handle, client_wants_float) {
+            Ok(data) => response.inner.data = data,
+            Err(e) => {
+                tracing::error!("Failed to read SHM embeddings for {}: {:?}", request_id, e);
+                let err_response =
+                    ErrorMessage::internal_server_error("Failed to read embedding shared memory");
+                inflight.mark_error(extract_error_type_from_response(&err_response));
+                return Err(err_response);
+            }
+        }
+    }
+
     // Worker always emits Base64 -- convert back to Float when the client
     // asked for float (or didn't specify, defaulting to float per spec).
     if client_wants_float {
@@ -1061,6 +1079,64 @@ fn decode_base64_embedding_to_floats(s: &str) -> Result<Vec<f32>, anyhow::Error>
         floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
     }
     Ok(floats)
+}
+
+/// Read a contiguous `[count, dim]` little-endian f32 buffer that the worker
+/// staged in POSIX shared memory (`/dev/shm/<name>` on Linux, written by
+/// Python's `multiprocessing.shared_memory`), split it into per-vector
+/// `Embedding`s, and unlink the segment. `as_float` selects the client-visible
+/// encoding (raw floats vs base64) to match the request's `encoding_format`.
+///
+/// The frontend owns cleanup: it `remove_file`s the segment once the bytes are
+/// copied into owned `Vec`s, so the worker must create the segment without
+/// registering it for its own resource-tracker cleanup.
+fn read_shm_embeddings(
+    handle: &crate::protocols::openai::embeddings::EmbeddingShmHandle,
+    as_float: bool,
+) -> Result<Vec<dynamo_protocols::types::Embedding>, anyhow::Error> {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use dynamo_protocols::types::{Embedding, EmbeddingVector};
+
+    let path = format!("/dev/shm/{}", handle.name);
+    let bytes = std::fs::read(&path).map_err(|e| anyhow::anyhow!("read shm {}: {}", path, e))?;
+
+    let vec_bytes_len = handle.dim * std::mem::size_of::<f32>();
+    let expected = handle.count * vec_bytes_len;
+    if bytes.len() < expected {
+        let _ = std::fs::remove_file(&path);
+        anyhow::bail!(
+            "shm segment {} too small: {} bytes < expected {} ({} x {} f32)",
+            path,
+            bytes.len(),
+            expected,
+            handle.count,
+            handle.dim
+        );
+    }
+
+    let mut data = Vec::with_capacity(handle.count);
+    for i in 0..handle.count {
+        let start = i * vec_bytes_len;
+        let vec_bytes = &bytes[start..start + vec_bytes_len];
+        let embedding = if as_float {
+            let mut floats = Vec::with_capacity(handle.dim);
+            for chunk in vec_bytes.chunks_exact(std::mem::size_of::<f32>()) {
+                floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+            }
+            EmbeddingVector::Float(floats)
+        } else {
+            EmbeddingVector::Base64(STANDARD.encode(vec_bytes))
+        };
+        data.push(Embedding {
+            index: i as u32,
+            object: "embedding".to_string(),
+            embedding,
+        });
+    }
+
+    // Unlink now that the bytes are copied into owned Vecs.
+    let _ = std::fs::remove_file(&path);
+    Ok(data)
 }
 
 async fn handler_chat_completions(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2128,6 +2128,7 @@ impl OpenAIPreprocessor {
                             total_tokens: engine_output.total_tokens,
                         },
                     },
+                    data_shm: None,
                 };
 
                 Ok(response)

--- a/lib/llm/src/protocols/openai/embeddings.rs
+++ b/lib/llm/src/protocols/openai/embeddings.rs
@@ -32,6 +32,32 @@ pub struct NvCreateEmbeddingResponse {
     #[serde(flatten)]
     #[schema(value_type = Object)]
     pub inner: dynamo_protocols::types::CreateEmbeddingResponse,
+
+    /// Internal-only handle for an embedding response delivered via POSIX
+    /// shared memory (same-node fast path). When present, `inner.data` is
+    /// empty and the vectors live in `/dev/shm/<name>`; the HTTP handler reads
+    /// them directly, populates `inner.data`, and unlinks the segment. Always
+    /// `None` in the client-facing response (skipped when serializing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_shm: Option<EmbeddingShmHandle>,
+}
+
+/// Handle describing an embedding response staged in POSIX shared memory.
+///
+/// The worker writes a contiguous `[count, dim]` little-endian `f32` buffer to
+/// the shared-memory object `name` (a tmpfs file at `/dev/shm/<name>` on Linux)
+/// and sends only this small handle over the request plane. The frontend reads
+/// the `count * dim * 4` bytes directly and unlinks the segment. This avoids
+/// base64-encoding + JSON-serializing the vectors across the worker->frontend
+/// hop on a co-located deployment.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct EmbeddingShmHandle {
+    /// POSIX shared-memory object name (tmpfs file `/dev/shm/<name>` on Linux).
+    pub name: String,
+    /// Number of embedding vectors stored in the buffer.
+    pub count: usize,
+    /// Dimensionality (number of `f32` elements) of each vector.
+    pub dim: usize,
 }
 
 impl NvCreateEmbeddingResponse {
@@ -46,6 +72,7 @@ impl NvCreateEmbeddingResponse {
                     total_tokens: 0,
                 },
             },
+            data_shm: None,
         }
     }
 }

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -21,6 +21,11 @@ impl StreamAggregable for NvCreateEmbeddingResponse {
         self.inner.data.extend(next.inner.data);
         self.inner.usage.prompt_tokens += next.inner.usage.prompt_tokens;
         self.inner.usage.total_tokens += next.inner.usage.total_tokens;
+        // Carry the SHM handle through aggregation; the empty() base starts
+        // with None, so a single chunk's handle would otherwise be dropped.
+        if next.data_shm.is_some() {
+            self.data_shm = next.data_shm;
+        }
     }
 }
 
@@ -61,6 +66,7 @@ mod tests {
                     total_tokens,
                 },
             },
+            data_shm: None,
         };
 
         Annotated::from_data(response)


### PR DESCRIPTION
> [!WARNING]
> **Superseded — recommend closing.** Re-benchmarking on GB200 found the dynamo embedding worker returns per-token output (wrong shape, dim scales with input length) on vLLM 0.21 — fixed in #10248. With that corrected, the SHM transport provides **no measurable benefit** at a real 1024-dim embedding; the earlier wins were artifacts of the oversized per-token payload. See the corrected same-node p50/p90/p99 matrix in the comment below. **Recommend closing in favor of #10248.**

---

> [!IMPORTANT]
> **Status: parked — not recommended for text embeddings.** Benchmarks (GB200, Qwen3-Embedding-0.6B, batch 15 → 1024) show this SHM path matches the much simpler `numpy.tobytes` serialization fix in #10221 — **same latency** — while adding a same-node constraint (frontend + worker must share `/dev/shm`), per-request `shm_open`/`unlink` syscalls, and a leak-on-error risk. There is also no way for it to compound with #10221: when SHM is on, the base64 path #10221 optimizes is never executed.
>
> **Recommendation:** ship #10221 for text embeddings; keep this PR for the **large-payload / multimodal** path (e.g. frontend→worker image `mm_kwargs`), where the wire transfer itself dominates and shared memory pulls meaningfully ahead. Holding as draft until there's such a consumer.

#### Overview:

For small embedding models the GPU forward pass is sub-millisecond, so **per-request framework overhead dominates** end-to-end latency. A large slice of that overhead is serializing the embedding vectors on the **worker → frontend** hop: the Python worker turns the pooling tensor into a base64 string and ships it as JSON, and the Rust frontend parses + decodes it.

This PR adds an opt-in, **same-node shared-memory fast path** for the embedding response. Instead of serializing the vectors onto the wire, the worker writes them as raw `f32` bytes into a POSIX shared-memory segment (`/dev/shm`) and sends only a tiny `{name, count, dim}` **handle** in the normal response; the frontend reads the bytes directly and unlinks the segment. This is the same `multiprocessing.shared_memory` handle-passing pattern as the multimodal `mm_kwargs_transfer` path, adapted to the worker→frontend direction with a Rust reader.

Enabled with `DYN_EMBEDDING_SHM=1`. Measured on GB200 (Qwen3-Embedding-0.6B, dim 3072): for small batches it matches the cheaper serialization fix; for larger response payloads (e.g. batch 64, ~786 KB) it begins to pull ahead, and the gap grows with payload size.

#### Architecture:

The frontend (Rust HTTP) and worker (Python/vLLM) stay as **two separate processes** — no merged CLI, no single-process mode. The only change is *how the response payload crosses between them when they're co-located* (sharing `/dev/shm`):

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant F as Frontend<br/>(Rust, HTTP)
    participant W as Worker<br/>(Python, vLLM)
    participant S as /dev/shm<br/>(POSIX shared memory)

    C->>F: POST /v1/embeddings
    F->>W: request (token ids) over request plane
    W->>W: engine.encode → pooling tensor [count, dim]

    alt DYN_EMBEDDING_SHM=1  (same-node fast path)
        W->>S: write [count, dim] f32 (numpy.tobytes)
        W-->>F: response { data: [], data_shm: {name, count, dim} }
        Note over W,F: only a tiny handle crosses the wire
        F->>S: std::fs::read("/dev/shm/<name>")
        F->>S: remove_file  (unlink — frontend owns cleanup)
        F->>F: build vectors in client's encoding (float / base64)
    else default  (base64 over the wire)
        W->>W: tensor → base64
        W-->>F: response { data: [ {embedding: "<base64>"}, ... ] }
        F->>F: base64 → float (if client asked for float)
    end

    F-->>C: embeddings JSON
```

Key properties:
- **Opt-in & same-node only.** When `DYN_EMBEDDING_SHM` is unset, the existing base64-over-the-wire path is used unchanged. SHM requires the frontend and worker to share `/dev/shm` (one pod / shared IPC); cross-node deployments keep the normal path.
- **No protocol break.** The handle rides on an internal `data_shm` field that is never serialized to the client; the public `/v1/embeddings` response is identical.
- **No new deps.** POSIX shm is tmpfs at `/dev/shm`, so the frontend just uses `std::fs::read` / `remove_file` — no `libc`/`mmap`.

#### Details:

**Worker (Python — `components/src/dynamo/vllm/handlers.py`)**
- `_write_embeddings_to_shm()` stacks the batch into one contiguous `[count, dim]` little-endian `f32` buffer (`torch.stack` → `numpy.tobytes`), writes it to a fresh `multiprocessing.shared_memory` segment, and returns the `{name, count, dim}` handle.
- The embedding handler yields `{ "data": [], "data_shm": {...} }` when `DYN_EMBEDDING_SHM` is set, else the unchanged base64 list.
- The segment is **unregistered from `resource_tracker`** so the worker doesn't race the frontend to unlink it — the frontend owns cleanup.

**Frontend (Rust)**
- `lib/llm/src/protocols/openai/embeddings.rs`: `NvCreateEmbeddingResponse` gains an internal `data_shm: Option<EmbeddingShmHandle>` (`#[serde(skip_serializing_if)]`, so never sent to the client).
- `.../embeddings/aggregator.rs`: `merge` carries the handle through the stream fold.
- `lib/llm/src/http/service/openai.rs`: `read_shm_embeddings()` does `std::fs::read("/dev/shm/<name>")` → `count × dim` `f32` → vectors in the client's requested encoding → `remove_file` (unlink). The `embeddings` handler invokes it before the existing base64-decode step.

#### Benchmark (GB200, Qwen3-Embedding-0.6B, dim 3072, ISL 80):

Per-request latency (ms, avg). σ = standard deviation of per-request latency across the run (run noise, **not** an error bar on the mean); `%` figures compare the avg. Small batches: rate-limited (no queueing), 200/100 reqs. Large batches: closed-loop `--concurrency 1`, 40/25 reqs.

| batch | response (raw f32) | baseline (`tolist`+`struct.pack`) | numpy.tobytes (#10221) | **SHM** (this PR) | numpy.tobytes + SHM |
| -- | -- | -- | -- | -- | -- |
| 15 | ~184 KB | 124.25 | 86.94 | **85.49** | 85.31 |
| 64 | ~786 KB | 469.54 | 306.57 | **290.69** | 294.72 |
| 128 | ~1.5 MB | 934.16 | 584.31 | **573.98** | 566.64 |
| 256 | ~3 MB | 1,860.85 | 1,182.62 | **1,128.59** | 1,126.00 |
| 512 | ~6 MB | 3,684.53 | 2,364.84 | **2,301.73** | 2,200.67 |
| 1024 | ~12 MB | 7,491.99 | 4,694.72 | **4,615.99** | 4,447.78 |

(avg ms.) Both serialization-killers beat the baseline by ~30–37%, growing with batch. **SHM's edge over the much simpler `numpy.tobytes` (#10221) is only ~2–5% and within run-to-run noise** at every size (the two ran on different nodes) — i.e. statistically indistinguishable for text embeddings. SHM's real advantage is reserved for payloads large enough that the wire transfer dominates (multimodal), which is why this PR is parked rather than recommended for the embedding path.

#### Where should the reviewer start?

- `lib/llm/src/http/service/openai.rs` — `read_shm_embeddings` + the `data_shm` branch in the `embeddings` handler (the read + unlink).
- `lib/llm/src/protocols/openai/embeddings.rs` and `.../embeddings/aggregator.rs` — the internal `data_shm` field and the fold carry-through.
- `components/src/dynamo/vllm/handlers.py` — `_write_embeddings_to_shm` and the gated yield.

#### Caveats / follow-ups:

- **Leak-on-error:** if the frontend dies after the worker writes but before it unlinks, the segment lingers in `/dev/shm` until the container restarts. A worker-side reaper / TTL is wanted before this is used outside benchmarking.
- Same-node constraint is enforced only by operator config today (the env var); auto-detecting co-location is a follow-up.
- For small text-embedding payloads, a simpler change — building the base64 directly from the tensor with `numpy.tobytes` — captures most of the same win without shared memory and works cross-node; this SHM path is aimed at larger payloads where the wire transfer itself dominates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

