### PR TITLE
fix(trtllm): install nixl in dev/local-dev images

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -396,6 +396,15 @@ RUN if [ ! -d /opt/dynamo/venv ]; then \
     fi
 {% endif %}
 
+{% if framework == "trtllm" %}
+# TRT-LLM dev images build Dynamo from source, but still need the third-party
+# packages listed for the runtime image.
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
+    export UV_CACHE_DIR=/root/.cache/uv && \
+    uv pip install --no-deps --requirement /tmp/requirements.trtllm.txt
+{% endif %}
+
 # Install only the ADDITIONAL dev/test dependencies.
 # Runtime deps (common, framework, planner, benchmark) are already installed
 # in the parent runtime image — re-resolving them here would risk version drift.

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -117,23 +117,14 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
 # this path and runs in dev-derived test images.
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
-{# dev/local-dev create the venv later in the shared dev stage, so install
-   third-party deps into system Python. Runtime targets use the active venv. #}
-{% if target in ("dev", "local-dev") %}
-{% set trtllm_pip_flags = "--system --break-system-packages" %}
-{% else %}
-{% set trtllm_pip_flags = "" %}
-{% endif %}
-
-# Install TRT-LLM third-party deps for all targets. dev/local-dev build Dynamo
-# wheels from source later, but still need these packages available through the
-# shared dev venv's system-site-packages. --no-deps preserves upstream's solve.
+{% if target not in ("dev", "local-dev") %}
+# Install TRT-LLM third-party deps before the Dynamo wheels. Dev targets install
+# the same requirements later, after the shared dev stage creates its venv.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
     export UV_CACHE_DIR=/root/.cache/uv && \
-    uv pip install {{ trtllm_pip_flags }} --no-deps --requirement /tmp/requirements.trtllm.txt
+    uv pip install --no-deps --requirement /tmp/requirements.trtllm.txt
 
-{% if target not in ("dev", "local-dev") %}
 # Dynamo's own wheels — built from source in dev/local-dev, so install only for
 # runtime targets. --no-deps preserves upstream's solve.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -117,24 +117,17 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
 # this path and runs in dev-derived test images.
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
-{# dev/local-dev have no venv yet (created later in the shared dev stage), so
-   third-party deps must go into upstream's externally-managed system Python;
-   runtime targets install into the active venv. #}
+{# dev/local-dev create the venv later in the shared dev stage, so install
+   third-party deps into system Python. Runtime targets use the active venv. #}
 {% if target in ("dev", "local-dev") %}
 {% set trtllm_pip_flags = "--system --break-system-packages" %}
 {% else %}
 {% set trtllm_pip_flags = "" %}
 {% endif %}
 
-# Third-party Python deps the Dynamo wheels declare but upstream
-# tensorrt-llm/release lacks, plus the huggingface-hub pin and KVBM-matching
-# nixl-cu13. Installed for ALL targets — dev/local-dev build only the *Dynamo*
-# wheels from source, but still need these PyPI packages. In particular `nixl`
-# is not a declared dependency of ai_dynamo_runtime, so the source build never
-# pulls it in; gating this behind non-dev left dev/local-dev images without nixl.
-# The requirements.trtllm.txt file itself carries a `--no-binary imageio-ffmpeg`
-# directive that keeps the GPL-encumbered prebuilt ffmpeg off disk; IMAGEIO_FFMPEG_EXE
-# below points imageio at the in-tree LGPL CLI. --no-deps preserves upstream's solve.
+# Install TRT-LLM third-party deps for all targets. dev/local-dev build Dynamo
+# wheels from source later, but still need these packages available through the
+# shared dev venv's system-site-packages. --no-deps preserves upstream's solve.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
     export UV_CACHE_DIR=/root/.cache/uv && \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -117,21 +117,36 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
 # this path and runs in dev-derived test images.
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
-{% if target not in ("dev", "local-dev") %}
+{# dev/local-dev have no venv yet (created later in the shared dev stage), so
+   third-party deps must go into upstream's externally-managed system Python;
+   runtime targets install into the active venv. #}
+{% if target in ("dev", "local-dev") %}
+{% set trtllm_pip_flags = "--system --break-system-packages" %}
+{% else %}
+{% set trtllm_pip_flags = "" %}
+{% endif %}
+
+# Third-party Python deps the Dynamo wheels declare but upstream
+# tensorrt-llm/release lacks, plus the huggingface-hub pin and KVBM-matching
+# nixl-cu13. Installed for ALL targets — dev/local-dev build only the *Dynamo*
+# wheels from source, but still need these PyPI packages. In particular `nixl`
+# is not a declared dependency of ai_dynamo_runtime, so the source build never
+# pulls it in; gating this behind non-dev left dev/local-dev images without nixl.
+# The requirements.trtllm.txt file itself carries a `--no-binary imageio-ffmpeg`
+# directive that keeps the GPL-encumbered prebuilt ffmpeg off disk; IMAGEIO_FFMPEG_EXE
+# below points imageio at the in-tree LGPL CLI. --no-deps preserves upstream's solve.
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
     export UV_CACHE_DIR=/root/.cache/uv && \
-    \
-    # Dynamo's own wheels — --no-deps preserves upstream's solve.
+    uv pip install {{ trtllm_pip_flags }} --no-deps --requirement /tmp/requirements.trtllm.txt
+
+{% if target not in ("dev", "local-dev") %}
+# Dynamo's own wheels — built from source in dev/local-dev, so install only for
+# runtime targets. --no-deps preserves upstream's solve.
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install --no-deps /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl && \
     uv pip install --no-deps /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
-    \
-    # Third-party deps Dynamo wheels declare but upstream lacks, plus the
-    # huggingface-hub pin and KVBM-matching nixl-cu13. See the file for context.
-    # The requirements.trtllm.txt file itself carries a `--no-binary imageio-ffmpeg`
-    # directive that keeps the GPL-encumbered prebuilt ffmpeg off disk; IMAGEIO_FFMPEG_EXE
-    # below points imageio at the in-tree LGPL CLI.
-    uv pip install --no-deps --requirement /tmp/requirements.trtllm.txt && \
     \
     if [ "${ENABLE_KVBM}" = "true" ]; then \
         KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1); \


### PR DESCRIPTION
## Problem

The TRT-LLM `dev` and `local-dev` images skip `container/deps/requirements.trtllm.txt` because the install block in `trtllm_runtime.Dockerfile` was gated to non-dev targets.

That requirements file currently carries TRT-LLM-only third-party packages, including `msgspec`, `uvloop`, `imageio`, `nixl==1.0.1`, and `nixl-cu13==1.0.1`. `dev` and `local-dev` build the Dynamo wheels from source later in the shared dev stage, so those PyPI packages are never installed there. In particular, `nixl` is not pulled in by the source build, leaving the dev images without the Python NIXL package needed by KVBM.

## Fix

Install `requirements.trtllm.txt` in the stage that has the right Python environment:

- `runtime`: install the requirements in `trtllm_runtime.Dockerfile`, after the Dynamo venv is created and before the Dynamo wheels are installed.
- `dev` / `local-dev`: install the same requirements in `dev.Dockerfile`, after the shared dev stage creates `/opt/dynamo/venv`.

The install is now a plain `uv pip install --no-deps --requirement ...` in both paths. The Dynamo-built wheel installs (`ai_dynamo*`, `kvbm`, and `gpu_memory_service`) remain gated to runtime targets because dev images build those from source.

## Testing

Rendered all three targets with `container/render.py --framework trtllm --device cuda --cuda-version 13.1`:

- `dev` / `local-dev`: `requirements.trtllm.txt` is installed from the shared dev stage after `/opt/dynamo/venv` is created; the Dynamo-wheel block is omitted.
- `runtime`: `requirements.trtllm.txt` is installed into the active Dynamo venv; the Dynamo-wheel block remains present.

Also checked the rendered TRT-LLM targets for `uv pip install --system`, `uv pip install ... break-system-packages`, and `trtllm_pip_flags`; none remain in this install path.

## Follow-up

`dev.Dockerfile` still sets the TRT-LLM dev image NIXL env vars to `/opt/dynamo/nixl`, which is created by the vLLM-CUDA path. That is separate from this missing-Python-package fix and can be handled in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime setup so required third-party dependencies are installed more consistently across deployment targets.
  * Adjusted installation behavior to better support development and non-development builds without affecting runtime availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->