### PR TITLE
fix(container): replace GPL ffmpeg with LGPL in-tree build in vllm-runtime (nemotron-super)

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -39,6 +39,11 @@ dynamo:
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   ffmpeg_version: "8.1"
+  # ffmpeg CLI build inputs: NVENC API headers (H.264 HW encoder) and the
+  # BSD-licensed libvpx VP9 encoder, so wheel_builder can build an LGPL-only
+  # ffmpeg CLI to replace the GPL binary shipped by imageio-ffmpeg / the base.
+  nv_codec_headers_ref: "n13.0.19.0"
+  libvpx_ref: "v1.14.1"
   efa_version: 1.47.0
 
 vllm:

--- a/container/deps/requirements.vllm.txt
+++ b/container/deps/requirements.vllm.txt
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Third-party Python dependencies for the vllm runtime image. Installed
+# with --reinstall-package imageio-ffmpeg --no-deps to replace the upstream
+# vllm/vllm-openai base image's imageio-ffmpeg wheel (which ships a
+# GPL-encumbered prebuilt ffmpeg binary) with a source build that leaves
+# no binary on disk. IMAGEIO_FFMPEG_EXE points imageio at the LGPL ffmpeg
+# CLI copied from wheel_builder, so any media path encodes through that
+# instead of a bundled GPL binary.
+
+--no-binary imageio-ffmpeg
+
+imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive at top of file

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -55,6 +55,8 @@ ARG ETCD_VERSION={{ context.dynamo.etcd_version }}
 
 ARG ENABLE_MEDIA_FFMPEG={{ context[framework].enable_media_ffmpeg }}
 ARG FFMPEG_VERSION={{ context.dynamo.ffmpeg_version }}
+ARG NV_CODEC_HEADERS_REF={{ context.dynamo.nv_codec_headers_ref }}
+ARG LIBVPX_REF={{ context.dynamo.libvpx_ref }}
 {% if device == "cuda" -%}
 ARG ENABLE_GPU_MEMORY_SERVICE={{ context[framework].enable_gpu_memory_service }}
 {% endif %}

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -158,14 +158,17 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
         if [ -n "$GMS_WHEEL" ]; then uv pip install {{ pip_target }} --no-deps "$GMS_WHEEL"; fi; \
     fi
 
-# vLLM-Omni's audio helpers shell out to SoX, and the launch script examples use
-# jq for readable curl output just like the upstream omni image does.
+# The launch script examples use jq for readable curl output just like the
+# upstream omni image does.
+#
+# NOTE: vLLM-Omni no longer shells out to the GPL SoX binary — its audio
+# normalization is a pure-numpy peak_normalize() (vllm_omni/utils/audio.py), so
+# sox / libsox-fmt-all (and their GPL/UNKNOWN codec deps) are intentionally not
+# installed here.
 RUN set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        jq \
-        sox \
-        libsox-fmt-all; \
+        jq; \
     rm -rf /var/lib/apt/lists/*
 
 # Layer the released vLLM-Omni package matching the pinned upstream ref while
@@ -204,15 +207,58 @@ RUN uv pip uninstall triton && \
 {% endif %}
 {% endif %}
 
-{% if context.vllm.enable_media_ffmpeg == "true" %}
-# Copy ffmpeg libraries from wheel_builder (requires root, runs before USER dynamo)
+# The upstream vllm/vllm-openai base image ships a GPL/GPL-3.0 ffmpeg built
+# against libx264/libx265/libmp3lame. Purge that entire apt codec stack and
+# replace it with the LGPL-only in-tree ffmpeg built in wheel_builder
+# (--disable-gpl --disable-nonfree; H.264 via NVENC, VP9 via libvpx). PyAV,
+# torchaudio, torchvision, soundfile and Pillow all bundle their own libraries
+# and do not link the system ffmpeg/codecs, so removing them is safe. dpkg-query
+# keeps the purge robust across base-image/arch version suffixes (e.g.
+# libavcodec58 vs 60), and autoremove then sweeps the now-orphaned media deps.
+#
+# CRITICAL: the base image marks the CUDA math libs (libcublas/libcusolver/
+# libcusparse) auto-installed, and the torch wheels here ship NO bundled cublas
+# — torch loads the system copies. A bare autoremove would delete them and break
+# GPU inference, so pin every CUDA/NVIDIA lib as manually-installed first.
+RUN set -eux; \
+    keep=$(dpkg-query -W -f='${Package}\n' 2>/dev/null \
+        | grep -E '^(libcu|libnv|libnccl|cuda)' || true); \
+    if [ -n "$keep" ]; then apt-mark manual $keep >/dev/null; fi; \
+    purge=$(dpkg-query -W -f='${Package}\n' 2>/dev/null \
+        | grep -E '^(ffmpeg|libav[a-z]|libsw[a-z]|libpostproc|libx264|libx265|libmp3lame|libaom|libdav1d|libvpx|libtheora|libvorbis|libopus|libsoxr)' \
+        || true); \
+    if [ -n "$purge" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get purge -y $purge; \
+    fi; \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y --purge; \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the LGPL ffmpeg from wheel_builder: versioned shared libs (libav*.so*,
+# libsw*.so*) plus the LGPL CLI binary that imageio/diffusers target via
+# IMAGEIO_FFMPEG_EXE for video encoding. Ungated by enable_media_ffmpeg because
+# the base GPL ffmpeg was just purged, so the LGPL CLI must always be present
+# for the omni video-export path to have something to encode with.
 RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/local/ \
     mkdir -p /usr/local/lib/pkgconfig && \
     cp -rnL /tmp/usr/local/include/libav* /tmp/usr/local/include/libsw* /usr/local/include/ && \
-    cp -nL /tmp/usr/local/lib/libav*.so /tmp/usr/local/lib/libsw*.so /usr/local/lib/ && \
+    cp -nL /tmp/usr/local/lib/libav*.so* /tmp/usr/local/lib/libsw*.so* /usr/local/lib/ && \
+    cp -nL /tmp/usr/local/lib/lib*vpx*.so* /usr/local/lib/ 2>/dev/null || true && \
     cp -nL /tmp/usr/local/lib/pkgconfig/libav*.pc /tmp/usr/local/lib/pkgconfig/libsw*.pc /usr/local/lib/pkgconfig/ && \
-    cp -r /tmp/usr/local/src/ffmpeg /usr/local/src/
-{% endif %}
+    cp -nL /tmp/usr/local/bin/ffmpeg /usr/local/bin/ffmpeg && \
+    cp -r /tmp/usr/local/src/ffmpeg /usr/local/src/ && \
+    ldconfig
+ENV IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg
+
+# Replace the upstream vllm/vllm-openai image's imageio-ffmpeg (which ships a
+# GPL-encumbered prebuilt ffmpeg binary in <site-packages>/imageio_ffmpeg/binaries/)
+# with a source install that leaves no binary on disk. IMAGEIO_FFMPEG_EXE (set
+# above) points imageio at the LGPL CLI copied from wheel_builder. The
+# --no-binary directive lives in the requirements file itself.
+RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/requirements.vllm.txt \
+    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    export UV_CACHE_DIR=/root/.cache/uv && \
+    uv pip install {{ pip_target }} --reinstall-package imageio-ffmpeg --no-deps \
+        --requirement /tmp/requirements.vllm.txt
 
 # Remove the vLLM source tree shipped in the base image to avoid pytest
 # collection conflicts (duplicate conftest plugin registration) and stale

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -255,9 +255,16 @@ RUN if [ "$USE_SCCACHE" = "true" ]; then \
 ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
     SCCACHE_REGION=${USE_SCCACHE:+${SCCACHE_REGION}}
 
-# Always build FFmpeg so libs are available for Rust checks in CI
-# Do not delete the source tarball for legal reasons
+# Always build FFmpeg so libs are available for Rust checks in CI.
+# We also build the ffmpeg CLI with h264_nvenc + libvpx_vp9 encoders so Python
+# code can encode video without the GPL-licensed binary shipped by imageio-ffmpeg.
+# Stays LGPL-only: --disable-gpl --disable-nonfree are preserved; H.264 comes from
+# NVIDIA's NVENC (proprietary HW encoder, already a runtime dependency of these
+# GPU images) and VP9 from libvpx (BSD).
+# Do not delete the source tarball for legal reasons.
 ARG FFMPEG_VERSION
+ARG NV_CODEC_HEADERS_REF
+ARG LIBVPX_REF
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
     --mount=type=secret,id=aws-role-arn,env=AWS_ROLE_ARN \
     export AWS_WEB_IDENTITY_TOKEN_FILE=/run/secrets/aws-token && \
@@ -266,11 +273,26 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         eval $(/tmp/use-sccache.sh setup-env); \
     fi && \
     if [ "$DEVICE" = "xpu" ] || [ "$DEVICE" = "cpu" ]; then \
-    apt-get update -y && apt-get install -y build-essential pkg-config xz-utils; \
+    apt-get update -y && apt-get install -y build-essential pkg-config xz-utils git yasm; \
     apt-get clean && rm -rf /var/lib/apt/lists/*; \
     elif [ "$DEVICE" = "cuda" ]; then \
-    dnf install -y --setopt=tsflags=nocontexts pkg-config xz; \
+    dnf install -y --setopt=tsflags=nocontexts pkg-config xz git yasm; \
     fi && \
+    # nv-codec-headers: provides the NVENC/NVDEC API headers ffmpeg compiles against.
+    # Header-only, no runtime dep here; libcuda/libnvidia-encode are loaded at runtime
+    # in the consuming container.
+    cd /tmp && \
+    git clone --depth 1 --branch ${NV_CODEC_HEADERS_REF} https://github.com/FFmpeg/nv-codec-headers.git && \
+    make -C nv-codec-headers PREFIX=/usr/local install && \
+    # libvpx: BSD-licensed VP9 encoder needed for the WebM output path. Built from
+    # source so we don't need to track distro package names (libvpx-dev on Debian
+    # vs libvpx-devel via EPEL on RHEL/manylinux).
+    git clone --depth 1 --branch ${LIBVPX_REF} https://chromium.googlesource.com/webm/libvpx.git && \
+    cd libvpx && \
+    ./configure --prefix=/usr/local --enable-shared --disable-static --disable-examples --disable-unit-tests --disable-tools --disable-docs && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
     cd /tmp && \
     curl --retry 5 --retry-delay 3 -LO https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz && \
     tar xf ffmpeg-${FFMPEG_VERSION}.tar.xz && \
@@ -279,17 +301,21 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --prefix=/usr/local \
         --disable-gpl \
         --disable-nonfree \
-        --disable-programs \
         --disable-doc \
         --disable-static \
         --disable-x86asm \
         --disable-network \
-        --disable-encoders \
-        --disable-muxers \
         --disable-bsfs \
         --disable-devices \
         --disable-libdrm \
-        --enable-shared && \
+        --enable-shared \
+        --enable-nvenc \
+        --enable-libvpx \
+        --disable-encoders \
+        --enable-encoder=h264_nvenc,libvpx_vp9 \
+        --disable-muxers \
+        --enable-muxer=mov,mp4,matroska,webm \
+        --enable-protocol=file,pipe && \
     make -j$(nproc) && \
     make install && \
     /tmp/use-sccache.sh show-stats "FFMPEG" && \


### PR DESCRIPTION
## What

Brings the **vllm cuda13** release container into LGPL compliance by removing every GPL-licensed ffmpeg/codec artifact it inherits, mirroring the validated fix on `release/1.3.0-cosmos3-dev.1` — limited to the **bare minimum** for a text-only model.

## Why

The shipped vllm cuda13 image builds `FROM vllm/vllm-openai` and currently ships three GPL sources, none of which were addressed on this branch:

| GPL source | Status before |
|---|---|
| apt GPL ffmpeg stack (`libav*`, `libx264/5`, `libmp3lame`, …) from the base image | unpurged |
| `imageio-ffmpeg` wheel's bundled GPL ffmpeg binary | unstripped |
| `sox` + `libsox-fmt-all` apt packages (explicitly installed; dead weight — vLLM-Omni uses a pure-numpy `peak_normalize()` now) | installed |

## Changes (compliance only)

- **wheel_builder**: build the LGPL ffmpeg **CLI** (`h264_nvenc` + `libvpx_vp9`, `--disable-gpl --disable-nonfree` preserved) via `nv-codec-headers` + `libvpx`, replacing the prior libs-only build.
- **vllm_runtime**: drop `sox`/`libsox-fmt-all`; purge the base GPL apt codec stack (pinning CUDA libs as manually-installed first so `autoremove` can't delete `libcublas`/`libcusolver`/`libcusparse` and break GPU inference); copy the LGPL libs + CLI and point `IMAGEIO_FFMPEG_EXE` at it; reinstall `imageio-ffmpeg --no-binary` so no GPL binary remains on disk.
- **context.yaml / args.Dockerfile / requirements.vllm.txt**: wire the new `nv_codec_headers_ref` + `libvpx_ref` build inputs and the `--no-binary imageio-ffmpeg` directive.

## Explicitly excluded

The cosmos3 **video-encoder** changes (`output_formatter.py` h264_nvenc routing, `video_utils.py` RGB→YUV color fix #10159) are **not** included — Nemotron-3-Super is text-only and never runs the video-export path. The vLLM PR #40984 KV-cache-metadata backport is untouched. Purge is safe because PyAV/torchaudio/torchvision/soundfile/Pillow all bundle their own libraries.

## Testing

`container/render.py --framework vllm --device cuda --cuda-version 13.0 --target runtime` renders cleanly; verified the purge/copy/strip blocks and the LGPL CLI build appear and `sox`/`--disable-programs` are gone. Full image build/validation should run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->