### PR TITLE
fix(frontend): return HTTP 415 for unsupported image formats instead of 500

### DIFF
--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -223,7 +223,9 @@ class ImageLoader:
             except Exception as e:
                 if "Unsupported image format" in str(e):
                     logger.error(f"Unsupported image format decoding: '{image_url}'")
-                    raise HttpStatusError(415, "Unsupported Media Type", image_url) from e
+                    raise HttpStatusError(
+                        415, "Unsupported Media Type", image_url
+                    ) from e
                 logger.error(f"{type(e).__name__} decoding image: '{image_url}': {e}")
                 raise ValueError(f"Failed to decoding image: '{image_url}': {e}") from e
 
@@ -248,7 +250,10 @@ class ImageLoader:
             List of loaded image data
 
         Raises:
-            Exception: If any image fails to load
+            HttpStatusError: If any image fails with an HTTP status error
+                (e.g. 415 Unsupported Media Type); the status is preserved so the
+                frontend returns the correct client-error code instead of 500.
+            Exception: If any image fails to load for any other reason
             ValueError: If enable_frontend_decoding=True but nixl_connector is None
         """
         image_futures = []
@@ -276,6 +281,7 @@ class ImageLoader:
         results = await asyncio.gather(*image_futures, return_exceptions=True)
         loaded_images = []
         collective_exceptions = ""
+        status_error: HttpStatusError | None = None
         for media_item, result in zip(image_mm_items, results):
             if isinstance(result, Exception):
                 source = media_item.get(URL_VARIANT_KEY, "decoded")
@@ -283,8 +289,17 @@ class ImageLoader:
                 collective_exceptions += (
                     f"Failed to load image from {source[:80]}...: {result}\n"
                 )
+                # Preserve HTTP status semantics (e.g. 415 Unsupported Media Type).
+                # Folding an HttpStatusError into a generic Exception below would
+                # strip the status and force the frontend back to a 500. Surface
+                # the first one so single-item batches keep their client-error code.
+                if status_error is None and isinstance(result, HttpStatusError):
+                    status_error = result
                 continue
             loaded_images.append(result)
+
+        if status_error is not None:
+            raise status_error
 
         if collective_exceptions:
             raise Exception(collective_exceptions)

--- a/components/src/dynamo/common/multimodal/image_loader.py
+++ b/components/src/dynamo/common/multimodal/image_loader.py
@@ -140,6 +140,15 @@ class ImageLoader:
         except HttpError as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise
+        except Image.UnidentifiedImageError as e:
+            logger.error(f"Unsupported image format loading: '{image_url}'")
+            raise HttpStatusError(415, "Unsupported Media Type", image_url) from e
+        except ValueError as e:
+            if "Unsupported image format" in str(e):
+                logger.error(f"Unsupported image format loading: '{image_url}'")
+                raise HttpStatusError(415, "Unsupported Media Type", image_url) from e
+            logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
+            raise ValueError(f"Failed to load image: '{image_url}': {e}") from e
         except Exception as e:
             logger.error(f"{type(e).__name__} loading image: '{image_url}': {e}")
             raise ValueError(f"Failed to load image: '{image_url}': {e}") from e
@@ -208,7 +217,13 @@ class ImageLoader:
                         raise ValueError(f"Invalid base64 encoding: {e}") from e
                     image_data = BytesIO(image_bytes)
                 return await self._open_image(image_data)
+            except Image.UnidentifiedImageError as e:
+                logger.error(f"Unsupported image format decoding: '{image_url}'")
+                raise HttpStatusError(415, "Unsupported Media Type", image_url) from e
             except Exception as e:
+                if "Unsupported image format" in str(e):
+                    logger.error(f"Unsupported image format decoding: '{image_url}'")
+                    raise HttpStatusError(415, "Unsupported Media Type", image_url) from e
                 logger.error(f"{type(e).__name__} decoding image: '{image_url}': {e}")
                 raise ValueError(f"Failed to decoding image: '{image_url}': {e}") from e
 

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -16,6 +16,7 @@
 """Tests for ImageLoader in-flight dedup, cancellation, and error contract."""
 
 import asyncio
+import base64
 from io import BytesIO
 from unittest.mock import AsyncMock, patch
 
@@ -24,7 +25,7 @@ from PIL import Image
 
 from dynamo.common.http import HttpStatusError, HttpTimeoutError
 from dynamo.common.http.url_validator import UrlValidationPolicy
-from dynamo.common.multimodal.image_loader import ImageLoader
+from dynamo.common.multimodal.image_loader import URL_VARIANT_KEY, ImageLoader
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -240,11 +241,34 @@ async def test_unsupported_format_url_raises_415(loader: ImageLoader) -> None:
 
 async def test_unsupported_format_data_url_raises_415(loader: ImageLoader) -> None:
     """A data: URL carrying an SVG payload should raise HttpStatusError 415."""
-    import base64
-
     svg_b64 = base64.b64encode(_make_svg_bytes()).decode()
     with pytest.raises(HttpStatusError) as exc_info:
         await loader.load_image(f"data:image/svg+xml;base64,{svg_b64}")
+    assert exc_info.value.status == 415
+
+
+async def test_unsupported_format_batch_url_raises_415(loader: ImageLoader) -> None:
+    """The batch path must preserve the 415 status instead of collapsing it into a
+    generic Exception. This is the path the frontend actually drives, so the status
+    has to survive load_image_batch's exception aggregation."""
+    mock_fetch = _mock_fetch_bytes(content=_make_svg_bytes())
+    with patch(_FETCH_BYTES_PATH, mock_fetch):
+        with pytest.raises(HttpStatusError) as exc_info:
+            await loader.load_image_batch(
+                [{URL_VARIANT_KEY: "https://example.com/image.svg"}]
+            )
+        assert exc_info.value.status == 415
+
+
+async def test_unsupported_format_batch_data_url_raises_415(
+    loader: ImageLoader,
+) -> None:
+    """The batch path must preserve the 415 status for data: URLs as well."""
+    svg_b64 = base64.b64encode(_make_svg_bytes()).decode()
+    with pytest.raises(HttpStatusError) as exc_info:
+        await loader.load_image_batch(
+            [{URL_VARIANT_KEY: f"data:image/svg+xml;base64,{svg_b64}"}]
+        )
     assert exc_info.value.status == 415
 
 

--- a/components/src/dynamo/common/tests/multimodal/test_image_loader.py
+++ b/components/src/dynamo/common/tests/multimodal/test_image_loader.py
@@ -224,6 +224,30 @@ async def test_cache_hit_skips_fetch(loader: ImageLoader) -> None:
     assert result is img
 
 
+def _make_svg_bytes() -> bytes:
+    return b"<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'/>"
+
+
+async def test_unsupported_format_url_raises_415(loader: ImageLoader) -> None:
+    """Fetching a URL that returns an unsupported image format (e.g. SVG) should raise
+    HttpStatusError with status 415, not 500."""
+    mock_fetch = _mock_fetch_bytes(content=_make_svg_bytes())
+    with patch(_FETCH_BYTES_PATH, mock_fetch):
+        with pytest.raises(HttpStatusError) as exc_info:
+            await loader.load_image("https://example.com/image.svg")
+        assert exc_info.value.status == 415
+
+
+async def test_unsupported_format_data_url_raises_415(loader: ImageLoader) -> None:
+    """A data: URL carrying an SVG payload should raise HttpStatusError 415."""
+    import base64
+
+    svg_b64 = base64.b64encode(_make_svg_bytes()).decode()
+    with pytest.raises(HttpStatusError) as exc_info:
+        await loader.load_image(f"data:image/svg+xml;base64,{svg_b64}")
+    assert exc_info.value.status == 415
+
+
 async def test_cache_is_lru_not_fifo(loader: ImageLoader) -> None:
     """Accessing a cached entry should protect it from eviction (LRU, not FIFO)."""
     loader._cache_size = 3


### PR DESCRIPTION
## Summary

When a client submits an image in an unsupported format (e.g. SVG), `ImageLoader` was returning HTTP 500 instead of the semantically correct 415 Unsupported Media Type.

**Root cause:** `Image.open(..., formats=["JPEG", "PNG", "WEBP"])` raises `PIL.UnidentifiedImageError` for any unrecognized format. This was caught by the generic `except Exception` handler in `_fetch_and_process` and re-wrapped as `ValueError`, causing the frontend to return 500.

**Fix:** Catch `Image.UnidentifiedImageError` explicitly (and the belt-and-suspenders `ValueError("Unsupported image format: ...")` from `_open_image_sync`) in both code paths — the HTTP/HTTPS path in `_fetch_and_process` and the `data:` URL branch in `load_image` — and raise `HttpStatusError(415, "Unsupported Media Type", url)` instead. The existing `HttpStatusError` passthrough in the frontend delivers the correct 415 to the client.

## Files changed

- `components/src/dynamo/common/multimodal/image_loader.py` — two exception handlers patched
- `components/src/dynamo/common/tests/multimodal/test_image_loader.py` — two new unit tests

## Test plan

- [x] `test_unsupported_format_url_raises_415` — SVG served at an HTTP URL raises `HttpStatusError(415)`
- [x] `test_unsupported_format_data_url_raises_415` — SVG in a `data:` URL raises `HttpStatusError(415)`
- [x] All existing `test_image_loader.py` tests still pass
- [x] Tests are `gpu_0` (CPU-only, no GPU required)

Fixes #10263
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced error handling for unsupported image formats. When encountering incompatible image types (such as SVG files), the system now provides a clearer "Unsupported Media Type" error message instead of a generic error. This applies to images loaded from URLs and embedded data URLs, improving user experience when dealing with format incompatibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->