### PR TITLE
fix(trtllm): summarize KV event debug logs

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/embedding/embedding_handler.py
@@ -60,7 +60,24 @@ class EmbeddingWorkerHandler(BaseWorkerHandler):
             request: Embedding request dictionary.
             context: Context object for cancellation handling.
         """
-        logging.debug(f"Embedding request: {request}")
+        embedding_input = request.get("input")
+        if isinstance(embedding_input, str):
+            input_type = "str"
+            input_length = len(embedding_input)
+        elif isinstance(embedding_input, list):
+            input_type = "list"
+            input_length = len(embedding_input)
+        else:
+            input_type = "other"
+            input_length = None
+
+        logging.debug(
+            "Embedding request: input_type=%s input_length=%s has_dimensions=%s has_encoding_format=%s",
+            input_type,
+            input_length,
+            "dimensions" in request,
+            "encoding_format" in request,
+        )
 
         # Parse the embedding request - should only receive EmbeddingRequest format
         embedding_request = EmbeddingRequest(**request)

--- a/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/image_diffusion/image_diffusion_handler.py
@@ -84,7 +84,14 @@ class ImageDiffusionWorkerHandler(BaseGenerativeHandler):
         Yields:
             Response dict with generated images (OpenAI-compatible format).
         """
-        logger.info(f"Image diffusion request: {request}")
+        prompt = request.get("prompt")
+        logger.info(
+            "Image diffusion request: prompt_len=%s has_n=%s has_input_reference=%s has_nvext=%s",
+            len(prompt) if isinstance(prompt, str) else None,
+            "n" in request,
+            request.get("input_reference") is not None,
+            "nvext" in request,
+        )
 
         # Get trace header for distributed tracing (for logging/observability)
         trace_header = context.trace_headers() if self.enable_trace else None

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -511,11 +511,10 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
                         precomputed_embeddings
                     )
                     request.transfer_payload = transfer_request
-                    logger.debug(f"Request: {request.model_dump_json()}")
-
             # Get the response generator from downstream worker
+            payload = request.model_dump_json()
             response_generator = await self.pd_worker_client.round_robin(
-                request.model_dump_json(), context=context
+                payload, context=context
             )
 
             # Parse PD worker responses and yield as LLMEngineOutput-

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -92,7 +92,7 @@ _IDLE_SLEEP_S = 0.01
 
 # Mirror the legacy `dynamo.trtllm` worker — required for TRT-LLM to actually
 # publish KV cache events. Without this, `get_kv_cache_events` returns empty.
-_DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+_DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
 
 # Note: `metrics_dict` is set per-instance on `GenerationResult` (only
 # when TRT-LLM's perf-stats collection is enabled and the request
@@ -149,6 +149,17 @@ class TrtllmLLMEngine(LLMEngine):
         self.publish_events_and_metrics = publish_events_and_metrics
         self._component = component
         self._additional_metrics: Optional["AdditionalMetricsCollector"] = None
+        kv_cache_config = self.engine_args.get("kv_cache_config", {})
+        if isinstance(kv_cache_config, dict):
+            event_buffer_max_size = kv_cache_config.get("event_buffer_max_size", 0)
+        elif isinstance(kv_cache_config, KvCacheConfig):
+            event_buffer_max_size = kv_cache_config.event_buffer_max_size
+        else:
+            raise TypeError(
+                "kv_cache_config must be a dict or KvCacheConfig, "
+                f"got {type(kv_cache_config).__name__}"
+            )
+        self._kv_event_buffer_max_size = int(event_buffer_max_size or 0)
         self._trtllm_metrics_collector: Optional["MetricsCollector"] = None
         # Resolved once at construction so the hot poll loop doesn't run
         # `hasattr` per iteration; same for the per-request log method
@@ -338,6 +349,9 @@ class TrtllmLLMEngine(LLMEngine):
                 "engine_type": "trtllm",
             },
         )
+        self._additional_metrics.set_kv_event_buffer_capacity(
+            self._kv_event_buffer_max_size
+        )
         self._trtllm_metrics_collector = MetricsCollector(
             {"model_name": gauge_model_name, "engine_type": "trtllm"}
         )
@@ -489,6 +503,8 @@ class TrtllmLLMEngine(LLMEngine):
             if not events:
                 time.sleep(_IDLE_SLEEP_S)
                 continue
+            if self._additional_metrics is not None:
+                self._additional_metrics.record_kv_event_drain_batch(len(events))
             for event in events:
                 try:
                     self._dispatch_kv_event(event)
@@ -515,6 +531,10 @@ class TrtllmLLMEngine(LLMEngine):
                     last + 1,
                     event_id,
                 )
+                if self._additional_metrics is not None:
+                    self._additional_metrics.record_kv_event_id_gap(
+                        max(0, event_id - (last + 1))
+                    )
             self._last_event_id_by_rank[rank] = event_id
         publisher = self._kv_publishers.get(rank)
         if publisher is None:

--- a/components/src/dynamo/trtllm/metrics.py
+++ b/components/src/dynamo/trtllm/metrics.py
@@ -28,12 +28,13 @@ This module adds metrics that have no engine/runtime/frontend equivalent:
   - Request types (image, structured output)
   - KV transfer metrics (success counter, latency, throughput, per-request bytes)
   - Abort tracking
+  - KV event buffer drain telemetry
 """
 
 import logging
 from datetime import timedelta
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 from dynamo.prometheus_names import trtllm_additional as metric_names
 
@@ -79,6 +80,27 @@ KV_TRANSFER_BYTES_BUCKETS = (
     500_000_000,
     1_000_000_000,
     5_000_000_000,
+    float("inf"),
+)
+KV_EVENT_DRAIN_BATCH_BUCKETS = (
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1_024,
+    2_048,
+    4_096,
+    8_192,
+    16_384,
+    32_768,
+    65_536,
+    131_072,
     float("inf"),
 )
 
@@ -142,6 +164,27 @@ class AdditionalMetricsCollector:
             buckets=KV_TRANSFER_SPEED_BUCKETS,
         )
 
+        # --- KV event buffer telemetry ---
+        # TRT-LLM exposes drained event batches, not its live internal queue depth.
+        # Keep these names explicit so dashboards do not mistake a drain size for
+        # an instantaneous queue-depth sample.
+        self.kv_event_buffer_capacity = Gauge(
+            metric_names.KV_EVENT_BUFFER_CAPACITY,
+            "Configured maximum TRT-LLM KV events buffered before older events are dropped",
+            labelnames=self._labelnames,
+        )
+        self.kv_event_drain_batch_size = Histogram(
+            metric_names.KV_EVENT_DRAIN_BATCH_SIZE,
+            "Number of TRT-LLM KV events returned to Dynamo in one polling drain",
+            labelnames=self._labelnames,
+            buckets=KV_EVENT_DRAIN_BATCH_BUCKETS,
+        )
+        self.kv_event_id_gap_events = Counter(
+            metric_names.KV_EVENT_ID_GAP_EVENTS_TOTAL,
+            "Total number of missing TRT-LLM KV event IDs detected by Dynamo",
+            labelnames=self._labelnames,
+        )
+
         logger.info("AdditionalMetricsCollector initialized")
 
     # --- Request helpers ---
@@ -200,3 +243,18 @@ class AdditionalMetricsCollector:
             self.kv_transfer_speed.labels(*self._labelvalues).observe(speed_gb_s)
 
         return True
+
+    # --- KV event buffer telemetry ---
+
+    def set_kv_event_buffer_capacity(self, capacity: int):
+        """Publish the configured TRT-LLM KV event buffer limit."""
+        self.kv_event_buffer_capacity.labels(*self._labelvalues).set(capacity)
+
+    def record_kv_event_drain_batch(self, batch_size: int):
+        """Record one non-empty batch drained from TRT-LLM by Dynamo."""
+        self.kv_event_drain_batch_size.labels(*self._labelvalues).observe(batch_size)
+
+    def record_kv_event_id_gap(self, missing_events: int):
+        """Record TRT-LLM event IDs skipped between two observed events."""
+        if missing_events > 0:
+            self.kv_event_id_gap_events.labels(*self._labelvalues).inc(missing_events)

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -321,6 +321,7 @@ class ManagedThread(threading.Thread):
                     )
                     if self.error_queue is not None:
                         self.error_queue.put(e)
+                    break
         finally:
             try:
                 loop.run_until_complete(loop.shutdown_asyncgens())
@@ -590,6 +591,7 @@ class Publisher:
                 pass
             except Exception as e:
                 logging.warning(f"Publisher polling loop error: {e}", exc_info=True)
+                raise
 
             if batch_size and batch_size_handler_fn is not None:
                 batch_size_handler_fn(batch_size)
@@ -946,6 +948,9 @@ class Publisher:
                 len(removed_block_hashes),
                 skipped_partial_blocks,
             )
+            if not removed_block_hashes:
+                return
+
             # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
             # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
             if self.zmq_kv_event_publisher:

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -38,7 +38,7 @@ from prometheus_client import CollectorRegistry
 from dynamo.common.utils.prometheus import LLMBackendMetrics
 from dynamo.llm import FpmDirectPublisher, KvEventPublisher, WorkerMetricsPublisher
 
-logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 # Create a dedicated registry for dynamo_component metrics
 # This ensures these metrics are isolated and can be exposed via their own callback
@@ -780,7 +780,6 @@ class Publisher:
         return True
 
     def _handle_kv_event(self, event):
-        logging.debug(f"KV cache event received: {event}")
         # drop the events that is not emitted from the global attention layer.
         if self.should_drop_event(event):
             return
@@ -862,8 +861,16 @@ class Publisher:
             # Default to 0 for backwards compatibility with older TRT-LLM versions
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
-            logging.debug(
-                f"publish stored event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, token_ids: {token_ids}, num_block_tokens: {num_block_tokens}, block_hashes: {block_hashes}, lora_name: {lora_name}, parent_hash: {parent_hash}"
+            logger.debug(
+                "Publishing stored KV event: engine_event_id=%s "
+                "attention_dp_rank=%s blocks=%s tokens=%s lora_name=%s "
+                "has_parent=%s",
+                event_id,
+                attention_dp_rank,
+                len(block_hashes),
+                len(token_ids),
+                lora_name,
+                parent_hash is not None,
             )
             # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
             # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
@@ -899,23 +906,27 @@ class Publisher:
         elif data["type"] == "removed":
             self.processing_initial_created_events = False
             removed_block_hashes: list[int] = []
+            skipped_partial_blocks = 0
             for block_hash in data["block_hashes"]:
                 block_hash = _to_signed_i64(block_hash)
                 if block_hash is None:
                     continue
                 if block_hash in self.partial_block_hashes:
-                    logging.debug(
-                        f"Skipping removing block hash {block_hash} since it is a partial block"
-                    )
                     self.partial_block_hashes.remove(block_hash)
+                    skipped_partial_blocks += 1
                     continue
                 removed_block_hashes.append(block_hash)
 
             # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
-            logging.debug(
-                f"publish removed event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, block_hashes: {removed_block_hashes}"
+            logger.debug(
+                "Publishing removed KV event: engine_event_id=%s "
+                "attention_dp_rank=%s blocks=%s skipped_partial_blocks=%s",
+                event_id,
+                attention_dp_rank,
+                len(removed_block_hashes),
+                skipped_partial_blocks,
             )
             # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
             # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -380,6 +380,8 @@ class Publisher:
         kv_block_size: int,
         metrics_labels: Any,
         component_gauges: LLMBackendMetrics,
+        additional_metrics: Any = None,
+        event_buffer_max_size: int = 0,
         zmq_endpoint: Optional[str] = None,
         enable_local_indexer: bool = False,
         metrics_collector: Any = None,
@@ -391,6 +393,9 @@ class Publisher:
         self.max_window_size = None
         self.metrics_labels = metrics_labels
         self.component_gauges = component_gauges
+        self.additional_metrics = additional_metrics
+        if self.additional_metrics is not None:
+            self.additional_metrics.set_kv_event_buffer_capacity(event_buffer_max_size)
         self.enable_local_indexer = enable_local_indexer
         self.metrics_collector = metrics_collector
         self.attention_dp_size = engine.get_attention_dp_size()
@@ -433,8 +438,9 @@ class Publisher:
         self.partial_block_hashes: set[int] = set()
         self.error_queue: Queue = Queue()
         self._stop_event = threading.Event()
-        # Track the last engine event_id to assert consecutive event IDs from the engine
-        self._last_engine_event_id: Optional[int] = None
+        # Track the last engine event_id per attention-DP rank. TRT-LLM emits
+        # independent rank-local sequences before gathering them on rank 0.
+        self._last_engine_event_id_by_rank: dict[int, int] = {}
 
         # Initialize ZMQ publisher if endpoint is provided (consolidator enabled)
         if zmq_endpoint:
@@ -569,18 +575,24 @@ class Publisher:
         min_sleep: float,
         max_sleep: float,
         backoff_factor: float,
+        batch_size_handler_fn=None,
     ):
         sleep_s = min_sleep
         while not self._stop_event.is_set():
             had_data = False
+            batch_size = 0
             try:
                 async for item in fetch_fn():
                     had_data = True
+                    batch_size += 1
                     handler_fn(item)
             except (asyncio.TimeoutError, TimeoutError, asyncio.QueueEmpty):
                 pass
             except Exception as e:
                 logging.warning(f"Publisher polling loop error: {e}", exc_info=True)
+
+            if batch_size and batch_size_handler_fn is not None:
+                batch_size_handler_fn(batch_size)
 
             if not had_data:
                 await asyncio.sleep(sleep_s)
@@ -776,24 +788,37 @@ class Publisher:
             _KV_EVENTS_MIN_SLEEP_SEC,
             _KV_EVENTS_MAX_SLEEP_SEC,
             _KV_EVENTS_BACKOFF_FACTOR,
+            self._record_kv_event_drain_batch,
         )
         return True
 
+    def _record_kv_event_drain_batch(self, batch_size: int) -> None:
+        if self.additional_metrics is not None:
+            self.additional_metrics.record_kv_event_drain_batch(batch_size)
+
     def _handle_kv_event(self, event):
+        event_id = event["event_id"]
+        attention_dp_rank = event.get("attention_dp_rank", 0)
+
+        # Check the raw engine stream before filtering non-global-attention
+        # events so expected filtering does not look like queue loss.
+        last_event_id = self._last_engine_event_id_by_rank.get(attention_dp_rank)
+        if last_event_id is not None:
+            expected_id = last_event_id + 1
+            if event_id != expected_id:
+                logging.warning(
+                    f"Non-consecutive engine event_id on rank={attention_dp_rank}: "
+                    f"expected {expected_id}, got {event_id}"
+                )
+                if self.additional_metrics is not None:
+                    self.additional_metrics.record_kv_event_id_gap(
+                        max(0, event_id - expected_id)
+                    )
+        self._last_engine_event_id_by_rank[attention_dp_rank] = event_id
+
         # drop the events that is not emitted from the global attention layer.
         if self.should_drop_event(event):
             return
-
-        event_id = event["event_id"]
-
-        # Check for consecutive event IDs from the engine
-        if self._last_engine_event_id is not None:
-            expected_id = self._last_engine_event_id + 1
-            if event_id != expected_id:
-                logging.warning(
-                    f"Non-consecutive engine event_id: expected {expected_id}, got {event_id}"
-                )
-        self._last_engine_event_id = event_id
 
         data = event["data"]
         if data["type"] == "stored":
@@ -857,10 +882,6 @@ class Publisher:
 
             lora_name = data.get("lora_name")
 
-            # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
-            # Default to 0 for backwards compatibility with older TRT-LLM versions
-            attention_dp_rank = event.get("attention_dp_rank", 0)
-
             logger.debug(
                 "Publishing stored KV event: engine_event_id=%s "
                 "attention_dp_rank=%s blocks=%s tokens=%s lora_name=%s "
@@ -916,9 +937,6 @@ class Publisher:
                     skipped_partial_blocks += 1
                     continue
                 removed_block_hashes.append(block_hash)
-
-            # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
-            attention_dp_rank = event.get("attention_dp_rank", 0)
 
             logger.debug(
                 "Publishing removed KV event: engine_event_id=%s "
@@ -1051,6 +1069,8 @@ async def get_publisher(
     kv_block_size: int,
     metrics_labels: Any,
     component_gauges: LLMBackendMetrics,
+    additional_metrics: Any = None,
+    event_buffer_max_size: int = 0,
     zmq_endpoint: Optional[str] = None,
     enable_local_indexer: bool = False,
     metrics_collector: Any = None,
@@ -1062,6 +1082,8 @@ async def get_publisher(
         kv_block_size,
         metrics_labels,
         component_gauges=component_gauges,
+        additional_metrics=additional_metrics,
+        event_buffer_max_size=event_buffer_max_size,
         zmq_endpoint=zmq_endpoint,
         enable_local_indexer=enable_local_indexer,
         metrics_collector=metrics_collector,

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -983,7 +983,14 @@ class HandlerBase(BaseGenerativeHandler):
             embeddings: Optional tensor or dict containing embeddings for multimodal processing
             ep_disaggregated_params: Optional DisaggregatedParams from encode worker (full EPD flow)
         """
-        logging.debug(f"Request: {request}")
+        request_token_ids = request.get("token_ids")
+        logging.debug(
+            "Request summary: token_ids=%s keys=%s has_embeddings=%s has_ep_disaggregated_params=%s",
+            len(request_token_ids) if isinstance(request_token_ids, list) else None,
+            len(request),
+            embeddings is not None,
+            ep_disaggregated_params is not None,
+        )
 
         # Additional metrics: request type detection
         metrics_collector = self.additional_metrics

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -137,7 +137,12 @@ class PrefillHandler(HandlerBase):
         Frontend routes to decode workers automatically.
         """
         logging.debug(f"Prefill Request ID: {context.id()}")
-        logging.debug(f"PrefillHandler.generate received request: {request}")
+        request_token_ids = request.get("token_ids")
+        logging.debug(
+            "PrefillHandler.generate received request: token_ids=%s keys=%s",
+            len(request_token_ids) if isinstance(request_token_ids, list) else None,
+            len(request),
+        )
         embeddings_tensor = None
         ep_disaggregated_params = None
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client import CollectorRegistry
+from prometheus_client import Counter as RealCounter
+from prometheus_client import Gauge as RealGauge
+from prometheus_client import Histogram as RealHistogram
+from prometheus_client import generate_latest
 
 from dynamo.trtllm.metrics import AdditionalMetricsCollector
 
@@ -38,14 +42,13 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
         """Create a fresh registry and collector for each test."""
         self.registry = CollectorRegistry()
 
-        # Patch prometheus_client.Counter and Histogram to use our test registry
+        # Patch prometheus_client metrics to use our test registry
         with patch("dynamo.trtllm.metrics.Counter") as MockCounter, patch(
             "dynamo.trtllm.metrics.Histogram"
-        ) as MockHistogram:
-            from prometheus_client import Counter, Histogram
+        ) as MockHistogram, patch("dynamo.trtllm.metrics.Gauge") as MockGauge:
 
             def make_counter(name, documentation, labelnames=None, **_kw):
-                return Counter(
+                return RealCounter(
                     name,
                     documentation,
                     labelnames=labelnames or [],
@@ -58,12 +61,21 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
                 kwargs = {"registry": self.registry}
                 if buckets is not None:
                     kwargs["buckets"] = buckets
-                return Histogram(
+                return RealHistogram(
                     name, documentation, labelnames=labelnames or [], **kwargs
+                )
+
+            def make_gauge(name, documentation, labelnames=None, **_kw):
+                return RealGauge(
+                    name,
+                    documentation,
+                    labelnames=labelnames or [],
+                    registry=self.registry,
                 )
 
             MockCounter.side_effect = make_counter
             MockHistogram.side_effect = make_histogram
+            MockGauge.side_effect = make_gauge
 
             self.collector = AdditionalMetricsCollector(
                 labels={
@@ -223,6 +235,37 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
         # None means unobserved; Prometheus counters without .inc() do not
         # appear as a sample row.
         self.assertIn(count, (None, 0.0))
+
+    def test_kv_event_buffer_telemetry(self):
+        """KV event drains report capacity, distribution, and ID loss."""
+        self.collector.set_kv_event_buffer_capacity(100_000)
+        self.collector.record_kv_event_drain_batch(64)
+        self.collector.record_kv_event_drain_batch(512)
+        self.collector.record_kv_event_drain_batch(128)
+        self.collector.record_kv_event_id_gap(7)
+        self.collector.record_kv_event_id_gap(0)
+
+        labels = {
+            "model_name": "test-model",
+            "disaggregation_mode": "prefill_and_decode",
+            "engine_type": "trtllm",
+        }
+        self.assertEqual(
+            self.registry.get_sample_value("trtllm_kv_event_buffer_capacity", labels),
+            100_000,
+        )
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "trtllm_kv_event_drain_batch_size_count", labels
+            ),
+            3,
+        )
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "trtllm_kv_event_id_gap_events_total", labels
+            ),
+            7,
+        )
 
     def test_no_duplicate_metrics(self):
         """Test that removed duplicate metrics are not present."""

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -26,9 +26,14 @@ in ``test_invoke_handler_matches_publisher_keyword_set``.
 
 from __future__ import annotations
 
+import asyncio
+import queue
+import threading
 from unittest.mock import MagicMock
 
 import pytest
+
+from dynamo.trtllm import publisher as publisher_mod
 
 pytestmark = [
     pytest.mark.unit,
@@ -224,12 +229,6 @@ def _build_publisher_stub(monkeypatch, *, attention_dp_size: int, fpm_enabled: b
     via ``monkeypatch`` so initialize() reaches the FPM gate cleanly without
     needing a blanket try/except to swallow upstream failures.
     """
-    import asyncio
-    import queue
-    import threading
-
-    from dynamo.trtllm import publisher as publisher_mod
-
     engine = MagicMock()
     engine.get_attention_dp_size.return_value = attention_dp_size
 
@@ -255,7 +254,7 @@ def _build_publisher_stub(monkeypatch, *, attention_dp_size: int, fpm_enabled: b
     pub.partial_block_hashes = set()
     pub.error_queue = queue.Queue()
     pub._stop_event = threading.Event()
-    pub._last_engine_event_id = None
+    pub._last_engine_event_id_by_rank = {}
 
     fake_fpm_cls = MagicMock()
     monkeypatch.setattr(publisher_mod, "FpmDirectPublisher", fake_fpm_cls)
@@ -317,6 +316,80 @@ def test_publisher_does_not_init_fpm_publisher_under_attention_dp(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# KV event buffer telemetry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_event_polling_loop_records_drained_batch_size():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+    drained_batches = []
+
+    async def fetch_events():
+        for event_id in range(3):
+            yield {"event_id": event_id}
+
+    def handle_event(event):
+        if event["event_id"] == 2:
+            pub._stop_event.set()
+
+    await pub._polling_loop(
+        fetch_events,
+        handle_event,
+        min_sleep=0.001,
+        max_sleep=0.001,
+        backoff_factor=1.0,
+        batch_size_handler_fn=drained_batches.append,
+    )
+
+    assert drained_batches == [3]
+
+
+def test_kv_event_id_gap_records_missing_event_count():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.additional_metrics = MagicMock()
+    pub.processing_initial_created_events = True
+    pub.max_window_size = None
+    pub._last_engine_event_id_by_rank = {0: 10}
+
+    pub._handle_kv_event({"event_id": 14, "data": {"type": "created"}})
+
+    pub.additional_metrics.record_kv_event_id_gap.assert_called_once_with(3)
+
+
+def test_filtered_kv_events_do_not_create_false_event_id_gaps():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.additional_metrics = MagicMock()
+    pub._last_engine_event_id_by_rank = {0: 10}
+    pub.should_drop_event = MagicMock(side_effect=[True, False])
+    pub.processing_initial_created_events = True
+    pub.max_window_size = None
+
+    pub._handle_kv_event({"event_id": 11, "data": {"type": "stored"}})
+    pub._handle_kv_event({"event_id": 12, "data": {"type": "created"}})
+
+    pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
+
+
+def test_interleaved_attention_dp_ranks_do_not_create_false_event_id_gaps():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.additional_metrics = MagicMock()
+    pub._last_engine_event_id_by_rank = {}
+    pub.should_drop_event = MagicMock(return_value=True)
+
+    for event in [
+        {"event_id": 10, "attention_dp_rank": 0},
+        {"event_id": 3, "attention_dp_rank": 1},
+        {"event_id": 11, "attention_dp_rank": 0},
+        {"event_id": 4, "attention_dp_rank": 1},
+    ]:
+        pub._handle_kv_event(event)
+
+    pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # First-stat schema probe
 # ---------------------------------------------------------------------------
 
@@ -327,8 +400,6 @@ def _build_schema_probe_publisher(fpm_publisher_mock=None):
     Bypasses __init__ (heavy deps) and seeds only the attributes the probe
     method reads or writes: fpm_publisher and _fpm_schema_checked.
     """
-    from dynamo.trtllm import publisher as publisher_mod
-
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.fpm_publisher = (
         fpm_publisher_mock if fpm_publisher_mock is not None else MagicMock()
@@ -443,8 +514,6 @@ def test_schema_probe_field_list_matches_default_ibs_set():
     """Guardrail: the required-fields tuple must stay in sync with the IBS
     default fixture. If someone adds an IBS field to the production reader
     but forgets the probe constant (or vice versa), this test catches it."""
-    from dynamo.trtllm import publisher as publisher_mod
-
     assert set(publisher_mod._FPM_REQUIRED_IBS_FIELDS) == set(_DEFAULT_IBS.keys())
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -346,6 +346,45 @@ async def test_kv_event_polling_loop_records_drained_batch_size():
     assert drained_batches == [3]
 
 
+@pytest.mark.asyncio
+async def test_polling_loop_reraises_unexpected_handler_error():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+
+    async def fetch_events():
+        yield {"event_id": 0}
+
+    def handle_event(_event):
+        raise RuntimeError("handler failed")
+
+    with pytest.raises(RuntimeError, match="handler failed"):
+        await pub._polling_loop(
+            fetch_events,
+            handle_event,
+            min_sleep=0.001,
+            max_sleep=0.001,
+            backoff_factor=1.0,
+        )
+
+
+def test_managed_thread_stops_after_task_error():
+    errors = queue.Queue()
+    calls = 0
+
+    async def failing_task():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("task failed")
+
+    thread = publisher_mod.ManagedThread(failing_task, error_queue=errors)
+    thread.start()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert calls == 1
+    assert str(errors.get_nowait()) == "task failed"
+
+
 def test_kv_event_id_gap_records_missing_event_count():
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.additional_metrics = MagicMock()
@@ -370,6 +409,25 @@ def test_filtered_kv_events_do_not_create_false_event_id_gaps():
     pub._handle_kv_event({"event_id": 12, "data": {"type": "created"}})
 
     pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
+
+
+def test_partial_only_removed_event_does_not_publish_empty_batch():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    kv_event_publisher = MagicMock()
+    pub.additional_metrics = None
+    pub._last_engine_event_id_by_rank = {}
+    pub.should_drop_event = MagicMock(return_value=False)
+    pub.processing_initial_created_events = True
+    pub.partial_block_hashes = {123}
+    pub.zmq_kv_event_publisher = None
+    pub.kv_event_publishers = {0: kv_event_publisher}
+
+    pub._handle_kv_event(
+        {"event_id": 1, "data": {"type": "removed", "block_hashes": [123]}}
+    )
+
+    assert pub.partial_block_hashes == set()
+    kv_event_publisher.publish_removed.assert_not_called()
 
 
 def test_interleaved_attention_dp_ranks_do_not_create_false_event_id_gaps():

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -115,6 +115,30 @@ def test_config_use_kv_events_derived_from_publish_events(monkeypatch):
     assert config_off.use_kv_events is False
 
 
+@pytest.mark.asyncio
+async def test_init_llm_worker_rejects_invalid_kv_cache_config_override(monkeypatch):
+    monkeypatch.delenv("DYN_TRTLLM_OVERRIDE_ENGINE_ARGS", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_PUBLISH_KV_EVENTS", raising=False)
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--publish-kv-events",
+            "--override-engine-args",
+            '{"kv_cache_config": []}',
+        ]
+    )
+
+    with pytest.raises(
+        TypeError, match="kv_cache_config must be a dict or KvCacheConfig, got list"
+    ):
+        await init_llm_worker(
+            runtime=mock.MagicMock(),
+            config=config,
+            shutdown_event=asyncio.Event(),
+        )
+
+
 def test_config_has_connector(monkeypatch):
     """Config.has_connector returns True only for the single configured connector."""
     monkeypatch.delenv("DYN_CONNECTOR", raising=False)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -68,7 +68,7 @@ from dynamo.trtllm.request_handlers.handlers import (
 from dynamo.trtllm.utils.trtllm_utils import deep_update
 
 # Default buffer size for kv cache events.
-DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
 
 
 def build_kv_connector_config(config: Config):
@@ -725,6 +725,10 @@ async def init_llm_worker(
                 config.kv_block_size,
                 metrics_labels,
                 component_gauges=component_gauges,
+                additional_metrics=additional_metrics,
+                event_buffer_max_size=engine_args["kv_cache_config"].get(
+                    "event_buffer_max_size", 0
+                ),
                 zmq_endpoint=trtllm_zmq_bind_endpoint,
                 enable_local_indexer=config.enable_local_indexer,
                 metrics_collector=metrics_collector,

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -299,6 +299,7 @@ async def init_llm_worker(
 
     _sync_config_from_engine_args(config, arg_map)
 
+    event_buffer_max_size = 0
     if config.publish_events_and_metrics:
         # 'event_buffer_max_size' is required to enable TRTLLM to publish kv cache events.
         # Add it to kv_cache_config while preserving all settings from YAML
@@ -309,18 +310,24 @@ async def init_llm_worker(
             current_kv_config = current_kv_config.model_dump(exclude_none=True)
             arg_map["kv_cache_config"] = current_kv_config
 
-        if isinstance(current_kv_config, dict):
-            # Preserve a user-specified event_buffer_max_size from YAML/overrides;
-            # only apply the default when it is unset or zero (TRTLLM's disabled value).
-            existing = current_kv_config.get("event_buffer_max_size")
-            if existing:
-                logging.info(
-                    f"Using existing event_buffer_max_size={existing} from kv_cache_config"
-                )
-            else:
-                current_kv_config[
-                    "event_buffer_max_size"
-                ] = DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
+        if not isinstance(current_kv_config, dict):
+            raise TypeError(
+                "kv_cache_config must be a dict or KvCacheConfig, "
+                f"got {type(current_kv_config).__name__}"
+            )
+
+        # Preserve a user-specified event_buffer_max_size from YAML/overrides;
+        # only apply the default when it is unset or zero (TRTLLM's disabled value).
+        existing = current_kv_config.get("event_buffer_max_size")
+        if existing:
+            logging.info(
+                f"Using existing event_buffer_max_size={existing} from kv_cache_config"
+            )
+        else:
+            current_kv_config[
+                "event_buffer_max_size"
+            ] = DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
+        event_buffer_max_size = int(current_kv_config["event_buffer_max_size"])
 
         # Only pytorch backend is supported for now to publish events and metrics.
         if "backend" not in arg_map:
@@ -726,9 +733,7 @@ async def init_llm_worker(
                 metrics_labels,
                 component_gauges=component_gauges,
                 additional_metrics=additional_metrics,
-                event_buffer_max_size=engine_args["kv_cache_config"].get(
-                    "event_buffer_max_size", 0
-                ),
+                event_buffer_max_size=event_buffer_max_size,
                 zmq_endpoint=trtllm_zmq_bind_endpoint,
                 enable_local_indexer=config.enable_local_indexer,
                 metrics_collector=metrics_collector,

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -129,7 +129,6 @@ class EncodeWorkerHandler:
     async def generate(
         self, request: vLLMMultimodalRequest, context
     ) -> AsyncIterator[str]:
-        logger.debug(f"Got raw request: {request}")
         if not isinstance(request, vLLMMultimodalRequest):
             if isinstance(request, str):
                 request = vLLMMultimodalRequest.model_validate_json(request)
@@ -327,7 +326,7 @@ class EncodeWorkerHandler:
                         (transfer_request[1], embedding_item.embeddings)
                     )
 
-            logger.debug(f"Request: {request.model_dump_json()}")
+            payload = request.model_dump_json()
 
             time_end = time.perf_counter()
             self._accumulated_time += time_end - time_start
@@ -341,7 +340,7 @@ class EncodeWorkerHandler:
             )
 
             # Yield transformed request back
-            yield request.model_dump_json()
+            yield payload
 
         except Exception as e:
             logger.error(f"Error processing request {request_id}: {e}")

--- a/components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py
@@ -193,7 +193,6 @@ async def _fetch_from_encode_workers(
         multimodal_groups: List[MultiModalGroup] = []
         for stream in encode_response_streams:
             async for response in stream:
-                logger.debug(f"Received response from encode worker: {response}")
                 output = vLLMMultimodalRequest.model_validate_json(response.data())  # type: ignore[attr-defined]
                 if output.multimodal_inputs:
                     multimodal_groups.extend(output.multimodal_inputs)

--- a/components/src/dynamo/vllm/tests/test_vllm_logging.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_logging.py
@@ -27,6 +27,7 @@ import os
 
 import pytest
 
+import dynamo.runtime.logging as dynamo_logging
 from dynamo.runtime.logging import (
     VllmColorFormatter,
     configure_dynamo_logging,
@@ -43,7 +44,7 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
+def _clean_env(monkeypatch, tmp_path):
     """Remove logging-related env vars before each test."""
     for var in [
         "DYN_LOG",
@@ -55,6 +56,11 @@ def _clean_env(monkeypatch):
         "SGLANG_LOGGING_CONFIG_PATH",
     ]:
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        dynamo_logging,
+        "_DEFAULT_DYNAMO_LOGGING_CONFIG_PATH",
+        str(tmp_path / "default-dynamo-logging.toml"),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -160,14 +166,32 @@ def test_python_log_level_mapping(filters, expected):
     assert python_log_level_mapping(filters) == expected
 
 
-def test_toml_logging_config_keeps_python_debug_available(monkeypatch):
-    monkeypatch.setenv("DYN_LOGGING_CONFIG_PATH", "/tmp/dynamo-logging.toml")
+def test_toml_logging_config_keeps_python_debug_available(monkeypatch, tmp_path):
+    config_path = tmp_path / "dynamo-logging.toml"
+    config_path.touch()
+    monkeypatch.setenv("DYN_LOGGING_CONFIG_PATH", str(config_path))
 
     configure_dynamo_logging()
 
     root_logger = logging.getLogger()
     assert root_logger.level == logging.DEBUG
     assert root_logger.handlers[0].level == logging.DEBUG
+
+
+def test_missing_toml_logging_config_does_not_keep_python_debug(monkeypatch, tmp_path):
+    monkeypatch.setenv("DYN_LOGGING_CONFIG_PATH", str(tmp_path / "missing.toml"))
+
+    assert python_log_level_mapping("info") == logging.INFO
+
+
+def test_default_toml_logging_config_keeps_python_debug(monkeypatch, tmp_path):
+    config_path = tmp_path / "default-dynamo-logging.toml"
+    config_path.touch()
+    monkeypatch.setattr(
+        dynamo_logging, "_DEFAULT_DYNAMO_LOGGING_CONFIG_PATH", str(config_path)
+    )
+
+    assert python_log_level_mapping("info") == logging.DEBUG
 
 
 def test_no_config_file_written():

--- a/components/src/dynamo/vllm/tests/test_vllm_logging.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_logging.py
@@ -31,6 +31,7 @@ from dynamo.runtime.logging import (
     VllmColorFormatter,
     configure_dynamo_logging,
     configure_vllm_logging,
+    python_log_level_mapping,
 )
 
 pytestmark = [
@@ -46,6 +47,7 @@ def _clean_env(monkeypatch):
     """Remove logging-related env vars before each test."""
     for var in [
         "DYN_LOG",
+        "DYN_LOGGING_CONFIG_PATH",
         "VLLM_LOGGING_LEVEL",
         "VLLM_CONFIGURE_LOGGING",
         "VLLM_LOGGING_CONFIG_PATH",
@@ -123,6 +125,49 @@ def test_dyn_log_does_not_affect_vllm_level(monkeypatch):
     assert vllm_logger.level == logging.INFO
     assert isinstance(vllm_logger.handlers[0], logging.StreamHandler)
     assert isinstance(vllm_logger.handlers[0].formatter, VllmColorFormatter)
+
+
+def test_default_dyn_log_filters_python_debug_before_bridge():
+    """Default DYN_LOG=info must avoid formatting Python DEBUG bridge records."""
+    configure_dynamo_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.INFO
+    assert root_logger.handlers[0].level == logging.INFO
+
+
+def test_scoped_dyn_log_debug_keeps_python_debug_available(monkeypatch):
+    """Scoped Rust debug filters still need Python DEBUG records forwarded."""
+    monkeypatch.setenv("DYN_LOG", "info,dynamo_trtllm=debug")
+
+    configure_dynamo_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.DEBUG
+    assert root_logger.handlers[0].level == logging.DEBUG
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        ("info", logging.INFO),
+        ("warn", logging.WARNING),
+        ("info,dynamo_trtllm=debug", logging.DEBUG),
+        ("warn,dynamo_trtllm=trace", logging.DEBUG),
+    ],
+)
+def test_python_log_level_mapping(filters, expected):
+    assert python_log_level_mapping(filters) == expected
+
+
+def test_toml_logging_config_keeps_python_debug_available(monkeypatch):
+    monkeypatch.setenv("DYN_LOGGING_CONFIG_PATH", "/tmp/dynamo-logging.toml")
+
+    configure_dynamo_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.DEBUG
+    assert root_logger.handlers[0].level == logging.DEBUG
 
 
 def test_no_config_file_written():

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -423,6 +423,12 @@ class trtllm_additional:
     KV_TRANSFER_BYTES = "trtllm_kv_transfer_bytes"
     # KV cache transfer speed per request in GB/s
     KV_TRANSFER_SPEED_GB_S = "trtllm_kv_transfer_speed_gb_s"
+    # Configured maximum number of TRT-LLM KV events buffered before older events are dropped
+    KV_EVENT_BUFFER_CAPACITY = "trtllm_kv_event_buffer_capacity"
+    # Number of TRT-LLM KV events returned to Dynamo in one polling drain
+    KV_EVENT_DRAIN_BATCH_SIZE = "trtllm_kv_event_drain_batch_size"
+    # Total number of missing TRT-LLM KV event IDs detected by Dynamo
+    KV_EVENT_ID_GAP_EVENTS_TOTAL = "trtllm_kv_event_id_gap_events_total"
 
 
 class work_handler:

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -195,7 +195,8 @@ def log_level_mapping(level: str) -> int:
 
 def python_log_level_mapping(filters: str) -> int:
     """Return the lowest Python level enabled by a Rust-style DYN_LOG filter."""
-    if os.getenv("DYN_LOGGING_CONFIG_PATH") or os.path.isfile(
+    config_path = os.getenv("DYN_LOGGING_CONFIG_PATH")
+    if (config_path is not None and os.path.isfile(config_path)) or os.path.isfile(
         _DEFAULT_DYNAMO_LOGGING_CONFIG_PATH
     ):
         # Rust merges TOML log filters after DYN_LOG. Preserve DEBUG records so

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -22,6 +22,8 @@ from datetime import datetime, timezone
 
 from dynamo._core import log_message
 
+_DEFAULT_DYNAMO_LOGGING_CONFIG_PATH = "/opt/dynamo/etc/logging.toml"
+
 
 class LogHandler(logging.Handler):
     """
@@ -101,13 +103,18 @@ class VllmColorFormatter(logging.Formatter):
 
 
 # Configure the Python logger to use the NimLogHandler
-def configure_logger(service_name: str | None, worker_id: int | None) -> None:
+def configure_logger(
+    service_name: str | None, worker_id: int | None, level: int = logging.INFO
+) -> None:
     """
     Called once to configure the Python logger to use the LogHandler
     """
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(level)
     handler = LogHandler()
+    # Child loggers can propagate records below the root logger's level. Keep
+    # the bridge handler aligned so those records are dropped before formatting.
+    handler.setLevel(level)
 
     # Simple formatter without date and level info since it's already provided by Rust
     formatter = logging.Formatter("%(message)s")
@@ -141,12 +148,14 @@ def configure_dynamo_logging(
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
 
-    # Configure the logger with Dynamo's handler
-    configure_logger(service_name, worker_id)
-
     # map the DYN_LOG variable to a logging level
     dyn_var = os.environ.get("DYN_LOG", "info")
     dyn_level = log_level_mapping(dyn_var)
+
+    # Configure the logger with Dynamo's handler. Rust applies the final
+    # target-specific filtering, but Python should cheaply discard levels that
+    # no DYN_LOG directive can enable before formatting bridge records.
+    configure_logger(service_name, worker_id, python_log_level_mapping(dyn_var))
 
     # configure inference engine loggers
     configure_vllm_logging(dyn_level)
@@ -182,6 +191,27 @@ def log_level_mapping(level: str) -> int:
         return logging.INFO
     else:
         return logging.INFO
+
+
+def python_log_level_mapping(filters: str) -> int:
+    """Return the lowest Python level enabled by a Rust-style DYN_LOG filter."""
+    if os.getenv("DYN_LOGGING_CONFIG_PATH") or os.path.isfile(
+        _DEFAULT_DYNAMO_LOGGING_CONFIG_PATH
+    ):
+        # Rust merges TOML log filters after DYN_LOG. Preserve DEBUG records so
+        # Python does not discard messages enabled only by file configuration.
+        return logging.DEBUG
+
+    levels = []
+    for directive in filters.split(","):
+        level = directive.rsplit("=", 1)[-1].strip().lower()
+        if level == "trace":
+            # Python has no TRACE level. Keep DEBUG records available for Rust
+            # when any target explicitly enables trace output.
+            levels.append(logging.DEBUG)
+        else:
+            levels.append(log_level_mapping(level))
+    return min(levels, default=logging.INFO)
 
 
 def configure_sglang_logging(dyn_level: int) -> None:

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -750,6 +750,15 @@ pub mod trtllm_additional {
 
     /// KV cache transfer speed per request in GB/s
     pub const KV_TRANSFER_SPEED_GB_S: &str = "trtllm_kv_transfer_speed_gb_s";
+
+    /// Configured maximum number of TRT-LLM KV events buffered before older events are dropped
+    pub const KV_EVENT_BUFFER_CAPACITY: &str = "trtllm_kv_event_buffer_capacity";
+
+    /// Number of TRT-LLM KV events returned to Dynamo in one polling drain
+    pub const KV_EVENT_DRAIN_BATCH_SIZE: &str = "trtllm_kv_event_drain_batch_size";
+
+    /// Total number of missing TRT-LLM KV event IDs detected by Dynamo
+    pub const KV_EVENT_ID_GAP_EVENTS_TOTAL: &str = "trtllm_kv_event_id_gap_events_total";
 }
 
 // KV cache statistics metrics


### PR DESCRIPTION
Replace large TRT-LLM KV event payload dumps with compact stored and removed event summaries. This avoids eagerly formatting multi-megabyte debug messages in the KV publisher hot loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus telemetry for KV event buffer capacity, drain batch sizes, and missing event-ID gaps; raised the default KV event buffer limit.

* **Refactor**
  * Reduced noisy debug output in request and worker logs; switched to structured, concise request summaries and per-rank event-id tracking for clearer diagnostics.

* **Tests**
  * Expanded unit/regression tests covering KV-event telemetry and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->