### PR TITLE
refactor(backend): rename quiesce controllers to pause

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -6,7 +6,7 @@ KV-aware (DP-rank) routing, health-check canaries, OpenTelemetry
 tracing, and request-side guided decoding / structural tag.
 
 > **Work in progress.** Logprob response wire, multimodal, diffusion
-> (image/video/DLLM), LoRA, engine routes (sleep/wake, profiling,
+> (image/video/DLLM), LoRA, engine routes (pause/resume, profiling,
 > weight updates), text-in-text-out, and snapshot/CRIU are still on
 > the non-unified path. See [Feature Gaps](#feature-gaps) for the
 > per-engine matrix.
@@ -437,7 +437,7 @@ Lifecycle and runtime:
 - `drain()` hook for pre-cleanup work
 - `DynamoException` error chain wrapping
 - Finish reason normalization handled by the Rust layer
-- Engine control plumbing, with per-backend profiling, quiesce/resume, and supported weight-update controls
+- Engine control plumbing, with per-backend profiling, pause/resume, and supported weight-update controls
 - **Disaggregated serving** (`agg`/`prefill`/`decode`) — KV transfer
   uses NIXL across all three engines; SGLang exchanges a Dynamo-level
   bootstrap address, vLLM and TRT-LLM use an engine-internal handshake.
@@ -498,7 +498,7 @@ Request handling:
 
 | Feature | Description |
 |---------|-------------|
-| Sleep/wake/quiesce | 3-level engine lifecycle control (`VllmEngineQuiesceController`) with shutdown-delay tags |
+| Sleep/wake | 3-level vLLM engine lifecycle control (`VllmEnginePauseController`) with shutdown-delay tags |
 | Elastic EP scaling | `scale_elastic_ep` endpoint with Ray node management |
 | GMS shadow mode | GPU Memory Service integration with failover lock (`--gms-shadow-mode`, `configure_gms_lock_mode`) |
 | ModelExpress P2P | Distributed model loading via P2P (`--model-express-url`, `register_modelexpress_loaders`, `mx-source` / `mx-target` load formats) |
@@ -523,7 +523,7 @@ Request handling:
 | Multimodal encode worker | Front-facing `MMEncoder`, embedding LRU cache, NIXL transfer (`MultimodalEncodeWorkerHandler`) |
 | Multimodal worker | Aggregated and disaggregated-prefill multimodal inference with `EmbeddingsProcessor` |
 | Deferred signal handling | `install_graceful_shutdown` captures SGLang's internal `loop.add_signal_handler` registrations for coordinated teardown |
-| Snapshot quiesce | Legacy `prepare_snapshot_engine` wires `SGLangEngineQuiesceController` to the shared `EngineSnapshotController` (CRIU + identity reload); unified path doesn't invoke it |
+| Snapshot pause | Legacy `prepare_snapshot_engine` wires `SGLangEnginePauseController` to the shared `EngineSnapshotController` (CRIU + identity reload); unified path doesn't invoke it |
 | Image/video health-check payloads | `ImageDiffusionHealthCheckPayload`, `VideoGenerationHealthCheckPayload` |
 | `register_model_with_readiness_gate` + image/video fast paths | `register.py` skips HF `config.json` download for `ModelType.Images` / `ModelType.Videos` |
 | Output modalities override | Required for diffusion workers (default `["text"]` -> `["image"]` / `["video"]`) |

--- a/components/src/dynamo/common/backend/tests/test_engine.py
+++ b/components/src/dynamo/common/backend/tests/test_engine.py
@@ -383,7 +383,7 @@ async def test_default_engine_controls_are_empty():
     """Engines opt into management controls explicitly."""
     engine = _Complete()
     assert engine.supported_controls() == set()
-    assert await engine.engine_control("sleep", {}) == {
+    assert await engine.engine_control("pause", {}) == {
         "status": "error",
-        "message": "unsupported engine control: sleep",
+        "message": "unsupported engine control: pause",
     }

--- a/components/src/dynamo/common/utils/snapshot.py
+++ b/components/src/dynamo/common/utils/snapshot.py
@@ -53,11 +53,11 @@ class CheckpointConfig:
 
     async def run_lifecycle(
         self,
-        quiesce_controller: Any,
-        *quiesce_args: object,
+        pause_controller: Any,
+        *pause_args: object,
     ) -> bool:
-        logger.info("Quiescing model")
-        await quiesce_controller.quiesce(*quiesce_args)
+        logger.info("Pausing model")
+        await pause_controller.pause(*pause_args)
 
         try:
             with open(self.ready_file, "w", encoding="utf-8") as ready_file:
@@ -76,8 +76,8 @@ class CheckpointConfig:
         if event == "restore":
             logger.info("Restore sentinel detected")
             logger.info("Resuming model after restore")
-            await quiesce_controller.resume()
-            quiesce_controller.mark_resumed()
+            await pause_controller.resume()
+            pause_controller.mark_resumed()
             return True
 
         logger.info("Snapshot completion sentinel detected")
@@ -186,14 +186,14 @@ def configure_checkpoint_transport_env() -> None:
 @dataclass
 class EngineSnapshotController(Generic[EngineT]):
     engine: EngineT
-    quiesce_controller: Any
+    pause_controller: Any
     checkpoint_config: CheckpointConfig
-    quiesce_args: tuple[object, ...] = ()
+    pause_args: tuple[object, ...] = ()
 
     async def wait_for_restore(self) -> bool:
         return await self.checkpoint_config.run_lifecycle(
-            self.quiesce_controller,
-            *self.quiesce_args,
+            self.pause_controller,
+            *self.pause_args,
         )
 
     def reload_restore_identity(

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -65,8 +65,8 @@ from dynamo.sglang.capacity import (
     local_dp_rank_bounds,
     runtime_capacity,
 )
+from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import format_zmq_endpoint
-from dynamo.sglang.quiesce import SGLangEngineQuiesceController
 
 if TYPE_CHECKING:
     from dynamo._core.backend import EngineMetrics  # type: ignore[import-not-found]
@@ -130,8 +130,8 @@ class SglangLLMEngine(LLMEngine):
         # `dp_rank` against this node's range before forwarding to SGLang.
         self._dp_start: int = 0
         self._dp_size: int = 1
-        self._quiesce_controller: SGLangEngineQuiesceController | None = None
-        self._quiesce_lock = asyncio.Lock()
+        self._pause_controller: SGLangEnginePauseController | None = None
+        self._pause_lock = asyncio.Lock()
 
     @classmethod
     async def from_args(
@@ -159,7 +159,7 @@ class SglangLLMEngine(LLMEngine):
         del worker_id  # SGLang bootstrap uses host/port/room triples
 
         self.engine = sgl.Engine(server_args=self.server_args)
-        self._quiesce_controller = SGLangEngineQuiesceController(self.engine)
+        self._pause_controller = SGLangEnginePauseController(self.engine)
 
         tokenizer = (
             self.engine.tokenizer_manager.tokenizer
@@ -450,7 +450,7 @@ class SglangLLMEngine(LLMEngine):
         return await handler(body or {})
 
     async def release_memory_occupation(self, body: dict) -> dict:
-        controller = self._quiesce_controller
+        controller = self._pause_controller
         if controller is None:
             return {
                 "status": "error",
@@ -459,8 +459,8 @@ class SglangLLMEngine(LLMEngine):
 
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
-            if controller.is_quiesced:
+        async with self._pause_lock:
+            if controller.is_paused:
                 return {"status": "ok", "message": "Memory already released"}
             if controller.needs_resume_recovery:
                 return {
@@ -468,7 +468,7 @@ class SglangLLMEngine(LLMEngine):
                     "message": "resume_memory_occupation required before retrying release",
                 }
             try:
-                await controller.quiesce(tags)
+                await controller.pause(tags)
                 return {
                     "status": "ok",
                     "message": (
@@ -482,7 +482,7 @@ class SglangLLMEngine(LLMEngine):
                 return {"status": "error", "message": str(e)}
 
     async def resume_memory_occupation(self, body: dict) -> dict:
-        controller = self._quiesce_controller
+        controller = self._pause_controller
         if controller is None:
             return {
                 "status": "error",
@@ -491,9 +491,9 @@ class SglangLLMEngine(LLMEngine):
 
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
+        async with self._pause_lock:
             needs_recovery = controller.needs_resume_recovery
-            if not controller.is_quiesced and not needs_recovery:
+            if not controller.is_paused and not needs_recovery:
                 return {"status": "ok", "message": "Memory already resumed"}
             try:
                 await controller.resume(tags)
@@ -638,7 +638,7 @@ class SglangLLMEngine(LLMEngine):
             except Exception:
                 pass
             self._metrics_zmq_ctx = None
-        self._quiesce_controller = None
+        self._pause_controller = None
         if self.engine is not None:
             self.engine.shutdown()
             logger.info("SGLang engine shutdown")

--- a/components/src/dynamo/sglang/pause.py
+++ b/components/src/dynamo/sglang/pause.py
@@ -16,22 +16,22 @@ from sglang.srt.managers.io_struct import (
 logger = logging.getLogger(__name__)
 
 
-class SGLangEngineQuiesceController:
+class SGLangEnginePauseController:
     def __init__(self, engine: Any):
         self._engine = engine
-        self._is_quiesced = False
+        self._is_paused = False
         self._generation_paused = False
 
     @property
-    def is_quiesced(self) -> bool:
-        return self._is_quiesced
+    def is_paused(self) -> bool:
+        return self._is_paused
 
     @property
     def needs_resume_recovery(self) -> bool:
         return self._generation_paused
 
-    async def quiesce(self, tags: list[str] | None = None) -> bool:
-        if self._is_quiesced or self._generation_paused:
+    async def pause(self, tags: list[str] | None = None) -> bool:
+        if self._is_paused or self._generation_paused:
             return False
 
         await self._engine.tokenizer_manager.pause_generation(PauseGenerationReqInput())
@@ -53,14 +53,14 @@ class SGLangEngineQuiesceController:
                 )
             raise
 
-        self._is_quiesced = True
+        self._is_paused = True
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
-        if not self._is_quiesced and not self._generation_paused:
+        if not self._is_paused and not self._generation_paused:
             return False
 
-        if self._is_quiesced:
+        if self._is_paused:
             await self._engine.tokenizer_manager.resume_memory_occupation(
                 ResumeMemoryOccupationReqInput(tags=tags),
                 None,
@@ -73,5 +73,5 @@ class SGLangEngineQuiesceController:
         return True
 
     def mark_resumed(self) -> None:
-        self._is_quiesced = False
+        self._is_paused = False
         self._generation_paused = False

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -43,8 +43,8 @@ from dynamo.llm import (
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
+from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import DynamoSglangPublisher
-from dynamo.sglang.quiesce import SGLangEngineQuiesceController
 
 logger = logging.getLogger(__name__)
 
@@ -662,10 +662,10 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             # have an sgl.Engine.
             self.input_param_manager = InputParamManager(None)
             self._engine_supports_priority = False
-        self._quiesce_controller = (
-            SGLangEngineQuiesceController(engine) if engine is not None else None
+        self._pause_controller = (
+            SGLangEnginePauseController(engine) if engine is not None else None
         )
-        self._quiesce_lock = asyncio.Lock()
+        self._pause_lock = asyncio.Lock()
 
         # LoRA tracking (via LoraMixin)
         self._init_lora_tracking()
@@ -691,7 +691,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         2. Pause generation - drain in-flight requests
         3. Release memory - safe now that no requests are active
         """
-        if self._quiesce_controller is None:
+        if self._pause_controller is None:
             return {
                 "status": "error",
                 "message": "memory control not supported on this worker",
@@ -699,13 +699,13 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
 
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
-            if self._quiesce_controller.is_quiesced:
+        async with self._pause_lock:
+            if self._pause_controller.is_paused:
                 return {
                     "status": "ok",
                     "message": "Memory already released",
                 }
-            if self._quiesce_controller.needs_resume_recovery:
+            if self._pause_controller.needs_resume_recovery:
                 return {
                     "status": "error",
                     "message": "resume_memory_occupation required before retrying release",
@@ -718,7 +718,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
                     await self.generate_endpoint.unregister_endpoint_instance()
                     unregistered = True
 
-                await self._quiesce_controller.quiesce(tags)
+                await self._pause_controller.pause(tags)
 
                 return {
                     "status": "ok",
@@ -730,13 +730,13 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
                 }
             except Exception as e:
                 logging.error(f"Failed to release memory occupation: {e}")
-                # If quiesce rolled back cleanly the engine is serving-safe again,
+                # If pause rolled back cleanly the engine is serving-safe again,
                 # but discovery still shows us unregistered and resume will
                 # early-return. Re-register so the worker rejoins the routing pool.
                 if (
                     unregistered
-                    and not self._quiesce_controller.is_quiesced
-                    and not self._quiesce_controller.needs_resume_recovery
+                    and not self._pause_controller.is_paused
+                    and not self._pause_controller.needs_resume_recovery
                     and self.generate_endpoint is not None
                 ):
                     try:
@@ -761,7 +761,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         2. Continue generation - ready to serve requests
         3. Re-register to discovery - allow frontend to route here
         """
-        if self._quiesce_controller is None:
+        if self._pause_controller is None:
             return {
                 "status": "error",
                 "message": "memory control not supported on this worker",
@@ -769,20 +769,20 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
 
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
-            needs_recovery = self._quiesce_controller.needs_resume_recovery
-            if not self._quiesce_controller.is_quiesced and not needs_recovery:
+        async with self._pause_lock:
+            needs_recovery = self._pause_controller.needs_resume_recovery
+            if not self._pause_controller.is_paused and not needs_recovery:
                 return {
                     "status": "ok",
                     "message": "Memory already resumed",
                 }
 
             try:
-                await self._quiesce_controller.resume(tags)
+                await self._pause_controller.resume(tags)
 
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.register_endpoint_instance()
-                self._quiesce_controller.mark_resumed()
+                self._pause_controller.mark_resumed()
 
                 return {
                     "status": "ok",

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -3,7 +3,6 @@
 
 """Dynamo Snapshot integration for SGLang workers."""
 
-
 import gc
 import logging
 import time
@@ -12,7 +11,7 @@ import sglang as sgl
 
 from dynamo.common.utils.snapshot import CheckpointConfig, EngineSnapshotController
 
-from .request_handlers.handler_base import SGLangEngineQuiesceController
+from .pause import SGLangEnginePauseController
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +61,7 @@ async def prepare_snapshot_engine(
 
     snapshot_controller = EngineSnapshotController(
         engine=engine,
-        quiesce_controller=SGLangEngineQuiesceController(engine),
+        pause_controller=SGLangEnginePauseController(engine),
         checkpoint_config=checkpoint_cfg,
     )
     if not await snapshot_controller.wait_for_restore():

--- a/components/src/dynamo/sglang/tests/test_sglang_engine_routes.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_engine_routes.py
@@ -42,7 +42,7 @@ except ImportError:
     sys.modules.setdefault("sglang.srt.managers.io_struct", _make_io_struct_stub())
 
 from dynamo.sglang.llm_engine import SglangLLMEngine  # noqa: E402
-from dynamo.sglang.quiesce import SGLangEngineQuiesceController  # noqa: E402
+from dynamo.sglang.pause import SGLangEnginePauseController  # noqa: E402
 
 pytestmark = [
     pytest.mark.unit,
@@ -58,10 +58,10 @@ def _stub_sglang_io_struct(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "sglang.srt.managers.io_struct", _make_io_struct_stub()
     )
-    monkeypatch.setattr("dynamo.sglang.quiesce.PauseGenerationReqInput", _Req)
-    monkeypatch.setattr("dynamo.sglang.quiesce.ReleaseMemoryOccupationReqInput", _Req)
-    monkeypatch.setattr("dynamo.sglang.quiesce.ResumeMemoryOccupationReqInput", _Req)
-    monkeypatch.setattr("dynamo.sglang.quiesce.ContinueGenerationReqInput", _Req)
+    monkeypatch.setattr("dynamo.sglang.pause.PauseGenerationReqInput", _Req)
+    monkeypatch.setattr("dynamo.sglang.pause.ReleaseMemoryOccupationReqInput", _Req)
+    monkeypatch.setattr("dynamo.sglang.pause.ResumeMemoryOccupationReqInput", _Req)
+    monkeypatch.setattr("dynamo.sglang.pause.ContinueGenerationReqInput", _Req)
     monkeypatch.setattr("dynamo.sglang.llm_engine.UpdateWeightFromDiskReqInput", _Req)
     monkeypatch.setattr(
         "dynamo.sglang.llm_engine.UpdateWeightsFromTensorReqInput", _Req
@@ -91,8 +91,8 @@ def _make_engine() -> SglangLLMEngine:
         server_args=SimpleNamespace(weight_version=None),
     )
     engine.engine = SimpleNamespace(tokenizer_manager=tokenizer_manager)
-    engine._quiesce_controller = SGLangEngineQuiesceController(engine.engine)
-    engine._quiesce_lock = asyncio.Lock()
+    engine._pause_controller = SGLangEnginePauseController(engine.engine)
+    engine._pause_lock = asyncio.Lock()
     return engine
 
 
@@ -152,8 +152,8 @@ async def test_resume_recovers_generation_pause_after_failed_release_rollback():
     release_result = await engine.release_memory_occupation({})
 
     assert release_result["status"] == "error"
-    assert engine._quiesce_controller.is_quiesced is False
-    assert engine._quiesce_controller.needs_resume_recovery is True
+    assert engine._pause_controller.is_paused is False
+    assert engine._pause_controller.needs_resume_recovery is True
     failed_continue.assert_awaited_once()
 
     manager.continue_generation = AsyncMock()
@@ -162,7 +162,7 @@ async def test_resume_recovers_generation_pause_after_failed_release_rollback():
     assert resume_result["status"] == "ok"
     manager.resume_memory_occupation.assert_not_awaited()
     manager.continue_generation.assert_awaited_once()
-    assert engine._quiesce_controller.needs_resume_recovery is False
+    assert engine._pause_controller.needs_resume_recovery is False
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_memory_occupation_handlers.py
@@ -11,7 +11,7 @@ import pytest
 
 from dynamo.sglang.request_handlers.handler_base import (
     BaseWorkerHandler,
-    SGLangEngineQuiesceController,
+    SGLangEnginePauseController,
 )
 
 pytestmark = [
@@ -60,8 +60,8 @@ def handler():
         unregister_endpoint_instance=AsyncMock(),
         register_endpoint_instance=AsyncMock(),
     )
-    handler._quiesce_controller = SGLangEngineQuiesceController(handler.engine)
-    handler._quiesce_lock = asyncio.Lock()
+    handler._pause_controller = SGLangEnginePauseController(handler.engine)
+    handler._pause_lock = asyncio.Lock()
     return handler
 
 
@@ -148,8 +148,8 @@ async def test_resume_recovers_generation_pause_after_failed_release_rollback(ha
     release_result = await handler.release_memory_occupation({})
 
     assert release_result["status"] == "error"
-    assert handler._quiesce_controller.is_quiesced is False
-    assert handler._quiesce_controller.needs_resume_recovery is True
+    assert handler._pause_controller.is_paused is False
+    assert handler._pause_controller.needs_resume_recovery is True
     failed_continue.assert_awaited_once()
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
 
@@ -160,11 +160,11 @@ async def test_resume_recovers_generation_pause_after_failed_release_rollback(ha
     manager.resume_memory_occupation.assert_not_awaited()
     manager.continue_generation.assert_awaited_once()
     handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
-    assert handler._quiesce_controller.needs_resume_recovery is False
+    assert handler._pause_controller.needs_resume_recovery is False
 
 
 @pytest.mark.asyncio
-async def test_release_reregisters_after_clean_quiesce_rollback(handler):
+async def test_release_reregisters_after_clean_pause_rollback(handler):
     manager = handler.engine.tokenizer_manager
     manager.release_memory_occupation = AsyncMock(
         side_effect=RuntimeError("release failed")
@@ -174,8 +174,8 @@ async def test_release_reregisters_after_clean_quiesce_rollback(handler):
 
     # Rollback continued generation cleanly, so the engine is serving-safe again.
     assert release_result["status"] == "error"
-    assert handler._quiesce_controller.is_quiesced is False
-    assert handler._quiesce_controller.needs_resume_recovery is False
+    assert handler._pause_controller.is_paused is False
+    assert handler._pause_controller.needs_resume_recovery is False
     manager.continue_generation.assert_awaited_once()
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
     # The endpoint must rejoin the routing pool since resume will early-return.
@@ -190,13 +190,13 @@ async def test_release_reregisters_after_clean_quiesce_rollback(handler):
         ("resume_memory_occupation", "register_endpoint_instance"),
     ],
 )
-async def test_memory_control_returns_error_without_quiesce_controller(
+async def test_memory_control_returns_error_without_pause_controller(
     handler,
     method_name,
     endpoint_method,
 ):
     handler.engine = None
-    handler._quiesce_controller = None
+    handler._pause_controller = None
 
     result = await getattr(handler, method_name)({})
 
@@ -208,7 +208,7 @@ async def test_memory_control_returns_error_without_quiesce_controller(
 
 
 @pytest.mark.asyncio
-async def test_resume_keeps_quiesced_state_when_register_fails(handler):
+async def test_resume_keeps_paused_state_when_register_fails(handler):
     await handler.release_memory_occupation({})
     handler.generate_endpoint.register_endpoint_instance = AsyncMock(
         side_effect=RuntimeError("discovery write timeout")
@@ -217,5 +217,5 @@ async def test_resume_keeps_quiesced_state_when_register_fails(handler):
     result = await handler.resume_memory_occupation({})
 
     assert result["status"] == "error"
-    assert handler._quiesce_controller is not None
-    assert handler._quiesce_controller.is_quiesced is True
+    assert handler._pause_controller is not None
+    assert handler._pause_controller.is_paused is True

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -61,7 +61,7 @@ from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
 from dynamo.trtllm.logits_processing.adapter import attach_logits_processors
-from dynamo.trtllm.request_handlers.handler_base import TRTLLMEngineQuiesceController
+from dynamo.trtllm.request_handlers.handler_base import TRTLLMEnginePauseController
 from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParams,
     DisaggregatedParamsCodec,
@@ -189,8 +189,8 @@ class TrtllmLLMEngine(LLMEngine):
         # One-shot guards so a misbehaving engine doesn't flood logs.
         self._warned_dispatch_failed = False
         self._warned_unknown_dp_rank = False
-        self._quiesce_controller: TRTLLMEngineQuiesceController | None = None
-        self._quiesce_lock = asyncio.Lock()
+        self._pause_controller: TRTLLMEnginePauseController | None = None
+        self._pause_lock = asyncio.Lock()
         self._inflight_lock = asyncio.Lock()
         self._inflight_requests = 0
         self._no_inflight_requests = asyncio.Event()
@@ -320,7 +320,7 @@ class TrtllmLLMEngine(LLMEngine):
 
         self._engine = TensorRTLLMEngine(self.engine_args, self.disaggregation_mode)
         await self._engine.initialize()
-        self._quiesce_controller = TRTLLMEngineQuiesceController(self._engine)
+        self._pause_controller = TRTLLMEnginePauseController(self._engine)
 
         # Resolve the engine-declared spec now the engine (and its tokenizer)
         # is initialized; see `logits_processor_spec()`.
@@ -627,20 +627,20 @@ class TrtllmLLMEngine(LLMEngine):
 
     @staticmethod
     def _controller_needs_resume_recovery(
-        controller: TRTLLMEngineQuiesceController,
+        controller: TRTLLMEnginePauseController,
     ) -> bool:
         needs_recovery = getattr(controller, "needs_resume_recovery", False)
         return needs_recovery if isinstance(needs_recovery, bool) else False
 
     async def release_memory_occupation(self, body: dict) -> dict:
-        controller = self._quiesce_controller
+        controller = self._pause_controller
         if controller is None:
             return {"status": "error", "message": "engine is not initialized"}
 
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
-            if controller.is_quiesced:
+        async with self._pause_lock:
+            if controller.is_paused:
                 return {"status": "ok", "message": "Memory already released"}
             if (
                 self._resume_recovery_required
@@ -655,35 +655,35 @@ class TrtllmLLMEngine(LLMEngine):
                 timeout_s = float(body.get("timeout_s", 30.0))
                 await self._wait_for_inflight_requests(timeout_s)
             except Exception as exc:
-                logger.error("release_memory_occupation failed before quiesce: %s", exc)
+                logger.error("release_memory_occupation failed before pause: %s", exc)
                 await self._set_reject_new_requests(False)
                 return {"status": "error", "message": str(exc)}
 
             try:
-                await controller.quiesce(tags)
+                await controller.pause(tags)
                 self._resume_recovery_required = False
                 return {"status": "ok", "message": "Memory released"}
             except Exception as exc:
-                logger.error("release_memory_occupation quiesce failed: %s", exc)
+                logger.error("release_memory_occupation pause failed: %s", exc)
                 self._resume_recovery_required = True
                 return {"status": "error", "message": str(exc)}
 
     async def resume_memory_occupation(self, body: dict) -> dict:
-        controller = self._quiesce_controller
+        controller = self._pause_controller
         if controller is None:
             return {"status": "error", "message": "engine is not initialized"}
 
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
+        async with self._pause_lock:
             needs_recovery = (
                 self._resume_recovery_required
                 or self._controller_needs_resume_recovery(controller)
             )
-            if not controller.is_quiesced and not needs_recovery:
+            if not controller.is_paused and not needs_recovery:
                 return {"status": "ok", "message": "Memory already resumed"}
             try:
-                if controller.is_quiesced or self._controller_needs_resume_recovery(
+                if controller.is_paused or self._controller_needs_resume_recovery(
                     controller
                 ):
                     await controller.resume(tags)
@@ -1041,7 +1041,7 @@ class TrtllmLLMEngine(LLMEngine):
         self._kv_events_thread = None
         self._metrics_thread = None
         self._kv_publishers.clear()
-        self._quiesce_controller = None
+        self._pause_controller = None
         if self._engine is not None:
             await self._engine.cleanup()
             logger.info("TensorRT-LLM engine shutdown")

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -63,27 +63,27 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 
-class TRTLLMEngineQuiesceController:
-    """Adapts TRT-LLM sleep/wake to the standard quiesce controller interface.
+class TRTLLMEnginePauseController:
+    """Adapts TRT-LLM sleep/wake to the standard pause controller interface.
 
     Two memory domains: KV cache via TRT-LLM collective_rpc, weights via GMS.
     """
 
     def __init__(self, engine: TensorRTLLMEngine):
         self._engine = engine
-        self._is_quiesced = False
+        self._is_paused = False
         self._pending_resume_tags: set[str] = set()
 
     @property
-    def is_quiesced(self) -> bool:
-        return self._is_quiesced
+    def is_paused(self) -> bool:
+        return self._is_paused
 
     @property
     def needs_resume_recovery(self) -> bool:
         return bool(self._pending_resume_tags)
 
-    async def quiesce(self, tags: list[str] | None = None) -> bool:
-        if self._is_quiesced or self._pending_resume_tags:
+    async def pause(self, tags: list[str] | None = None) -> bool:
+        if self._is_paused or self._pending_resume_tags:
             return False
         tags = tags or ["kv_cache", "weights"]
         if "kv_cache" in tags:
@@ -92,11 +92,11 @@ class TRTLLMEngineQuiesceController:
         if "weights" in tags:
             self._pending_resume_tags.add("weights")
             self._release_gms_weights()
-        self._is_quiesced = True
+        self._is_paused = True
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
-        if not self._is_quiesced and not self._pending_resume_tags:
+        if not self._is_paused and not self._pending_resume_tags:
             return False
         requested_tags = set(tags or ["kv_cache", "weights"])
         # During recovery, restore the domains that may actually be asleep
@@ -111,7 +111,7 @@ class TRTLLMEngineQuiesceController:
         return True
 
     def mark_resumed(self) -> None:
-        self._is_quiesced = False
+        self._is_paused = False
         self._pending_resume_tags.clear()
 
     def _collective_rpc(self, method: str, rpc_tags: list[str]) -> None:
@@ -267,12 +267,12 @@ class HandlerBase(BaseGenerativeHandler):
         self.max_seq_len = config.max_seq_len
         self.disagg_machine_id = config.disagg_machine_id
         # Sleep/wake state
-        self._quiesce_lock = asyncio.Lock()
+        self._pause_lock = asyncio.Lock()
         self._inflight_lock = asyncio.Lock()
         self._inflight_requests = 0
         self._no_inflight_requests = asyncio.Event()
         self._no_inflight_requests.set()
-        self._quiesce_controller = TRTLLMEngineQuiesceController(config.engine)
+        self._pause_controller = TRTLLMEnginePauseController(config.engine)
         self._reject_new_requests = False
 
     def check_error(self, result: dict) -> bool:
@@ -322,25 +322,25 @@ class HandlerBase(BaseGenerativeHandler):
 
     @staticmethod
     def _controller_needs_resume_recovery(
-        controller: TRTLLMEngineQuiesceController,
+        controller: TRTLLMEnginePauseController,
     ) -> bool:
         needs_recovery = getattr(controller, "needs_resume_recovery", False)
         return needs_recovery if isinstance(needs_recovery, bool) else False
 
     # ------------------------------------------------------------------
-    # Sleep / wake public API (delegates to TRTLLMEngineQuiesceController)
+    # Sleep / wake public API (delegates to TRTLLMEnginePauseController)
     # ------------------------------------------------------------------
 
     async def release_memory_occupation(self, body: dict) -> dict:
-        """Release GPU memory: unregister endpoint, drain requests, quiesce engine."""
+        """Release GPU memory: unregister endpoint, drain requests, pause engine."""
         body = body or {}
         tags = body.get("tags")
 
-        async with self._quiesce_lock:
-            if self._quiesce_controller.is_quiesced:
+        async with self._pause_lock:
+            if self._pause_controller.is_paused:
                 return {"status": "ok", "message": "Memory already released"}
-            if self._controller_needs_resume_recovery(self._quiesce_controller):
-                # A prior release rolled back into a half-quiesced state; quiesce()
+            if self._controller_needs_resume_recovery(self._pause_controller):
+                # A prior release rolled back into a half-paused state; pause()
                 # would no-op and falsely report success. Force a resume first.
                 return {
                     "status": "error",
@@ -355,19 +355,19 @@ class HandlerBase(BaseGenerativeHandler):
 
                 timeout_s = float(body.get("timeout_s", 30.0))
                 await self._wait_for_inflight_requests(timeout_s)
-                await self._quiesce_controller.quiesce(tags)
+                await self._pause_controller.pause(tags)
 
                 return {"status": "ok", "message": "Memory released"}
             except Exception as exc:
                 logger.error("release_memory_occupation failed: %s", exc)
                 # Rollback: TRT-LLM has no pause_generation(), so we
                 # manually unregistered the endpoint and set reject flag
-                # above. Restore both on failure. If quiesce partially
+                # above. Restore both on failure. If pause partially
                 # succeeded, resume the completed domains first.
-                if self._controller_needs_resume_recovery(self._quiesce_controller):
+                if self._controller_needs_resume_recovery(self._pause_controller):
                     try:
-                        await self._quiesce_controller.resume(tags)
-                        self._quiesce_controller.mark_resumed()
+                        await self._pause_controller.resume(tags)
+                        self._pause_controller.mark_resumed()
                     except Exception as resume_exc:
                         logger.error(
                             "release_memory_occupation rollback resume failed: %s",
@@ -387,21 +387,21 @@ class HandlerBase(BaseGenerativeHandler):
         body = body or {}
         tags = body.get("tags")
 
-        async with self._quiesce_lock:
+        async with self._pause_lock:
             needs_recovery = self._controller_needs_resume_recovery(
-                self._quiesce_controller
+                self._pause_controller
             )
-            if not self._quiesce_controller.is_quiesced and not needs_recovery:
+            if not self._pause_controller.is_paused and not needs_recovery:
                 return {"status": "ok", "message": "Memory already resumed"}
 
             try:
-                await self._quiesce_controller.resume(tags)
+                await self._pause_controller.resume(tags)
 
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.register_endpoint_instance()
 
                 await self._set_reject_new_requests(False)
-                self._quiesce_controller.mark_resumed()
+                self._pause_controller.mark_resumed()
                 return {"status": "ok", "message": "Memory resumed"}
             except Exception as exc:
                 logger.error("resume_memory_occupation failed: %s", exc)

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine_routes.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine_routes.py
@@ -34,7 +34,7 @@ pytestmark = [
 
 def _make_engine() -> TrtllmLLMEngine:
     engine = TrtllmLLMEngine.__new__(TrtllmLLMEngine)
-    engine._quiesce_lock = asyncio.Lock()
+    engine._pause_lock = asyncio.Lock()
     engine._inflight_lock = asyncio.Lock()
     engine._inflight_requests = 0
     engine._no_inflight_requests = asyncio.Event()
@@ -43,23 +43,23 @@ def _make_engine() -> TrtllmLLMEngine:
     engine._resume_recovery_required = False
 
     controller = MagicMock()
-    controller.is_quiesced = False
+    controller.is_paused = False
     controller.needs_resume_recovery = False
 
-    async def _quiesce(tags=None):
-        controller.is_quiesced = True
+    async def _pause(tags=None):
+        controller.is_paused = True
         return True
 
     async def _resume(tags=None):
         return True
 
     def _mark_resumed():
-        controller.is_quiesced = False
+        controller.is_paused = False
 
-    controller.quiesce = AsyncMock(side_effect=_quiesce)
+    controller.pause = AsyncMock(side_effect=_pause)
     controller.resume = AsyncMock(side_effect=_resume)
     controller.mark_resumed = MagicMock(side_effect=_mark_resumed)
-    engine._quiesce_controller = controller
+    engine._pause_controller = controller
     return engine
 
 
@@ -74,7 +74,7 @@ async def test_engine_controls_expose_trtllm_management_capabilities():
 
 
 @pytest.mark.asyncio
-async def test_release_and_resume_delegate_to_quiesce_controller():
+async def test_release_and_resume_delegate_to_pause_controller():
     engine = _make_engine()
 
     release_result = await engine.engine_control(
@@ -86,9 +86,9 @@ async def test_release_and_resume_delegate_to_quiesce_controller():
 
     assert release_result["status"] == "ok"
     assert resume_result["status"] == "ok"
-    engine._quiesce_controller.quiesce.assert_awaited_once_with(["kv_cache"])
-    engine._quiesce_controller.resume.assert_awaited_once_with(["kv_cache"])
-    engine._quiesce_controller.mark_resumed.assert_called_once_with()
+    engine._pause_controller.pause.assert_awaited_once_with(["kv_cache"])
+    engine._pause_controller.resume.assert_awaited_once_with(["kv_cache"])
+    engine._pause_controller.mark_resumed.assert_called_once_with()
     assert engine._reject_new_requests is False
 
 
@@ -106,11 +106,9 @@ async def test_release_rejects_new_requests_until_resume():
 
 
 @pytest.mark.asyncio
-async def test_resume_clears_reject_after_failed_quiesce():
+async def test_resume_clears_reject_after_failed_pause():
     engine = _make_engine()
-    engine._quiesce_controller.quiesce = AsyncMock(
-        side_effect=RuntimeError("sleep failed")
-    )
+    engine._pause_controller.pause = AsyncMock(side_effect=RuntimeError("sleep failed"))
 
     release = await engine.release_memory_occupation({})
 
@@ -122,26 +120,26 @@ async def test_resume_clears_reject_after_failed_quiesce():
     resume = await engine.resume_memory_occupation({})
 
     assert resume["status"] == "ok"
-    engine._quiesce_controller.resume.assert_not_awaited()
-    engine._quiesce_controller.mark_resumed.assert_called_once_with()
+    engine._pause_controller.resume.assert_not_awaited()
+    engine._pause_controller.mark_resumed.assert_called_once_with()
     assert engine._reject_new_requests is False
     assert engine._resume_recovery_required is False
 
 
 @pytest.mark.asyncio
-async def test_resume_recovers_partial_quiesce_before_accepting_requests():
+async def test_resume_recovers_partial_pause_before_accepting_requests():
     engine = _make_engine()
 
-    async def _quiesce_failed(tags=None):
-        engine._quiesce_controller.needs_resume_recovery = True
+    async def _pause_failed(tags=None):
+        engine._pause_controller.needs_resume_recovery = True
         raise RuntimeError("weights failed")
 
     async def _resume(tags=None):
-        engine._quiesce_controller.needs_resume_recovery = False
+        engine._pause_controller.needs_resume_recovery = False
         return True
 
-    engine._quiesce_controller.quiesce = AsyncMock(side_effect=_quiesce_failed)
-    engine._quiesce_controller.resume = AsyncMock(side_effect=_resume)
+    engine._pause_controller.pause = AsyncMock(side_effect=_pause_failed)
+    engine._pause_controller.resume = AsyncMock(side_effect=_resume)
 
     release = await engine.release_memory_occupation({})
 
@@ -152,8 +150,8 @@ async def test_resume_recovers_partial_quiesce_before_accepting_requests():
     resume = await engine.resume_memory_occupation({})
 
     assert resume["status"] == "ok"
-    engine._quiesce_controller.resume.assert_awaited_once_with(None)
-    engine._quiesce_controller.mark_resumed.assert_called_once_with()
+    engine._pause_controller.resume.assert_awaited_once_with(None)
+    engine._pause_controller.mark_resumed.assert_called_once_with()
     assert engine._reject_new_requests is False
     assert engine._resume_recovery_required is False
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_sleep_wake_handlers.py
@@ -4,7 +4,7 @@
 """Unit tests for TRT-LLM sleep/wake handler logic.
 
 Tests cover in-flight tracking, reject-flag, and sleep/wake delegation to
-TRTLLMEngineQuiesceController without requiring a real GPU or TRT-LLM engine.
+TRTLLMEnginePauseController without requiring a real GPU or TRT-LLM engine.
 """
 
 import asyncio
@@ -31,7 +31,7 @@ pytest.importorskip("tensorrt_llm")
 
 from dynamo.trtllm.request_handlers.handler_base import (  # noqa: E402
     HandlerBase,
-    TRTLLMEngineQuiesceController,
+    TRTLLMEnginePauseController,
 )
 
 pytestmark = [
@@ -53,43 +53,43 @@ class _ConcreteHandler(HandlerBase):
 
 
 def _make_handler() -> _ConcreteHandler:
-    """Create a HandlerBase subclass with mocked quiesce controller and endpoint."""
+    """Create a HandlerBase subclass with mocked pause controller and endpoint."""
     handler = _ConcreteHandler.__new__(_ConcreteHandler)
     handler.generate_endpoint = SimpleNamespace(
         unregister_endpoint_instance=AsyncMock(),
         register_endpoint_instance=AsyncMock(),
     )
-    handler._quiesce_lock = asyncio.Lock()
+    handler._pause_lock = asyncio.Lock()
     handler._inflight_lock = asyncio.Lock()
     handler._inflight_requests = 0
     handler._no_inflight_requests = asyncio.Event()
     handler._no_inflight_requests.set()
     handler._reject_new_requests = False
-    # Mock the quiesce controller that release/resume delegate to.
-    # quiesce side_effect mirrors the real implementation;
+    # Mock the pause controller that release/resume delegate to.
+    # pause side_effect mirrors the real implementation;
     # tests don't need to manually update state after a release call.
-    handler._quiesce_controller = MagicMock()
-    handler._quiesce_controller.is_quiesced = False
-    handler._quiesce_controller.needs_resume_recovery = False
+    handler._pause_controller = MagicMock()
+    handler._pause_controller.is_paused = False
+    handler._pause_controller.needs_resume_recovery = False
 
-    async def _quiesce(tags=None):
-        handler._quiesce_controller.is_quiesced = True
+    async def _pause(tags=None):
+        handler._pause_controller.is_paused = True
         return True
 
-    handler._quiesce_controller.quiesce = AsyncMock(side_effect=_quiesce)
-    handler._quiesce_controller.resume = AsyncMock(return_value=True)
-    handler._quiesce_controller.mark_resumed = MagicMock()
+    handler._pause_controller.pause = AsyncMock(side_effect=_pause)
+    handler._pause_controller.resume = AsyncMock(return_value=True)
+    handler._pause_controller.mark_resumed = MagicMock()
     return handler
 
 
 # ---------------------------------------------------------------------------
-# TRTLLMEngineQuiesceController recovery state
+# TRTLLMEnginePauseController recovery state
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_quiesce_tracks_partial_state_for_resume_recovery():
-    controller = TRTLLMEngineQuiesceController(MagicMock())
+async def test_pause_tracks_partial_state_for_resume_recovery():
+    controller = TRTLLMEnginePauseController(MagicMock())
     controller._collective_rpc = MagicMock()
     controller._release_gms_weights = MagicMock(
         side_effect=RuntimeError("weights failed")
@@ -97,9 +97,9 @@ async def test_quiesce_tracks_partial_state_for_resume_recovery():
     controller._restore_gms_weights = MagicMock()
 
     with pytest.raises(RuntimeError, match="weights failed"):
-        await controller.quiesce()
+        await controller.pause()
 
-    assert controller.is_quiesced is False
+    assert controller.is_paused is False
     assert controller.needs_resume_recovery is True
 
     resumed = await controller.resume()
@@ -114,13 +114,13 @@ async def test_quiesce_tracks_partial_state_for_resume_recovery():
 
 
 @pytest.mark.asyncio
-async def test_resume_restores_completed_quiesce_domains():
-    controller = TRTLLMEngineQuiesceController(MagicMock())
+async def test_resume_restores_completed_pause_domains():
+    controller = TRTLLMEnginePauseController(MagicMock())
     controller._collective_rpc = MagicMock()
     controller._release_gms_weights = MagicMock()
     controller._restore_gms_weights = MagicMock()
 
-    assert await controller.quiesce(["kv_cache"]) is True
+    assert await controller.pause(["kv_cache"]) is True
 
     resumed = await controller.resume(["weights"])
 
@@ -130,7 +130,7 @@ async def test_resume_restores_completed_quiesce_domains():
     )
     controller._restore_gms_weights.assert_not_called()
     controller.mark_resumed()
-    assert controller.is_quiesced is False
+    assert controller.is_paused is False
     assert controller.needs_resume_recovery is False
 
 
@@ -172,13 +172,13 @@ async def test_mark_request_finished_is_idempotent():
 
 
 @pytest.mark.asyncio
-async def test_release_is_noop_when_already_quiesced():
+async def test_release_is_noop_when_already_paused():
     handler = _make_handler()
-    handler._quiesce_controller.is_quiesced = True
+    handler._pause_controller.is_paused = True
     result = await handler.release_memory_occupation({})
     assert result["status"] == "ok"
     assert "already released" in result["message"]
-    handler._quiesce_controller.quiesce.assert_not_called()
+    handler._pause_controller.pause.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -189,11 +189,11 @@ async def test_release_returns_error_for_non_numeric_timeout():
 
 
 @pytest.mark.asyncio
-async def test_release_delegates_to_quiesce_controller():
+async def test_release_delegates_to_pause_controller():
     handler = _make_handler()
     result = await handler.release_memory_occupation({})
     assert result["status"] == "ok"
-    handler._quiesce_controller.quiesce.assert_awaited_once_with(None)
+    handler._pause_controller.pause.assert_awaited_once_with(None)
 
 
 @pytest.mark.asyncio
@@ -201,13 +201,13 @@ async def test_release_passes_tags_to_controller():
     handler = _make_handler()
     result = await handler.release_memory_occupation({"tags": ["weights"]})
     assert result["status"] == "ok"
-    handler._quiesce_controller.quiesce.assert_awaited_once_with(["weights"])
+    handler._pause_controller.pause.assert_awaited_once_with(["weights"])
 
 
 @pytest.mark.asyncio
 async def test_release_unregisters_endpoint_and_restores_on_error():
     handler = _make_handler()
-    handler._quiesce_controller.quiesce = AsyncMock(
+    handler._pause_controller.pause = AsyncMock(
         side_effect=RuntimeError("engine error")
     )
     result = await handler.release_memory_occupation({})
@@ -220,37 +220,37 @@ async def test_release_unregisters_endpoint_and_restores_on_error():
 @pytest.mark.asyncio
 async def test_release_rejected_while_resume_recovery_pending():
     handler = _make_handler()
-    # A prior release left the controller half-quiesced; quiesce() would no-op.
-    handler._quiesce_controller.needs_resume_recovery = True
+    # A prior release left the controller half-paused; pause() would no-op.
+    handler._pause_controller.needs_resume_recovery = True
 
     result = await handler.release_memory_occupation({})
 
     assert result["status"] == "error"
     assert "resume_memory_occupation required" in result["message"]
-    handler._quiesce_controller.quiesce.assert_not_called()
+    handler._pause_controller.pause.assert_not_called()
     handler.generate_endpoint.unregister_endpoint_instance.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_release_recovers_partial_quiesce_before_restoring_endpoint():
+async def test_release_recovers_partial_pause_before_restoring_endpoint():
     handler = _make_handler()
 
-    async def _quiesce_failed(tags=None):
-        handler._quiesce_controller.needs_resume_recovery = True
+    async def _pause_failed(tags=None):
+        handler._pause_controller.needs_resume_recovery = True
         raise RuntimeError("engine error")
 
     async def _resume(tags=None):
-        handler._quiesce_controller.needs_resume_recovery = False
+        handler._pause_controller.needs_resume_recovery = False
         return True
 
-    handler._quiesce_controller.quiesce = AsyncMock(side_effect=_quiesce_failed)
-    handler._quiesce_controller.resume = AsyncMock(side_effect=_resume)
+    handler._pause_controller.pause = AsyncMock(side_effect=_pause_failed)
+    handler._pause_controller.resume = AsyncMock(side_effect=_resume)
 
     result = await handler.release_memory_occupation({})
 
     assert result["status"] == "error"
-    handler._quiesce_controller.resume.assert_awaited_once_with(None)
-    handler._quiesce_controller.mark_resumed.assert_called_once_with()
+    handler._pause_controller.resume.assert_awaited_once_with(None)
+    handler._pause_controller.mark_resumed.assert_called_once_with()
     handler.generate_endpoint.unregister_endpoint_instance.assert_called_once()
     handler.generate_endpoint.register_endpoint_instance.assert_called_once()
     assert not handler._reject_new_requests
@@ -262,12 +262,12 @@ async def test_release_recovers_partial_quiesce_before_restoring_endpoint():
 
 
 @pytest.mark.asyncio
-async def test_resume_is_noop_when_not_quiesced():
+async def test_resume_is_noop_when_not_paused():
     handler = _make_handler()
     result = await handler.resume_memory_occupation({})
     assert result["status"] == "ok"
     assert "already resumed" in result["message"]
-    handler._quiesce_controller.resume.assert_not_called()
+    handler._pause_controller.resume.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -278,8 +278,8 @@ async def test_release_and_resume_round_trip():
 
     resume = await handler.resume_memory_occupation({})
     assert resume["status"] == "ok"
-    handler._quiesce_controller.resume.assert_awaited_once()
-    handler._quiesce_controller.mark_resumed.assert_called_once()
+    handler._pause_controller.resume.assert_awaited_once()
+    handler._pause_controller.mark_resumed.assert_called_once()
     assert not handler._reject_new_requests
     handler.generate_endpoint.register_endpoint_instance.assert_called_once()
 
@@ -287,10 +287,10 @@ async def test_release_and_resume_round_trip():
 @pytest.mark.asyncio
 async def test_resume_passes_tags_to_controller():
     handler = _make_handler()
-    handler._quiesce_controller.is_quiesced = True
+    handler._pause_controller.is_paused = True
     result = await handler.resume_memory_occupation({"tags": ["kv_cache"]})
     assert result["status"] == "ok"
-    handler._quiesce_controller.resume.assert_awaited_once_with(["kv_cache"])
+    handler._pause_controller.resume.assert_awaited_once_with(["kv_cache"])
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -168,8 +168,8 @@ class DynamoVllmArgGroup(ArgGroup):
             default=False,
             help=(
                 "Enable GMS shadow/standby mode. Shadow engines skip KV cache "
-                "allocation at startup, automatically sleep after initialization, "
-                "and wake on demand when the active engine dies. "
+                "allocation at startup, automatically pause after initialization, "
+                "and resume on demand when the active engine dies. "
                 "Requires --load-format=gms."
             ),
         )

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -228,22 +228,22 @@ async def _deferred_abort_guard(
             await guard.close()
 
 
-class VllmEngineQuiesceController:
+class VllmEnginePauseController:
     def __init__(self, engine_client: Any):
         self._engine_client = engine_client
-        self._is_quiesced = False
+        self._is_paused = False
         self._generation_paused = False
 
     @property
-    def is_quiesced(self) -> bool:
-        return self._is_quiesced
+    def is_paused(self) -> bool:
+        return self._is_paused
 
     @property
     def needs_resume_recovery(self) -> bool:
         return self._generation_paused
 
-    async def quiesce(self, *args: object) -> bool:
-        if self._is_quiesced or self._generation_paused:
+    async def pause(self, *args: object) -> bool:
+        if self._is_paused or self._generation_paused:
             return False
 
         level = args[0] if args else None
@@ -259,16 +259,18 @@ class VllmEngineQuiesceController:
                 await self._engine_client.resume_generation()
                 self._generation_paused = False
             except Exception:
-                logger.exception("Failed to resume generation after sleep failure")
+                logger.exception(
+                    "Failed to resume generation after native vLLM sleep failure"
+                )
             raise
-        self._is_quiesced = True
+        self._is_paused = True
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
-        if not self._is_quiesced and not self._generation_paused:
+        if not self._is_paused and not self._generation_paused:
             return False
 
-        if self._is_quiesced:
+        if self._is_paused:
             if tags is None:
                 await self._engine_client.wake_up()
             else:
@@ -279,7 +281,7 @@ class VllmEngineQuiesceController:
         return True
 
     def mark_resumed(self) -> None:
-        self._is_quiesced = False
+        self._is_paused = False
         self._generation_paused = False
 
 
@@ -649,8 +651,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
-        self._quiesce_controller = VllmEngineQuiesceController(self.engine_client)
-        self._quiesce_lock = asyncio.Lock()
+        self._pause_controller = VllmEnginePauseController(self.engine_client)
+        self._pause_lock = asyncio.Lock()
         self._mm_kwargs_receiver: MmKwargsNixlReceiver | None = None
 
         # Some models (Kimi-K2.5) declare their image modality as
@@ -749,17 +751,17 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         Order of operations:
         1. Unregister from discovery - stop accepting new requests
         2. Abort and drain in-flight requests
-        3. Sleep engine - safe now that GPU is quiesced
+        3. Sleep engine - safe once generation has stopped
         """
         body = body or {}
         level = body.get("level", 1)
-        async with self._quiesce_lock:
-            if self._quiesce_controller.is_quiesced:
+        async with self._pause_lock:
+            if self._pause_controller.is_paused:
                 return {
                     "status": "ok",
                     "message": "Engine already sleeping",
                 }
-            if self._quiesce_controller.needs_resume_recovery:
+            if self._pause_controller.needs_resume_recovery:
                 return {
                     "status": "error",
                     "message": "wake_up required before retrying sleep",
@@ -775,9 +777,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "[Sleep] Unregistered endpoint from discovery - worker removed from routing pool"
                     )
 
-                # Step 2: Abort in-flight requests and wait for them to drain so the
-                # GPU is fully quiesced before unmapping memory.
-                if not await self._quiesce_controller.quiesce(level):
+                # Step 2: Abort in-flight requests and wait for them to drain so
+                # generation is fully paused before unmapping memory.
+                if not await self._pause_controller.pause(level):
                     return {
                         "status": "ok",
                         "message": "Engine already sleeping",
@@ -789,13 +791,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 }
             except Exception as e:
                 logger.error(f"Failed to sleep engine: {e}")
-                # If quiesce rolled back cleanly the engine is serving-safe again,
+                # If pause rolled back cleanly the engine is serving-safe again,
                 # but discovery still shows us unregistered and wake_up will
                 # early-return. Re-register so the worker rejoins the routing pool.
                 if (
                     unregistered
-                    and not self._quiesce_controller.is_quiesced
-                    and not self._quiesce_controller.needs_resume_recovery
+                    and not self._pause_controller.is_paused
+                    and not self._pause_controller.needs_resume_recovery
                     and self.generate_endpoint is not None
                 ):
                     try:
@@ -924,20 +926,20 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """
         body = body or {}
         tags = body.get("tags")
-        async with self._quiesce_lock:
-            needs_recovery = self._quiesce_controller.needs_resume_recovery
-            if not self._quiesce_controller.is_quiesced and not needs_recovery:
+        async with self._pause_lock:
+            needs_recovery = self._pause_controller.needs_resume_recovery
+            if not self._pause_controller.is_paused and not needs_recovery:
                 return {"status": "ok", "message": "Engine already awake"}
 
             try:
                 # Step 1: Wake engine first - must be ready before accepting requests
-                await self._quiesce_controller.resume(tags)
+                await self._pause_controller.resume(tags)
                 if self.generate_endpoint is not None:
                     await self.generate_endpoint.register_endpoint_instance()
                     logger.info(
                         "[Wake] Re-registered endpoint to discovery - worker added back to routing pool"
                     )
-                self._quiesce_controller.mark_resumed()
+                self._pause_controller.mark_resumed()
 
                 return {
                     "status": "ok",
@@ -2972,8 +2974,7 @@ class EmbeddingWorkerHandler:
         dimensions = request.get("dimensions")
         if dimensions is not None and not isinstance(dimensions, int):
             raise TypeError(
-                f"Invalid 'dimensions' type {type(dimensions).__name__}; "
-                "expected int"
+                f"Invalid 'dimensions' type {type(dimensions).__name__}; expected int"
             )
         if dimensions is not None and dimensions < 1:
             raise ValueError(f"dimensions must be >= 1, got {dimensions}")

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -54,7 +54,7 @@ from dynamo.vllm.cache_info import (
 from dynamo.vllm.capacity import per_rank_kv_blocks
 
 from .handlers import (
-    VllmEngineQuiesceController,
+    VllmEnginePauseController,
     build_sampling_params,
     get_dp_range_for_worker,
 )
@@ -155,8 +155,8 @@ class VllmLLMEngine(LLMEngine):
         # factory call sees a valid object. `num_gpu_blocks` is patched
         # after KV profiling finishes.
         self._stat_logger_factory: Optional[_UnifiedStatLoggerFactory] = None
-        self._quiesce_controller: VllmEngineQuiesceController | None = None
-        self._quiesce_lock = asyncio.Lock()
+        self._pause_controller: VllmEnginePauseController | None = None
+        self._pause_lock = asyncio.Lock()
         self._scale_ep_lock = asyncio.Lock()
         self._scale_ep_in_progress = False
 
@@ -220,7 +220,7 @@ class VllmLLMEngine(LLMEngine):
             usage_context=UsageContext.OPENAI_API_SERVER,
             stat_loggers=[self._stat_logger_factory],
         )
-        self._quiesce_controller = VllmEngineQuiesceController(self.engine_client)
+        self._pause_controller = VllmEnginePauseController(self.engine_client)
         num_gpu_blocks = self.engine_client.vllm_config.cache_config.num_gpu_blocks or 0
         per_rank_num_gpu_blocks = per_rank_kv_blocks(num_gpu_blocks, self._dp_range[1])
         if per_rank_num_gpu_blocks is None:
@@ -465,12 +465,12 @@ class VllmLLMEngine(LLMEngine):
     async def sleep(self, body: dict) -> dict:
         body = body or {}
         level = body.get("level", 1)
-        controller = self._quiesce_controller
+        controller = self._pause_controller
         if controller is None:
             return {"status": "error", "message": "engine is not initialized"}
 
-        async with self._quiesce_lock:
-            if controller.is_quiesced:
+        async with self._pause_lock:
+            if controller.is_paused:
                 return {"status": "ok", "message": "Engine already sleeping"}
             if controller.needs_resume_recovery:
                 return {
@@ -478,7 +478,7 @@ class VllmLLMEngine(LLMEngine):
                     "message": "wake_up required before retrying sleep",
                 }
             try:
-                if not await controller.quiesce(level):
+                if not await controller.pause(level):
                     return {"status": "ok", "message": "Engine already sleeping"}
                 return {"status": "ok", "message": f"Engine slept (level={level})"}
             except Exception as e:
@@ -488,13 +488,13 @@ class VllmLLMEngine(LLMEngine):
     async def wake_up(self, body: dict) -> dict:
         body = body or {}
         tags = body.get("tags")
-        controller = self._quiesce_controller
+        controller = self._pause_controller
         if controller is None:
             return {"status": "error", "message": "engine is not initialized"}
 
-        async with self._quiesce_lock:
+        async with self._pause_lock:
             needs_recovery = controller.needs_resume_recovery
-            if not controller.is_quiesced and not needs_recovery:
+            if not controller.is_paused and not needs_recovery:
                 return {"status": "ok", "message": "Engine already awake"}
             try:
                 await controller.resume(tags)
@@ -614,7 +614,7 @@ class VllmLLMEngine(LLMEngine):
                 self.engine_client.shutdown()
         finally:
             self.engine_client = None
-            self._quiesce_controller = None
+            self._pause_controller = None
             if self._prometheus_temp_dir is not None:
                 if (
                     os.environ.get("PROMETHEUS_MULTIPROC_DIR")

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from dynamo.common.utils.snapshot import CheckpointConfig, EngineSnapshotController
 
 from .args import Config
-from .handlers import VllmEngineQuiesceController
+from .handlers import VllmEnginePauseController
 from .worker_factory import EngineSetupResult
 
 logger = logging.getLogger(__name__)
@@ -36,9 +36,9 @@ async def prepare_snapshot_engine(
     gc.collect()
     snapshot_controller = EngineSnapshotController(
         engine=engine,
-        quiesce_controller=VllmEngineQuiesceController(engine[0]),
+        pause_controller=VllmEnginePauseController(engine[0]),
         checkpoint_config=checkpoint_config,
-        quiesce_args=(None,),
+        pause_args=(None,),
     )
     if not await snapshot_controller.wait_for_restore():
         raise SystemExit(0)

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_routes.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_routes.py
@@ -10,7 +10,7 @@ import pytest
 pytest.importorskip("vllm.v1.engine.async_llm")
 pytest.importorskip("vllm.usage.usage_lib")
 
-from dynamo.vllm.handlers import VllmEngineQuiesceController  # noqa: E402
+from dynamo.vllm.handlers import VllmEnginePauseController  # noqa: E402
 from dynamo.vllm.llm_engine import VllmLLMEngine  # noqa: E402
 
 pytestmark = [
@@ -35,8 +35,8 @@ def _make_engine(include_scale: bool = False) -> VllmLLMEngine:
         engine_client.scale_elastic_ep = AsyncMock()
 
     engine.engine_client = engine_client
-    engine._quiesce_controller = VllmEngineQuiesceController(engine_client)
-    engine._quiesce_lock = asyncio.Lock()
+    engine._pause_controller = VllmEnginePauseController(engine_client)
+    engine._pause_lock = asyncio.Lock()
     engine._scale_ep_lock = asyncio.Lock()
     return engine
 
@@ -76,8 +76,8 @@ async def test_wake_up_recovers_generation_pause_after_failed_sleep_rollback():
     sleep_result = await engine.sleep({"level": 1})
 
     assert sleep_result["status"] == "error"
-    assert engine._quiesce_controller.is_quiesced is False
-    assert engine._quiesce_controller.needs_resume_recovery is True
+    assert engine._pause_controller.is_paused is False
+    assert engine._pause_controller.needs_resume_recovery is True
     failed_resume.assert_awaited_once()
 
     engine.engine_client.resume_generation = AsyncMock()
@@ -86,7 +86,7 @@ async def test_wake_up_recovers_generation_pause_after_failed_sleep_rollback():
     assert wake_result["status"] == "ok"
     engine.engine_client.wake_up.assert_not_awaited()
     engine.engine_client.resume_generation.assert_awaited_once()
-    assert engine._quiesce_controller.needs_resume_recovery is False
+    assert engine._pause_controller.needs_resume_recovery is False
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -7,7 +7,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from dynamo.vllm.handlers import BaseWorkerHandler, VllmEngineQuiesceController
+pytest.importorskip("torch")
+pytest.importorskip("vllm.config")
+pytest.importorskip("vllm.v1.engine.exceptions")
+
+from dynamo.vllm.handlers import (  # noqa: E402
+    BaseWorkerHandler,
+    VllmEnginePauseController,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -34,8 +41,8 @@ def _make_handler() -> _TestWorkerHandler:
         unregister_endpoint_instance=AsyncMock(),
         register_endpoint_instance=AsyncMock(),
     )
-    handler._quiesce_controller = VllmEngineQuiesceController(handler.engine_client)
-    handler._quiesce_lock = asyncio.Lock()
+    handler._pause_controller = VllmEnginePauseController(handler.engine_client)
+    handler._pause_lock = asyncio.Lock()
     return handler
 
 
@@ -75,16 +82,16 @@ async def test_sleep_and_wake_are_idempotent():
 
 
 @pytest.mark.asyncio
-async def test_quiesce_without_level_uses_vllm_default_sleep():
+async def test_pause_without_level_uses_vllm_default_sleep():
     engine_client = SimpleNamespace(
         pause_generation=AsyncMock(),
         sleep=AsyncMock(),
         wake_up=AsyncMock(),
         resume_generation=AsyncMock(),
     )
-    controller = VllmEngineQuiesceController(engine_client)
+    controller = VllmEnginePauseController(engine_client)
 
-    changed = await controller.quiesce(None)
+    changed = await controller.pause(None)
 
     assert changed is True
     engine_client.pause_generation.assert_awaited_once()
@@ -94,7 +101,7 @@ async def test_quiesce_without_level_uses_vllm_default_sleep():
 @pytest.mark.asyncio
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
-    await handler._quiesce_controller.quiesce(1)
+    await handler._pause_controller.pause(1)
 
     result = await handler.wake_up({"tags": ["weights"]})
 
@@ -114,8 +121,8 @@ async def test_wake_up_recovers_generation_pause_after_failed_sleep_rollback():
     sleep_result = await handler.sleep({"level": 1})
 
     assert sleep_result["status"] == "error"
-    assert handler._quiesce_controller.is_quiesced is False
-    assert handler._quiesce_controller.needs_resume_recovery is True
+    assert handler._pause_controller.is_paused is False
+    assert handler._pause_controller.needs_resume_recovery is True
     failed_resume.assert_awaited_once()
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
 
@@ -126,11 +133,11 @@ async def test_wake_up_recovers_generation_pause_after_failed_sleep_rollback():
     handler.engine_client.wake_up.assert_not_awaited()
     handler.engine_client.resume_generation.assert_awaited_once()
     handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
-    assert handler._quiesce_controller.needs_resume_recovery is False
+    assert handler._pause_controller.needs_resume_recovery is False
 
 
 @pytest.mark.asyncio
-async def test_sleep_reregisters_after_clean_quiesce_rollback():
+async def test_sleep_reregisters_after_clean_pause_rollback():
     handler = _make_handler()
     handler.engine_client.sleep = AsyncMock(side_effect=RuntimeError("sleep failed"))
 
@@ -138,8 +145,8 @@ async def test_sleep_reregisters_after_clean_quiesce_rollback():
 
     # Rollback resumed generation cleanly, so the engine is serving-safe again.
     assert result["status"] == "error"
-    assert handler._quiesce_controller.is_quiesced is False
-    assert handler._quiesce_controller.needs_resume_recovery is False
+    assert handler._pause_controller.is_paused is False
+    assert handler._pause_controller.needs_resume_recovery is False
     handler.engine_client.resume_generation.assert_awaited_once()
     handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
     # The endpoint must rejoin the routing pool since wake_up will early-return.
@@ -163,7 +170,7 @@ async def test_sleep_returns_error_for_unregister_failure():
 @pytest.mark.asyncio
 async def test_wake_up_returns_error_for_register_failure():
     handler = _make_handler()
-    await handler._quiesce_controller.quiesce(1)
+    await handler._pause_controller.pause(1)
     handler.generate_endpoint.register_endpoint_instance = AsyncMock(
         side_effect=RuntimeError("discovery write timeout")
     )
@@ -173,4 +180,4 @@ async def test_wake_up_returns_error_for_register_failure():
     assert result["status"] == "error"
     handler.engine_client.wake_up.assert_awaited_once_with()
     handler.engine_client.resume_generation.assert_awaited_once()
-    assert handler._quiesce_controller.is_quiesced is True
+    assert handler._pause_controller.is_paused is True

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -88,7 +88,7 @@ async def _wait_and_load_benchmark(bench_cfg: dict, vllm_config: VllmConfig) -> 
         while not p.exists():
             if _time.monotonic() > deadline:
                 raise TimeoutError(
-                    f"Benchmark did not complete within {timeout}s. " f"Missing: {p}"
+                    f"Benchmark did not complete within {timeout}s. Missing: {p}"
                 )
             await asyncio.sleep(0.1)
 
@@ -198,7 +198,8 @@ class WorkerFactory:
         shutdown_endpoints[:] = [generate_endpoint]
 
         handler = EncodeWorkerHandler(
-            config.engine_args, config.embedding_transfer_mode  # type: ignore[arg-type]
+            config.engine_args,
+            config.embedding_transfer_mode,  # type: ignore[arg-type]
         )
         await handler.async_init(runtime)
         logger.info("Starting to serve the encode worker endpoint...")
@@ -332,7 +333,7 @@ class WorkerFactory:
         if not config.gms_shadow_mode:
             return
 
-        await handler._quiesce_controller.quiesce(1)
+        await handler._pause_controller.pause(1)
 
         runtime.set_health_status(True)
         logger.info(
@@ -347,8 +348,8 @@ class WorkerFactory:
         await lock.acquire(engine_id=f"engine-{engine_id}")
         logger.info("[Shadow] Lock acquired, waking engine")
 
-        await handler._quiesce_controller.resume()
-        handler._quiesce_controller.mark_resumed()
+        await handler._pause_controller.resume()
+        handler._pause_controller.mark_resumed()
         logger.info("[Shadow] Engine awake, registering with discovery")
 
     async def _create_decode_worker(

--- a/docs/development/backend-guide.md
+++ b/docs/development/backend-guide.md
@@ -18,7 +18,7 @@ subtitle: Create custom Python workers and engines for Dynamo
 > metrics, KV event publishing, KV-aware routing, OpenTelemetry
 > tracing, health-check canaries, guided decoding, and custom Jinja
 > chat templates. Stay on this path for workloads that depend on
-> multimodal, LoRA, logprob extraction, engine routes (sleep/wake,
+> multimodal, LoRA, logprob extraction, engine routes (pause/resume,
 > profiling, weight updates), text-in-text-out, snapshot/CRIU, or
 > diffusion — features the unified backend does not yet cover. See
 > the [unified-path feature gaps](python-backend-guide.md#feature-gaps)

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -76,7 +76,7 @@ Lifecycle and runtime:
 - `drain()` hook for pre-cleanup work (e.g. in-flight NIXL transfers)
 - `DynamoException` error chain wrapping
 - Finish reason normalization (handled by the Rust layer)
-- Engine control plumbing, with per-backend profiling, quiesce/resume, and supported weight-update controls
+- Engine control plumbing, with per-backend profiling, pause/resume, and supported weight-update controls
 
 Observability:
 - Health-check canary via `health_check_payload()` (plus

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -85,7 +85,7 @@ Lifecycle and runtime:
 - Graceful shutdown with signal handling and 3-phase
   distributed-runtime teardown
 - Debug-build stream validator and the `testing::run_conformance` kit
-- Engine control plumbing, with per-backend profiling, quiesce/resume, and supported weight-update controls
+- Engine control plumbing, with per-backend profiling, pause/resume, and supported weight-update controls
 
 Observability:
 - Health-check canary via `LLMEngine::health_check_payload()` plus

--- a/docs/kubernetes/shadow-engine-failover.md
+++ b/docs/kubernetes/shadow-engine-failover.md
@@ -93,7 +93,7 @@ active and standby engines share the same weight memory boundary instead of
 loading independent copies.
 
 Direct GMS enablement is useful for backend integration testing and
-sleep/wake-style lifecycle experiments. By itself, it does not configure
+pause/resume-style lifecycle experiments. By itself, it does not configure
 active/passive failover; use the `failover` field for the shadow engine flow.
 
 ## Prerequisites

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0
 > bridging, KV event publishing, KV-aware (DP-rank) routing,
 > health-check canaries, OpenTelemetry tracing, and request-side
 > guided decoding. Logprob response wire, multimodal, diffusion
-> (image/video/DLLM), LoRA, engine routes (sleep/wake, profiling,
+> (image/video/DLLM), LoRA, engine routes (pause/resume, profiling,
 > weight updates), text-in-text-out, and snapshot/CRIU are still on
 > the non-unified path. See the
 > [Python package README](../../components/src/dynamo/common/backend/README.md#feature-gaps)

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -519,7 +519,7 @@ impl Worker {
         let registry = endpoint.drt().engine_routes();
         let control_count = controls.len();
         // Serialize discovery-mutating controls so a concurrent resume cannot
-        // re-register the endpoint between a quiesce control's unregister and
+        // re-register the endpoint between a pause control's unregister and
         // its engine-state mutation (and vice versa).
         let control_lock = Arc::new(tokio::sync::Mutex::new(()));
         for control_name in controls {
@@ -913,13 +913,13 @@ enum EngineControlPolicy {
 fn engine_control_policy(control: &str) -> EngineControlPolicy {
     // This policy only governs discovery (un)registration ordering. Draining
     // in-flight work before memory is freed is delegated to each backend's
-    // quiesce controller: vLLM and SGLang call the engine-native
-    // pause_generation() before sleep/release_memory_occupation, while TRT-LLM
-    // rejects new requests and waits for inflight requests to finish. The
+    // pause controller: vLLM calls pause_generation() before native sleep(),
+    // SGLang calls pause_generation() before release_memory_occupation(), and
+    // TRT-LLM rejects new requests and waits for inflight requests to finish. The
     // UnregisterBefore step here is an additional guard (stop new routing), not
     // the drain itself.
     match control {
-        // Quiesce controls make the engine unsafe for new requests, so remove
+        // Pause controls make the engine unsafe for new requests, so remove
         // the endpoint before they mutate engine state. Resume controls make
         // the engine serving-safe again, so advertise it only after success.
         "sleep" | "release_memory_occupation" => EngineControlPolicy::UnregisterBefore,
@@ -1020,7 +1020,7 @@ fn wrap_engine_control_callback(
                     }
                 }
                 EngineControlPolicy::RegisterAfter => {
-                    // Hold across callback + register so a concurrent quiesce
+                    // Hold across callback + register so a concurrent pause
                     // cannot unregister between them.
                     let _guard = control_lock.lock().await;
 
@@ -1028,11 +1028,11 @@ fn wrap_engine_control_callback(
                     if !control_response_is_error(&response)
                         && let Err(e) = endpoint.register_endpoint_instance().await
                     {
-                        // The engine is awake but absent from discovery. The
+                        // The engine is serving-safe but absent from discovery. The
                         // operation is idempotent: retrying /engine/{control_name}
-                        // re-registers without re-waking the engine (the controller
-                        // short-circuits "already awake"), so surface that it is
-                        // safe to retry.
+                        // re-registers without repeating the wake/resume work (the
+                        // controller short-circuits "already awake/resumed"), so surface
+                        // that it is safe to retry.
                         return Ok(control_error_response(format!(
                             "engine resumed but re-registration failed after /engine/{control_name}: {e}; retry /engine/{control_name} to rejoin discovery"
                         )));

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -579,14 +579,14 @@ The integration patches `torch_memory_saver` to route both weight and KV-cache o
 - Other tags are not supported in GMS mode
 - The `--enable-memory-saver` flag is required to activate the memory saver pathway
 
-### Shadow Engine Failover (Sleep / Wake)
+### Shadow Engine Failover (Pause / Resume)
 
 Both integrations support releasing and reclaiming GPU memory for shadow engine patterns. The API names differ by framework:
 
 - **vLLM**: `sleep` / `wake_up` (via `/engine/sleep` and `/engine/wake_up` HTTP endpoints)
 - **SGLang**: `release_memory_occupation` / `resume_memory_occupation` (via the corresponding HTTP endpoints)
 
-Under the hood, sleeping calls `unmap_all_vas()` + `abort()` to release GPU memory while preserving VA reservations. Waking is tag-specific:
+Under the hood, pausing calls `unmap_all_vas()` + `abort()` to release GPU memory while preserving VA reservations. Resuming is tag-specific:
 
 - **weights**: `connect(RO)` + `remap_all_vas()`
 - **kv_cache**: `connect(RW)` + `reallocate_all_handles("kv_cache")` + `remap_all_vas()`

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -61,7 +61,7 @@ apply_scratch_kv_patches()
 logger.info("[GMS] Worker module loaded - model loader registered, all patches applied")
 
 # MX imports — only when MX_ENABLED=1 (modelexpress is an optional dependency).
-# Sleep/wake serving lifecycle is implemented in modelexpress.lifecycle, which
+# Pause/resume serving lifecycle is implemented in modelexpress.lifecycle, which
 # composes publish/unpublish_metadata + register_tensors + MxClient/NIXL
 # teardown into a single pause/resume pair.
 if os.environ.get("MX_ENABLED", "0") == "1":

--- a/tests/gpu_memory_service/common/runtime.py
+++ b/tests/gpu_memory_service/common/runtime.py
@@ -127,9 +127,9 @@ class GMSProcessManager:
 
 
 class GMSEngineProcess(EngineProcess, ABC):
-    """Backend process wrapper with a common quiesce/resume surface."""
+    """Backend process wrapper with a common pause/resume surface."""
 
-    quiesce_route: str
+    pause_route: str
     resume_route: str
 
     def __init__(
@@ -181,7 +181,7 @@ class GMSEngineProcess(EngineProcess, ABC):
         return json.dumps({"gms_read_only": True})
 
     @abstractmethod
-    def quiesce_payload(self) -> dict:
+    def pause_payload(self) -> dict:
         raise NotImplementedError
 
     def resume_payload(self) -> dict:
@@ -210,12 +210,12 @@ class GMSEngineProcess(EngineProcess, ABC):
         logger.info("%s %s: %s", self.engine_id, action, result)
         return result
 
-    def quiesce(self) -> dict:
+    def pause(self) -> dict:
         return self._request_engine(
-            self.quiesce_route,
-            self.quiesce_payload(),
+            self.pause_route,
+            self.pause_payload(),
             30,
-            "quiesce",
+            "pause",
         )
 
     def resume(self, timeout: int = 30) -> dict:
@@ -234,7 +234,7 @@ class GMSEngineProcess(EngineProcess, ABC):
 
 
 class VLLMWithGMSProcess(GMSEngineProcess):
-    quiesce_route = "sleep"
+    pause_route = "sleep"
     resume_route = "wake_up"
 
     def __init__(
@@ -300,14 +300,14 @@ class VLLMWithGMSProcess(GMSEngineProcess):
             )
         return command
 
-    def quiesce_payload(self) -> dict:
+    def pause_payload(self) -> dict:
         return {"level": 2}
 
 
 class TRTLLMWithGMSProcess(GMSEngineProcess):
-    """TensorRT-LLM engine with GMS weights + sleep/wake enabled."""
+    """TensorRT-LLM engine with GMS weights + pause/resume enabled."""
 
-    quiesce_route = "release_memory_occupation"
+    pause_route = "release_memory_occupation"
     resume_route = "resume_memory_occupation"
 
     # Override via environment variables for CI or custom setups.
@@ -390,12 +390,12 @@ class TRTLLMWithGMSProcess(GMSEngineProcess):
             command.extend(["--model-loader-extra-config", extra_config])
         return command
 
-    def quiesce_payload(self) -> dict:
+    def pause_payload(self) -> dict:
         return {}
 
 
 class SGLangWithGMSProcess(GMSEngineProcess):
-    quiesce_route = "release_memory_occupation"
+    pause_route = "release_memory_occupation"
     resume_route = "resume_memory_occupation"
 
     def __init__(
@@ -451,5 +451,5 @@ class SGLangWithGMSProcess(GMSEngineProcess):
     def env_updates(self) -> dict[str, str]:
         return {"NVCC_PREPEND_FLAGS": "-ccbin /usr/bin/g++"}
 
-    def quiesce_payload(self) -> dict:
+    def pause_payload(self) -> dict:
         return {}

--- a/tests/gpu_memory_service/flow_assertions.py
+++ b/tests/gpu_memory_service/flow_assertions.py
@@ -57,12 +57,12 @@ def assert_completion_ok(
             time.sleep(retry_interval)
 
 
-def quiesce_engine(
+def pause_engine(
     weights_gms,
     kv_cache_gms,
     engine,
     *,
-    quiesce_label: str,
+    pause_label: str,
     expected_weights_hash: str | None = None,
 ):
     weights_state, _ = wait_for_active_layout(
@@ -71,10 +71,10 @@ def quiesce_engine(
         expected_weights_hash=expected_weights_hash,
     )
 
-    assert engine.quiesce()["status"] == "ok"
-    logger.info("%s completed", quiesce_label)
+    assert engine.pause()["status"] == "ok"
+    logger.info("%s completed", pause_label)
 
-    wait_for_quiesced_layout(weights_gms, kv_cache_gms, weights_state)
+    wait_for_paused_layout(weights_gms, kv_cache_gms, weights_state)
     return weights_state
 
 
@@ -108,41 +108,38 @@ def wait_for_active_layout(
         time.sleep(0.1)
 
 
-def wait_for_quiesced_layout(
+def wait_for_paused_layout(
     weights_gms,
     kv_cache_gms,
-    weights_state_before_quiesce,
+    weights_state_before_pause,
     *,
     require_no_ro_sessions: bool = False,
     timeout: float = 30.0,
 ):
     deadline = time.monotonic() + timeout
     while True:
-        weights_after_quiesce = weights_gms.get_runtime_state()
-        kv_after_quiesce = kv_cache_gms.get_runtime_state()
+        weights_after_pause = weights_gms.get_runtime_state()
+        kv_after_pause = kv_cache_gms.get_runtime_state()
         if (
-            weights_after_quiesce.state == ServerState.COMMITTED
-            and weights_after_quiesce.allocation_count
-            == weights_state_before_quiesce.allocation_count
-            and weights_after_quiesce.memory_layout_hash
-            == weights_state_before_quiesce.memory_layout_hash
-            and kv_after_quiesce.state == ServerState.EMPTY
-            and kv_after_quiesce.allocation_count == 0
+            weights_after_pause.state == ServerState.COMMITTED
+            and weights_after_pause.allocation_count
+            == weights_state_before_pause.allocation_count
+            and weights_after_pause.memory_layout_hash
+            == weights_state_before_pause.memory_layout_hash
+            and kv_after_pause.state == ServerState.EMPTY
+            and kv_after_pause.allocation_count == 0
         ):
-            if (
-                not require_no_ro_sessions
-                or weights_after_quiesce.ro_session_count == 0
-            ):
-                return weights_after_quiesce, kv_after_quiesce
+            if not require_no_ro_sessions or weights_after_pause.ro_session_count == 0:
+                return weights_after_pause, kv_after_pause
         if time.monotonic() > deadline:
-            raise TimeoutError("GMS state did not reach the quiesced layout")
+            raise TimeoutError("GMS state did not reach the paused layout")
         time.sleep(0.1)
 
 
 def wait_for_resumed_layout(
     weights_gms,
     kv_cache_gms,
-    weights_state_before_quiesce,
+    weights_state_before_pause,
     *,
     min_weight_ro_sessions: int = 0,
     timeout: float = 30.0,
@@ -155,9 +152,9 @@ def wait_for_resumed_layout(
             weights_after_resume.state == ServerState.RO
             and weights_after_resume.ro_session_count >= min_weight_ro_sessions
             and weights_after_resume.allocation_count
-            == weights_state_before_quiesce.allocation_count
+            == weights_state_before_pause.allocation_count
             and weights_after_resume.memory_layout_hash
-            == weights_state_before_quiesce.memory_layout_hash
+            == weights_state_before_pause.memory_layout_hash
             and kv_after_resume.state == ServerState.RW
             and kv_after_resume.allocation_count > 0
         ):

--- a/tests/gpu_memory_service/test_pause_resume.py
+++ b/tests/gpu_memory_service/test_pause_resume.py
@@ -16,7 +16,7 @@ from tests.gpu_memory_service.flow_assertions import (
     assert_completion_ok,
     assert_kv_history,
     assert_weights_published_once,
-    quiesce_engine,
+    pause_engine,
     wait_for_resumed_layout,
     wait_for_weights_state,
 )
@@ -27,12 +27,12 @@ pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance]
 # Event flow under test:
 # 1. Weights are published once as a committed layout.
 # 2. KV cache starts as a live RW layout build.
-# 3. Quiesce keeps weights committed but aborts and clears the KV layout.
+# 3. Pause keeps weights committed but aborts and clears the KV layout.
 # 4. Resume reconnects weights as RO to the same committed layout.
 # 5. Resume recreates KV cache in a fresh RW layout after the old one was cleared.
 
 
-def _run_quiesce_resume_test(
+def _run_pause_resume_test(
     request,
     engine_cls,
 ) -> None:
@@ -48,21 +48,21 @@ def _run_quiesce_resume_test(
             success_message="Initial inference result",
         )
 
-        # Before quiesce, weights must already be published and visible to RO
+        # Before pause, weights must already be published and visible to RO
         # readers while KV cache remains a live RW layout owned by the engine.
-        weights_before_quiesce = quiesce_engine(
+        weights_before_pause = pause_engine(
             weights_gms,
             kv_cache_gms,
             engine,
-            quiesce_label="Engine quiesce",
+            pause_label="Engine pause",
         )
 
-        # Weights are immutable across quiesce/resume, so their event history should
+        # Weights are immutable across pause/resume, so their event history should
         # still be the original publish: connect once, commit once.
         weights_events = weights_gms.get_event_history().events
         assert_weights_published_once(weights_events)
 
-        # KV cache is different: quiesce must abort the old RW layout and clear
+        # KV cache is different: pause must abort the old RW layout and clear
         # its server-owned allocations before resume can start a new RW layout.
         kv_events = kv_cache_gms.get_event_history().events
         assert_kv_history(kv_events, cleared_layouts=1)
@@ -76,7 +76,7 @@ def _run_quiesce_resume_test(
         wait_for_resumed_layout(
             weights_gms,
             kv_cache_gms,
-            weights_before_quiesce,
+            weights_before_pause,
         )
 
         weights_events_after_resume = weights_gms.get_event_history().events
@@ -105,12 +105,12 @@ def _run_quiesce_resume_test(
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 @pytest.mark.timeout(300)
 @pytest.mark.vllm
-def test_gms_basic_quiesce_resume_vllm(
+def test_gms_basic_pause_resume_vllm(
     request,
     runtime_services_dynamic_ports,
     predownload_models,
 ):
-    _run_quiesce_resume_test(request, VLLMWithGMSProcess)
+    _run_pause_resume_test(request, VLLMWithGMSProcess)
 
 
 @pytest.mark.e2e
@@ -118,12 +118,12 @@ def test_gms_basic_quiesce_resume_vllm(
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 @pytest.mark.timeout(300)
 @pytest.mark.sglang
-def test_gms_basic_quiesce_resume_sglang(
+def test_gms_basic_pause_resume_sglang(
     request,
     runtime_services_dynamic_ports,
     predownload_models,
 ):
-    _run_quiesce_resume_test(request, SGLangWithGMSProcess)
+    _run_pause_resume_test(request, SGLangWithGMSProcess)
 
 
 # ---------------------------------------------------------------------------
@@ -137,12 +137,12 @@ def test_gms_basic_quiesce_resume_sglang(
 @pytest.mark.gpu_1
 @pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME)
 @pytest.mark.timeout(600)
-def test_gms_basic_quiesce_resume_trtllm(
+def test_gms_basic_pause_resume_trtllm(
     request,
     runtime_services_dynamic_ports,
     predownload_models,
 ):
-    """Weights-only quiesce/resume for TRT-LLM (no KV cache GMS)."""
+    """Weights-only pause/resume for TRT-LLM (no KV cache GMS)."""
     with GMSProcessManager(request, TRTLLMWithGMSProcess, tags=("weights",)) as manager:
         frontend_port = manager.frontend_port
         weights_gms = manager.weights_gms
@@ -158,7 +158,7 @@ def test_gms_basic_quiesce_resume_trtllm(
         ws = wait_for_weights_state(weights_gms, ServerState.RO, timeout=60.0)
         weights_hash = ws.memory_layout_hash
 
-        assert engine.quiesce()["status"] == "ok"
+        assert engine.pause()["status"] == "ok"
 
         wait_for_weights_state(
             weights_gms, ServerState.COMMITTED, expected_hash=weights_hash

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -22,7 +22,7 @@ from tests.gpu_memory_service.flow_assertions import (
     assert_completion_ok,
     assert_kv_history,
     assert_weights_published_once,
-    quiesce_engine,
+    pause_engine,
     wait_for_active_layout,
     wait_for_resumed_layout,
     wait_for_weights_state,
@@ -33,8 +33,8 @@ from tests.utils.managed_process import ManagedProcess
 pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance]
 
 # Event flow under test:
-# 1. Shadow A starts as the initial weights publisher, then quiesces without serving traffic.
-# 2. Shadow B starts in read-only mode from the committed weights layout, then quiesces without serving traffic.
+# 1. Shadow A starts as the initial weights publisher, then pauses without serving traffic.
+# 2. Shadow B starts in read-only mode from the committed weights layout, then pauses without serving traffic.
 # 3. Primary starts in read-only mode and owns the next RW KV layout.
 # 4. Shadow A tries to resume while primary still owns the KV-cache RW layout.
 # 5. Primary is SIGKILLed; the old KV session clears before its GPU memory is reclaimed.
@@ -183,31 +183,31 @@ def _run_shadow_failover_test(
         shadow_a = manager.start_engine(
             "shadow-a",
         )
-        weights_state_after_shadow_a = quiesce_engine(
+        weights_state_after_shadow_a = pause_engine(
             weights_gms,
             kv_cache_gms,
             shadow_a,
-            quiesce_label="Shadow quiesce",
+            pause_label="Shadow pause",
         )
         weights_hash = weights_state_after_shadow_a.memory_layout_hash
         shadow_b = manager.start_engine(
             "shadow-b",
             read_only_weights=True,
         )
-        weights_state_after_shadow_b = quiesce_engine(
+        weights_state_after_shadow_b = pause_engine(
             weights_gms,
             kv_cache_gms,
             shadow_b,
-            quiesce_label="Shadow quiesce",
+            pause_label="Shadow pause",
             expected_weights_hash=weights_hash,
         )
         assert weights_state_after_shadow_b.memory_layout_hash == weights_hash
 
-        weights_events_after_shadow_quiesce = weights_gms.get_event_history().events
-        assert_weights_published_once(weights_events_after_shadow_quiesce)
+        weights_events_after_shadow_pause = weights_gms.get_event_history().events
+        assert_weights_published_once(weights_events_after_shadow_pause)
 
-        kv_events_after_shadow_quiesce = kv_cache_gms.get_event_history().events
-        assert_kv_history(kv_events_after_shadow_quiesce, cleared_layouts=2)
+        kv_events_after_shadow_pause = kv_cache_gms.get_event_history().events
+        assert_kv_history(kv_events_after_shadow_pause, cleared_layouts=2)
 
         primary, weights_with_primary = _start_primary(
             manager,
@@ -234,7 +234,7 @@ def _run_shadow_failover_test(
         )
 
         # The final KV history should show the full handoff:
-        # shadow A quiesced -> shadow B quiesced -> primary layout ->
+        # shadow A paused -> shadow B paused -> primary layout ->
         # primary abort/clear -> shadow A reconnects -> shadow A sees OOM.
         weights_events_after_resume = weights_gms.get_event_history().events
         assert_weights_published_once(weights_events_after_resume)
@@ -282,21 +282,21 @@ def test_gms_shadow_engine_failover_sglang(
 # ---------------------------------------------------------------------------
 
 
-def _trtllm_quiesce(
+def _trtllm_pause(
     weights_gms,
     engine,
     *,
     label: str,
     expected_hash: str | None = None,
 ):
-    """Quiesce a weights-only TRT-LLM engine and return the weights state."""
+    """Pause a weights-only TRT-LLM engine and return the weights state."""
     wait_for_weights_state(
         weights_gms,
         ServerState.RO,
         expected_hash=expected_hash,
         timeout=60.0,
     )
-    assert engine.quiesce()["status"] == "ok"
+    assert engine.pause()["status"] == "ok"
     logger.info("%s completed", label)
     ws = wait_for_weights_state(weights_gms, ServerState.COMMITTED)
     return ws
@@ -316,7 +316,7 @@ def test_gms_shadow_engine_failover_trtllm(
         frontend_port = manager.frontend_port
         weights_gms = manager.weights_gms
 
-        # Shadow A publishes weights, then quiesces.
+        # Shadow A publishes weights, then pauses.
         shadow_a = manager.start_engine("shadow-a")
         assert_completion_ok(
             frontend_port,
@@ -324,10 +324,10 @@ def test_gms_shadow_engine_failover_trtllm(
             failure_message="Shadow A inference failed",
             success_message="Shadow A inference OK",
         )
-        ws_a = _trtllm_quiesce(weights_gms, shadow_a, label="Shadow A quiesce")
+        ws_a = _trtllm_pause(weights_gms, shadow_a, label="Shadow A pause")
         weights_hash = ws_a.memory_layout_hash
 
-        # Shadow B starts RO, then quiesces.
+        # Shadow B starts RO, then pauses.
         shadow_b = manager.start_engine("shadow-b", read_only_weights=True)
         assert_completion_ok(
             frontend_port,
@@ -335,10 +335,10 @@ def test_gms_shadow_engine_failover_trtllm(
             failure_message="Shadow B inference failed",
             success_message="Shadow B inference OK",
         )
-        _trtllm_quiesce(
+        _trtllm_pause(
             weights_gms,
             shadow_b,
-            label="Shadow B quiesce",
+            label="Shadow B pause",
             expected_hash=weights_hash,
         )
         assert_weights_published_once(weights_gms.get_event_history().events)


### PR DESCRIPTION
## Summary

- Rename the Dynamo-level lifecycle controller vocabulary from `quiesce/resume` to `pause/resume` across vLLM, SGLang, TRT-LLM, and snapshot helpers.
- Keep backend-facing route/method terminology unchanged:
  - vLLM handlers/routes remain `sleep` / `wake_up` (`/engine/sleep`, `/engine/wake_up`) and still call native vLLM `sleep()` / `wake_up()` underneath.
  - SGLang routes remain `release_memory_occupation` / `resume_memory_occupation`.
  - TRT-LLM routes remain `release_memory_occupation` / `resume_memory_occupation`, with native sleep/wake RPC terminology preserved where applicable.
- Rename SGLang's controller module from `dynamo.sglang.quiesce` to `dynamo.sglang.pause`.
- Update docs and GMS test helpers to use `pause/resume` for the shared high-level lifecycle concept while preserving backend-specific route names.

## Duplicate-work check

I searched open PRs for `quiesce pause resume controller`, `quiesce`, and `pause resume` before opening this PR.

Related but not duplicate:
- #8621 (`refactor(trtllm): delete dead quiesce/resume surface + fix standby MDC gap`) is a broader TRT-LLM/GMS shadow-failover refactor that touches adjacent TRT-LLM files. This PR is a cross-backend naming cleanup for the internal/high-level controller vocabulary and deliberately keeps backend route terminology intact.

## Tests / validation

Ran in a `uv` virtualenv using `.venv/bin/python`:

- `uv venv --python 3.12`
- `.venv/bin/isort <changed python files>`: passed
- `.venv/bin/black <changed python files>`: passed
- `.venv/bin/ruff check <changed python files>`: passed
- `cargo fmt --all --check`: passed
- `git diff --check`: passed
- `.venv/bin/python -m py_compile <changed python implementation/test-helper files>`: passed
- `grep` for `quiesce` / `quiesced` / `quiescing` in `components/src/dynamo`: no matches
- vLLM route/control grep confirms public vLLM handlers/routes are `sleep` / `wake_up`, with only the internal `VllmEnginePauseController.pause()` / `.resume()` using pause/resume terminology
- `PYTHONPATH=components/src .venv/bin/python -m pytest components/src/dynamo/vllm/tests/test_vllm_engine_routes.py -q`: skipped because vLLM is not installed in this minimal env
- `PYTHONPATH=components/src .venv/bin/python -m pytest components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py -q`: skipped because torch is not installed in this minimal env

Previously attempted but blocked by local minimal environment:
- `PYTHONPATH=components/src .venv/bin/python -m pytest components/src/dynamo/common/backend/tests/test_engine.py::test_default_engine_controls_are_empty -q`: skipped because `dynamo._core.backend` is not built in this env
- `PYTHONPATH=components/src .venv/bin/python -m pytest tests/runtime/test_engine_controls_e2e.py::test_engine_control_route_invokes_registered_callback -q`: blocked by missing `filelock` test dependency in this minimal env
- `cargo test -p dynamo-backend-common engine_control_policy_wraps_discovery_mutating_controls`: blocked before tests by local NIXL/bindgen toolchain issue (`libclang-18.so.1` could not load `libstdc++.so.6`)

AI assistance was used for this change.
