### PR TITLE
perf: cap log-crate trace at compile time

### DIFF
--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -81,7 +81,18 @@ figment = { version = "0.10.19", features = ["env", "json", "toml", "test"] }
 notify = { version = "6.1", default-features = false, features = ["macos_fsevent"] }
 libc = { version = "0.2" }
 local-ip-address = { version = "0.6.3" }
-log = { version = "0.4" }
+# `release_max_level_debug` compiles out `log::trace!` in release builds (a
+# compile-time `STATIC_MAX_LEVEL` check — no runtime cost, cannot be overridden).
+# Dependencies that log through the `log` crate — notably HF `tokenizers`, whose
+# `NormalizedString::transform_range` emits a `log::trace!` *per character*
+# during normalization — otherwise route tens of thousands of filtered-out
+# events per request through the `log`->tracing bridge + EnvFilter, which
+# profiling showed costing ~half the frontend CPU on the stock-tokenizer path.
+# We cap at `debug` (not `info`) so `log::debug!` from deps and Dynamo's own
+# `log::debug!` (e.g. the NATS transport) are still available in release; only
+# the per-char `trace!` spam is removed. Dynamo's own logging is `tracing` (a
+# separate crate), so `DYN_LOG=trace` still surfaces all Dynamo logs in release.
+log = { version = "0.4", features = ["release_max_level_debug"] }
 nuid = { version = "0.5" }
 once_cell = { version = "1" }
 percent-encoding = { version = "2.3.2" } # also used by tonic, reqwest, axum, etc


### PR DESCRIPTION
Dependencies that log through the `log` crate route their events into tracing via the `log`->tracing bridge, which leaves `log`'s max level at TRACE so it can forward everything. The HF `tokenizers` crate's `NormalizedString::transform_range` emits a `log::trace!` *per character* during normalization, so on the stock (`DYN_TOKENIZER=default`) path each request pushed tens of thousands of filtered-out trace events through the full build-record -> bridge -> EnvFilter -> discard path. On-CPU profiling showed this consuming ~half of frontend CPU (steady ~394% of 4 cores; ~49% of samples in tracing/log filter machinery).

Enable the `log` crate's `release_max_level_debug` feature so `log::trace!` compiles to a no-op in release builds (a `STATIC_MAX_LEVEL` check). The per-char spam is removed at compile time, dropping the tracing/log machinery from ~49% to ~0.9% and frontend CPU from ~394% to ~261% on the default-tokenizer path. We cap at `debug` (not `info`) so `log::debug!` from deps and Dynamo (e.g. the NATS transport) remain in release; only the `trace!` spam is removed. Dynamo's own logging is `tracing` (a separate crate), unaffected -- `DYN_LOG=trace` still surfaces all Dynamo logs in release. fastokens is unaffected (it doesn't emit these).

On a long-context agentic benchmark, this PR leads to a 45% improvement in throughput through a single frontend.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized logging configuration in production builds to improve performance by reducing verbose log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->