### PR TITLE
fix: gate KV indexer test endpoints behind an env flag

### DIFF
--- a/lib/kv-router/src/standalone_indexer/server.rs
+++ b/lib/kv-router/src/standalone_indexer/server.rs
@@ -24,6 +24,21 @@ use super::registry::{IndexerKey, ListenerControlError, WorkerRegistry};
 /// We need to fit one million tokens as JSON text, this should do it.
 const QUERY_REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
+/// Gates the listener-control test endpoints; unset in production, set by the
+/// e2e harness. Accepts `1`/`true`/`yes`/`on`.
+const DYN_KV_INDEXER_TEST_ENDPOINTS: &str = "DYN_KV_INDEXER_TEST_ENDPOINTS";
+
+fn test_endpoints_enabled() -> bool {
+    matches!(
+        std::env::var(DYN_KV_INDEXER_TEST_ENDPOINTS)
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 pub struct AppState {
     pub registry: Arc<WorkerRegistry>,
     #[cfg(feature = "metrics")]
@@ -521,6 +536,12 @@ async fn handle_metrics(State(state): State<Arc<AppState>>) -> impl IntoResponse
 }
 
 pub fn create_router(state: Arc<AppState>) -> Router {
+    build_router(state, test_endpoints_enabled())
+}
+
+/// Mounts the listener-control test endpoints only when `test_endpoints` is
+/// true; the explicit parameter lets tests exercise both states.
+fn build_router(state: Arc<AppState>, test_endpoints: bool) -> Router {
     let router = Router::new()
         .route("/register", post(register))
         .route("/unregister", post(unregister))
@@ -536,10 +557,18 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/peers", get(list_peers))
         .route("/health", get(handle_health));
 
-    let router = router
-        .route("/test/pause_listener", post(test_pause_listener))
-        .route("/test/resume_listener", post(test_resume_listener))
-        .with_state(state.clone());
+    let mut router = router;
+    if test_endpoints {
+        tracing::warn!(
+            "Mounting listener-control test endpoints (/test/pause_listener, \
+             /test/resume_listener). These manipulate worker listener state and must never be \
+             enabled in production."
+        );
+        router = router
+            .route("/test/pause_listener", post(test_pause_listener))
+            .route("/test/resume_listener", post(test_resume_listener));
+    }
+    let router = router.with_state(state.clone());
 
     #[cfg(feature = "metrics")]
     let router = {
@@ -708,6 +737,66 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    fn empty_indexer_router(test_endpoints: bool) -> Router {
+        build_router(
+            Arc::new(AppState {
+                registry: Arc::new(WorkerRegistry::new(1)),
+                #[cfg(feature = "metrics")]
+                prom_registry: prometheus::Registry::new(),
+            }),
+            test_endpoints,
+        )
+    }
+
+    /// Malformed body so the states are distinguishable: an unmounted route
+    /// 404s before parsing, a mounted handler rejects it with a non-404. (A
+    /// valid body would 404 via `WorkerNotFound` either way.)
+    async fn post_malformed(app: &Router, uri: &str) -> StatusCode {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("not json"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
+    const LISTENER_CONTROL_ROUTES: [&str; 2] = ["/test/pause_listener", "/test/resume_listener"];
+
+    #[tokio::test]
+    async fn listener_control_endpoints_are_not_mounted_by_default() {
+        let app = empty_indexer_router(false);
+        for uri in LISTENER_CONTROL_ROUTES {
+            assert_eq!(
+                post_malformed(&app, uri).await,
+                StatusCode::NOT_FOUND,
+                "{uri} must not be mounted unless test endpoints are explicitly enabled"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn listener_control_endpoints_are_mounted_when_enabled() {
+        let app = empty_indexer_router(true);
+        for uri in LISTENER_CONTROL_ROUTES {
+            let status = post_malformed(&app, uri).await;
+            assert_ne!(
+                status,
+                StatusCode::NOT_FOUND,
+                "{uri} should be mounted and reject the malformed body, not 404"
+            );
+            assert!(
+                status.is_client_error(),
+                "{uri} should reject the malformed body with a 4xx, got {status}"
+            );
+        }
     }
 
     // ── /workers endpoint tests ───────────────────────────────────────────────

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -38,6 +38,14 @@ def get_kv_indexer_command() -> list[str]:
     return [sys.executable, "-m", "dynamo.indexer"]
 
 
+def get_kv_indexer_test_env() -> Dict[str, str]:
+    """Indexer launch env that enables the listener-control test endpoints
+    (gated off by default; used by the ZMQ replay scenario)."""
+    env = os.environ.copy()
+    env["DYN_KV_INDEXER_TEST_ENDPOINTS"] = "1"
+    return env
+
+
 def assert_event_dumps_equal(
     expected: list[dict],
     actual: list[dict],

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -42,6 +42,7 @@ from tests.router.common import (
 from tests.router.helper import (
     generate_random_suffix,
     get_kv_indexer_command,
+    get_kv_indexer_test_env,
     get_runtime,
     poll_for_worker_instances,
     topology_env,
@@ -418,6 +419,7 @@ class MockerProcess:
                 log_dir=self._request.node.name,
                 terminate_all_matching_process_names=False,
                 display_name="dynamo-kv-indexer",
+                env=get_kv_indexer_test_env(),
             )
             logger.info(
                 f"Starting standalone indexer on port {self._standalone_indexer_port}"
@@ -587,6 +589,7 @@ class MockerProcess:
             log_dir=self._request.node.name,
             terminate_all_matching_process_names=False,
             display_name="dynamo-kv-indexer-b",
+            env=get_kv_indexer_test_env(),
         )
         logger.info(
             f"Starting standalone indexer B on port {self._standalone_indexer_b_port} "

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -25,6 +25,7 @@ from tests.router.e2e_harness import (
 from tests.router.helper import (
     generate_random_suffix,
     get_kv_indexer_command,
+    get_kv_indexer_test_env,
     wait_for_indexer_workers_active,
 )
 from tests.utils.constants import DefaultPort
@@ -340,6 +341,7 @@ class VLLMProcess(ManagedEngineProcessMixin):
             log_dir=self._request.node.name,
             terminate_all_matching_process_names=False,
             display_name="dynamo-kv-indexer",
+            env=get_kv_indexer_test_env(),
         )
         logger.info(
             "Starting standalone indexer on port %s", self._standalone_indexer_port
@@ -472,6 +474,7 @@ class VLLMProcess(ManagedEngineProcessMixin):
             log_dir=self._request.node.name,
             terminate_all_matching_process_names=False,
             display_name="dynamo-kv-indexer-b",
+            env=get_kv_indexer_test_env(),
         )
         logger.info(
             "Starting standalone indexer B on port %s with peer http://localhost:%s",


### PR DESCRIPTION
## Summary

The standalone KV indexer unconditionally mounted `/test/pause_listener` and `/test/resume_listener`, shipping listener-control debug code in the production binary (CWE-489 — Active Debug Code). These routes mutate worker ZMQ listener state and are used **only** by the router e2e ZMQ-replay scenario; nothing in production calls them.

This gates them behind the `DYN_KV_INDEXER_TEST_ENDPOINTS` env flag (default **off**):
- Production leaves it unset → the routes are never mounted.
- The router e2e harness sets it → the replay scenario keeps working.

`create_router` now delegates to `build_router(state, test_endpoints)` so the gate is injectable and both the mounted and unmounted states are unit-tested directly.

## Changes
- `lib/kv-router/src/standalone_indexer/server.rs`: env-flag gate + `build_router` refactor; two tests asserting the routes are absent by default and present (rejecting a malformed body with a non-404 4xx) when enabled.
- `tests/router/helper.py`: `get_kv_indexer_test_env()` sets the flag.
- `tests/router/test_router_e2e_with_mockers.py`, `tests/router/test_router_e2e_with_vllm.py`: pass that env to all standalone-indexer launches.

## Tests / checks run
- `cargo check -p dynamo-kv-router --features standalone-indexer` — clean
- `cargo test -p dynamo-kv-router --features standalone-indexer` standalone-indexer suites — 23 unit + 4 HTTP integration pass
- Mutation check: forcing the gate open makes the default-off test fail (confirms the regression check bites)
- `cargo fmt --check`, `pre-commit` (black/isort/flake8/ruff/codespell), `py_compile` — all pass

## Notes
The malformed-body test is deliberate: a well-formed request to a nonexistent worker returns 404 via `WorkerNotFound` whether or not the route is mounted, so it could not distinguish the two states. A malformed body 404s at routing when unmounted but is rejected with a 4xx by the extractor when mounted.

Refs: DYN-2627
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced environment-controlled gating for indexer listener management endpoints. Test endpoints for pausing and resuming listeners are now disabled by default and only enabled via explicit configuration.

* **Tests**
  * Added test coverage validating listener-control endpoints are properly gated and correctly respond when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->