### PR TITLE
fix(parser): add batch.6.b and stream.2.c and drop stray reasoning close from normal_text

### DIFF
--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -363,7 +363,8 @@ impl ReasoningParser for BasicReasoningParser {
                         self.stripped_think_start = true;
                         continue;
                     }
-                    (Some(s), _) => {
+                    (Some(s), None) => {
+                        // Only <think> remains; enter reasoning.
                         accumulated_normal.push_str(&current_text[..s]);
                         let after_start = s + self.think_start_token.len();
                         self._buffer = current_text[after_start..].to_string();
@@ -371,8 +372,12 @@ impl ReasoningParser for BasicReasoningParser {
                         self.stripped_think_start = true;
                         continue;
                     }
-                    (None, Some(e)) => {
-                        // Stray </think> with no opening tag — drop the marker, stay in normal.
+                    (_, Some(e)) => {
+                        // Stray </think> arrives before the next <think> (or with no
+                        // opener remaining). Drop the marker, keep the text on either
+                        // side, stay in normal mode. Mirrors the batch path so a
+                        // pattern like `<o>A</c>B</c>C<o>D</c>E` does not leak the
+                        // middle stray close even when a later opener is in buffer.
                         accumulated_normal.push_str(&current_text[..e]);
                         let after_end = e + self.think_end_token.len();
                         self._buffer = current_text[after_end..].to_string();
@@ -682,6 +687,26 @@ mod tests {
         let result = parser.detect_and_parse_reasoning("no think tags here", &[]);
         assert_eq!(result.normal_text, "");
         assert_eq!(result.reasoning_text, "no think tags here");
+    }
+
+    #[test] // REASONING.batch.6.b — streaming parity for stray close after complete pair
+    fn test_streaming_stray_close_between_two_reasoning_spans() {
+        // Pattern: <open>A</close>B</close>C<open>D</close>E — the middle </close>
+        // has no matching open and must be stripped, even though a later <open>
+        // exists in the buffer. Previously the streaming path entered the next
+        // reasoning block first and leaked the middle stray close into
+        // normal_text. The batch path was already correct.
+        let mut parser =
+            BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
+        let input = "<think>checking the weather</think>It is sunny.</think> Have a nice day.<think>double-checking</think> Confirmed.";
+        let r = parser.parse_reasoning_streaming_incremental(input, &[]);
+        assert!(
+            !r.normal_text.contains("</think>"),
+            "stray </think> must not leak into normal_text; got {:?}",
+            r.normal_text
+        );
+        assert_eq!(r.normal_text, "It is sunny. Have a nice day. Confirmed.");
+        assert_eq!(r.reasoning_text, "checking the weatherdouble-checking");
     }
 
     #[test] // REASONING.stream.2.b, REASONING.batch.2.c, REASONING.stream.1.b

--- a/lib/parsers/src/reasoning/base_parser.rs
+++ b/lib/parsers/src/reasoning/base_parser.rs
@@ -196,15 +196,35 @@ impl ReasoningParser for BasicReasoningParser {
                     }
                 }
             } else {
-                // We're in normal text — look for start token
-                if let Some(start_offset) = text[cursor..].find(&self.think_start_token) {
-                    normal_parts.push(&text[cursor..cursor + start_offset]);
-                    cursor += start_offset + self.think_start_token.len();
-                    currently_reasoning = true;
-                } else {
-                    // No more think blocks — rest is normal text
-                    normal_parts.push(&text[cursor..]);
-                    cursor = text.len();
+                // We're in normal text. Look for the next reasoning open marker,
+                // but also detect any stray close marker (unmatched </think>) and
+                // strip it: parser-owned syntax must never reach normal_text per the
+                // lossless-split contract.
+                let start_offset = text[cursor..].find(&self.think_start_token);
+                let end_offset = text[cursor..].find(&self.think_end_token);
+                match (start_offset, end_offset) {
+                    (Some(s), Some(e)) if s <= e => {
+                        // <think> appears first → enter reasoning normally.
+                        normal_parts.push(&text[cursor..cursor + s]);
+                        cursor += s + self.think_start_token.len();
+                        currently_reasoning = true;
+                    }
+                    (Some(s), None) => {
+                        normal_parts.push(&text[cursor..cursor + s]);
+                        cursor += s + self.think_start_token.len();
+                        currently_reasoning = true;
+                    }
+                    (_, Some(e)) => {
+                        // Stray </think> before the next <think> (or no <think> at all).
+                        // Drop the marker, keep the text on both sides, stay in normal mode.
+                        normal_parts.push(&text[cursor..cursor + e]);
+                        cursor += e + self.think_end_token.len();
+                    }
+                    (None, None) => {
+                        // No more markers — rest is normal text.
+                        normal_parts.push(&text[cursor..]);
+                        cursor = text.len();
+                    }
                 }
             }
         }
@@ -328,31 +348,57 @@ impl ReasoningParser for BasicReasoningParser {
                     break;
                 }
             } else {
-                // Not in reasoning — look for the next <think> block.
-                if let Some(think_pos) = current_text.find(self.think_start_token.as_str()) {
-                    accumulated_normal.push_str(&current_text[..think_pos]);
-                    let after_start = think_pos + self.think_start_token.len();
-                    self._buffer = current_text[after_start..].to_string();
-                    self._in_reasoning = true;
-                    self.stripped_think_start = true;
-                    continue; // Process reasoning content
-                } else {
-                    // No complete start token — check for partial at end of buffer
-                    // (e.g., "Hello world <th" where "<th" is a prefix of "<think>").
-                    // Require overlap >= 2 so a lone `<` passes through for tool call
-                    // XML tags like `<invoke>` or `<minimax:tool_call>`.
-                    let ol = overlap(&current_text, &self.think_start_token);
-                    if ol >= 2 {
-                        let safe_end = current_text.len() - ol;
-                        if safe_end > 0 {
-                            accumulated_normal.push_str(&current_text[..safe_end]);
-                        }
-                        self._buffer = current_text[safe_end..].to_string();
-                    } else {
-                        accumulated_normal.push_str(&current_text);
-                        self._buffer.clear();
+                // Not in reasoning. Look for the next <think> block, but also detect
+                // a stray </think> (unmatched close marker) and drop it: parser-owned
+                // syntax must never reach normal_text per the lossless-split contract.
+                let think_pos = current_text.find(self.think_start_token.as_str());
+                let stray_close_pos = current_text.find(self.think_end_token.as_str());
+                match (think_pos, stray_close_pos) {
+                    (Some(s), Some(e)) if s <= e => {
+                        // <think> arrives first → enter reasoning.
+                        accumulated_normal.push_str(&current_text[..s]);
+                        let after_start = s + self.think_start_token.len();
+                        self._buffer = current_text[after_start..].to_string();
+                        self._in_reasoning = true;
+                        self.stripped_think_start = true;
+                        continue;
                     }
-                    break;
+                    (Some(s), _) => {
+                        accumulated_normal.push_str(&current_text[..s]);
+                        let after_start = s + self.think_start_token.len();
+                        self._buffer = current_text[after_start..].to_string();
+                        self._in_reasoning = true;
+                        self.stripped_think_start = true;
+                        continue;
+                    }
+                    (None, Some(e)) => {
+                        // Stray </think> with no opening tag — drop the marker, stay in normal.
+                        accumulated_normal.push_str(&current_text[..e]);
+                        let after_end = e + self.think_end_token.len();
+                        self._buffer = current_text[after_end..].to_string();
+                        continue;
+                    }
+                    (None, None) => {
+                        // No complete marker — check for partial at end of buffer.
+                        // The partial could be a prefix of either <think> or </think>
+                        // (both start with `<`), so check both and use the wider overlap.
+                        // Require overlap >= 2 so a lone `<` passes through for tool call
+                        // XML tags like `<invoke>` or `<minimax:tool_call>`.
+                        let ol_start = overlap(&current_text, &self.think_start_token);
+                        let ol_end = overlap(&current_text, &self.think_end_token);
+                        let ol = ol_start.max(ol_end);
+                        if ol >= 2 {
+                            let safe_end = current_text.len() - ol;
+                            if safe_end > 0 {
+                                accumulated_normal.push_str(&current_text[..safe_end]);
+                            }
+                            self._buffer = current_text[safe_end..].to_string();
+                        } else {
+                            accumulated_normal.push_str(&current_text);
+                            self._buffer.clear();
+                        }
+                        break;
+                    }
                 }
             }
         }
@@ -555,7 +601,7 @@ mod tests {
         assert_eq!(result3.reasoning_text, "more");
     }
 
-    #[test] // REASONING.batch.2.f — nested marker-looking content
+    #[test] // REASONING.batch.6.b — stray close marker after a complete reasoning span
     fn test_nested_reasoning_blocks() {
         let mut parser =
             BasicReasoningParser::new("<think>".to_string(), "</think>".to_string(), false, true);
@@ -565,9 +611,11 @@ mod tests {
         );
         // Cursor-based parsing: first <think> starts reasoning, first </think> ends it.
         // "outer <think>inner" is reasoning (inner <think> is just text within reasoning).
-        // " reasoning</think> normal" is normal text (stray </think> passes through).
+        // After exiting reasoning, the cursor encounters another stray </think> in
+        // " reasoning</think> normal"; per the lossless-split contract it is stripped,
+        // leaving "reasoning normal" in normal_text after trim.
         assert_eq!(result.reasoning_text, "outer <think>inner");
-        assert_eq!(result.normal_text, "reasoning</think> normal");
+        assert_eq!(result.normal_text, "reasoning normal");
     }
 
     #[test] // REASONING.batch.5

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -165,7 +165,25 @@ impl ReasoningParser for Gemma4ReasoningParser {
         let mut reasoning = String::new();
         let mut cursor = 0;
 
-        while let Some(start_rel) = text[cursor..].find(START_TOKEN) {
+        loop {
+            let next_start = text[cursor..].find(START_TOKEN);
+            let stray_end = text[cursor..].find(END_TOKEN);
+
+            // Stray END_TOKEN appears before the next START_TOKEN (or no next start).
+            // Drop it per the lossless-split contract: parser-owned syntax must never
+            // reach normal_text.
+            if let Some(e_rel) = stray_end
+                && next_start.is_none_or(|s_rel| e_rel < s_rel)
+            {
+                let e = cursor + e_rel;
+                normal.push_str(&text[cursor..e]);
+                cursor = e + END_TOKEN.len();
+                continue;
+            }
+
+            let Some(start_rel) = next_start else {
+                break;
+            };
             let start = cursor + start_rel;
             normal.push_str(&text[cursor..start]);
 
@@ -204,9 +222,21 @@ impl ReasoningParser for Gemma4ReasoningParser {
 
         loop {
             if !self.in_reasoning {
-                // Look for either the full start marker or a partial-prefix at
-                // the buffer's end (which we must hold back).
-                if let Some(idx) = work.find(START_TOKEN) {
+                // Look for the next start marker, but also drop any stray end
+                // marker that appears before a start (lossless-split contract).
+                // Prefer the earlier of the two.
+                let next_start = work.find(START_TOKEN);
+                let stray_end = work.find(END_TOKEN);
+
+                if let Some(e_idx) = stray_end
+                    && next_start.is_none_or(|s_idx| e_idx < s_idx)
+                {
+                    normal.push_str(&work[..e_idx]);
+                    work = work[e_idx + END_TOKEN.len()..].to_string();
+                    continue;
+                }
+
+                if let Some(idx) = next_start {
                     normal.push_str(&work[..idx]);
                     work = work[idx + START_TOKEN.len()..].to_string();
                     self.in_reasoning = true;
@@ -214,7 +244,12 @@ impl ReasoningParser for Gemma4ReasoningParser {
                     self.reasoning_accum.clear();
                     continue;
                 }
-                let lap = overlap(&work, START_TOKEN);
+                // No complete marker — check for partial at end of buffer.
+                // The partial could be a prefix of either START_TOKEN or
+                // END_TOKEN (both begin with `<`), so use the wider overlap.
+                let lap_start = overlap(&work, START_TOKEN);
+                let lap_end = overlap(&work, END_TOKEN);
+                let lap = lap_start.max(lap_end);
                 if lap > 0 {
                     let split = work.len() - lap;
                     normal.push_str(&work[..split]);

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -132,12 +132,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '<think>preamble</think>body</think>answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.batch.yaml
@@ -127,3 +127,20 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -122,12 +122,11 @@ cases:
     - '<think>preamble</think>'
     - 'body</think>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_r1/REASONING.stream.yaml
@@ -114,3 +114,23 @@ cases:
         normal_text: ''
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -147,3 +147,20 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.batch.yaml
@@ -152,12 +152,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '<think>preamble</think>body</think>answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -122,3 +122,23 @@ cases:
         reasoning_text: ''
         normal_text: plain answer
         reason: Dynamo/vLLM keep marker-free stream text in force-reasoning mode; SGLang only enters reasoning after an explicit start marker.
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v3/REASONING.stream.yaml
@@ -130,12 +130,11 @@ cases:
     - '<think>preamble</think>'
     - 'body</think>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -158,3 +158,20 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.batch.yaml
@@ -163,12 +163,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '<think>preamble</think>body</think>answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -117,3 +117,23 @@ cases:
         normal_text: plain answer
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/deepseek_v4/REASONING.stream.yaml
@@ -125,12 +125,11 @@ cases:
     - '<think>preamble</think>'
     - 'body</think>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -174,3 +174,22 @@ cases:
            middle <|channel>thought
           second<channel|> done
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: |-
+      <|channel>thought
+      preamble<channel|>body<channel|>answer
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body<channel|>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.batch.yaml
@@ -181,12 +181,11 @@ cases:
     model_text: |-
       <|channel>thought
       preamble<channel|>body<channel|>answer
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body<channel|>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: stray <channel|> close marker after a complete reasoning span is stripped (parser-owned syntax must not appear in normal_text).'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body<channel|>answer'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -145,12 +145,11 @@ cases:
     - "<|channel>thought\npreamble<channel|>"
     - 'body<channel|>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body<channel|>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: stray <channel|> close marker after a complete reasoning span is stripped (parser-owned syntax must not appear in normal_text).'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body<channel|>answer'

--- a/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gemma4/REASONING.stream.yaml
@@ -137,3 +137,23 @@ cases:
         normal_text: plain answer
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - "<|channel>thought\npreamble<channel|>"
+    - 'body<channel|>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body<channel|>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body<channel|>answer'

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -204,8 +204,6 @@ cases:
       dynamo:
         unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
       vllm:
-        reasoning_text: ''
-        normal_text: ''
+        unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
       sglang:
-        reasoning_text: ''
-        normal_text: ''
+        unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.batch.yaml
@@ -195,3 +195,17 @@ cases:
     description: Open analysis channel interrupted by downstream tool-call text is not configured for Harmony
     ref: *upstream_ref
     reason: Harmony tool calls require a commentary channel envelope; the closed analysis to commentary handoff is covered by REASONING.batch.3.a.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: ''
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: gpt_oss does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        reasoning_text: ''
+        normal_text: ''

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -162,8 +162,6 @@ cases:
       dynamo:
         unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
       vllm:
-        reasoning_text: ''
-        normal_text: ''
+        unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
       sglang:
-        reasoning_text: ''
-        normal_text: ''
+        unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'

--- a/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/gpt_oss/REASONING.stream.yaml
@@ -153,3 +153,17 @@ cases:
         normal_text: ''
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks: []
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: gpt_oss parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        reasoning_text: ''
+        normal_text: ''

--- a/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -151,7 +151,6 @@ cases:
       dynamo:
         unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
       vllm:
-        reasoning_text: ''
-        normal_text: ''
+        unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
       sglang:
         unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"

--- a/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.batch.yaml
@@ -142,3 +142,16 @@ cases:
     description: Open Granite reasoning interrupted by downstream tool-call text is not covered by a paired Dynamo tool call parser
     ref: *upstream_ref
     reason: Granite reasoning parsing has no paired Dynamo tool call parser fixture or open-reasoning tool boundary in this seed fixture set.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: ''
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: granite does not use paired open/close markers, so the 1-open + 2-close unbalanced-tag shape has no direct analog.'
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"

--- a/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -109,3 +109,16 @@ cases:
       vllm: *d_s4
       sglang:
         unavailable: SGLang has no reasoning parser for family='granite'
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks: []
+    expected:
+      dynamo:
+        unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
+      vllm:
+        reasoning_text: ''
+        normal_text: ''
+      sglang:
+        unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"

--- a/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/granite/REASONING.stream.yaml
@@ -118,7 +118,6 @@ cases:
       dynamo:
         unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
       vllm:
-        reasoning_text: ''
-        normal_text: ''
+        unavailable: 'Pattern not applicable: granite parser does not use paired open/close markers, so the unbalanced-tag shape has no analog.'
       sglang:
         unavailable: "UNAVAILABLE: SGLang has no reasoning parser for family='granite'"

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -146,12 +146,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '◁think▷preamble◁/think▷body◁/think▷answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body◁/think▷answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         unavailable: "UNAVAILABLE: vLLM has no reasoning parser for family='kimi'"
       sglang:

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.batch.yaml
@@ -141,3 +141,19 @@ cases:
     description: Open reasoning interrupted by downstream tool-call text is not configured for this Kimi delimiter family
     ref: dynamo
     reason: Dynamo's Kimi Unicode-delimiter reasoning parser has no downstream tool-call boundary while reasoning is open; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '◁think▷preamble◁/think▷body◁/think▷answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body◁/think▷answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        unavailable: "UNAVAILABLE: vLLM has no reasoning parser for family='kimi'"
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body◁/think▷answer'

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -109,12 +109,11 @@ cases:
     - '◁think▷preamble◁/think▷'
     - 'body◁/think▷'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body◁/think▷answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         unavailable: "UNAVAILABLE: vLLM has no reasoning parser for family='kimi'"
       sglang:

--- a/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi/REASONING.stream.yaml
@@ -101,3 +101,22 @@ cases:
       vllm:
         unavailable: vLLM has no Kimi reasoning parser for this delimiter family.
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '◁think▷preamble◁/think▷'
+    - 'body◁/think▷'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body◁/think▷answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        unavailable: "UNAVAILABLE: vLLM has no reasoning parser for family='kimi'"
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body◁/think▷answer'

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -169,12 +169,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '<think>preamble</think>body</think>answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.batch.yaml
@@ -164,3 +164,20 @@ cases:
         reasoning_text: choose tool
         normal_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
       sglang: *id004
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -119,3 +119,23 @@ cases:
         reasoning_text: plain answer
         normal_text: ''
       sglang: *sg_stream_1_b
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: '<think>preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/kimi_k25/REASONING.stream.yaml
@@ -127,12 +127,11 @@ cases:
     - '<think>preamble</think>'
     - 'body</think>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: '<think>preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.batch.yaml
@@ -137,3 +137,19 @@ cases:
     description: Open reasoning interrupted by downstream tool-call text is not configured for MiniMax append-think
     ref: *upstream_ref
     reason: MiniMax append-think emits a synthetic normal-text wrapper instead of running an open reasoning-span boundary; closed-span handoff is covered by REASONING.batch.3.a.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag; passthrough — model output has no leading <think>, parser prepends it)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: 'preamble</think>body</think>answer'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+        reason: 'MiniMaxAppendThinkParser prepends <think> before parsing (matching the append-think chat template); in default mode (no force_reasoning) the parser does not split on </think>, so the entire output stays in normal_text. This mirrors REASONING.batch.6.a passthrough behavior.'
+      vllm:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+      sglang:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'

--- a/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/minimax_append_think/REASONING.stream.yaml
@@ -91,3 +91,22 @@ cases:
         normal_text: <think>plain answer
       vllm: *d_s4
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag; passthrough — chunks reassemble without leading <think>)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - 'preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    expected:
+      dynamo:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+        reason: 'MiniMaxAppendThinkParser prepends <think> before parsing (matching the append-think chat template); in default mode (no force_reasoning) the parser does not split on </think>, so the entire output stays in normal_text. This mirrors REASONING.batch.6.a passthrough behavior.'
+      vllm:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'
+      sglang:
+        reasoning_text: ''
+        normal_text: '<think>preamble</think>body</think>answer'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -139,3 +139,20 @@ cases:
       sglang:
         reasoning_text: first
         normal_text: ' middle [THINK]second[/THINK] done'
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '[THINK]preamble[/THINK]body[/THINK]answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body[/THINK]answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.batch.yaml
@@ -144,12 +144,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '[THINK]preamble[/THINK]body[/THINK]answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body[/THINK]answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body[/THINK]answer'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -113,3 +113,23 @@ cases:
       sglang:
         reasoning_text: ''
         normal_text: plain answer
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '[THINK]preamble[/THINK]'
+    - 'body[/THINK]'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body[/THINK]answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body[/THINK]answer'

--- a/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/mistral/REASONING.stream.yaml
@@ -121,12 +121,11 @@ cases:
     - '[THINK]preamble[/THINK]'
     - 'body[/THINK]'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body[/THINK]answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body[/THINK]answer'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -155,12 +155,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '<think>preamble</think>body</think>answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.batch.yaml
@@ -150,3 +150,20 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -122,3 +122,23 @@ cases:
         normal_text: ''
         reason: vLLM GLM/Nemotron parser (`glm45`) defaults thinking on and routes marker-free deltas to reasoning.
       sglang: *id001
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/nemotron_deci/REASONING.stream.yaml
@@ -130,12 +130,11 @@ cases:
     - '<think>preamble</think>'
     - 'body</think>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -164,3 +164,20 @@ cases:
         reasoning_text: first
         normal_text: ' middle <think>second</think> done'
         reason: Dynamo extracts every complete reasoning span and concatenates them; SGLang exits reasoning at the first end marker and leaves the later span, with its literal markers, in normal_text.
+  REASONING.batch.6.b:
+    description: Stray end marker after a complete reasoning span(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    model_text: '<think>preamble</think>body</think>answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.batch.yaml
@@ -169,12 +169,11 @@ cases:
     ref: dynamo
     spec_ref: tests/parity/README.md
     model_text: '<think>preamble</think>body</think>answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: "Dynamo's BasicReasoningParser splits at the first close marker and leaves the stray second close marker as a literal in normal_text (see lib/parsers/src/reasoning/base_parser.rs first-close-wins logic). Repro: F6 case#2 on Nemotron-3-Ultra."
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -118,3 +118,23 @@ cases:
         normal_text: ''
         reason: vLLM Qwen streaming parser treats text before a reasoning end marker as reasoning; serving may bypass it when thinking is disabled.
       sglang: *d_s4
+  REASONING.stream.2.c:
+    description: Stray end marker after a complete reasoning span, across chunks(unbalanced-tag)
+    ref: dynamo
+    spec_ref: tests/parity/README.md
+    chunks:
+    - '<think>preamble</think>'
+    - 'body</think>'
+    - 'answer'
+    dynamo_leak: true
+    expected:
+      dynamo:
+        reasoning_text: preamble
+        normal_text: 'body</think>answer'
+        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+      vllm:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'
+      sglang:
+        reasoning_text: 'preamble'
+        normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
+++ b/tests/parity/reasoning/fixtures/qwen3/REASONING.stream.yaml
@@ -126,12 +126,11 @@ cases:
     - '<think>preamble</think>'
     - 'body</think>'
     - 'answer'
-    dynamo_leak: true
     expected:
       dynamo:
         reasoning_text: preamble
-        normal_text: 'body</think>answer'
-        reason: 'Same first-close-wins defect as batch mode: chunks after the first close are forwarded as normal_text with the stray second close marker intact. Repro: F6 case#2.'
+        normal_text: 'bodyanswer'
+        reason: 'Lossless split: when a stray close marker appears outside any reasoning block, it is stripped (parser-owned syntax must not appear in normal_text). Reasoning is captured from the first <open>...<close> pair only; subsequent stray closes are discarded.'
       vllm:
         reasoning_text: 'preamble'
         normal_text: 'body</think>answer'

--- a/tests/parity/reasoning/table.py
+++ b/tests/parity/reasoning/table.py
@@ -72,7 +72,7 @@ CASE_GROUPS = [
         ("stream.1.a", "stream.1.b"),
     ),
     ("Reasoning extraction", ("stream.2.a",)),
-    ("Multi-span", ("stream.2.b",)),
+    ("Multi-span", ("stream.2.b", "stream.2.c")),
     ("Chunk boundaries", ("stream.3.a", "stream.3.b", "stream.3.c")),
 ]
 _CASE_GROUP_BY_CASE = {


### PR DESCRIPTION

#### Overview:

This PR adds two new reasoning-parser parity cases — `REASONING.batch.6.b` and `REASONING.stream.2.c` — covering the "1 open + 2 close" pattern (`<open>preamble<close>body<close>answer`), and fixes `BasicReasoningParser` + `Gemma4ReasoningParser` to honor the lossless-split contract on close markers must not leak into `normal_text`.

#### Details:

Model input
```
<think>preamble</think>body</think>answer
```

Before fix:
```
reasoning_text = "preamble"
normal_text    = "body</think>answer"
```
After fix:
```
reasoning_text = "preamble"
normal_text    = "bodyanswer"
```

Parity chart before (after adding new cases):
<img width="1106" height="533" alt="image" src="https://github.com/user-attachments/assets/3622400c-1a29-47eb-ad46-09943dcd75b9" />

Parity chart after:
<img width="1109" height="528" alt="image" src="https://github.com/user-attachments/assets/9aef1560-7729-47bf-a583-8b884d2907e3" />


The cursor loop now also detects a stray close marker in the non-reasoning branch and drops it (lossless-split). The `<think>`-family dangling-end-recovery (`REASONING.batch.4` — text before a lone close becomes reasoning) is preserved.

#### Where should the reviewer start?

1. `lib/parsers/src/reasoning/base_parser.rs`
2. `lib/parsers/src/reasoning/gemma4_parser.rs` 
3. `tests/parity/reasoning/fixtures/*/REASONING.batch.yaml` + `REASONING.stream.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stray closing reasoning markers that appear after complete reasoning spans. Orphaned closing markers are now properly stripped from output instead of leaking into normal text.

* **Tests**
  * Added comprehensive test coverage for edge cases involving unbalanced reasoning markers across multiple model families in both batch and streaming parsing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->