### PR TITLE
feat: bypass global router in response stream

### DIFF
--- a/components/src/dynamo/common/global_router_protocol.py
+++ b/components/src/dynamo/common/global_router_protocol.py
@@ -7,6 +7,9 @@ from typing import Any, Mapping, Optional
 
 GLOBAL_ROUTER_CONTROL_FIELD = "global_router_control"
 GLOBAL_ROUTER_RETRY_ATTEMPT_KEY = "global_router_retry_attempt"
+GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S_KEY = (
+    "dynamo.global_router_response_prologue_timeout_s"
+)
 
 GLOBAL_ROUTER_ACTION_RETRY = "retry"
 GLOBAL_ROUTER_ACTION_EXHAUSTED = "exhausted"

--- a/components/src/dynamo/common/global_router_protocol.py
+++ b/components/src/dynamo/common/global_router_protocol.py
@@ -20,9 +20,9 @@ def get_global_router_retry_attempt(request: Mapping[str, Any]) -> Optional[int]
         return None
 
     value = routing[GLOBAL_ROUTER_RETRY_ATTEMPT_KEY]
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"{GLOBAL_ROUTER_RETRY_ATTEMPT_KEY} must be an integer")
-    retry_attempt = int(value)
+    retry_attempt = value
     if retry_attempt < 0:
         raise ValueError(f"{GLOBAL_ROUTER_RETRY_ATTEMPT_KEY} must be >= 0")
     return retry_attempt

--- a/components/src/dynamo/common/global_router_protocol.py
+++ b/components/src/dynamo/common/global_router_protocol.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared request/control fields for frontend <-> global-router coordination."""
+
+from typing import Any, Mapping, Optional
+
+GLOBAL_ROUTER_CONTROL_FIELD = "global_router_control"
+GLOBAL_ROUTER_RETRY_ATTEMPT_KEY = "global_router_retry_attempt"
+
+GLOBAL_ROUTER_ACTION_RETRY = "retry"
+
+
+def get_global_router_retry_attempt(request: Mapping[str, Any]) -> Optional[int]:
+    routing = request.get("routing") or {}
+    if not isinstance(routing, Mapping):
+        return None
+    if GLOBAL_ROUTER_RETRY_ATTEMPT_KEY not in routing:
+        return None
+
+    value = routing[GLOBAL_ROUTER_RETRY_ATTEMPT_KEY]
+    if isinstance(value, bool):
+        raise ValueError(f"{GLOBAL_ROUTER_RETRY_ATTEMPT_KEY} must be an integer")
+    retry_attempt = int(value)
+    if retry_attempt < 0:
+        raise ValueError(f"{GLOBAL_ROUTER_RETRY_ATTEMPT_KEY} must be >= 0")
+    return retry_attempt
+
+
+def make_global_router_retry_control(
+    *,
+    request_type: str,
+    retry_attempt: int,
+    next_retry_attempt: int,
+    failed_pool: int,
+    failed_namespace: str,
+    next_pool: int,
+    next_namespace: str,
+    error: str,
+) -> dict[str, Any]:
+    return {
+        GLOBAL_ROUTER_CONTROL_FIELD: {
+            "action": GLOBAL_ROUTER_ACTION_RETRY,
+            "request_type": request_type,
+            "retry_attempt": retry_attempt,
+            "next_retry_attempt": next_retry_attempt,
+            "failed_pool": failed_pool,
+            "failed_namespace": failed_namespace,
+            "next_pool": next_pool,
+            "next_namespace": next_namespace,
+            "error": error,
+        }
+    }
+
+
+def get_global_router_control(data: Any) -> Optional[Mapping[str, Any]]:
+    if not isinstance(data, Mapping):
+        return None
+    control = data.get(GLOBAL_ROUTER_CONTROL_FIELD)
+    if not isinstance(control, Mapping):
+        return None
+    return control

--- a/components/src/dynamo/common/global_router_protocol.py
+++ b/components/src/dynamo/common/global_router_protocol.py
@@ -9,6 +9,7 @@ GLOBAL_ROUTER_CONTROL_FIELD = "global_router_control"
 GLOBAL_ROUTER_RETRY_ATTEMPT_KEY = "global_router_retry_attempt"
 
 GLOBAL_ROUTER_ACTION_RETRY = "retry"
+GLOBAL_ROUTER_ACTION_EXHAUSTED = "exhausted"
 
 
 def get_global_router_retry_attempt(request: Mapping[str, Any]) -> Optional[int]:
@@ -48,6 +49,26 @@ def make_global_router_retry_control(
             "failed_namespace": failed_namespace,
             "next_pool": next_pool,
             "next_namespace": next_namespace,
+            "error": error,
+        }
+    }
+
+
+def make_global_router_retry_exhausted_control(
+    *,
+    request_type: str,
+    retry_attempt: int,
+    error: str,
+    failed_pool: Optional[int] = None,
+    failed_namespace: Optional[str] = None,
+) -> dict[str, Any]:
+    return {
+        GLOBAL_ROUTER_CONTROL_FIELD: {
+            "action": GLOBAL_ROUTER_ACTION_EXHAUSTED,
+            "request_type": request_type,
+            "retry_attempt": retry_attempt,
+            "failed_pool": failed_pool,
+            "failed_namespace": failed_namespace,
             "error": error,
         }
     }

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -448,6 +448,35 @@ def test_frontend_global_router_adapter_accepts_vllm_processor(monkeypatch) -> N
     assert config.routed_engine_adapter == "global-router"
 
 
+def test_frontend_global_router_prologue_timeout_flag(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        ["--dyn-global-router-response-prologue-timeout-s", "12.5"]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.global_router_response_prologue_timeout_s == 12.5
+
+
+def test_frontend_global_router_prologue_timeout_must_be_positive(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("DYN_GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--dyn-global-router-response-prologue-timeout-s", "0"])
+
+    config = FrontendConfig.from_cli_args(args)
+    with pytest.raises(ValueError, match="response-prologue-timeout-s must be > 0"):
+        config.validate()
+
+
 def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
     """Default --admission-control is 'none': busy thresholds are cleared
     even though the underlying threshold flags have non-None defaults."""

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -414,6 +414,40 @@ def test_load_aware_frontend_implies_kv_router_mode() -> None:
     assert config.router_assume_kv_reuse is False
 
 
+def test_frontend_global_router_adapter_requires_python_processor(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_ROUTED_ENGINE_ADAPTER", raising=False)
+    monkeypatch.delenv("DYN_CHAT_PROCESSOR", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--dyn-routed-engine-adapter", "global-router"])
+
+    config = FrontendConfig.from_cli_args(args)
+    with pytest.raises(ValueError, match="requires --dyn-chat-processor"):
+        config.validate()
+
+
+def test_frontend_global_router_adapter_accepts_vllm_processor(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_ROUTED_ENGINE_ADAPTER", raising=False)
+    monkeypatch.delenv("DYN_CHAT_PROCESSOR", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--dyn-chat-processor",
+            "vllm",
+            "--dyn-routed-engine-adapter",
+            "global-router",
+        ]
+    )
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.routed_engine_adapter == "global-router"
+
+
 def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
     """Default --admission-control is 'none': busy thresholds are cleared
     even though the underlying threshold flags have non-None defaults."""

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -488,9 +488,10 @@ class FrontendArgGroup(ArgGroup):
             default=30.0,
             dest="global_router_response_prologue_timeout_s",
             help=(
-                "[EXPERIMENTAL] Timeout in seconds for the frontend to wait for "
-                "a global-router delegated response stream prologue before "
-                "retrying the next priority pool. Applies only with "
+                "[EXPERIMENTAL] Timeout in seconds for the Rust routed-engine "
+                "client to wait for a global-router delegated response stream "
+                "prologue before failing the attempt so the frontend can retry "
+                "the next priority pool. Applies only with "
                 "--dyn-routed-engine-adapter=global-router."
             ),
             arg_type=float,

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -77,6 +77,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     event_plane: Optional[str] = None
     chat_processor: str
     routed_engine_adapter: str
+    global_router_response_prologue_timeout_s: Optional[float]
     enable_anthropic_api: bool
     strip_anthropic_preamble: bool
     debug_perf: bool
@@ -129,6 +130,13 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
             raise ValueError(
                 "--dyn-routed-engine-adapter=global-router currently requires "
                 "--dyn-chat-processor=vllm or --dyn-chat-processor=sglang"
+            )
+        if (
+            self.global_router_response_prologue_timeout_s is not None
+            and self.global_router_response_prologue_timeout_s <= 0
+        ):
+            raise ValueError(
+                "--dyn-global-router-response-prologue-timeout-s must be > 0"
             )
         if self.router_prefill_load_model == "aic":
             if self.router_mode != "kv":
@@ -472,6 +480,20 @@ class FrontendArgGroup(ArgGroup):
                 "through a global router."
             ),
             choices=["default", "global-router"],
+        )
+        add_argument(
+            g,
+            flag_name="--dyn-global-router-response-prologue-timeout-s",
+            env_var="DYN_GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S",
+            default=30.0,
+            dest="global_router_response_prologue_timeout_s",
+            help=(
+                "[EXPERIMENTAL] Timeout in seconds for the frontend to wait for "
+                "a global-router delegated response stream prologue before "
+                "retrying the next priority pool. Applies only with "
+                "--dyn-routed-engine-adapter=global-router."
+            ),
+            arg_type=float,
         )
 
         add_negatable_bool_argument(

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -76,6 +76,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     request_plane: str
     event_plane: Optional[str] = None
     chat_processor: str
+    routed_engine_adapter: str
     enable_anthropic_api: bool
     strip_anthropic_preamble: bool
     debug_perf: bool
@@ -87,6 +88,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     trust_remote_code: bool
 
     _VALID_TOKENIZER_BACKENDS = {"default", "fastokens"}
+    _VALID_ROUTED_ENGINE_ADAPTERS = {"default", "global-router"}
 
     def validate(self) -> None:
         if self.load_aware:
@@ -113,6 +115,20 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
             raise ValueError(
                 f"--tokenizer: invalid value '{self.tokenizer_backend}' "
                 f"(choose from {sorted(self._VALID_TOKENIZER_BACKENDS)})"
+            )
+        if self.routed_engine_adapter not in self._VALID_ROUTED_ENGINE_ADAPTERS:
+            raise ValueError(
+                f"--dyn-routed-engine-adapter: invalid value "
+                f"'{self.routed_engine_adapter}' "
+                f"(choose from {sorted(self._VALID_ROUTED_ENGINE_ADAPTERS)})"
+            )
+        if (
+            self.routed_engine_adapter == "global-router"
+            and self.chat_processor == "dynamo"
+        ):
+            raise ValueError(
+                "--dyn-routed-engine-adapter=global-router currently requires "
+                "--dyn-chat-processor=vllm or --dyn-chat-processor=sglang"
             )
         if self.router_prefill_load_model == "aic":
             if self.router_mode != "kv":
@@ -442,6 +458,20 @@ class FrontendArgGroup(ArgGroup):
                 "parsing, and reasoning parsing."
             ),
             choices=["dynamo", "vllm", "sglang"],
+        )
+        add_argument(
+            g,
+            flag_name="--dyn-routed-engine-adapter",
+            env_var="DYN_ROUTED_ENGINE_ADAPTER",
+            default="default",
+            dest="routed_engine_adapter",
+            help=(
+                "[EXPERIMENTAL] Routed-engine topology adapter. 'default' calls "
+                "the discovered routed engine directly. 'global-router' enables "
+                "frontend-managed retry attempts for direct delegated responses "
+                "through a global router."
+            ),
+            choices=["default", "global-router"],
         )
 
         add_negatable_bool_argument(

--- a/components/src/dynamo/frontend/routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/routed_engine_adapters.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from dynamo.common.global_router_protocol import (
+    GLOBAL_ROUTER_ACTION_EXHAUSTED,
     GLOBAL_ROUTER_ACTION_RETRY,
     GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
     get_global_router_control,
@@ -27,6 +28,14 @@ VALID_ROUTED_ENGINE_ADAPTERS = {
 }
 
 _MAX_GLOBAL_ROUTER_RETRY_CONTROLS = 32
+
+
+class _GlobalRouterControlError(RuntimeError):
+    pass
+
+
+class _GlobalRouterRetryExhausted(_GlobalRouterControlError):
+    pass
 
 
 def wrap_routed_engine(config: Any, routed_engine: RoutedEngine) -> RoutedEngine:
@@ -58,44 +67,84 @@ class GlobalRouterRoutedEngineAdapter:
         retry_controls = 0
 
         while True:
-            stream = await self._routed_engine.generate(
-                _request_for_retry_attempt(request, attempt), **kwargs
-            )
             yielded_output = False
             next_attempt = None
+            retry_error = None
 
-            async for output in stream:
-                data = output.data() if hasattr(output, "data") else output
-                control = get_global_router_control(data)
-                if control is not None:
-                    if yielded_output:
-                        raise RuntimeError(
-                            "global router retry control received after response "
-                            "streaming started"
+            try:
+                stream = await self._routed_engine.generate(
+                    _request_for_retry_attempt(request, attempt), **kwargs
+                )
+
+                async for output in stream:
+                    data = output.data() if hasattr(output, "data") else output
+                    control = get_global_router_control(data)
+                    if control is not None:
+                        if yielded_output:
+                            raise RuntimeError(
+                                "global router retry control received after response "
+                                "streaming started"
+                            )
+                        action = control.get("action")
+                        if action == GLOBAL_ROUTER_ACTION_EXHAUSTED:
+                            raise _GlobalRouterRetryExhausted(
+                                _retry_exhausted_message(control)
+                            )
+                        next_attempt = _next_retry_attempt(control)
+                        logger.warning(
+                            "Retrying global-router request via next pool: "
+                            "attempt=%s next_attempt=%s failed_namespace=%s "
+                            "next_namespace=%s error=%s",
+                            attempt,
+                            next_attempt,
+                            control.get("failed_namespace"),
+                            control.get("next_namespace"),
+                            control.get("error"),
                         )
-                    next_attempt = _next_retry_attempt(control)
-                    logger.warning(
-                        "Retrying global-router request via next pool: "
-                        "attempt=%s next_attempt=%s failed_namespace=%s "
-                        "next_namespace=%s error=%s",
-                        attempt,
-                        next_attempt,
-                        control.get("failed_namespace"),
-                        control.get("next_namespace"),
-                        control.get("error"),
-                    )
-                    break
+                        break
 
-                yielded_output = True
-                yield output
+                    yielded_output = True
+                    yield output
+            except _GlobalRouterControlError:
+                raise
+            except Exception as exc:
+                if yielded_output:
+                    raise
+                next_attempt = attempt + 1
+                retry_error = exc
+                logger.warning(
+                    "Retrying global-router request after pre-output delegated "
+                    "response failure: attempt=%s next_attempt=%s error=%s",
+                    attempt,
+                    next_attempt,
+                    exc,
+                )
 
             if next_attempt is None:
                 return
+            if next_attempt <= attempt:
+                raise RuntimeError(
+                    "global router retry attempt did not increase: "
+                    f"attempt={attempt} next_attempt={next_attempt}"
+                )
 
             retry_controls += 1
             if retry_controls > _MAX_GLOBAL_ROUTER_RETRY_CONTROLS:
-                raise RuntimeError("global router retry control loop exceeded limit")
+                raise RuntimeError(
+                    "global router retry control loop exceeded limit"
+                ) from retry_error
             attempt = next_attempt
+
+
+def _retry_exhausted_message(control: Any) -> str:
+    error = control.get("error")
+    if error:
+        return str(error)
+    return (
+        "global router retry attempts exhausted: "
+        f"request_type={control.get('request_type')} "
+        f"retry_attempt={control.get('retry_attempt')}"
+    )
 
 
 def _request_for_retry_attempt(request: Any, retry_attempt: int) -> Any:
@@ -110,16 +159,22 @@ def _request_for_retry_attempt(request: Any, retry_attempt: int) -> Any:
 
 def _next_retry_attempt(control: Any) -> int:
     if control.get("action") != GLOBAL_ROUTER_ACTION_RETRY:
-        raise RuntimeError(f"unsupported global router control action: {control!r}")
+        raise _GlobalRouterControlError(
+            f"unsupported global router control action: {control!r}"
+        )
     value = control.get("next_retry_attempt")
     if isinstance(value, bool):
-        raise RuntimeError(f"invalid global router next retry attempt: {value!r}")
+        raise _GlobalRouterControlError(
+            f"invalid global router next retry attempt: {value!r}"
+        )
     try:
         next_attempt = int(value)
     except (TypeError, ValueError) as exc:
-        raise RuntimeError(
+        raise _GlobalRouterControlError(
             f"invalid global router next retry attempt: {value!r}"
         ) from exc
     if next_attempt < 0:
-        raise RuntimeError(f"invalid global router next retry attempt: {value!r}")
+        raise _GlobalRouterControlError(
+            f"invalid global router next retry attempt: {value!r}"
+        )
     return next_attempt

--- a/components/src/dynamo/frontend/routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/routed_engine_adapters.py
@@ -3,13 +3,13 @@
 
 """Topology-specific wrappers for frontend routed-engine calls."""
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from dynamo.common.global_router_protocol import (
     GLOBAL_ROUTER_ACTION_EXHAUSTED,
     GLOBAL_ROUTER_ACTION_RETRY,
+    GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S_KEY,
     GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
     get_global_router_control,
 )
@@ -90,16 +90,19 @@ class GlobalRouterRoutedEngineAdapter:
                 stream = await self._generate_attempt(
                     _request_for_retry_attempt(request, attempt), **kwargs
                 )
-            except TimeoutError as exc:
-                next_attempt = attempt + 1
-                retry_error = exc
-                logger.warning(
-                    "Retrying global-router request after response prologue "
-                    "timeout: attempt=%s next_attempt=%s timeout_s=%s",
-                    attempt,
-                    next_attempt,
-                    self._response_prologue_timeout_s,
-                )
+            except Exception as exc:
+                if _is_response_prologue_timeout(exc):
+                    next_attempt = attempt + 1
+                    retry_error = exc
+                    logger.warning(
+                        "Retrying global-router request after response prologue "
+                        "timeout: attempt=%s next_attempt=%s timeout_s=%s",
+                        attempt,
+                        next_attempt,
+                        self._response_prologue_timeout_s,
+                    )
+                else:
+                    raise
             else:
                 try:
                     async for output in stream:
@@ -165,13 +168,11 @@ class GlobalRouterRoutedEngineAdapter:
     async def _generate_attempt(
         self, request: Any, **kwargs: Any
     ) -> AsyncIterator[Any]:
-        generate = self._routed_engine.generate(request, **kwargs)
-        if self._response_prologue_timeout_s is None:
-            return await generate
-        return await asyncio.wait_for(
-            generate,
-            timeout=self._response_prologue_timeout_s,
+        _set_response_prologue_timeout_metadata(
+            kwargs.get("context"),
+            self._response_prologue_timeout_s,
         )
+        return await self._routed_engine.generate(request, **kwargs)
 
 
 def _retry_exhausted_message(control: Any) -> str:
@@ -193,6 +194,26 @@ def _request_for_retry_attempt(request: Any, retry_attempt: int) -> Any:
     routing[GLOBAL_ROUTER_RETRY_ATTEMPT_KEY] = retry_attempt
     next_request["routing"] = routing
     return next_request
+
+
+def _set_response_prologue_timeout_metadata(
+    context: Any,
+    timeout_s: float | None,
+) -> None:
+    if context is None or timeout_s is None:
+        return
+    metadata = getattr(context, "metadata", None)
+    if metadata is None:
+        return
+    metadata[GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S_KEY] = str(timeout_s)
+
+
+def _is_response_prologue_timeout(exc: Exception) -> bool:
+    message = str(exc)
+    return (
+        "ConnectionTimeout" in message
+        and "response stream prologue timed out" in message
+    )
 
 
 def _next_retry_attempt(control: Any) -> int:

--- a/components/src/dynamo/frontend/routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/routed_engine_adapters.py
@@ -3,6 +3,7 @@
 
 """Topology-specific wrappers for frontend routed-engine calls."""
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -28,6 +29,7 @@ VALID_ROUTED_ENGINE_ADAPTERS = {
 }
 
 _MAX_GLOBAL_ROUTER_RETRY_CONTROLS = 32
+_DEFAULT_GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S = 30.0
 
 
 class _GlobalRouterControlError(RuntimeError):
@@ -41,7 +43,14 @@ class _GlobalRouterRetryExhausted(_GlobalRouterControlError):
 def wrap_routed_engine(config: Any, routed_engine: RoutedEngine) -> RoutedEngine:
     adapter = getattr(config, "routed_engine_adapter", ROUTED_ENGINE_ADAPTER_DEFAULT)
     if adapter == ROUTED_ENGINE_ADAPTER_GLOBAL_ROUTER:
-        return GlobalRouterRoutedEngineAdapter(routed_engine)
+        return GlobalRouterRoutedEngineAdapter(
+            routed_engine,
+            response_prologue_timeout_s=getattr(
+                config,
+                "global_router_response_prologue_timeout_s",
+                _DEFAULT_GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S,
+            ),
+        )
     return routed_engine
 
 
@@ -54,8 +63,14 @@ class GlobalRouterRoutedEngineAdapter:
     the same request with the next retry attempt.
     """
 
-    def __init__(self, routed_engine: RoutedEngine):
+    def __init__(
+        self,
+        routed_engine: RoutedEngine,
+        response_prologue_timeout_s: float
+        | None = (_DEFAULT_GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S),
+    ):
         self._routed_engine = routed_engine
+        self._response_prologue_timeout_s = response_prologue_timeout_s
 
     async def generate(self, request: Any, **kwargs: Any) -> AsyncIterator[Any]:
         return self._generate_with_global_router_retries(request, **kwargs)
@@ -64,7 +79,7 @@ class GlobalRouterRoutedEngineAdapter:
         self, request: Any, **kwargs: Any
     ) -> AsyncIterator[Any]:
         attempt = 0
-        retry_controls = 0
+        retry_steps = 0
 
         while True:
             yielded_output = False
@@ -72,53 +87,65 @@ class GlobalRouterRoutedEngineAdapter:
             retry_error = None
 
             try:
-                stream = await self._routed_engine.generate(
+                stream = await self._generate_attempt(
                     _request_for_retry_attempt(request, attempt), **kwargs
                 )
-
-                async for output in stream:
-                    data = output.data() if hasattr(output, "data") else output
-                    control = get_global_router_control(data)
-                    if control is not None:
-                        if yielded_output:
-                            raise RuntimeError(
-                                "global router retry control received after response "
-                                "streaming started"
-                            )
-                        action = control.get("action")
-                        if action == GLOBAL_ROUTER_ACTION_EXHAUSTED:
-                            raise _GlobalRouterRetryExhausted(
-                                _retry_exhausted_message(control)
-                            )
-                        next_attempt = _next_retry_attempt(control)
-                        logger.warning(
-                            "Retrying global-router request via next pool: "
-                            "attempt=%s next_attempt=%s failed_namespace=%s "
-                            "next_namespace=%s error=%s",
-                            attempt,
-                            next_attempt,
-                            control.get("failed_namespace"),
-                            control.get("next_namespace"),
-                            control.get("error"),
-                        )
-                        break
-
-                    yielded_output = True
-                    yield output
-            except _GlobalRouterControlError:
-                raise
-            except Exception as exc:
-                if yielded_output:
-                    raise
+            except TimeoutError as exc:
                 next_attempt = attempt + 1
                 retry_error = exc
                 logger.warning(
-                    "Retrying global-router request after pre-output delegated "
-                    "response failure: attempt=%s next_attempt=%s error=%s",
+                    "Retrying global-router request after response prologue "
+                    "timeout: attempt=%s next_attempt=%s timeout_s=%s",
                     attempt,
                     next_attempt,
-                    exc,
+                    self._response_prologue_timeout_s,
                 )
+            else:
+                try:
+                    async for output in stream:
+                        data = output.data() if hasattr(output, "data") else output
+                        control = get_global_router_control(data)
+                        if control is not None:
+                            if yielded_output:
+                                raise RuntimeError(
+                                    "global router retry control received after response "
+                                    "streaming started"
+                                )
+                            action = control.get("action")
+                            if action == GLOBAL_ROUTER_ACTION_EXHAUSTED:
+                                raise _GlobalRouterRetryExhausted(
+                                    _retry_exhausted_message(control)
+                                )
+                            next_attempt = _next_retry_attempt(control)
+                            logger.warning(
+                                "Retrying global-router request via next pool: "
+                                "attempt=%s next_attempt=%s failed_namespace=%s "
+                                "next_namespace=%s error=%s",
+                                attempt,
+                                next_attempt,
+                                control.get("failed_namespace"),
+                                control.get("next_namespace"),
+                                control.get("error"),
+                            )
+                            break
+
+                        yielded_output = True
+                        yield output
+                except _GlobalRouterControlError:
+                    raise
+                except Exception as exc:
+                    if yielded_output:
+                        raise
+                    next_attempt = attempt + 1
+                    retry_error = exc
+                    logger.warning(
+                        "Retrying global-router request after established delegated "
+                        "response stream failed before output: attempt=%s "
+                        "next_attempt=%s error=%s",
+                        attempt,
+                        next_attempt,
+                        exc,
+                    )
 
             if next_attempt is None:
                 return
@@ -128,12 +155,23 @@ class GlobalRouterRoutedEngineAdapter:
                     f"attempt={attempt} next_attempt={next_attempt}"
                 )
 
-            retry_controls += 1
-            if retry_controls > _MAX_GLOBAL_ROUTER_RETRY_CONTROLS:
+            retry_steps += 1
+            if retry_steps > _MAX_GLOBAL_ROUTER_RETRY_CONTROLS:
                 raise RuntimeError(
-                    "global router retry control loop exceeded limit"
+                    "global router retry loop exceeded limit"
                 ) from retry_error
             attempt = next_attempt
+
+    async def _generate_attempt(
+        self, request: Any, **kwargs: Any
+    ) -> AsyncIterator[Any]:
+        generate = self._routed_engine.generate(request, **kwargs)
+        if self._response_prologue_timeout_s is None:
+            return await generate
+        return await asyncio.wait_for(
+            generate,
+            timeout=self._response_prologue_timeout_s,
+        )
 
 
 def _retry_exhausted_message(control: Any) -> str:

--- a/components/src/dynamo/frontend/routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/routed_engine_adapters.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Topology-specific wrappers for frontend routed-engine calls."""
+
+import logging
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
+from dynamo.common.global_router_protocol import (
+    GLOBAL_ROUTER_ACTION_RETRY,
+    GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
+    get_global_router_control,
+)
+
+if TYPE_CHECKING:
+    from dynamo.llm import RoutedEngine
+else:
+    RoutedEngine = Any
+
+logger = logging.getLogger(__name__)
+
+ROUTED_ENGINE_ADAPTER_DEFAULT = "default"
+ROUTED_ENGINE_ADAPTER_GLOBAL_ROUTER = "global-router"
+VALID_ROUTED_ENGINE_ADAPTERS = {
+    ROUTED_ENGINE_ADAPTER_DEFAULT,
+    ROUTED_ENGINE_ADAPTER_GLOBAL_ROUTER,
+}
+
+_MAX_GLOBAL_ROUTER_RETRY_CONTROLS = 32
+
+
+def wrap_routed_engine(config: Any, routed_engine: RoutedEngine) -> RoutedEngine:
+    adapter = getattr(config, "routed_engine_adapter", ROUTED_ENGINE_ADAPTER_DEFAULT)
+    if adapter == ROUTED_ENGINE_ADAPTER_GLOBAL_ROUTER:
+        return GlobalRouterRoutedEngineAdapter(routed_engine)
+    return routed_engine
+
+
+class GlobalRouterRoutedEngineAdapter:
+    """Frontend-side retry loop for direct responses through a global router.
+
+    The global router handles one pool attempt per request when this adapter is
+    enabled. If that dispatch fails before a delegated response is established,
+    the global router emits a control item instructing the frontend to reissue
+    the same request with the next retry attempt.
+    """
+
+    def __init__(self, routed_engine: RoutedEngine):
+        self._routed_engine = routed_engine
+
+    async def generate(self, request: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        return self._generate_with_global_router_retries(request, **kwargs)
+
+    async def _generate_with_global_router_retries(
+        self, request: Any, **kwargs: Any
+    ) -> AsyncIterator[Any]:
+        attempt = 0
+        retry_controls = 0
+
+        while True:
+            stream = await self._routed_engine.generate(
+                _request_for_retry_attempt(request, attempt), **kwargs
+            )
+            yielded_output = False
+            next_attempt = None
+
+            async for output in stream:
+                data = output.data() if hasattr(output, "data") else output
+                control = get_global_router_control(data)
+                if control is not None:
+                    if yielded_output:
+                        raise RuntimeError(
+                            "global router retry control received after response "
+                            "streaming started"
+                        )
+                    next_attempt = _next_retry_attempt(control)
+                    logger.warning(
+                        "Retrying global-router request via next pool: "
+                        "attempt=%s next_attempt=%s failed_namespace=%s "
+                        "next_namespace=%s error=%s",
+                        attempt,
+                        next_attempt,
+                        control.get("failed_namespace"),
+                        control.get("next_namespace"),
+                        control.get("error"),
+                    )
+                    break
+
+                yielded_output = True
+                yield output
+
+            if next_attempt is None:
+                return
+
+            retry_controls += 1
+            if retry_controls > _MAX_GLOBAL_ROUTER_RETRY_CONTROLS:
+                raise RuntimeError("global router retry control loop exceeded limit")
+            attempt = next_attempt
+
+
+def _request_for_retry_attempt(request: Any, retry_attempt: int) -> Any:
+    if not isinstance(request, dict):
+        raise TypeError("global-router routed-engine adapter requires dict requests")
+    next_request = dict(request)
+    routing = dict(request.get("routing") or {})
+    routing[GLOBAL_ROUTER_RETRY_ATTEMPT_KEY] = retry_attempt
+    next_request["routing"] = routing
+    return next_request
+
+
+def _next_retry_attempt(control: Any) -> int:
+    if control.get("action") != GLOBAL_ROUTER_ACTION_RETRY:
+        raise RuntimeError(f"unsupported global router control action: {control!r}")
+    value = control.get("next_retry_attempt")
+    if isinstance(value, bool):
+        raise RuntimeError(f"invalid global router next retry attempt: {value!r}")
+    try:
+        next_attempt = int(value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"invalid global router next retry attempt: {value!r}"
+        ) from exc
+    if next_attempt < 0:
+        raise RuntimeError(f"invalid global router next retry attempt: {value!r}")
+    return next_attempt

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -19,6 +19,7 @@ from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
 from dynamo._internal import ModelDeploymentCard
 from dynamo.frontend.frontend_args import FrontendConfig
+from dynamo.frontend.routed_engine_adapters import wrap_routed_engine
 from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
 from dynamo.llm.exceptions import InvalidArgument, Unknown
 
@@ -688,6 +689,8 @@ class SglangEngineFactory:
             )
 
         logger.info("SGLang processor stream_interval=%d", self.stream_interval)
+
+        routed_engine = wrap_routed_engine(self.config, routed_engine)
 
         gen = SglangProcessor(
             tokenizer,

--- a/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for frontend routed-engine topology adapters."""
+
+from typing import Any
+
+import pytest
+
+from dynamo.common.global_router_protocol import (
+    GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
+    make_global_router_retry_control,
+)
+from dynamo.frontend.routed_engine_adapters import GlobalRouterRoutedEngineAdapter
+
+
+class FakeRoutedItem:
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def data(self) -> dict[str, Any]:
+        return self._data
+
+
+class SequenceRoutedEngine:
+    def __init__(self, streams: list[list[FakeRoutedItem]]):
+        self._streams = list(streams)
+        self.requests: list[dict[str, Any]] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def generate(self, request: dict[str, Any], **kwargs: Any):
+        self.requests.append(request)
+        self.kwargs.append(kwargs)
+        items = self._streams.pop(0)
+
+        async def stream():
+            for item in items:
+                yield item
+
+        return stream()
+
+
+async def _collect(stream) -> list[dict[str, Any]]:
+    return [item.data() async for item in stream]
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_reissues_request_on_retry_control():
+    control = make_global_router_retry_control(
+        request_type="prefill",
+        retry_attempt=0,
+        next_retry_attempt=1,
+        failed_pool=2,
+        failed_namespace="prefill-slow",
+        next_pool=1,
+        next_namespace="prefill-mid",
+        error="dispatch failed",
+    )
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            [FakeRoutedItem(control)],
+            [FakeRoutedItem({"token_ids": [101], "index": 0})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+    request = {"token_ids": [1, 2, 3], "routing": {"priority": 7}}
+
+    stream = await adapter.generate(request, request_id="request-123")
+    outputs = await _collect(stream)
+
+    assert outputs == [{"token_ids": [101], "index": 0}]
+    assert routed_engine.requests[0]["routing"] == {
+        "priority": 7,
+        GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 0,
+    }
+    assert routed_engine.requests[1]["routing"] == {
+        "priority": 7,
+        GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 1,
+    }
+    assert request["routing"] == {"priority": 7}
+    assert routed_engine.kwargs == [
+        {"request_id": "request-123"},
+        {"request_id": "request-123"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_does_not_yield_retry_control():
+    control = make_global_router_retry_control(
+        request_type="agg",
+        retry_attempt=0,
+        next_retry_attempt=1,
+        failed_pool=0,
+        failed_namespace="agg-slow",
+        next_pool=1,
+        next_namespace="agg-fast",
+        error="dispatch failed",
+    )
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            [FakeRoutedItem(control)],
+            [FakeRoutedItem({"done": True})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    outputs = await _collect(stream)
+
+    assert outputs == [{"done": True}]
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_rejects_retry_control_after_output():
+    control = make_global_router_retry_control(
+        request_type="prefill",
+        retry_attempt=0,
+        next_retry_attempt=1,
+        failed_pool=2,
+        failed_namespace="prefill-slow",
+        next_pool=1,
+        next_namespace="prefill-mid",
+        error="dispatch failed",
+    )
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            [
+                FakeRoutedItem({"token_ids": [101], "index": 0}),
+                FakeRoutedItem(control),
+            ],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    with pytest.raises(RuntimeError, match="after response streaming started"):
+        await _collect(stream)

--- a/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
@@ -3,6 +3,7 @@
 
 """Tests for frontend routed-engine topology adapters."""
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -12,9 +13,17 @@ from dynamo.common.global_router_protocol import (
     make_global_router_retry_control,
     make_global_router_retry_exhausted_control,
 )
-from dynamo.frontend.routed_engine_adapters import GlobalRouterRoutedEngineAdapter
+from dynamo.frontend.routed_engine_adapters import (
+    GlobalRouterRoutedEngineAdapter,
+    wrap_routed_engine,
+)
 
-pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.asyncio,
+]
 
 
 class FakeRoutedItem:
@@ -35,6 +44,9 @@ class SequenceRoutedEngine:
         self.requests.append(request)
         self.kwargs.append(kwargs)
         items = self._streams.pop(0)
+        if isinstance(items, DelayedGenerate):
+            await asyncio.sleep(items.delay_s)
+            items = items.items
         if isinstance(items, Exception):
             raise items
 
@@ -47,11 +59,28 @@ class SequenceRoutedEngine:
         return stream()
 
 
+class DelayedGenerate:
+    def __init__(self, delay_s: float, items: list[FakeRoutedItem]):
+        self.delay_s = delay_s
+        self.items = items
+
+
+class FakeConfig:
+    def __init__(
+        self,
+        routed_engine_adapter: str = "global-router",
+        global_router_response_prologue_timeout_s: float | None = 30.0,
+    ):
+        self.routed_engine_adapter = routed_engine_adapter
+        self.global_router_response_prologue_timeout_s = (
+            global_router_response_prologue_timeout_s
+        )
+
+
 async def _collect(stream) -> list[dict[str, Any]]:
     return [item.data() async for item in stream]
 
 
-@pytest.mark.asyncio
 async def test_global_router_adapter_reissues_request_on_retry_control():
     control = make_global_router_retry_control(
         request_type="prefill",
@@ -91,7 +120,6 @@ async def test_global_router_adapter_reissues_request_on_retry_control():
     ]
 
 
-@pytest.mark.asyncio
 async def test_global_router_adapter_does_not_yield_retry_control():
     control = make_global_router_retry_control(
         request_type="agg",
@@ -117,7 +145,6 @@ async def test_global_router_adapter_does_not_yield_retry_control():
     assert outputs == [{"done": True}]
 
 
-@pytest.mark.asyncio
 async def test_global_router_adapter_rejects_retry_control_after_output():
     control = make_global_router_retry_control(
         request_type="prefill",
@@ -144,8 +171,7 @@ async def test_global_router_adapter_rejects_retry_control_after_output():
         await _collect(stream)
 
 
-@pytest.mark.asyncio
-async def test_global_router_adapter_retries_generate_failure_before_output():
+async def test_global_router_adapter_does_not_retry_generate_failure_before_output():
     routed_engine = SequenceRoutedEngine(
         streams=[
             RuntimeError("response prologue failed"),
@@ -153,6 +179,28 @@ async def test_global_router_adapter_retries_generate_failure_before_output():
         ]
     )
     adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    with pytest.raises(RuntimeError, match="response prologue failed"):
+        await _collect(stream)
+
+    assert [
+        request["routing"][GLOBAL_ROUTER_RETRY_ATTEMPT_KEY]
+        for request in routed_engine.requests
+    ] == [0]
+
+
+async def test_global_router_adapter_retries_generate_timeout_before_output():
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            DelayedGenerate(0.05, [FakeRoutedItem({"late": True})]),
+            [FakeRoutedItem({"done": True})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(
+        routed_engine,
+        response_prologue_timeout_s=0.001,
+    )
 
     stream = await adapter.generate({"token_ids": [1]})
     outputs = await _collect(stream)
@@ -164,7 +212,18 @@ async def test_global_router_adapter_retries_generate_failure_before_output():
     ] == [0, 1]
 
 
-@pytest.mark.asyncio
+async def test_wrap_global_router_adapter_passes_prologue_timeout():
+    routed_engine = SequenceRoutedEngine(streams=[])
+
+    adapter = wrap_routed_engine(
+        FakeConfig(global_router_response_prologue_timeout_s=12.5),
+        routed_engine,
+    )
+
+    assert isinstance(adapter, GlobalRouterRoutedEngineAdapter)
+    assert adapter._response_prologue_timeout_s == 12.5
+
+
 async def test_global_router_adapter_retries_stream_failure_before_output():
     routed_engine = SequenceRoutedEngine(
         streams=[
@@ -184,7 +243,6 @@ async def test_global_router_adapter_retries_stream_failure_before_output():
     ] == [0, 1]
 
 
-@pytest.mark.asyncio
 async def test_global_router_adapter_does_not_retry_stream_failure_after_output():
     routed_engine = SequenceRoutedEngine(
         streams=[
@@ -204,7 +262,6 @@ async def test_global_router_adapter_does_not_retry_stream_failure_after_output(
     assert len(routed_engine.requests) == 1
 
 
-@pytest.mark.asyncio
 async def test_global_router_adapter_raises_retry_exhausted_control():
     control = make_global_router_retry_exhausted_control(
         request_type="prefill",

--- a/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
@@ -13,6 +13,8 @@ from dynamo.common.global_router_protocol import (
 )
 from dynamo.frontend.routed_engine_adapters import GlobalRouterRoutedEngineAdapter
 
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
 
 class FakeRoutedItem:
     def __init__(self, data: dict[str, Any]):

--- a/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
@@ -10,6 +10,7 @@ import pytest
 from dynamo.common.global_router_protocol import (
     GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
     make_global_router_retry_control,
+    make_global_router_retry_exhausted_control,
 )
 from dynamo.frontend.routed_engine_adapters import GlobalRouterRoutedEngineAdapter
 
@@ -25,7 +26,7 @@ class FakeRoutedItem:
 
 
 class SequenceRoutedEngine:
-    def __init__(self, streams: list[list[FakeRoutedItem]]):
+    def __init__(self, streams: list[Any]):
         self._streams = list(streams)
         self.requests: list[dict[str, Any]] = []
         self.kwargs: list[dict[str, Any]] = []
@@ -34,9 +35,13 @@ class SequenceRoutedEngine:
         self.requests.append(request)
         self.kwargs.append(kwargs)
         items = self._streams.pop(0)
+        if isinstance(items, Exception):
+            raise items
 
         async def stream():
             for item in items:
+                if isinstance(item, Exception):
+                    raise item
                 yield item
 
         return stream()
@@ -137,3 +142,82 @@ async def test_global_router_adapter_rejects_retry_control_after_output():
     stream = await adapter.generate({"token_ids": [1]})
     with pytest.raises(RuntimeError, match="after response streaming started"):
         await _collect(stream)
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_retries_generate_failure_before_output():
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            RuntimeError("response prologue failed"),
+            [FakeRoutedItem({"done": True})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    outputs = await _collect(stream)
+
+    assert outputs == [{"done": True}]
+    assert [
+        request["routing"][GLOBAL_ROUTER_RETRY_ATTEMPT_KEY]
+        for request in routed_engine.requests
+    ] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_retries_stream_failure_before_output():
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            [RuntimeError("stream failed before output")],
+            [FakeRoutedItem({"done": True})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    outputs = await _collect(stream)
+
+    assert outputs == [{"done": True}]
+    assert [
+        request["routing"][GLOBAL_ROUTER_RETRY_ATTEMPT_KEY]
+        for request in routed_engine.requests
+    ] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_does_not_retry_stream_failure_after_output():
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            [
+                FakeRoutedItem({"token_ids": [101], "index": 0}),
+                RuntimeError("stream failed after output"),
+            ],
+            [FakeRoutedItem({"done": True})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    with pytest.raises(RuntimeError, match="stream failed after output"):
+        await _collect(stream)
+
+    assert len(routed_engine.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_global_router_adapter_raises_retry_exhausted_control():
+    control = make_global_router_retry_exhausted_control(
+        request_type="prefill",
+        retry_attempt=3,
+        failed_pool=0,
+        failed_namespace="prefill-fast",
+        error="no priority retry pools remain",
+    )
+    routed_engine = SequenceRoutedEngine(streams=[[FakeRoutedItem(control)]])
+    adapter = GlobalRouterRoutedEngineAdapter(routed_engine)
+
+    stream = await adapter.generate({"token_ids": [1]})
+    with pytest.raises(RuntimeError, match="no priority retry pools remain"):
+        await _collect(stream)
+
+    assert len(routed_engine.requests) == 1

--- a/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
+++ b/components/src/dynamo/frontend/tests/test_routed_engine_adapters.py
@@ -3,12 +3,12 @@
 
 """Tests for frontend routed-engine topology adapters."""
 
-import asyncio
 from typing import Any
 
 import pytest
 
 from dynamo.common.global_router_protocol import (
+    GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S_KEY,
     GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
     make_global_router_retry_control,
     make_global_router_retry_exhausted_control,
@@ -44,9 +44,6 @@ class SequenceRoutedEngine:
         self.requests.append(request)
         self.kwargs.append(kwargs)
         items = self._streams.pop(0)
-        if isinstance(items, DelayedGenerate):
-            await asyncio.sleep(items.delay_s)
-            items = items.items
         if isinstance(items, Exception):
             raise items
 
@@ -59,12 +56,6 @@ class SequenceRoutedEngine:
         return stream()
 
 
-class DelayedGenerate:
-    def __init__(self, delay_s: float, items: list[FakeRoutedItem]):
-        self.delay_s = delay_s
-        self.items = items
-
-
 class FakeConfig:
     def __init__(
         self,
@@ -75,6 +66,11 @@ class FakeConfig:
         self.global_router_response_prologue_timeout_s = (
             global_router_response_prologue_timeout_s
         )
+
+
+class FakeContext:
+    def __init__(self):
+        self.metadata: dict[str, str] = {}
 
 
 async def _collect(stream) -> list[dict[str, Any]]:
@@ -193,7 +189,9 @@ async def test_global_router_adapter_does_not_retry_generate_failure_before_outp
 async def test_global_router_adapter_retries_generate_timeout_before_output():
     routed_engine = SequenceRoutedEngine(
         streams=[
-            DelayedGenerate(0.05, [FakeRoutedItem({"late": True})]),
+            RuntimeError(
+                "ConnectionTimeout: response stream prologue timed out after 0.001s"
+            ),
             [FakeRoutedItem({"done": True})],
         ]
     )
@@ -210,6 +208,25 @@ async def test_global_router_adapter_retries_generate_timeout_before_output():
         request["routing"][GLOBAL_ROUTER_RETRY_ATTEMPT_KEY]
         for request in routed_engine.requests
     ] == [0, 1]
+
+
+async def test_global_router_adapter_sets_prologue_timeout_metadata():
+    routed_engine = SequenceRoutedEngine(
+        streams=[
+            [FakeRoutedItem({"done": True})],
+        ]
+    )
+    adapter = GlobalRouterRoutedEngineAdapter(
+        routed_engine,
+        response_prologue_timeout_s=12.5,
+    )
+    context = FakeContext()
+
+    stream = await adapter.generate({"token_ids": [1]}, context=context)
+    outputs = await _collect(stream)
+
+    assert outputs == [{"done": True}]
+    assert context.metadata[GLOBAL_ROUTER_RESPONSE_PROLOGUE_TIMEOUT_S_KEY] == "12.5"
 
 
 async def test_wrap_global_router_adapter_passes_prologue_timeout():

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -34,6 +34,7 @@ from dynamo.common.multimodal.mm_kwargs_transfer import (
 from dynamo.common.multimodal.routing_utils import build_mm_routing_info_from_features
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.frontend.frontend_args import FrontendConfig
+from dynamo.frontend.routed_engine_adapters import wrap_routed_engine
 from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
 
 from .prepost import StreamingPostProcessor, preprocess_chat_request
@@ -832,6 +833,8 @@ class EngineFactory:
             reasoning_parser_class = None
 
         block_size = self.config.kv_cache_block_size or 16
+
+        routed_engine = wrap_routed_engine(self.config, routed_engine)
 
         gen = VllmProcessor(
             tokenizer,

--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -240,6 +240,22 @@ If the grid selects `prefill-slow` (pool `2`) and that request fails, the global
 
 In disaggregated mode, prefill and decode retry are independent. A prefill failure retries through `prefill_pool_priorities`; a decode failure retries through `decode_pool_priorities`. If a failed decode attempt already caused the prefill engine to retire or drop the request's KV cache, the retry is still allowed; the backend should handle any resulting cache miss or failure on the new attempt. Current Dynamo backends do not support this yet.
 
+### Delegated Response Streams
+
+By default, the global router relays response streams through itself. To allow downstream local routers to stream responses directly to the frontend, start the global router with:
+
+```bash
+--enable-delegated-response-stream
+```
+
+When delegated response streaming is enabled with priority retry, the frontend must also use the global-router routed-engine adapter:
+
+```bash
+--dyn-routed-engine-adapter=global-router
+```
+
+The adapter lets the frontend reissue the request with the next retry attempt if the delegated response path fails before any output has been streamed. If priority retry has multiple candidate pools and the frontend adapter is not enabled, the global router rejects the request instead of falling back to a relayed stream with delayed response-stream setup.
+
 ### Passing SLA Targets
 
 Clients can pass TTFT and ITL targets via `nvext.router` in the request:

--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -254,7 +254,15 @@ When delegated response streaming is enabled with priority retry, the frontend m
 --dyn-routed-engine-adapter=global-router
 ```
 
-The adapter lets the frontend reissue the request with the next retry attempt if the delegated response path fails before any output has been streamed. If priority retry has multiple candidate pools and the frontend adapter is not enabled, the global router rejects the request instead of falling back to a relayed stream with delayed response-stream setup.
+The adapter lets the frontend reissue the request with the next retry attempt when the global router returns retry control, or when an already-established delegated response stream fails before any output has been streamed. If priority retry has multiple candidate pools and the frontend adapter is not enabled, the global router rejects the request instead of falling back to a relayed stream with delayed response-stream setup.
+
+The frontend adapter also bounds how long it waits for the delegated response stream prologue. Configure this with:
+
+```bash
+--dyn-global-router-response-prologue-timeout-s 30
+```
+
+If the timeout expires before the response prologue is observed, the frontend treats the selected pool as too slow or unavailable and retries the next priority attempt when one is available.
 
 ### Passing SLA Targets
 

--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -248,21 +248,21 @@ By default, the global router relays response streams through itself. To allow d
 --enable-delegated-response-stream
 ```
 
-When delegated response streaming is enabled with priority retry, the frontend must also use the global-router routed-engine adapter:
+When delegated response streaming is enabled, the frontend must also use the global-router routed-engine adapter before the global router will delegate a response stream:
 
 ```bash
 --dyn-routed-engine-adapter=global-router
 ```
 
-The adapter lets the frontend reissue the request with the next retry attempt when the global router returns retry control, or when an already-established delegated response stream fails before any output has been streamed. If priority retry has multiple candidate pools and the frontend adapter is not enabled, the global router rejects the request instead of falling back to a relayed stream with delayed response-stream setup.
+The adapter lets the frontend reissue the request with the next retry attempt when the global router returns retry control, or when an already-established delegated response stream fails before any output has been streamed. If the frontend adapter is not enabled, the global router relays the response stream through itself instead of delegating.
 
-The frontend adapter also bounds how long it waits for the delegated response stream prologue. Configure this with:
+The frontend adapter also carries a prologue timeout to the Rust routed-engine client. Configure this with:
 
 ```bash
 --dyn-global-router-response-prologue-timeout-s 30
 ```
 
-If the timeout expires before the response prologue is observed, the frontend treats the selected pool as too slow or unavailable and retries the next priority attempt when one is available.
+If the timeout expires before the response prologue is observed, Rust cancels the pending response registration and fails the attempt. The frontend treats the selected pool as too slow or unavailable and retries the next priority attempt when one is available.
 
 ### Passing SLA Targets
 

--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -134,6 +134,7 @@ async def _serve_disagg(
                     ("service", "global_router"),
                     ("type", "prefill"),
                 ],
+                defer_response_stream=True,
             ),
             decode_endpoint.serve_endpoint(
                 handler.handle_decode,
@@ -142,6 +143,7 @@ async def _serve_disagg(
                     ("service", "global_router"),
                     ("type", "decode"),
                 ],
+                defer_response_stream=True,
             ),
         )
     except Exception as e:
@@ -184,6 +186,7 @@ async def _serve_agg(
                 ("service", "global_router"),
                 ("type", "agg"),
             ],
+            defer_response_stream=True,
         )
     except Exception as e:
         logger.error(f"Failed to serve agg endpoint: {e}")

--- a/components/src/dynamo/global_router/__main__.py
+++ b/components/src/dynamo/global_router/__main__.py
@@ -69,6 +69,7 @@ async def worker(runtime: DistributedRuntime):
         model_name=config.model_name,
         default_ttft_target_ms=config.default_ttft_target_ms,
         default_itl_target_ms=config.default_itl_target_ms,
+        enable_delegated_response_stream=config.enable_delegated_response_stream,
     )
 
     # Initialize connections to local routers
@@ -134,7 +135,7 @@ async def _serve_disagg(
                     ("service", "global_router"),
                     ("type", "prefill"),
                 ],
-                defer_response_stream=True,
+                defer_response_stream=config.enable_delegated_response_stream,
             ),
             decode_endpoint.serve_endpoint(
                 handler.handle_decode,
@@ -143,7 +144,7 @@ async def _serve_disagg(
                     ("service", "global_router"),
                     ("type", "decode"),
                 ],
-                defer_response_stream=True,
+                defer_response_stream=config.enable_delegated_response_stream,
             ),
         )
     except Exception as e:
@@ -186,7 +187,7 @@ async def _serve_agg(
                 ("service", "global_router"),
                 ("type", "agg"),
             ],
-            defer_response_stream=True,
+            defer_response_stream=config.enable_delegated_response_stream,
         )
     except Exception as e:
         logger.error(f"Failed to serve agg endpoint: {e}")

--- a/components/src/dynamo/global_router/backend_args.py
+++ b/components/src/dynamo/global_router/backend_args.py
@@ -7,7 +7,11 @@ from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import add_argument, env_or_default
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    env_or_default,
+)
 
 
 class DynamoGlobalRouterArgGroup(ArgGroup):
@@ -68,6 +72,17 @@ class DynamoGlobalRouterArgGroup(ArgGroup):
             help="Default ITL target (ms) for decode pool selection when SLA not present in request.",
             arg_type=float,
         )
+        add_negatable_bool_argument(
+            g,
+            flag_name="--enable-delegated-response-stream",
+            env_var="DYN_GLOBAL_ROUTER_ENABLE_DELEGATED_RESPONSE_STREAM",
+            default=False,
+            help=(
+                "[EXPERIMENTAL] Allow the global router to delegate response streams "
+                "directly to downstream routers. Frontends using priority retry must "
+                "also set --dyn-routed-engine-adapter=global-router."
+            ),
+        )
 
 
 class DynamoGlobalRouterConfig(ConfigBase):
@@ -79,6 +94,7 @@ class DynamoGlobalRouterConfig(ConfigBase):
     component_name: str
     default_ttft_target_ms: Optional[float] = None
     default_itl_target_ms: Optional[float] = None
+    enable_delegated_response_stream: bool = False
 
     def validate(self) -> None:
         """Require config_path and model_name to be set via CLI or env."""

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -17,6 +17,10 @@ import json
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
+from dynamo.common.global_router_protocol import (
+    get_global_router_retry_attempt,
+    make_global_router_retry_control,
+)
 from dynamo.runtime import Client, DistributedRuntime
 
 from .pool_selection import get_priority_retry_order, load_config
@@ -101,6 +105,28 @@ class GlobalRouterHandler:
             pool_priorities=pool_priorities,
             enable_priority_retry=self.config.enable_priority_retry,
         )
+        if response_connection_info is not None:
+            retry_attempt = get_global_router_retry_attempt(request)
+            if retry_attempt is not None:
+                async for output in self._forward_delegated_retry_attempt(
+                    request=request,
+                    request_type=request_type,
+                    retry_attempt=retry_attempt,
+                    pool_order=pool_order,
+                    namespaces=namespaces,
+                    clients=clients,
+                    response_connection_info=response_connection_info,
+                    context=context,
+                ):
+                    yield output
+                return
+
+        should_delegate_response = response_connection_info is not None and len(pool_order) == 1
+        if response_connection_info is not None and not should_delegate_response:
+            logger.info(
+                f"Priority retry enabled for {request_type}; relaying response stream "
+                f"through global router to preserve retry semantics: retry_order={pool_order}"
+            )
 
         for attempt_idx, pool_idx in enumerate(pool_order):
             namespace = namespaces[pool_idx]
@@ -108,7 +134,7 @@ class GlobalRouterHandler:
             yielded_output = False
 
             try:
-                if response_connection_info is not None:
+                if should_delegate_response:
                     request_id = context.id() if context is not None else None
                     logger.info(
                         f"Delegating {request_type} response stream directly to downstream "
@@ -167,6 +193,77 @@ class GlobalRouterHandler:
                     f"({namespace}): {e}; retrying faster pool {next_pool_idx} "
                     f"({next_namespace})"
                 )
+
+    async def _forward_delegated_retry_attempt(
+        self,
+        request: Dict[str, Any],
+        request_type: str,
+        retry_attempt: int,
+        pool_order: List[int],
+        namespaces: List[str],
+        clients: Dict[str, Client],
+        response_connection_info: Dict[str, Any],
+        context: Optional[Any] = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """
+        Forward exactly one delegated-response attempt.
+
+        The frontend adapter owns the retry loop in this mode. The global router
+        returns a control item only when dispatch fails before the delegated
+        response stream is established.
+        """
+        if retry_attempt >= len(pool_order):
+            raise RuntimeError(
+                f"global router retry attempt {retry_attempt} exceeds retry order "
+                f"for {request_type}: retry_order={pool_order}"
+            )
+
+        pool_idx = pool_order[retry_attempt]
+        namespace = namespaces[pool_idx]
+        client = clients[namespace]
+        request_id = context.id() if context is not None else None
+
+        try:
+            logger.info(
+                f"Delegating {request_type} response stream directly to downstream "
+                f"router: request_id={request_id}, namespace={namespace}, "
+                f"retry_attempt={retry_attempt}, "
+                f"transport={response_connection_info.get('transport')}, "
+                f"response_subject={_connection_subject(response_connection_info)}"
+            )
+            await client.forward(request, response_connection_info, context=context)
+            logger.info(
+                f"Delegated {request_type} request to {namespace}; global router "
+                f"will not publish response stream: request_id={request_id}, "
+                f"retry_attempt={retry_attempt}"
+            )
+            return
+        except Exception as e:
+            if retry_attempt == len(pool_order) - 1:
+                logger.error(
+                    f"Error forwarding delegated {request_type} request to "
+                    f"{namespace}; no priority retry pools remain: {e}"
+                )
+                raise
+
+            next_retry_attempt = retry_attempt + 1
+            next_pool_idx = pool_order[next_retry_attempt]
+            next_namespace = namespaces[next_pool_idx]
+            logger.warning(
+                f"Error forwarding delegated {request_type} request to pool "
+                f"{pool_idx} ({namespace}): {e}; asking frontend to retry pool "
+                f"{next_pool_idx} ({next_namespace})"
+            )
+            yield make_global_router_retry_control(
+                request_type=request_type,
+                retry_attempt=retry_attempt,
+                next_retry_attempt=next_retry_attempt,
+                failed_pool=pool_idx,
+                failed_namespace=namespace,
+                next_pool=next_pool_idx,
+                next_namespace=next_namespace,
+                error=str(e),
+            )
 
     async def initialize(self) -> None:
         """

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -20,6 +20,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 from dynamo.common.global_router_protocol import (
     get_global_router_retry_attempt,
     make_global_router_retry_control,
+    make_global_router_retry_exhausted_control,
 )
 from dynamo.runtime import Client, DistributedRuntime
 
@@ -53,12 +54,14 @@ class GlobalRouterHandler:
         model_name: str,
         default_ttft_target_ms: Optional[float] = None,
         default_itl_target_ms: Optional[float] = None,
+        enable_delegated_response_stream: bool = False,
     ):
         self.runtime = runtime
         self.config = load_config(config_path)
         self.model_name = model_name
         self.default_ttft_target_ms = default_ttft_target_ms
         self.default_itl_target_ms = default_itl_target_ms
+        self.enable_delegated_response_stream = enable_delegated_response_stream
 
         # Clients to local routers in each pool namespace
         # Will be populated in initialize()
@@ -105,7 +108,10 @@ class GlobalRouterHandler:
             pool_priorities=pool_priorities,
             enable_priority_retry=self.config.enable_priority_retry,
         )
-        if response_connection_info is not None:
+        if (
+            self.enable_delegated_response_stream
+            and response_connection_info is not None
+        ):
             retry_attempt = get_global_router_retry_attempt(request)
             if retry_attempt is not None:
                 async for output in self._forward_delegated_retry_attempt(
@@ -122,12 +128,22 @@ class GlobalRouterHandler:
                 return
 
         should_delegate_response = (
-            response_connection_info is not None and len(pool_order) == 1
+            self.enable_delegated_response_stream
+            and response_connection_info is not None
+            and len(pool_order) == 1
         )
         if response_connection_info is not None and not should_delegate_response:
+            if self.enable_delegated_response_stream:
+                retry_attempt = get_global_router_retry_attempt(request)
+                if retry_attempt is None:
+                    raise RuntimeError(
+                        "global-router delegated response streaming with priority "
+                        "retry requires frontend "
+                        "--dyn-routed-engine-adapter=global-router"
+                    )
             logger.info(
-                f"Priority retry enabled for {request_type}; relaying response stream "
-                f"through global router to preserve retry semantics: retry_order={pool_order}"
+                f"Relaying {request_type} response stream through global router "
+                f"to preserve retry semantics: retry_order={pool_order}"
             )
 
         for attempt_idx, pool_idx in enumerate(pool_order):
@@ -215,10 +231,17 @@ class GlobalRouterHandler:
         response stream is established.
         """
         if retry_attempt >= len(pool_order):
-            raise RuntimeError(
+            error = (
                 f"global router retry attempt {retry_attempt} exceeds retry order "
                 f"for {request_type}: retry_order={pool_order}"
             )
+            logger.error(error)
+            yield make_global_router_retry_exhausted_control(
+                request_type=request_type,
+                retry_attempt=retry_attempt,
+                error=error,
+            )
+            return
 
         pool_idx = pool_order[retry_attempt]
         namespace = namespaces[pool_idx]
@@ -247,7 +270,14 @@ class GlobalRouterHandler:
                     f"{namespace}; no priority retry pools remain: {e}"
                 )
                 logger.error(message)
-                raise RuntimeError(message) from e
+                yield make_global_router_retry_exhausted_control(
+                    request_type=request_type,
+                    retry_attempt=retry_attempt,
+                    failed_pool=pool_idx,
+                    failed_namespace=namespace,
+                    error=message,
+                )
+                return
 
             next_retry_attempt = retry_attempt + 1
             next_pool_idx = pool_order[next_retry_attempt]

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -121,7 +121,9 @@ class GlobalRouterHandler:
                     yield output
                 return
 
-        should_delegate_response = response_connection_info is not None and len(pool_order) == 1
+        should_delegate_response = (
+            response_connection_info is not None and len(pool_order) == 1
+        )
         if response_connection_info is not None and not should_delegate_response:
             logger.info(
                 f"Priority retry enabled for {request_type}; relaying response stream "
@@ -240,11 +242,12 @@ class GlobalRouterHandler:
             return
         except Exception as e:
             if retry_attempt == len(pool_order) - 1:
-                logger.error(
+                message = (
                     f"Error forwarding delegated {request_type} request to "
                     f"{namespace}; no priority retry pools remain: {e}"
                 )
-                raise
+                logger.error(message)
+                raise RuntimeError(message) from e
 
             next_retry_attempt = retry_attempt + 1
             next_pool_idx = pool_order[next_retry_attempt]

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -108,6 +108,7 @@ class GlobalRouterHandler:
             pool_priorities=pool_priorities,
             enable_priority_retry=self.config.enable_priority_retry,
         )
+        retry_attempt = None
         if (
             self.enable_delegated_response_stream
             and response_connection_info is not None
@@ -127,24 +128,19 @@ class GlobalRouterHandler:
                     yield output
                 return
 
-        should_delegate_response = (
-            self.enable_delegated_response_stream
-            and response_connection_info is not None
-            and len(pool_order) == 1
-        )
-        if response_connection_info is not None and not should_delegate_response:
-            if self.enable_delegated_response_stream:
-                retry_attempt = get_global_router_retry_attempt(request)
-                if retry_attempt is None:
-                    raise RuntimeError(
-                        "global-router delegated response streaming with priority "
-                        "retry requires frontend "
-                        "--dyn-routed-engine-adapter=global-router"
-                    )
-            logger.info(
-                f"Relaying {request_type} response stream through global router "
-                f"to preserve retry semantics: retry_order={pool_order}"
-            )
+        if response_connection_info is not None:
+            if self.enable_delegated_response_stream and retry_attempt is None:
+                logger.info(
+                    f"Relaying {request_type} response stream through global router "
+                    f"because delegated response streaming requires frontend "
+                    f"--dyn-routed-engine-adapter=global-router metadata: "
+                    f"retry_order={pool_order}"
+                )
+            else:
+                logger.info(
+                    f"Relaying {request_type} response stream through global router "
+                    f"to preserve retry semantics: retry_order={pool_order}"
+                )
 
         for attempt_idx, pool_idx in enumerate(pool_order):
             namespace = namespaces[pool_idx]
@@ -152,25 +148,6 @@ class GlobalRouterHandler:
             yielded_output = False
 
             try:
-                if should_delegate_response:
-                    request_id = context.id() if context is not None else None
-                    logger.info(
-                        f"Delegating {request_type} response stream directly to downstream "
-                        f"router: request_id={request_id}, namespace={namespace}, "
-                        f"transport={response_connection_info.get('transport')}, "
-                        f"response_subject={_connection_subject(response_connection_info)}"
-                    )
-                    await client.forward(
-                        request,
-                        response_connection_info,
-                        context=context,
-                    )
-                    logger.info(
-                        f"Delegated {request_type} request to {namespace}; global router "
-                        f"will not publish response stream: request_id={request_id}"
-                    )
-                    return
-
                 logger.info(
                     f"Relaying {request_type} response stream through global router: "
                     f"namespace={namespace}"

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -13,6 +13,7 @@ Supports two modes:
 Both modes support priority-based pool overrides from agent hints.
 """
 
+import json
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -21,6 +22,13 @@ from dynamo.runtime import Client, DistributedRuntime
 from .pool_selection import get_priority_retry_order, load_config
 
 logger = logging.getLogger(__name__)
+
+
+def _connection_subject(connection_info: Dict[str, Any]) -> Optional[str]:
+    try:
+        return json.loads(connection_info.get("info", "{}")).get("subject")
+    except (TypeError, json.JSONDecodeError):
+        return None
 
 
 class GlobalRouterHandler:
@@ -79,6 +87,8 @@ class GlobalRouterHandler:
         namespaces: List[str],
         clients: Dict[str, Client],
         pool_priorities: List[int],
+        response_connection_info: Optional[Dict[str, Any]] = None,
+        context: Optional[Any] = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Forward a request to the selected pool and retry faster pools on failure.
@@ -98,6 +108,29 @@ class GlobalRouterHandler:
             yielded_output = False
 
             try:
+                if response_connection_info is not None:
+                    request_id = context.id() if context is not None else None
+                    logger.info(
+                        f"Delegating {request_type} response stream directly to downstream "
+                        f"router: request_id={request_id}, namespace={namespace}, "
+                        f"transport={response_connection_info.get('transport')}, "
+                        f"response_subject={_connection_subject(response_connection_info)}"
+                    )
+                    await client.forward(
+                        request,
+                        response_connection_info,
+                        context=context,
+                    )
+                    logger.info(
+                        f"Delegated {request_type} request to {namespace}; global router "
+                        f"will not publish response stream: request_id={request_id}"
+                    )
+                    return
+
+                logger.info(
+                    f"Relaying {request_type} response stream through global router: "
+                    f"namespace={namespace}"
+                )
                 stream = await client.generate(request)
                 async for output in stream:
                     yielded_output = True
@@ -206,7 +239,7 @@ class GlobalRouterHandler:
         logger.info(f"Global Router initialized (agg): {len(self.agg_clients)} pools")
 
     async def handle_prefill(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], context: Optional[Any] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Handle prefill requests from the frontend (disagg mode).
@@ -260,11 +293,15 @@ class GlobalRouterHandler:
             namespaces=self.config.prefill_pool_dynamo_namespaces,
             clients=self.prefill_clients,
             pool_priorities=self.config.prefill_pool_priorities,
+            response_connection_info=(
+                context.connection_info() if context is not None else None
+            ),
+            context=context,
         ):
             yield data
 
     async def handle_decode(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], context: Optional[Any] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Handle decode requests from the frontend (disagg mode).
@@ -319,11 +356,15 @@ class GlobalRouterHandler:
             namespaces=self.config.decode_pool_dynamo_namespaces,
             clients=self.decode_clients,
             pool_priorities=self.config.decode_pool_priorities,
+            response_connection_info=(
+                context.connection_info() if context is not None else None
+            ),
+            context=context,
         ):
             yield data
 
     async def handle_generate(
-        self, request: Dict[str, Any]
+        self, request: Dict[str, Any], context: Optional[Any] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Handle generate requests (agg mode).
@@ -378,6 +419,10 @@ class GlobalRouterHandler:
             namespaces=self.config.agg_pool_dynamo_namespaces,
             clients=self.agg_clients,
             pool_priorities=self.config.agg_pool_priorities,
+            response_connection_info=(
+                context.connection_info() if context is not None else None
+            ),
+            context=context,
         ):
             yield data
 

--- a/components/src/dynamo/global_router/tests/test_priority_retry.py
+++ b/components/src/dynamo/global_router/tests/test_priority_retry.py
@@ -157,11 +157,15 @@ def _agg_config() -> dict[str, Any]:
     }
 
 
-def _handler(config_path: Path) -> GlobalRouterHandler:
+def _handler(
+    config_path: Path,
+    enable_delegated_response_stream: bool = True,
+) -> GlobalRouterHandler:
     return GlobalRouterHandler(
         runtime=object(),
         config_path=str(config_path),
         model_name="test-model",
+        enable_delegated_response_stream=enable_delegated_response_stream,
     )
 
 
@@ -229,8 +233,13 @@ async def test_priority_retry_disabled_raises_first_failure(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_delegated_response_uses_relay_when_priority_retry_has_fallback(tmp_path):
-    handler = _handler(_write_config(tmp_path, _disagg_config()))
+async def test_delegation_disabled_uses_relay_when_priority_retry_has_fallback(
+    tmp_path,
+):
+    handler = _handler(
+        _write_config(tmp_path, _disagg_config()),
+        enable_delegated_response_stream=False,
+    )
     fast = FakeClient("prefill-fast", outputs=[{"pool": "prefill-fast"}])
     mid = FakeClient("prefill-mid", fail_before_output=True)
     slow = FakeClient("prefill-slow", fail_on_generate=True)
@@ -251,6 +260,47 @@ async def test_delegated_response_uses_relay_when_priority_retry_has_fallback(tm
     assert slow.forward_calls == 0
     assert mid.forward_calls == 0
     assert fast.forward_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_delegated_priority_retry_requires_frontend_adapter(tmp_path):
+    handler = _handler(_write_config(tmp_path, _disagg_config()))
+    handler.prefill_clients = {
+        "prefill-fast": FakeClient("prefill-fast"),
+        "prefill-mid": FakeClient("prefill-mid"),
+        "prefill-slow": FakeClient("prefill-slow"),
+    }
+
+    with pytest.raises(RuntimeError, match="dyn-routed-engine-adapter=global-router"):
+        await _collect_outputs(
+            handler.handle_prefill({"token_ids": [1, 2, 3]}, context=FakeContext())
+        )
+
+
+@pytest.mark.asyncio
+async def test_delegated_retry_metadata_is_ignored_when_delegation_disabled(tmp_path):
+    handler = _handler(
+        _write_config(tmp_path, _disagg_config()),
+        enable_delegated_response_stream=False,
+    )
+    slow = FakeClient("prefill-slow", outputs=[{"pool": "prefill-slow"}])
+    handler.prefill_clients = {
+        "prefill-fast": FakeClient("prefill-fast"),
+        "prefill-mid": FakeClient("prefill-mid"),
+        "prefill-slow": slow,
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 1},
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill(request, context=FakeContext())
+    )
+
+    assert outputs == [{"pool": "prefill-slow"}]
+    assert slow.calls == 1
+    assert slow.forward_calls == 0
 
 
 @pytest.mark.asyncio
@@ -338,7 +388,7 @@ async def test_delegated_retry_attempt_returns_retry_control_on_forward_failure(
 
 
 @pytest.mark.asyncio
-async def test_delegated_retry_attempt_raises_when_retry_order_exhausted(tmp_path):
+async def test_delegated_retry_attempt_returns_exhausted_control(tmp_path):
     handler = _handler(_write_config(tmp_path, _disagg_config()))
     fast = FakeClient("prefill-fast", fail_on_generate=True)
     handler.prefill_clients = {
@@ -351,10 +401,43 @@ async def test_delegated_retry_attempt_raises_when_retry_order_exhausted(tmp_pat
         "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 2},
     }
 
-    with pytest.raises(RuntimeError, match="no priority retry pools remain"):
-        await _collect_outputs(handler.handle_prefill(request, context=FakeContext()))
+    outputs = await _collect_outputs(
+        handler.handle_prefill(request, context=FakeContext())
+    )
 
+    assert len(outputs) == 1
+    control = outputs[0][GLOBAL_ROUTER_CONTROL_FIELD]
+    assert control["action"] == "exhausted"
+    assert control["retry_attempt"] == 2
+    assert control["failed_namespace"] == "prefill-fast"
+    assert "no priority retry pools remain" in control["error"]
     assert fast.forward_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_delegated_retry_attempt_returns_exhausted_control_when_attempt_exceeds_order(
+    tmp_path,
+):
+    handler = _handler(_write_config(tmp_path, _disagg_config()))
+    handler.prefill_clients = {
+        "prefill-fast": FakeClient("prefill-fast"),
+        "prefill-mid": FakeClient("prefill-mid"),
+        "prefill-slow": FakeClient("prefill-slow"),
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 3},
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill(request, context=FakeContext())
+    )
+
+    assert len(outputs) == 1
+    control = outputs[0][GLOBAL_ROUTER_CONTROL_FIELD]
+    assert control["action"] == "exhausted"
+    assert control["retry_attempt"] == 3
+    assert "exceeds retry order" in control["error"]
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/global_router/tests/test_priority_retry.py
+++ b/components/src/dynamo/global_router/tests/test_priority_retry.py
@@ -12,6 +12,7 @@ import pytest
 from dynamo.common.global_router_protocol import (
     GLOBAL_ROUTER_CONTROL_FIELD,
     GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
+    get_global_router_retry_attempt,
 )
 from dynamo.global_router.handler import GlobalRouterHandler
 
@@ -167,6 +168,27 @@ def _handler(
         model_name="test-model",
         enable_delegated_response_stream=enable_delegated_response_stream,
     )
+
+
+@pytest.mark.parametrize("value", [True, False, "1", 1.9, None])
+def test_global_router_retry_attempt_must_be_integer(value: Any) -> None:
+    request = {"routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: value}}
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        get_global_router_retry_attempt(request)
+
+
+def test_global_router_retry_attempt_rejects_negative_integer() -> None:
+    request = {"routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: -1}}
+
+    with pytest.raises(ValueError, match="must be >= 0"):
+        get_global_router_retry_attempt(request)
+
+
+def test_global_router_retry_attempt_accepts_integer() -> None:
+    request = {"routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 1}}
+
+    assert get_global_router_retry_attempt(request) == 1
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/global_router/tests/test_priority_retry.py
+++ b/components/src/dynamo/global_router/tests/test_priority_retry.py
@@ -285,18 +285,26 @@ async def test_delegation_disabled_uses_relay_when_priority_retry_has_fallback(
 
 
 @pytest.mark.asyncio
-async def test_delegated_priority_retry_requires_frontend_adapter(tmp_path):
+async def test_delegated_response_relays_without_frontend_adapter_metadata(tmp_path):
     handler = _handler(_write_config(tmp_path, _disagg_config()))
+    fast = FakeClient("prefill-fast", outputs=[{"pool": "prefill-fast"}])
+    mid = FakeClient("prefill-mid", outputs=[{"pool": "prefill-mid"}])
+    slow = FakeClient("prefill-slow", outputs=[{"pool": "prefill-slow"}])
     handler.prefill_clients = {
-        "prefill-fast": FakeClient("prefill-fast"),
-        "prefill-mid": FakeClient("prefill-mid"),
-        "prefill-slow": FakeClient("prefill-slow"),
+        "prefill-fast": fast,
+        "prefill-mid": mid,
+        "prefill-slow": slow,
     }
 
-    with pytest.raises(RuntimeError, match="dyn-routed-engine-adapter=global-router"):
-        await _collect_outputs(
-            handler.handle_prefill({"token_ids": [1, 2, 3]}, context=FakeContext())
-        )
+    outputs = await _collect_outputs(
+        handler.handle_prefill({"token_ids": [1, 2, 3]}, context=FakeContext())
+    )
+
+    assert outputs == [{"pool": "prefill-slow"}]
+    assert slow.calls == 1
+    assert slow.forward_calls == 0
+    assert mid.calls == 0
+    assert fast.calls == 0
 
 
 @pytest.mark.asyncio
@@ -326,7 +334,7 @@ async def test_delegated_retry_metadata_is_ignored_when_delegation_disabled(tmp_
 
 
 @pytest.mark.asyncio
-async def test_delegated_response_uses_forward_when_priority_retry_has_no_fallback(
+async def test_delegated_response_relays_without_adapter_when_priority_retry_has_no_fallback(
     tmp_path,
 ):
     handler = _handler(
@@ -341,6 +349,33 @@ async def test_delegated_response_uses_forward_when_priority_retry_has_no_fallba
 
     outputs = await _collect_outputs(
         handler.handle_prefill({"token_ids": [1, 2, 3]}, context=FakeContext())
+    )
+
+    assert outputs == [{"pool": "prefill-slow"}]
+    assert slow.forward_calls == 0
+    assert slow.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_delegated_response_uses_forward_with_adapter_metadata_when_no_fallback(
+    tmp_path,
+):
+    handler = _handler(
+        _write_config(tmp_path, _disagg_config(enable_priority_retry=False))
+    )
+    slow = FakeClient("prefill-slow", outputs=[{"pool": "prefill-slow"}])
+    handler.prefill_clients = {
+        "prefill-fast": FakeClient("prefill-fast"),
+        "prefill-mid": FakeClient("prefill-mid"),
+        "prefill-slow": slow,
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 0},
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill(request, context=FakeContext())
     )
 
     assert outputs == []

--- a/components/src/dynamo/global_router/tests/test_priority_retry.py
+++ b/components/src/dynamo/global_router/tests/test_priority_retry.py
@@ -9,6 +9,10 @@ from typing import Any
 
 import pytest
 
+from dynamo.common.global_router_protocol import (
+    GLOBAL_ROUTER_CONTROL_FIELD,
+    GLOBAL_ROUTER_RETRY_ATTEMPT_KEY,
+)
 from dynamo.global_router.handler import GlobalRouterHandler
 
 pytestmark = [
@@ -34,6 +38,8 @@ class FakeClient:
         self.fail_before_output = fail_before_output
         self.fail_after_output = fail_after_output
         self.calls = 0
+        self.forward_calls = 0
+        self.forward_requests: list[dict[str, Any]] = []
 
     async def generate(self, request: dict[str, Any]):
         self.calls += 1
@@ -50,9 +56,34 @@ class FakeClient:
 
         return stream()
 
+    async def forward(
+        self,
+        request: dict[str, Any],
+        response_connection_info: dict[str, Any],
+        context: Any | None = None,
+    ):
+        self.forward_calls += 1
+        self.forward_requests.append(request)
+        if self.fail_on_generate:
+            raise RuntimeError(f"{self.name} forward failed")
+
 
 async def _collect_outputs(generator) -> list[dict[str, Any]]:
     return [output async for output in generator]
+
+
+class FakeContext:
+    def __init__(self):
+        self._connection_info = {
+            "transport": "tcp",
+            "info": json.dumps({"subject": "frontend-response-subject"}),
+        }
+
+    def id(self) -> str:
+        return "request-123"
+
+    def connection_info(self) -> dict[str, Any]:
+        return self._connection_info
 
 
 def _write_config(tmp_dir: Path, config_data: dict[str, Any]) -> Path:
@@ -195,6 +226,135 @@ async def test_priority_retry_disabled_raises_first_failure(tmp_path):
 
     assert slow.calls == 1
     assert fast.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_delegated_response_uses_relay_when_priority_retry_has_fallback(tmp_path):
+    handler = _handler(_write_config(tmp_path, _disagg_config()))
+    fast = FakeClient("prefill-fast", outputs=[{"pool": "prefill-fast"}])
+    mid = FakeClient("prefill-mid", fail_before_output=True)
+    slow = FakeClient("prefill-slow", fail_on_generate=True)
+    handler.prefill_clients = {
+        "prefill-fast": fast,
+        "prefill-mid": mid,
+        "prefill-slow": slow,
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill({"token_ids": [1, 2, 3]}, context=FakeContext())
+    )
+
+    assert outputs == [{"pool": "prefill-fast"}]
+    assert slow.calls == 1
+    assert mid.calls == 1
+    assert fast.calls == 1
+    assert slow.forward_calls == 0
+    assert mid.forward_calls == 0
+    assert fast.forward_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_delegated_response_uses_forward_when_priority_retry_has_no_fallback(
+    tmp_path,
+):
+    handler = _handler(
+        _write_config(tmp_path, _disagg_config(enable_priority_retry=False))
+    )
+    slow = FakeClient("prefill-slow", outputs=[{"pool": "prefill-slow"}])
+    handler.prefill_clients = {
+        "prefill-fast": FakeClient("prefill-fast"),
+        "prefill-mid": FakeClient("prefill-mid"),
+        "prefill-slow": slow,
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill({"token_ids": [1, 2, 3]}, context=FakeContext())
+    )
+
+    assert outputs == []
+    assert slow.forward_calls == 1
+    assert slow.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_delegated_retry_attempt_uses_selected_priority_pool(tmp_path):
+    handler = _handler(_write_config(tmp_path, _disagg_config()))
+    fast = FakeClient("prefill-fast")
+    mid = FakeClient("prefill-mid")
+    slow = FakeClient("prefill-slow")
+    handler.prefill_clients = {
+        "prefill-fast": fast,
+        "prefill-mid": mid,
+        "prefill-slow": slow,
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 1},
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill(request, context=FakeContext())
+    )
+
+    assert outputs == []
+    assert slow.forward_calls == 0
+    assert mid.forward_calls == 1
+    assert fast.forward_calls == 0
+    assert mid.forward_requests == [request]
+
+
+@pytest.mark.asyncio
+async def test_delegated_retry_attempt_returns_retry_control_on_forward_failure(
+    tmp_path,
+):
+    handler = _handler(_write_config(tmp_path, _disagg_config()))
+    fast = FakeClient("prefill-fast")
+    mid = FakeClient("prefill-mid")
+    slow = FakeClient("prefill-slow", fail_on_generate=True)
+    handler.prefill_clients = {
+        "prefill-fast": fast,
+        "prefill-mid": mid,
+        "prefill-slow": slow,
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 0},
+    }
+
+    outputs = await _collect_outputs(
+        handler.handle_prefill(request, context=FakeContext())
+    )
+
+    assert len(outputs) == 1
+    control = outputs[0][GLOBAL_ROUTER_CONTROL_FIELD]
+    assert control["action"] == "retry"
+    assert control["retry_attempt"] == 0
+    assert control["next_retry_attempt"] == 1
+    assert control["failed_namespace"] == "prefill-slow"
+    assert control["next_namespace"] == "prefill-mid"
+    assert slow.forward_calls == 1
+    assert mid.forward_calls == 0
+    assert fast.forward_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_delegated_retry_attempt_raises_when_retry_order_exhausted(tmp_path):
+    handler = _handler(_write_config(tmp_path, _disagg_config()))
+    fast = FakeClient("prefill-fast", fail_on_generate=True)
+    handler.prefill_clients = {
+        "prefill-fast": fast,
+        "prefill-mid": FakeClient("prefill-mid"),
+        "prefill-slow": FakeClient("prefill-slow"),
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {GLOBAL_ROUTER_RETRY_ATTEMPT_KEY: 2},
+    }
+
+    with pytest.raises(RuntimeError, match="no priority retry pools remain"):
+        await _collect_outputs(handler.handle_prefill(request, context=FakeContext()))
+
+    assert fast.forward_calls == 1
 
 
 @pytest.mark.asyncio

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -11,9 +11,9 @@
 // `set_status` operations mirror the OTel `Span` API.
 
 use dynamo_runtime::logging::DistributedTraceContext;
-use dynamo_runtime::pipeline::network::ConnectionInfo;
 pub use dynamo_runtime::pipeline::AsyncEngineContext;
 use dynamo_runtime::pipeline::context::Controller;
+use dynamo_runtime::pipeline::network::ConnectionInfo;
 use opentelemetry::global::BoxedSpan;
 use opentelemetry::trace::{Span as OtelSpan, Status, TraceContextExt, Tracer};
 use opentelemetry::{KeyValue, global};

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -11,6 +11,7 @@
 // `set_status` operations mirror the OTel `Span` API.
 
 use dynamo_runtime::logging::DistributedTraceContext;
+use dynamo_runtime::pipeline::network::ConnectionInfo;
 pub use dynamo_runtime::pipeline::AsyncEngineContext;
 use dynamo_runtime::pipeline::context::Controller;
 use opentelemetry::global::BoxedSpan;
@@ -19,7 +20,10 @@ use opentelemetry::{KeyValue, global};
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString};
 use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::sync::{
+    Arc, Mutex, MutexGuard, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::sync::watch;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -64,6 +68,8 @@ pub struct Context {
     /// prefill requests.
     first_token: Option<watch::Sender<bool>>,
     metadata: Arc<Mutex<BTreeMap<String, String>>>,
+    connection_info: Option<ConnectionInfo>,
+    response_delegated: Option<Arc<AtomicBool>>,
     /// Captured `engine.generate` span. `None` for Python-instantiated test
     /// contexts (where no parent span was plumbed in) — `current_span` /
     /// `start_span` return a no-op `SpanProxy` in that case.
@@ -178,11 +184,41 @@ impl Context {
         first_token: Option<watch::Sender<bool>>,
         metadata: BTreeMap<String, String>,
     ) -> Self {
+        Self::new_with_response_controls(inner, trace_context, first_token, metadata, None, None)
+    }
+
+    pub fn new_with_connection_info(
+        inner: Arc<dyn AsyncEngineContext>,
+        trace_context: Option<DistributedTraceContext>,
+        first_token: Option<watch::Sender<bool>>,
+        metadata: BTreeMap<String, String>,
+        connection_info: Option<ConnectionInfo>,
+    ) -> Self {
+        Self::new_with_response_controls(
+            inner,
+            trace_context,
+            first_token,
+            metadata,
+            connection_info,
+            None,
+        )
+    }
+
+    pub fn new_with_response_controls(
+        inner: Arc<dyn AsyncEngineContext>,
+        trace_context: Option<DistributedTraceContext>,
+        first_token: Option<watch::Sender<bool>>,
+        metadata: BTreeMap<String, String>,
+        connection_info: Option<ConnectionInfo>,
+        response_delegated: Option<Arc<AtomicBool>>,
+    ) -> Self {
         Self {
             inner,
             trace_context,
             first_token,
             metadata: Arc::new(Mutex::new(metadata)),
+            connection_info,
+            response_delegated,
             span: None,
         }
     }
@@ -208,6 +244,12 @@ impl Context {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
+    }
+
+    pub fn set_response_delegated(&self) {
+        if let Some(response_delegated) = &self.response_delegated {
+            response_delegated.store(true, Ordering::SeqCst);
+        }
     }
 
     /// Build the `traceparent` header value. Prefers the engine.generate
@@ -258,6 +300,8 @@ impl Context {
             trace_context: None,
             first_token: None,
             metadata: Arc::new(Mutex::new(metadata.unwrap_or_default())),
+            connection_info: None,
+            response_delegated: None,
             span: None,
         }
     }
@@ -316,6 +360,23 @@ impl Context {
             .metadata
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = metadata;
+    }
+
+    /// Response stream connection information supplied by the upstream caller.
+    /// Python routers can pass this to `Client.forward(...)` to delegate response
+    /// ownership to a downstream router or worker.
+    fn connection_info(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+        match &self.connection_info {
+            Some(connection_info) => {
+                let py_obj: PyObject = pythonize::pythonize(py, connection_info)?.into();
+                Ok(Some(py_obj))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn mark_response_delegated(&self) {
+        self.set_response_delegated();
     }
 
     #[getter]

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -1,10 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{
-    Arc,
-    atomic::AtomicBool,
-};
+use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::{Error, Result};
 use pyo3::prelude::*;

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::AtomicBool,
+};
 
 use anyhow::{Error, Result};
 use pyo3::prelude::*;
@@ -16,6 +19,9 @@ use tokio_util::sync::CancellationToken;
 
 use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
 use dynamo_runtime::logging::get_distributed_tracing_context;
+use dynamo_runtime::pipeline::network::{
+    ConnectionInfo, RESPONSE_CONNECTION_INFO_CONTEXT_KEY, RESPONSE_DELEGATED_CONTEXT_KEY,
+};
 pub use dynamo_runtime::{
     pipeline::{AsyncEngine, AsyncEngineContextProvider, Data, ManyOut, ResponseStream, SingleIn},
     protocols::{annotated::Annotated, maybe_error::MaybeError},
@@ -151,6 +157,12 @@ where
         // Create a context
         let (request, context) = request.transfer(());
         let ctx = context.context();
+        let connection_info = context
+            .clone_unique::<ConnectionInfo>(RESPONSE_CONNECTION_INFO_CONTEXT_KEY)
+            .ok();
+        let response_delegated = context
+            .clone_unique::<Arc<AtomicBool>>(RESPONSE_DELEGATED_CONTEXT_KEY)
+            .ok();
 
         let id = context.id().to_string();
         tracing::trace!("processing request: {}", id);
@@ -186,7 +198,14 @@ where
                 // Create context with trace information
                 let py_ctx = Py::new(
                     py,
-                    Context::new(ctx_python.clone(), current_trace_context, None, metadata),
+                    Context::new_with_response_controls(
+                        ctx_python.clone(),
+                        current_trace_context,
+                        None,
+                        metadata,
+                        connection_info,
+                        response_delegated,
+                    ),
                 )?;
 
                 let gen_result = if has_context {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -971,7 +971,7 @@ impl DistributedRuntime {
 
 #[pymethods]
 impl Endpoint {
-    #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None))]
+    #[pyo3(signature = (generator, graceful_shutdown = true, metrics_labels = None, health_check_payload = None, defer_response_stream = false))]
     fn serve_endpoint<'p>(
         &self,
         py: Python<'p>,
@@ -979,12 +979,17 @@ impl Endpoint {
         graceful_shutdown: Option<bool>,
         metrics_labels: Option<Vec<(String, String)>>,
         health_check_payload: Option<&Bound<'p, PyDict>>,
+        defer_response_stream: Option<bool>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let engine = Arc::new(engine::PythonAsyncEngine::new(
             generator,
             self.event_loop.clone(),
         )?);
-        let ingress = JsonServerStreamingIngress::for_engine(engine.clone()).map_err(to_pyerr)?;
+        let ingress = JsonServerStreamingIngress::for_engine_with_deferred_response_stream(
+            engine.clone(),
+            defer_response_stream.unwrap_or(false),
+        )
+        .map_err(to_pyerr)?;
 
         // Convert Python dict to serde_json::Value if provided and validate it's an object
         let health_payload_json = health_check_payload
@@ -1356,6 +1361,45 @@ impl Client {
             tokio::spawn(process_stream(stream, tx));
 
             Ok(AsyncResponseStream::new(rx, annotated))
+        })
+    }
+
+    /// Forward a request while preserving the caller-provided response connection.
+    #[pyo3(signature = (request, connection_info, context=None))]
+    fn forward<'p>(
+        &self,
+        py: Python<'p>,
+        request: PyObject,
+        connection_info: PyObject,
+        context: Option<context::Context>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let request: serde_json::Value = pythonize::depythonize(&request.into_bound(py))?;
+        let request_ctx = create_request_context(request, &context);
+        let connection_info: rs::pipeline::network::ConnectionInfo =
+            pythonize::depythonize(&connection_info.into_bound(py))?;
+
+        let client = self.router.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            match context {
+                Some(context) => {
+                    let span = get_span_for_context(&context, "forward");
+                    client
+                        .forward(request_ctx, connection_info)
+                        .instrument(span)
+                        .await
+                        .map_err(to_pyerr)?;
+                    context.set_response_delegated();
+                }
+                _ => {
+                    client
+                        .forward(request_ctx, connection_info)
+                        .await
+                        .map_err(to_pyerr)?;
+                }
+            };
+
+            Ok(())
         })
     }
 }

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -350,6 +350,14 @@ pub struct ConnectionInfo {
     pub info: String,
 }
 
+/// Runtime context key used to expose the original response stream connection
+/// to Python handlers that need to delegate response ownership downstream.
+pub const RESPONSE_CONNECTION_INFO_CONTEXT_KEY: &str = "dynamo.response_connection_info";
+
+/// Runtime context key for a shared flag set when a handler delegates response
+/// publishing to a downstream endpoint.
+pub const RESPONSE_DELEGATED_CONTEXT_KEY: &str = "dynamo.response_delegated";
+
 /// When registering a new TransportStream on the server, the caller specifies if the
 /// stream is a sender, receiver or both.
 ///
@@ -436,14 +444,20 @@ pub struct Ingress<Req: PipelineIO, Resp: PipelineIO> {
     metrics: OnceLock<Arc<WorkHandlerMetrics>>,
     /// Endpoint-specific notifier for health check timer resets
     endpoint_health_check_notifier: OnceLock<Arc<tokio::sync::Notify>>,
+    defer_response_stream: bool,
 }
 
 impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
     pub fn new() -> Arc<Self> {
+        Self::new_with_deferred_response_stream(false)
+    }
+
+    pub fn new_with_deferred_response_stream(defer_response_stream: bool) -> Arc<Self> {
         Arc::new(Self {
             segment: OnceLock::new(),
             metrics: OnceLock::new(),
             endpoint_health_check_notifier: OnceLock::new(),
+            defer_response_stream,
         })
     }
 
@@ -491,13 +505,20 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
     }
 
     pub fn for_engine(engine: ServiceEngine<Req, Resp>) -> Result<Arc<Self>> {
+        Self::for_engine_with_deferred_response_stream(engine, false)
+    }
+
+    pub fn for_engine_with_deferred_response_stream(
+        engine: ServiceEngine<Req, Resp>,
+        defer_response_stream: bool,
+    ) -> Result<Arc<Self>> {
         let frontend = SegmentSource::<Req, Resp>::new();
         let backend = ServiceBackend::from_engine(engine);
 
         // create the pipeline
         let pipeline = frontend.link(backend)?.link(frontend)?;
 
-        let ingress = Ingress::new();
+        let ingress = Ingress::new_with_deferred_response_stream(defer_response_stream);
         ingress.attach(pipeline)?;
 
         Ok(ingress)

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -137,6 +137,12 @@ impl<T> AddressedRequest<T> {
     }
 }
 
+fn tcp_response_subject(connection_info: &ConnectionInfo) -> Option<String> {
+    serde_json::from_str::<tcp::TcpStreamConnectionInfo>(&connection_info.info)
+        .ok()
+        .map(|ci| ci.subject)
+}
+
 pub struct AddressedPushRouter {
     // Request transport (unified trait object - works with all transports)
     req_client: Arc<dyn RequestPlaneClient>,
@@ -187,6 +193,81 @@ impl AddressedPushRouter {
         self.resp_transport
             .clear_instance_tombstone(instance_id)
             .await
+    }
+}
+
+impl AddressedPushRouter {
+    pub async fn send_with_connection_info<T>(
+        &self,
+        request: SingleIn<AddressedRequest<T>>,
+        connection_info: ConnectionInfo,
+    ) -> Result<(), Error>
+    where
+        T: Data + Serialize,
+    {
+        let queue_start = Instant::now();
+        REQUEST_PLANE_INFLIGHT.inc();
+        let inflight_guard = InflightGuard::new();
+
+        let request_id = request.context().id().to_string();
+        let (addressed_request, context) = request.transfer(());
+        let (request, address, _instance_info) = addressed_request.into_parts();
+        let engine_ctx = context.context();
+        let response_transport = connection_info.transport.clone();
+        let response_subject = tcp_response_subject(&connection_info);
+
+        // TODO: once we add a tombstone-only API:
+        // if let Some(inst) = &instance_info {
+        //     self.ensure_instance_not_tombstoned(&inst.endpoint_instance_id()).await?;
+        // }
+
+        let control_message = RequestControlMessage {
+            id: engine_ctx.id().to_string(),
+            request_type: RequestType::SingleIn,
+            response_type: ResponseType::ManyOut,
+            connection_info,
+            metadata: context.metadata().clone(),
+            frontend_send_ts_ns: None,
+        };
+
+        let ctrl = serde_json::to_vec(&control_message)?;
+        let data = serde_json::to_vec(&request)?;
+
+        let msg = TwoPartMessage::from_parts(ctrl.into(), data.into());
+        let buffer = TwoPartCodec::default().encode_message(msg)?;
+
+        REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
+
+        let tx_start = Instant::now();
+
+        let mut headers = std::collections::HashMap::new();
+        inject_trace_headers_into_map(&mut headers);
+        headers.insert("request-id".to_string(), request_id.clone());
+
+        let send_ts_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        headers.insert("x-frontend-send-ts-ns".to_string(), send_ts_ns.to_string());
+
+        tracing::info!(
+            request_id = %request_id,
+            address = %address,
+            response_transport = %response_transport,
+            response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+            "forwarding request with delegated response stream"
+        );
+
+        self.req_client
+            .send_request(address, buffer, headers)
+            .await?;
+
+        REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
+
+        // Do not disarm. No response stream takes over this gauge.
+        drop(inflight_guard);
+
+        Ok(())
     }
 }
 

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use super::unified_client::RequestPlaneClient;
 use super::*;
@@ -39,6 +39,8 @@ use tokio_stream::{StreamExt, StreamNotifyClose, wrappers::ReceiverStream};
 use tracing::Instrument;
 
 const CONTROL_MESSAGE_MAX_BYTES: usize = 128 * 1024;
+const RESPONSE_PROLOGUE_TIMEOUT_METADATA_KEY: &str =
+    "dynamo.global_router_response_prologue_timeout_s";
 
 fn serialize_control_message(control_message: &RequestControlMessage) -> Result<Vec<u8>, Error> {
     let ctrl = serde_json::to_vec(control_message)?;
@@ -51,6 +53,25 @@ fn serialize_control_message(control_message: &RequestControlMessage) -> Result<
         .into());
     }
     Ok(ctrl)
+}
+
+fn response_prologue_timeout_from_metadata(
+    metadata: &BTreeMap<String, String>,
+) -> Option<Duration> {
+    let raw = metadata.get(RESPONSE_PROLOGUE_TIMEOUT_METADATA_KEY)?;
+    match raw.parse::<f64>() {
+        Ok(seconds) if seconds.is_finite() && seconds > 0.0 => {
+            Some(Duration::from_secs_f64(seconds))
+        }
+        _ => {
+            tracing::warn!(
+                key = RESPONSE_PROLOGUE_TIMEOUT_METADATA_KEY,
+                value = %raw,
+                "ignoring invalid response prologue timeout metadata"
+            );
+            None
+        }
+    }
 }
 
 /// RAII guard that decrements REQUEST_PLANE_INFLIGHT on drop unless disarmed.
@@ -287,6 +308,7 @@ where
         let (request, address, instance_info) = addressed_request.into_parts();
         let engine_ctx = context.context();
         let engine_ctx_ = engine_ctx.clone();
+        let response_prologue_timeout = response_prologue_timeout_from_metadata(context.metadata());
 
         // registration options for the data plane in a singe in / many out configuration
         let options = StreamOptions::builder()
@@ -437,9 +459,31 @@ where
         let _nvtx_wait = dynamo_nvtx_range!("transport.tcp.wait_backend");
         tracing::trace!(request_id, "awaiting transport handshake");
 
+        let response_stream_result = if let Some(timeout) = response_prologue_timeout {
+            match tokio::time::timeout(timeout, response_stream_provider).await {
+                Ok(result) => result,
+                Err(_) => {
+                    if let Some(subject) = &recv_subject {
+                        self.resp_transport.cancel_recv_stream(subject).await;
+                    }
+                    return Err(anyhow::anyhow!(
+                        DynamoError::builder()
+                            .error_type(ErrorType::ConnectionTimeout)
+                            .message(format!(
+                                "response stream prologue timed out after {:.3}s",
+                                timeout.as_secs_f64()
+                            ))
+                            .build()
+                    ));
+                }
+            }
+        } else {
+            response_stream_provider.await
+        };
+
         // RecvError → migratable Disconnected (watcher cancelled the subject
         // or the worker died before establishing the response stream).
-        let response_stream = match response_stream_provider.await {
+        let response_stream = match response_stream_result {
             Ok(Ok(stream)) => stream,
             Ok(Err(e)) => {
                 // generate() failed before any response bytes; migrate via
@@ -549,10 +593,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        CONTROL_MESSAGE_MAX_BYTES, ConnectionInfo, RequestControlMessage, RequestType,
-        ResponseType, serialize_control_message,
+        CONTROL_MESSAGE_MAX_BYTES, ConnectionInfo, RESPONSE_PROLOGUE_TIMEOUT_METADATA_KEY,
+        RequestControlMessage, RequestType, ResponseType, response_prologue_timeout_from_metadata,
+        serialize_control_message,
     };
     use std::collections::BTreeMap;
+    use std::time::Duration;
 
     fn base_control_message(metadata: BTreeMap<String, String>) -> RequestControlMessage {
         RequestControlMessage {
@@ -591,5 +637,32 @@ mod tests {
             .to_string();
         assert!(err.contains("request control message too large"));
         assert!(err.contains(&CONTROL_MESSAGE_MAX_BYTES.to_string()));
+    }
+
+    #[test]
+    fn response_prologue_timeout_metadata_accepts_positive_seconds() {
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            RESPONSE_PROLOGUE_TIMEOUT_METADATA_KEY.to_string(),
+            "12.5".to_string(),
+        );
+
+        assert_eq!(
+            response_prologue_timeout_from_metadata(&metadata),
+            Some(Duration::from_secs_f64(12.5))
+        );
+    }
+
+    #[test]
+    fn response_prologue_timeout_metadata_ignores_invalid_values() {
+        for value in ["0", "-1", "nan", "inf", "not-a-number"] {
+            let mut metadata = BTreeMap::new();
+            metadata.insert(
+                RESPONSE_PROLOGUE_TIMEOUT_METADATA_KEY.to_string(),
+                value.to_string(),
+            );
+
+            assert_eq!(response_prologue_timeout_from_metadata(&metadata), None);
+        }
     }
 }

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -230,7 +230,7 @@ impl AddressedPushRouter {
             frontend_send_ts_ns: None,
         };
 
-        let ctrl = serde_json::to_vec(&control_message)?;
+        let ctrl = serialize_control_message(&control_message)?;
         let data = serde_json::to_vec(&request)?;
 
         let msg = TwoPartMessage::from_parts(ctrl.into(), data.into());

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -15,6 +15,7 @@ use crate::{
     pipeline::{
         AddressedPushRouter, AddressedRequest, Error, ManyIn, ManyOut, SingleIn,
         error::{PipelineError, PipelineErrorExt},
+        network::ConnectionInfo,
     },
     protocols::{EndpointId, maybe_error::MaybeError},
     traits::DistributedRuntimeProvider,
@@ -99,6 +100,31 @@ impl Drop for OccupancyPermit {
         if self.armed {
             self.state.decrement(self.instance_id);
         }
+    }
+}
+
+struct SelectedRoute {
+    instance_id: u64,
+    permit: Option<OccupancyPermit>,
+}
+
+impl SelectedRoute {
+    fn new(instance_id: u64) -> Self {
+        Self {
+            instance_id,
+            permit: None,
+        }
+    }
+
+    fn with_permit(permit: OccupancyPermit) -> Self {
+        Self {
+            instance_id: permit.instance_id(),
+            permit: Some(permit),
+        }
+    }
+
+    fn instance_id(&self) -> u64 {
+        self.instance_id
     }
 }
 
@@ -754,6 +780,316 @@ where
                 self.client.endpoint.id()
             )
         })
+    }
+
+    async fn select_route(&self) -> anyhow::Result<SelectedRoute> {
+        match self.router_mode {
+            RouterMode::Random => {
+                let instance_id = {
+                    let routing_instances = self.client.routing_instances();
+                    let count = routing_instances.free_ids().len();
+                    if count == 0 {
+                        return Err(self.empty_free_pool_error(&routing_instances));
+                    }
+                    let counter = rand::rng().random::<u64>() as usize;
+                    routing_instances.free_ids()[counter % count]
+                };
+                tracing::trace!("random router selected {instance_id}");
+                Ok(SelectedRoute::new(instance_id))
+            }
+            RouterMode::RoundRobin => {
+                let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
+                let instance_id = {
+                    let routing_instances = self.client.routing_instances();
+                    let count = routing_instances.free_ids().len();
+                    if count == 0 {
+                        return Err(self.empty_free_pool_error(&routing_instances));
+                    }
+                    routing_instances.free_ids()[counter % count]
+                };
+                tracing::trace!("round robin router selected {instance_id}");
+                Ok(SelectedRoute::new(instance_id))
+            }
+            RouterMode::PowerOfTwoChoices => {
+                let state = self.occupancy_state()?;
+                let instance_id = {
+                    let routing_instances = self.client.routing_instances();
+                    if routing_instances.free_ids().is_empty() {
+                        return Err(self.empty_free_pool_error(&routing_instances));
+                    }
+                    p2c_select_from(state.as_ref(), routing_instances.free_ids())
+                };
+                state.increment(instance_id);
+                Ok(SelectedRoute::with_permit(OccupancyPermit::new(
+                    state,
+                    instance_id,
+                )))
+            }
+            RouterMode::LeastLoaded => {
+                let state = self.occupancy_state()?;
+                let routing_instances = self.client.routing_instances();
+                let instance_ids = routing_instances.free_ids().to_vec();
+                let instance_id = state
+                    .select_exact_min_and_increment(&instance_ids)
+                    .await
+                    .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
+                tracing::trace!(
+                    "least loaded router selected {instance_id} (connections: {})",
+                    state.load(instance_id)
+                );
+                Ok(SelectedRoute::with_permit(OccupancyPermit::new(
+                    state,
+                    instance_id,
+                )))
+            }
+            RouterMode::DeviceAwareWeighted => {
+                let state = self.occupancy_state()?;
+                let routing_instances = self.client.routing_instances();
+                let instance_ids = routing_instances.free_ids().to_vec();
+                if instance_ids.is_empty() {
+                    return Err(self.empty_free_pool_error(&routing_instances));
+                }
+
+                let endpoint_id = self.client.endpoint.id();
+                let instances = self.client.instances();
+                let device_type_map: std::collections::HashMap<u64, Option<DeviceType>> = instances
+                    .iter()
+                    .map(|inst| (inst.instance_id, inst.device_type.clone()))
+                    .collect();
+
+                let cuda_to_cpu_ratio = std::env::var("DYN_ENCODER_CUDA_TO_CPU_RATIO")
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .filter(|v| *v >= 1)
+                    .unwrap_or(8);
+                let candidates = device_aware_candidate_group(
+                    state.as_ref(),
+                    &instance_ids,
+                    &device_type_map,
+                    cuda_to_cpu_ratio,
+                );
+
+                let instance_id = state
+                    .select_exact_min_and_increment(&candidates)
+                    .await
+                    .ok_or_else(|| self.empty_free_pool_error(&routing_instances))?;
+                let is_cpu = matches!(
+                    device_type_map.get(&instance_id),
+                    Some(Some(DeviceType::Cpu))
+                );
+                tracing::info!(
+                    endpoint = %endpoint_id,
+                    selected_instance = instance_id,
+                    is_cpu,
+                    "DeviceAwareWeighted selected instance"
+                );
+                Ok(SelectedRoute::with_permit(OccupancyPermit::new(
+                    state,
+                    instance_id,
+                )))
+            }
+            RouterMode::KV => {
+                anyhow::bail!("KV routing should not use PushRouter route selection directly");
+            }
+            RouterMode::Direct => {
+                anyhow::bail!(
+                    "Direct routing should not call forward on PushRouter directly; use DirectRoutingRouter wrapper"
+                );
+            }
+        }
+    }
+
+    fn check_worker_capacity(&self, request_id: &str, instance_id: u64) -> anyhow::Result<()> {
+        if self.fault_detection_enabled {
+            let routing_instances = self.client.routing_instances();
+            let selected_worker_overloaded = routing_instances.is_overloaded(instance_id);
+            let counts = routing_instances.counts();
+            if tracing::enabled!(tracing::Level::DEBUG) {
+                tracing::debug!(
+                    request_id = %request_id,
+                    instance_id,
+                    router_mode = ?self.router_mode,
+                    free_workers = counts.free,
+                    overloaded_workers = counts.overloaded,
+                    total_workers = counts.discovered,
+                    selected_worker_overloaded,
+                    "checked worker overload state"
+                );
+            }
+            if selected_worker_overloaded {
+                tracing::warn!(
+                    instance_id,
+                    overloaded_workers = counts.overloaded,
+                    total_workers = counts.discovered,
+                    "Rejecting request: selected worker is overloaded"
+                );
+                let cause = PipelineError::ServiceOverloaded(
+                    "Selected worker is overloaded, please retry later".to_string(),
+                );
+                return Err(DynamoError::builder()
+                    .error_type(ErrorType::ResourceExhausted)
+                    .message("Selected worker is overloaded, please retry later")
+                    .cause(cause)
+                    .build()
+                    .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn resolve_transport_address(
+        &self,
+        instance_id: &mut u64,
+    ) -> anyhow::Result<(String, &'static str, Instance)> {
+        use crate::component::TransportType;
+
+        let resolve_transport = |id: u64| {
+            let instances = self.client.instances();
+            instances
+                .iter()
+                .find(|i| i.instance_id == id)
+                .map(|instance| {
+                    let (addr, kind) = match &instance.transport {
+                        TransportType::Tcp(tcp_endpoint) => {
+                            tracing::debug!(
+                                instance_id = id,
+                                tcp_endpoint = %tcp_endpoint,
+                                "Using TCP transport for instance"
+                            );
+                            (tcp_endpoint.clone(), "transport.tcp.request")
+                        }
+                        TransportType::Nats(subject) => {
+                            tracing::debug!(
+                                instance_id = id,
+                                subject = %subject,
+                                "Using NATS transport for instance"
+                            );
+                            (subject.clone(), "transport.nats.request")
+                        }
+                    };
+                    (addr, kind, instance.clone())
+                })
+        };
+
+        if let Some(result) = resolve_transport(*instance_id) {
+            return Ok(result);
+        }
+
+        let routing_instances = self.client.routing_instances();
+        let fallback_id = routing_instances
+            .free_ids()
+            .iter()
+            .copied()
+            .find(|&id| id != *instance_id);
+        match fallback_id {
+            Some(id) => {
+                tracing::warn!(
+                    original_instance = *instance_id,
+                    fallback_instance = id,
+                    "Instance disappeared during routing, reselecting"
+                );
+                *instance_id = id;
+                resolve_transport(id).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Fallback instance {} also not found for endpoint {}",
+                        id,
+                        self.client.endpoint.id()
+                    )
+                })
+            }
+            None => Err(anyhow::anyhow!(
+                "Instance {} not found and no other instances available for endpoint {}",
+                *instance_id,
+                self.client.endpoint.id()
+            )),
+        }
+    }
+
+    fn route_span(&self, request_id: &str, instance_id: u64) -> tracing::Span {
+        if matches!(self.router_mode, RouterMode::KV) {
+            tracing::Span::none()
+        } else {
+            tracing::info_span!(
+                "router.route_request",
+                request_id = %request_id,
+                worker_id = instance_id,
+                router_mode = ?self.router_mode,
+            )
+        }
+    }
+
+    fn prepare_addressed_request(
+        &self,
+        mut instance_id: u64,
+        request: SingleIn<T>,
+    ) -> anyhow::Result<(
+        u64,
+        &'static str,
+        SingleIn<AddressedRequest<T>>,
+        tracing::Span,
+    )> {
+        let route_start = Instant::now();
+        let request_id = request.id().to_string();
+        let route_span = self.route_span(&request_id, instance_id);
+
+        self.check_worker_capacity(&request_id, instance_id)?;
+
+        let (address, transport_kind, instance) =
+            self.resolve_transport_address(&mut instance_id)?;
+
+        let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
+
+        STAGE_DURATION_SECONDS
+            .with_label_values(&[STAGE_ROUTE])
+            .observe(route_start.elapsed().as_secs_f64());
+
+        Ok((instance_id, transport_kind, request, route_span))
+    }
+
+    async fn forward_with_response(
+        &self,
+        instance_id: u64,
+        request: SingleIn<T>,
+        response_connection_info: ConnectionInfo,
+    ) -> anyhow::Result<()> {
+        let (instance_id, transport_kind, request, route_span) =
+            self.prepare_addressed_request(instance_id, request)?;
+
+        let _nvtx_transport = dynamo_nvtx_range!(transport_kind);
+        let result = self
+            .addressed
+            .send_with_connection_info(request, response_connection_info)
+            .instrument(route_span)
+            .await;
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if self.fault_detection_enabled && is_inhibited(err.as_ref()) {
+                    tracing::debug!("Reporting instance {instance_id} down due to error: {err}");
+                    self.client.report_instance_down(instance_id);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    pub async fn forward(
+        &self,
+        request: SingleIn<T>,
+        response_connection_info: ConnectionInfo,
+    ) -> anyhow::Result<()> {
+        let selected = self.select_route().await?;
+        let instance_id = selected.instance_id();
+        let result = self
+            .forward_with_response(instance_id, request, response_connection_info)
+            .await;
+
+        // Forwarded responses bypass this router, so occupancy only covers
+        // selection through request-plane send.
+        drop(selected);
+        result
     }
 
     /*

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -10,7 +10,10 @@ use crate::metrics::work_handler_perf::{
 use crate::protocols::maybe_error::MaybeError;
 use prometheus::{Histogram, IntCounter, IntCounterVec, IntGauge};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Instant;
 use tracing::Instrument;
 use tracing::info_span;
@@ -145,8 +148,12 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
     /// classification (client-side disconnect vs. real failure), and the
     /// health-check notifier policy (notify only on non-error chunks and
     /// at clean stream end).
-    async fn pump_response_stream<U>(&self, mut stream: ManyOut<U>, publisher: &StreamSender)
-    where
+    async fn pump_response_stream<U>(
+        &self,
+        mut stream: ManyOut<U>,
+        publisher: &StreamSender,
+        mut first_response: Option<U>,
+    ) where
         U: Data + Serialize + MaybeError + std::fmt::Debug,
     {
         let context = stream.context();
@@ -154,7 +161,14 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
         // TODO: Detect end-of-stream using Server-Sent Events (SSE)
         let mut send_complete_final = true;
         let mut saw_error_response = false;
-        while let Some(resp) = stream.next().await {
+        loop {
+            let resp = match first_response.take() {
+                Some(resp) => Some(resp),
+                None => stream.next().await,
+            };
+            let Some(resp) = resp else {
+                break;
+            };
             tracing::trace!("Sending response: {:?}", resp);
             let is_error = resp.err().is_some();
             if is_error {
@@ -233,6 +247,45 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
         }
     }
 }
+
+fn tcp_response_subject(connection_info: &ConnectionInfo) -> Option<String> {
+    serde_json::from_str::<tcp::TcpStreamConnectionInfo>(&connection_info.info)
+        .ok()
+        .map(|ci| ci.subject)
+}
+
+async fn create_response_publisher(
+    context: Arc<dyn AsyncEngineContext>,
+    connection_info: ConnectionInfo,
+    metrics: Option<&Arc<WorkHandlerMetrics>>,
+) -> Result<StreamSender, PipelineError> {
+    let request_id = context.id().to_string();
+    let response_transport = connection_info.transport.clone();
+    let response_subject = tcp_response_subject(&connection_info);
+
+    tracing::info!(
+        request_id = %request_id,
+        response_transport = %response_transport,
+        response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+        "opening response stream to upstream caller"
+    );
+
+    tcp::client::TcpClient::create_response_stream(
+        context,
+        connection_info,
+        metrics.map(|m| m.cancellation_total.clone()),
+    )
+    .await
+    .map_err(|e| {
+        if let Some(m) = metrics {
+            m.error_counter
+                .with_label_values(&[work_handler::error_types::RESPONSE_STREAM])
+                .inc();
+        }
+        PipelineError::Generic(format!("Failed to create response stream: {:?}", e,))
+    })
+}
+
 /// The output of [`IngressDispatch::parse_and_build_request`]: the typed
 /// request the engine consumes, plus the bits of the on-wire control
 /// message the shared handler needs after parsing (the response-stream
@@ -240,6 +293,7 @@ impl<Req: PipelineIO + Sync, Resp: PipelineIO> Ingress<Req, Resp> {
 struct ParsedRequest<Req> {
     request: Req,
     response_connection_info: ConnectionInfo,
+    response_delegated: Arc<AtomicBool>,
     frontend_send_ts_ns: Option<u64>,
 }
 
@@ -325,12 +379,19 @@ where
         );
         tracing::trace!("received request: {:?}", request_t);
 
-        let request: context::Context<T> =
+        let mut request: context::Context<T> =
             Context::with_id_and_metadata(request_t, control_msg.id, control_msg.metadata);
+        let response_delegated = Arc::new(AtomicBool::new(false));
+        request.insert_unique(
+            RESPONSE_CONNECTION_INFO_CONTEXT_KEY,
+            control_msg.connection_info.clone(),
+        );
+        request.insert_unique(RESPONSE_DELEGATED_CONTEXT_KEY, response_delegated.clone());
 
         Ok(ParsedRequest {
             request,
             response_connection_info: control_msg.connection_info,
+            response_delegated,
             frontend_send_ts_ns: control_msg.frontend_send_ts_ns,
         })
     }
@@ -380,6 +441,7 @@ where
         let ParsedRequest {
             request,
             response_connection_info,
+            response_delegated,
             frontend_send_ts_ns,
         } = self.parse_and_build_request(payload).await?;
 
@@ -389,23 +451,27 @@ where
             WORK_HANDLER_NETWORK_TRANSIT_SECONDS.observe(transit_ns as f64 / 1_000_000_000.0);
         }
 
-        // todo - eventually have a handler class which will returned an abstracted object, but for now,
-        // we only support tcp here, so we can just unwrap the connection info
-        tracing::trace!("creating tcp response stream");
-        let mut publisher = tcp::client::TcpClient::create_response_stream(
-            request.context(),
-            response_connection_info,
-            self.metrics().map(|m| m.cancellation_total.clone()),
-        )
-        .await
-        .map_err(|e| {
-            if let Some(m) = self.metrics() {
-                m.error_counter
-                    .with_label_values(&[work_handler::error_types::RESPONSE_STREAM])
-                    .inc();
-            }
-            PipelineError::Generic(format!("Failed to create response stream: {:?}", e,))
-        })?;
+        let request_context = request.context();
+        let mut publisher = if self.defer_response_stream {
+            let response_subject = tcp_response_subject(&response_connection_info);
+            tracing::info!(
+                request_id = %request_context.id(),
+                response_transport = %response_connection_info.transport,
+                response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+                "deferring response stream creation; handler may delegate response"
+            );
+            None
+        } else {
+            tracing::trace!("creating tcp response stream");
+            Some(
+                create_response_publisher(
+                    request_context.clone(),
+                    response_connection_info.clone(),
+                    self.metrics(),
+                )
+                .await?,
+            )
+        };
 
         tracing::trace!("calling generate");
         let stream = self
@@ -425,10 +491,44 @@ where
 
         // the prolouge is sent to the client to indicate that the stream is ready to receive data
         // or if the generate call failed, the error is sent to the client
+        let mut first_response = None;
         let stream = match stream {
             Ok(stream) => {
+                let mut stream = stream;
+                if self.defer_response_stream {
+                    first_response = stream.next().await;
+                    if response_delegated.load(Ordering::SeqCst) {
+                        if first_response.is_some() {
+                            tracing::warn!(
+                                "response stream was delegated after yielding a response; dropping local response"
+                            );
+                        }
+                        let response_subject = tcp_response_subject(&response_connection_info);
+                        tracing::info!(
+                            request_id = %request_context.id(),
+                            response_transport = %response_connection_info.transport,
+                            response_subject = response_subject.as_deref().unwrap_or("<unknown>"),
+                            "response stream delegated downstream; ingress will not publish response"
+                        );
+                        return Ok(());
+                    }
+
+                    tracing::trace!("creating deferred tcp response stream");
+                    publisher = Some(
+                        create_response_publisher(
+                            request_context.clone(),
+                            response_connection_info.clone(),
+                            self.metrics(),
+                        )
+                        .await?,
+                    );
+                }
                 tracing::trace!("Successfully generated response stream; sending prologue");
-                let _result = publisher.send_prologue(None).await;
+                let _result = publisher
+                    .as_mut()
+                    .expect("response publisher initialized")
+                    .send_prologue(None)
+                    .await;
                 WORK_HANDLER_TIME_TO_FIRST_RESPONSE_SECONDS
                     .observe(start_time.elapsed().as_secs_f64());
                 stream
@@ -448,12 +548,28 @@ where
                     tracing::error!("Failed to generate response stream: {error_string}");
                 }
 
-                let _result = publisher.send_prologue(Some(error_string)).await;
+                if publisher.is_none() {
+                    publisher = Some(
+                        create_response_publisher(
+                            request_context.clone(),
+                            response_connection_info.clone(),
+                            self.metrics(),
+                        )
+                        .await?,
+                    );
+                }
+                let _result = publisher
+                    .as_mut()
+                    .expect("response publisher initialized")
+                    .send_prologue(Some(error_string))
+                    .await;
                 Err(e)?
             }
         };
 
-        self.pump_response_stream(stream, &publisher).await;
+        let publisher = publisher.expect("response publisher initialized");
+        self.pump_response_stream(stream, &publisher, first_response)
+            .await;
 
         // Ensure the metrics guard is not dropped until the end of the function.
         // Drop fires "request completed" log via RAII.


### PR DESCRIPTION
#### Overview

This PR makes incremental progress toward the longer-term goal of decoupling routers from the response data path. See the [DEP](https://docs.google.com/document/d/18OAi8XyaEjQv0D1-73G0rnwyD2Jz-u0NW32KsFV58XE/edit?tab=t.0) for the broader design.

#### Details

Before this PR, requests routed through a global router also chained response streams back through the routing path. In that topology, the engine streamed responses to the local router, the local router streamed them to the global router, and the global router streamed them back to the frontend.

This PR keeps routers in the request-control path, but removes the global router from the response data path. The local router can now forward delegated TCP response connection information to the selected engine, allowing the response stream to flow back toward the frontend without being relayed through the global router. This removes an extra response-stream hop and avoids the Rust/Python boundary traversal in the global-router Python-wrapped generator.

The main complexity is preserving priority retry behavior. Today, the global router can retry a request against lower-priority pools when a failure occurs before the first output token. Since the global router no longer observes the response stream directly, the frontend now coordinates retries by passing retry-attempt metadata to the global router. The global router uses that retry attempt to select the appropriate pool and returns whether another retryable pool remains, avoiding extra discovery/control calls.

Because frontend behavior differs depending on whether it is targeting local routers directly or a global router, this PR adds an explicit frontend flag for the global-router adapter path. Longer term, this could become a discovery property so routers advertise their role instead of requiring explicit frontend configuration.

#### Where should the reviewer start?

1. `addressed_router.rs` and `push_router.rs` for delegated TCP connection info handling.
2. `components/src/dynamo/frontend/routed_engine_adapters.py` and `components/src/dynamo/global_router/handler.py` for the priority retry flow.

#### Related Issues

Closes #LLM-136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `--dyn-routed-engine-adapter` CLI flag to select engine adapter mode: `default` or `global-router`, enabling advanced request routing strategies.
  * Added global router retry semantics for automatic request delegation and intelligent response forwarding with configurable retry attempts and pool selection.

* **Tests**
  * Added comprehensive test coverage for global router adapter configuration validation and delegated retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->