### PR TITLE
[merge after 0.22.0rc1 is in pypi] fix(omni): bump vllm-omni to 0.22.0rc1

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -67,7 +67,7 @@ vllm:
     base_image_tag: 22.04
     runtime_image_tag: v0.22.0
   flashinf_ref: v0.6.8.post1
-  vllm_omni_ref: "v0.21.0rc1"
+  vllm_omni_ref: "v0.22.0rc1"
   nixl_ref: v1.1.0
   max_jobs: "10"
   enable_media_ffmpeg: "false"

--- a/container/deps/vllm/protected_packages.txt
+++ b/container/deps/vllm/protected_packages.txt
@@ -10,7 +10,7 @@ triton
 vllm
 transformers
 tokenizers
-# vLLM-Omni (v0.21.0rc1) may require a newer safetensors than the upstream
+# vLLM-Omni (v0.22.0rc1) may require a newer safetensors than the upstream
 # vLLM 0.22.0 image ships, so safetensors is intentionally left unfrozen here.
 # safetensors
 msgspec


### PR DESCRIPTION
## Summary
- bump `vllm_omni_ref` to `v0.22.0rc1`
- update the safetensors protected-packages note to match the new vLLM-Omni ref

## Merge gate
Do not merge this PR until `vllm-omni==0.22.0rc1` is published on PyPI. Maintainers said the release should be pushed soon.

## Tests
- `bash -n container/deps/vllm/install_vllm_omni.sh`
- `git diff origin/main --check`
- commit hooks
