### PR TITLE
fix(ci): self-healing vCluster port-forward for deploy tests

### DIFF
--- a/.github/actions/connect-vcluster/action.yml
+++ b/.github/actions/connect-vcluster/action.yml
@@ -31,6 +31,98 @@ runs:
     - name: Install vCluster CLI
       uses: ./.github/actions/install-vcluster-cli
 
+    - name: Install port-forward supervisor
+      id: supervisor
+      shell: bash
+      env:
+        VCLUSTER_NAME: ${{ inputs.vcluster_name }}
+        NAMESPACE: ${{ inputs.vcluster_namespace }}
+      run: |
+        # Self-healing port-forward to the vCluster API on 127.0.0.1:8443.
+        #
+        # A plain `kubectl port-forward ... &` does not survive its underlying
+        # connection being dropped (idle/stream reset by an intermediate proxy, or a
+        # credential rotation): kubectl holds the original stream and never reconnects,
+        # leaving 127.0.0.1:8443 permanently dead for the rest of the job. We instead
+        # run a supervisor that health-probes the tunnel and relaunches
+        # `kubectl port-forward` on failure. Each relaunch re-reads the current
+        # $KUBECONFIG, so the tunnel survives credential rotation as well.
+        #
+        # The supervisor and the kubectl child both run backgrounded and detached from
+        # this step's shell, so they persist across GitHub Actions steps (steps run
+        # natively here, ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=false).
+        SUPERVISOR="${{ github.workspace }}/.pf-supervisor.sh"
+        cat > "${SUPERVISOR}" <<'SUPERVISOR_EOF'
+        #!/usr/bin/env bash
+        # Usage: pf-supervisor.sh {start|stop}
+        set -u
+
+        PF_PID_FILE="${PF_PID_FILE:-/tmp/dynamo-pf-supervisor.pid}"
+        PF_LOG_FILE="${PF_LOG_FILE:-/tmp/dynamo-pf-supervisor.log}"
+        HEALTH_URL="https://127.0.0.1:8443/healthz"
+        PROBE_INTERVAL=3
+
+        pf_healthy() {
+          curl -sk --connect-timeout 1 --max-time 2 "${HEALTH_URL}" >/dev/null
+        }
+
+        # The supervisor loop: own one `kubectl port-forward` child at a time and
+        # restart it whenever the tunnel stops responding. NAMESPACE / VCLUSTER_NAME /
+        # KUBECONFIG are inherited from the environment of the `start` caller.
+        supervise() {
+          local kpid=""
+          while true; do
+            if [ -z "${kpid}" ] || ! kill -0 "${kpid}" 2>/dev/null || ! pf_healthy; then
+              if [ -n "${kpid}" ]; then
+                echo "$(date -u +%T) port-forward unhealthy; restarting (was pid ${kpid})"
+                kill "${kpid}" 2>/dev/null || true
+                wait "${kpid}" 2>/dev/null || true
+              fi
+              kubectl port-forward -n "${NAMESPACE}" "svc/${VCLUSTER_NAME}" 8443:443 &
+              kpid=$!
+              echo "$(date -u +%T) started kubectl port-forward (pid ${kpid})"
+            fi
+            sleep "${PROBE_INTERVAL}"
+          done
+        }
+
+        case "${1:-}" in
+          start)
+            # On the persistent ARC runner a prior job may have left a supervisor
+            # bound to a now-deleted vCluster. Reuse it only if it still serves a
+            # healthy tunnel; otherwise tear it down and start fresh.
+            if [ -f "${PF_PID_FILE}" ] && kill -0 "$(cat "${PF_PID_FILE}")" 2>/dev/null; then
+              if pf_healthy; then
+                echo "port-forward supervisor already running (pid $(cat "${PF_PID_FILE}"))"
+                exit 0
+              fi
+              echo "stale port-forward supervisor (pid $(cat "${PF_PID_FILE}")); replacing"
+              kill "$(cat "${PF_PID_FILE}")" 2>/dev/null || true
+              rm -f "${PF_PID_FILE}"
+            fi
+            setsid bash -c "$(declare -f pf_healthy supervise); HEALTH_URL='${HEALTH_URL}' PROBE_INTERVAL='${PROBE_INTERVAL}' supervise" \
+              </dev/null >>"${PF_LOG_FILE}" 2>&1 &
+            echo $! > "${PF_PID_FILE}"
+            echo "port-forward supervisor started (pid $(cat "${PF_PID_FILE}"))"
+            ;;
+          stop)
+            if [ -f "${PF_PID_FILE}" ]; then
+              kill "$(cat "${PF_PID_FILE}")" 2>/dev/null || true
+              rm -f "${PF_PID_FILE}"
+            fi
+            # Reap any kubectl port-forward bound to our local port.
+            pkill -f "port-forward -n ${NAMESPACE} svc/${VCLUSTER_NAME} 8443:443" 2>/dev/null || true
+            echo "port-forward supervisor stopped"
+            ;;
+          *)
+            echo "usage: $0 {start|stop}" >&2
+            exit 2
+            ;;
+        esac
+        SUPERVISOR_EOF
+        chmod +x "${SUPERVISOR}"
+        echo "PF_SUPERVISOR=${SUPERVISOR}" >> "$GITHUB_ENV"
+
     - name: Connect to vCluster
       id: connect
       shell: bash
@@ -41,18 +133,18 @@ runs:
         echo "::group::Port-forward and generate vCluster kubeconfig"
         set -e
 
-        # In the Self-bootstrap rerun path, setup-dynamo-operator already started a
-        # backgrounded `kubectl port-forward` to 127.0.0.1:8443 that survives across
-        # steps. Reuse it instead of racing for the same local port (which would
-        # fail with "address already in use" and break this step).
+        # A backgrounded supervisor owns the port-forward (see the
+        # "Install port-forward supervisor" step) and survives across steps, so any
+        # earlier step in this job (e.g. the
+        # Self-bootstrap rerun path's connect-vcluster invocation) may have already
+        # started it. Reuse a healthy tunnel instead of racing for the same local
+        # port, which would fail with "address already in use".
         if curl -sk --connect-timeout 1 --max-time 2 https://127.0.0.1:8443/healthz >/dev/null; then
           echo "Existing port-forward on 127.0.0.1:8443 detected; reusing"
         else
           # The vCluster pod must be Ready before port-forwarding. A Pending pod
           # causes `kubectl port-forward` to exit immediately ("unable to forward
-          # port because pod is not running. Current status=Pending"); because it's
-          # backgrounded, the script continues, and the connectivity check later
-          # fails with "connection refused" on 127.0.0.1:8443.
+          # port because pod is not running. Current status=Pending").
           #
           # Assumes the pod is already scheduled by the time we get here — true for
           # all current callers (deploy-operator creates the StatefulSet upstream,
@@ -69,17 +161,11 @@ runs:
             -n "${NAMESPACE}" \
             --timeout=300s
 
-          kubectl port-forward -n "${NAMESPACE}" "svc/${VCLUSTER_NAME}" 8443:443 &
-          PF_PID=$!
-
-          # Poll until the local port is actually reachable. Replaces the previous
-          # fixed `sleep 5`, which is too short when the pod just restarted or
-          # endpoints take longer to propagate.
+          # Start the self-healing supervisor (defined in the previous step) and
+          # wait for the tunnel to come up. The supervisor keeps it alive for the
+          # rest of the job, re-reading the current $KUBECONFIG on each relaunch.
+          "${PF_SUPERVISOR}" start
           for attempt in $(seq 1 30); do
-            if ! kill -0 "${PF_PID}" 2>/dev/null; then
-              echo "::error::kubectl port-forward exited before local port was reachable"
-              exit 1
-            fi
             if curl -sk --connect-timeout 1 --max-time 2 https://127.0.0.1:8443/healthz >/dev/null; then
               echo "vCluster API reachable after ${attempt} attempt(s)"
               break

--- a/.github/actions/teardown-dynamo-operator/action.yml
+++ b/.github/actions/teardown-dynamo-operator/action.yml
@@ -26,6 +26,22 @@ runs:
     - name: Install vCluster CLI
       uses: ./.github/actions/install-vcluster-cli
 
+    - name: Stop port-forward supervisor
+      shell: bash
+      env:
+        VCLUSTER_NAME: ${{ inputs.vcluster_name }}
+        NAMESPACE: ${{ inputs.vcluster_namespace }}
+      run: |
+        # Stop the self-healing port-forward started by connect-vcluster so it does
+        # not leak on the persistent ARC runner and interfere with later jobs. The
+        # script path and PID file are deterministic; tolerate their absence.
+        SUPERVISOR="${{ github.workspace }}/.pf-supervisor.sh"
+        if [ -x "${SUPERVISOR}" ]; then
+          "${SUPERVISOR}" stop || true
+        else
+          pkill -f "port-forward -n ${NAMESPACE} svc/${VCLUSTER_NAME} 8443:443" 2>/dev/null || true
+        fi
+
     - name: Delete vCluster
       shell: bash
       env:

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -20,6 +20,30 @@ from kubernetes_asyncio.client import exceptions
 from tests.utils.test_output import resolve_test_output_path
 
 
+async def _retry_on_transient_connection_error(coro_factory, logger, attempts=5, delay=2):
+    """Await ``coro_factory()``, retrying only on transient transport failures.
+
+    In CI the vCluster API is reached through a port-forward to 127.0.0.1:8443 that a
+    supervisor relaunches whenever the long-lived stream drops. During the brief
+    window between the old tunnel dying and the new one coming up, a call fails with a
+    connection error (``OSError`` / aiohttp's ``ClientConnectorError``, which
+    subclasses ``OSError``). Those are retried with a short backoff; ``ApiException``
+    is a real API response (not transport) and is not caught here, so it propagates
+    unchanged.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return await coro_factory()
+        except OSError as e:
+            if attempt == attempts:
+                raise
+            logger.warning(
+                f"Transient connection error talking to the cluster API "
+                f"(attempt {attempt}/{attempts}), retrying in {delay}s: {e}"
+            )
+            await asyncio.sleep(delay)
+
+
 def _get_workspace_dir() -> str:
     """Get workspace directory without depending on dynamo.common package.
 
@@ -1245,12 +1269,15 @@ class ManagedDeployment:
 
         try:
             assert self._custom_api is not None, "Kubernetes API not initialized"
-            await self._custom_api.create_namespaced_custom_object(
-                group="nvidia.com",
-                version=self.deployment_spec.api_version,
-                namespace=self.namespace,
-                plural="dynamographdeployments",
-                body=self.deployment_spec.spec(),
+            await _retry_on_transient_connection_error(
+                lambda: self._custom_api.create_namespaced_custom_object(
+                    group="nvidia.com",
+                    version=self.deployment_spec.api_version,
+                    namespace=self.namespace,
+                    plural="dynamographdeployments",
+                    body=self.deployment_spec.spec(),
+                ),
+                self._logger,
             )
             self._logger.info(self.deployment_spec.spec())
             self._logger.info(f"Deployment Started {self._deployment_name}")
@@ -1494,12 +1521,15 @@ class ManagedDeployment:
         """
         try:
             if self._deployment_name and self._custom_api is not None:
-                await self._custom_api.delete_namespaced_custom_object(
-                    group="nvidia.com",
-                    version=self.deployment_spec.api_version,
-                    namespace=self.namespace,
-                    plural="dynamographdeployments",
-                    name=self._deployment_name,
+                await _retry_on_transient_connection_error(
+                    lambda: self._custom_api.delete_namespaced_custom_object(
+                        group="nvidia.com",
+                        version=self.deployment_spec.api_version,
+                        namespace=self.namespace,
+                        plural="dynamographdeployments",
+                        name=self._deployment_name,
+                    ),
+                    self._logger,
                 )
         except exceptions.ApiException as e:
             if e.status != 404:  # Ignore if already deleted


### PR DESCRIPTION
## Summary

Deploy tests (`tests/deploy/test_deploy.py`) reach the vCluster API through a single long-lived, backgrounded `kubectl port-forward` to `127.0.0.1:8443`, established in `connect-vcluster`. After the deploy jobs moved to the `prod-deploy-tester-v1` runner, that stream now traverses an extra proxy hop and drops mid-job (idle / stream reset) with **no auto-reconnect**, leaving the vCluster API unreachable for the rest of the job.

Symptoms observed in CI:
- **Fast failure** when the tunnel dies before the readiness wait begins — the first API call (`_delete_deployment` in `__aenter__`) raises `ConnectionRefusedError('127.0.0.1', 8443)` and the job fails in ~1-2 min.
- **1200s timeout** when it dies mid-wait — the poll loop retries a dead socket until pytest-timeout.

The deployments themselves are healthy: running the same test against a host cluster directly (no vCluster hop) passes end-to-end in ~2.5 min. The failure is purely the port-forward losing connectivity, with no mechanism to recover.

## Changes

- **`connect-vcluster`**: replace the one-shot `kubectl port-forward ... &` with a detached supervisor that health-probes `127.0.0.1:8443/healthz` and relaunches `kubectl port-forward` whenever the tunnel stops responding. Each relaunch re-reads the current `$KUBECONFIG`, so it is robust to credential rotation as well as transient stream resets. The reuse fast-path and readiness poll are preserved.
- **`teardown-dynamo-operator`**: stop the supervisor on teardown so it does not leak on the persistent runner and interfere with later jobs.
- **`managed_deployment.py`**: wrap the initial DGD create/delete custom-object calls in a small retry that catches only transient transport errors (`OSError` / aiohttp `ClientConnectorError`), so a brief gap during a tunnel relaunch no longer fails the test. Real `ApiException` responses still propagate unchanged.

## Why this is the right fix

The supervisor is agnostic to *why* the stream dropped (idle reset, proxy reset, transient error, or credential rotation) — it simply restores the tunnel. This is not a credential-expiry problem, so no runner or credential-TTL change is required.

## Validation

- `python -m py_compile tests/utils/managed_deployment.py`
- `bash -n` on the extracted supervisor script; behavioral test confirming it relaunches `kubectl` on health-probe failure and that `stop` cleans up.
- Retry helper unit-behavior: recovers after transient `ConnectionRefusedError`, propagates `ApiException` immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
