### PR TITLE
chore: bump trtllm to v1.3.0rc17

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -103,7 +103,7 @@ trtllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: nvcr.io/nvidia/tensorrt-llm/release
     base_image_tag: 26.02-cuda13.1-devel-ubuntu24.04
-    runtime_image_tag: 1.3.0rc16
+    runtime_image_tag: 1.3.0rc17
   nixl_ref: 0.10.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.11` | `1.3.0rc16` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.11` | `1.3.0rc17` | `0.21.0` | `0.10.1` (TRT-LLM); `1.1.0` (vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.1** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.3.0rc16",
+    "tensorrt-llm==1.3.0rc17",
 ]
 
 vllm = [


### PR DESCRIPTION
## Automated dependency upgrade — trtllm v1.3.0rc17

Post-merge CI passed on this branch.

- **Framework:** trtllm
- **Target version:** v1.3.0rc17
- **Branch:** deps/upgrade-trtllm-v1.3.0rc17
- **Validating run:** https://github.com/ai-dynamo/dynamo/actions/runs/26882525425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TensorRT-LLM dependency from 1.3.0rc16 to 1.3.0rc17 in runtime and package configurations, with corresponding documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->