### PR TITLE
trtllm: monitor executor health

### DIFF
--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -13,6 +13,7 @@ from tensorrt_llm.llmapi.llm import BaseLLM
 from transformers import AutoConfig
 
 from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.engine_monitor import TrtllmEngineMonitor
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ class TensorRTLLMEngine:
         disaggregation_mode: Optional[DisaggregationMode] = None,
     ) -> None:
         self._llm: Optional[LLM] = None
+        self._health_monitor: Optional[TrtllmEngineMonitor] = None
         self.disaggregation_mode = (
             disaggregation_mode
             if disaggregation_mode is not None
@@ -95,6 +97,7 @@ class TensorRTLLMEngine:
                 self._llm = self._llm_cls(**self.engine_args)
 
     async def cleanup(self) -> None:
+        await self.stop_health_monitor()
         if self._llm:
             try:
                 self._llm.shutdown()
@@ -108,6 +111,50 @@ class TensorRTLLMEngine:
         if not self._llm:
             raise RuntimeError("Engine not initialized")
         return self._llm
+
+    def supports_health_check(self) -> bool:
+        return self._get_health_check_fn() is not None
+
+    def check_health(self) -> bool:
+        if self._llm is None:
+            return False
+        check_health = self._get_health_check_fn()
+        if check_health is None:
+            return True
+        return bool(check_health())
+
+    def get_health_check_fatal_error(self) -> Optional[BaseException]:
+        if self._llm is None:
+            return None
+        executor = getattr(self._llm, "_executor", None)
+        return getattr(executor, "_fatal_error", None)
+
+    def start_health_monitor(
+        self, shutdown_event: Optional[Any] = None
+    ) -> Optional[TrtllmEngineMonitor]:
+        if self._health_monitor is None:
+            self._health_monitor = TrtllmEngineMonitor(
+                self, shutdown_event=shutdown_event
+            )
+        return self._health_monitor
+
+    async def stop_health_monitor(self) -> None:
+        if self._health_monitor is None:
+            return
+        await self._health_monitor.stop()
+        self._health_monitor = None
+
+    def _get_health_check_fn(self):
+        if self._llm is None:
+            return None
+        check_health = getattr(self._llm, "_check_health", None)
+        if callable(check_health):
+            return check_health
+        executor = getattr(self._llm, "_executor", None)
+        check_health = getattr(executor, "check_health", None)
+        if callable(check_health):
+            return check_health
+        return None
 
     def get_attention_dp_size(self) -> int:
         """Return attention_dp_size (tensor_parallel_size if attention DP enabled, else 1).

--- a/components/src/dynamo/trtllm/engine_monitor.py
+++ b/components/src/dynamo/trtllm/engine_monitor.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT-LLM executor health monitor."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from dynamo.trtllm.engine import TensorRTLLMEngine
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_INTERVAL = 2.0
+HEALTH_SHUTDOWN_TIMEOUT = 90.0
+HEALTH_CHECK_INTERVAL_ENV = "DYN_TRTLLM_HEALTH_CHECK_INTERVAL"
+HEALTH_SHUTDOWN_TIMEOUT_ENV = "DYN_TRTLLM_HEALTH_SHUTDOWN_TIMEOUT"
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %.1f", name, value, default)
+        return default
+    if parsed < 0:
+        logger.warning("Negative %s=%r; using 0", name, value)
+        return 0.0
+    return parsed
+
+
+class TrtllmEngineMonitor:
+    """Poll TRT-LLM's internal health API and stop the worker on fatal state."""
+
+    def __init__(
+        self,
+        engine: "TensorRTLLMEngine",
+        shutdown_event: Optional[asyncio.Event] = None,
+        *,
+        interval: Optional[float] = None,
+        shutdown_timeout: Optional[float] = None,
+        kill_fn: Callable[[int, int], None] = os.kill,
+        exit_fn: Callable[[int], None] = os._exit,
+        pid_fn: Callable[[], int] = os.getpid,
+    ) -> None:
+        self.engine = engine
+        self.shutdown_event = shutdown_event
+        self.interval = (
+            _env_float(HEALTH_CHECK_INTERVAL_ENV, HEALTH_CHECK_INTERVAL)
+            if interval is None
+            else interval
+        )
+        self.shutdown_timeout = (
+            _env_float(HEALTH_SHUTDOWN_TIMEOUT_ENV, HEALTH_SHUTDOWN_TIMEOUT)
+            if shutdown_timeout is None
+            else shutdown_timeout
+        )
+        self._kill_fn = kill_fn
+        self._exit_fn = exit_fn
+        self._pid_fn = pid_fn
+        self._monitor_task: Optional[asyncio.Task[None]] = None
+
+        if not engine.supports_health_check():
+            logger.info(
+                "TRT-LLM health monitor disabled; installed TRT-LLM does not "
+                "expose _check_health() or executor.check_health()."
+            )
+            return
+
+        self._monitor_task = asyncio.create_task(self._check_engine_health())
+        logger.info("TRT-LLM engine health monitor started.")
+
+    async def stop(self) -> None:
+        if self._monitor_task is None:
+            return
+        if self._monitor_task is asyncio.current_task():
+            return
+        self._monitor_task.cancel()
+        try:
+            await self._monitor_task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._monitor_task = None
+
+    async def _check_engine_health(self) -> None:
+        while True:
+            try:
+                if self.shutdown_event is not None and self.shutdown_event.is_set():
+                    logger.info(
+                        "TRT-LLM health monitor stopping because shutdown_event is set."
+                    )
+                    break
+
+                try:
+                    healthy = await asyncio.to_thread(self.engine.check_health)
+                except Exception as exc:
+                    logger.error("TRT-LLM health check raised: %r", exc, exc_info=True)
+                    await self._shutdown_worker(f"health check raised {exc!r}")
+                    break
+
+                if not healthy:
+                    fatal_error = self.engine.get_health_check_fatal_error()
+                    if fatal_error is not None:
+                        logger.error("TRT-LLM engine is unhealthy: %r", fatal_error)
+                    else:
+                        logger.error("TRT-LLM engine is unhealthy.")
+                    await self._shutdown_worker("TRT-LLM health check failed")
+                    break
+
+                if self.shutdown_event is not None:
+                    try:
+                        await asyncio.wait_for(
+                            self.shutdown_event.wait(), timeout=self.interval
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                else:
+                    await asyncio.sleep(self.interval)
+            except asyncio.CancelledError:
+                logger.debug("TRT-LLM health monitor cancelled.")
+                break
+
+    async def _shutdown_worker(self, reason: str) -> None:
+        logger.warning(
+            "Initiating worker shutdown after TRT-LLM fatal health state: %s", reason
+        )
+        self._kill_fn(self._pid_fn(), signal.SIGINT)
+        try:
+            await asyncio.sleep(self.shutdown_timeout)
+        except asyncio.CancelledError:
+            logger.debug("TRT-LLM health monitor shutdown wait cancelled.")
+            raise
+        logger.critical(
+            "TRT-LLM health-triggered shutdown did not complete within %.1fs; "
+            "forcing process exit.",
+            self.shutdown_timeout,
+        )
+        self._exit_fn(1)

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -292,6 +292,7 @@ class TrtllmLLMEngine(LLMEngine):
 
         self._engine = TensorRTLLMEngine(self.engine_args, self.disaggregation_mode)
         await self._engine.initialize()
+        self._engine.start_health_monitor()
 
         from tensorrt_llm.metrics import MetricsCollector
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine_monitor.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine_monitor.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import signal
+
+import pytest
+
+from dynamo.trtllm.engine_monitor import TrtllmEngineMonitor
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+class _FakeEngine:
+    def __init__(
+        self,
+        health_results=None,
+        *,
+        supports_health_check=True,
+        fatal_error=None,
+        health_exception=None,
+    ):
+        self._health_results = list(health_results or [True])
+        self._supports_health_check = supports_health_check
+        self._fatal_error = fatal_error
+        self._health_exception = health_exception
+        self.check_count = 0
+
+    def supports_health_check(self):
+        return self._supports_health_check
+
+    def check_health(self):
+        self.check_count += 1
+        if self._health_exception is not None:
+            raise self._health_exception
+        if len(self._health_results) > 1:
+            return self._health_results.pop(0)
+        return self._health_results[0]
+
+    def get_health_check_fatal_error(self):
+        return self._fatal_error
+
+
+def _recorder():
+    calls = []
+
+    def kill_fn(pid, sig):
+        calls.append(("kill", pid, sig))
+
+    def exit_fn(code):
+        calls.append(("exit", code))
+
+    return calls, kill_fn, exit_fn
+
+
+@pytest.mark.asyncio
+async def test_monitor_disables_without_health_api():
+    calls, kill_fn, exit_fn = _recorder()
+    engine = _FakeEngine(supports_health_check=False)
+
+    monitor = TrtllmEngineMonitor(
+        engine,
+        interval=0.01,
+        shutdown_timeout=0.01,
+        kill_fn=kill_fn,
+        exit_fn=exit_fn,
+        pid_fn=lambda: 123,
+    )
+
+    assert monitor._monitor_task is None
+    assert calls == []
+    await monitor.stop()
+
+
+@pytest.mark.asyncio
+async def test_monitor_stops_cleanly_on_shutdown_event():
+    calls, kill_fn, exit_fn = _recorder()
+    shutdown_event = asyncio.Event()
+    engine = _FakeEngine([True])
+    monitor = TrtllmEngineMonitor(
+        engine,
+        shutdown_event=shutdown_event,
+        interval=0.01,
+        shutdown_timeout=0.01,
+        kill_fn=kill_fn,
+        exit_fn=exit_fn,
+        pid_fn=lambda: 123,
+    )
+
+    await asyncio.sleep(0.02)
+    shutdown_event.set()
+    assert monitor._monitor_task is not None
+    await asyncio.wait_for(monitor._monitor_task, timeout=1.0)
+
+    assert engine.check_count >= 1
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_monitor_signals_and_exits_when_unhealthy():
+    calls, kill_fn, exit_fn = _recorder()
+    engine = _FakeEngine([False], fatal_error=RuntimeError("fatal"))
+
+    monitor = TrtllmEngineMonitor(
+        engine,
+        interval=0.01,
+        shutdown_timeout=0.01,
+        kill_fn=kill_fn,
+        exit_fn=exit_fn,
+        pid_fn=lambda: 123,
+    )
+
+    assert monitor._monitor_task is not None
+    await asyncio.wait_for(monitor._monitor_task, timeout=1.0)
+
+    assert calls == [
+        ("kill", 123, signal.SIGINT),
+        ("exit", 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_monitor_treats_health_exception_as_fatal():
+    calls, kill_fn, exit_fn = _recorder()
+    engine = _FakeEngine(health_exception=RuntimeError("health failed"))
+
+    monitor = TrtllmEngineMonitor(
+        engine,
+        interval=0.01,
+        shutdown_timeout=0.01,
+        kill_fn=kill_fn,
+        exit_fn=exit_fn,
+        pid_fn=lambda: 456,
+    )
+
+    assert monitor._monitor_task is not None
+    await asyncio.wait_for(monitor._monitor_task, timeout=1.0)
+
+    assert calls == [
+        ("kill", 456, signal.SIGINT),
+        ("exit", 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_monitor_stop_cancels_poll_task():
+    calls, kill_fn, exit_fn = _recorder()
+    engine = _FakeEngine([True])
+    monitor = TrtllmEngineMonitor(
+        engine,
+        interval=10.0,
+        shutdown_timeout=0.01,
+        kill_fn=kill_fn,
+        exit_fn=exit_fn,
+        pid_fn=lambda: 123,
+    )
+
+    await asyncio.sleep(0.02)
+    await monitor.stop()
+
+    assert monitor._monitor_task is None
+    assert calls == []

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -488,6 +488,7 @@ async def init_llm_worker(
         # The callback uses this to poll active request count during shutdown.
         if engine_holder is not None:
             engine_holder.append(engine)
+        engine.start_health_monitor(shutdown_event=shutdown_event)
 
         endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"


### PR DESCRIPTION
## Summary
- add a TensorRT-LLM engine health monitor that polls the new executor health API off the event loop
- expose a TensorRTLLMEngine health adapter that supports both unified and legacy worker startup paths
- trigger SIGINT on fatal/unhealthy executor state and hard-exit if the worker does not terminate within the shutdown budget
- add unit coverage for unsupported health APIs, shutdown cancellation, unhealthy results, exceptions, and explicit stop behavior

## Testing
- python -m py_compile components/src/dynamo/trtllm/engine_monitor.py components/src/dynamo/trtllm/engine.py components/src/dynamo/trtllm/llm_engine.py components/src/dynamo/trtllm/workers/llm_worker.py components/src/dynamo/trtllm/tests/test_trtllm_engine_monitor.py
- ruff check components/src/dynamo/trtllm/engine_monitor.py components/src/dynamo/trtllm/engine.py components/src/dynamo/trtllm/llm_engine.py components/src/dynamo/trtllm/workers/llm_worker.py components/src/dynamo/trtllm/tests/test_trtllm_engine_monitor.py
- ruff format --check components/src/dynamo/trtllm/engine_monitor.py components/src/dynamo/trtllm/engine.py components/src/dynamo/trtllm/llm_engine.py components/src/dynamo/trtllm/tests/test_trtllm_engine_monitor.py
- PYTHONPATH=components/src .venv/bin/python -m pytest -q -c /dev/null components/src/dynamo/trtllm/tests/test_trtllm_engine_monitor.py

## Notes
- Full repo pytest was blocked in the system environment because pytest-asyncio is not installed.
- uv run pytest was blocked by the current extras resolution conflict between nixl[cu12]==1.1.0 and nixl[cu12]<1.1.0.
- ruff format --check on llm_worker.py is blocked by a pre-existing unrelated one-line formatting diff around current_kv_config["event_buffer_max_size"].