### PR TITLE
perf(embedding): build embedding base64 directly from the tensor (numpy.tobytes)

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3144,27 +3144,16 @@ def _classify_embedding_input(input_field: Any) -> list[Any]:
     )
 
 
-def _flatten_pooling_tensor(data: "torch.Tensor") -> "torch.Tensor":
-    """Flatten a vLLM ``PoolingOutput.data`` tensor to a 1-D float32 CPU tensor.
-
-    Shared by :func:`_pooling_output_to_list` and
-    :func:`_pooling_output_to_base64` so the detach/cpu/flatten/cast step isn't
-    duplicated. ``float32`` matches the OpenAI base64 f32 wire format.
-
-    vLLM's pooling pipeline can return a tensor with a singleton batch dim
-    (shape ``(1, hidden_dim)``) instead of a 1D vector; we flatten unconditionally.
-    """
-    return data.detach().cpu().flatten().to(torch.float32)
-
-
 def _pooling_output_to_list(data: Any) -> list[float]:
     """Convert a vLLM PoolingOutput.data tensor (or list) to a flat list[float].
 
+    vLLM's pooling pipeline can return a tensor with a singleton batch dim
+    (shape ``(1, hidden_dim)``) instead of a 1D vector (shape ``(hidden_dim,)``).
     The OpenAI ``/v1/embeddings`` response expects ``data[].embedding`` to be a
-    flat array of floats.
+    flat array of floats, so we flatten unconditionally.
     """
     if isinstance(data, torch.Tensor):
-        return _flatten_pooling_tensor(data).tolist()
+        return data.detach().cpu().flatten().tolist()
     if isinstance(data, (list, tuple)):
         # Already a list — flatten one level if it's a list-of-lists.
         if data and isinstance(data[0], (list, tuple)):
@@ -3198,7 +3187,7 @@ def _pooling_output_to_base64(data: Any, dimensions: int | None = None) -> str:
     are identical to the ``struct``-based path on little-endian hosts.
     """
     if isinstance(data, torch.Tensor):
-        vec = _flatten_pooling_tensor(data)
+        vec = data.detach().cpu().flatten().to(torch.float32)
         if dimensions is not None:
             if dimensions > vec.numel():
                 raise ValueError(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3035,29 +3035,23 @@ class EmbeddingWorkerHandler:
             if pending:
                 await asyncio.gather(*pending, return_exceptions=True)
 
+        # Always emit base64 over the worker->frontend wire format. The Rust
+        # frontend decodes back to float when the client's ``encoding_format``
+        # is float (or unset); base64 bytes are ~3x smaller and far faster to
+        # (de)serialize than a JSON float array, and the client-visible wire
+        # format is preserved because Rust converts at the HTTP boundary. The
+        # base64 is built straight from the pooling tensor (torch ->
+        # numpy.tobytes), skipping the per-embedding Python float list +
+        # struct.pack varargs. Bytes are identical on little-endian hosts.
         embedding_objects: list[Dict[str, Any]] = []
         prompt_tokens = 0
         for idx, final_output in enumerate(outputs):
-            embedding = _pooling_output_to_list(final_output.outputs.data)
-            if dimensions is not None:
-                if dimensions > len(embedding):
-                    raise ValueError(
-                        f"dimensions={dimensions} exceeds model embedding "
-                        f"dimension {len(embedding)}"
-                    )
-                embedding = embedding[:dimensions]
-
-            # Always emit base64 over the worker->frontend wire format. The
-            # Rust frontend decodes back to float when the client's
-            # ``encoding_format`` is float (or unset). 15x1024-float responses
-            # serialized as JSON arrays cost ~110 ms in Python json.dumps +
-            # Rust serde parse; base64 bytes are ~3x smaller and ~10x faster
-            # to (de)serialize. Client-visible wire format is preserved
-            # because Rust converts at the HTTP boundary.
             embedding_objects.append(
                 {
                     "object": "embedding",
-                    "embedding": _encode_floats_to_base64(embedding),
+                    "embedding": _pooling_output_to_base64(
+                        final_output.outputs.data, dimensions
+                    ),
                     "index": idx,
                 }
             )
@@ -3150,16 +3144,27 @@ def _classify_embedding_input(input_field: Any) -> list[Any]:
     )
 
 
+def _flatten_pooling_tensor(data: "torch.Tensor") -> "torch.Tensor":
+    """Flatten a vLLM ``PoolingOutput.data`` tensor to a 1-D float32 CPU tensor.
+
+    Shared by :func:`_pooling_output_to_list` and
+    :func:`_pooling_output_to_base64` so the detach/cpu/flatten/cast step isn't
+    duplicated. ``float32`` matches the OpenAI base64 f32 wire format.
+
+    vLLM's pooling pipeline can return a tensor with a singleton batch dim
+    (shape ``(1, hidden_dim)``) instead of a 1D vector; we flatten unconditionally.
+    """
+    return data.detach().cpu().flatten().to(torch.float32)
+
+
 def _pooling_output_to_list(data: Any) -> list[float]:
     """Convert a vLLM PoolingOutput.data tensor (or list) to a flat list[float].
 
-    vLLM's pooling pipeline can return a tensor with a singleton batch dim
-    (shape ``(1, hidden_dim)``) instead of a 1D vector (shape ``(hidden_dim,)``).
     The OpenAI ``/v1/embeddings`` response expects ``data[].embedding`` to be a
-    flat array of floats, so we flatten unconditionally.
+    flat array of floats.
     """
     if isinstance(data, torch.Tensor):
-        return data.detach().cpu().flatten().tolist()
+        return _flatten_pooling_tensor(data).tolist()
     if isinstance(data, (list, tuple)):
         # Already a list — flatten one level if it's a list-of-lists.
         if data and isinstance(data[0], (list, tuple)):
@@ -3182,3 +3187,33 @@ def _encode_floats_to_base64(floats: list[float]) -> str:
     """
     packed = struct.pack(f"<{len(floats)}f", *floats)
     return base64.b64encode(packed).decode("ascii")
+
+
+def _pooling_output_to_base64(data: Any, dimensions: int | None = None) -> str:
+    """Serialize a vLLM ``PoolingOutput.data`` tensor straight to a base64
+    float32 string, skipping the intermediate Python ``list[float]`` and the
+    ``struct.pack("<{N}f", *floats)`` varargs expansion.
+
+    ``torch -> numpy.tobytes -> base64`` keeps the heavy work in C; output bytes
+    are identical to the ``struct``-based path on little-endian hosts.
+    """
+    if isinstance(data, torch.Tensor):
+        vec = _flatten_pooling_tensor(data)
+        if dimensions is not None:
+            if dimensions > vec.numel():
+                raise ValueError(
+                    f"dimensions={dimensions} exceeds model embedding "
+                    f"dimension {vec.numel()}"
+                )
+            vec = vec[:dimensions]
+        return base64.b64encode(vec.contiguous().numpy().tobytes()).decode("ascii")
+    # Fallback for non-tensor pooling outputs (rare): reuse the list path.
+    floats = _pooling_output_to_list(data)
+    if dimensions is not None:
+        if dimensions > len(floats):
+            raise ValueError(
+                f"dimensions={dimensions} exceeds model embedding "
+                f"dimension {len(floats)}"
+            )
+        floats = floats[:dimensions]
+    return _encode_floats_to_base64(floats)


### PR DESCRIPTION
> [!WARNING]
> **Superseded — recommend closing.** Re-benchmarking on GB200 found the dynamo embedding worker returns per-token output (wrong shape, dim scales with input length) on vLLM 0.21 — fixed in #10248. With that corrected, this PR's `numpy.tobytes` optimization provides **no measurable benefit** at a real 1024-dim embedding; the 30–37% gains reported below were artifacts of the oversized per-token payload. See the corrected same-node p50/p90/p99 matrix in the comment below. **Recommend closing in favor of #10248.**

---

> [!IMPORTANT]
> **Recommended embedding fix.** Captures the full −30–35% latency win **cross-node** with a one-line, behavior-preserving change. Benchmarks (below) show it matches the shared-memory path (#10220) without that PR's same-node constraint or extra failure modes, so it — not SHM — is the one to ship for text embeddings. (Complements the already-merged base64 wire-format change in #10139: that made *shipping* the payload cheap; this makes *producing* it cheap.)
>

#### Overview:

Speeds up embedding-response serialization on the worker by building the base64 payload **directly from the pooling tensor** via `numpy.tobytes`, instead of going through a Python float list + `struct.pack` varargs expansion.

The current path is `tensor.detach().cpu().flatten().tolist()` → `struct.pack("<{N}f", *floats)` → base64. For a batch-15 × 3072-dim response that's **46,080 Python float objects** materialized and then unpacked as **46,080 positional args** into `struct.pack` — an O(N) interpreter-level pass over every element. This PR replaces it with `tensor → numpy.tobytes() → base64`, a single C-level copy. The emitted base64 bytes are identical on little-endian hosts.

Measured on GB200 (Qwen3-Embedding-0.6B, dim 3072): **−30%** at batch 15 (124 → 87 ms) and **−35%** at batch 64 (470 → 307 ms) per-request latency. The win grows with batch size, since it scales with the number of floats serialized. It also works cross-node (no shared memory required) and complements the base64-wire-format change in #10139 (this PR makes *producing* that base64 cheaper; #10139 made *shipping* it cheaper).

#### Details:

- `components/src/dynamo/vllm/handlers.py`: new `_pooling_output_to_base64()` builds base64 straight from the tensor. Shared tensor-prep (`detach().cpu().flatten().to(float32)`) is factored into a small helper reused by `_pooling_output_to_list`, so there's no duplicated tensor handling. A list/tuple fallback preserves behavior for non-tensor pooling outputs.
- `.to(torch.float32)` makes bf16/fp16 pooling outputs match the `struct.pack("<f")` width, keeping the emitted bytes identical.

#### Benchmark (GB200, Qwen3-Embedding-0.6B, dim 3072, ISL 80):

Per-request latency (ms, avg). Small batches: rate-limited (no queueing), 200/100 reqs. Large batches: closed-loop `--concurrency 1`, 40/25 reqs.

| batch | response (raw f32) | baseline (`tolist`+`struct.pack`) | **numpy.tobytes** (this PR) | SHM (#10220) | numpy.tobytes + SHM | this PR vs baseline |
| -- | -- | -- | -- | -- | -- | -- |
| 15 | ~184 KB | 124.25 | **86.94** | 85.49 | 85.31 | −30% |
| 64 | ~786 KB | 469.54 | **306.57** | 290.69 | 294.72 | −35% |
| 128 | ~1.5 MB | 934.16 | **584.31** | 573.98 | 566.64 | −37% |
| 256 | ~3 MB | 1,860.85 | **1,182.62** | 1,128.59 | 1,126.00 | −36% |
| 512 | ~6 MB | 3,684.53 | **2,364.84** | 2,301.73 | 2,200.67 | −36% |
| 1024 | ~12 MB | 7,491.99 | **4,694.72** | 4,615.99 | 4,447.78 | −37% |

The fix holds a consistent **−30 to −37%** vs baseline, and the absolute saving **grows with batch** (37 ms at batch 15 → ~2.8 s at batch 1024) — the baseline's `tolist()` + `struct.pack("<{N}f", *floats)` is an O(N) interpreter-level pass that scales badly. SHM (#10220) tracks this PR within ~2–5% across all sizes (within run-to-run noise; the two configs ran on different nodes), so the shared-memory transport buys little over this serialization fix for text embeddings. Baseline large-batch runs used fewer samples (n=20 for 128/256, n=10 for 512/1024) since each request is so slow.

**Gap to bare `vllm serve`** (standalone vLLM v0.21.0 — the same vLLM Dynamo is built on, so this is the floor that isolates Dynamo's overhead):

| batch | bare vLLM | dynamo baseline | dynamo (this PR) | this PR vs vLLM | **gap closed** |
| -- | -- | -- | -- | -- | -- |
| 15 | 35.70 | 124.25 | 86.76 | 2.4× | **~42%** |
| 64 | 70.48 | 469.54 | 304.27 | 4.3× | **~41%** |
| 128 | 124.19 | 934.16 | 584.31 | 4.7× | **~43%** |
| 256 | 233.09 | 1,860.85 | 1,182.62 | 5.1× | **~42%** |
| 512 | 441.74 | 3,684.53 | 2,364.84 | 5.4× | **~41%** |
| 1024 | 876.34 | 7,491.99 | 4,694.72 | 5.4× | **~42%** |

This PR **closes ~42% of the Dynamo-over-vLLM overhead** at every batch (gap closed = `1 − (thisPR − vLLM)/(baseline − vLLM)`). A residual gap remains (Dynamo+this PR is 2.4–5.4× bare vLLM) — the two-process architecture's inherent cost: the extra worker→frontend serialization hop (base64 encode + transport + Rust decode) plus the Rust HTTP frontend, tokenizer, and request-plane, none of which single-process `vllm serve` pays. That residual is what SHM/single-process target separately.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/handlers.py` — `_pooling_output_to_base64` and its use in the embedding response loop.

#### Related:

- Linear: DIS-2178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

