### PR TITLE
test(parity): merge Nemotron V3 with Qwen3 coder row and remove Nemotron DeciLM

### DIFF
--- a/tests/parity/parity_table.html.j2
+++ b/tests/parity/parity_table.html.j2
@@ -257,6 +257,10 @@ td.cell .ttip a:hover, td.parser .ttip a:hover { color: #dbeafe; background: tra
   <span style="color:#8a6d3b">—</span> missing fixture coverage ·
   <span class="parser-suffix">†</span> = no vLLM peer tool calling parser for this family ·
   <span class="parser-suffix">§</span> = no SGLang peer tool calling parser for this family.
+  <br>
+  <span class="parser-suffix">‡</span> Nemotron V3 (Ultra) reuses the qwen3_coder tool calling parser;
+  Nemotron V1 / V2 (DeciLM) is removed from the chart for being an older generation, but the
+  nemotron_deci parser is still supported.
   <br><br>
   <strong>Tooltip fields:</strong>
   <code>input_text</code>=raw model output fed into the tool calling parser ·

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -110,6 +110,19 @@ PARSER_TO_REASONING_FAMILY = {
     "qwen3_coder": "qwen3",
 }
 
+# Row label / placement overrides keyed by tool calling family; ‡ is explained
+# by the legend note (see `_legend_html`).
+_REASONING_LABEL_OVERRIDES = {"nemotron_nano": "Nemotron V3‡"}
+_REASONING_TOP_N_APPEND = ["nemotron_nano"]
+_REASONING_HIDDEN_TOOL_FAMILIES = {"nemotron_deci"}
+
+
+def _model_label_html(model: str) -> str:
+    """Escape a model label, styling any ‡ marker like the †/§ suffixes."""
+    return html_lib.escape(model).replace(
+        "‡", '<span class="parser-suffix">‡</span>'
+    )
+
 _FAMILY_METADATA = {
     "basic": {
         "models": ["Generic CoT models"],
@@ -640,7 +653,9 @@ def _build_display_groups(
 
     def make_row(tool_family: str) -> dict[str, str | None]:
         return {
-            "model_label": parser_labels.get(tool_family, tool_family),
+            "model_label": _REASONING_LABEL_OVERRIDES.get(
+                tool_family, parser_labels.get(tool_family, tool_family)
+            ),
             "tool_family": tool_family,
             "reasoning_family": PARSER_TO_REASONING_FAMILY.get(tool_family),
         }
@@ -649,15 +664,32 @@ def _build_display_groups(
         reasoning_family = PARSER_TO_REASONING_FAMILY.get(tool_family)
         return reasoning_family in rows
 
-    top_n = [
-        make_row(tool_family)
-        for tool_family in TOP_N_FAMILIES
-        if tool_family in parser_families and has_reasoning_fixture(tool_family)
+    def displayable(tool_family: str) -> bool:
+        return (
+            tool_family in parser_families
+            and has_reasoning_fixture(tool_family)
+            and tool_family not in _REASONING_HIDDEN_TOOL_FAMILIES
+        )
+
+    top_n_families = [
+        tool_family for tool_family in TOP_N_FAMILIES if displayable(tool_family)
     ]
+    top_n_families += [
+        tool_family
+        for tool_family in _REASONING_TOP_N_APPEND
+        if displayable(tool_family) and tool_family not in top_n_families
+    ]
+    top_n = [make_row(tool_family) for tool_family in top_n_families]
+
+    excluded = (
+        set(TOP_N_FAMILIES)
+        | set(_REASONING_TOP_N_APPEND)
+        | _REASONING_HIDDEN_TOOL_FAMILIES
+    )
     other_tool_families = sorted(
         (
             tool_family
-            for tool_family in parser_families - set(TOP_N_FAMILIES)
+            for tool_family in parser_families - excluded
             if has_reasoning_fixture(tool_family)
         ),
         key=lambda family: parser_labels.get(family, family).lower(),
@@ -1951,7 +1983,7 @@ def _render_row_html(
     reasoning_family = row["reasoning_family"]
     cells = [
         f'<tr><td class="model" data-col-hide-group="model">'
-        f"{html_lib.escape(str(row['model_label']))}</td>",
+        f"{_model_label_html(str(row['model_label']))}</td>",
         _column_placeholder_html("model"),
         _parser_cell_html(tool_family, reasoning_family, no_vllm, no_sglang),
         _column_placeholder_html("parser"),
@@ -2085,6 +2117,11 @@ def _legend_html(rows: dict[str, dict[str, Any]], columns: list[str]) -> str:
         "for this family · "
         '<span class="parser-suffix">§</span> = no SGLang peer reasoning parser '
         "for this family."
+        "<br>"
+        '<span class="parser-suffix">‡</span> Nemotron V3 (Ultra) reuses the '
+        "qwen3_coder tool calling parser; Nemotron V1 / V2 (DeciLM) is removed "
+        "from the chart for being an older generation, but the nemotron_deci "
+        "parser is still supported."
         "<br><br>"
         "<strong>Tooltip fields:</strong> "
         "<code>input_text</code>=raw model output or stream chunks fed into "

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -114,6 +114,7 @@ PARSER_TO_REASONING_FAMILY = {
 # by the legend note (see `_legend_html`).
 _REASONING_LABEL_OVERRIDES = {"nemotron_nano": "Nemotron V3‡"}
 _REASONING_TOP_N_APPEND = ["nemotron_nano"]
+# nemotron_deci: for older nemotron v2 models, hide to avoid confusion with nemotron v3 models
 _REASONING_HIDDEN_TOOL_FAMILIES = {"nemotron_deci"}
 
 

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -119,9 +119,8 @@ _REASONING_HIDDEN_TOOL_FAMILIES = {"nemotron_deci"}
 
 def _model_label_html(model: str) -> str:
     """Escape a model label, styling any ‡ marker like the †/§ suffixes."""
-    return html_lib.escape(model).replace(
-        "‡", '<span class="parser-suffix">‡</span>'
-    )
+    return html_lib.escape(model).replace("‡", '<span class="parser-suffix">‡</span>')
+
 
 _FAMILY_METADATA = {
     "basic": {

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -87,6 +87,8 @@ RUST_TOOL_CALLING_DIR = REPO_ROOT / "lib/parsers/src/tool_calling"
 _TOOL_CALLING_LABEL_OVERRIDES = {
     "qwen3_coder": "Qwen 3 Coder / Nemotron V3‡",
 }
+# nemotron_nano: an alias for qwen3_coder, hide to avoid duplicate row
+# nemotron_deci: for older v2 nemotron models, hide to avoid confusion with nemotron v3 models
 _HIDDEN_TOOL_CALLING_FAMILIES = {"nemotron_deci", "nemotron_nano"}
 
 

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -92,9 +92,7 @@ _HIDDEN_TOOL_CALLING_FAMILIES = {"nemotron_deci", "nemotron_nano"}
 
 def _model_label_html(model: str) -> str:
     """Escape a model label, styling any ‡ marker like the †/§ suffixes."""
-    return html_lib.escape(model).replace(
-        "‡", '<span class="parser-suffix">‡</span>'
-    )
+    return html_lib.escape(model).replace("‡", '<span class="parser-suffix">‡</span>')
 
 
 def _make_jinja_env() -> Environment:

--- a/tests/parity/toolcalling/table.py
+++ b/tests/parity/toolcalling/table.py
@@ -82,6 +82,20 @@ TEMPLATE_DIR = REPO_ROOT / "tests/parity"
 
 RUST_TOOL_CALLING_DIR = REPO_ROOT / "lib/parsers/src/tool_calling"
 
+# Row-label / visibility overrides keyed by tool calling family; ‡ is explained
+# by the legend note in parity_table.html.j2.
+_TOOL_CALLING_LABEL_OVERRIDES = {
+    "qwen3_coder": "Qwen 3 Coder / Nemotron V3‡",
+}
+_HIDDEN_TOOL_CALLING_FAMILIES = {"nemotron_deci", "nemotron_nano"}
+
+
+def _model_label_html(model: str) -> str:
+    """Escape a model label, styling any ‡ marker like the †/§ suffixes."""
+    return html_lib.escape(model).replace(
+        "‡", '<span class="parser-suffix">‡</span>'
+    )
+
 
 def _make_jinja_env() -> Environment:
     return Environment(
@@ -548,10 +562,12 @@ def _build_display_groups(
     Others: every YAML-discovered family not in TOP_N, sorted by label.
     Missing labels fall back to the family ID.
     """
-    families = {fam for fam, _ in cases.keys()}
+    families = {
+        fam for fam, _ in cases.keys() if fam not in _HIDDEN_TOOL_CALLING_FAMILIES
+    }
 
     def label_of(fam: str) -> str:
-        return labels.get(fam, fam)
+        return _TOOL_CALLING_LABEL_OVERRIDES.get(fam, labels.get(fam, fam))
 
     top_n = [(label_of(f), f) for f in TOP_N_FAMILIES if f in families]
     other_fams = sorted(
@@ -788,6 +804,10 @@ _LEGEND_MD = (
     "`—` missing fixture coverage · "
     "`†` (tool calling parser column) = no vLLM peer parser for this family · "
     "`§` (tool calling parser column) = no SGLang peer parser for this family."
+    "\n\n"
+    "`‡` Nemotron V3 (Ultra) reuses the qwen3_coder tool calling parser; "
+    "Nemotron V1 / V2 (DeciLM) is removed from the chart for being an older "
+    "generation, but the nemotron_deci parser is still supported."
 )
 
 
@@ -1242,7 +1262,7 @@ def render_row_html(
     inheritance: dict[str, dict],
 ) -> str:
     cells = [
-        f'<tr><td class="model" data-col-hide-group="model">{html_lib.escape(model)}</td>',
+        f'<tr><td class="model" data-col-hide-group="model">{_model_label_html(model)}</td>',
         _column_placeholder_html("model"),
         _parser_cell_html(family, refs, no_vllm, no_sglang, inheritance),
         _column_placeholder_html("parser"),

--- a/tests/parity/toolcalling/test_generate_parity_table.py
+++ b/tests/parity/toolcalling/test_generate_parity_table.py
@@ -88,7 +88,8 @@ def test_generate_parser_parity_table_html() -> None:
     assert "<strong>Parity:</strong>" in html
     assert "color: #8b949e;" in html
     assert '<span style="color:#8b949e">·</span> Dynamo-only fixture' in html
-    assert 'data-marker-dynamo="·"' in html
+    # `·` came only from the now-hidden nemotron_deci / nemotron_nano rows.
+    assert 'data-marker-dynamo="·"' not in html
     assert '<span style="color:#555">D</span> Dynamo-only fixture' not in html
     assert "green = selected implementation output is clean" in html
     assert "red = selected implementation leaks parser markup" in html


### PR DESCRIPTION
#### Overview:

Cleans up how the Nemotron family is presented in the tool-calling and reasoning parity tables. Nemotron V3 (Ultra) reuses the `qwen3_coder` parser, and the older DeciLM-based V1/V2 (`nemotron_deci`) are now removed from the chart.

No yaml file changes, just display logic.

#### Details:
before change:
<img width="577" height="679" alt="image" src="https://github.com/user-attachments/assets/560fb577-7a4b-47d2-8a93-247a0c16780a" />

after change:
<img width="586" height="654" alt="image" src="https://github.com/user-attachments/assets/042d8f5a-283d-4a9e-ba78-393b60aec819" />


#### Where should the reviewer start?

- `tests/parity/toolcalling/table.py` and `tests/parity/reasoning/table.py` —
  the override/hide constants and the `_model_label_html` helper.
- `tests/parity/parity_table.html.j2` — the `‡` legend note.

#### Related Issues:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parity table legends explaining model handling and special display markers.

* **Parity Table Updates**
  * Modified model visibility and labeling in tables; certain models are now hidden while others receive updated display markers for improved clarity.

* **Tests**
  * Updated test expectations for chart rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->