### PR TITLE
revert: move deploy tests back to prod-default-small-v2 runner

### DIFF
--- a/.github/actions/check-vcluster-exists/action.yml
+++ b/.github/actions/check-vcluster-exists/action.yml
@@ -5,7 +5,6 @@ inputs:
   kubeconfig_base64:
     description: 'Base64-encoded kubeconfig for host cluster access'
     required: true
-    default: ''
   vcluster_name:
     description: 'Name of the vCluster to look for'
     required: true
@@ -31,11 +30,9 @@ runs:
         VCLUSTER_NAME: ${{ inputs.vcluster_name }}
         NAMESPACE: ${{ inputs.vcluster_namespace }}
       run: |
-        if [ -n "${{ inputs.kubeconfig_base64 }}" ]; then
-          echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > /tmp/host-kubeconfig
-          chmod 600 /tmp/host-kubeconfig
-          export KUBECONFIG=/tmp/host-kubeconfig
-        fi
+        echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > /tmp/host-kubeconfig
+        chmod 600 /tmp/host-kubeconfig
+        export KUBECONFIG=/tmp/host-kubeconfig
         RESULT=$(vcluster list --output json -n ${NAMESPACE})
         if echo "$RESULT" | jq -e 'arrays | map(select(.Name == "'"${VCLUSTER_NAME}"'")) | length > 0' &>/dev/null; then
           echo "exists=true" >> $GITHUB_OUTPUT

--- a/.github/actions/connect-vcluster/action.yml
+++ b/.github/actions/connect-vcluster/action.yml
@@ -4,8 +4,7 @@ description: 'Establish a port-forward to a vCluster and output its kubeconfig a
 inputs:
   host_kubeconfig_base64:
     description: 'Base64-encoded kubeconfig for host cluster access'
-    required: false
-    default: ''
+    required: true
   vcluster_name:
     description: 'Name of the vCluster to connect to'
     required: true
@@ -21,7 +20,6 @@ runs:
   using: "composite"
   steps:
     - name: Setup host kubeconfig
-      if: inputs.host_kubeconfig_base64 != ''
       shell: bash
       run: |
         echo "${{ inputs.host_kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig-host

--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -4,8 +4,7 @@ description: 'Create a vCluster, install the Dynamo platform operator inside it 
 inputs:
   kubeconfig_base64:
     description: 'Base64-encoded kubeconfig for host cluster access'
-    required: false
-    default: ''
+    required: true
   vcluster_name:
     description: 'Name for the vCluster instance (auto-generated from github.run_id if empty)'
     required: false
@@ -79,7 +78,6 @@ runs:
         echo "operator_tag=${{ inputs.operator_tag }}" >> "$GITHUB_OUTPUT"
 
     - name: Setup host kubeconfig
-      if: inputs.kubeconfig_base64 != ''
       shell: bash
       run: |
         echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig-host

--- a/.github/actions/teardown-dynamo-operator/action.yml
+++ b/.github/actions/teardown-dynamo-operator/action.yml
@@ -4,8 +4,7 @@ description: 'Delete a vCluster and its host namespace'
 inputs:
   kubeconfig_base64:
     description: 'Base64-encoded kubeconfig for host cluster access'
-    required: false
-    default: ''
+    required: true
   vcluster_name:
     description: 'Name of the vCluster to delete'
     required: true
@@ -16,7 +15,6 @@ runs:
   using: "composite"
   steps:
     - name: Setup host kubeconfig
-      if: inputs.kubeconfig_base64 != ''
       shell: bash
       run: |
         echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -636,7 +636,7 @@ jobs:
 
   deploy-operator:
     needs: [operator]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-default-small-v2
     outputs:
       namespace: ${{ steps.setup.outputs.namespace }}
       vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
@@ -647,6 +647,7 @@ jobs:
       id: setup
       uses: ./.github/actions/setup-dynamo-operator
       with:
+        kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
         registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
         operator_tag: ${{ needs.operator.outputs.operator_default_tag }}
         hf_token: ${{ secrets.HF_TOKEN }}
@@ -692,13 +693,14 @@ jobs:
   deploy-cleanup:
     if: always()
     needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm, deploy-test-gaie]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-default-small-v2
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Teardown vCluster
       if: needs.deploy-operator.outputs.namespace != '' && needs.deploy-operator.outputs.vcluster_name != ''
       uses: ./.github/actions/teardown-dynamo-operator
       with:
+        kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
         vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
         vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
 
@@ -707,7 +709,7 @@ jobs:
   # ============================================================================
   deploy-test-gaie:
     name: GAIE Deploy Test
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-default-small-v2
     needs: [deploy-operator, frontend-copy-to-acr, vllm-copy-to-acr]
     timeout-minutes: 30
     permissions:
@@ -719,12 +721,14 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
+          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
+          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
@@ -736,6 +740,7 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
+          host_kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
       - name: Install GAIE prerequisites (Gateway API, agentgateway, Inference Extension CRDs)

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -640,7 +640,7 @@ jobs:
        needs.changed-files.outputs.deploy == 'true') &&
       (needs.operator.result == 'success' || needs.operator.result == 'skipped')
     needs: [changed-files, operator]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-default-small-v2
     outputs:
       namespace: ${{ steps.setup.outputs.namespace }}
       vcluster_name: ${{ steps.setup.outputs.vcluster_name }}
@@ -651,6 +651,7 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-dynamo-operator
         with:
+          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
           operator_tag: ${{ needs.operator.result == 'success' && needs.operator.outputs.operator_default_tag || 'main-operator' }}
           hf_token: ${{ secrets.HF_TOKEN }}
@@ -708,13 +709,14 @@ jobs:
   deploy-cleanup:
     if: always()
     needs: [deploy-operator, deploy-test-vllm, deploy-test-sglang, deploy-test-trtllm]
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-default-small-v2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Teardown vCluster
         if: needs.deploy-operator.outputs.namespace != '' && needs.deploy-operator.outputs.vcluster_name != ''
         uses: ./.github/actions/teardown-dynamo-operator
         with:
+          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
           vcluster_namespace: ${{ needs.deploy-operator.outputs.namespace }}
 

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   deploy-test:
-    runs-on: prod-deploy-tester-v1
+    runs-on: prod-default-small-v2
     timeout-minutes: 25
     permissions:
       contents: read
@@ -50,12 +50,14 @@ jobs:
         id: vcluster-check
         uses: ./.github/actions/check-vcluster-exists
         with:
+          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
       - name: Self-bootstrap vCluster (rerun)
         if: steps.vcluster-check.outputs.exists != 'true'
         uses: ./.github/actions/setup-dynamo-operator
         with:
+          kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
@@ -67,6 +69,7 @@ jobs:
         id: connect-vcluster
         uses: ./.github/actions/connect-vcluster
         with:
+          host_kubeconfig_base64: ${{ secrets.AZURE_AKS_CI_KUBECONFIG_B64 }}
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
       - name: Run Dynamo Deploy Test


### PR DESCRIPTION
## Summary

Reverts commit `b25ba7d63d8ba95ab0a90dfe2cf8e07649047ce9`, which moved the deploy/operator jobs from `prod-default-small-v2` to the `prod-deploy-tester-v1` runner and switched cluster auth from the static `AZURE_AKS_CI_KUBECONFIG_B64` secret to the runner's rotating, proxied kubeconfig.

This restores the previous runner and static kubeconfig for all six deploy jobs (`deploy-operator`, `deploy-cleanup`, `deploy-test-gaie`, and the `shared-deploy-test` matrix).

## Why

On `prod-deploy-tester-v1` the deploy tests reach the vCluster API over a proxied, cross-cloud path, and the long-lived `kubectl port-forward` to `127.0.0.1:8443` drops mid-job with no auto-reconnect. The result is the deploy-test failures we've been seeing:
- **Fast failure** — first vCluster API call refused (`ConnectionRefusedError('127.0.0.1', 8443)`), job dies in ~1-2 min.
- **1200s timeout** — the tunnel dies mid wait-for-ready and the poll loop spins on a dead socket.

Running the same test against a cluster directly (no proxied port-forward) passes end-to-end, so the deployment path itself is healthy — the runner/connection is the variable.

## Intent

This is a **mitigation + hypothesis check**: it should turn the deploy tests green again and confirm the runner as the root cause. A durable fix that keeps a modern runner — running the deploy test as an **in-cluster Job** so there is no cross-cloud port-forward at all — is in progress and will supersede this revert.

## Caveats

- Depends on the `prod-default-small-v2` runner pool and the `AZURE_AKS_CI_KUBECONFIG_B64` secret still being present. If either was decommissioned during the migration, this revert won't run and we should go straight to the in-cluster-Job fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored deployment actions to enforce required kubeconfig configuration for Dynamo operator and vCluster operations
  * Updated CI/CD workflows to consistently pass required credentials and use optimized runner pool assignments for deployment and integration testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->