### PR TITLE
docs(skills): add dynamo-frontend-benchmark contributor skill

### DIFF
--- a/.agents/contributor-skills/dynamo-frontend-benchmark/SKILL.md
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: dynamo-frontend-benchmark
+description: Benchmark and profile the Dynamo frontend (dynamo.frontend HTTP + tokenizer + KV router) against mock workers (dynamo.mocker). Use when measuring frontend throughput/latency, A/B-testing a frontend change, or on-CPU/off-CPU profiling the frontend or mock workers to find bottlenecks. Covers topology setup, CPU isolation, aiperf load generation, perf/BPF profiling, throughput analysis, and the sharp edges of this setup.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - performance
+    - benchmarking
+    - profiling
+    - frontend
+    - kv-router
+---
+
+# Dynamo frontend benchmarking
+
+End-to-end harness for measuring and profiling the Dynamo **frontend** under load
+from a configurable client, served by **mock workers** so the backend isn't the
+variable under test. Bundled scripts are in `scripts/`; they all
+`source env.sh`, which requires `DYN_REPO` to point at your Dynamo checkout.
+
+## TL;DR workflow
+
+```bash
+export DYN_REPO=/path/to/dynamo          # checkout with built .venv
+# 0. one-time: request plane up, venv built, FlameGraph cloned (see Setup)
+sudo bash scripts/isolate.sh             # optional but recommended: CPU isolation
+BLOCK_SIZE=512 FRONTEND_LD_PRELOAD=$DYN_REPO/bench/jemalloc/libjemalloc.so \
+  bash scripts/start.sh                  # frontend (pinned) + N mockers
+WARMUP_REQUESTS=512 bash scripts/run_aiperf.sh   # one measured run
+python3 scripts/extract_throughput.py $DYN_REPO/bench/results/aiperf-*  # robust numbers
+bash scripts/stop.sh                     # teardown + etcd drain
+```
+
+For an A/B: **teardown + restart between every run**, interleave arms, take the
+median of 3+. For profiling: `profile_oncpu.sh` (non-root) and
+`capture_offcpu.sh` (sudo).
+
+## What this measures (and what it doesn't)
+
+- **Frontend**: HTTP (axum/hyper), tokenization (fastokens or HF), KV-router
+  block hashing + radix-tree scheduling, request dispatch, SSE response relay.
+- **Mock workers** (`dynamo.mocker`): simulate generation with `--speedup-ratio`
+  (e.g. 1e6 = ~instant) and KV-cache block bookkeeping. **Not** a real vLLM
+  worker — no GPU compute. Use them to remove backend variance, not to model
+  production backends.
+- **Closed-loop client** (aiperf): fixed `--concurrency`, so
+  **throughput ≈ concurrency / request_latency** (Little's law). This is the
+  single most important fact for interpreting results (see Pitfalls).
+
+## Setup (one-time)
+
+1. **Request plane** — Dynamo needs etcd (`:2379`) + NATS with JetStream (`:4222`):
+   - etcd is often a systemd service (survives reboot). Check: `etcdctl endpoint health`.
+   - **NATS is usually a user binary that does NOT auto-start on reboot.** Start:
+     `nohup nats-server -js > /tmp/nats.log 2>&1 &` then confirm `ss -ltn | grep 4222`.
+2. **Build the bindings** into a venv: `uv venv && source .venv/bin/activate &&
+   (cd lib/bindings/python && maturin develop --uv --release)`. Rust changes
+   require rebuilding this; **never run a build concurrently with a benchmark** —
+   it steals cores and contaminates results.
+3. **aiperf**: `pip install aiperf` (the GenAI-perf successor) in some venv; set `AIPERF`.
+4. **FlameGraph**: `git clone https://github.com/brendangregg/FlameGraph` and set
+   `FLAMEGRAPH_DIR`.
+5. **jemalloc** (optional, for the frontend): get a `libjemalloc.so` and pass it
+   via `FRONTEND_LD_PRELOAD` to `start.sh`. Big alloc-churn reductions vs glibc.
+6. **perf access** for on-CPU profiling: `sudo sysctl kernel.perf_event_paranoid=-1
+   kernel.kptr_restrict=0`. Off-CPU (sched tracepoints / BPF) **still needs root**
+   even with paranoid=-1 (tracefs event files are root-only).
+
+## Topology & config (`env.sh`)
+
+- `FRONTEND_CORES` (e.g. `0-3`), `OTHER_CORES` (e.g. `4-23`): frontend is pinned
+  with `taskset`; mockers + client share `OTHER_CORES`. **Keep `FRONTEND_CORES`
+  small so frontend CPU effects are observable**, but give `OTHER_CORES` enough
+  headroom that the client doesn't starve the mockers (see Pitfalls).
+- `BLOCK_SIZE`: **frontend `--kv-cache-block-size` and mocker `--block-size` MUST
+  match.** Affects both sides — see "Block size" below.
+- `DYN_TOKENIZER` = `fastokens` (PCRE2+rayon, fast) or `default` (HF tokenizers).
+- `DYN_TOKENIZER_CACHE` / `_BYTES`: L1 prefix cache (helps with shared system prompts).
+
+## Running a throughput benchmark — methodology
+
+The harness encodes hard-won protocol. Follow it or results drift:
+
+1. **Full teardown + fresh restart between every run** (`stop.sh` then `start.sh`).
+   The KV router and tokenizer cache accumulate state across runs; reusing an
+   instance inflates later runs.
+2. **Drain etcd to 0 workers** between runs (`stop.sh` does this; verify with
+   `count_workers`). Dead frontends/mockers leave lease-backed keys that expire,
+   but verify the slate is clean before starting.
+3. **Warmup** (`WARMUP_REQUESTS=512`) to prime the prefix cache + warm the
+   allocator before the measured phase. The first run after a fresh build is
+   still a cold-start outlier — discard it.
+4. **jemalloc on the frontend** via `FRONTEND_LD_PRELOAD` for stable allocator behavior.
+5. **A/B**: same binary serves both arms when the difference is a runtime flag;
+   otherwise rebuild between arms (never during a run). **Interleave** arms
+   (A,B,A,B,…) to cancel drift, run 3+ each, compare **medians** (means get
+   dragged by the cold first run).
+
+`run_aiperf.sh` knobs (env overrides): `CONCURRENCY`, `REQUEST_COUNT`,
+`WARMUP_REQUESTS`. Default workload: shared-system-prompt 48000 +
+user-context 12000 (≈60k-token prompts), output-tokens-mean 500,
+conversation-turn-mean 4.
+
+## Profiling
+
+### On-CPU (where compute goes) — non-root
+```bash
+bash scripts/profile_oncpu.sh --frontend --conc 2048   # or --mocker, or --pid N --cores 0-3
+python3 scripts/analyze_folded.py <out>/oncpu.folded
+```
+- Uses `perf record -F 99 --call-graph dwarf`. **DWARF is required**: release
+  `.so`s have no frame pointers, so `-g` (FP unwinding) truncates Rust stacks.
+- Also samples the target's cores (`mpstat`) and process CPU (`pidstat`) so you
+  can see if it saturates. `analyze_folded.py` prints top **self-time** leaves.
+
+### Off-CPU (what blocked threads wait on) — REQUIRES sudo
+```bash
+sudo DYN_REPO=$DYN_REPO bash scripts/capture_offcpu.sh --frontend --conc 2048
+python3 scripts/analyze_folded.py <out>/offcpu_bcc.folded --offcpu
+```
+- Captures two ways: `offcputime-bpfcc -df` (duration-weighted, user+kernel,
+  folded) and `perf -e sched:sched_switch --call-graph dwarf` (backup, reliable
+  Rust user frames). bcc's folded format uses a literal `-` frame to separate
+  user (root→leaf) from kernel stacks; the **innermost user frame before `-`** is
+  what called into the blocking syscall — `analyze_folded.py --offcpu` aggregates by it.
+- Interpreting categories: `futex/park` = tokio workers idle (no runnable task)
+  OR mutex; `epoll` = waiting on network/backend; `__lll_lock_wait` = glibc
+  malloc-arena contention; `rayon` = fastokens pool idle/spin. **Lock contention
+  in app code shows as parking_lot/Mutex/RwLock frames** — if those are ~0%, the
+  process is idle-waiting, not internally serialized.
+
+## Analysis cheatsheet
+
+- **Throughput**: `extract_throughput.py <artifact_dir>` — recompute from raw
+  JSONL (do NOT trust the finalizer; see Pitfalls). Closed-loop sanity check:
+  `throughput ≈ concurrency / mean_latency`.
+- **Cores busy** (avg): from `mpstat` per-core `%idle` → `busy = 100 - idle`;
+  or `cpu_ms_per_req × req_per_s / 1000`. Per-request CPU = Δ(utime+stime from
+  `/proc/<pid>/stat`)/CLK_TCK ÷ requests.
+- **Latency decomposition**: `request_latency ≈ TTFT + (output_tokens × ITL)`.
+  If TTFT dominates and explodes under load → queueing upstream of generation.
+
+## Pitfalls & gotchas (read this)
+
+**Benchmark methodology**
+- **Closed-loop, not open-loop.** Fixed concurrency means you measure
+  `concurrency / latency`, NOT the server's max throughput. Idle frontend cores
+  usually mean the system is **latency-bound** (each request spends most of its
+  life waiting between streamed tokens), not that the frontend is slow. To push
+  the frontend toward saturation: raise concurrency AND lower per-request
+  latency (smaller block size → more frontend KV work; shorter outputs).
+- **Congestion collapse at high concurrency.** Pushing concurrency too high can
+  *lower* throughput (latency explodes faster than concurrency rises). Sweep
+  concurrency to find the knee; don't assume "more load = more throughput".
+- **Client/server core contention.** aiperf is CPU-heavy (client-side tokenizes
+  every prompt, manages every stream across ~25 procs). Co-located with the
+  mockers on `OTHER_CORES`, it can saturate those cores and **starve the mockers**
+  — making a "collapse" that's really the *load generator* running out of CPU.
+  Always check the CPU split (`pidstat` mocker vs `mpstat` on `OTHER_CORES`);
+  if cores are pegged but the mocker is low, the client is the bottleneck.
+- **Cold-start first run** is systematically slow even with warmup — discard it.
+- **Don't build while benchmarking.** Compiles steal cores and ruin the run.
+
+**aiperf**
+- **The finalizer hangs/deadlocks on large runs** ("processing records…"). The
+  per-request `profile_export.jsonl` is written incrementally — kill the
+  finalizer and use `extract_throughput.py`. Don't wait for
+  `profile_export_aiperf.json`.
+- **Orphan processes.** aiperf's controller spawns many workers; killing the
+  parent can orphan them. Worse: if you ran a capture **with sudo**, aiperf ran
+  **as root** and a non-root `pkill` can't reap it — use `sudo pkill -9 -f aiperf`.
+  Stray aiperf workers hold ZMQ/mmap resources and make the *next* run stall.
+- `--benchmark-duration N` (time-based) avoids the giant fixed `--request-count`
+  + finalizer problem for profiling loads.
+
+**Profiling**
+- **Off-CPU needs root.** Tracepoints (`sched:sched_switch`) and BPF
+  (`offcputime`) require root even at `perf_event_paranoid=-1` (tracefs event
+  files are root-readable only). On-CPU `perf -F.. -g` works non-root at paranoid≤1.
+- **Native `perf --off-cpu` is often NOT compiled in** (needs `BUILD_BPF_SKEL=1`);
+  it silently no-ops with a warning. Use `offcputime-bpfcc` / bpftrace instead.
+- **No frame pointers in release builds** → BPF user-stack walking truncates.
+  Prefer `perf --call-graph dwarf`; bcc still gives good kernel stacks + partial
+  user frames. `analyze_folded.py` handles the bcc `-` separator.
+- Async-runtime off-CPU is dominated by **worker park (futex)** which is benign
+  idle, not contention. Look for app-level lock frames (parking_lot/Mutex) to
+  find real serialization. A blocked async *task* ≠ a blocked *thread*.
+
+**Topology / environment**
+- **Block size must match** frontend and mocker. And **very large block sizes
+  break the current mocker**: at `BLOCK_SIZE=2048` requests are received but the
+  mocker never emits a token (40s hang → client cancel, `output_tokens=0`,
+  "Failed to publish response"). 512 and 1024 work; 64 is realistic. Smoke-test
+  a single request after any block-size change.
+- **Block size is a lever, not just a detail.** Smaller blocks → more blocks per
+  prompt → more frontend KV-routing work (radix tree, hashing) AND more mocker
+  block bookkeeping. At bs=64 a 60k-token prompt is ~940 blocks and the mocker's
+  KV bookkeeping can dominate (~48% of its CPU); at bs=512 (~117 blocks) it drops
+  to ~3%. Pick the block size deliberately for what you're stressing.
+- **CPU isolation doesn't survive reboot** (`isolate.sh` sets runtime cgroup
+  cpusets on system.slice). Re-run `sudo bash scripts/isolate.sh` after every
+  reboot. `unisolate.sh` reverts. Check: `cat /sys/fs/cgroup/system.slice/cpuset.cpus.effective`.
+- **NATS doesn't auto-start after reboot** (user binary); etcd usually does
+  (systemd). After a reboot, restart NATS before `start.sh`.
+- **jemalloc is frontend-only** here (via `FRONTEND_LD_PRELOAD`); the mocker runs
+  on glibc, so its alloc churn can show glibc-arena lock contention
+  (`__lll_lock_wait` under `__libc_free`/`Vec::finish_grow`) in off-CPU. Preload
+  jemalloc on the mocker too if that matters.
+- `DYN_RUNTIME_NUM_WORKER_THREADS` may be **ignored** (the runtime can be reused
+  via `runtime_from_existing`, bypassing `from_settings`). Verify thread counts
+  in `/proc/<pid>/task` rather than assuming the env var took effect.
+
+**Known result (calibration)**: with mock workers, the Dynamo **frontend is
+rarely the bottleneck** — it's latency/IO-bound, sitting ~60–85% of its pinned
+cores with ~0 internal lock contention. Frontend micro-opts therefore show flat
+e2e throughput on this setup; their value is CPU-efficiency/headroom. To make
+the frontend the bottleneck, use small block size + high concurrency, or
+real backends, or move the client off-box.
+
+## Script reference (`scripts/`)
+- `env.sh` — config; **set `DYN_REPO`**; everything else overridable.
+- `start.sh` — launch frontend (pinned, optional `FRONTEND_LD_PRELOAD`/`FASTOKENS_*`)
+  + `NUM_WORKERS` mockers; port preflight, etcd worker-count verify.
+- `stop.sh` — teardown both + drain etcd to 0.
+- `run_aiperf.sh` — one measured run (`CONCURRENCY`/`REQUEST_COUNT`/`WARMUP_REQUESTS`).
+- `isolate.sh` / `unisolate.sh` — CPU isolation (sudo; Lite by default, `--full` for max).
+- `smoke.sh` — single-request sanity check (use after any topology/block-size change).
+- `profile_oncpu.sh` — on-CPU perf + flamegraph (non-root): `--frontend`/`--mocker`/`--pid`.
+- `capture_offcpu.sh` — off-CPU bcc + perf (sudo): `--frontend`/`--mocker`/`--pid`.
+- `analyze_folded.py` — top self-time (on-CPU) or innermost-frame + category (off-CPU).
+- `extract_throughput.py` — robust throughput/latency from raw aiperf JSONL.

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/analyze_folded.py
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/analyze_folded.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Analyze a folded-stack file from perf (on-CPU) or offcputime-bpfcc (off-CPU).
+
+Usage:
+    python3 analyze_folded.py <file.folded> [--offcpu]
+
+Folded format (one line per stack):  frame;frame;...;leaf  <count>
+ - perf on-CPU (stackcollapse-perf.pl): count = samples; leaf = where CPU was spent.
+ - offcputime-bpfcc -df: count = microseconds blocked; a literal "-" frame
+   separates the USER stack (root->leaf) from the KERNEL stack. The innermost
+   USER frame (just before "-") is what called into the blocking syscall.
+
+On-CPU: prints top self-time (exclusive) leaves -> where compute goes.
+Off-CPU (--offcpu): prints top innermost-user-frames + a primitive breakdown
+   (futex/park vs epoll/network vs lock vs rayon) -> what threads wait on.
+"""
+import re, sys
+from collections import defaultdict
+
+def clean(fr):
+    fr = re.sub(r'::h[0-9a-f]{16}.*', '', fr)
+    fr = re.sub(r'\.llvm\..*', '', fr)
+    for a, b in [('$LT$','<'),('$GT$','>'),('$u20$',' '),('$C$',','),
+                 ('$u7b$','{'),('$u7d$','}'),('..','::')]:
+        fr = fr.replace(a, b)
+    return fr[:100]
+
+def load(path):
+    stacks = []
+    for line in open(path):
+        line = line.rstrip('\n')
+        i = line.rfind(' ')
+        if i < 0:
+            continue
+        try:
+            v = int(line[i+1:])
+        except ValueError:
+            continue
+        stacks.append((line[:i].split(';'), v))
+    return stacks
+
+def oncpu(stacks):
+    tot = sum(v for _, v in stacks)
+    agg = defaultdict(int)
+    for frames, v in stacks:
+        agg[clean(frames[-1])] += v
+    print(f"total samples={tot}; top self-time (exclusive) leaves:")
+    for fr, v in sorted(agg.items(), key=lambda x: -x[1])[:20]:
+        print(f"{100*v/tot:5.1f}%  {fr}")
+
+def offcpu(stacks):
+    tot = sum(v for _, v in stacks)
+    by_frame = defaultdict(int)
+    by_cat = defaultdict(int)
+    for frames, v in stacks:
+        k = frames.index('-') if '-' in frames else len(frames)
+        iu = clean(frames[k-1]) if k > 0 else clean(frames[-1])
+        by_frame[iu] += v
+        s = ';'.join(frames).lower()
+        leaf = frames[k-1].lower() if k > 0 else ''
+        if 'rayon' in s:
+            cat = 'rayon pool (idle/spin)'
+        elif 'epoll' in leaf or 'epoll' in s and 'io' in s:
+            cat = 'epoll / network wait'
+        elif 'mutex' in s or 'rwlock' in s or 'parking_lot' in s or '__lll_lock' in s:
+            cat = 'LOCK (mutex/rwlock/glibc)'
+        elif 'mpsc' in s or 'channel' in s or 'notify' in s or 'semaphore' in s:
+            cat = 'channel/notify/semaphore'
+        elif 'syscall' in leaf or 'futex' in s:
+            cat = 'park/idle (futex)'
+        else:
+            cat = 'other'
+        by_cat[cat] += v
+    print(f"total off-CPU={tot/1e6:.0f} core-s; innermost USER frame before blocking:")
+    for fr, v in sorted(by_frame.items(), key=lambda x: -x[1])[:18]:
+        print(f"{100*v/tot:5.1f}%  {v/1e6:7.1f}s  {fr}")
+    print("\nby primitive category:")
+    for c, v in sorted(by_cat.items(), key=lambda x: -x[1]):
+        print(f"{100*v/tot:5.1f}%  {c}")
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    stacks = load(sys.argv[1])
+    if not stacks:
+        print("no parseable stacks (empty/failed capture?)"); sys.exit(1)
+    (offcpu if '--offcpu' in sys.argv else oncpu)(stacks)

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/analyze_folded.py
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/analyze_folded.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 """Analyze a folded-stack file from perf (on-CPU) or offcputime-bpfcc (off-CPU).
 
 Usage:
@@ -14,30 +17,41 @@ On-CPU: prints top self-time (exclusive) leaves -> where compute goes.
 Off-CPU (--offcpu): prints top innermost-user-frames + a primitive breakdown
    (futex/park vs epoll/network vs lock vs rayon) -> what threads wait on.
 """
-import re, sys
+import re
+import sys
 from collections import defaultdict
 
+
 def clean(fr):
-    fr = re.sub(r'::h[0-9a-f]{16}.*', '', fr)
-    fr = re.sub(r'\.llvm\..*', '', fr)
-    for a, b in [('$LT$','<'),('$GT$','>'),('$u20$',' '),('$C$',','),
-                 ('$u7b$','{'),('$u7d$','}'),('..','::')]:
+    fr = re.sub(r"::h[0-9a-f]{16}.*", "", fr)
+    fr = re.sub(r"\.llvm\..*", "", fr)
+    for a, b in [
+        ("$LT$", "<"),
+        ("$GT$", ">"),
+        ("$u20$", " "),
+        ("$C$", ","),
+        ("$u7b$", "{"),
+        ("$u7d$", "}"),
+        ("..", "::"),
+    ]:
         fr = fr.replace(a, b)
     return fr[:100]
+
 
 def load(path):
     stacks = []
     for line in open(path):
-        line = line.rstrip('\n')
-        i = line.rfind(' ')
+        line = line.rstrip("\n")
+        i = line.rfind(" ")
         if i < 0:
             continue
         try:
-            v = int(line[i+1:])
+            v = int(line[i + 1 :])
         except ValueError:
             continue
-        stacks.append((line[:i].split(';'), v))
+        stacks.append((line[:i].split(";"), v))
     return stacks
+
 
 def oncpu(stacks):
     tot = sum(v for _, v in stacks)
@@ -48,28 +62,29 @@ def oncpu(stacks):
     for fr, v in sorted(agg.items(), key=lambda x: -x[1])[:20]:
         print(f"{100*v/tot:5.1f}%  {fr}")
 
+
 def offcpu(stacks):
     tot = sum(v for _, v in stacks)
     by_frame = defaultdict(int)
     by_cat = defaultdict(int)
     for frames, v in stacks:
-        k = frames.index('-') if '-' in frames else len(frames)
-        iu = clean(frames[k-1]) if k > 0 else clean(frames[-1])
+        k = frames.index("-") if "-" in frames else len(frames)
+        iu = clean(frames[k - 1]) if k > 0 else clean(frames[-1])
         by_frame[iu] += v
-        s = ';'.join(frames).lower()
-        leaf = frames[k-1].lower() if k > 0 else ''
-        if 'rayon' in s:
-            cat = 'rayon pool (idle/spin)'
-        elif 'epoll' in leaf or 'epoll' in s and 'io' in s:
-            cat = 'epoll / network wait'
-        elif 'mutex' in s or 'rwlock' in s or 'parking_lot' in s or '__lll_lock' in s:
-            cat = 'LOCK (mutex/rwlock/glibc)'
-        elif 'mpsc' in s or 'channel' in s or 'notify' in s or 'semaphore' in s:
-            cat = 'channel/notify/semaphore'
-        elif 'syscall' in leaf or 'futex' in s:
-            cat = 'park/idle (futex)'
+        s = ";".join(frames).lower()
+        leaf = frames[k - 1].lower() if k > 0 else ""
+        if "rayon" in s:
+            cat = "rayon pool (idle/spin)"
+        elif "epoll" in leaf or "epoll" in s and "io" in s:
+            cat = "epoll / network wait"
+        elif "mutex" in s or "rwlock" in s or "parking_lot" in s or "__lll_lock" in s:
+            cat = "LOCK (mutex/rwlock/glibc)"
+        elif "mpsc" in s or "channel" in s or "notify" in s or "semaphore" in s:
+            cat = "channel/notify/semaphore"
+        elif "syscall" in leaf or "futex" in s:
+            cat = "park/idle (futex)"
         else:
-            cat = 'other'
+            cat = "other"
         by_cat[cat] += v
     print(f"total off-CPU={tot/1e6:.0f} core-s; innermost USER frame before blocking:")
     for fr, v in sorted(by_frame.items(), key=lambda x: -x[1])[:18]:
@@ -78,10 +93,13 @@ def offcpu(stacks):
     for c, v in sorted(by_cat.items(), key=lambda x: -x[1]):
         print(f"{100*v/tot:5.1f}%  {c}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(__doc__); sys.exit(1)
+        print(__doc__)
+        sys.exit(1)
     stacks = load(sys.argv[1])
     if not stacks:
-        print("no parseable stacks (empty/failed capture?)"); sys.exit(1)
-    (offcpu if '--offcpu' in sys.argv else oncpu)(stacks)
+        print("no parseable stacks (empty/failed capture?)")
+        sys.exit(1)
+    (offcpu if "--offcpu" in sys.argv else oncpu)(stacks)

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/capture_offcpu.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/capture_offcpu.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Off-CPU profile of a target process (frontend or mocker) under load.
 # Shows what blocked threads are WAITING on (futex/lock, epoll/network, park).
 #
@@ -25,12 +28,21 @@ esac; done
 
 [[ $EUID -eq 0 ]] || { echo "ERROR: run with sudo (sched tracepoints + BPF need root)."; exit 1; }
 [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null || { echo "ERROR: target PID '$PID' not running."; exit 1; }
+command -v setsid >/dev/null 2>&1 || { echo "ERROR: setsid is required to isolate the aiperf load process group."; exit 1; }
 STAMP="$(date +%Y%m%d-%H%M%S)"
 OUT="$RESULTS_DIR/../profiling/offcpu-$TAG-$STAMP"; mkdir -p "$OUT"
 echo "[offcpu] target=$TAG PID=$PID conc=$CONC out=$OUT"
 
+cleanup_load() {
+  if [[ -n "${LOAD_PGID:-}" ]]; then
+    kill -- "-$LOAD_PGID" 2>/dev/null || true
+  elif [[ -n "${LOAD_PID:-}" ]]; then
+    kill "$LOAD_PID" 2>/dev/null || true
+  fi
+}
+
 # Drive load (time-based; small dataset = fast client-side gen).
-taskset -c "$OTHER_CORES" "$AIPERF" profile --model "$MODEL" --tokenizer "$MODEL" \
+setsid taskset -c "$OTHER_CORES" "$AIPERF" profile --model "$MODEL" --tokenizer "$MODEL" \
   --url "http://localhost:${HTTP_PORT}" --endpoint-type chat --streaming \
   --shared-system-prompt-length 48000 --user-context-prompt-length 12000 \
   --num-dataset-entries 1024 --output-tokens-mean 500 --conversation-turn-mean 4 \
@@ -38,7 +50,9 @@ taskset -c "$OTHER_CORES" "$AIPERF" profile --model "$MODEL" --tokenizer "$MODEL
   --extra-inputs "ignore_eos:true" --artifact-dir "$OUT/load_artifacts" \
   > "$OUT/load_aiperf.log" 2>&1 &
 LOAD_PID=$!
-trap 'kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null' EXIT
+LOAD_PGID="$(ps -o pgid= -p "$LOAD_PID" 2>/dev/null | tr -d '[:space:]')"
+LOAD_PGID="${LOAD_PGID:-$LOAD_PID}"
+trap cleanup_load EXIT
 echo "[load] settling ${SETTLE}s ..."; sleep "$SETTLE"
 
 # 1) bcc offcputime: duration-weighted, user+kernel, folded directly.
@@ -58,7 +72,7 @@ if [[ -s "$OUT/offcpu_bcc.folded" && -x "$FLAMEGRAPH_DIR/flamegraph.pl" ]]; then
     "$OUT/offcpu_bcc.folded" > "$OUT/offcpu_bcc.svg" 2>/dev/null || true
 fi
 
-kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null; trap - EXIT
+cleanup_load; trap - EXIT
 # Hand artifacts back to the invoking (non-root) user so analysis can read them.
 chown -R "$(stat -c %U "$RESULTS_DIR")":"$(stat -c %G "$RESULTS_DIR")" "$OUT" 2>/dev/null || true
 echo "[done] $OUT  (offcpu_bcc.folded / .svg ; sched.data for perf-DWARF)"

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/capture_offcpu.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/capture_offcpu.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Off-CPU profile of a target process (frontend or mocker) under load.
+# Shows what blocked threads are WAITING on (futex/lock, epoll/network, park).
+#
+# MUST run as root: sched tracepoints + BPF are root-only even with
+# perf_event_paranoid=-1 (tracefs event files are root-readable only).
+#
+#   sudo DYN_REPO=/path/to/dynamo bash capture_offcpu.sh --pid <PID> [--conc 2048]
+#   # or target the frontend automatically:
+#   sudo DYN_REPO=/path/to/dynamo bash capture_offcpu.sh --frontend
+#
+# Pre-req: topology already up (start.sh). This only drives load + captures.
+set -uo pipefail
+cd "$(dirname "$0")"; source ./env.sh
+
+CONC=2048; LOAD_SECS=200; SETTLE=45; CAP_SECS=45; MIN_US=1000; PID=""; TAG="proc"
+while [[ $# -gt 0 ]]; do case $1 in
+  --pid) PID="$2"; shift 2;;
+  --frontend) PID="$(cat "$LOG_DIR/frontend.pid")"; TAG="frontend"; shift;;
+  --mocker) PID="$(pgrep -f 'python.*dynamo.mocker'|head -1)"; TAG="mocker"; shift;;
+  --conc) CONC="$2"; shift 2;;
+  --cap) CAP_SECS="$2"; shift 2;;
+  *) echo "unknown arg $1"; exit 1;;
+esac; done
+
+[[ $EUID -eq 0 ]] || { echo "ERROR: run with sudo (sched tracepoints + BPF need root)."; exit 1; }
+[[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null || { echo "ERROR: target PID '$PID' not running."; exit 1; }
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="$RESULTS_DIR/../profiling/offcpu-$TAG-$STAMP"; mkdir -p "$OUT"
+echo "[offcpu] target=$TAG PID=$PID conc=$CONC out=$OUT"
+
+# Drive load (time-based; small dataset = fast client-side gen).
+taskset -c "$OTHER_CORES" "$AIPERF" profile --model "$MODEL" --tokenizer "$MODEL" \
+  --url "http://localhost:${HTTP_PORT}" --endpoint-type chat --streaming \
+  --shared-system-prompt-length 48000 --user-context-prompt-length 12000 \
+  --num-dataset-entries 1024 --output-tokens-mean 500 --conversation-turn-mean 4 \
+  --concurrency "$CONC" --benchmark-duration "$LOAD_SECS" --warmup-request-count 256 \
+  --extra-inputs "ignore_eos:true" --artifact-dir "$OUT/load_artifacts" \
+  > "$OUT/load_aiperf.log" 2>&1 &
+LOAD_PID=$!
+trap 'kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null' EXIT
+echo "[load] settling ${SETTLE}s ..."; sleep "$SETTLE"
+
+# 1) bcc offcputime: duration-weighted, user+kernel, folded directly.
+echo "[cap] offcputime-bpfcc ${CAP_SECS}s ..."
+offcputime-bpfcc -df -d "$CAP_SECS" -p "$PID" -m "$MIN_US" > "$OUT/offcpu_bcc.folded" 2>"$OUT/offcpu_bcc.err" \
+  || echo "  (bcc failed; see offcpu_bcc.err)"
+
+# 2) perf sched_switch + DWARF: reliable Rust user stacks (release .so has no frame pointers).
+echo "[cap] perf sched_switch --call-graph dwarf ${CAP_SECS}s ..."
+perf record -e sched:sched_switch --call-graph dwarf -p "$PID" \
+  -o "$OUT/sched.data" -- sleep "$CAP_SECS" 2>"$OUT/perf_record.err" \
+  || echo "  (perf failed; see perf_record.err)"
+
+# 3) flamegraph from the bcc folded stacks.
+if [[ -s "$OUT/offcpu_bcc.folded" && -x "$FLAMEGRAPH_DIR/flamegraph.pl" ]]; then
+  "$FLAMEGRAPH_DIR/flamegraph.pl" --title "off-CPU $TAG (c=$CONC)" --countname us --color io \
+    "$OUT/offcpu_bcc.folded" > "$OUT/offcpu_bcc.svg" 2>/dev/null || true
+fi
+
+kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null; trap - EXIT
+# Hand artifacts back to the invoking (non-root) user so analysis can read them.
+chown -R "$(stat -c %U "$RESULTS_DIR")":"$(stat -c %G "$RESULTS_DIR")" "$OUT" 2>/dev/null || true
+echo "[done] $OUT  (offcpu_bcc.folded / .svg ; sched.data for perf-DWARF)"
+echo "REMINDER: aiperf ran as ROOT; if orphans linger, 'sudo pkill -9 -f aiperf'."

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/env.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/env.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Shared environment for the Dynamo frontend benchmark harness.
 # Source from the other scripts: `source "$(dirname "$0")/env.sh"`
 #

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/env.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/env.sh
@@ -1,0 +1,54 @@
+# Shared environment for the Dynamo frontend benchmark harness.
+# Source from the other scripts: `source "$(dirname "$0")/env.sh"`
+#
+# REQUIRED: set DYN_REPO to your Dynamo checkout (or worktree) that contains the
+# built `.venv` (uv venv + `maturin develop --uv --release`). Everything else
+# derives from it and is overridable from the calling shell.
+
+# --- Repo / venv -----------------------------------------------------------
+export DYN_REPO="${DYN_REPO:?set DYN_REPO to your dynamo checkout, e.g. export DYN_REPO=/path/to/dynamo}"
+export WORKTREE="$DYN_REPO"                       # alias used by some scripts
+export VENV="${VENV:-$DYN_REPO/.venv}"
+export DYN_PY="${DYN_PY:-$VENV/bin/python}"       # runs dynamo.frontend / dynamo.mocker
+# aiperf client: a venv with aiperf installed (can be the same venv or another).
+export AIPERF="${AIPERF:-$VENV/bin/aiperf}"
+# FlameGraph scripts (stackcollapse-perf.pl, flamegraph.pl). Clone from
+# https://github.com/brendangregg/FlameGraph if absent.
+export FLAMEGRAPH_DIR="${FLAMEGRAPH_DIR:-$DYN_REPO/FlameGraph}"
+
+# --- Model / topology ------------------------------------------------------
+export MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+export ENDPOINT="${ENDPOINT:-dyn://dynamo.backend.generate}"   # mocker default
+export HTTP_PORT="${HTTP_PORT:-8000}"
+# Block size: frontend (--kv-cache-block-size) and mocker (--block-size) MUST
+# agree. 64 is realistic; larger reduces the MOCK's per-request KV-block
+# bookkeeping (see SKILL.md "Block size"). NOTE: very large sizes (>=2048) break
+# the current mocker (requests hang, never emit a token).
+export BLOCK_SIZE="${BLOCK_SIZE:-64}"
+export NUM_WORKERS="${NUM_WORKERS:-4}"
+
+# --- Discovery (etcd + nats) ----------------------------------------------
+export ETCD_ENDPOINT="${ETCD_ENDPOINT:-localhost:2379}"
+# Worker instances register one lease-backed key per worker here; dead workers
+# self-expire. Used to verify exactly NUM_WORKERS are live and no stale ones linger.
+export INSTANCE_PREFIX="${INSTANCE_PREFIX:-v1/instances/dynamo/backend/generate/}"
+# count live registered workers (grep -c exits 1 on zero, which would trip set -e)
+count_workers() { ETCDCTL_API=3 etcdctl --endpoints="$ETCD_ENDPOINT" get --prefix "$INSTANCE_PREFIX" --keys-only 2>/dev/null | grep -c 'generate/' || true; }
+
+# --- CPU isolation ---------------------------------------------------------
+# Frontend (HTTP + tokenizer + KV router) pinned to FRONTEND_CORES.
+# Everything else (mock workers + aiperf client) on OTHER_CORES.
+# Keep FRONTEND_CORES small (e.g. 4) to make frontend CPU effects observable;
+# give OTHER_CORES enough cores that the client does not starve the mockers.
+export FRONTEND_CORES="${FRONTEND_CORES:-0-3}"
+export OTHER_CORES="${OTHER_CORES:-4-23}"
+
+# --- Tokenizer flags (read by the frontend's model-card loader) ------------
+export DYN_TOKENIZER="${DYN_TOKENIZER:-fastokens}"          # or "default" (HF)
+export DYN_TOKENIZER_CACHE="${DYN_TOKENIZER_CACHE:-1}"
+export DYN_TOKENIZER_CACHE_BYTES="${DYN_TOKENIZER_CACHE_BYTES:-$((1024 * 1024 * 1024))}"  # 1 GiB
+
+# --- Output dirs -----------------------------------------------------------
+export LOG_DIR="${LOG_DIR:-$DYN_REPO/bench/logs}"
+export RESULTS_DIR="${RESULTS_DIR:-$DYN_REPO/bench/results}"
+mkdir -p "$LOG_DIR" "$RESULTS_DIR"

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/extract_throughput.py
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/extract_throughput.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 """Recompute throughput/latency from aiperf's raw profile_export.jsonl.
 
 WHY: aiperf's finalizer can hang for minutes (or effectively deadlock) on large
@@ -11,32 +14,51 @@ Usage: python3 extract_throughput.py <artifact_dir_or_jsonl> [--conc N]
 Each JSONL line: {"metadata": {...request_start_ns, request_end_ns,
 benchmark_phase, was_cancelled...}, "metrics": {request_latency, time_to_first_token, ...}}
 """
-import json, os, sys, statistics as st
+import json
+import os
+import statistics as st
+import sys
+
 
 def find_jsonl(p):
-    if p.endswith('.jsonl'):
+    if p.endswith(".jsonl"):
         return p
     for root, _, files in os.walk(p):
-        if 'profile_export.jsonl' in files:
-            return os.path.join(root, 'profile_export.jsonl')
+        if "profile_export.jsonl" in files:
+            return os.path.join(root, "profile_export.jsonl")
     sys.exit(f"no profile_export.jsonl under {p}")
+
 
 def main():
     path = find_jsonl(sys.argv[1])
     conc = None
-    if '--conc' in sys.argv:
-        conc = int(sys.argv[sys.argv.index('--conc')+1])
+    if "--conc" in sys.argv:
+        conc = int(sys.argv[sys.argv.index("--conc") + 1])
     S, E, lat, ttft = [], [], [], []
     for line in open(path):
-        if not line.strip():
+        line = line.strip()
+        if not line:
             continue
-        r = json.loads(line); m = r['metadata']
-        if m.get('benchmark_phase') != 'profiling' or m.get('was_cancelled'):
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
             continue
-        S.append(m['request_start_ns']); E.append(m['request_end_ns'])
-        mt = r.get('metrics', {})
-        if 'request_latency' in mt: lat.append(mt['request_latency']['value'])
-        if 'time_to_first_token' in mt: ttft.append(mt['time_to_first_token']['value'])
+        m = r.get("metadata") or {}
+        if m.get("benchmark_phase") != "profiling" or m.get("was_cancelled"):
+            continue
+        start = m.get("request_start_ns")
+        end = m.get("request_end_ns")
+        if start is None or end is None:
+            continue
+        S.append(start)
+        E.append(end)
+        mt = r.get("metrics") or {}
+        request_latency = mt.get("request_latency") or {}
+        time_to_first_token = mt.get("time_to_first_token") or {}
+        if "value" in request_latency:
+            lat.append(request_latency["value"])
+        if "value" in time_to_first_token:
+            ttft.append(time_to_first_token["value"])
     if not S:
         sys.exit("no completed profiling-phase records")
     wall = (max(E) - min(S)) / 1e9
@@ -46,16 +68,24 @@ def main():
     print(f"wall (1st start->last end): {wall:.1f}s")
     print(f"THROUGHPUT     : {tput:.1f} req/s")
     if lat:
-        print(f"request_latency: mean {st.mean(lat):.0f}ms  p50 {st.median(lat):.0f}ms  "
-              f"p99 {sorted(lat)[int(0.99*len(lat))]:.0f}ms")
+        print(
+            f"request_latency: mean {st.mean(lat):.0f}ms  p50 {st.median(lat):.0f}ms  "
+            f"p99 {sorted(lat)[int(0.99*len(lat))]:.0f}ms"
+        )
     if ttft:
-        print(f"TTFT           : p50 {st.median(ttft):.0f}ms  p99 {sorted(ttft)[int(0.99*len(ttft))]:.0f}ms")
+        print(
+            f"TTFT           : p50 {st.median(ttft):.0f}ms  p99 {sorted(ttft)[int(0.99*len(ttft))]:.0f}ms"
+        )
     if conc and lat:
         # Little's law sanity check (closed loop): tput ~= concurrency / latency
-        print(f"Little's law   : {conc}/{st.mean(lat)/1000:.2f}s = {conc/(st.mean(lat)/1000):.0f} req/s "
-              f"(vs measured {tput:.0f})")
+        print(
+            f"Little's law   : {conc}/{st.mean(lat)/1000:.2f}s = {conc/(st.mean(lat)/1000):.0f} req/s "
+            f"(vs measured {tput:.0f})"
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(__doc__); sys.exit(1)
+        print(__doc__)
+        sys.exit(1)
     main()

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/extract_throughput.py
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/extract_throughput.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Recompute throughput/latency from aiperf's raw profile_export.jsonl.
+
+WHY: aiperf's finalizer can hang for minutes (or effectively deadlock) on large
+runs while "processing records". Don't wait for profile_export_aiperf.json --
+the raw per-request JSONL is written incrementally and has everything you need.
+Kill the finalizer and run this instead.
+
+Usage: python3 extract_throughput.py <artifact_dir_or_jsonl> [--conc N]
+
+Each JSONL line: {"metadata": {...request_start_ns, request_end_ns,
+benchmark_phase, was_cancelled...}, "metrics": {request_latency, time_to_first_token, ...}}
+"""
+import json, os, sys, statistics as st
+
+def find_jsonl(p):
+    if p.endswith('.jsonl'):
+        return p
+    for root, _, files in os.walk(p):
+        if 'profile_export.jsonl' in files:
+            return os.path.join(root, 'profile_export.jsonl')
+    sys.exit(f"no profile_export.jsonl under {p}")
+
+def main():
+    path = find_jsonl(sys.argv[1])
+    conc = None
+    if '--conc' in sys.argv:
+        conc = int(sys.argv[sys.argv.index('--conc')+1])
+    S, E, lat, ttft = [], [], [], []
+    for line in open(path):
+        if not line.strip():
+            continue
+        r = json.loads(line); m = r['metadata']
+        if m.get('benchmark_phase') != 'profiling' or m.get('was_cancelled'):
+            continue
+        S.append(m['request_start_ns']); E.append(m['request_end_ns'])
+        mt = r.get('metrics', {})
+        if 'request_latency' in mt: lat.append(mt['request_latency']['value'])
+        if 'time_to_first_token' in mt: ttft.append(mt['time_to_first_token']['value'])
+    if not S:
+        sys.exit("no completed profiling-phase records")
+    wall = (max(E) - min(S)) / 1e9
+    tput = len(S) / wall
+    print(f"file: {path}")
+    print(f"completed reqs : {len(S)}")
+    print(f"wall (1st start->last end): {wall:.1f}s")
+    print(f"THROUGHPUT     : {tput:.1f} req/s")
+    if lat:
+        print(f"request_latency: mean {st.mean(lat):.0f}ms  p50 {st.median(lat):.0f}ms  "
+              f"p99 {sorted(lat)[int(0.99*len(lat))]:.0f}ms")
+    if ttft:
+        print(f"TTFT           : p50 {st.median(ttft):.0f}ms  p99 {sorted(ttft)[int(0.99*len(ttft))]:.0f}ms")
+    if conc and lat:
+        # Little's law sanity check (closed loop): tput ~= concurrency / latency
+        print(f"Little's law   : {conc}/{st.mean(lat)/1000:.2f}s = {conc/(st.mean(lat)/1000):.0f} req/s "
+              f"(vs measured {tput:.0f})")
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    main()

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/isolate.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/isolate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Reserve cores 0-3 for the frontend by moving other userspace to cores 4-23
 # (systemd cgroup cpuset). Reversible (--runtime), no reboot.
 #

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/isolate.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/isolate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Reserve cores 0-3 for the frontend by moving other userspace to cores 4-23
+# (systemd cgroup cpuset). Reversible (--runtime), no reboot.
+#
+#   sudo bash bench/isolate.sh           # LITE (default): confine daemons only
+#   sudo bash bench/isolate.sh --full    # also confine user.slice (max isolation)
+#   sudo bash bench/unisolate.sh         # revert (or reboot)
+#
+# LITE (recommended): confine `system.slice` + `init.scope` (the security
+# daemons / system services that were the dominant noise) to 4-23, and LEAVE
+# `user.slice` on all cores. The frontend then runs with plain `taskset -c 0-3`
+# — so after this one-time sudo, `start.sh`/`stop.sh`/benchmarks need NO sudo.
+# Residual: your own user.slice procs (IDE/node/other sessions) may still touch
+# 0-3, but they're small and steady vs. the scanners.
+#
+# FULL (--full): also confine `user.slice` to 4-23, fully clearing 0-3 of
+# userspace. The frontend then can't use taskset (its slice forbids 0-3), so it
+# must launch via `ISOLATE=1 ./start.sh` (sudo systemd-run into bench.slice) —
+# i.e. a sudo on every frontend restart. Use only when you need maximum cleanliness.
+set -uo pipefail
+HOST_CORES="${HOST_CORES:-4-23}"
+FULL=0; [[ "${1:-}" == "--full" ]] && FULL=1
+[[ $EUID -eq 0 ]] || { echo "ERROR: run as root (sudo bash bench/isolate.sh)"; exit 1; }
+
+UNITS=(system.slice init.scope)
+[[ $FULL -eq 1 ]] && UNITS+=(user.slice)
+
+echo "[isolate] mode=$([[ $FULL -eq 1 ]] && echo FULL || echo LITE); confining ${UNITS[*]} to cores ${HOST_CORES} ..."
+for unit in "${UNITS[@]}"; do
+    systemctl set-property --runtime "$unit" AllowedCPUs="${HOST_CORES}" \
+        && echo "  $unit -> ${HOST_CORES}" || echo "  WARN: failed to set $unit"
+done
+
+echo "[isolate] steering IRQs off 0-3 (stop irqbalance so it doesn't undo this) ..."
+systemctl stop irqbalance 2>/dev/null || true
+moved=0
+for f in /proc/irq/*/smp_affinity_list; do
+    echo "${HOST_CORES}" > "$f" 2>/dev/null && moved=$((moved+1))
+done
+echo "  steered ${moved} IRQ(s) (some are pinned/unmovable — expected)."
+
+echo "[isolate] verify — effective cpus (want ${HOST_CORES}):"
+for unit in "${UNITS[@]}"; do
+    [[ "$unit" == "init.scope" ]] && path="init.scope" || path="$unit"
+    echo "  $unit: $(cat /sys/fs/cgroup/$path/cpuset.cpus.effective 2>/dev/null || echo '?')"
+done
+
+if [[ $FULL -eq 1 ]]; then
+    echo "[isolate] FULL: launch with  ISOLATE=1 ./start.sh  (frontend -> bench.slice on 0-3, needs sudo each restart)."
+    echo "          stop the isolated frontend with: sudo systemctl stop bench.slice"
+else
+    echo "[isolate] LITE: just run  ./start.sh  as usual (taskset puts the frontend on 0-3) — NO further sudo."
+fi

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/profile_oncpu.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/profile_oncpu.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# On-CPU profile of a target process (frontend or mocker) under load.
+# Non-root (needs perf_event_paranoid <= 1; -1 is ideal). Topology must be up.
+# Also samples the target's cores so you can see if it saturates.
+#
+#   DYN_REPO=/path bash profile_oncpu.sh --frontend [--conc 2048]
+#   DYN_REPO=/path bash profile_oncpu.sh --mocker
+#   DYN_REPO=/path bash profile_oncpu.sh --pid <PID> --cores 0-3
+set -uo pipefail
+cd "$(dirname "$0")"; source ./env.sh
+
+CONC=2048; LOAD_SECS=150; SETTLE=40; CAP_SECS=40; PID=""; CORES=""; TAG="proc"
+while [[ $# -gt 0 ]]; do case $1 in
+  --frontend) PID="$(cat "$LOG_DIR/frontend.pid")"; CORES="$FRONTEND_CORES"; TAG="frontend"; shift;;
+  --mocker)   PID="$(pgrep -f 'python.*dynamo.mocker'|head -1)"; CORES="$OTHER_CORES"; TAG="mocker"; shift;;
+  --pid)      PID="$2"; shift 2;;
+  --cores)    CORES="$2"; shift 2;;
+  --conc)     CONC="$2"; shift 2;;
+  *) echo "unknown arg $1"; exit 1;;
+esac; done
+[[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null || { echo "ERROR: target PID '$PID' not running."; exit 1; }
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="$RESULTS_DIR/../profiling/oncpu-$TAG-$STAMP"; mkdir -p "$OUT"
+echo "[oncpu] target=$TAG PID=$PID cores=$CORES conc=$CONC out=$OUT"
+
+taskset -c "$OTHER_CORES" "$AIPERF" profile --model "$MODEL" --tokenizer "$MODEL" \
+  --url "http://localhost:${HTTP_PORT}" --endpoint-type chat --streaming \
+  --shared-system-prompt-length 48000 --user-context-prompt-length 12000 \
+  --num-dataset-entries 1024 --output-tokens-mean 500 --conversation-turn-mean 4 \
+  --concurrency "$CONC" --benchmark-duration "$LOAD_SECS" --warmup-request-count 256 \
+  --extra-inputs "ignore_eos:true" --artifact-dir "$OUT/load_artifacts" \
+  > "$OUT/load_aiperf.log" 2>&1 &
+LOAD_PID=$!
+trap 'kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null' EXIT
+echo "[load] settling ${SETTLE}s ..."; sleep "$SETTLE"
+
+# per-core utilization of the target's cores + per-process CPU
+[[ -n "$CORES" ]] && mpstat -P "${CORES//-/,}" "$CAP_SECS" 1 > "$OUT/mpstat.txt" 2>/dev/null &
+pidstat -p "$PID" 2 > "$OUT/pidstat.txt" 2>/dev/null & PS1=$!
+
+echo "[perf] on-CPU record ${CAP_SECS}s ..."
+# DWARF call graph: the release .so has no frame pointers, so -g (FP) would
+# truncate stacks. -F 99 keeps overhead low; raise to 199/499 for more detail.
+perf record -F 99 --call-graph dwarf -p "$PID" -o "$OUT/oncpu.data" -- sleep "$CAP_SECS" 2>"$OUT/perf.err" || echo "perf failed"
+kill "$PS1" 2>/dev/null || true
+
+echo "[fold] flamegraph ..."
+perf script -i "$OUT/oncpu.data" 2>/dev/null | "$FLAMEGRAPH_DIR/stackcollapse-perf.pl" > "$OUT/oncpu.folded" 2>/dev/null
+"$FLAMEGRAPH_DIR/flamegraph.pl" --title "on-CPU $TAG (c=$CONC)" "$OUT/oncpu.folded" > "$OUT/oncpu.svg" 2>/dev/null
+
+kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null; trap - EXIT
+echo "[done] $OUT"
+echo "--- target cores busy (mpstat) ---"
+[[ -f "$OUT/mpstat.txt" ]] && awk '$NF ~ /^[0-9.]+$/ && $3 ~ /^[0-9]+$/ {b=100-$NF; s+=b; n++} END{if(n)printf "mean %.1f%%/core\n",s/n}' "$OUT/mpstat.txt"
+echo "--- analyze with:  python3 analyze_folded.py $OUT/oncpu.folded ---"

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/profile_oncpu.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/profile_oncpu.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # On-CPU profile of a target process (frontend or mocker) under load.
 # Non-root (needs perf_event_paranoid <= 1; -1 is ideal). Topology must be up.
 # Also samples the target's cores so you can see if it saturates.
@@ -20,6 +23,28 @@ while [[ $# -gt 0 ]]; do case $1 in
 esac; done
 [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null || { echo "ERROR: target PID '$PID' not running."; exit 1; }
 
+expand_cpu_list() {
+  local spec="$1"
+  local part start end cpu
+  local out=()
+  IFS=',' read -ra parts <<< "$spec"
+  for part in "${parts[@]}"; do
+    if [[ "$part" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+      start="${BASH_REMATCH[1]}"
+      end="${BASH_REMATCH[2]}"
+      if (( start <= end )); then
+        for ((cpu=start; cpu<=end; cpu++)); do out+=("$cpu"); done
+      else
+        for ((cpu=start; cpu>=end; cpu--)); do out+=("$cpu"); done
+      fi
+    else
+      out+=("$part")
+    fi
+  done
+  local IFS=,
+  echo "${out[*]}"
+}
+
 STAMP="$(date +%Y%m%d-%H%M%S)"
 OUT="$RESULTS_DIR/../profiling/oncpu-$TAG-$STAMP"; mkdir -p "$OUT"
 echo "[oncpu] target=$TAG PID=$PID cores=$CORES conc=$CONC out=$OUT"
@@ -36,7 +61,10 @@ trap 'kill "$LOAD_PID" 2>/dev/null; pkill -f "aiperf profile" 2>/dev/null' EXIT
 echo "[load] settling ${SETTLE}s ..."; sleep "$SETTLE"
 
 # per-core utilization of the target's cores + per-process CPU
-[[ -n "$CORES" ]] && mpstat -P "${CORES//-/,}" "$CAP_SECS" 1 > "$OUT/mpstat.txt" 2>/dev/null &
+if [[ -n "$CORES" ]]; then
+  MPSTAT_CORES="$(expand_cpu_list "$CORES")"
+  mpstat -P "$MPSTAT_CORES" "$CAP_SECS" 1 > "$OUT/mpstat.txt" 2>/dev/null &
+fi
 pidstat -p "$PID" 2 > "$OUT/pidstat.txt" 2>/dev/null & PS1=$!
 
 echo "[perf] on-CPU record ${CAP_SECS}s ..."

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/run_aiperf.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/run_aiperf.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Full benchmark run. NOT executed during setup — trigger this yourself.
 #   bench/run_aiperf.sh
 # Requires bench/start.sh to have been run first (frontend + workers up).

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/run_aiperf.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/run_aiperf.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Full benchmark run. NOT executed during setup — trigger this yourself.
+#   bench/run_aiperf.sh
+# Requires bench/start.sh to have been run first (frontend + workers up).
+set -euo pipefail
+cd "$(dirname "$0")"
+source ./env.sh
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+ART="$RESULTS_DIR/aiperf-$STAMP"
+echo "[aiperf] artifacts -> $ART"
+
+# Optional warmup: set WARMUP_REQUESTS to prime the shared-prefix cache + warm
+# the allocator/steady-state before the measured phase (removes cold-start skew).
+WARMUP_ARGS=()
+if [[ -n "${WARMUP_REQUESTS:-}" ]]; then
+    WARMUP_ARGS=(--warmup-request-count "$WARMUP_REQUESTS")
+    echo "[aiperf] warmup: $WARMUP_REQUESTS requests"
+fi
+
+# aiperf client pinned to the non-frontend cores so it never competes with the
+# 4-core frontend under test.
+taskset -c "$OTHER_CORES" "$AIPERF" profile \
+    --model "$MODEL" \
+    --tokenizer "$MODEL" \
+    --url "http://localhost:${HTTP_PORT}" \
+    --endpoint-type chat \
+    --streaming \
+    --shared-system-prompt-length 48000 \
+    --user-context-prompt-length 12000 \
+    --num-dataset-entries 10000 \
+    --output-tokens-mean 500 \
+    --conversation-turn-mean 4 \
+    --concurrency "${CONCURRENCY:-256}" \
+    --request-count "${REQUEST_COUNT:-2048}" \
+    "${WARMUP_ARGS[@]}" \
+    --extra-inputs "ignore_eos:true" \
+    --artifact-dir "$ART"
+
+echo "[aiperf] done. Results in $ART"

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/smoke.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Single streaming request to confirm the frontend -> KV router -> mock worker
+# pipeline is alive before running the full aiperf profile.
+set -euo pipefail
+cd "$(dirname "$0")"
+source ./env.sh
+
+echo "[smoke] GET /v1/models:"
+curl -sf "http://localhost:${HTTP_PORT}/v1/models" | head -c 400; echo; echo
+
+echo "[smoke] streaming chat completion:"
+curl -sf -X POST "http://localhost:${HTTP_PORT}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -H "Accept: text/event-stream" \
+    -d "{
+        \"model\": \"${MODEL}\",
+        \"messages\": [
+            {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},
+            {\"role\": \"user\", \"content\": \"Say hello in five words.\"}
+        ],
+        \"stream\": true,
+        \"max_tokens\": 16,
+        \"ignore_eos\": true
+    }" | head -20
+echo
+echo "[smoke] done. If you saw SSE 'data:' chunks above, the pipeline works."

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/smoke.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/smoke.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Single streaming request to confirm the frontend -> KV router -> mock worker
 # pipeline is alive before running the full aiperf profile.
 set -euo pipefail
@@ -9,6 +12,7 @@ echo "[smoke] GET /v1/models:"
 curl -sf "http://localhost:${HTTP_PORT}/v1/models" | head -c 400; echo; echo
 
 echo "[smoke] streaming chat completion:"
+set +o pipefail
 curl -sf -X POST "http://localhost:${HTTP_PORT}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -H "Accept: text/event-stream" \
@@ -22,5 +26,13 @@ curl -sf -X POST "http://localhost:${HTTP_PORT}/v1/chat/completions" \
         \"max_tokens\": 16,
         \"ignore_eos\": true
     }" | head -20
+stream_status=("${PIPESTATUS[@]}")
+set -o pipefail
+if [[ "${stream_status[0]}" -ne 0 && "${stream_status[0]}" -ne 23 ]]; then
+    exit "${stream_status[0]}"
+fi
+if [[ "${stream_status[1]}" -ne 0 ]]; then
+    exit "${stream_status[1]}"
+fi
 echo
 echo "[smoke] done. If you saw SSE 'data:' chunks above, the pipeline works."

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/start.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/start.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Start the benchmark topology:
 #   - 4 mock workers (one process, --num-workers 4) on cores 4-23
 #   - 1 frontend (HTTP + KV router + tokenizer) on cores 0-3
@@ -51,6 +54,25 @@ taskset -c "$OTHER_CORES" "$DYN_PY" -m dynamo.mocker \
 WORKERS_PID=$!
 echo "$WORKERS_PID" > "$LOG_DIR/workers.pid"
 echo "[workers] pid $WORKERS_PID, logging to $LOG_DIR/workers.log"
+
+STARTUP_OK=0
+terminate_process_tree() {
+    local pid="$1"
+    local child
+    [[ -n "$pid" ]] || return
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        terminate_process_tree "$child"
+    done
+    kill "$pid" 2>/dev/null || true
+}
+
+cleanup_startup_failure() {
+    [[ "$STARTUP_OK" == "1" ]] && return
+    echo "[cleanup] startup failed; stopping launched worker/frontend processes ..."
+    terminate_process_tree "${FRONTEND_PID:-}"
+    terminate_process_tree "${WORKERS_PID:-}"
+}
+trap cleanup_startup_failure EXIT
 
 # Wait for EXACTLY NUM_WORKERS fresh instances to register.
 echo "[workers] waiting for ${NUM_WORKERS} instances to register in etcd ..."
@@ -125,8 +147,10 @@ for i in $(seq 1 60); do
         tail -25 "$LOG_DIR/frontend.log"
         exit 1
     fi
-    if curl -sf "http://localhost:${HTTP_PORT}/v1/models" 2>/dev/null | grep -q "Qwen3-0.6B"; then
+    if curl -sf "http://localhost:${HTTP_PORT}/v1/models" 2>/dev/null | grep -Fq "$MODEL"; then
         echo "[ready] frontend (pid $FRONTEND_PID) serving model after ${i}s; ${NUM_WORKERS} workers live."
+        STARTUP_OK=1
+        trap - EXIT
         exit 0
     fi
     sleep 1

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/start.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/start.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Start the benchmark topology:
+#   - 4 mock workers (one process, --num-workers 4) on cores 4-23
+#   - 1 frontend (HTTP + KV router + tokenizer) on cores 0-3
+# Assumes etcd (:2379) and nats (:4222, JetStream) are already running.
+#
+# Hardened against the two failure modes we hit:
+#   1. frontend silently failing to bind :8000 while a dying old frontend or a
+#      stale socket answers the readiness poll -> we wait for the port to be
+#      free first, and fail fast if the launched frontend PID dies.
+#   2. stale worker registrations in etcd from a previous (killed) run -> we
+#      wait for the instance prefix to be empty before launching, then require
+#      EXACTLY NUM_WORKERS fresh instances to appear.
+set -euo pipefail
+cd "$(dirname "$0")"
+source ./env.sh
+
+# --- Sanity: infra ---------------------------------------------------------
+ss -ltn 2>/dev/null | grep -q ':2379' || { echo "ERROR: etcd not listening on :2379"; exit 1; }
+ss -ltn 2>/dev/null | grep -q ':4222' || { echo "ERROR: nats not listening on :4222 (start with: nats-server -js)"; exit 1; }
+echo "[infra] etcd :2379 and nats :4222 are up."
+
+# --- Pre-flight: port :8000 must be free -----------------------------------
+echo "[preflight] waiting for port :${HTTP_PORT} to be free ..."
+for i in $(seq 1 30); do
+    ss -ltn 2>/dev/null | grep -q ":${HTTP_PORT}\b" || { echo "[preflight] :${HTTP_PORT} free."; break; }
+    [[ $i -eq 30 ]] && { echo "ERROR: port :${HTTP_PORT} still in use after 30s. Run ./stop.sh."; exit 1; }
+    sleep 1
+done
+
+# --- Pre-flight: no stale worker instances in etcd -------------------------
+echo "[preflight] waiting for stale worker instances to clear from etcd ..."
+for i in $(seq 1 30); do
+    n="$(count_workers)"
+    [[ "$n" -eq 0 ]] && { echo "[preflight] etcd worker instances clear."; break; }
+    [[ $i -eq 30 ]] && { echo "ERROR: $n stale worker instance(s) still in etcd after 30s (prefix $INSTANCE_PREFIX)."; exit 1; }
+    sleep 1
+done
+
+# --- 4 mock workers (cores ${OTHER_CORES}) ---------------------------------
+echo "[workers] launching ${NUM_WORKERS} mock workers on cores ${OTHER_CORES} ..."
+taskset -c "$OTHER_CORES" "$DYN_PY" -m dynamo.mocker \
+    --model-path "$MODEL" \
+    --endpoint "$ENDPOINT" \
+    --num-workers "$NUM_WORKERS" \
+    --speedup-ratio 1000000 \
+    --max-num-seqs 100000 \
+    --max-num-batched-tokens 10000000 \
+    --block-size "$BLOCK_SIZE" \
+    > "$LOG_DIR/workers.log" 2>&1 &
+WORKERS_PID=$!
+echo "$WORKERS_PID" > "$LOG_DIR/workers.pid"
+echo "[workers] pid $WORKERS_PID, logging to $LOG_DIR/workers.log"
+
+# Wait for EXACTLY NUM_WORKERS fresh instances to register.
+echo "[workers] waiting for ${NUM_WORKERS} instances to register in etcd ..."
+for i in $(seq 1 60); do
+    kill -0 "$WORKERS_PID" 2>/dev/null || { echo "ERROR: workers process died. Tail:"; tail -20 "$LOG_DIR/workers.log"; exit 1; }
+    n="$(count_workers)"
+    [[ "$n" -eq "$NUM_WORKERS" ]] && { echo "[workers] ${n} instances registered."; break; }
+    [[ "$n" -gt "$NUM_WORKERS" ]] && { echo "ERROR: $n worker instances registered (> ${NUM_WORKERS}); stale entries present."; exit 1; }
+    [[ $i -eq 60 ]] && { echo "ERROR: only $n/${NUM_WORKERS} workers registered after 60s."; exit 1; }
+    sleep 1
+done
+
+# --- Frontend (cores ${FRONTEND_CORES}) ------------------------------------
+# Optional: FRONTEND_LD_PRELOAD applies an allocator (e.g. jemalloc) to the
+# frontend ONLY, leaving the mock workers on glibc — keeps the A/B isolated.
+if [[ -n "${FRONTEND_LD_PRELOAD:-}" ]]; then
+    echo "[frontend] LD_PRELOAD=$FRONTEND_LD_PRELOAD"
+fi
+if [[ -n "${FRONTEND_MALLOC_CONF:-}" ]]; then
+    echo "[frontend] MALLOC_CONF=$FRONTEND_MALLOC_CONF"
+fi
+if [[ "${ISOLATE:-0}" == "1" ]]; then
+    # Reserved-core mode (see bench/isolate.sh): cores ${FRONTEND_CORES} are kept
+    # clear of all other userspace via slice confinement. Launch the frontend in a
+    # top-level `bench.slice` pinned to those cores (a child of the confined
+    # user.slice could NOT claim them — cgroup cpuset is hierarchical). Needs root
+    # for systemd-run; `env ...` carries the vars through sudo's env scrub.
+    echo "[frontend] ISOLATE=1: launching in bench.slice on cores ${FRONTEND_CORES} (systemd-run, needs root) ..."
+    sudo systemd-run --scope --slice=bench -p AllowedCPUs="${FRONTEND_CORES}" \
+        env LD_PRELOAD="${FRONTEND_LD_PRELOAD:-}" \
+            MALLOC_CONF="${FRONTEND_MALLOC_CONF:-}" \
+            FASTOKENS_SEQUENTIAL="${FASTOKENS_SEQUENTIAL:-}" \
+            DYN_TOKENIZER="$DYN_TOKENIZER" \
+            DYN_TOKENIZER_CACHE="$DYN_TOKENIZER_CACHE" \
+            DYN_TOKENIZER_CACHE_BYTES="$DYN_TOKENIZER_CACHE_BYTES" \
+            "$DYN_PY" -m dynamo.frontend \
+                --router-mode kv \
+                --kv-cache-block-size "$BLOCK_SIZE" \
+                --http-port "$HTTP_PORT" \
+        > "$LOG_DIR/frontend.log" 2>&1 &
+    # PID is a descendant of systemd-run/sudo; resolve the python process.
+    FRONTEND_PID=""
+    for _ in $(seq 1 20); do
+        FRONTEND_PID="$(pgrep -f 'dynamo.frontend --router-mode kv' | head -1)"
+        [[ -n "$FRONTEND_PID" ]] && break
+        sleep 0.5
+    done
+    [[ -n "$FRONTEND_PID" ]] || { echo "ERROR: frontend (isolated) did not start; check $LOG_DIR/frontend.log"; tail -20 "$LOG_DIR/frontend.log"; exit 1; }
+else
+    echo "[frontend] launching on cores ${FRONTEND_CORES} (fastokens + 1GiB cache, kv routing) ..."
+    LD_PRELOAD="${FRONTEND_LD_PRELOAD:-}" \
+    MALLOC_CONF="${FRONTEND_MALLOC_CONF:-}" \
+    FASTOKENS_SEQUENTIAL="${FASTOKENS_SEQUENTIAL:-}" \
+    DYN_TOKENIZER="$DYN_TOKENIZER" \
+    DYN_TOKENIZER_CACHE="$DYN_TOKENIZER_CACHE" \
+    DYN_TOKENIZER_CACHE_BYTES="$DYN_TOKENIZER_CACHE_BYTES" \
+    taskset -c "$FRONTEND_CORES" "$DYN_PY" -m dynamo.frontend \
+        --router-mode kv \
+        --kv-cache-block-size "$BLOCK_SIZE" \
+        --http-port "$HTTP_PORT" \
+        > "$LOG_DIR/frontend.log" 2>&1 &
+    FRONTEND_PID=$!
+fi
+echo "$FRONTEND_PID" > "$LOG_DIR/frontend.pid"
+echo "[frontend] pid $FRONTEND_PID, logging to $LOG_DIR/frontend.log"
+
+# --- Wait for readiness: PID must stay alive AND model must be served ------
+echo "[wait] polling http://localhost:${HTTP_PORT}/v1/models for ${MODEL} ..."
+for i in $(seq 1 60); do
+    if ! kill -0 "$FRONTEND_PID" 2>/dev/null; then
+        echo "ERROR: frontend process died during startup (likely bind failure). Tail:"
+        tail -25 "$LOG_DIR/frontend.log"
+        exit 1
+    fi
+    if curl -sf "http://localhost:${HTTP_PORT}/v1/models" 2>/dev/null | grep -q "Qwen3-0.6B"; then
+        echo "[ready] frontend (pid $FRONTEND_PID) serving model after ${i}s; ${NUM_WORKERS} workers live."
+        exit 0
+    fi
+    sleep 1
+done
+echo "ERROR: model did not appear within 60s. Check $LOG_DIR/frontend.log and $LOG_DIR/workers.log"
+exit 1

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/stop.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/stop.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Stop the benchmark topology (frontend + workers). Leaves etcd/nats running.
+# Waits until processes are gone, :8000 is free, and worker instances have
+# drained from etcd, so a subsequent ./start.sh sees a clean slate.
+set -uo pipefail
+cd "$(dirname "$0")"
+source ./env.sh
+
+# If the frontend was started isolated (ISOLATE=1 → root-owned in bench.slice),
+# a plain kill can't reap it. Try a non-interactive stop of the slice; if that
+# needs a password it's skipped (stop it yourself: sudo systemctl stop bench.slice).
+if systemctl is-active --quiet bench.slice 2>/dev/null; then
+    sudo -n systemctl stop bench.slice 2>/dev/null \
+        && echo "[stop] stopped isolated frontend (bench.slice)" \
+        || echo "[stop] NOTE: isolated frontend in bench.slice — run: sudo systemctl stop bench.slice"
+fi
+
+for name in frontend workers; do
+    pidfile="$LOG_DIR/$name.pid"
+    if [[ -f "$pidfile" ]]; then
+        pid="$(cat "$pidfile")"
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "[stop] terminating $name (pid $pid) ..."
+            kill "$pid" 2>/dev/null || true
+            pkill -P "$pid" 2>/dev/null || true
+            # give it up to 10s to exit gracefully, then SIGKILL
+            for i in $(seq 1 10); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+            kill -0 "$pid" 2>/dev/null && { echo "[stop] $name still alive; SIGKILL"; kill -9 "$pid" 2>/dev/null || true; }
+        fi
+        rm -f "$pidfile"
+    fi
+done
+# Belt-and-suspenders: kill any stragglers from this worktree.
+pkill -f "dynamo.mocker --model-path $MODEL" 2>/dev/null || true
+pkill -f "dynamo.frontend --router-mode kv" 2>/dev/null || true
+
+# Wait for :8000 to free.
+for i in $(seq 1 15); do ss -ltn 2>/dev/null | grep -q ":${HTTP_PORT}\b" || break; sleep 1; done
+ss -ltn 2>/dev/null | grep -q ":${HTTP_PORT}\b" && echo "[stop] WARNING: :${HTTP_PORT} still held." || echo "[stop] :${HTTP_PORT} free."
+
+# Wait for worker instances to drain from etcd (lease expiry).
+for i in $(seq 1 20); do n="$(count_workers)"; [[ "$n" -eq 0 ]] && break; sleep 1; done
+n="$(count_workers)"
+[[ "$n" -eq 0 ]] && echo "[stop] etcd worker instances drained." || echo "[stop] WARNING: $n worker instance(s) still in etcd."
+echo "[stop] done."

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/stop.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/stop.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Stop the benchmark topology (frontend + workers). Leaves etcd/nats running.
 # Waits until processes are gone, :8000 is free, and worker instances have
 # drained from etcd, so a subsequent ./start.sh sees a clean slate.

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/unisolate.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/unisolate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Revert bench/isolate.sh: give all cores back to every slice, restore IRQ
 # balancing, and tear down the frontend's bench.slice.
 #   sudo bash bench/unisolate.sh
@@ -10,18 +13,23 @@ echo "[unisolate] stopping any isolated frontend (bench.slice) ..."
 systemctl stop bench.slice 2>/dev/null || true
 
 echo "[unisolate] restoring slices to all cpus ..."
-# `revert --runtime` drops the transient drop-ins; fall back to explicit 0-23.
+ONLINE_CPUS="$(cat /sys/devices/system/cpu/online 2>/dev/null || true)"
+if [[ -z "$ONLINE_CPUS" ]]; then
+    CPU_COUNT="$(nproc 2>/dev/null || echo 1)"
+    ONLINE_CPUS="0-$((CPU_COUNT - 1))"
+fi
+# `revert --runtime` drops the transient drop-ins; fall back to online CPUs.
 if ! systemctl revert --runtime system.slice user.slice init.scope 2>/dev/null; then
     for unit in system.slice user.slice init.scope; do
-        systemctl set-property --runtime "$unit" AllowedCPUs=0-23 2>/dev/null || true
+        systemctl set-property --runtime "$unit" AllowedCPUs="$ONLINE_CPUS" 2>/dev/null || true
     done
 fi
 
 echo "[unisolate] restoring IRQ affinity + irqbalance ..."
-for f in /proc/irq/*/smp_affinity_list; do echo 0-23 > "$f" 2>/dev/null || true; done
+for f in /proc/irq/*/smp_affinity_list; do echo "$ONLINE_CPUS" > "$f" 2>/dev/null || true; done
 systemctl start irqbalance 2>/dev/null || true
 
-echo "[unisolate] verify — effective cpus (want 0-23):"
+echo "[unisolate] verify — effective cpus (want $ONLINE_CPUS):"
 for unit in system.slice user.slice; do
     echo "  $unit: $(cat /sys/fs/cgroup/$unit/cpuset.cpus.effective 2>/dev/null)"
 done

--- a/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/unisolate.sh
+++ b/.agents/contributor-skills/dynamo-frontend-benchmark/scripts/unisolate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Revert bench/isolate.sh: give all cores back to every slice, restore IRQ
+# balancing, and tear down the frontend's bench.slice.
+#   sudo bash bench/unisolate.sh
+# (A reboot also clears everything, since isolate.sh used --runtime.)
+set -uo pipefail
+[[ $EUID -eq 0 ]] || { echo "ERROR: run as root (sudo bash bench/unisolate.sh)"; exit 1; }
+
+echo "[unisolate] stopping any isolated frontend (bench.slice) ..."
+systemctl stop bench.slice 2>/dev/null || true
+
+echo "[unisolate] restoring slices to all cpus ..."
+# `revert --runtime` drops the transient drop-ins; fall back to explicit 0-23.
+if ! systemctl revert --runtime system.slice user.slice init.scope 2>/dev/null; then
+    for unit in system.slice user.slice init.scope; do
+        systemctl set-property --runtime "$unit" AllowedCPUs=0-23 2>/dev/null || true
+    done
+fi
+
+echo "[unisolate] restoring IRQ affinity + irqbalance ..."
+for f in /proc/irq/*/smp_affinity_list; do echo 0-23 > "$f" 2>/dev/null || true; done
+systemctl start irqbalance 2>/dev/null || true
+
+echo "[unisolate] verify — effective cpus (want 0-23):"
+for unit in system.slice user.slice; do
+    echo "  $unit: $(cat /sys/fs/cgroup/$unit/cpuset.cpus.effective 2>/dev/null)"
+done
+echo "[unisolate] done."


### PR DESCRIPTION
## What

Adds a contributor skill — `dynamo-frontend-benchmark` — under `.agents/contributor-skills/`, capturing a complete, reproducible methodology for **benchmarking and profiling the Dynamo frontend** (`dynamo.frontend`: HTTP + tokenizer + KV router) against mock workers (`dynamo.mocker`).

It exists so the next person (or agent) can measure frontend throughput/latency, A/B a frontend change, or on-CPU/off-CPU profile the frontend or mock workers **without rediscovering the many sharp edges** of this setup.

## Contents

- **`SKILL.md`** — setup (etcd + NATS-JetStream request plane, `maturin develop` build, `perf_event_paranoid` access), topology/config, the **teardown + etcd-drain + warmup A/B protocol**, on-CPU (`perf -F 99 --call-graph dwarf`) and off-CPU (`offcputime-bpfcc` / `perf sched_switch`) profiling, analysis (Little's law, cores-busy, latency decomposition), and an extensive **pitfalls** section.
- **`scripts/`** — portable harness (all `source env.sh`; set `DYN_REPO`): `start.sh`/`stop.sh` (with etcd drain), `run_aiperf.sh`, `isolate.sh`/`unisolate.sh`, `smoke.sh`, parameterized `profile_oncpu.sh` / `capture_offcpu.sh`, and `analyze_folded.py` / `extract_throughput.py` helpers.

## Pitfalls captured (the valuable part)

- **Closed-loop client**: throughput = concurrency / latency — idle frontend cores usually mean latency-bound, not slow frontend. Congestion collapse at high concurrency.
- **Client/server core contention**: aiperf is CPU-heavy and co-located with the mockers; it can saturate shared cores and starve them, masquerading as a server bottleneck.
- **aiperf finalizer hangs** on large runs → recompute from raw `profile_export.jsonl` (`extract_throughput.py`); **root-owned orphans** from sudo captures need `sudo pkill`.
- **Off-CPU needs root** (sched tracepoints/BPF) even at `perf_event_paranoid=-1`; native `perf --off-cpu` often not compiled in.
- **No frame pointers** in release `.so` → use `--call-graph dwarf`, not `-g`.
- **Block size must match** frontend/mocker, and `>=2048` breaks the current mocker (requests hang, zero tokens). It's also a lever: smaller blocks → more frontend KV-routing work + more mock bookkeeping.
- **CPU isolation and NATS don't survive reboot**; jemalloc is frontend-only here.

## Notes

- Filed as **draft**.
- Placed under `.agents/contributor-skills/` alongside the other contributor/dev skills (e.g. `dynamo-clone-hotpath-audit`); force-added per the existing convention there.
- Scripts are dev tooling (not wired into CI/build); `bash -n` and `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a comprehensive frontend benchmarking harness with profiling tools for performance analysis and optimization under load conditions.

* **Documentation**
  * Added detailed benchmarking methodology guide covering measurement goals, profiling workflows, analysis techniques, and operational best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->