### PR TITLE
feat(container): add Nemotron-3 Ultra vLLM runtime support

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -771,6 +771,7 @@ class InstrumentedScheduler(AsyncScheduler):
                 NewRequestData(
                     req_id=req_id,
                     prompt_token_ids=prompt,
+                    prefill_token_ids=prompt,
                     mm_features=[],
                     sampling_params=req.sampling_params,
                     pooling_params=None,

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -553,6 +553,39 @@ def test_bench_inject_fake_decode_pads_prompt_for_async_placeholder():
     )
 
 
+def test_bench_inject_fake_decode_sets_prefill_token_ids():
+    """vLLM 0.22's v2 GPU model runner requires ``prefill_token_ids`` for
+    every ``NewRequestData``. The synthetic decode path constructs that
+    object directly, so it must mirror the normal scheduler's v2 payload.
+    """
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_seq = 0
+    stub._bench_active_req_ids = set()
+    stub.requests = {}
+    stub.running = []
+    stub.finished_req_ids = set()
+    stub._bench_block_hasher = None
+    stub.kv_cache_manager = MagicMock()
+    stub.kv_cache_manager.num_kv_cache_groups = 1
+    stub.kv_cache_manager.take_new_block_ids = MagicMock(return_value=None)
+    stub.needs_kv_cache_zeroing = False
+    stub.connector = None
+    stub.ec_connector = None
+
+    new_blocks = MagicMock()
+    new_blocks.get_block_ids.return_value = ([1, 2],)
+    stub.kv_cache_manager.allocate_slots = MagicMock(return_value=new_blocks)
+
+    output = InstrumentedScheduler._bench_inject_fake_decode(
+        stub, ctx_len=16, batch_size=1
+    )
+
+    new_req = output.scheduled_new_reqs[0]
+    assert len(new_req.prompt_token_ids) == 17
+    assert new_req.prefill_token_ids == new_req.prompt_token_ids
+    assert new_req.num_computed_tokens == 16
+
+
 # ---------------------------------------------------------------------------
 # Decode-grid sizing must account for the +1-padded allocation
 # ---------------------------------------------------------------------------

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -50,7 +50,7 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.21.0
+    runtime_image_tag: v0.22.0-ubuntu2404
   xpu:
     base_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
     runtime_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo

--- a/container/deps/vllm/patches/v0.22.0/ultra/0001-pr42554-mamba-prefix-cache-pd-runtime.patch
+++ b/container/deps/vllm/patches/v0.22.0/ultra/0001-pr42554-mamba-prefix-cache-pd-runtime.patch
@@ -1,0 +1,56 @@
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+index ea8b46c28..55081a603 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+@@ -2333,9 +2333,25 @@ class NixlConnectorWorker:
+             for i, remote_group in enumerate(remote_block_ids):
+                 num_local_blocks = len(local_block_ids[i])
+                 num_remote_blocks = len(remote_group)
+-                if _is_ssm_spec(self._group_spec_types[i]):
+-                    assert num_local_blocks == num_remote_blocks
++                if (
++                    _is_ssm_spec(self._group_spec_types[i])
++                    and num_local_blocks < num_remote_blocks
++                ):
++                    # NOTE (NickLucche): With prefix caching on SSM, (remote) blocks
++                    # prior to the last one are placeholders (null blocks). Mind that
++                    # this doesn't really impact transfer, as we only still care about
++                    # the last "block", the full in-place state.
++                    assert num_local_blocks == 1, "SSM can only have one local block"
++                    remote_block_ids[i] = remote_group[-num_local_blocks:]
++                elif (
++                    self._physical_blocks_per_logical_kv_block
++                    == remote_physical_per_logical
++                    and num_local_blocks < num_remote_blocks
++                ):
++                    # Partial prefix cache hit for FA group.
++                    remote_block_ids[i] = remote_group[-num_local_blocks:]
+                 else:
++                    # TODO Handle prefix caching with different block_sizes
+                     max_padding = max(
+                         self._physical_blocks_per_logical_kv_block,
+                         remote_physical_per_logical,
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index c69c9a811..bfb061cf8 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -283,9 +283,6 @@ class Scheduler(SchedulerInterface):
+         num_new_local_computed_tokens: int = 0,
+         num_external_computed_tokens: int = 0,
+     ) -> int:
+-        assert num_external_computed_tokens == 0, (
+-            "External KV connector is not verified yet"
+-        )
+         num_computed_tokens = (
+             request.num_computed_tokens
+             + num_new_local_computed_tokens
+@@ -687,7 +684,8 @@ class Scheduler(SchedulerInterface):
+                             # The request cannot be scheduled.
+                             break
+ 
+-                if self.need_mamba_block_aligned_split:
++                # Skip block alignment when setting up async receive (no local work).
++                if self.need_mamba_block_aligned_split and not load_kv_async:
+                     num_new_tokens = self._mamba_block_aligned_split(
+                         request,
+                         num_new_tokens,

--- a/container/deps/vllm/patches/v0.22.0/ultra/0002-ultra-hybrid-hash-block-kv-events.patch
+++ b/container/deps/vllm/patches/v0.22.0/ultra/0002-ultra-hybrid-hash-block-kv-events.patch
@@ -1,0 +1,228 @@
+diff --git a/vllm/platforms/interface.py b/vllm/platforms/interface.py
+index cf774b7bd..9661a5664 100644
+--- a/vllm/platforms/interface.py
++++ b/vllm/platforms/interface.py
+@@ -645,11 +645,17 @@ class Platform:
+             )
+ 
+         if cache_config.block_size < attn_block_size:
++            # Preserve request-hashing granularity before inflating physical
++            # blocks for hybrid Mamba/attention page compatibility.
++            if cache_config.hash_block_size is None:
++                cache_config.hash_block_size = cache_config.block_size
+             cache_config.block_size = attn_block_size
+             logger.info(
+                 "Setting attention block size to %d tokens "
+-                "to ensure that attention page size is >= mamba page size.",
++                "to ensure that attention page size is >= mamba page size "
++                "(hash block size %d).",
+                 attn_block_size,
++                cache_config.hash_block_size,
+             )
+ 
+         if cache_config.mamba_cache_mode == "align":
+diff --git a/vllm/v1/core/single_type_kv_cache_manager.py b/vllm/v1/core/single_type_kv_cache_manager.py
+index e29919022..ac1540812 100644
+--- a/vllm/v1/core/single_type_kv_cache_manager.py
++++ b/vllm/v1/core/single_type_kv_cache_manager.py
+@@ -4,13 +4,17 @@ import itertools
+ from abc import ABC, abstractmethod
+ from collections import defaultdict
+ from collections.abc import Sequence
++from typing import Any
+ 
++from vllm.distributed.kv_events import BlockStored, MEDIUM_GPU
+ from vllm.utils.math_utils import cdiv
+ from vllm.v1.core.block_pool import BlockPool
+ from vllm.v1.core.kv_cache_utils import (
+     BlockHashList,
+     BlockHashWithGroupId,
+     KVCacheBlock,
++    generate_block_hash_extra_keys,
++    maybe_convert_block_hash,
+ )
+ from vllm.v1.kv_cache_interface import (
+     ChunkedLocalAttentionSpec,
+@@ -78,6 +82,8 @@ class SingleTypeKVCacheManager(ABC):
+         # This is only used to track the RUNNING requests, we do not track the
+         # data for preempted ones.
+         self.num_cached_block: dict[str, int] = {}
++        # Per-request cursor for synthetic hash-block KV events.
++        self._last_emitted_hash_block: dict[str, int] = {}
+ 
+         self.kv_cache_group_id = kv_cache_group_id
+         self._null_block = block_pool.null_block
+@@ -298,27 +304,95 @@ class SingleTypeKVCacheManager(ABC):
+         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+         num_full_blocks = num_tokens // self.block_size
+ 
+-        if num_cached_blocks >= num_full_blocks:
++        if num_full_blocks > num_cached_blocks:
++            # Fast path: when the coordinator imposes no alignment constraint
++            if alignment_tokens is None or alignment_tokens <= self.block_size:
++                block_mask = None
++            else:
++                block_mask = self._cache_block_mask(
++                    num_cached_blocks, num_full_blocks, alignment_tokens
++                )
++            self.block_pool.cache_full_blocks(
++                request=request,
++                blocks=self.req_to_blocks[request.request_id],
++                num_cached_blocks=num_cached_blocks,
++                num_full_blocks=num_full_blocks,
++                block_size=self.block_size,
++                kv_cache_group_id=self.kv_cache_group_id,
++                block_mask=block_mask,
++            )
++
++            self.num_cached_block[request.request_id] = num_full_blocks
++
++        self._maybe_emit_sub_block_events(request, num_tokens)
++
++    def _maybe_emit_sub_block_events(
++        self, request: Request, num_tokens: int
++    ) -> None:
++        """Emit hash-block KV events before an inflated block is full.
++
++        Hybrid Mamba models may inflate physical attention blocks above the
++        user/request hash block size. The normal cache_full_blocks() path emits
++        only after a full physical block is complete. Dynamo routing needs
++        FullAttention events at request hash granularity, including prompts
++        shorter than the inflated physical block.
++        """
++        if type(self.kv_cache_spec) not in (FullAttentionSpec, TQFullAttentionSpec):
++            return
++        block_pool = self.block_pool
++        if not block_pool.enable_kv_cache_events:
++            return
++        hash_block_size = block_pool.hash_block_size
++        if hash_block_size >= self.block_size:
+             return
+ 
+-        # Fast path: when the coordinator imposes no alignment constraint
+-        if alignment_tokens is None or alignment_tokens <= self.block_size:
+-            block_mask = None
+-        else:
+-            block_mask = self._cache_block_mask(
+-                num_cached_blocks, num_full_blocks, alignment_tokens
++        num_hash_blocks = num_tokens // hash_block_size
++        last_emitted = self._last_emitted_hash_block.get(request.request_id, 0)
++        if num_hash_blocks <= last_emitted:
++            return
++        if len(request.block_hashes) < num_hash_blocks:
++            return
++
++        block_hashes = [
++            maybe_convert_block_hash(request.block_hashes[i])
++            for i in range(last_emitted, num_hash_blocks)
++        ]
++        parent_block_hash = (
++            maybe_convert_block_hash(request.block_hashes[last_emitted - 1])
++            if last_emitted > 0
++            else None
++        )
++        start_token_idx = last_emitted * hash_block_size
++        end_token_idx = num_hash_blocks * hash_block_size
++
++        extra_keys_list: list[tuple[Any, ...] | None] = []
++        curr_mm_idx = 0
++        for block_idx in range(last_emitted, num_hash_blocks):
++            block_start = block_idx * hash_block_size
++            block_end = block_start + hash_block_size
++            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
++                request, block_start, block_end, curr_mm_idx
++            )
++            extra_keys_list.append(extra_keys)
++
++        block_pool.kv_event_queue.append(
++            BlockStored(
++                block_hashes=block_hashes,
++                parent_block_hash=parent_block_hash,
++                token_ids=request.all_token_ids[start_token_idx:end_token_idx],
++                block_size=hash_block_size,
++                lora_id=request.lora_request.adapter_id
++                if request.lora_request
++                else None,
++                medium=MEDIUM_GPU,
++                lora_name=request.lora_request.name
++                if request.lora_request
++                else None,
++                extra_keys=extra_keys_list if extra_keys_list else None,
++                group_idx=self.kv_cache_group_id,
+             )
+-        self.block_pool.cache_full_blocks(
+-            request=request,
+-            blocks=self.req_to_blocks[request.request_id],
+-            num_cached_blocks=num_cached_blocks,
+-            num_full_blocks=num_full_blocks,
+-            block_size=self.block_size,
+-            kv_cache_group_id=self.kv_cache_group_id,
+-            block_mask=block_mask,
+         )
+-
+-        self.num_cached_block[request.request_id] = num_full_blocks
++        self._last_emitted_hash_block[request.request_id] = num_hash_blocks
+ 
+     def _cache_block_mask(
+         self,
+@@ -351,6 +425,7 @@ class SingleTypeKVCacheManager(ABC):
+ 
+         self.block_pool.free_blocks(ordered_blocks)
+         self.num_cached_block.pop(request_id, None)
++        self._last_emitted_hash_block.pop(request_id, None)
+ 
+     @abstractmethod
+     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+diff --git a/vllm/v1/engine/core.py b/vllm/v1/engine/core.py
+index c9503e46d..af6aa4ee0 100644
+--- a/vllm/v1/engine/core.py
++++ b/vllm/v1/engine/core.py
+@@ -144,6 +144,9 @@ class EngineCore:
+         scheduler_block_size, hash_block_size = resolve_kv_cache_block_sizes(
+             kv_cache_config, vllm_config
+         )
++        # Retain request-hashing granularity for external routing metadata when
++        # hybrid models inflate physical KV block sizes.
++        self._kv_cache_metadata_block_size = hash_block_size
+ 
+         self.scheduler: SchedulerInterface = Scheduler(
+             vllm_config=vllm_config,
+@@ -276,6 +279,13 @@ class EngineCore:
+         vllm_config.cache_config.num_gpu_blocks = scheduler_kv_cache_config.num_blocks
+         kv_cache_groups = scheduler_kv_cache_config.kv_cache_groups
+         if kv_cache_groups:
++            # Preserve the original configured block size as the hash/event
++            # granularity before worker-side hybrid block inflation flows back
++            # into the engine cache config.
++            if vllm_config.cache_config.hash_block_size is None:
++                vllm_config.cache_config.hash_block_size = (
++                    vllm_config.cache_config.block_size
++                )
+             vllm_config.cache_config.block_size = min(
+                 g.kv_cache_spec.block_size for g in kv_cache_groups
+             )
+@@ -321,14 +331,23 @@ class EngineCore:
+         if kv_cache_config is None:
+             return []
+ 
++        metadata_block_size = getattr(self, "_kv_cache_metadata_block_size", None)
+         metadata: list[dict[str, int | str | None]] = []
+         for group_idx, group in enumerate(kv_cache_config.kv_cache_groups):
+             spec = group.kv_cache_spec
++            # Dynamo router metadata must use request hash/event granularity,
++            # not the inflated physical KV block size.
++            effective_block_size = (
++                metadata_block_size
++                if metadata_block_size is not None
++                and metadata_block_size < spec.block_size
++                else spec.block_size
++            )
+             metadata.append(
+                 {
+                     "group_idx": group_idx,
+                     "kind": get_kv_cache_spec_kind(spec).value,
+-                    "block_size": spec.block_size,
++                    "block_size": effective_block_size,
+                     "sliding_window": getattr(spec, "sliding_window", None),
+                 }
+             )

--- a/container/deps/vllm/patches/v0.22.0/ultra/0003-ultra-mtp-ds-conv-state-layout.patch
+++ b/container/deps/vllm/patches/v0.22.0/ultra/0003-ultra-mtp-ds-conv-state-layout.patch
@@ -1,0 +1,145 @@
+diff --git a/vllm/model_executor/layers/mamba/mamba_utils.py b/vllm/model_executor/layers/mamba/mamba_utils.py
+index c1fd81e40..39a69895b 100644
+--- a/vllm/model_executor/layers/mamba/mamba_utils.py
++++ b/vllm/model_executor/layers/mamba/mamba_utils.py
+@@ -273,6 +273,11 @@ class MambaCopySpec:
+     Data class specifying the memory-copy parameters for Mamba states used for
+     prefix caching in align mode.
+ 
++    NEMOTRON_ULTRA_MTP_DS_COPY: DS-layout conv-state speculative copies with
++    offset > 0 cannot be represented as one contiguous span. For that case,
++    ``ds_conv_tail`` carries the source block and accepted-token offset; the
++    worker-side copy path launches a strided copy kernel.
++
+     Attributes:
+         start_addr (int): Starting address for the memory copy operation.
+         num_elements (int): Number of elements to copy from the starting address.
+@@ -280,6 +285,9 @@ class MambaCopySpec:
+ 
+     start_addr: int
+     num_elements: int
++    ds_conv_tail: bool = False
++    src_block_id: int = -1
++    offset: int = 0
+ 
+ 
+ MambaStateCopyFunc: TypeAlias = Callable[
+@@ -312,12 +320,16 @@ def get_conv_copy_spec(
+     if is_conv_state_dim_first():
+         # DS layout: (num_blocks, dim, state_len) — state_len is last.
+         if offset > 0:
+-            # Slicing along the last dim yields a non-contiguous view
+-            # because features (dim) are strided by state_len.
+-            raise NotImplementedError(
+-                "DS conv state layout does not yet support speculative "
+-                "decoding with mamba_cache_mode='align' "
+-                "(num_accepted_tokens > 1)."
++            # NEMOTRON_ULTRA_MTP_DS_COPY: DS layout stores rows as
++            # (dim, state_len), so the accepted-token tail is strided across
++            # rows. Return a marker spec and let the worker-side copy path use
++            # a strided kernel.
++            return MambaCopySpec(
++                start_addr=0,
++                num_elements=0,
++                ds_conv_tail=True,
++                src_block_id=src_block_id,
++                offset=offset,
+             )
+         src_state = state[src_block_id]
+     else:
+diff --git a/vllm/v1/worker/mamba_utils.py b/vllm/v1/worker/mamba_utils.py
+index 485b274ea..1f8c83b80 100644
+--- a/vllm/v1/worker/mamba_utils.py
++++ b/vllm/v1/worker/mamba_utils.py
+@@ -202,6 +202,73 @@ def batch_memcpy(src_ptrs, dst_ptrs, sizes):
+     batch_memcpy_kernel[grid](src_ptrs, dst_ptrs, sizes, BLOCK_SIZE=BLOCK_SIZE)
+ 
+ 
++# NEMOTRON_ULTRA_MTP_DS_COPY: DS-layout conv-state tail copy for MTP align mode.
++@triton.jit
++def ds_conv_tail_copy_kernel(
++    state,
++    src_block_id,
++    dst_block_id,
++    dim: tl.constexpr,
++    state_len: tl.constexpr,
++    offset,
++    stride_block: tl.constexpr,
++    stride_dim: tl.constexpr,
++    stride_state: tl.constexpr,
++    BLOCK_D: tl.constexpr,
++    BLOCK_T: tl.constexpr,
++):
++    pid_d = tl.program_id(0)
++    pid_t = tl.program_id(1)
++    rows = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
++    cols = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)
++    tail_len = state_len - offset
++    mask = (rows[:, None] < dim) & (cols[None, :] < tail_len)
++    src = (
++        state
++        + src_block_id * stride_block
++        + rows[:, None] * stride_dim
++        + (cols[None, :] + offset) * stride_state
++    )
++    dst = (
++        state
++        + dst_block_id * stride_block
++        + rows[:, None] * stride_dim
++        + cols[None, :] * stride_state
++    )
++    values = tl.load(src, mask=mask, other=0)
++    tl.store(dst, values, mask=mask)
++
++
++def ds_conv_tail_copy(
++    state: torch.Tensor, src_block_id: int, dst_block_id: int, offset: int
++) -> None:
++    """Copy DS-layout conv tail from source block into destination prefix."""
++    if offset <= 0:
++        raise ValueError("ds_conv_tail_copy expects offset > 0")
++    if state.dim() != 3:
++        raise ValueError(f"expected 3D Mamba conv state, got {tuple(state.shape)}")
++    _, dim, state_len = state.shape
++    if offset >= state_len:
++        return
++    stride_block, stride_dim, stride_state = state.stride()
++    block_d = 16
++    block_t = 8
++    grid = (triton.cdiv(dim, block_d), triton.cdiv(state_len - offset, block_t))
++    ds_conv_tail_copy_kernel[grid](
++        state,
++        int(src_block_id),
++        int(dst_block_id),
++        int(dim),
++        int(state_len),
++        int(offset),
++        int(stride_block),
++        int(stride_dim),
++        int(stride_state),
++        BLOCK_D=block_d,
++        BLOCK_T=block_t,
++    )
++
++
+ def get_mamba_groups(kv_cache_config: KVCacheConfig) -> tuple[list[int], MambaSpec]:
+     mamba_group_ids: list[int] = []
+     mamba_specs: list[MambaSpec] = []
+@@ -600,6 +667,17 @@ def collect_mamba_copy_meta(
+                     state, block_ids, src_block_idx, accept_token_bias + 1
+                 )
+ 
++                if getattr(copy_spec, "ds_conv_tail", False):
++                    # NEMOTRON_ULTRA_MTP_DS_COPY: DS conv tail is not one
++                    # contiguous memcpy span. Launch a strided copy kernel.
++                    ds_conv_tail_copy(
++                        state,
++                        copy_spec.src_block_id,
++                        dest_block_id,
++                        copy_spec.offset,
++                    )
++                    continue
++
+                 src_ptrs_np[offset] = copy_spec.start_addr
+                 dst_ptrs_np[offset] = state[dest_block_id].data_ptr()
+                 sizes_np[offset] = copy_spec.num_elements * state.element_size()

--- a/container/deps/vllm/patches/v0.22.0/ultra/0004-ultra-ssm-nixl-tailfix.patch
+++ b/container/deps/vllm/patches/v0.22.0/ultra/0004-ultra-ssm-nixl-tailfix.patch
@@ -1,0 +1,28 @@
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+index 55081a603..67a348c6a 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+@@ -2337,11 +2337,18 @@ class NixlConnectorWorker:
+                     _is_ssm_spec(self._group_spec_types[i])
+                     and num_local_blocks < num_remote_blocks
+                 ):
+-                    # NOTE (NickLucche): With prefix caching on SSM, (remote) blocks
+-                    # prior to the last one are placeholders (null blocks). Mind that
+-                    # this doesn't really impact transfer, as we only still care about
+-                    # the last "block", the full in-place state.
+-                    assert num_local_blocks == 1, "SSM can only have one local block"
++                    # NEMOTRON_ULTRA_SSM_NIXL_TAILFIX: SSM state groups may
++                    # allocate multiple local blocks after long-context
++                    # prefix-cache transfer. Tail-align remote SSM blocks to
++                    # the local suffix instead of asserting a single local
++                    # block.
++                    assert num_local_blocks > 0, (
++                        "SSM group has no local blocks to receive"
++                    )
++                    assert num_local_blocks <= num_remote_blocks, (
++                        f"SSM group {i}: local blocks {num_local_blocks} "
++                        f"> remote blocks {num_remote_blocks}"
++                    )
+                     remote_block_ids[i] = remote_group[-num_local_blocks:]
+                 elif (
+                     self._physical_blocks_per_logical_kv_block

--- a/container/deps/vllm/validate_nemotron_ultra_runtime.py
+++ b/container/deps/vllm/validate_nemotron_ultra_runtime.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Validate installed Nemotron Ultra vLLM runtime markers."""
+
+from __future__ import annotations
+
+import importlib.metadata as metadata
+import importlib.util
+import json
+from pathlib import Path
+
+import vllm
+
+MARKER_GROUPS = {
+    "semantic_kv_events": [
+        "kv_cache_spec_kind",
+        "kv_cache_spec_sliding_window",
+        "get_kv_cache_spec_kind",
+    ],
+    "mamba_spec_decode_runtime": [
+        "postprocess_mamba_fused_kernel",
+        "MambaSpecDecodeGPUContext",
+        "MambaBuffers",
+        "postprocess_mamba_align_gpu",
+    ],
+    "pr42554_mamba_pd_runtime": [
+        "Skip block alignment when setting up async receive",
+        "Partial prefix cache hit for FA group",
+    ],
+    "hybrid_hash_block_events": [
+        "_maybe_emit_sub_block_events",
+        "hash_block_size",
+        "BlockStored",
+    ],
+    "mtp_ds_copy": [
+        "NEMOTRON_ULTRA_MTP_DS_COPY",
+        "ds_conv_tail_copy",
+    ],
+    "ssm_nixl_tailfix": [
+        "NEMOTRON_ULTRA_SSM_NIXL_TAILFIX",
+        "SSM group has no local blocks to receive",
+    ],
+}
+
+
+def find_marker(files: list[Path], root: Path, marker: str) -> str | None:
+    for path in files:
+        if marker in path.read_text(errors="ignore"):
+            return str(path.relative_to(root))
+    return None
+
+
+def main() -> None:
+    root = Path(vllm.__file__).resolve().parent
+    files = sorted(path for path in root.rglob("*.py") if path.is_file())
+    missing: dict[str, list[str]] = {}
+    evidence: dict[str, dict[str, str | None]] = {}
+
+    for group, markers in MARKER_GROUPS.items():
+        group_evidence = {}
+        for marker in markers:
+            hit = find_marker(files, root, marker)
+            group_evidence[marker] = hit
+            if hit is None:
+                missing.setdefault(group, []).append(marker)
+        evidence[group] = group_evidence
+
+    vllm_version = metadata.version("vllm")
+    if vllm_version != "0.22.0":
+        missing.setdefault("vllm_version", []).append(vllm_version)
+
+    humming_spec = importlib.util.find_spec("humming")
+    if humming_spec is None:
+        missing.setdefault("humming", []).append("humming python package")
+
+    payload = {
+        "vllm_root": str(root),
+        "vllm_version": vllm_version,
+        "humming_origin": humming_spec.origin if humming_spec else None,
+        "marker_evidence": evidence,
+        "missing": missing,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if missing:
+        raise SystemExit(f"missing Nemotron Ultra runtime markers: {missing}")
+
+
+if __name__ == "__main__":
+    main()

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -36,9 +36,12 @@ COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
 COPY --from=dynamo_base /bin/uv /bin/uvx /bin/
 
-# Create dynamo user with group 0 for OpenShift compatibility
+# Create dynamo user with group 0 for OpenShift compatibility.
+# Pin -u 1000 explicitly: the vllm/vllm-openai >=0.22 image ships a `vllm` user at
+# UID 2000, so after freeing 1000 (ubuntu) useradd would otherwise auto-assign the
+# next-highest UID (2001) and fail the `id -u dynamo` == 1000 assertion below.
 RUN userdel -r ubuntu > /dev/null 2>&1 || true \
-    && useradd -m -s /bin/bash -g 0 dynamo \
+    && useradd -u 1000 -m -s /bin/bash -g 0 dynamo \
     && [ `id -u dynamo` -eq 1000 ] \
     && mkdir -p /home/dynamo/.cache /opt/dynamo \
     && ln -sf /usr/bin/python3 /usr/local/bin/python \
@@ -86,6 +89,26 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     set -eux; \
     export UV_CACHE_DIR=/root/.cache/uv; \
     bash /tmp/install_vllm_omni.sh
+
+{% if cuda_version == "13.0" %}
+RUN --mount=type=bind,source=./container/deps/vllm/patches/v0.22.0/ultra,target=/tmp/nemotron-ultra-vllm-patches,readonly \
+    --mount=type=bind,source=./container/deps/vllm/validate_nemotron_ultra_runtime.py,target=/tmp/validate_nemotron_ultra_runtime.py,readonly \
+    set -eux; \
+    installed_vllm_version="$(python3 -c 'import importlib.metadata as md; print(md.version("vllm"))')"; \
+    test "${installed_vllm_version}" = "0.22.0"; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends patch; \
+    site_parent="$(python3 -c 'import pathlib, vllm; print(pathlib.Path(vllm.__file__).resolve().parent.parent)')"; \
+    for patch_file in /tmp/nemotron-ultra-vllm-patches/*.patch; do \
+        echo "Applying ${patch_file}"; \
+        patch --batch --forward -p1 -d "${site_parent}" < "${patch_file}"; \
+    done; \
+    apt-get purge -y patch; \
+    rm -rf /var/lib/apt/lists/*; \
+    python3 -m pip install --no-cache-dir 'humming-kernels[cu13]==0.1.0'; \
+    python3 /tmp/validate_nemotron_ultra_runtime.py
+
+{% endif %}
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
#### Overview:

Adds Nemotron-3 Ultra support to the CUDA 13 vLLM runtime container by moving the CUDA 13 runtime base to `vllm/vllm-openai:v0.22.0-ubuntu2404` and applying the Ultra-specific vLLM runtime patches during the container build.

The patch stack enables the Ultra P/D + hybrid Mamba/Attention runtime behavior needed by the Nemotron Ultra recipes, including Mamba prefix-cache/P-D runtime support, hybrid hash-block KV events, MTP DS conv-state layout handling, and the SSM/NIXL tail fix. The patches are applied to the installed vLLM package in the runtime image and validated during the Docker build.

#### Details:

  - Updates the CUDA 13 vLLM runtime image tag to `v0.22.0-ubuntu2404`.
  - Adds vendored vLLM patches under:
    - `container/deps/vllm/patches/v0.22.0/ultra/`
  - Applies the Ultra patch stack only for CUDA 13 builds in `container/templates/vllm_runtime.Dockerfile`.
  - Installs `humming-kernels[cu13]==0.1.0`.
  - Adds `validate_nemotron_ultra_runtime.py` to verify required runtime markers after patch application.
  - Removes the `patch` package after patching while preserving compiler/toolchain packages needed by Triton/TorchInductor at runtime.
  - Pins the `dynamo` user UID to 1000 for compatibility with the vLLM 0.22 base image user layout.
  - Leaves the CUDA 12.9 path unchanged.

  Validated with a final release-branch e2e container run:
  - Docker build PASS
  - installed marker validation PASS
  - final image `patch` binary/package absent
  - `gcc`/`cc`/`make` retained
  - AGG smoke PASS
  - direct 1P1D smoke PASS

  Smoke coverage included:
  - `/health`
  - `/v1/models`
  - short chat completion with expected response text
  - shared-prefix cached-token probe
  - KV/prefix log evidence gate
  - limited Moontrace-shape probe
  - cleanup and post-run Docker/GPU state check

#### Where should the reviewer start?

  - `container/templates/vllm_runtime.Dockerfile`
  - `container/context.yaml`
  - `container/deps/vllm/validate_nemotron_ultra_runtime.py`
  - `container/deps/vllm/patches/v0.22.0/ultra/`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->