### PR TITLE
perf(frontend): profile-guided hot-path optimizations (tokenizer cache, metric handles, log-trace cap)

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -433,6 +433,11 @@ pub struct ResponseMetricCollector {
     decode_dp_rank: Option<u32>,
     // Decode worker type for Prometheus labeling - stored at routing time to avoid MDC lookup
     decode_worker_type: Option<String>,
+    // Cached per-worker ITL gauge handle. The decode-worker labels are latched once at
+    // routing time (`set_worker_info` only sets when unset), so this GaugeVec handle is
+    // resolved a single time and reused — the per-token observe path then does no label
+    // formatting (`worker_id.to_string()`) or label hashing, only `set`.
+    decode_itl_gauge: Option<prometheus::Gauge>,
 }
 
 impl Default for Metrics {
@@ -1384,6 +1389,7 @@ impl ResponseMetricCollector {
             decode_worker_id: None,
             decode_dp_rank: None,
             decode_worker_type: None,
+            decode_itl_gauge: None,
         }
     }
 
@@ -1530,7 +1536,14 @@ impl ResponseMetricCollector {
             // Update per-worker ITL gauge - attributed to decode worker.
             // Use stored worker_type (from routing time) to avoid MDC lookup.
             // Falls back to WORKER_TYPE_DECODE if not available.
-            if let Some(worker_id) = self.decode_worker_id {
+            //
+            // The worker labels are fixed for the request's lifetime (latched in
+            // `set_worker_info`), so resolve the GaugeVec handle once and cache it.
+            // This keeps the per-token path free of `to_string()` allocations and
+            // label hashing; subsequent tokens only call `set`.
+            if self.decode_itl_gauge.is_none()
+                && let Some(worker_id) = self.decode_worker_id
+            {
                 let worker_id_str = worker_id.to_string();
                 let dp_rank_str = self
                     .decode_dp_rank
@@ -1539,9 +1552,12 @@ impl ResponseMetricCollector {
                     .decode_worker_type
                     .as_deref()
                     .unwrap_or(WORKER_TYPE_DECODE);
-                WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE
-                    .with_label_values(&[worker_id_str.as_str(), dp_rank_str.as_str(), worker_type])
-                    .set(itl);
+                self.decode_itl_gauge = Some(WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.with_label_values(
+                    &[worker_id_str.as_str(), dp_rank_str.as_str(), worker_type],
+                ));
+            }
+            if let Some(gauge) = &self.decode_itl_gauge {
+                gauge.set(itl);
             }
         }
 
@@ -2047,6 +2063,50 @@ mod tests {
             .with_label_values(&[model])
             .get();
         assert_eq!(out, 7, "output tokens = 3 + 4 via cached counter handle");
+    }
+
+    #[test]
+    fn test_cached_decode_itl_gauge_records_for_worker() {
+        // The per-worker ITL gauge handle is resolved once (worker labels are latched
+        // at routing time via `set_worker_info`) and reused on every output token.
+        // Verify observations through the cached handle land on the same GaugeVec
+        // series the labels address. Regression guard for the per-token handle cache.
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).ok();
+        let model = "itl-gauge-model";
+
+        // Distinctive worker id so this never collides with other tests on the
+        // process-global WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.
+        let worker_id: u64 = 9_876_543_210;
+        let mut collector = metrics.clone().create_response_collector(model);
+        collector.set_worker_info(
+            None,
+            None,
+            None,
+            Some(worker_id),
+            Some(0),
+            Some("decode".to_string()),
+        );
+
+        // First chunk: TTFT only, no ITL yet (no prior response time) -> gauge unset.
+        collector.observe_response(10, 1);
+        // Elapse measurable time so ITL > 0, then a second chunk drives the cached
+        // per-worker ITL gauge.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        collector.observe_response(10, 1);
+
+        let worker_id_str = worker_id.to_string();
+        let gauge = WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.with_label_values(&[
+            worker_id_str.as_str(),
+            "0",
+            "decode",
+        ]);
+        assert!(
+            gauge.get() > 0.0,
+            "cached per-worker ITL gauge must record a positive ITL through the vec, got {}",
+            gauge.get()
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -394,6 +394,16 @@ pub enum ErrorType {
 pub struct ResponseMetricCollector {
     metrics: Arc<Metrics>,
     model: String,
+    // Per-model metric handles resolved once at construction. The collector lives for a
+    // single request and `model` is fixed, so caching these avoids re-hashing the `model`
+    // label via `with_label_values` on every chunk (and, for ITL, on every output token —
+    // it was previously resolved inside a `for _ in 0..num_tokens` loop). Each handle
+    // shares the underlying metric with its vec, so observations are equivalent.
+    output_tokens_counter: prometheus::IntCounter,
+    time_to_first_token: prometheus::Histogram,
+    inter_token_latency: prometheus::Histogram,
+    input_sequence_length: prometheus::Histogram,
+    cached_tokens: prometheus::Histogram,
     start_time: Instant,
     // we use is_first_token to distinguish TTFT from ITL. It is true by default and
     // flipped to false when the first token is returned and TTFT is published.
@@ -1341,9 +1351,21 @@ impl std::fmt::Display for ErrorType {
 
 impl ResponseMetricCollector {
     fn new(metrics: Arc<Metrics>, model: String) -> Self {
+        // Resolve the per-model handles once (cheap clones of the vec entries) so the
+        // per-chunk / per-token hot path in `observe_response` does no label hashing.
+        let output_tokens_counter = metrics.output_tokens_counter.with_label_values(&[&model]);
+        let time_to_first_token = metrics.time_to_first_token.with_label_values(&[&model]);
+        let inter_token_latency = metrics.inter_token_latency.with_label_values(&[&model]);
+        let input_sequence_length = metrics.input_sequence_length.with_label_values(&[&model]);
+        let cached_tokens = metrics.cached_tokens.with_label_values(&[&model]);
         ResponseMetricCollector {
             metrics,
             model,
+            output_tokens_counter,
+            time_to_first_token,
+            inter_token_latency,
+            input_sequence_length,
+            cached_tokens,
             is_first_token: true,
             last_response_time: None,
             start_time: Instant::now(),
@@ -1413,10 +1435,7 @@ impl ResponseMetricCollector {
             && !self.cached_tokens_observed
         {
             self.cached_tokens_observed = true;
-            self.metrics
-                .cached_tokens
-                .with_label_values(&[&self.model])
-                .observe(tokens as f64);
+            self.cached_tokens.observe(tokens as f64);
         }
     }
 
@@ -1456,10 +1475,7 @@ impl ResponseMetricCollector {
         self.isl = isl;
 
         // Increment the real-time output tokens counter
-        self.metrics
-            .output_tokens_counter
-            .with_label_values(&[&self.model])
-            .inc_by(num_tokens as u64);
+        self.output_tokens_counter.inc_by(num_tokens as u64);
 
         if self.is_first_token {
             // NOTE: when there are multiple tokens in the first response,
@@ -1469,10 +1485,7 @@ impl ResponseMetricCollector {
             // Publish TTFT and store for span recording
             let ttft = self.start_time.elapsed().as_secs_f64();
             self.ttft_ms = Some(ttft * 1000.0);
-            self.metrics
-                .time_to_first_token
-                .with_label_values(&[&self.model])
-                .observe(ttft);
+            self.time_to_first_token.observe(ttft);
 
             // Update per-worker TTFT and input sequence tokens gauges - attributed to prefill worker.
             // Both gauges are updated atomically from the same request to correlate latency with input size.
@@ -1498,10 +1511,7 @@ impl ResponseMetricCollector {
 
             // Publish ISL
             // TODO: publish ISL as soon as the tokenization process completes
-            self.metrics
-                .input_sequence_length
-                .with_label_values(&[&self.model])
-                .observe(isl as f64);
+            self.input_sequence_length.observe(isl as f64);
         }
 
         let current_duration = self.start_time.elapsed();
@@ -1511,11 +1521,10 @@ impl ResponseMetricCollector {
             let itl = response_duration.as_secs_f64() / num_tokens as f64;
             self.itl_sum_secs += itl * num_tokens as f64;
             self.itl_count += num_tokens as u64;
+            // Handle resolved once at construction — the observe loop no longer re-hashes
+            // the `model` label on every output token.
             for _ in 0..num_tokens {
-                self.metrics
-                    .inter_token_latency
-                    .with_label_values(&[&self.model])
-                    .observe(itl);
+                self.inter_token_latency.observe(itl);
             }
 
             // Update per-worker ITL gauge - attributed to decode worker.
@@ -2005,6 +2014,39 @@ mod tests {
             .with_label_values(&[model])
             .get();
         assert_eq!(counter_value, 22);
+    }
+
+    #[test]
+    fn test_cached_handles_record_through_vec() {
+        // The collector resolves per-model handles once at construction; observing
+        // through them must update the same metric the vec exposes. Regression guard
+        // for the handle cache (incl. the per-token ITL loop using the cached handle).
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+        let model = "cached-handle-model";
+
+        let mut collector = metrics.clone().create_response_collector(model);
+        // First chunk (3 tokens): TTFT + ISL observed once; no ITL yet.
+        collector.observe_response(42, 3);
+        // Second chunk (4 tokens): ITL observed once per token via the cached handle.
+        collector.observe_response(42, 4);
+
+        let ttft = metrics.time_to_first_token.with_label_values(&[model]);
+        assert_eq!(ttft.get_sample_count(), 1, "TTFT observed once");
+
+        let isl = metrics.input_sequence_length.with_label_values(&[model]);
+        assert_eq!(isl.get_sample_count(), 1, "ISL observed once");
+        assert_eq!(isl.get_sample_sum(), 42.0);
+
+        let itl = metrics.inter_token_latency.with_label_values(&[model]);
+        assert_eq!(itl.get_sample_count(), 4, "ITL observed once per token of 2nd chunk");
+
+        let out = metrics
+            .output_tokens_counter
+            .with_label_values(&[model])
+            .get();
+        assert_eq!(out, 7, "output tokens = 3 + 4 via cached counter handle");
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1552,9 +1552,12 @@ impl ResponseMetricCollector {
                     .decode_worker_type
                     .as_deref()
                     .unwrap_or(WORKER_TYPE_DECODE);
-                self.decode_itl_gauge = Some(WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.with_label_values(
-                    &[worker_id_str.as_str(), dp_rank_str.as_str(), worker_type],
-                ));
+                self.decode_itl_gauge =
+                    Some(WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.with_label_values(&[
+                        worker_id_str.as_str(),
+                        dp_rank_str.as_str(),
+                        worker_type,
+                    ]));
             }
             if let Some(gauge) = &self.decode_itl_gauge {
                 gauge.set(itl);
@@ -2056,7 +2059,11 @@ mod tests {
         assert_eq!(isl.get_sample_sum(), 42.0);
 
         let itl = metrics.inter_token_latency.with_label_values(&[model]);
-        assert_eq!(itl.get_sample_count(), 4, "ITL observed once per token of 2nd chunk");
+        assert_eq!(
+            itl.get_sample_count(),
+            4,
+            "ITL observed once per token of 2nd chunk"
+        );
 
         let out = metrics
             .output_tokens_counter

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -81,7 +81,18 @@ figment = { version = "0.10.19", features = ["env", "json", "toml", "test"] }
 notify = { version = "6.1", default-features = false, features = ["macos_fsevent"] }
 libc = { version = "0.2" }
 local-ip-address = { version = "0.6.3" }
-log = { version = "0.4" }
+# `release_max_level_debug` compiles out `log::trace!` in release builds (a
+# compile-time `STATIC_MAX_LEVEL` check — no runtime cost, cannot be overridden).
+# Dependencies that log through the `log` crate — notably HF `tokenizers`, whose
+# `NormalizedString::transform_range` emits a `log::trace!` *per character*
+# during normalization — otherwise route tens of thousands of filtered-out
+# events per request through the `log`->tracing bridge + EnvFilter, which
+# profiling showed costing ~half the frontend CPU on the stock-tokenizer path.
+# We cap at `debug` (not `info`) so `log::debug!` from deps and Dynamo's own
+# `log::debug!` (e.g. the NATS transport) are still available in release; only
+# the per-char `trace!` spam is removed. Dynamo's own logging is `tracing` (a
+# separate crate), so `DYN_LOG=trace` still surfaces all Dynamo logs in release.
+log = { version = "0.4", features = ["release_max_level_debug"] }
 nuid = { version = "0.5" }
 once_cell = { version = "1" }
 percent-encoding = { version = "2.3.2" } # also used by tonic, reqwest, axum, etc

--- a/lib/tokenizers/src/cache/l1.rs
+++ b/lib/tokenizers/src/cache/l1.rs
@@ -522,7 +522,8 @@ mod tests {
 
         let suffix = &target[prefix_len..];
         let suffix_enc = tokenizer.encode(suffix).unwrap();
-        let mut merged = prefix_tokens.clone();
+        // longest_prefix_match returns the shared `Arc<[u32]>`; copy into a Vec to append the suffix.
+        let mut merged = prefix_tokens.to_vec();
         merged.extend_from_slice(suffix_enc.token_ids());
 
         let plain = tokenizer.encode(&target).unwrap();
@@ -775,7 +776,7 @@ mod tests {
         );
         let expected = tok.encode(&turns[1][..deepest]).unwrap();
         assert_eq!(
-            saved_tokens,
+            &*saved_tokens,
             expected.token_ids(),
             "persisted entry tokens must equal the uncached encode of the cached prefix"
         );

--- a/lib/tokenizers/src/cache/l1.rs
+++ b/lib/tokenizers/src/cache/l1.rs
@@ -153,7 +153,10 @@ impl L1Cache {
     /// extends the cached tokens with a fresh encode of `input[byte_offset..]`;
     /// `deepest_boundary` is the deepest special-token boundary in `input` (end-exclusive),
     /// handed back so [`extend_after_match`] need not rescan the input for it.
-    pub fn longest_prefix_match(&self, input: &str) -> Option<(Vec<TokenIdType>, usize, usize)> {
+    pub fn longest_prefix_match(
+        &self,
+        input: &str,
+    ) -> Option<(Arc<[TokenIdType]>, usize, usize)> {
         let boundaries = self.boundaries(input);
 
         if boundaries.is_empty() {
@@ -188,7 +191,10 @@ impl L1Cache {
                 if let Some(cb) = &self.on_hit {
                     cb();
                 }
-                return Some((tokens.to_vec(), boundary_pos, deepest_boundary));
+                // Return the shared `Arc` directly — the caller decides whether to
+                // materialize a `Vec` (and reserves exact capacity when it does),
+                // avoiding a clone of the (large) cached prefix on every hit.
+                return Some((tokens, boundary_pos, deepest_boundary));
             }
         }
 
@@ -304,7 +310,7 @@ impl L1Cache {
     pub fn extend_after_match<E: Encoder + ?Sized>(
         &self,
         input: &str,
-        prefix_tokens: Vec<TokenIdType>,
+        prefix_tokens: Arc<[TokenIdType]>,
         prefix_len: usize,
         deepest_boundary: usize,
         tokenizer: &E,
@@ -318,9 +324,12 @@ impl L1Cache {
 
         let Some(deepest) = deepest else {
             // No new boundary in the suffix — nothing worth caching. Encode the suffix
-            // once and merge, identical to the non-extend hit path.
+            // once and merge, identical to the non-extend hit path. Reserve exact capacity
+            // so the prefix isn't re-copied by a Vec grow-realloc.
             let suffix_enc = tokenizer.encode(&input[prefix_len..])?;
-            let mut merged = prefix_tokens;
+            let mut merged =
+                Vec::with_capacity(prefix_tokens.len() + suffix_enc.token_ids().len());
+            merged.extend_from_slice(&prefix_tokens);
             merged.extend_from_slice(suffix_enc.token_ids());
             return Ok(merged);
         };
@@ -328,8 +337,15 @@ impl L1Cache {
         // Cumulative tokens up to `deepest` = matched prefix + the spanning segment.
         // Both `prefix_len` and `deepest` are special-token boundaries, so encoding the
         // span as one chunk and concatenating preserves the merge invariant.
+        // Encode both segments up front so `cumulative` can be reserved to its final
+        // size (prefix + seg_a + seg_b) — this eliminates the two grow-reallocs (each of
+        // which re-copied the whole large prefix) the previous Vec-append path incurred.
         let seg_a = tokenizer.encode(&input[prefix_len..deepest])?;
-        let mut cumulative = prefix_tokens;
+        let seg_b = tokenizer.encode(&input[deepest..])?;
+        let mut cumulative = Vec::with_capacity(
+            prefix_tokens.len() + seg_a.token_ids().len() + seg_b.token_ids().len(),
+        );
+        cumulative.extend_from_slice(&prefix_tokens);
         cumulative.extend_from_slice(seg_a.token_ids());
 
         // Key is blake3 of input[0..deepest]. Built with the same streaming idiom as
@@ -339,14 +355,15 @@ impl L1Cache {
         hasher.update(&input.as_bytes()[..deepest]);
         let hash_bytes: Blake3Hash = *hasher.finalize().as_bytes();
 
+        // Snapshot prefix+seg_a (`as_slice().into()` copies only the populated len, not the
+        // reserved capacity) and cache it.
         let tokens: Arc<[TokenIdType]> = cumulative.as_slice().into();
         self.cache.insert(hash_bytes, tokens);
 
-        // Tokenize the trailing segment after `deepest` for the returned result.
-        let seg_b = tokenizer.encode(&input[deepest..])?;
-        let mut merged = cumulative;
-        merged.extend_from_slice(seg_b.token_ids());
-        Ok(merged)
+        // Append the trailing segment for the returned result — no realloc, capacity was
+        // reserved above.
+        cumulative.extend_from_slice(seg_b.token_ids());
+        Ok(cumulative)
     }
 
     /// Number of live entries. Flushes moka's deferred maintenance first so the count is

--- a/lib/tokenizers/src/cache/l1.rs
+++ b/lib/tokenizers/src/cache/l1.rs
@@ -153,10 +153,7 @@ impl L1Cache {
     /// extends the cached tokens with a fresh encode of `input[byte_offset..]`;
     /// `deepest_boundary` is the deepest special-token boundary in `input` (end-exclusive),
     /// handed back so [`extend_after_match`] need not rescan the input for it.
-    pub fn longest_prefix_match(
-        &self,
-        input: &str,
-    ) -> Option<(Arc<[TokenIdType]>, usize, usize)> {
+    pub fn longest_prefix_match(&self, input: &str) -> Option<(Arc<[TokenIdType]>, usize, usize)> {
         let boundaries = self.boundaries(input);
 
         if boundaries.is_empty() {
@@ -327,8 +324,7 @@ impl L1Cache {
             // once and merge, identical to the non-extend hit path. Reserve exact capacity
             // so the prefix isn't re-copied by a Vec grow-realloc.
             let suffix_enc = tokenizer.encode(&input[prefix_len..])?;
-            let mut merged =
-                Vec::with_capacity(prefix_tokens.len() + suffix_enc.token_ids().len());
+            let mut merged = Vec::with_capacity(prefix_tokens.len() + suffix_enc.token_ids().len());
             merged.extend_from_slice(&prefix_tokens);
             merged.extend_from_slice(suffix_enc.token_ids());
             return Ok(merged);

--- a/lib/tokenizers/src/cache/mod.rs
+++ b/lib/tokenizers/src/cache/mod.rs
@@ -149,7 +149,7 @@ impl Encoder for CachedTokenizer {
         {
             let suffix = &input[prefix_len..];
             if suffix.is_empty() {
-                return Ok(Encoding::Sp(prefix_tokens));
+                return Ok(Encoding::Sp(prefix_tokens.to_vec()));
             }
             if self.extend_on_hit {
                 // Cache the new suffix at its deepest boundary so the next turn hits
@@ -164,7 +164,11 @@ impl Encoder for CachedTokenizer {
                 )?));
             }
             let suffix_enc = self.inner.encode(suffix)?;
-            let mut merged: Vec<TokenIdType> = prefix_tokens;
+            // Reserve exact capacity so appending the suffix doesn't grow-realloc and
+            // re-copy the (large) cached prefix.
+            let mut merged: Vec<TokenIdType> =
+                Vec::with_capacity(prefix_tokens.len() + suffix_enc.token_ids().len());
+            merged.extend_from_slice(&prefix_tokens);
             merged.extend_from_slice(suffix_enc.token_ids());
             return Ok(Encoding::Sp(merged));
         }


### PR DESCRIPTION
## Summary

Three independent, **profile-guided** optimizations to the frontend hot path, found while profiling a mock-worker benchmark (one frontend pinned to 4 cores, 4 `dynamo.mocker` workers, KV routing, 1 GiB tokenizer cache, Qwen3-0.6B; 48k-token shared system prompt + 12k per-session context, concurrency 256). On-CPU `perf` profiling guided each change.

### 1. Tokenizer L1 cache — don't clone the cached prefix on a hit (`lib/tokenizers`)
On an L1 prefix-cache hit the cache stores prefixes as `Arc<[TokenIdType]>`, but `longest_prefix_match` returned `tokens.to_vec()` — cloning the entire cached prefix (~192 KB for a 48k-token shared system prompt) on **every** request. The merge path then grew the exact-capacity `Vec`, re-copying the prefix again via realloc.
- Return the shared `Arc`; callers materialize a `Vec` with exact reserved capacity.
- Profile: `_int_realloc` ~3.2% → ~0; the cache's own alloc/copy footprint → ~0.3%.

### 2. Frontend metrics — cache per-model handles in `ResponseMetricCollector` (`lib/llm`)
The collector resolved its per-model Prometheus handles via `with_label_values(&[model])` on **every streamed chunk** — and for inter-token latency on **every output token** (the `observe` was inside `for _ in 0..num_tokens`), re-hashing the `model` label and taking the metric-vec lock each time.
- Resolve the five model-keyed handles once at construction; hoist the ITL handle out of the per-token loop.
- Profile: `with_label_values` self-time ~1.39% → ~0.65%. Metric values unchanged (handles share state with the vec); new test added.

### 3. Logging — cap `log`-crate trace at compile time (`lib/runtime`)
Dependencies that log via the `log` crate route events into tracing through the `log`→tracing bridge, which leaves `log`'s max level at TRACE. The HF `tokenizers` crate emits a `log::trace!` **per character** in `NormalizedString::transform_range`, so on the stock (`DYN_TOKENIZER=default`) path each request pushed *tens of thousands* of filtered-out trace events through the full build-record → bridge → `EnvFilter` → discard path.
- Enable the `log` crate's `release_max_level_debug` feature so `log::trace!` compiles to a no-op in release.
- Profile (default tokenizer): tracing/log filter machinery **~49% → ~0.9%**, steady frontend CPU **~394% → ~261%**.
- **End-to-end throughput (stock tokenizer): ~1.45× (+45%)** — ~275 vs ~189 req/s.
- Capped at `debug` (not `info`) so dep/Dynamo `log::debug!` (e.g. NATS transport) is retained in release; only the `trace!` spam is removed. Dynamo's own logging is `tracing` (separate crate), unaffected — `DYN_LOG=trace` still surfaces all Dynamo logs in release. No-op on the fastokens path (it doesn't emit these).

## Testing
- `cargo test -p dynamo-llm --lib http::service::metrics` — 31 passed (incl. new `test_cached_handles_record_through_vec`).
- `cargo test -p dynamo-runtime --lib metrics::frontend_perf` — passed.
- Streaming + non-streaming smoke checks; `/metrics` confirms live recording unchanged.

## Notes
- The three commits are independent and can be reviewed/split separately.

### Note on the `release_max_level_debug` behavior change (commit 3)
The cap is a **single global, compile-time** gate (the `log` crate can't represent `tracing`'s per-target `EnvFilter`), so in **release** builds it removes **all** `log`-crate `trace!` — not just tokenizers':
- **Dependency-internal `log::trace!`** (hyper / h2 / rustls / kube, …): no longer visible in a release build even via `DYN_LOG=…=trace`. Recoverable with a debug build. (`debug!`/`info!`/`warn!`/`error!` are retained.)
- **~11 of Dynamo's own `log::trace!`** in `lib/llm/src/kv/reuse.rs` (static-string channel-teardown diagnostics like `"…ack; receiver dropped"`, benign during cancellation/shutdown) — also compiled out in release.

Cleaner long-term fix: Dynamo has ~39 stray `log::` calls that don't follow its `tracing` convention (11 `trace!` in `kv/reuse.rs` + ~28 `debug!/info!/warn!` in `runtime/src/transports/nats.rs`). Converting those to `tracing::` would make them `DYN_LOG`-controllable *and* immune to the cap, so only true third-party `log` noise is affected. Left out of this PR to keep it focused; happy to do it here or as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized metrics collection processing to reduce overhead on frequently-executed code paths.
  * Improved tokenizer cache efficiency through optimized memory handling.

* **Chores**
  * Updated logging configuration to reduce trace output volume in release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->