### PR TITLE
chore(mocker): scope helpers to their owners

### DIFF
--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -5,6 +5,7 @@ use derive_builder::Builder;
 use dynamo_kv_router::config::RouterQueuePolicy;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use uuid::Uuid;
 use validator::{Validate, ValidationError};
@@ -259,6 +260,20 @@ pub enum PreemptionMode {
     Fifo,
 }
 
+impl FromStr for PreemptionMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "lifo" => Ok(Self::Lifo),
+            "fifo" => Ok(Self::Fifo),
+            other => Err(format!(
+                "Invalid preemption_mode: '{other}'. Must be 'lifo' or 'fifo'."
+            )),
+        }
+    }
+}
+
 /// Engine type for selecting scheduling and KV cache simulation behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum EngineType {
@@ -270,6 +285,21 @@ pub enum EngineType {
     /// TensorRT-LLM-style scheduling. Reuses the vLLM scheduler
     /// core with a TensorRT-LLM-style admission policy.
     Trtllm,
+}
+
+impl FromStr for EngineType {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "vllm" => Ok(Self::Vllm),
+            "sglang" => Ok(Self::Sglang),
+            "trtllm" => Ok(Self::Trtllm),
+            other => Err(format!(
+                "Invalid engine_type '{other}'. Must be 'vllm', 'sglang', or 'trtllm'."
+            )),
+        }
+    }
 }
 
 /// Scheduling policy applied by the shared vLLM scheduler core.
@@ -296,6 +326,21 @@ pub enum WorkerType {
     Prefill,
     /// Dedicated decode worker in disaggregated mode
     Decode,
+}
+
+impl FromStr for WorkerType {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "aggregated" => Ok(Self::Aggregated),
+            "prefill" => Ok(Self::Prefill),
+            "decode" => Ok(Self::Decode),
+            other => Err(format!(
+                "Invalid worker_type '{other}'. Must be 'aggregated', 'prefill', or 'decode'."
+            )),
+        }
+    }
 }
 
 /// Configuration for reasoning/thinking token output in the mocker.
@@ -458,38 +503,6 @@ struct MockEngineArgsSerde {
     trtllm: OptionalConfigValue<TrtllmArgs>,
     #[serde(rename = "has_perf_model")]
     _has_perf_model: OptionalConfigValue<serde_json::Value>,
-}
-
-fn parse_engine_type(value: &str) -> Result<EngineType, String> {
-    match value {
-        "vllm" => Ok(EngineType::Vllm),
-        "sglang" => Ok(EngineType::Sglang),
-        "trtllm" => Ok(EngineType::Trtllm),
-        other => Err(format!(
-            "Invalid engine_type '{other}'. Must be 'vllm', 'sglang', or 'trtllm'."
-        )),
-    }
-}
-
-fn parse_worker_type(value: &str) -> Result<WorkerType, String> {
-    match value {
-        "aggregated" => Ok(WorkerType::Aggregated),
-        "prefill" => Ok(WorkerType::Prefill),
-        "decode" => Ok(WorkerType::Decode),
-        other => Err(format!(
-            "Invalid worker_type '{other}'. Must be 'aggregated', 'prefill', or 'decode'."
-        )),
-    }
-}
-
-fn parse_preemption_mode(value: &str) -> Result<PreemptionMode, String> {
-    match value {
-        "lifo" => Ok(PreemptionMode::Lifo),
-        "fifo" => Ok(PreemptionMode::Fifo),
-        other => Err(format!(
-            "Invalid preemption_mode: '{other}'. Must be 'lifo' or 'fifo'."
-        )),
-    }
 }
 
 fn load_perf_model(path: &Path) -> Arc<PerfModel> {
@@ -861,7 +874,7 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         let mut builder = Self::builder();
 
         if let Some(engine_type) = compat.engine_type.into_non_null("engine_type")? {
-            builder = builder.engine_type(parse_engine_type(&engine_type)?);
+            builder = builder.engine_type(engine_type.parse()?);
         }
         if let Some(Some(num_gpu_blocks)) = compat.num_gpu_blocks.into_nullable() {
             builder = builder.num_gpu_blocks(num_gpu_blocks);
@@ -906,7 +919,7 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         let worker_type = if let Some(worker_type) =
             compat.worker_type.into_non_null("worker_type")?
         {
-            parse_worker_type(&worker_type)?
+            worker_type.parse()?
         } else {
             let is_prefill = compat
                 .is_prefill
@@ -1035,7 +1048,7 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
             builder = builder.zmq_replay_port(zmq_replay_port);
         }
         if let Some(preemption_mode) = compat.preemption_mode.into_non_null("preemption_mode")? {
-            builder = builder.preemption_mode(parse_preemption_mode(&preemption_mode)?);
+            builder = builder.preemption_mode(preemption_mode.parse()?);
         }
         if let Some(router_queue_policy) = compat.router_queue_policy.into_nullable() {
             let router_queue_policy = router_queue_policy

--- a/lib/mocker/src/kvbm_offload/worker.rs
+++ b/lib/mocker/src/kvbm_offload/worker.rs
@@ -74,6 +74,24 @@ impl TransferDirection {
     }
 }
 
+impl TryFrom<(LogicalLayoutHandle, LogicalLayoutHandle)> for TransferDirection {
+    type Error = anyhow::Error;
+
+    fn try_from((src, dst): (LogicalLayoutHandle, LogicalLayoutHandle)) -> Result<Self> {
+        match (src, dst) {
+            (LogicalLayoutHandle::G1, LogicalLayoutHandle::G2) => Ok(Self::G1ToG2),
+            (LogicalLayoutHandle::G2, LogicalLayoutHandle::G1) => Ok(Self::G2ToG1),
+            (LogicalLayoutHandle::G2, LogicalLayoutHandle::G3) => Ok(Self::G2ToG3),
+            (LogicalLayoutHandle::G3, LogicalLayoutHandle::G2) => Ok(Self::G3ToG2),
+            (s, d) => bail!(
+                "MockWorker only simulates local G1↔G2 and G2↔G3 transfers; got src={:?} dst={:?}",
+                s,
+                d
+            ),
+        }
+    }
+}
+
 struct PipelineAwaiter {
     event: Event,
     owner_id: u64,
@@ -604,24 +622,6 @@ impl MockWorker {
     }
 }
 
-/// Map `(src, dst)` logical layout handles to a mocker-supported direction.
-fn infer_direction(
-    src: LogicalLayoutHandle,
-    dst: LogicalLayoutHandle,
-) -> Result<TransferDirection> {
-    match (src, dst) {
-        (LogicalLayoutHandle::G1, LogicalLayoutHandle::G2) => Ok(TransferDirection::G1ToG2),
-        (LogicalLayoutHandle::G2, LogicalLayoutHandle::G1) => Ok(TransferDirection::G2ToG1),
-        (LogicalLayoutHandle::G2, LogicalLayoutHandle::G3) => Ok(TransferDirection::G2ToG3),
-        (LogicalLayoutHandle::G3, LogicalLayoutHandle::G2) => Ok(TransferDirection::G3ToG2),
-        (s, d) => bail!(
-            "MockWorker only simulates local G1↔G2 and G2↔G3 transfers; got src={:?} dst={:?}",
-            s,
-            d
-        ),
-    }
-}
-
 impl WorkerTransfers for MockWorker {
     fn execute_local_transfer(
         &self,
@@ -631,7 +631,7 @@ impl WorkerTransfers for MockWorker {
         _dst_block_ids: Arc<[BlockId]>,
         _options: TransferOptions,
     ) -> Result<TransferCompleteNotification> {
-        let direction = infer_direction(src, dst)?;
+        let direction = TransferDirection::try_from((src, dst))?;
         let now_ms = self.now_ms();
         self.reserve_transfer(direction, now_ms, src_block_ids.len())
     }

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -5,9 +5,6 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 use anyhow::{Context, Result, anyhow, bail};
-use dynamo_kv_router::protocols::{
-    BlockHashOptions, compute_block_hash_for_seq, compute_seq_hash_for_block,
-};
 use rustc_hash::FxHashMap;
 use uuid::Uuid;
 
@@ -97,17 +94,6 @@ pub struct WorkloadDriver {
     agentic_remaining_dependencies: Vec<usize>,
     agentic_ready_after_ms: Vec<f64>,
     agentic_dependents: FxHashMap<String, Vec<usize>>,
-}
-
-fn replay_hashes_from_tokens(tokens: &[u32], engine_block_size: u32) -> ReplayRequestHashes {
-    let local_block_hashes =
-        compute_block_hash_for_seq(tokens, engine_block_size, BlockHashOptions::default());
-    let sequence_hashes = compute_seq_hash_for_block(&local_block_hashes);
-
-    ReplayRequestHashes {
-        local_block_hashes,
-        sequence_hashes,
-    }
 }
 
 impl WorkloadDriver {
@@ -395,7 +381,7 @@ impl WorkloadDriver {
                     session.cumulative_tokens.extend_from_slice(&turn.tokens);
                     let request_tokens = session.cumulative_tokens.clone();
                     let replay_hashes =
-                        replay_hashes_from_tokens(&request_tokens, self.engine_block_size);
+                        ReplayRequestHashes::from_tokens(&request_tokens, self.engine_block_size);
                     (request_tokens, replay_hashes)
                 }
             };

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -10,8 +10,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use dynamo_data_gen::{AgenticMooncakeRow, MooncakeRow};
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::protocols::{
-    BlockHashOptions, ExternalSequenceBlockHash, WorkerId, XXH3_SEED, compute_block_hash_for_seq,
-    compute_seq_hash_for_block,
+    ExternalSequenceBlockHash, WorkerId, XXH3_SEED, compute_seq_hash_for_block,
 };
 use dynamo_tokens::compute_hash_v2;
 use rand::rngs::StdRng;
@@ -104,14 +103,7 @@ impl TurnTrace {
         let tokens = self.synthesize_tokens(trace_block_size)?;
         let engine_block_size =
             u32::try_from(engine_block_size).context("engine_block_size does not fit in u32")?;
-        let local_block_hashes =
-            compute_block_hash_for_seq(&tokens, engine_block_size, BlockHashOptions::default());
-        let sequence_hashes = compute_seq_hash_for_block(&local_block_hashes);
-
-        Ok(ReplayRequestHashes {
-            local_block_hashes,
-            sequence_hashes,
-        })
+        Ok(ReplayRequestHashes::from_tokens(&tokens, engine_block_size))
     }
 }
 
@@ -166,14 +158,7 @@ impl AgenticTurnTrace {
         let tokens = self.synthesize_tokens(trace_block_size)?;
         let engine_block_size =
             u32::try_from(engine_block_size).context("engine_block_size does not fit in u32")?;
-        let local_block_hashes =
-            compute_block_hash_for_seq(&tokens, engine_block_size, BlockHashOptions::default());
-        let sequence_hashes = compute_seq_hash_for_block(&local_block_hashes);
-
-        Ok(ReplayRequestHashes {
-            local_block_hashes,
-            sequence_hashes,
-        })
+        Ok(ReplayRequestHashes::from_tokens(&tokens, engine_block_size))
     }
 }
 

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_kv_router::LocalBlockHash;
-use dynamo_kv_router::protocols::{ExternalSequenceBlockHash, WorkerId};
+use dynamo_kv_router::protocols::{
+    BlockHashOptions, ExternalSequenceBlockHash, WorkerId, compute_block_hash_for_seq,
+    compute_seq_hash_for_block,
+};
 use dynamo_tokens::SequenceHash;
 use uuid::Uuid;
 
@@ -122,6 +125,19 @@ pub struct RouterSequence {
 pub struct ReplayRequestHashes {
     pub local_block_hashes: Vec<LocalBlockHash>,
     pub sequence_hashes: Vec<SequenceHash>,
+}
+
+impl ReplayRequestHashes {
+    pub(crate) fn from_tokens(tokens: &[u32], engine_block_size: u32) -> Self {
+        let local_block_hashes =
+            compute_block_hash_for_seq(tokens, engine_block_size, BlockHashOptions::default());
+        let sequence_hashes = compute_seq_hash_for_block(&local_block_hashes);
+
+        Self {
+            local_block_hashes,
+            sequence_hashes,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -15,7 +15,7 @@ use super::config::SglangConfig;
 use super::decode::{cache_materialized_prefix, simulate_decode_step};
 use super::policy::apply_schedule_policy;
 use super::prefill::get_new_batch_prefill;
-use super::request::{SglangRequest, direct_to_sglang};
+use super::request::SglangRequest;
 use crate::scheduler::{
     CapturedRouterEventBuffer, EnginePassResult, MockerMetrics, RouterEventVisibility,
     build_fpm_snapshot, capture_router_event_sink,
@@ -81,7 +81,7 @@ impl SglangCore {
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
-        let request = direct_to_sglang(request);
+        let request = SglangRequest::from(request);
         request.debug_assert_invariants(self.config.block_size);
         let uuid = request.uuid;
         self.waiting.push_back(request);

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -17,7 +17,6 @@ use crate::scheduler::{
 };
 
 use super::core::SglangCore;
-use super::request::{SglangRequest, direct_to_sglang};
 
 #[derive(Clone)]
 pub struct SglangScheduler {
@@ -100,14 +99,9 @@ impl SglangScheduler {
             let mut core = SglangCore::new_with_sink(args, dp_rank, buffering_publishers);
 
             loop {
-                if receive_requests(
-                    &mut core.waiting,
-                    &mut request_rx,
-                    &cancel_token_clone,
-                    &core.running,
-                )
-                .await
-                .is_none()
+                if receive_requests(&mut core, &mut request_rx, &cancel_token_clone)
+                    .await
+                    .is_none()
                 {
                     break;
                 }
@@ -165,28 +159,27 @@ impl SchedulerHandle for SglangScheduler {
 }
 
 async fn receive_requests(
-    waiting: &mut std::collections::VecDeque<SglangRequest>,
+    core: &mut SglangCore,
     request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
     cancel_token: &CancellationToken,
-    running: &[SglangRequest],
 ) -> Option<()> {
     if cancel_token.is_cancelled() {
         return None;
     }
 
-    if waiting.is_empty() && running.is_empty() {
+    if core.is_empty() {
         tokio::select! {
             biased;
             _ = cancel_token.cancelled() => return None,
             result = request_rx.recv() => {
                 let request = result?;
-                waiting.push_back(direct_to_sglang(request));
+                core.receive(request);
             }
         }
     }
 
     while let Ok(request) = request_rx.try_recv() {
-        waiting.push_back(direct_to_sglang(request));
+        core.receive(request);
     }
 
     Some(())

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -159,16 +159,18 @@ impl SglangRequest {
     }
 }
 
-pub(super) fn direct_to_sglang(req: DirectRequest) -> SglangRequest {
-    SglangRequest {
-        uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
-        prompt_tokens: req.tokens.iter().map(|&t| t as u64).collect(),
-        max_output_tokens: req.max_output_tokens,
-        output_ids: Vec::new(),
-        last_node: None,
-        kv_indices: Vec::new(),
-        materialized_tokens: 0,
-        cached_tokens: 0,
-        allocated_tokens: 0,
+impl From<DirectRequest> for SglangRequest {
+    fn from(req: DirectRequest) -> Self {
+        Self {
+            uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
+            prompt_tokens: req.tokens.iter().map(|&t| t as u64).collect(),
+            max_output_tokens: req.max_output_tokens,
+            output_ids: Vec::new(),
+            last_node: None,
+            kv_indices: Vec::new(),
+            materialized_tokens: 0,
+            cached_tokens: 0,
+            allocated_tokens: 0,
+        }
     }
 }

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -46,6 +46,40 @@ pub(crate) struct VllmRequestState {
     pub(crate) num_preemptions: usize,
 }
 
+impl VllmRequestState {
+    fn debug_assert_invariants(&self, _uuid: Uuid) {
+        #[cfg(debug_assertions)]
+        {
+            let uuid = _uuid;
+            let seq_len = self.sequence.len();
+            let allocated = self.sequence.num_allocated_tokens();
+            debug_assert!(
+                self.num_computed_tokens <= seq_len,
+                "request {uuid} computed {} tokens but sequence length is {seq_len}",
+                self.num_computed_tokens
+            );
+            debug_assert!(
+                allocated <= seq_len,
+                "request {uuid} allocated {allocated} tokens but sequence length is {seq_len}"
+            );
+        }
+    }
+
+    fn debug_assert_progress(&self, _uuid: Uuid) {
+        #[cfg(debug_assertions)]
+        {
+            let uuid = _uuid;
+            self.debug_assert_invariants(uuid);
+            let allocated = self.sequence.num_allocated_tokens();
+            debug_assert!(
+                allocated >= self.num_computed_tokens,
+                "request {uuid} allocated {allocated} tokens but computed {}",
+                self.num_computed_tokens
+            );
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct SchedulerState {
     pub(crate) waiting: VecDeque<Uuid>,
@@ -86,6 +120,13 @@ enum ScheduleOutcome {
 impl SchedulerState {
     pub(crate) fn is_empty(&self) -> bool {
         self.requests.is_empty()
+    }
+
+    fn request_sequence_len(&self, uuid: Uuid) -> usize {
+        self.requests
+            .get(&uuid)
+            .map(|request| request.sequence.len())
+            .unwrap_or_default()
     }
 
     fn push_waiting(&mut self, uuid: Uuid) {
@@ -196,7 +237,7 @@ impl SchedulerState {
         request.num_preemptions += 1;
         self.preemptions_total += 1;
         let signals = request.sequence.reset_with_signal();
-        debug_assert_vllm_request_invariants(uuid, request);
+        request.debug_assert_invariants(uuid);
         #[cfg(debug_assertions)]
         {
             debug_assert_eq!(
@@ -213,6 +254,72 @@ impl SchedulerState {
     pub(super) fn insert_running_for_test(&mut self, uuid: Uuid) {
         self.running_members.insert(uuid);
         self.running.push_back(uuid);
+    }
+
+    fn debug_assert_ready_to_decode(&self, _uuid: Uuid) {
+        #[cfg(debug_assertions)]
+        {
+            let uuid = _uuid;
+            let Some(request) = self.requests.get(&uuid) else {
+                return;
+            };
+            let seq_len = request.sequence.len();
+            if request.num_computed_tokens < seq_len {
+                return;
+            }
+            let allocated = request.sequence.num_allocated_tokens();
+            debug_assert_eq!(
+                allocated, seq_len,
+                "request {uuid} is decode-ready but allocated {allocated} tokens for sequence length {seq_len}"
+            );
+        }
+    }
+
+    fn debug_assert_invariants(&self) {
+        #[cfg(debug_assertions)]
+        {
+            let mut seen = std::collections::HashSet::new();
+            for uuid in &self.waiting_members {
+                debug_assert!(
+                    seen.insert(*uuid),
+                    "request {uuid} appears multiple times across waiting/running queues"
+                );
+                let request = self
+                    .requests
+                    .get(uuid)
+                    .expect("waiting request missing from state map");
+                debug_assert!(
+                    request.status != RequestStatus::Running,
+                    "request {uuid} is queued in waiting but marked Running"
+                );
+                request.debug_assert_invariants(*uuid);
+            }
+            for uuid in &self.running_members {
+                debug_assert!(
+                    seen.insert(*uuid),
+                    "request {uuid} appears multiple times across waiting/running queues"
+                );
+                let request = self
+                    .requests
+                    .get(uuid)
+                    .expect("running request missing from state map");
+                debug_assert_eq!(
+                    request.status,
+                    RequestStatus::Running,
+                    "request {uuid} is queued in running but marked {:?}",
+                    request.status
+                );
+                request.debug_assert_invariants(*uuid);
+            }
+            debug_assert!(
+                self.waiting.len() >= self.waiting_members.len(),
+                "waiting queue dropped live membership entries"
+            );
+            debug_assert!(
+                self.running.len() >= self.running_members.len(),
+                "running queue dropped live membership entries"
+            );
+        }
     }
 }
 
@@ -372,7 +479,7 @@ impl VllmCore {
         );
         self.state.push_waiting(uuid);
         if let Some(request) = self.state.requests.get(&uuid) {
-            debug_assert_vllm_request_progress(uuid, request);
+            request.debug_assert_progress(uuid);
         }
         uuid
     }
@@ -811,7 +918,7 @@ impl VllmCore {
         }
 
         let fpm = self.compute_fpm(&scheduled, (end_ms - now_ms) / 1000.0);
-        debug_assert_vllm_scheduler_state(&self.state);
+        self.state.debug_assert_invariants();
         EnginePassResult {
             end_ms,
             completed_requests: requests_before.saturating_sub(self.state.requests.len()),
@@ -918,7 +1025,7 @@ impl VllmCore {
             .requests
             .get(&uuid)
             .unwrap_or_else(|| panic!("schedule_request: {uuid} missing from state.requests"));
-        debug_assert_vllm_request_invariants(uuid, request);
+        request.debug_assert_invariants(uuid);
         let cached_prefix_tokens = if request.num_computed_tokens == 0 {
             self.kv_manager
                 .get_prefill_cost(&request.sequence)
@@ -1026,12 +1133,10 @@ impl VllmCore {
         }
 
         if let Some(request) = self.state.requests.get(&uuid) {
-            debug_assert_vllm_request_invariants(uuid, request);
+            request.debug_assert_invariants(uuid);
         }
         let tokens_used = actual_computed_after.saturating_sub(effective_computed_before);
-        if tokens_used == 0
-            && actual_computed_after < request_sequence_len(&self.state.requests, uuid)
-        {
+        if tokens_used == 0 && actual_computed_after < self.state.request_sequence_len(uuid) {
             return ScheduleOutcome::Blocked;
         }
 
@@ -1126,7 +1231,7 @@ impl VllmCore {
             let mut emitted = false;
             let mut completed = false;
             loop {
-                debug_assert_vllm_ready_to_decode(&self.state.requests, uuid);
+                self.state.debug_assert_ready_to_decode(uuid);
                 let Some(sequence) = self.state.running_sequence_mut(uuid) else {
                     break;
                 };
@@ -1162,7 +1267,7 @@ impl VllmCore {
                 collector.on_token(uuid, decode_end_ms);
             }
             if let Some(request) = self.state.requests.get(&uuid) {
-                debug_assert_vllm_request_progress(uuid, request);
+                request.debug_assert_progress(uuid);
                 let handoff_delay_ms = compute_prefill_handoff_delay_ms(
                     self.args.worker_type,
                     completed,
@@ -1199,115 +1304,6 @@ impl VllmCore {
             self.state.compact_running();
         }
         (decode_time, output_signals)
-    }
-}
-
-fn request_sequence_len(requests: &FxHashMap<Uuid, VllmRequestState>, uuid: Uuid) -> usize {
-    requests
-        .get(&uuid)
-        .map(|request| request.sequence.len())
-        .unwrap_or_default()
-}
-
-fn debug_assert_vllm_request_invariants(_uuid: Uuid, _request: &VllmRequestState) {
-    #[cfg(debug_assertions)]
-    {
-        let uuid = _uuid;
-        let request = _request;
-        let seq_len = request.sequence.len();
-        let allocated = request.sequence.num_allocated_tokens();
-        debug_assert!(
-            request.num_computed_tokens <= seq_len,
-            "request {uuid} computed {} tokens but sequence length is {seq_len}",
-            request.num_computed_tokens
-        );
-        debug_assert!(
-            allocated <= seq_len,
-            "request {uuid} allocated {allocated} tokens but sequence length is {seq_len}"
-        );
-    }
-}
-
-fn debug_assert_vllm_request_progress(_uuid: Uuid, _request: &VllmRequestState) {
-    #[cfg(debug_assertions)]
-    {
-        let uuid = _uuid;
-        let request = _request;
-        debug_assert_vllm_request_invariants(uuid, request);
-        let allocated = request.sequence.num_allocated_tokens();
-        debug_assert!(
-            allocated >= request.num_computed_tokens,
-            "request {uuid} allocated {allocated} tokens but computed {}",
-            request.num_computed_tokens
-        );
-    }
-}
-
-fn debug_assert_vllm_ready_to_decode(_requests: &FxHashMap<Uuid, VllmRequestState>, _uuid: Uuid) {
-    #[cfg(debug_assertions)]
-    {
-        let requests = _requests;
-        let uuid = _uuid;
-        let Some(request) = requests.get(&uuid) else {
-            return;
-        };
-        let seq_len = request.sequence.len();
-        if request.num_computed_tokens < seq_len {
-            return;
-        }
-        let allocated = request.sequence.num_allocated_tokens();
-        debug_assert_eq!(
-            allocated, seq_len,
-            "request {uuid} is decode-ready but allocated {allocated} tokens for sequence length {seq_len}"
-        );
-    }
-}
-
-fn debug_assert_vllm_scheduler_state(_state: &SchedulerState) {
-    #[cfg(debug_assertions)]
-    {
-        let state = _state;
-        let mut seen = std::collections::HashSet::new();
-        for uuid in &state.waiting_members {
-            debug_assert!(
-                seen.insert(*uuid),
-                "request {uuid} appears multiple times across waiting/running queues"
-            );
-            let request = state
-                .requests
-                .get(uuid)
-                .expect("waiting request missing from state map");
-            debug_assert!(
-                request.status != RequestStatus::Running,
-                "request {uuid} is queued in waiting but marked Running"
-            );
-            debug_assert_vllm_request_invariants(*uuid, request);
-        }
-        for uuid in &state.running_members {
-            debug_assert!(
-                seen.insert(*uuid),
-                "request {uuid} appears multiple times across waiting/running queues"
-            );
-            let request = state
-                .requests
-                .get(uuid)
-                .expect("running request missing from state map");
-            debug_assert_eq!(
-                request.status,
-                RequestStatus::Running,
-                "request {uuid} is queued in running but marked {:?}",
-                request.status
-            );
-            debug_assert_vllm_request_invariants(*uuid, request);
-        }
-        debug_assert!(
-            state.waiting.len() >= state.waiting_members.len(),
-            "waiting queue dropped live membership entries"
-        );
-        debug_assert!(
-            state.running.len() >= state.running_members.len(),
-            "running queue dropped live membership entries"
-        );
     }
 }
 


### PR DESCRIPTION
Move small mocker helpers onto the types that own their contracts, centralize replay hash construction, and route live SGLang ingestion through the core receive path. This is a behavior-preserving cleanup intended to reduce duplicated logic and keep invariants beside their state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal string parsing to use Rust's standard trait implementations.
  * Improved request conversion handling across the scheduler modules.
  * Refactored invariant checks into reusable internal methods for better maintainability.
  * Consolidated hash computation logic into shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->