### PR TITLE
feat(ci): run deploy tests as an in-cluster Job

### DIFF
--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -1,16 +1,16 @@
 name: 'Dynamo Graph Deployment Test'
-description: 'Deploy a DynamoGraphDeployment to Kubernetes, validate it serves requests, and cleanup'
+description: 'Run the deploy test suite as an in-cluster Job so pytest talks to the vCluster API in-network (no port-forward)'
 
 inputs:
-  # Kubernetes Configuration
-  kubeconfig_base64:
-    description: 'Base64-encoded kubeconfig for cluster access'
+  # Cluster targeting
+  host_namespace:
+    description: 'Host namespace where the vCluster (and its kubeconfig secret vc-<name>) lives, and where the test Job runs'
     required: true
-  namespace:
-    description: 'Kubernetes namespace for deployment'
+  vcluster_name:
+    description: 'Name of the vCluster; used to locate secret vc-<name> and build the in-cluster API server URL'
     required: true
   registry:
-    description: 'Container registry hostname'
+    description: 'Container registry hostname (ACR) the host cluster pulls images from'
     required: true
   operator_tag:
     description: 'Operator image tag (default: main-operator)'
@@ -29,6 +29,7 @@ inputs:
     required: false
     default: ''
 
+  # Test configuration
   framework:
     description: 'Framework name (vllm, sglang, trtllm)'
     required: false
@@ -41,6 +42,9 @@ inputs:
     description: 'Full container image reference for the framework runtime'
     required: false
     default: ''
+  test_image:
+    description: 'Full container image reference for the per-SHA test image the Job runs (contains /workspace tests + deps)'
+    required: true
   platform_arch:
     description: 'Platform architecture (amd64, arm64)'
     required: false
@@ -57,135 +61,195 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Kubeconfig
-      id: setup-kubeconfig
+    # The runner already has ambient host-cluster access via KUBECONFIG (set up by
+    # the runner/setup-dynamo-operator). We never build a vCluster kubeconfig on the
+    # runner anymore: the Job reads the vCluster kubeconfig in-cluster from secret
+    # vc-<name> and reaches the API over the stable ClusterIP, so there is no
+    # long-lived port-forward to drop mid-job.
+    - name: Resolve names
+      id: names
       shell: bash
       env:
-        NAMESPACE: ${{ inputs.namespace }}
+        FRAMEWORK: ${{ inputs.framework }}
+        PROFILE: ${{ inputs.profile }}
+        TEST_NAME: ${{ inputs.test_name }}
       run: |
-        set +x
-        echo "${{ inputs.kubeconfig_base64 }}" | base64 -d > ${{ github.workspace }}/.kubeconfig
-        chmod 600 ${{ github.workspace }}/.kubeconfig
-        echo "KUBECONFIG=${{ github.workspace }}/.kubeconfig" >> $GITHUB_ENV
+        set -euo pipefail
+        if [ -z "${TEST_NAME}" ]; then
+          TEST_NAME="${FRAMEWORK:-unknown}_${PROFILE:-unknown}"
+        fi
+        echo "test_name=${TEST_NAME}" >> "$GITHUB_OUTPUT"
 
-        export KUBECONFIG=${{ github.workspace }}/.kubeconfig
-        kubectl config set-context --current --namespace=${NAMESPACE}
-        kubectl config get-contexts
+        # Job names must be DNS-1123 and <= 63 chars. Lowercase, replace illegal
+        # chars, and key on run id + attempt + profile so reruns/matrix entries
+        # never collide.
+        RAW="deploy-test-${PROFILE:-unknown}-${{ github.run_id }}-${{ github.run_attempt }}"
+        JOB_NAME=$(echo "${RAW}" | tr '[:upper:]_' '[:lower:]-' | tr -cd 'a-z0-9-' | cut -c1-63)
+        echo "job_name=${JOB_NAME}" >> "$GITHUB_OUTPUT"
 
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-      with:
-        python-version: '3.12'
-        cache: 'pip'
-        cache-dependency-path: 'container/deps/requirements.test.txt'
-    - name: Install test dependencies
-      shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r container/deps/requirements.test.txt
-
-    - name: Deploy and Test
-      id: deploy
+    - name: Render and apply test Job
+      id: apply
       shell: bash
       env:
-        KUBECONFIG: ${{ github.workspace }}/.kubeconfig
-        NAMESPACE: ${{ inputs.namespace }}
+        HOST_NAMESPACE: ${{ inputs.host_namespace }}
+        VCLUSTER_NAME: ${{ inputs.vcluster_name }}
+        JOB_NAME: ${{ steps.names.outputs.job_name }}
+        TEST_IMAGE: ${{ inputs.test_image }}
         FRAMEWORK: ${{ inputs.framework }}
         PROFILE: ${{ inputs.profile }}
         IMAGE: ${{ inputs.image }}
-        DYN_TEST_OUTPUT_PATH: ${{ github.workspace }}/test-output
-        TEST_NAME: ${{ inputs.test_name }}
         EXTRA_PYTEST_ARGS: ${{ inputs.extra_pytest_args }}
-        DYNAMO_TEST_FRAMEWORK: ${{ inputs.framework }}
-        DYNAMO_TEST_PLATFORM: ${{ inputs.platform_arch }}
-        DYNAMO_TEST_TYPE: deploy_${{ inputs.profile }}
-        DYNAMO_TEST_WORKFLOW: ${{ github.workflow }}
+        TEST_NAME: ${{ steps.names.outputs.test_name }}
+        PLATFORM_ARCH: ${{ inputs.platform_arch }}
+        # Echoed by the in-pod prologue verbatim; keep components separate so we
+        # never need quoting gymnastics for the pytest invocation.
+        JUNIT_FILENAME: pytest_deploy_${{ steps.names.outputs.test_name }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
       run: |
-        mkdir -p test-results
+        set -euo pipefail
 
-        PYTEST_ARGS=""
-        if [ -n "${FRAMEWORK}" ]; then
-          PYTEST_ARGS+=" --framework=${FRAMEWORK}"
-        fi
-        if [ -n "${PROFILE}" ]; then
-          PYTEST_ARGS+=" --profile=${PROFILE}"
-        fi
-        if [ -n "${IMAGE}" ]; then
-          PYTEST_ARGS+=" --image=${IMAGE}"
-        fi
+        # In-cluster API server for the vCluster. The cert embedded in the
+        # vc-<name> secret authenticates regardless of the network path, so we
+        # only swap the server URL to the stable ClusterIP service.
+        VC_SERVER="https://${VCLUSTER_NAME}.${HOST_NAMESPACE}.svc:443"
 
-        if [ -z "${TEST_NAME}" ]; then
-          TEST_NAME="${FRAMEWORK:-unknown}_${PROFILE:-unknown}"
-        fi
+        export DEPLOY_TEST_JOB_NAME="${JOB_NAME}"
+        bash "${GITHUB_ACTION_PATH}/render-job.sh" \
+          "${JOB_NAME}" \
+          "${HOST_NAMESPACE}" \
+          "${TEST_IMAGE}" \
+          "${VCLUSTER_NAME}" \
+          "${VC_SERVER}" \
+          | tee "${RUNNER_TEMP}/${JOB_NAME}.yaml"
 
-        pytest tests/deploy/test_deploy.py \
-          --namespace="${NAMESPACE}" \
-          ${PYTEST_ARGS} \
-          ${EXTRA_PYTEST_ARGS} \
-          -v -s \
-          --durations=10 \
-          --junitxml=test-results/pytest_deploy_${TEST_NAME}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml \
-          --alluredir=test-results/allure-results \
-          --log-cli-level=INFO
-
-    - name: Cleanup Deployment
-      if: always()
-      shell: bash
-      env:
-        NAMESPACE: ${{ inputs.namespace }}
-        GRAPH_NAME: ${{ steps.deploy.outputs.graph_name }}
-      run: |
-        echo "::group::Cleanup Deployment"
-        set -x
-        export KUBECONFIG=${{ github.workspace }}/.kubeconfig
-
-        echo "=== PRE-CLEANUP STATUS ==="
-        kubectl get dynamographdeployments -n $NAMESPACE || true
-        kubectl get pods -n $NAMESPACE || true
-
-        kubectl get dynamographdeployments -n $NAMESPACE --no-headers 2>/dev/null \
-          | awk '$2 == "False" {print $1}' \
-          | while read -r dep_name; do
-              echo ">>> DETAILED DESCRIPTION FOR FAILED DEPLOYMENT: $dep_name"
-              kubectl describe dynamographdeployments "$dep_name" -n $NAMESPACE
-          done || true
-
-        if kubectl get dynamographdeployments "${GRAPH_NAME}" -n $NAMESPACE &>/dev/null; then
-          echo "DGD ${GRAPH_NAME} still exists after test, deleting..."
-          kubectl delete dynamographdeployments ${GRAPH_NAME} -n $NAMESPACE --timeout=60s
-        else
-          echo "DGD ${GRAPH_NAME} already cleaned up by test"
-        fi
+        echo "::group::Apply Job ${JOB_NAME}"
+        kubectl apply -f "${RUNNER_TEMP}/${JOB_NAME}.yaml"
         echo "::endgroup::"
 
+    - name: Wait for Job and stream logs
+      id: wait
+      shell: bash
+      env:
+        HOST_NAMESPACE: ${{ inputs.host_namespace }}
+        JOB_NAME: ${{ steps.names.outputs.job_name }}
+      run: |
+        set -uo pipefail
+        # Bounded poll of .status — no `logs -f`, so there is no long-lived
+        # stream that can silently drop. Tracks the pod so we can tail fresh
+        # log lines each tick without re-printing the whole buffer.
+        TIMEOUT=$((25 * 60))
+        DEADLINE=$(( $(date +%s) + TIMEOUT ))
 
-    - name: Determine test name for artifacts
-      id: test-name
+        echo "::group::Wait for Job ${JOB_NAME}"
+        POD=""
+        SINCE=1s
+        RESULT="timeout"
+        while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+          if [ -z "${POD}" ]; then
+            POD=$(kubectl get pods -n "${HOST_NAMESPACE}" \
+              -l "job-name=${JOB_NAME}" \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          fi
+          if [ -n "${POD}" ]; then
+            kubectl logs -n "${HOST_NAMESPACE}" "${POD}" --since="${SINCE}" 2>/dev/null || true
+            SINCE=10s
+          fi
+
+          SUCCEEDED=$(kubectl get job -n "${HOST_NAMESPACE}" "${JOB_NAME}" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)
+          FAILED=$(kubectl get job -n "${HOST_NAMESPACE}" "${JOB_NAME}" -o jsonpath='{.status.failed}' 2>/dev/null || true)
+          if [ "${SUCCEEDED:-0}" = "1" ]; then
+            RESULT="succeeded"
+            break
+          fi
+          if [ -n "${FAILED}" ] && [ "${FAILED}" != "0" ]; then
+            RESULT="failed"
+            break
+          fi
+          sleep 10
+        done
+        echo "::endgroup::"
+
+        echo "result=${RESULT}" >> "$GITHUB_OUTPUT"
+        echo "Job ${JOB_NAME} result: ${RESULT}"
+
+    - name: Collect JUnit and pod logs
       if: always()
       shell: bash
       env:
-        TEST_NAME: ${{ inputs.test_name }}
-        FRAMEWORK: ${{ inputs.framework }}
-        PROFILE: ${{ inputs.profile }}
+        HOST_NAMESPACE: ${{ inputs.host_namespace }}
+        JOB_NAME: ${{ steps.names.outputs.job_name }}
+        TEST_NAME: ${{ steps.names.outputs.test_name }}
+        PLATFORM_ARCH: ${{ inputs.platform_arch }}
+        JUNIT_FILENAME: pytest_deploy_${{ steps.names.outputs.test_name }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
       run: |
-        if [ -z "${TEST_NAME}" ]; then
-          TEST_NAME="${FRAMEWORK:-unknown}_${PROFILE:-unknown}"
+        set -uo pipefail
+        mkdir -p test-results/allure-results "${{ github.workspace }}/test-output"
+
+        POD=$(kubectl get pods -n "${HOST_NAMESPACE}" \
+          -l "job-name=${JOB_NAME}" \
+          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+
+        if [ -n "${POD}" ]; then
+          echo "::group::Final pod logs (${POD})"
+          kubectl logs -n "${HOST_NAMESPACE}" "${POD}" --tail=-1 \
+            > "${{ github.workspace }}/test-output/${POD}.log" 2>&1 || true
+          cat "${{ github.workspace }}/test-output/${POD}.log" || true
+          echo "::endgroup::"
+
+          # Pull the JUnit XML the Job wrote to /results. kubectl cp needs tar in
+          # the source container; the test image has it. The pod has terminated
+          # by now (Never restart), so cp reads from the stopped container's fs.
+          echo "::group::Extract JUnit XML"
+          kubectl cp -n "${HOST_NAMESPACE}" \
+            "${POD}:/results/${JUNIT_FILENAME}" \
+            "test-results/${JUNIT_FILENAME}" 2>/dev/null \
+            || echo "::warning::Could not copy JUnit XML from ${POD}:/results/${JUNIT_FILENAME}"
+          kubectl cp -n "${HOST_NAMESPACE}" \
+            "${POD}:/results/allure-results" \
+            "test-results/allure-results" 2>/dev/null \
+            || echo "Allure results not present (optional)"
+          echo "::endgroup::"
+        else
+          echo "::warning::No pod found for Job ${JOB_NAME}; nothing to collect"
         fi
-        echo "name=${TEST_NAME}" >> $GITHUB_OUTPUT
+
+    - name: Delete test Job
+      if: always()
+      shell: bash
+      env:
+        HOST_NAMESPACE: ${{ inputs.host_namespace }}
+        JOB_NAME: ${{ steps.names.outputs.job_name }}
+      run: |
+        set -uo pipefail
+        echo "::group::Delete Job ${JOB_NAME}"
+        kubectl delete job -n "${HOST_NAMESPACE}" "${JOB_NAME}" \
+          --ignore-not-found --timeout=60s || true
+        echo "::endgroup::"
+
+    - name: Report Job result
+      if: always()
+      shell: bash
+      env:
+        RESULT: ${{ steps.wait.outputs.result }}
+      run: |
+        case "${RESULT}" in
+          succeeded) echo "Deploy test Job succeeded"; exit 0 ;;
+          *) echo "::error::Deploy test Job ${RESULT:-unknown}"; exit 1 ;;
+        esac
 
     - name: Upload Test Results
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
       if: always()
       with:
-        name: test-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
-        path: test-results/pytest_deploy_${{ steps.test-name.outputs.name }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
+        name: test-results-${{ steps.names.outputs.test_name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/pytest_deploy_${{ steps.names.outputs.test_name }}_${{ inputs.platform_arch }}_${{ github.run_id }}_${{ job.check_run_id }}.xml
         retention-days: 7
+        if-no-files-found: warn
 
     - name: Upload Pod Logs
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
       if: always()
       with:
-        name: pod-logs-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        name: pod-logs-${{ steps.names.outputs.test_name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
         path: ${{ github.workspace }}/test-output/
         if-no-files-found: warn
         retention-days: 7
@@ -194,7 +258,7 @@ runs:
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6
       if: always()
       with:
-        name: allure-results-${{ steps.test-name.outputs.name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        name: allure-results-${{ steps.names.outputs.test_name }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
         path: test-results/allure-results/
         retention-days: 7
         if-no-files-found: ignore

--- a/.github/actions/dynamo-deploy-test/render-job.sh
+++ b/.github/actions/dynamo-deploy-test/render-job.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Render the in-cluster deploy-test Job manifest to stdout.
+#
+# The Job runs the deploy test suite from inside the host namespace so pytest
+# reaches the vCluster API over its stable ClusterIP — no port-forward, no
+# cross-cloud hop from the runner. It mounts the vCluster kubeconfig secret
+# (vc-<name>), rewrites only the server URL to the in-cluster service, and runs
+# the same pytest invocation the runner used to run, writing JUnit + allure to
+# an emptyDir the runner copies out afterwards.
+#
+# Args (positional, all required):
+#   1 JOB_NAME        DNS-1123 Job name
+#   2 HOST_NAMESPACE  host namespace the Job runs in (and where vc-<name> lives)
+#   3 TEST_IMAGE      full per-SHA test image reference
+#   4 VCLUSTER_NAME   vCluster name (secret is vc-<name>)
+#   5 VC_SERVER       in-cluster API server URL (https://<name>.<ns>.svc:443)
+#
+# Test inputs are passed via the environment (set by the calling step):
+#   FRAMEWORK PROFILE IMAGE EXTRA_PYTEST_ARGS JUNIT_FILENAME
+set -euo pipefail
+
+JOB_NAME="$1"
+HOST_NAMESPACE="$2"
+TEST_IMAGE="$3"
+VCLUSTER_NAME="$4"
+VC_SERVER="$5"
+
+# Assemble the pytest args the same way the old on-runner step did, so markers,
+# verbosity, and artifact paths are unchanged.
+PYTEST_ARGS=""
+[ -n "${FRAMEWORK:-}" ] && PYTEST_ARGS+=" --framework=${FRAMEWORK}"
+[ -n "${PROFILE:-}" ] && PYTEST_ARGS+=" --profile=${PROFILE}"
+[ -n "${IMAGE:-}" ] && PYTEST_ARGS+=" --image=${IMAGE}"
+
+# The test image is pure-Python (kr8s/kubernetes_asyncio) and reads KUBECONFIG.
+# The mounted secret is read-only, so copy it to a writable path and rewrite
+# only the server line — the embedded client cert authenticates over any path.
+# Run pytest under `set +e` so a non-zero exit still lets the Job surface its
+# status (and the JUnit XML is written regardless).
+read -r -d '' POD_SCRIPT <<POD_EOF || true
+set -euo pipefail
+mkdir -p /results/allure-results /tmp/kube
+cp /vc-kubeconfig/config /tmp/kube/config
+sed -i -E "s#server: https?://[^[:space:]]+#server: ${VC_SERVER}#" /tmp/kube/config
+export KUBECONFIG=/tmp/kube/config
+
+cd /workspace
+set +e
+pytest tests/deploy/test_deploy.py \\
+  --namespace=default \\
+ ${PYTEST_ARGS} \\
+ ${EXTRA_PYTEST_ARGS:-} \\
+  -v -s \\
+  --durations=10 \\
+  --junitxml=/results/${JUNIT_FILENAME} \\
+  --alluredir=/results/allure-results \\
+  --log-cli-level=INFO
+RC=\$?
+echo "pytest exit code: \${RC}"
+exit \${RC}
+POD_EOF
+
+cat <<JOB_EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: ${HOST_NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: dynamo-deploy-test
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 1800
+  template:
+    metadata:
+      labels:
+        job-name: ${JOB_NAME}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: deploy-test
+          image: ${TEST_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["bash", "-c"]
+          args:
+            - |
+$(printf '%s\n' "${POD_SCRIPT}" | sed 's/^/                /')
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: vc-kubeconfig
+              mountPath: /vc-kubeconfig
+              readOnly: true
+            - name: results
+              mountPath: /results
+      volumes:
+        - name: vc-kubeconfig
+          secret:
+            secretName: vc-${VCLUSTER_NAME}
+        - name: results
+          emptyDir: {}
+JOB_EOF

--- a/.github/workflows/shared-copy.yml
+++ b/.github/workflows/shared-copy.yml
@@ -84,3 +84,23 @@ jobs:
           target_azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
           target_azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
           override_arch: ${{ inputs.override_arch }}
+      # Mirror the matching per-SHA `-test` image too, so the in-cluster deploy
+      # test Job (which the Azure cluster pulls from ACR) has its image. Shares
+      # layers with the runtime image, so the extra copy is cheap. Same guard as
+      # the runtime copy above (it's a sibling step in this guarded job).
+      - name: Copy test image to target registry
+        timeout-minutes: ${{ inputs.copy_timeout_minutes }}
+        uses: ./.github/actions/skopeo-copy
+        with:
+          source_registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
+          source_image: ai-dynamo/dynamo
+          source_tag: ${{ steps.calculate-target-tag.outputs.image_tag }}-test
+          target_registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          target_image: ai-dynamo/dynamo
+          target_tag: ${{ steps.calculate-target-tag.outputs.image_tag }}-test
+          source_aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          source_aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          target_azure_acr_hostname: ${{ secrets.AZURE_ACR_HOSTNAME }}
+          target_azure_acr_user: ${{ secrets.AZURE_ACR_USER }}
+          target_azure_acr_password: ${{ secrets.AZURE_ACR_PASSWORD }}
+          override_arch: ${{ inputs.override_arch }}

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -63,23 +63,22 @@ jobs:
           hf_token: ${{ secrets.HF_TOKEN }}
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-      - name: Connect to vCluster
-        id: connect-vcluster
-        uses: ./.github/actions/connect-vcluster
-        with:
-          vcluster_name: ${{ inputs.vcluster_name }}
-          vcluster_namespace: ${{ inputs.namespace }}
+      # No more on-runner `connect-vcluster` / port-forward for the test: the
+      # deploy-test action launches an in-cluster Job that talks to the vCluster
+      # API over its ClusterIP. The runner only needs ambient host-cluster
+      # access (already on KUBECONFIG) to apply/poll/delete the Job.
       - name: Run Dynamo Deploy Test
         id: deploy-test
         uses: ./.github/actions/dynamo-deploy-test
         with:
-          kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
-          namespace: default
+          host_namespace: ${{ inputs.namespace }}
+          vcluster_name: ${{ inputs.vcluster_name }}
           registry: ${{ secrets.AZURE_ACR_HOSTNAME }}
           operator_tag: ${{ inputs.operator_tag }}
           hf_token: ${{ secrets.HF_TOKEN }}
           framework: ${{ inputs.framework }}
           profile: ${{ matrix.profile }}
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-${{ inputs.image_suffix }}
+          test_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-${{ inputs.image_suffix }}-test
           platform_arch: amd64
           extra_pytest_args: -m framework_only


### PR DESCRIPTION
> **Draft / WIP** — this changes CI execution and is really only validated by running it; expect 1–2 iterations. See "Risks to validate" below.

## Summary

Deploy tests currently run pytest **on the runner** and reach the vCluster API through a long-lived backgrounded `kubectl port-forward` to `127.0.0.1:8443`. On the external/cross-cloud runner that stream drops mid-job with no auto-reconnect, so deploy tests fail fast (first API call refused) or hit the 1200s timeout.

This runs the test **where the cluster is**. The runner becomes a thin orchestrator that applies a Kubernetes **Job in the vCluster's host namespace** and polls its status. Inside the Job, pytest (from the per-SHA `-test` image) talks to the vCluster API over its **in-network ClusterIP** and reaches the frontend in-network — no port-forward, no cross-cloud hop. The runner only makes short, reconnect-safe host-API calls (`apply`/`get`/`cp`/`delete`).

## Changes

- **`dynamo-deploy-test/action.yml`** — render + `kubectl apply` a Job, poll `.status` (no `logs -f`), `kubectl cp` JUnit/allure out of the pod, `kubectl delete` in `always()`. Drops the on-runner pytest + pip install. Keeps all three artifact uploads and the JUnit filename convention.
- **`dynamo-deploy-test/render-job.sh`** (new) — Job manifest (`restartPolicy: Never`, `backoffLimit: 0`); mounts the `vc-<name>` kubeconfig secret, rewrites only the `server:` to the ClusterIP, runs the identical pytest invocation (`-m framework_only`, JUnit + allure to `/results`).
- **`shared-copy.yml`** — mirror the `<sha>-<tag>-test` image ECR→ACR alongside the runtime image (shared layers, cheap) so the cluster can pull it.
- **`shared-deploy-test.yml`** — drop the runner-side `connect-vcluster`; pass `host_namespace`, `vcluster_name`, `test_image`. `connect-vcluster` left intact (still used by `setup-dynamo-operator`).

## Risks to validate in CI
1. **Runner host kubeconfig context** — the action relies on the runner's ambient `KUBECONFIG` having the right current-context for the deploy cluster; may need an explicit `kubectl config use-context`. ← most likely first fix.
2. **TLS SAN** — the vCluster serving cert must cover `<name>.<ns>.svc`; if not, add `insecure-skip-tls-verify`.
3. **Ordering** — the `shared-copy` `-test` mirror must run on the SHA before the Job can pull from ACR.

## Relationship to other PRs
- Supersedes #10239 (port-forward supervisor) — closing that.
- Complements #10243 (revert to the old runner): #10243 is the immediate mitigation; this is the durable fix that keeps a modern runner with no port-forward at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
