### PR TITLE
refactor(mm-routing): generalize MM routing terminology

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -102,7 +102,7 @@ cat <<EOF
 
 Now build the project:
   cargo build --features dynamo-llm/block-manager
-  cd lib/bindings/python && maturin develop --uv --features lightseek-mm && cd $WORKSPACE_DIR
+  cd lib/bindings/python && maturin develop --uv --features mm-routing && cd $WORKSPACE_DIR
   uv pip install --no-deps -e $WORKSPACE_DIR
 
 Optional:

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -488,9 +488,9 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     uv build --wheel --out-dir /opt/dynamo/dist && \
     cd /opt/dynamo/lib/bindings/python && \
     if [ "$ENABLE_MEDIA_FFMPEG" = "true" ]; then \
-        maturin build --release --features "media-ffmpeg,kv-indexer,lightseek-mm,aic-forward-pass" --out /opt/dynamo/dist; \
+        maturin build --release --features "media-ffmpeg,kv-indexer,mm-routing,aic-forward-pass" --out /opt/dynamo/dist; \
     else \
-        maturin build --release --features "kv-indexer,lightseek-mm,aic-forward-pass" --out /opt/dynamo/dist; \
+        maturin build --release --features "kv-indexer,mm-routing,aic-forward-pass" --out /opt/dynamo/dist; \
     fi && \
     /tmp/use-sccache.sh show-stats "Dynamo Runtime"
 

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -39,8 +39,8 @@ Without MM-aware routing, the standard router treats image token blocks as opaqu
 The Rust frontend's MM-aware routing path supports whatever VLM families the
 `llm-multimodal` crate registers — see
 [`ImageProcessorRegistry::with_defaults()`](https://docs.rs/llm-multimodal/1.5.0/llm_multimodal/vision/image_processor/struct.ImageProcessorRegistry.html#method.with_defaults)
-for the up-to-date list. A model that crate doesn't recognize falls back to
-text-prefix-only KV routing (request still completes; just no prefix-cache
+for the up-to-date list. A model the registry doesn't recognize falls back
+to text-prefix-only KV routing (request still completes; just no prefix-cache
 benefit across images).
 
 The Python chat-processor variant doesn't share this constraint — it
@@ -52,12 +52,12 @@ supports.
 ### vLLM (default — Rust frontend)
 
 ```text
-Frontend (Rust + llm-multimodal + KV router) → Backend Workers
+Frontend (Rust + KV router) → Backend Workers
         │
         ├─ Hash image (xxh3_64 of the raw URL — full-URL identity; use --frontend-decoding for content-addressed hashing)
-        ├─ Resolve image-token id via the llm-multimodal per-model ModelProcessorSpec
+        ├─ Resolve image-token id via per-model ModelProcessorSpec
         ├─ Read (W, H) from a Range: 0-65535 header fetch (or in-memory data: bytes)
-        ├─ llm_multimodal::count_tokens(W, H) → expanded image-token count N
+        ├─ count_tokens(W, H) → expanded image-token count N
         ├─ Expand placeholder × N in routing_token_ids (worker token_ids unchanged)
         ├─ Build per-block MM metadata (block_mm_infos)
         ├─ KV router selects best worker
@@ -66,10 +66,10 @@ Frontend (Rust + llm-multimodal + KV router) → Backend Workers
 ```
 
 1. The Rust frontend computes an `mm_hash` per image: `xxh3_64` of the decoded bytes for `data:` URIs (and for `http(s)://` when `media_decoder` is enabled on the model), otherwise `xxh3_64` of the full URL string. Two callers will share an `mm_hash` only when they send byte-identical URLs.
-2. The image-placeholder token id is resolved by delegating to the `llm-multimodal` per-model `ModelProcessorSpec` (one spec per supported VLM family — Qwen3-VL, Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4, Kimi-K2.5). Each spec reads the appropriate `config.json` field for its model family (`image_token_id`, `image_token_index`, or `media_placeholder_token_id`) and falls back to probing the tokenizer's vocab when only the placeholder string is registered. Models the registry doesn't recognise fall back to text-prefix-only routing.
+2. The image-placeholder token id is resolved by delegating to a per-model `ModelProcessorSpec` (one spec per supported VLM family — Qwen3-VL, Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4, Kimi-K2.5). Each spec reads the appropriate `config.json` field for its model family (`image_token_id`, `image_token_index`, or `media_placeholder_token_id`) and falls back to probing the tokenizer's vocab when only the placeholder string is registered. Models the registry doesn't recognise fall back to text-prefix-only routing.
 
 > **Note:** Qwen3.5 / Qwen3.6 image token expansion is not yet supported in the Rust frontend for MM routing, so KV routing will only consider the text inputs + unexpanded image token placeholders. Support will come in a follow-up release.
-3. Per-image `(W, H)` is read from a 64KB `Range`-bounded header fetch (or from in-memory bytes for `data:` URIs); the `llm-multimodal` crate computes the per-image expanded token count.
+3. Per-image `(W, H)` is read from a 64KB `Range`-bounded header fetch (or from in-memory bytes for `data:` URIs); the image-processor registry computes the per-image expanded token count.
 4. The single placeholder token is expanded to N copies in `routing_token_ids` (a router-only view); the worker still sees one placeholder per image in `token_ids`.
 5. Per-block MM metadata (`block_mm_infos`) is built from the expanded view; the KV router evaluates overlap across workers including image-bearing blocks.
 6. The frontend forwards each image's `mm_hash` (16-hex-char prefix, padded) via `extra_args["mm_hashes"]`; the backend handler injects them as vLLM's `multi_modal_uuids`, so vLLM's own KV-cache key matches the hash the router used.
@@ -106,11 +106,11 @@ For TRT-LLM, a dedicated MM Router Worker sits between the frontend and backend 
 ### SGLang
 
 ```text
-Frontend (Rust + llm-multimodal + KV router) → SGLang Workers
+Frontend (Rust + KV router) → SGLang Workers
         │                                                       │
         ├─ Hash image (same xxh3_64 path as vLLM Rust)           │
         ├─ Resolve image-token id + (W, H) (same as vLLM Rust)   │
-        ├─ llm_multimodal::count_tokens(W, H) → expanded count N │
+        ├─ count_tokens(W, H) → expanded count N                 │
         ├─ Expand placeholder × N in routing_token_ids           │
         ├─ KV router selects best worker                         │
         ├─ Substitute pad_value per image in worker token_ids:   │
@@ -146,17 +146,11 @@ cd $DYNAMO_HOME
 bash examples/backends/vllm/launch/agg_multimodal_router.sh
 ```
 
-The Rust frontend uses the [`llm-multimodal`][llm-multimodal-crate] crate
-([source][llm-multimodal-src]) for per-image token-count and placeholder
-expansion. `llm-multimodal` provides a pure-Rust `calculate_num_tokens(W, H,
-PreProcessorConfig)` per VLM family (Qwen2/2.5/3-VL, LLaVA, Pixtral, …),
-golden-tested against `transformers`, so the router can match vLLM's
-expanded image-token count without invoking the HF image processor. The
-frontend then forwards each `mm_hash` to the worker as `multi_modal_uuids`
-so vLLM's KV events publish the same key the router computes.
-
-[llm-multimodal-crate]: https://crates.io/crates/llm-multimodal
-[llm-multimodal-src]: https://github.com/lightseekorg/smg
+The Rust frontend computes per-image token counts and expands placeholders
+in-process via the `llm-multimodal` crate, so the router can match vLLM's
+expanded image-token count without invoking the HF image processor. Each
+`mm_hash` is then forwarded to the worker as `multi_modal_uuids` so vLLM's
+KV events publish the same key the router computes.
 
 Key environment variables:
 
@@ -232,7 +226,7 @@ Key environment variables:
 
 Both prerequisites are enabled by default in the dynamo sglang image; the list below is only for users building dynamo from source:
 
-- Dynamo built with `--features lightseek-mm` (Rust frontend's image-token counter + the SGLang glue). The container build always passes this; the cargo feature is opt-in only for source builds.
+- Dynamo built with `--features mm-routing` (Rust frontend's image-token counter + the SGLang glue). The container build always passes this; the cargo feature is opt-in only for source builds.
 - SGLang with the `GenerateReqInput.mm_hashes` field — added by [sgl-project/sglang#25300](https://github.com/sgl-project/sglang/pull/25300) and vendored into the dynamo sglang image via `container/deps/sglang/patches/<ver>/`.
 
   If you're running against your own sglang install (outside the dynamo image), apply it manually:

--- a/examples/backends/sglang/launch/agg_multimodal_router.sh
+++ b/examples/backends/sglang/launch/agg_multimodal_router.sh
@@ -4,7 +4,7 @@
 #
 # MM-aware KV routing for SGLang.
 #
-# Requires dynamo built with `--features lightseek-mm` (default in the
+# Requires dynamo built with `--features mm-routing` (default in the
 # dynamo sglang container image) and sglang carrying the
 # sgl-project/sglang#25300 mm_hashes patch. Without the mm_hashes kwarg
 # the dynamo glue silently falls back to text-prefix routing.

--- a/examples/backends/vllm/launch/agg_multimodal_router.sh
+++ b/examples/backends/vllm/launch/agg_multimodal_router.sh
@@ -2,16 +2,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Lightseek-powered exact MM-aware routing.
+# MM-aware exact KV routing for vLLM workers.
 #
 # Architecture:
 #   HTTP client
 #     -> Rust frontend
-#          - resolves the image-placeholder token id via lightseek's
-#            per-model ModelProcessorSpec (Qwen3-VL, Qwen2.5-VL, Qwen2-VL,
+#          - resolves the image-placeholder token id from the per-model
+#            ModelProcessorSpec registry (Qwen3-VL, Qwen2.5-VL, Qwen2-VL,
 #            LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4, Kimi-K2.5);
 #            each spec reads the appropriate config.json field
-#          - lightseek `calculate_num_tokens(W,H)` per image (header-only fetch)
+#          - per-image token-count math (header-only fetch for W,H)
 #          - expands placeholder -> N copies in routing_token_ids
 #          - hashes URL (xxh3) -> u64 -> 64-char hex -> extra_args["mm_hashes"]
 #          - builds block_mm_infos and feeds the KV router
@@ -21,7 +21,7 @@
 #            the router's routing-side block hashes -> bit-exact cache hits
 #
 # Build prerequisite (run once inside the dynamo dev container):
-#   cd /workspace/lib/bindings/python && maturin develop --release --features lightseek-mm
+#   cd /workspace/lib/bindings/python && maturin develop --release --features mm-routing
 #
 # Run inside the dynamo container that already has /workspace mounted.
 
@@ -35,7 +35,7 @@ source "${SCRIPT_DIR}/../../../common/gpu_utils.sh"
 source "${SCRIPT_DIR}/../../../common/launch_utils.sh"
 
 MODEL="${MODEL:-Qwen/Qwen3-VL-2B-Instruct}"
-NAMESPACE="${NAMESPACE:-lightseek-poc}"
+NAMESPACE="${NAMESPACE:-mm-router}"
 HTTP_PORT="${HTTP_PORT:-${DYN_HTTP_PORT:-8000}}"
 BLOCK_SIZE="${BLOCK_SIZE:-16}"
 GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.20}"
@@ -49,7 +49,7 @@ NATS_SERVER="${NATS_SERVER:-nats://127.0.0.1:4222}"
 ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-http://127.0.0.1:2379}"
 VLLM_SYSTEM_PORT_BASE="${VLLM_SYSTEM_PORT_BASE:-18081}"
 KV_EVENTS_PORT_BASE="${KV_EVENTS_PORT_BASE:-5557}"
-DYN_LOG_VAL="${DYN_LOG:-info,lightseek_mm=debug,dynamo_kv_router::scheduling=debug,dynamo_llm::kv_router=debug}"
+DYN_LOG_VAL="${DYN_LOG:-info,mm_routing=debug,dynamo_kv_router::scheduling=debug,dynamo_llm::kv_router=debug}"
 
 # Pass-through extra args for `python -m dynamo.vllm`.
 VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:-}"
@@ -72,7 +72,7 @@ Env vars:
   BLOCK_SIZE                  (default 16)
   MAX_MODEL_LEN               (default 4096)
   KV_EVENTS_PORT_BASE         (default 5557 — worker i uses port BASE + (i-1))
-  DYN_LOG                     (default info + lightseek_mm + scheduling debug)
+  DYN_LOG                     (default info + mm_routing + scheduling debug)
 
 Routing test (run after the script reports "All services are ready"):
   # Same image twice -> 2nd request should pin to same worker (high overlap_blocks)
@@ -98,7 +98,7 @@ EOF
     esac
 done
 
-echo "=== Lightseek MM Exact Routing Launch ==="
+echo "=== MM-aware Exact KV Routing Launch ==="
 echo "MODEL=${MODEL}"
 echo "NUM_WORKERS=${NUM_WORKERS}, BLOCK_SIZE=${BLOCK_SIZE}, GPU_MEM_FRAC=${GPU_MEMORY_UTILIZATION}"
 echo "HTTP_PORT=${HTTP_PORT}, NAMESPACE=${NAMESPACE}"
@@ -161,7 +161,7 @@ for i in $(seq 1 "${NUM_WORKERS}"); do
     wait_ready "http://127.0.0.1:${WORKER_PORT}/health" "vLLM backend $i"
 done
 
-echo "=== Starting frontend (KV router, lightseek MM exact routing) ==="
+echo "=== Starting frontend (KV router, MM-aware exact routing) ==="
 env "${COMMON_ENV[@]}" \
     "DYN_LOG=${DYN_LOG_VAL}" \
 python -m dynamo.frontend \
@@ -189,7 +189,7 @@ for i in $(seq 1 "${NUM_WORKERS}"); do
     echo "Worker $i kv-events: tcp://*:$((KV_EVENTS_PORT_BASE + (i - 1)))"
 done
 echo
-echo "Architecture: Rust frontend + lightseek -> ${NUM_WORKERS}x vLLM workers"
+echo "Architecture: Rust frontend (MM-aware KV router) -> ${NUM_WORKERS}x vLLM workers"
 echo "  - mm_hashes forwarded as multi_modal_uuids -> bit-exact match with vLLM KV events"
 echo "  - Image dims via header-only HTTP fetch (Range: bytes=0-65535)"
 echo "  - No PyO3, no GIL, no Python deps in the routing path"

--- a/examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
+++ b/examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
@@ -13,8 +13,8 @@
 # `KvRouter` directly. This is the original MM-aware routing path.
 #
 # The default script (`agg_multimodal_router.sh`) uses the Rust frontend with
-# the `lightseek-mm` feature instead — pure-Rust per-image token-count via
-# the `llm-multimodal` crate, no PyO3/GIL on the routing hot path. Use this
+# the `mm-routing` feature instead — pure-Rust per-image token-count, no
+# PyO3/GIL on the routing hot path. Use this
 # `_chat_processor` variant when you specifically want the vLLM Python path
 # (e.g., to take advantage of `DYNAMO_MM_TRANSFER` shm/NIXL pre-rendered
 # `mm_kwargs`).

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -29,13 +29,13 @@ kv-indexer-metrics = ["kv-indexer", "dynamo-kv-router/metrics"]
 mocker-kvbm-offload = ["dynamo-mocker/kvbm-offload"]
 aic-forward-pass = ["dynamo-mocker/aic-forward-pass", "dep:aiconfigurator-core"]
 nvtx = ["dynamo-runtime/nvtx"]
-# Enable in-process MM-aware KV routing via the lightseek crate
+# Enable in-process MM-aware KV routing
 # (per-image token-count + placeholder expansion + block-level mm_hash).
-# Opt-in at the wheel build (`maturin build --features lightseek-mm`)
+# Opt-in at the wheel build (`maturin build --features mm-routing`)
 # to keep the default wheel lean. Production containers and the MM
 # recipes pass this flag explicitly; the dev container's
 # `.devcontainer/post-create.sh` also enables it for local workflows.
-lightseek-mm = ["dynamo-llm/lightseek-mm"]
+mm-routing = ["dynamo-llm/mm-routing"]
 
 [dependencies]
 aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "69b3cff352303b95e5196a28966ae1ee4a3a3955", package = "aiconfigurator-core", optional = true }

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -30,7 +30,7 @@ integration = ["dynamo-runtime/integration"]
 media-ffmpeg = ["dep:video-rs", "dep:ffmpeg-next", "dep:memfile"]
 bench = ["dynamo-kv-router/bench"]
 kv-router-stress = ["dep:clap", "dep:indicatif", "bench"]
-lightseek-mm = ["dep:llm-multimodal", "dep:llm-tokenizer"]
+mm-routing = ["dep:llm-multimodal", "dep:llm-tokenizer"]
 agent-trace-bench = []
 
 [[bench]]
@@ -183,15 +183,15 @@ ndarray = { version = "0.16" }
 rmp-serde = "1.3"
 
 # Pure-Rust per-VLM-family image preprocessor token-count, used by the
-# `lightseek-mm` feature for MM-aware KV routing. Pinned to an exact
-# version because per-image token-count math (lightseek's
-# `calculate_num_tokens`) can change between minor releases as new
-# models are added or smart-resize parameters are tuned. Bumping should
-# be a deliberate, reviewed step paired with re-running our golden
-# cross-check against `transformers`.
+# `mm-routing` feature for MM-aware KV routing. Pinned to an exact
+# version because per-image token-count math (`calculate_num_tokens`)
+# can change between minor releases as new models are added or
+# smart-resize parameters are tuned. Bumping should be a deliberate,
+# reviewed step paired with re-running our golden cross-check against
+# `transformers`.
 llm-multimodal = { version = "=1.5.0", optional = true }
 # Companion to llm-multimodal: provides `HuggingFaceTokenizer` so the
-# model_dir's `tokenizer.json` can be passed to lightseek's
+# model_dir's `tokenizer.json` can be passed to the
 # `ModelRegistry::lookup` for image-placeholder token-id resolution.
 llm-tokenizer = { version = "=1.3.2", optional = true }
 

--- a/lib/llm/examples/mm_token_count.rs
+++ b/lib/llm/examples/mm_token_count.rs
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Standalone harness for the lightseek-mm path: load a HF model dir, decode
-// an image header to get (w, h), call lightseek's `calculate_num_tokens`, and
-// print the count. Useful for cross-checking against the same model's vLLM
-// output when investigating routing-cache mismatches.
+// Standalone harness for the MM-routing per-image token-count path: load a
+// HF model dir, decode an image header to get (w, h), call the image
+// processor's `calculate_num_tokens`, and print the count. Useful for
+// cross-checking against the same model's vLLM output when investigating
+// routing-cache mismatches.
 //
-//   cargo run -p dynamo-llm --example lightseek_count --features lightseek-mm \
+//   cargo run -p dynamo-llm --example mm_token_count --features mm-routing \
 //     -- <model_dir> <image_path> [model_id]
 
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 fn main() -> anyhow::Result<()> {
     use anyhow::Context;
     use dynamo_llm::preprocessor::lightseek_mm::LightseekMmCounter;
@@ -18,11 +19,11 @@ fn main() -> anyhow::Result<()> {
     let mut args = std::env::args().skip(1);
     let model_dir: PathBuf = args
         .next()
-        .context("usage: lightseek_count <model_dir> <image_path> [model_id]")?
+        .context("usage: mm_token_count <model_dir> <image_path> [model_id]")?
         .into();
     let image_path: PathBuf = args
         .next()
-        .context("usage: lightseek_count <model_dir> <image_path> [model_id]")?
+        .context("usage: mm_token_count <model_dir> <image_path> [model_id]")?
         .into();
     let model_id = args
         .next()
@@ -61,8 +62,8 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "lightseek-mm"))]
+#[cfg(not(feature = "mm-routing"))]
 fn main() {
-    eprintln!("rebuild with --features lightseek-mm");
+    eprintln!("rebuild with --features mm-routing");
     std::process::exit(2);
 }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -2278,7 +2278,7 @@ mod tests {
         assert!(!dest.exists(), "dest must not exist after cancel");
     }
 
-    /// Brings in the sibling that `lightseek-mm` needs.
+    /// Brings in the sibling that `mm-routing` needs.
     #[test]
     fn harvest_brings_in_non_weight_siblings() -> anyhow::Result<()> {
         let snap = tempfile::tempdir()?;

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -11,7 +11,7 @@
 //!
 //! The Preprocessor will accept any IngressRequest and transform it to a BackendRequest.
 
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 pub mod lightseek_mm;
 pub mod media;
 pub mod prompt;
@@ -42,7 +42,7 @@ use std::borrow::Cow;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
 
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 use crate::model_card::ModelInfoType;
 use crate::model_card::{ModelDeploymentCard, ModelInfo};
 use crate::preprocessor::media::MediaLoader;
@@ -187,7 +187,7 @@ pub struct MmImageEntry {
 /// and contains the other artifacts MM-aware routing reads at startup
 /// (`tokenizer.json`, `processor_config.json`, `preprocessor_config.json`).
 /// Returns `None` for cards built from non-disk sources.
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 fn mdc_model_dir(mdc: &ModelDeploymentCard) -> Option<std::path::PathBuf> {
     let ModelInfoType::HfConfigJson(cf) = mdc.model_info.as_ref()?;
     cf.path()?.parent().map(std::path::PathBuf::from)
@@ -204,11 +204,11 @@ fn mdc_model_dir(mdc: &ModelDeploymentCard) -> Option<std::path::PathBuf> {
 /// init / env-misconfig failures at deployment time, not on the first MM
 /// request 20 minutes in. Text-only deployments skip the force, leaving
 /// the LazyLock dormant.
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 static DIM_FETCH_MEDIA_FETCHER: std::sync::LazyLock<crate::preprocessor::media::MediaFetcher> =
     std::sync::LazyLock::new(crate::preprocessor::media::MediaFetcher::from_env);
 
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 static DIM_FETCH_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
     std::sync::LazyLock::new(|| {
         DIM_FETCH_MEDIA_FETCHER
@@ -231,7 +231,7 @@ struct PreprocessRequestOptions {
 /// TODO(mm-routing): collapse the 16-vs-64-char split. Blocked on
 /// kv-router's `parse_mm_hash_from_extra_key` using 64-char length as
 /// the MM-hash type tag in vLLM `BlockStored` extra_keys.
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MmRoutingProtocol {
     /// SGLang: image positions filled with `pad_value(mm_hash)`; no
@@ -251,21 +251,21 @@ enum MmRoutingProtocol {
 /// degrades to text-prefix.
 ///
 /// Pinned by `mm_pad_value_matches_sglang_protocol` in `mod tests`.
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 const MM_PAD_SHIFT_VALUE: u64 = 1_000_000;
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 const MM_PAD_HASH_MASK: u64 = (1 << 30) - 1;
 
 /// Compute the sglang per-image pad_value from a routing-side mm_hash.
 /// Wrapping the formula in a function (not just an inline closure) lets
 /// the test in `mod tests` pin both the constants and the formula
 /// directly.
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 fn pad_value_for_sglang(mm_hash: u64) -> crate::protocols::TokenIdType {
     (MM_PAD_SHIFT_VALUE + (mm_hash & MM_PAD_HASH_MASK)) as crate::protocols::TokenIdType
 }
 
-#[cfg(feature = "lightseek-mm")]
+#[cfg(feature = "mm-routing")]
 impl MmRoutingProtocol {
     /// Resolve from `runtime_config.backend_framework`. Returns `None` for
     /// missing or unrecognized values so MM-aware routing disables itself
@@ -335,12 +335,12 @@ pub struct OpenAIPreprocessor {
     /// Backend protocol the MM-routing fill path matches against. `None`
     /// when `runtime_config.backend_framework` is missing or unrecognized
     /// — MM-aware routing then falls back to text-prefix routing.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     mm_routing_protocol: Option<MmRoutingProtocol>,
     /// Per-image token-count engine. `None` when the feature is disabled, the
     /// model isn't covered by the registry, or `preprocessor_config.json` is
     /// unreadable.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     image_token_counter: Option<lightseek_mm::LightseekMmCounter>,
     /// Image-placeholder token id the routing-side sequence fills per image.
     /// Resolved from `config.json`'s `image_token_id` field when present,
@@ -351,21 +351,21 @@ pub struct OpenAIPreprocessor {
     ///
     /// `None` disables MM-aware routing for this model and the router falls
     /// back to text-prefix routing.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     routing_image_token_id: Option<crate::protocols::TokenIdType>,
     /// Per-family flatten-time image placeholder template (e.g.
     /// `"<|image_{n}|>"` for Phi-3, `"<image>"` for LLaVA-1.5). Threaded
     /// through from the formatter so the routing path can reverse the
     /// BPE-encoded numbered form (Phi-3) back into single placeholder
     /// tokens when the chat template uses numbered markers.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     image_placeholder_template: Option<&'static str>,
     /// BOS token id to prepend to the routing-side sequence so per-block
     /// hashes match the backend's HF processor output on models with
     /// `add_bos_token: true` (Phi-3-vision and other `LlamaTokenizer`
     /// families). `None` when the model doesn't need it or `bos_token`
     /// doesn't round-trip to a single id.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     routing_prepend_bos: Option<crate::protocols::TokenIdType>,
 }
 
@@ -493,21 +493,21 @@ impl OpenAIPreprocessor {
         // Resolve the backend label once at startup; used by the MM-routing
         // hot path to pick between sglang pad_value substitution and vLLM
         // mm_hashes forwarding without re-checking per request.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let mm_routing_protocol =
             MmRoutingProtocol::from_backend_framework(runtime_config.backend_framework.as_deref());
 
         // Capture MM-routing inputs before mdc is partially moved into MediaLoader.
         // model_type comes from config.json (e.g. "qwen3_vl") and lets the
-        // lightseek registry resolve fine-tunes loaded from custom-named
-        // directories where the family substring isn't in the path.
-        #[cfg(feature = "lightseek-mm")]
+        // image-processor registry resolve fine-tunes loaded from
+        // custom-named directories where the family substring isn't in the path.
+        #[cfg(feature = "mm-routing")]
         let model_dir_for_routing: Option<std::path::PathBuf> = mdc_model_dir(&mdc);
         // TODO(mm-routing): fastokens lacks a special-token mutator, so it
         // can't merge tokenizer_config.json specials and would BPE-shatter
         // placeholders (e.g. Qwen2-VL `<|image_pad|>`). Disable MM-routing
         // here; remove once fastokens upstream exposes the mutator.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let image_token_inputs: Option<(String, String, std::path::PathBuf)> = {
             let fastokens_active = std::env::var("DYN_TOKENIZER").as_deref() == Ok("fastokens");
             if fastokens_active && model_dir_for_routing.is_some() {
@@ -535,7 +535,7 @@ impl OpenAIPreprocessor {
 
         let context_length = mdc.context_length;
 
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let (image_token_counter, routing_image_token_id, bos_token_string) =
             match image_token_inputs {
                 Some((model_id, model_type, model_dir)) => {
@@ -553,8 +553,8 @@ impl OpenAIPreprocessor {
                         Err(e) => (None, Some(e.to_string())),
                     };
                     // One-shot config/tokenizer_config read for all
-                    // routing-side token info. Parsing lives in
-                    // `lightseek_mm`, next to the spec resolution.
+                    // routing-side token info. Parsing lives next to the
+                    // spec resolution in the MM-routing module.
                     let routing_tokens =
                         lightseek_mm::resolve_routing_tokens(&model_id, &model_dir);
                     // `chat_placeholder_token_id` already prefers config.json's
@@ -611,16 +611,16 @@ impl OpenAIPreprocessor {
                 }
             };
 
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let image_placeholder_template = formatter.image_placeholder_template();
 
         // Force the dim-fetch HTTP client to build at startup for any
         // MM-routable preprocessor, so TLS / env-var / reqwest-init
         // failures fail the deployment instead of crashing the first
         // MM request 20 minutes in. Text-only preprocessors skip the
-        // force (both lightseek hooks resolved to `None`) — no point
+        // force (both MM-routing hooks resolved to `None`) — no point
         // building a client they'll never use.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         if image_token_counter.is_some() || routing_image_token_id.is_some() {
             std::sync::LazyLock::force(&DIM_FETCH_MEDIA_FETCHER);
             std::sync::LazyLock::force(&DIM_FETCH_HTTP_CLIENT);
@@ -631,7 +631,7 @@ impl OpenAIPreprocessor {
         // when the configured `bos_token` round-trips to a single id. The
         // BOS string was harvested above by `resolve_routing_tokens` from
         // the same `tokenizer_config.json` pass.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let routing_prepend_bos = match bos_token_string {
             Some(bos_text) => match tokenizer.encode(&bos_text) {
                 Ok(enc) if enc.token_ids().len() == 1 => {
@@ -677,15 +677,15 @@ impl OpenAIPreprocessor {
             tool_call_parser,
             media_loader,
             context_length,
-            #[cfg(feature = "lightseek-mm")]
+            #[cfg(feature = "mm-routing")]
             mm_routing_protocol,
-            #[cfg(feature = "lightseek-mm")]
+            #[cfg(feature = "mm-routing")]
             image_token_counter,
-            #[cfg(feature = "lightseek-mm")]
+            #[cfg(feature = "mm-routing")]
             routing_image_token_id,
-            #[cfg(feature = "lightseek-mm")]
+            #[cfg(feature = "mm-routing")]
             image_placeholder_template,
-            #[cfg(feature = "lightseek-mm")]
+            #[cfg(feature = "mm-routing")]
             routing_prepend_bos,
         }))
     }
@@ -770,7 +770,7 @@ impl OpenAIPreprocessor {
         // Build the MM-aware view (expanded routing_token_ids + per-block
         // mm_hashes) for the KV router. No-op when no images are present or
         // the model has no resolved image-placeholder.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         self.gather_mm_exact_routing_info(
             &mut builder,
             &_mm_image_entries,
@@ -1019,10 +1019,10 @@ impl OpenAIPreprocessor {
         let mut media_map: MultimodalDataMap = HashMap::new();
         let mut fetch_tasks: Vec<(String, &ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
-        // Per-image (mm_hash, width, height) for the lightseek MM-routing path.
+        // Per-image (mm_hash, width, height) for the MM-routing path.
         // Accumulated in message order so we don't walk messages twice.
         // Cleared and returned to the caller; empty for non-image / text-only requests.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
@@ -1036,12 +1036,12 @@ impl OpenAIPreprocessor {
         // the request. The decoded path (`has_media_loader`) propagates
         // any dim-fetch failure via `?`, so the request errors out before
         // mm_hashes forwarding is even considered.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let mut total_image_count: usize = 0;
         // For the URL-passthrough case (media_loader is None) we collect image
         // URLs here and resolve dims via header-only HTTP after the loop so we
         // can issue all fetches in parallel.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         let mut url_passthrough_images: Vec<(u64, String)> = Vec::new();
 
         let Some(messages) = request.typed_messages() else {
@@ -1065,7 +1065,7 @@ impl OpenAIPreprocessor {
                         ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => "audio_url",
                         _ => continue,
                     };
-                    #[cfg(feature = "lightseek-mm")]
+                    #[cfg(feature = "mm-routing")]
                     if type_str == "image_url" {
                         total_image_count += 1;
                     }
@@ -1083,7 +1083,7 @@ impl OpenAIPreprocessor {
                         }
                         _ => continue,
                     };
-                    #[cfg(feature = "lightseek-mm")]
+                    #[cfg(feature = "mm-routing")]
                     if type_str == "image_url" {
                         total_image_count += 1;
                         let mm_hash = Self::hash_image_url(url.as_str());
@@ -1113,8 +1113,8 @@ impl OpenAIPreprocessor {
                 let rdma_descriptor = result?;
 
                 // Decoded RDMA descriptor carries shape `[H, W, C]`.
-                // Image-only; lightseek doesn't cover audio/video.
-                #[cfg(feature = "lightseek-mm")]
+                // Image-only; MM-routing doesn't cover audio/video.
+                #[cfg(feature = "mm-routing")]
                 if type_str == "image_url" {
                     let shape = &rdma_descriptor.tensor_info.shape;
                     if shape.len() >= 2 {
@@ -1149,7 +1149,7 @@ impl OpenAIPreprocessor {
                                 tokens = n,
                                 mm_hash = mm_hash,
                                 source = hash_source,
-                                "lightseek image-token count"
+                                "image-token count"
                             );
                         }
                         mm_image_entries.push(MmImageEntry {
@@ -1171,7 +1171,7 @@ impl OpenAIPreprocessor {
         // parallel to get (W, H) per image without downloading the full bytes.
         // Enables MM-aware routing for backends that register
         // `media_decoder: null` and decode images on the worker.
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         if !url_passthrough_images.is_empty() {
             let dim_results = futures::future::join_all(
                 url_passthrough_images
@@ -1192,7 +1192,7 @@ impl OpenAIPreprocessor {
                                 tokens = n,
                                 mm_hash = mm_hash,
                                 source = "url_passthrough_header_fetch",
-                                "lightseek image-token count"
+                                "image-token count"
                             );
                         }
                         mm_image_entries.push(MmImageEntry {
@@ -1217,7 +1217,7 @@ impl OpenAIPreprocessor {
                             target: "mm_routing",
                             url = %url_for_log,
                             error = %e,
-                            "lightseek: failed to fetch image dims; MM routing entry skipped"
+                            "mm-routing: failed to fetch image dims; MM routing entry skipped"
                         );
                     }
                 }
@@ -1268,7 +1268,7 @@ impl OpenAIPreprocessor {
             // a shorter `mm_hashes` list would misalign with the image
             // positions the backend derives from `multi_modal_data`, and
             // the wrong UUIDs would get injected onto the wrong images.
-            #[cfg(feature = "lightseek-mm")]
+            #[cfg(feature = "mm-routing")]
             if let Some(protocol) = self.mm_routing_protocol
                 && !mm_image_entries.is_empty()
                 && mm_image_entries.len() == total_image_count
@@ -1283,16 +1283,16 @@ impl OpenAIPreprocessor {
                     target: "mm_routing",
                     resolved = mm_image_entries.len(),
                     expected = total_image_count,
-                    "lightseek: not all images resolved an MM-routing entry; skipping mm_hashes forwarding"
+                    "mm-routing: not all images resolved an MM-routing entry; skipping mm_hashes forwarding"
                 );
             }
 
             builder.extra_args(Some(extra_args));
         }
 
-        #[cfg(feature = "lightseek-mm")]
+        #[cfg(feature = "mm-routing")]
         return Ok(mm_image_entries);
-        #[cfg(not(feature = "lightseek-mm"))]
+        #[cfg(not(feature = "mm-routing"))]
         Ok(Vec::new())
     }
 
@@ -1302,7 +1302,7 @@ impl OpenAIPreprocessor {
     /// templates; single-special-token families (Qwen-VL, LLaVA) ignore it.
     /// Returns `Ok(())` with no work performed on any precondition miss
     /// (caller falls back to text-prefix routing).
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     pub fn gather_mm_exact_routing_info(
         &self,
         builder: &mut PreprocessedRequestBuilder,
@@ -1391,7 +1391,7 @@ impl OpenAIPreprocessor {
                 return Ok(());
             };
 
-        // Compute per-image N via lightseek + run the expansion.
+        // Compute per-image N via the registry + run the expansion.
         let n_tokens: Vec<usize> = mm_image_entries
             .iter()
             .map(|e| counter.count_tokens(e.width, e.height))
@@ -1463,7 +1463,7 @@ impl OpenAIPreprocessor {
             block_size,
             total_tokens,
             n_blocks = block_mm_infos.len(),
-            "lightseek MmRoutingInfo built (exact)"
+            "MmRoutingInfo built (exact)"
         );
 
         builder.mm_routing_info(Some(MmRoutingInfo {
@@ -1502,7 +1502,7 @@ impl OpenAIPreprocessor {
     /// caller does NOT prepend its own BOS when this helper succeeds.
     /// Returns `None` (caller falls back to text-prefix routing) when the
     /// family guard trips or on any tokenize/decode failure.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     fn splice_phi3_numbered_placeholders_at_token_level(
         &self,
         prompt: &str,
@@ -1571,7 +1571,7 @@ impl OpenAIPreprocessor {
     /// Azure SAS) should use `--frontend-decoding`: that path hashes the
     /// decoded RGB bytes instead, so cross-URL cache reuse is restored
     /// without depending on URL conventions.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     fn hash_image_url(url: &str) -> u64 {
         xxhash_rust::xxh3::xxh3_64(url.as_bytes())
     }
@@ -1586,7 +1586,7 @@ impl OpenAIPreprocessor {
     /// (typical of multi-turn / session workloads) hit the cache and skip the
     /// HTTP fetch entirely. Without this cache, sticky-routing workloads pay
     /// 4–5× HTTP Range fetches per request just to compute routing tokens.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     async fn fetch_image_dims(mm_hash: u64, url: &str) -> Result<(u32, u32)> {
         use moka::future::Cache;
         use std::sync::LazyLock;
@@ -1631,7 +1631,7 @@ impl OpenAIPreprocessor {
             .map_err(|e| anyhow::anyhow!("fetch_image_dims failed: {}", e))
     }
 
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     async fn fetch_image_dims_uncached(url: &str) -> Result<(u32, u32)> {
         use image::ImageReader;
         use std::io::Cursor;
@@ -3715,7 +3715,7 @@ mod tests {
     /// the identity. For signed-URL workloads where rotation actually
     /// hides a stable object, `--frontend-decoding` hashes the decoded
     /// bytes instead.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     #[test]
     fn hash_image_url_distinguishes_query_strings() {
         let base = "https://cdn.example.com/img.jpg";
@@ -3731,7 +3731,7 @@ mod tests {
     /// routing for signed-URL workloads — `--frontend-decoding` is the
     /// recommended mode there because it hashes the decoded image bytes
     /// regardless of how the URL was signed.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     #[test]
     fn hash_image_url_distinguishes_rotating_signatures() {
         let base = "https://bucket.s3.amazonaws.com/img.jpg";
@@ -3749,7 +3749,7 @@ mod tests {
 
     /// Identical URLs must hash to the same value (the basic identity
     /// guarantee that makes URL-passthrough routing useful at all).
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     #[test]
     fn hash_image_url_is_deterministic_for_identical_urls() {
         let url = "https://cdn.example.com/img.jpg?width=256";
@@ -3761,7 +3761,7 @@ mod tests {
 
     /// data: URIs hash the entire URI string. Same payload → same hash;
     /// different payload → different hash.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     #[test]
     fn hash_image_url_data_uri_content_addressed() {
         let same = "data:image/png;base64,AAAA";
@@ -3778,7 +3778,7 @@ mod tests {
     }
 
     /// Non-HTTP / non-data schemes (s3://, gs://, file://) hash as-is.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     #[test]
     fn hash_image_url_other_schemes_passthrough() {
         let s3a = OpenAIPreprocessor::hash_image_url("s3://bucket/key?v=1");
@@ -3795,7 +3795,7 @@ mod tests {
     /// the routing-side pad_value would silently diverge from sglang's
     /// `BlockStored` event bytes and MM-routing would degrade to text-
     /// prefix without any error.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     #[test]
     fn mm_pad_value_matches_sglang_protocol() {
         // Constant pins (upstream:

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Pure-Rust per-image token-count and image-placeholder token-id resolution
-//! via the `llm-multimodal` crate. Compiled only when the `lightseek-mm`
+//! via the `llm-multimodal` crate. Compiled only when the `mm-routing`
 //! cargo feature is enabled.
 
 use std::path::Path;
@@ -20,7 +20,7 @@ use crate::protocols::TokenIdType;
 /// No-op `Tokenizer` impl used when a model directory has no `tokenizer.json`
 /// (e.g. Kimi-K2.5 ships `tiktoken.model` instead of an HF fast tokenizer).
 ///
-/// The lightseek `ModelMetadata` always expects a tokenizer reference, but
+/// `ModelMetadata` always expects a tokenizer reference, but
 /// some `ModelProcessorSpec` impls — Kimi-K2.5 in particular — read the
 /// image-placeholder token id straight out of `config.json` and never call
 /// the tokenizer. Passing `NullTokenizer` lets those specs run; specs that
@@ -96,20 +96,20 @@ impl LightseekMmCounter {
         let cfg_path = model_dir.join("preprocessor_config.json");
         let json = std::fs::read_to_string(&cfg_path).with_context(|| {
             format!(
-                "lightseek: failed to read preprocessor_config.json at {}",
+                "mm-routing: failed to read preprocessor_config.json at {}",
                 cfg_path.display()
             )
         })?;
         let config = PreProcessorConfig::from_json(&json).with_context(|| {
             format!(
-                "lightseek: failed to parse preprocessor_config.json at {}",
+                "mm-routing: failed to parse preprocessor_config.json at {}",
                 cfg_path.display()
             )
         })?;
 
         let processor = REGISTRY.find(model_id, model_type).ok_or_else(|| {
             anyhow!(
-                "lightseek: no image processor registered for model_id={:?} model_type={:?}",
+                "mm-routing: no image processor registered for model_id={:?} model_type={:?}",
                 model_id,
                 model_type
             )
@@ -132,8 +132,8 @@ impl LightseekMmCounter {
     }
 }
 
-/// Resolve the image-placeholder token id by delegating to lightseek's
-/// per-model `ModelProcessorSpec`. Each registered model (Qwen3-VL,
+/// Resolve the image-placeholder token id by delegating to a per-model
+/// `ModelProcessorSpec` from the registry. Each registered model (Qwen3-VL,
 /// Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4,
 /// Kimi-K2.5) reads the right field of `config.json` (`image_token_id`,
 /// `image_token_index`, `media_placeholder_token_id`) and falls back to the
@@ -176,7 +176,7 @@ fn resolve_image_token_id_with_config(
                         target: "mm_routing",
                         model_dir = %model_dir.display(),
                         err = %e,
-                        "lightseek: tokenizer.json not loaded; falling back to NullTokenizer"
+                        "mm-routing: tokenizer.json not loaded; falling back to NullTokenizer"
                     );
                     None
                 }
@@ -201,7 +201,7 @@ fn resolve_image_token_id_with_config(
                 target: "mm_routing",
                 model_id = %model_id,
                 err = %e,
-                "lightseek: ModelProcessorSpec could not resolve placeholder_token_id"
+                "mm-routing: ModelProcessorSpec could not resolve placeholder_token_id"
             );
             e
         })
@@ -279,7 +279,7 @@ fn read_json(model_dir: &Path, filename: &str) -> Option<serde_json::Value> {
                 target: "mm_routing",
                 path = %path.display(),
                 err = %e,
-                "lightseek: failed to read {filename}"
+                "mm-routing: failed to read {filename}"
             );
             return None;
         }
@@ -291,7 +291,7 @@ fn read_json(model_dir: &Path, filename: &str) -> Option<serde_json::Value> {
                 target: "mm_routing",
                 path = %path.display(),
                 err = %e,
-                "lightseek: failed to parse {filename}"
+                "mm-routing: failed to parse {filename}"
             );
             None
         }
@@ -334,10 +334,10 @@ fn extract_bos_token_from_tokenizer_config(cfg: &serde_json::Value) -> Option<St
 
 #[cfg(test)]
 mod tests {
-    //! Contract tests against the upstream lightseek registry. Pin the
-    //! behavior `OpenAIPreprocessor::new_with_parts` relies on so a future
-    //! smg matcher change shows up here instead of as a silent runtime
-    //! fallback to text-prefix-only routing.
+    //! Contract tests against the upstream `llm-multimodal` image-processor
+    //! registry. Pin the behavior `OpenAIPreprocessor::new_with_parts`
+    //! relies on so a future upstream matcher change shows up here instead
+    //! of as a silent runtime fallback to text-prefix-only routing.
     use super::*;
 
     #[test]
@@ -402,8 +402,8 @@ mod tests {
         }
         assert!(
             missing.is_empty(),
-            "lightseek registry has no processor for: {:?}. \
-             Either pick up an smg release that registers these, or trim \
+            "image-processor registry has no processor for: {:?}. \
+             Either pick up an upstream release that registers these, or trim \
              the supported-families list in docs.",
             missing
         );

--- a/lib/llm/src/preprocessor/media/rdma.rs
+++ b/lib/llm/src/preprocessor/media/rdma.rs
@@ -62,7 +62,7 @@ impl RdmaMediaDataDescriptor {
     /// happen to share a raw byte buffer but differ in dimensions or
     /// element layout (e.g. `3x224x224` vs `224x224x3`) don't collide on
     /// the same routing hash.
-    #[cfg(feature = "lightseek-mm")]
+    #[cfg(feature = "mm-routing")]
     pub(crate) fn content_hash(&self) -> Option<u64> {
         use dynamo_memory::MemoryDescriptor;
         use xxhash_rust::xxh3::Xxh3;

--- a/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
@@ -4,7 +4,7 @@
 """End-to-end test for MM-aware KV routing with frontend image decoding.
 
 Architecture:
-  Frontend (Rust preprocessor + lightseek + KV router + MediaLoader)
+  Frontend (Rust preprocessor + KV router + MediaLoader)
        ├─ DOWNLOADS the image bytes (because the worker registered a
        │  `media_decoder` via `--frontend-decoding`)
        ├─ DECODES into RGB bytes via the in-process MediaDecoder
@@ -370,7 +370,7 @@ def test_frontend_decode_logs_decoded_bytes_source(
     http_image_server_with_alias,
 ):
     """Smoke check: the frontend-decode path must emit the
-    `source=decoded_bytes` lightseek log line, proving we took the
+    `source=decoded_bytes` MM-routing log line, proving we took the
     content-hash branch and not the url_fallback branch."""
     frontend_port, router_proc = start_frontend_decode_services
     _send(

--- a/tests/mm_router/test_router_rust_mm_router_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_router_e2e.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""End-to-end tests for MM-aware KV routing with the Rust frontend (lightseek-mm).
+"""End-to-end tests for MM-aware KV routing with the Rust frontend (mm-routing).
 
 Architecture:
-  Frontend (Rust preprocessor + lightseek + KV router)
-       └─ resolves <|image_pad|>, computes per-image N via lightseek,
+  Frontend (Rust preprocessor + KV router)
+       └─ resolves <|image_pad|>, computes per-image N,
           expands placeholders, hashes URL→u64→64-char hex,
           forwards mm_hashes via extra_args["mm_hashes"]
        → vLLM worker (publishes KV events with the forwarded UUID)
@@ -17,7 +17,7 @@ These tests assert that:
   3. Different images on the same prompt produce strictly less overlap
      than identical-image repeats.
 
-The fallback path (model unsupported by lightseek or image-token
+The fallback path (model unsupported by the image-processor registry or image-token
 unresolvable) is unit-tested via `image_token::tests` and the
 graceful-degrade branches in `gather_mm_exact_routing_info`; reproducing
 it e2e would require a model whose loading is heavy and whose worker
@@ -144,7 +144,7 @@ class VLLMWorkerProcess(ManagedProcess):
 
 
 class FrontendProcess(ManagedProcess):
-    """Rust frontend with lightseek-mm. No --dyn-chat-processor flag (default 'dynamo')."""
+    """Rust frontend with mm-routing. No --dyn-chat-processor flag (default 'dynamo')."""
 
     def __init__(self, request, *, frontend_port: int):
         super().__init__(
@@ -463,7 +463,7 @@ def test_router_rust_mm_repeated_http_image_overlap(
     assert overlap_2 > overlap_1 + 1, (
         f"expected warm-request overlap to dominate cold by more than just the "
         f"text-prefix block, got req1={overlap_1}/{total_1}, "
-        f"req2={overlap_2}/{total_2} — if not, header-fetch + lightseek expansion "
+        f"req2={overlap_2}/{total_2} — if not, header-fetch + token expansion "
         f"is misaligned with the worker's KV events"
     )
     cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
@@ -516,10 +516,10 @@ def test_router_rust_mm_http_url_distinct_query_strings_dont_collide(
 
 
 @pytest.mark.timeout(300)
-def test_router_rust_mm_logs_lightseek_initialization(
+def test_router_rust_mm_logs_initialization(
     start_router_rust_mm_services, predownload_models
 ):
-    """Smoke test: frontend must emit the lightseek init + image-token-resolved
+    """Smoke test: frontend must emit the MM-routing init + image-token-resolved
     log lines for the served model. Catches regressions where the model dir
     isn't reachable from the MDC or the resolver silently misses a tier."""
     frontend_port, router_proc = start_router_rust_mm_services

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -41,7 +41,7 @@ VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg": "agg_multimodal.sh",
     "agg_video": "agg_multimodal.sh",
     # Aggregated MM-aware router. Default uses the Rust frontend with the
-    # `lightseek-mm` feature; the `_chat_processor` variant uses the vLLM
+    # `mm-routing` feature; the `_chat_processor` variant uses the vLLM
     # Python preprocessor (`--dyn-chat-processor=vllm`) to enable the
     # DYNAMO_MM_TRANSFER shm/NIXL pre-rendered mm_kwargs delivery channel.
     "agg_router": "agg_multimodal_router.sh",
@@ -100,7 +100,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 requested_vllm_kv_cache_bytes=1_719_075_000,
                 tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
             ),
-            # Pre_merge gater for the lightseek MM-routing path. Fine-grained
+            # Pre_merge gater for the MM-routing path. Fine-grained
             # assertions live in tests/mm_router/test_router_rust_mm_router_e2e.py
             # (post_merge).
             "agg_router": TopologyConfig(
@@ -121,8 +121,8 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
             # The chat-processor variant of the MM-aware router: same routing
             # architecture, but the frontend uses --dyn-chat-processor=vllm
-            # (Python preprocessor) instead of the Rust+lightseek path. Kept
-            # on post_merge — the lightseek variant above (`agg_router`) is
+            # (Python preprocessor) instead of the Rust MM-routing path. Kept
+            # on post_merge — the Rust-frontend variant above (`agg_router`) is
             # the pre_merge gate; adding chat_processor doubles the GPU0
             # queue time at 4-worker scale without catching distinct bugs
             # (both paths share the kv_router downstream).
@@ -190,11 +190,11 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
         },
     ),
-    # Lightseek-supported VLM coverage on `agg_router` (Rust-frontend
+    # Rust-frontend VLM coverage on `agg_router` (
     # MM-aware routing path). Each profile below adds the same smoke test
     # as Qwen3-VL-2B's agg_router (pre_merge), but on post_merge with the
     # corresponding family — Qwen2.5-VL, Qwen2-VL, Phi-3-vision — so the
-    # full lightseek model list (FAMILIES in lightseek_mm.rs) is exercised
+    # full MM-routing model list (FAMILIES in lightseek_mm.rs) is exercised
     # end-to-end. SINGLE_GPU=true packs both workers onto GPU 0 to match
     # the gpu_1 single-GPU box. Initial VRAM profiles are estimates; the
     # first post_merge run will surface real peaks and we'll tighten.
@@ -212,7 +212,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 # (151655) and vLLM's HF processor expands the same id N
                 # times in the prompt sequence — routing-side fills with
                 # this id so block hashes align with what the worker
-                # stores. (lightseek's per-spec id is `<|vision_pad|>`
+                # stores. (the per-spec id is `<|vision_pad|>`
                 # 151654; the routing path now uses config.json's
                 # `image_token_id` instead, see preprocessor.rs splice.)
                 tests=[
@@ -500,7 +500,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
         },
     ),
-    # LLaVA-NeXT covers a separate lightseek processor (LlavaNextProcessor,
+    # LLaVA-NeXT covers a separate image processor (LlavaNextProcessor,
     # anyres multi-crop) vs LLaVA-1.5's plain LlavaProcessor. Same gpu_2
     # multi-GPU layout as LLaVA-1.5 agg_router above; ~14 GiB / GPU.
     #


### PR DESCRIPTION
Generalize mm routing terminology in frontend.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes DIS-2174

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined multimodal KV routing documentation with improved architecture descriptions and clearer, less crate-specific terminology.

* **Refactor**
  * Consolidated build feature naming: multimodal KV routing now uses the `mm-routing` feature flag instead of `lightseek-mm`.
  * Updated terminology throughout build configurations, examples, and tests to reflect the new MM-aware KV routing architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->