### PR TITLE
docs(fern): correct quickstart container tags in versioned snapshots

### DIFF
--- a/fern/pages-v1.0.1/getting-started/quickstart.md
+++ b/fern/pages-v1.0.1/getting-started/quickstart.md
@@ -28,13 +28,13 @@ Containers have all dependencies pre-installed. No setup required.
 
 ```bash
 # SGLang
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.0
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.1
 
 # TensorRT-LLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.0
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.1
 
 # vLLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.0
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
 ```
 
 See [Release Artifacts](../reference/release-artifacts.md#container-images) for available

--- a/fern/pages-v1.0.2/getting-started/quickstart.md
+++ b/fern/pages-v1.0.2/getting-started/quickstart.md
@@ -28,13 +28,13 @@ Containers have all dependencies pre-installed. No setup required.
 
 ```bash
 # SGLang
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
 
 # TensorRT-LLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
 
 # vLLM
-docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
 ```
 
 See [Release Artifacts](../reference/release-artifacts.md#container-images) for available

--- a/fern/pages-v1.1.0/getting-started/quickstart.mdx
+++ b/fern/pages-v1.1.0/getting-started/quickstart.mdx
@@ -35,17 +35,17 @@ Containers have all dependencies pre-installed. Pick your backend:
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.0
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0
     ```
   </Tab>
 </Tabs>

--- a/fern/pages-v1.1.1/getting-started/quickstart.mdx
+++ b/fern/pages-v1.1.1/getting-started/quickstart.mdx
@@ -35,17 +35,17 @@ Containers have all dependencies pre-installed. Pick your backend:
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.1.1
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
     ```
   </Tab>
 </Tabs>

--- a/fern/pages-v1.2.0/getting-started/quickstart.mdx
+++ b/fern/pages-v1.2.0/getting-started/quickstart.mdx
@@ -39,17 +39,17 @@ Containers have all dependencies pre-installed. Pick your backend:
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
     ```
   </Tab>
 </Tabs>

--- a/fern/pages-v1.2.0/getting-started/quickstart.zh-CN.mdx
+++ b/fern/pages-v1.2.0/getting-started/quickstart.zh-CN.mdx
@@ -39,17 +39,17 @@ Dynamo 与后端无关 — 每种安装路径都适用于 **SGLang**、**TensorR
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.0
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.2
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary
Corrects the per-version Quickstart **Pull a Container** tags in the published `docs-website` snapshots. Each snapshot was frozen from `pages-dev` at tag time while the dev source still read `1.0.2`, so the runtime tags drifted behind their own version.

| Version | Before | After |
|---|---|---|
| v1.0.1 | 1.0.0 | 1.0.1 |
| v1.0.2 | 1.0.1 | 1.0.2 |
| v1.1.0 | 1.0.2 | 1.1.0 |
| v1.1.1 | 1.0.2 | 1.1.1 |
| v1.2.0 (+ zh-CN) | 1.0.2 | 1.2.0 |

Each tag now matches that snapshot's own `local-installation` guide. The dev/source fix lands separately on `main`; merging that PR triggers the Fern publish that pushes these snapshot corrections live.

## Test plan
- [ ] Spot-check published v1.1.1 + v1.2.0 Quickstart tabs after next publish

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->