### PR TITLE
fix(frontend): merge leading system messages to fix Codex CLI first-turn failure

### DIFF
--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -722,7 +722,17 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                     .map(|m| match m {
                         ChatCompletionRequestMessage::System(s) => match &s.content {
                             ChatCompletionRequestSystemMessageContent::Text(t) => t.as_str(),
-                            _ => "",
+                            // Today this converter only ever builds `Text` system
+                            // content, so the merge is lossless.  Log loudly if a
+                            // non-text variant (e.g. `Array`, should async-openai
+                            // start emitting it) reaches here so the dropped
+                            // content is diagnosable instead of silently lost.
+                            other => {
+                                tracing::debug!(
+                                    "dropping non-text system message content during leading-system merge: {other:?}"
+                                );
+                                ""
+                            }
                         },
                         _ => unreachable!(),
                     })

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -1314,24 +1314,26 @@ mod tests {
         let messages = &chat_req.inner.messages;
 
         // Must be exactly 2 messages: one merged System + one User
-        assert_eq!(messages.len(), 2, "expected merged system + user, got {messages:?}");
+        assert_eq!(
+            messages.len(),
+            2,
+            "expected merged system + user, got {messages:?}"
+        );
 
         match &messages[0] {
-            ChatCompletionRequestMessage::System(sys) => {
-                match &sys.content {
-                    ChatCompletionRequestSystemMessageContent::Text(t) => {
-                        assert!(
-                            t.contains("You are a coding agent."),
-                            "merged text missing instructions: {t}"
-                        );
-                        assert!(
-                            t.contains("Follow safety guidelines."),
-                            "merged text missing developer content: {t}"
-                        );
-                    }
-                    _ => panic!("expected text content"),
+            ChatCompletionRequestMessage::System(sys) => match &sys.content {
+                ChatCompletionRequestSystemMessageContent::Text(t) => {
+                    assert!(
+                        t.contains("You are a coding agent."),
+                        "merged text missing instructions: {t}"
+                    );
+                    assert!(
+                        t.contains("Follow safety guidelines."),
+                        "merged text missing developer content: {t}"
+                    );
                 }
-            }
+                _ => panic!("expected text content"),
+            },
             _ => panic!("expected system message at index 0"),
         }
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -704,6 +704,41 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             }
         }
 
+        // Merge any run of leading system messages into one.
+        //
+        // Some chat templates (e.g. Qwen's tool_use template) reject requests
+        // that have more than one system message at the start.  A Codex CLI
+        // first-turn request commonly produces two: one from `instructions` and
+        // one from a `developer`-role input item.  Concatenate them here with a
+        // newline separator so the backend sees exactly one system message.
+        {
+            let leading_system_count = messages
+                .iter()
+                .take_while(|m| matches!(m, ChatCompletionRequestMessage::System(_)))
+                .count();
+            if leading_system_count > 1 {
+                let combined: String = messages[..leading_system_count]
+                    .iter()
+                    .map(|m| match m {
+                        ChatCompletionRequestMessage::System(s) => match &s.content {
+                            ChatCompletionRequestSystemMessageContent::Text(t) => t.as_str(),
+                            _ => "",
+                        },
+                        _ => unreachable!(),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                messages.drain(0..leading_system_count);
+                messages.insert(
+                    0,
+                    ChatCompletionRequestMessage::System(ChatCompletionRequestSystemMessage {
+                        content: ChatCompletionRequestSystemMessageContent::Text(combined),
+                        name: None,
+                    }),
+                );
+            }
+        }
+
         let top_logprobs = convert_top_logprobs(resp.inner.top_logprobs);
 
         // Convert tools if present
@@ -1244,6 +1279,66 @@ mod tests {
             },
             _ => panic!("expected system message first"),
         }
+    }
+
+    #[test]
+    fn test_instructions_and_developer_role_merged_into_single_system_message() {
+        // Codex CLI sends `instructions` + a `developer`-role input item.
+        // Both convert to System messages; backends like Qwen reject more than one.
+        let req = NvCreateResponse {
+            inner: CreateResponse {
+                instructions: Some("You are a coding agent.".into()),
+                input: InputParam::Items(vec![
+                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
+                        content: vec![InputContent::InputText(InputTextContent {
+                            text: "Follow safety guidelines.".into(),
+                        })],
+                        role: InputRole::Developer,
+                        status: None,
+                    }))),
+                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
+                        content: vec![InputContent::InputText(InputTextContent {
+                            text: "What is 2+2?".into(),
+                        })],
+                        role: InputRole::User,
+                        status: None,
+                    }))),
+                ]),
+                model: Some("test-model".into()),
+                ..Default::default()
+            },
+            nvext: None,
+        };
+
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        let messages = &chat_req.inner.messages;
+
+        // Must be exactly 2 messages: one merged System + one User
+        assert_eq!(messages.len(), 2, "expected merged system + user, got {messages:?}");
+
+        match &messages[0] {
+            ChatCompletionRequestMessage::System(sys) => {
+                match &sys.content {
+                    ChatCompletionRequestSystemMessageContent::Text(t) => {
+                        assert!(
+                            t.contains("You are a coding agent."),
+                            "merged text missing instructions: {t}"
+                        );
+                        assert!(
+                            t.contains("Follow safety guidelines."),
+                            "merged text missing developer content: {t}"
+                        );
+                    }
+                    _ => panic!("expected text content"),
+                }
+            }
+            _ => panic!("expected system message at index 0"),
+        }
+
+        assert!(
+            matches!(messages[1], ChatCompletionRequestMessage::User(_)),
+            "expected user message at index 1"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -727,7 +727,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
                         _ => unreachable!(),
                     })
                     .collect::<Vec<_>>()
-                    .join("\n");
+                    .join("\n\n");
                 messages.drain(0..leading_system_count);
                 messages.insert(
                     0,


### PR DESCRIPTION
## Summary

**Root cause:** OpenAI Codex CLI sends `/v1/responses` requests with both a top-level `instructions` field and one or more `developer`-role items in `input`. The frontend converts each independently to a `System` chat message, producing a sequence like:

```
[System("You are a coding agent..."), System("Follow safety guidelines."), User("task")]
```

Qwen's `tool_use` chat template rejects multi-system-message prompts:
```
Failed to apply prompt template: invalid operation: System message must be at the beginning.
```

The frontend returns HTTP 500. Codex CLI surfaces this as "We're currently experiencing high demand" — not visibly a template error.

**Fix:** After building the full message list in `TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest`, detect any run of consecutive `System` messages at the front and concatenate them into one (newline-separated). The merge is lossless and transparent to backends that accept multiple system messages.

## Files changed

- `lib/llm/src/protocols/openai/responses/mod.rs` — merge logic added after input conversion; one new unit test

## Test plan

- [x] `test_instructions_and_developer_role_merged_into_single_system_message` — verifies instructions + developer item → single System message + User message (no GPU required)
- [x] Existing `test_instructions_prepended_as_system_message` still passes (single System, no merge needed)
- [x] Existing `test_input_items_multi_turn` still passes (System + User + Assistant + User, no leading merge triggered)

Fixes #10206
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system message consolidation to properly merge multiple system messages when both instructions and developer inputs are provided, ensuring a single consolidated system message in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->