### PR TITLE
docs: bump quickstart container tags to 1.2.0

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -39,17 +39,17 @@ Containers have all dependencies pre-installed. Pick your backend:
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
     ```
   </Tab>
 </Tabs>

--- a/docs/getting-started/quickstart.zh-CN.mdx
+++ b/docs/getting-started/quickstart.zh-CN.mdx
@@ -39,17 +39,17 @@ Dynamo 与后端无关 — 每种安装路径都适用于 **SGLang**、**TensorR
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary
- The Quickstart **Pull a Container** section was pinned to a stale `1.0.2` tag.
- Bumps the `sglang-runtime` / `tensorrtllm-runtime` / `vllm-runtime` tags to `1.2.0`, matching the current default/latest published docs version and the local-installation guide.

This is the root-cause fix: versioned docs snapshots are frozen copies of `pages-dev` at tag time, so leaving the dev source stale propagated `1.0.2` into every release snapshot. (Already-published snapshots are corrected separately on the `docs-website` branch.)

## Test plan
- [ ] Fern preview renders the three backend tabs with `:1.2.0`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart guide with the latest container image versions for SGLang, TensorRT-LLM, and vLLM Docker images. These newer versions include recent improvements, performance enhancements, and bug fixes for better reliability and functionality in containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->