### PR TITLE
fix(trtllm): raise KV event buffer default and expose telemetry

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -92,7 +92,7 @@ _IDLE_SLEEP_S = 0.01
 
 # Mirror the legacy `dynamo.trtllm` worker — required for TRT-LLM to actually
 # publish KV cache events. Without this, `get_kv_cache_events` returns empty.
-_DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+_DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
 
 # Note: `metrics_dict` is set per-instance on `GenerationResult` (only
 # when TRT-LLM's perf-stats collection is enabled and the request
@@ -149,6 +149,12 @@ class TrtllmLLMEngine(LLMEngine):
         self.publish_events_and_metrics = publish_events_and_metrics
         self._component = component
         self._additional_metrics: Optional["AdditionalMetricsCollector"] = None
+        kv_cache_config = self.engine_args.get("kv_cache_config", {})
+        self._kv_event_buffer_max_size = (
+            int(kv_cache_config.get("event_buffer_max_size", 0))
+            if isinstance(kv_cache_config, dict)
+            else int(getattr(kv_cache_config, "event_buffer_max_size", 0) or 0)
+        )
         self._trtllm_metrics_collector: Optional["MetricsCollector"] = None
         # Resolved once at construction so the hot poll loop doesn't run
         # `hasattr` per iteration; same for the per-request log method
@@ -338,6 +344,9 @@ class TrtllmLLMEngine(LLMEngine):
                 "engine_type": "trtllm",
             },
         )
+        self._additional_metrics.set_kv_event_buffer_capacity(
+            self._kv_event_buffer_max_size
+        )
         self._trtllm_metrics_collector = MetricsCollector(
             {"model_name": gauge_model_name, "engine_type": "trtllm"}
         )
@@ -489,6 +498,8 @@ class TrtllmLLMEngine(LLMEngine):
             if not events:
                 time.sleep(_IDLE_SLEEP_S)
                 continue
+            if self._additional_metrics is not None:
+                self._additional_metrics.record_kv_event_drain_batch(len(events))
             for event in events:
                 try:
                     self._dispatch_kv_event(event)
@@ -515,6 +526,10 @@ class TrtllmLLMEngine(LLMEngine):
                     last + 1,
                     event_id,
                 )
+                if self._additional_metrics is not None:
+                    self._additional_metrics.record_kv_event_id_gap(
+                        max(0, event_id - (last + 1))
+                    )
             self._last_event_id_by_rank[rank] = event_id
         publisher = self._kv_publishers.get(rank)
         if publisher is None:

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -150,11 +150,16 @@ class TrtllmLLMEngine(LLMEngine):
         self._component = component
         self._additional_metrics: Optional["AdditionalMetricsCollector"] = None
         kv_cache_config = self.engine_args.get("kv_cache_config", {})
-        self._kv_event_buffer_max_size = (
-            int(kv_cache_config.get("event_buffer_max_size", 0))
-            if isinstance(kv_cache_config, dict)
-            else int(getattr(kv_cache_config, "event_buffer_max_size", 0) or 0)
-        )
+        if isinstance(kv_cache_config, dict):
+            event_buffer_max_size = kv_cache_config.get("event_buffer_max_size", 0)
+        elif isinstance(kv_cache_config, KvCacheConfig):
+            event_buffer_max_size = kv_cache_config.event_buffer_max_size
+        else:
+            raise TypeError(
+                "kv_cache_config must be a dict or KvCacheConfig, "
+                f"got {type(kv_cache_config).__name__}"
+            )
+        self._kv_event_buffer_max_size = int(event_buffer_max_size or 0)
         self._trtllm_metrics_collector: Optional["MetricsCollector"] = None
         # Resolved once at construction so the hot poll loop doesn't run
         # `hasattr` per iteration; same for the per-request log method

--- a/components/src/dynamo/trtllm/metrics.py
+++ b/components/src/dynamo/trtllm/metrics.py
@@ -28,12 +28,13 @@ This module adds metrics that have no engine/runtime/frontend equivalent:
   - Request types (image, structured output)
   - KV transfer metrics (success counter, latency, throughput, per-request bytes)
   - Abort tracking
+  - KV event buffer drain telemetry
 """
 
 import logging
 from datetime import timedelta
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 from dynamo.prometheus_names import trtllm_additional as metric_names
 
@@ -79,6 +80,27 @@ KV_TRANSFER_BYTES_BUCKETS = (
     500_000_000,
     1_000_000_000,
     5_000_000_000,
+    float("inf"),
+)
+KV_EVENT_DRAIN_BATCH_BUCKETS = (
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1_024,
+    2_048,
+    4_096,
+    8_192,
+    16_384,
+    32_768,
+    65_536,
+    131_072,
     float("inf"),
 )
 
@@ -142,6 +164,27 @@ class AdditionalMetricsCollector:
             buckets=KV_TRANSFER_SPEED_BUCKETS,
         )
 
+        # --- KV event buffer telemetry ---
+        # TRT-LLM exposes drained event batches, not its live internal queue depth.
+        # Keep these names explicit so dashboards do not mistake a drain size for
+        # an instantaneous queue-depth sample.
+        self.kv_event_buffer_capacity = Gauge(
+            metric_names.KV_EVENT_BUFFER_CAPACITY,
+            "Configured maximum TRT-LLM KV events buffered before older events are dropped",
+            labelnames=self._labelnames,
+        )
+        self.kv_event_drain_batch_size = Histogram(
+            metric_names.KV_EVENT_DRAIN_BATCH_SIZE,
+            "Number of TRT-LLM KV events returned to Dynamo in one polling drain",
+            labelnames=self._labelnames,
+            buckets=KV_EVENT_DRAIN_BATCH_BUCKETS,
+        )
+        self.kv_event_id_gap_events = Counter(
+            metric_names.KV_EVENT_ID_GAP_EVENTS_TOTAL,
+            "Total number of missing TRT-LLM KV event IDs detected by Dynamo",
+            labelnames=self._labelnames,
+        )
+
         logger.info("AdditionalMetricsCollector initialized")
 
     # --- Request helpers ---
@@ -200,3 +243,18 @@ class AdditionalMetricsCollector:
             self.kv_transfer_speed.labels(*self._labelvalues).observe(speed_gb_s)
 
         return True
+
+    # --- KV event buffer telemetry ---
+
+    def set_kv_event_buffer_capacity(self, capacity: int):
+        """Publish the configured TRT-LLM KV event buffer limit."""
+        self.kv_event_buffer_capacity.labels(*self._labelvalues).set(capacity)
+
+    def record_kv_event_drain_batch(self, batch_size: int):
+        """Record one non-empty batch drained from TRT-LLM by Dynamo."""
+        self.kv_event_drain_batch_size.labels(*self._labelvalues).observe(batch_size)
+
+    def record_kv_event_id_gap(self, missing_events: int):
+        """Record TRT-LLM event IDs skipped between two observed events."""
+        if missing_events > 0:
+            self.kv_event_id_gap_events.labels(*self._labelvalues).inc(missing_events)

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -380,6 +380,8 @@ class Publisher:
         kv_block_size: int,
         metrics_labels: Any,
         component_gauges: LLMBackendMetrics,
+        additional_metrics: Any = None,
+        event_buffer_max_size: int = 0,
         zmq_endpoint: Optional[str] = None,
         enable_local_indexer: bool = False,
         metrics_collector: Any = None,
@@ -391,6 +393,9 @@ class Publisher:
         self.max_window_size = None
         self.metrics_labels = metrics_labels
         self.component_gauges = component_gauges
+        self.additional_metrics = additional_metrics
+        if self.additional_metrics is not None:
+            self.additional_metrics.set_kv_event_buffer_capacity(event_buffer_max_size)
         self.enable_local_indexer = enable_local_indexer
         self.metrics_collector = metrics_collector
         self.attention_dp_size = engine.get_attention_dp_size()
@@ -569,18 +574,24 @@ class Publisher:
         min_sleep: float,
         max_sleep: float,
         backoff_factor: float,
+        batch_size_handler_fn=None,
     ):
         sleep_s = min_sleep
         while not self._stop_event.is_set():
             had_data = False
+            batch_size = 0
             try:
                 async for item in fetch_fn():
                     had_data = True
+                    batch_size += 1
                     handler_fn(item)
             except (asyncio.TimeoutError, TimeoutError, asyncio.QueueEmpty):
                 pass
             except Exception as e:
                 logging.warning(f"Publisher polling loop error: {e}", exc_info=True)
+
+            if batch_size and batch_size_handler_fn is not None:
+                batch_size_handler_fn(batch_size)
 
             if not had_data:
                 await asyncio.sleep(sleep_s)
@@ -776,24 +787,34 @@ class Publisher:
             _KV_EVENTS_MIN_SLEEP_SEC,
             _KV_EVENTS_MAX_SLEEP_SEC,
             _KV_EVENTS_BACKOFF_FACTOR,
+            self._record_kv_event_drain_batch,
         )
         return True
 
-    def _handle_kv_event(self, event):
-        # drop the events that is not emitted from the global attention layer.
-        if self.should_drop_event(event):
-            return
+    def _record_kv_event_drain_batch(self, batch_size: int) -> None:
+        if self.additional_metrics is not None:
+            self.additional_metrics.record_kv_event_drain_batch(batch_size)
 
+    def _handle_kv_event(self, event):
         event_id = event["event_id"]
 
-        # Check for consecutive event IDs from the engine
+        # Check the raw engine stream before filtering non-global-attention
+        # events so expected filtering does not look like queue loss.
         if self._last_engine_event_id is not None:
             expected_id = self._last_engine_event_id + 1
             if event_id != expected_id:
                 logging.warning(
                     f"Non-consecutive engine event_id: expected {expected_id}, got {event_id}"
                 )
+                if self.additional_metrics is not None:
+                    self.additional_metrics.record_kv_event_id_gap(
+                        max(0, event_id - expected_id)
+                    )
         self._last_engine_event_id = event_id
+
+        # drop the events that is not emitted from the global attention layer.
+        if self.should_drop_event(event):
+            return
 
         data = event["data"]
         if data["type"] == "stored":
@@ -1051,6 +1072,8 @@ async def get_publisher(
     kv_block_size: int,
     metrics_labels: Any,
     component_gauges: LLMBackendMetrics,
+    additional_metrics: Any = None,
+    event_buffer_max_size: int = 0,
     zmq_endpoint: Optional[str] = None,
     enable_local_indexer: bool = False,
     metrics_collector: Any = None,
@@ -1062,6 +1085,8 @@ async def get_publisher(
         kv_block_size,
         metrics_labels,
         component_gauges=component_gauges,
+        additional_metrics=additional_metrics,
+        event_buffer_max_size=event_buffer_max_size,
         zmq_endpoint=zmq_endpoint,
         enable_local_indexer=enable_local_indexer,
         metrics_collector=metrics_collector,

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -438,8 +438,9 @@ class Publisher:
         self.partial_block_hashes: set[int] = set()
         self.error_queue: Queue = Queue()
         self._stop_event = threading.Event()
-        # Track the last engine event_id to assert consecutive event IDs from the engine
-        self._last_engine_event_id: Optional[int] = None
+        # Track the last engine event_id per attention-DP rank. TRT-LLM emits
+        # independent rank-local sequences before gathering them on rank 0.
+        self._last_engine_event_id_by_rank: dict[int, int] = {}
 
         # Initialize ZMQ publisher if endpoint is provided (consolidator enabled)
         if zmq_endpoint:
@@ -797,20 +798,23 @@ class Publisher:
 
     def _handle_kv_event(self, event):
         event_id = event["event_id"]
+        attention_dp_rank = event.get("attention_dp_rank", 0)
 
         # Check the raw engine stream before filtering non-global-attention
         # events so expected filtering does not look like queue loss.
-        if self._last_engine_event_id is not None:
-            expected_id = self._last_engine_event_id + 1
+        last_event_id = self._last_engine_event_id_by_rank.get(attention_dp_rank)
+        if last_event_id is not None:
+            expected_id = last_event_id + 1
             if event_id != expected_id:
                 logging.warning(
-                    f"Non-consecutive engine event_id: expected {expected_id}, got {event_id}"
+                    f"Non-consecutive engine event_id on rank={attention_dp_rank}: "
+                    f"expected {expected_id}, got {event_id}"
                 )
                 if self.additional_metrics is not None:
                     self.additional_metrics.record_kv_event_id_gap(
                         max(0, event_id - expected_id)
                     )
-        self._last_engine_event_id = event_id
+        self._last_engine_event_id_by_rank[attention_dp_rank] = event_id
 
         # drop the events that is not emitted from the global attention layer.
         if self.should_drop_event(event):
@@ -878,10 +882,6 @@ class Publisher:
 
             lora_name = data.get("lora_name")
 
-            # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
-            # Default to 0 for backwards compatibility with older TRT-LLM versions
-            attention_dp_rank = event.get("attention_dp_rank", 0)
-
             logger.debug(
                 "Publishing stored KV event: engine_event_id=%s "
                 "attention_dp_rank=%s blocks=%s tokens=%s lora_name=%s "
@@ -937,9 +937,6 @@ class Publisher:
                     skipped_partial_blocks += 1
                     continue
                 removed_block_hashes.append(block_hash)
-
-            # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
-            attention_dp_rank = event.get("attention_dp_rank", 0)
 
             logger.debug(
                 "Publishing removed KV event: engine_event_id=%s "

--- a/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client import CollectorRegistry
+from prometheus_client import Counter as RealCounter
+from prometheus_client import Gauge as RealGauge
+from prometheus_client import Histogram as RealHistogram
+from prometheus_client import generate_latest
 
 from dynamo.trtllm.metrics import AdditionalMetricsCollector
 
@@ -42,10 +46,9 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
         with patch("dynamo.trtllm.metrics.Counter") as MockCounter, patch(
             "dynamo.trtllm.metrics.Histogram"
         ) as MockHistogram, patch("dynamo.trtllm.metrics.Gauge") as MockGauge:
-            from prometheus_client import Counter, Gauge, Histogram
 
             def make_counter(name, documentation, labelnames=None, **_kw):
-                return Counter(
+                return RealCounter(
                     name,
                     documentation,
                     labelnames=labelnames or [],
@@ -58,12 +61,12 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
                 kwargs = {"registry": self.registry}
                 if buckets is not None:
                     kwargs["buckets"] = buckets
-                return Histogram(
+                return RealHistogram(
                     name, documentation, labelnames=labelnames or [], **kwargs
                 )
 
             def make_gauge(name, documentation, labelnames=None, **_kw):
-                return Gauge(
+                return RealGauge(
                     name,
                     documentation,
                     labelnames=labelnames or [],

--- a/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
@@ -38,11 +38,11 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
         """Create a fresh registry and collector for each test."""
         self.registry = CollectorRegistry()
 
-        # Patch prometheus_client.Counter and Histogram to use our test registry
+        # Patch prometheus_client metrics to use our test registry
         with patch("dynamo.trtllm.metrics.Counter") as MockCounter, patch(
             "dynamo.trtllm.metrics.Histogram"
-        ) as MockHistogram:
-            from prometheus_client import Counter, Histogram
+        ) as MockHistogram, patch("dynamo.trtllm.metrics.Gauge") as MockGauge:
+            from prometheus_client import Counter, Gauge, Histogram
 
             def make_counter(name, documentation, labelnames=None, **_kw):
                 return Counter(
@@ -62,8 +62,17 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
                     name, documentation, labelnames=labelnames or [], **kwargs
                 )
 
+            def make_gauge(name, documentation, labelnames=None, **_kw):
+                return Gauge(
+                    name,
+                    documentation,
+                    labelnames=labelnames or [],
+                    registry=self.registry,
+                )
+
             MockCounter.side_effect = make_counter
             MockHistogram.side_effect = make_histogram
+            MockGauge.side_effect = make_gauge
 
             self.collector = AdditionalMetricsCollector(
                 labels={
@@ -223,6 +232,37 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
         # None means unobserved; Prometheus counters without .inc() do not
         # appear as a sample row.
         self.assertIn(count, (None, 0.0))
+
+    def test_kv_event_buffer_telemetry(self):
+        """KV event drains report capacity, distribution, and ID loss."""
+        self.collector.set_kv_event_buffer_capacity(100_000)
+        self.collector.record_kv_event_drain_batch(64)
+        self.collector.record_kv_event_drain_batch(512)
+        self.collector.record_kv_event_drain_batch(128)
+        self.collector.record_kv_event_id_gap(7)
+        self.collector.record_kv_event_id_gap(0)
+
+        labels = {
+            "model_name": "test-model",
+            "disaggregation_mode": "prefill_and_decode",
+            "engine_type": "trtllm",
+        }
+        self.assertEqual(
+            self.registry.get_sample_value("trtllm_kv_event_buffer_capacity", labels),
+            100_000,
+        )
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "trtllm_kv_event_drain_batch_size_count", labels
+            ),
+            3,
+        )
+        self.assertEqual(
+            self.registry.get_sample_value(
+                "trtllm_kv_event_id_gap_events_total", labels
+            ),
+            7,
+        )
 
     def test_no_duplicate_metrics(self):
         """Test that removed duplicate metrics are not present."""

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -26,9 +26,14 @@ in ``test_invoke_handler_matches_publisher_keyword_set``.
 
 from __future__ import annotations
 
+import asyncio
+import queue
+import threading
 from unittest.mock import MagicMock
 
 import pytest
+
+from dynamo.trtllm import publisher as publisher_mod
 
 pytestmark = [
     pytest.mark.unit,
@@ -224,12 +229,6 @@ def _build_publisher_stub(monkeypatch, *, attention_dp_size: int, fpm_enabled: b
     via ``monkeypatch`` so initialize() reaches the FPM gate cleanly without
     needing a blanket try/except to swallow upstream failures.
     """
-    import asyncio
-    import queue
-    import threading
-
-    from dynamo.trtllm import publisher as publisher_mod
-
     engine = MagicMock()
     engine.get_attention_dp_size.return_value = attention_dp_size
 
@@ -323,10 +322,6 @@ def test_publisher_does_not_init_fpm_publisher_under_attention_dp(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_kv_event_polling_loop_records_drained_batch_size():
-    import threading
-
-    from dynamo.trtllm import publisher as publisher_mod
-
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub._stop_event = threading.Event()
     drained_batches = []
@@ -352,8 +347,6 @@ async def test_kv_event_polling_loop_records_drained_batch_size():
 
 
 def test_kv_event_id_gap_records_missing_event_count():
-    from dynamo.trtllm import publisher as publisher_mod
-
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.additional_metrics = MagicMock()
     pub.processing_initial_created_events = True
@@ -366,8 +359,6 @@ def test_kv_event_id_gap_records_missing_event_count():
 
 
 def test_filtered_kv_events_do_not_create_false_event_id_gaps():
-    from dynamo.trtllm import publisher as publisher_mod
-
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.additional_metrics = MagicMock()
     pub._last_engine_event_id_by_rank = {0: 10}
@@ -382,8 +373,6 @@ def test_filtered_kv_events_do_not_create_false_event_id_gaps():
 
 
 def test_interleaved_attention_dp_ranks_do_not_create_false_event_id_gaps():
-    from dynamo.trtllm import publisher as publisher_mod
-
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.additional_metrics = MagicMock()
     pub._last_engine_event_id_by_rank = {}
@@ -411,8 +400,6 @@ def _build_schema_probe_publisher(fpm_publisher_mock=None):
     Bypasses __init__ (heavy deps) and seeds only the attributes the probe
     method reads or writes: fpm_publisher and _fpm_schema_checked.
     """
-    from dynamo.trtllm import publisher as publisher_mod
-
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.fpm_publisher = (
         fpm_publisher_mock if fpm_publisher_mock is not None else MagicMock()
@@ -527,8 +514,6 @@ def test_schema_probe_field_list_matches_default_ibs_set():
     """Guardrail: the required-fields tuple must stay in sync with the IBS
     default fixture. If someone adds an IBS field to the production reader
     but forgets the probe constant (or vice versa), this test catches it."""
-    from dynamo.trtllm import publisher as publisher_mod
-
     assert set(publisher_mod._FPM_REQUIRED_IBS_FIELDS) == set(_DEFAULT_IBS.keys())
 
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -255,7 +255,7 @@ def _build_publisher_stub(monkeypatch, *, attention_dp_size: int, fpm_enabled: b
     pub.partial_block_hashes = set()
     pub.error_queue = queue.Queue()
     pub._stop_event = threading.Event()
-    pub._last_engine_event_id = None
+    pub._last_engine_event_id_by_rank = {}
 
     fake_fpm_cls = MagicMock()
     monkeypatch.setattr(publisher_mod, "FpmDirectPublisher", fake_fpm_cls)
@@ -358,7 +358,7 @@ def test_kv_event_id_gap_records_missing_event_count():
     pub.additional_metrics = MagicMock()
     pub.processing_initial_created_events = True
     pub.max_window_size = None
-    pub._last_engine_event_id = 10
+    pub._last_engine_event_id_by_rank = {0: 10}
 
     pub._handle_kv_event({"event_id": 14, "data": {"type": "created"}})
 
@@ -370,13 +370,32 @@ def test_filtered_kv_events_do_not_create_false_event_id_gaps():
 
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub.additional_metrics = MagicMock()
-    pub._last_engine_event_id = 10
+    pub._last_engine_event_id_by_rank = {0: 10}
     pub.should_drop_event = MagicMock(side_effect=[True, False])
     pub.processing_initial_created_events = True
     pub.max_window_size = None
 
     pub._handle_kv_event({"event_id": 11, "data": {"type": "stored"}})
     pub._handle_kv_event({"event_id": 12, "data": {"type": "created"}})
+
+    pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
+
+
+def test_interleaved_attention_dp_ranks_do_not_create_false_event_id_gaps():
+    from dynamo.trtllm import publisher as publisher_mod
+
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.additional_metrics = MagicMock()
+    pub._last_engine_event_id_by_rank = {}
+    pub.should_drop_event = MagicMock(return_value=True)
+
+    for event in [
+        {"event_id": 10, "attention_dp_rank": 0},
+        {"event_id": 3, "attention_dp_rank": 1},
+        {"event_id": 11, "attention_dp_rank": 0},
+        {"event_id": 4, "attention_dp_rank": 1},
+    ]:
+        pub._handle_kv_event(event)
 
     pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
 

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -317,6 +317,71 @@ def test_publisher_does_not_init_fpm_publisher_under_attention_dp(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# KV event buffer telemetry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_event_polling_loop_records_drained_batch_size():
+    import threading
+
+    from dynamo.trtllm import publisher as publisher_mod
+
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+    drained_batches = []
+
+    async def fetch_events():
+        for event_id in range(3):
+            yield {"event_id": event_id}
+
+    def handle_event(event):
+        if event["event_id"] == 2:
+            pub._stop_event.set()
+
+    await pub._polling_loop(
+        fetch_events,
+        handle_event,
+        min_sleep=0.001,
+        max_sleep=0.001,
+        backoff_factor=1.0,
+        batch_size_handler_fn=drained_batches.append,
+    )
+
+    assert drained_batches == [3]
+
+
+def test_kv_event_id_gap_records_missing_event_count():
+    from dynamo.trtllm import publisher as publisher_mod
+
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.additional_metrics = MagicMock()
+    pub.processing_initial_created_events = True
+    pub.max_window_size = None
+    pub._last_engine_event_id = 10
+
+    pub._handle_kv_event({"event_id": 14, "data": {"type": "created"}})
+
+    pub.additional_metrics.record_kv_event_id_gap.assert_called_once_with(3)
+
+
+def test_filtered_kv_events_do_not_create_false_event_id_gaps():
+    from dynamo.trtllm import publisher as publisher_mod
+
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub.additional_metrics = MagicMock()
+    pub._last_engine_event_id = 10
+    pub.should_drop_event = MagicMock(side_effect=[True, False])
+    pub.processing_initial_created_events = True
+    pub.max_window_size = None
+
+    pub._handle_kv_event({"event_id": 11, "data": {"type": "stored"}})
+    pub._handle_kv_event({"event_id": 12, "data": {"type": "created"}})
+
+    pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # First-stat schema probe
 # ---------------------------------------------------------------------------
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -68,7 +68,7 @@ from dynamo.trtllm.request_handlers.handlers import (
 from dynamo.trtllm.utils.trtllm_utils import deep_update
 
 # Default buffer size for kv cache events.
-DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
 
 
 def build_kv_connector_config(config: Config):
@@ -725,6 +725,10 @@ async def init_llm_worker(
                 config.kv_block_size,
                 metrics_labels,
                 component_gauges=component_gauges,
+                additional_metrics=additional_metrics,
+                event_buffer_max_size=engine_args["kv_cache_config"].get(
+                    "event_buffer_max_size", 0
+                ),
                 zmq_endpoint=trtllm_zmq_bind_endpoint,
                 enable_local_indexer=config.enable_local_indexer,
                 metrics_collector=metrics_collector,

--- a/components/src/dynamo/vllm/tests/test_vllm_logging.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_logging.py
@@ -31,6 +31,7 @@ from dynamo.runtime.logging import (
     VllmColorFormatter,
     configure_dynamo_logging,
     configure_vllm_logging,
+    python_log_level_mapping,
 )
 
 pytestmark = [
@@ -123,6 +124,39 @@ def test_dyn_log_does_not_affect_vllm_level(monkeypatch):
     assert vllm_logger.level == logging.INFO
     assert isinstance(vllm_logger.handlers[0], logging.StreamHandler)
     assert isinstance(vllm_logger.handlers[0].formatter, VllmColorFormatter)
+
+
+def test_default_dyn_log_filters_python_debug_before_bridge():
+    """Default DYN_LOG=info must avoid formatting Python DEBUG bridge records."""
+    configure_dynamo_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.INFO
+    assert root_logger.handlers[0].level == logging.INFO
+
+
+def test_scoped_dyn_log_debug_keeps_python_debug_available(monkeypatch):
+    """Scoped Rust debug filters still need Python DEBUG records forwarded."""
+    monkeypatch.setenv("DYN_LOG", "info,dynamo_trtllm=debug")
+
+    configure_dynamo_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.DEBUG
+    assert root_logger.handlers[0].level == logging.DEBUG
+
+
+@pytest.mark.parametrize(
+    ("filters", "expected"),
+    [
+        ("info", logging.INFO),
+        ("warn", logging.WARNING),
+        ("info,dynamo_trtllm=debug", logging.DEBUG),
+        ("warn,dynamo_trtllm=trace", logging.DEBUG),
+    ],
+)
+def test_python_log_level_mapping(filters, expected):
+    assert python_log_level_mapping(filters) == expected
 
 
 def test_no_config_file_written():

--- a/components/src/dynamo/vllm/tests/test_vllm_logging.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_logging.py
@@ -47,6 +47,7 @@ def _clean_env(monkeypatch):
     """Remove logging-related env vars before each test."""
     for var in [
         "DYN_LOG",
+        "DYN_LOGGING_CONFIG_PATH",
         "VLLM_LOGGING_LEVEL",
         "VLLM_CONFIGURE_LOGGING",
         "VLLM_LOGGING_CONFIG_PATH",
@@ -157,6 +158,16 @@ def test_scoped_dyn_log_debug_keeps_python_debug_available(monkeypatch):
 )
 def test_python_log_level_mapping(filters, expected):
     assert python_log_level_mapping(filters) == expected
+
+
+def test_toml_logging_config_keeps_python_debug_available(monkeypatch):
+    monkeypatch.setenv("DYN_LOGGING_CONFIG_PATH", "/tmp/dynamo-logging.toml")
+
+    configure_dynamo_logging()
+
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.DEBUG
+    assert root_logger.handlers[0].level == logging.DEBUG
 
 
 def test_no_config_file_written():

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -423,6 +423,12 @@ class trtllm_additional:
     KV_TRANSFER_BYTES = "trtllm_kv_transfer_bytes"
     # KV cache transfer speed per request in GB/s
     KV_TRANSFER_SPEED_GB_S = "trtllm_kv_transfer_speed_gb_s"
+    # Configured maximum number of TRT-LLM KV events buffered before older events are dropped
+    KV_EVENT_BUFFER_CAPACITY = "trtllm_kv_event_buffer_capacity"
+    # Number of TRT-LLM KV events returned to Dynamo in one polling drain
+    KV_EVENT_DRAIN_BATCH_SIZE = "trtllm_kv_event_drain_batch_size"
+    # Total number of missing TRT-LLM KV event IDs detected by Dynamo
+    KV_EVENT_ID_GAP_EVENTS_TOTAL = "trtllm_kv_event_id_gap_events_total"
 
 
 class work_handler:

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -101,13 +101,18 @@ class VllmColorFormatter(logging.Formatter):
 
 
 # Configure the Python logger to use the NimLogHandler
-def configure_logger(service_name: str | None, worker_id: int | None) -> None:
+def configure_logger(
+    service_name: str | None, worker_id: int | None, level: int = logging.INFO
+) -> None:
     """
     Called once to configure the Python logger to use the LogHandler
     """
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(level)
     handler = LogHandler()
+    # Child loggers can propagate records below the root logger's level. Keep
+    # the bridge handler aligned so those records are dropped before formatting.
+    handler.setLevel(level)
 
     # Simple formatter without date and level info since it's already provided by Rust
     formatter = logging.Formatter("%(message)s")
@@ -141,12 +146,14 @@ def configure_dynamo_logging(
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
 
-    # Configure the logger with Dynamo's handler
-    configure_logger(service_name, worker_id)
-
     # map the DYN_LOG variable to a logging level
     dyn_var = os.environ.get("DYN_LOG", "info")
     dyn_level = log_level_mapping(dyn_var)
+
+    # Configure the logger with Dynamo's handler. Rust applies the final
+    # target-specific filtering, but Python should cheaply discard levels that
+    # no DYN_LOG directive can enable before formatting bridge records.
+    configure_logger(service_name, worker_id, python_log_level_mapping(dyn_var))
 
     # configure inference engine loggers
     configure_vllm_logging(dyn_level)
@@ -182,6 +189,20 @@ def log_level_mapping(level: str) -> int:
         return logging.INFO
     else:
         return logging.INFO
+
+
+def python_log_level_mapping(filters: str) -> int:
+    """Return the lowest Python level enabled by a Rust-style DYN_LOG filter."""
+    levels = []
+    for directive in filters.split(","):
+        level = directive.rsplit("=", 1)[-1].strip().lower()
+        if level == "trace":
+            # Python has no TRACE level. Keep DEBUG records available for Rust
+            # when any target explicitly enables trace output.
+            levels.append(logging.DEBUG)
+        else:
+            levels.append(log_level_mapping(level))
+    return min(levels, default=logging.INFO)
 
 
 def configure_sglang_logging(dyn_level: int) -> None:

--- a/lib/bindings/python/src/dynamo/runtime/logging.py
+++ b/lib/bindings/python/src/dynamo/runtime/logging.py
@@ -22,6 +22,8 @@ from datetime import datetime, timezone
 
 from dynamo._core import log_message
 
+_DEFAULT_DYNAMO_LOGGING_CONFIG_PATH = "/opt/dynamo/etc/logging.toml"
+
 
 class LogHandler(logging.Handler):
     """
@@ -193,6 +195,13 @@ def log_level_mapping(level: str) -> int:
 
 def python_log_level_mapping(filters: str) -> int:
     """Return the lowest Python level enabled by a Rust-style DYN_LOG filter."""
+    if os.getenv("DYN_LOGGING_CONFIG_PATH") or os.path.isfile(
+        _DEFAULT_DYNAMO_LOGGING_CONFIG_PATH
+    ):
+        # Rust merges TOML log filters after DYN_LOG. Preserve DEBUG records so
+        # Python does not discard messages enabled only by file configuration.
+        return logging.DEBUG
+
     levels = []
     for directive in filters.split(","):
         level = directive.rsplit("=", 1)[-1].strip().lower()

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -750,6 +750,15 @@ pub mod trtllm_additional {
 
     /// KV cache transfer speed per request in GB/s
     pub const KV_TRANSFER_SPEED_GB_S: &str = "trtllm_kv_transfer_speed_gb_s";
+
+    /// Configured maximum number of TRT-LLM KV events buffered before older events are dropped
+    pub const KV_EVENT_BUFFER_CAPACITY: &str = "trtllm_kv_event_buffer_capacity";
+
+    /// Number of TRT-LLM KV events returned to Dynamo in one polling drain
+    pub const KV_EVENT_DRAIN_BATCH_SIZE: &str = "trtllm_kv_event_drain_batch_size";
+
+    /// Total number of missing TRT-LLM KV event IDs detected by Dynamo
+    pub const KV_EVENT_ID_GAP_EVENTS_TOTAL: &str = "trtllm_kv_event_id_gap_events_total";
 }
 
 // KV cache statistics metrics


### PR DESCRIPTION
> Stacked on #10298, which owns the compact TRT-LLM KV event debug-log summaries.

## Summary

- raise TRT-LLM `event_buffer_max_size` defaults from `1024` to `100_000` in both the legacy and unified workers while preserving explicit overrides
- expose TRT-LLM KV event buffer telemetry in Prometheus
- count missing TRT-LLM event IDs before legacy attention-layer filtering so expected filtering does not inflate the gap counter
- filter Python DEBUG bridge records before formatting when no `DYN_LOG` directive enables DEBUG, while preserving scoped Rust-side debug filters

## Metrics

Adds:

- `trtllm_kv_event_buffer_capacity`
- `trtllm_kv_event_drain_batch_size`
- `trtllm_kv_event_id_gap_events_total`

TRT-LLM currently exposes an atomic drain of its ready KV event batch, not a live internal queue-depth accessor. The drain metrics are named explicitly so they are useful as backlog signals without being mistaken for an instantaneous internal queue size.

## Motivation

In the TRT-LLM router hit-rate investigation, increasing the event buffer removed explicit overflow warnings but did not eliminate the full mismatch. This PR makes the larger buffer the default and adds telemetry for follow-up experiments.

## Validation

Passed locally:

- `python3 -m compileall -q components/src/dynamo/trtllm lib/bindings/python/src/dynamo/runtime/logging.py lib/bindings/python/src/dynamo/prometheus_names.py`
- `cargo fmt --all -- --check`
- `cargo test -p dynamo-codegen --bin gen-python-prometheus-names`
- `PYTHONPATH=components/src:lib/bindings/python/src python3 -m pytest components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py -q` (`11 passed, 2 skipped` for CUDA-only HandlerBase coverage)
- applicable pre-commit hooks (`pytest-marker-report` skipped because this host uses Python 3.10 while current `main` imports `typing.Required` from Python 3.11)
- direct Python logging bridge probe proving default `DYN_LOG=info` drops propagated DEBUG before formatting and scoped debug filters remain enabled
- direct Python publisher probe proving drain-batch accounting, missing-ID accounting, and filtered-event continuity

Notes:

- full logging pytest collection is unavailable on this workstation because `dynamo._core` is not built locally
- regenerating all Python Prometheus names reveals unrelated pre-existing generated-file drift on `main`; this PR keeps only the three new TRT-LLM constants in the generated Python file



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for KV event buffer: configured capacity, drained batch sizes, and missing/event-ID-gap counts.
  * Exposed configurable Python logging level mapping for finer-grained log control.

* **Improvements**
  * Increased default KV event buffer capacity (1,024 → 100,000) and improved event-gap tracking across ranks.

* **Tests**
  * Added unit tests covering KV event telemetry and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->