### PR TITLE
feat(llm): add Gemma 4 multimodal routing support

### DIFF
--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -72,19 +72,29 @@ static REGISTRY: LazyLock<ImageProcessorRegistry> =
     LazyLock::new(ImageProcessorRegistry::with_defaults);
 static MODEL_REGISTRY: LazyLock<ModelRegistry> = LazyLock::new(ModelRegistry::new);
 
-/// Maps `(width, height) → num_image_tokens` for a single model using the
-/// model's HF `preprocessor_config.json`.
+enum CounterKind {
+    Lightseek {
+        processor: &'static dyn ImagePreProcessor,
+        config: PreProcessorConfig,
+    },
+    Gemma4 {
+        patch_size: u32,
+        pooling_kernel_size: u32,
+        max_soft_tokens: usize,
+    },
+}
+
+/// Maps `(width, height) → num_image_tokens` for a single model.
 pub struct LightseekMmCounter {
-    processor: &'static dyn ImagePreProcessor,
-    config: PreProcessorConfig,
+    kind: CounterKind,
     model_id: String,
 }
 
 impl LightseekMmCounter {
-    /// Returns `Err` when `preprocessor_config.json` is missing or unparseable
-    /// or no registered processor matches `model_id` / `model_type`. Callers
-    /// should treat the error as "MM-aware routing disabled for this model"
-    /// rather than failing the request.
+    /// Returns `Err` when the model cannot be mapped to a supported
+    /// routing-side image-token counter. Callers should treat the error as
+    /// "MM-aware routing disabled for this model" rather than failing the
+    /// request.
     ///
     /// Uses sync filesystem I/O. This is intentional: `try_new` is called
     /// once per model during preprocessor construction (a startup-time path
@@ -93,6 +103,25 @@ impl LightseekMmCounter {
     /// Switching to async would cascade through `OpenAIPreprocessor::new`
     /// and every caller of it.
     pub fn try_new(model_id: &str, model_type: Option<&str>, model_dir: &Path) -> Result<Self> {
+        match Self::try_new_lightseek(model_id, model_type, model_dir) {
+            Ok(counter) => Ok(counter),
+            Err(lightseek_err) => {
+                Self::try_new_gemma4(model_id, model_type, model_dir).map_err(|gemma4_err| {
+                    anyhow!(
+                        "{}; Gemma4 fallback unavailable ({})",
+                        lightseek_err,
+                        gemma4_err
+                    )
+                })
+            }
+        }
+    }
+
+    fn try_new_lightseek(
+        model_id: &str,
+        model_type: Option<&str>,
+        model_dir: &Path,
+    ) -> Result<Self> {
         let cfg_path = model_dir.join("preprocessor_config.json");
         let json = std::fs::read_to_string(&cfg_path).with_context(|| {
             format!(
@@ -116,20 +145,148 @@ impl LightseekMmCounter {
         })?;
 
         Ok(Self {
-            processor,
-            config,
+            kind: CounterKind::Lightseek { processor, config },
+            model_id: model_id.to_string(),
+        })
+    }
+
+    fn try_new_gemma4(model_id: &str, model_type: Option<&str>, model_dir: &Path) -> Result<Self> {
+        let config = read_json(model_dir, "config.json")
+            .ok_or_else(|| anyhow!("Gemma4 fallback failed to read config.json"))?;
+        if !is_gemma4_config(model_type, &config) {
+            return Err(anyhow!(
+                "model_id={:?} model_type={:?} is not Gemma4",
+                model_id,
+                model_type
+            ));
+        }
+
+        let vision_config = config
+            .get("vision_config")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| anyhow!("Gemma4 config has no vision_config object"))?;
+        let patch_size = vision_config
+            .get("patch_size")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| u32::try_from(v).ok())
+            .ok_or_else(|| anyhow!("Gemma4 vision_config.patch_size missing"))?;
+        let pooling_kernel_size = vision_config
+            .get("pooling_kernel_size")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| u32::try_from(v).ok())
+            .ok_or_else(|| anyhow!("Gemma4 vision_config.pooling_kernel_size missing"))?;
+        let max_soft_tokens = vision_config
+            .get("num_soft_tokens")
+            .or_else(|| vision_config.get("default_output_length"))
+            .and_then(|v| v.as_u64())
+            .and_then(|v| usize::try_from(v).ok())
+            .ok_or_else(|| {
+                anyhow!("Gemma4 vision_config.num_soft_tokens/default_output_length missing")
+            })?;
+
+        if patch_size == 0 || pooling_kernel_size == 0 || max_soft_tokens == 0 {
+            return Err(anyhow!(
+                "Gemma4 token-count parameters must be non-zero: \
+                 patch_size={patch_size}, pooling_kernel_size={pooling_kernel_size}, \
+                 max_soft_tokens={max_soft_tokens}"
+            ));
+        }
+
+        Ok(Self {
+            kind: CounterKind::Gemma4 {
+                patch_size,
+                pooling_kernel_size,
+                max_soft_tokens,
+            },
             model_id: model_id.to_string(),
         })
     }
 
     pub fn count_tokens(&self, width: u32, height: u32) -> usize {
-        self.processor
-            .calculate_num_tokens(width, height, &self.config)
+        match &self.kind {
+            CounterKind::Lightseek { processor, config } => {
+                processor.calculate_num_tokens(width, height, config)
+            }
+            CounterKind::Gemma4 {
+                patch_size,
+                pooling_kernel_size,
+                max_soft_tokens,
+            } => gemma4_image_token_count(
+                width,
+                height,
+                *patch_size,
+                *pooling_kernel_size,
+                *max_soft_tokens,
+            ),
+        }
     }
 
     pub fn model_id(&self) -> &str {
         &self.model_id
     }
+}
+
+fn is_gemma4_config(model_type_hint: Option<&str>, config: &serde_json::Value) -> bool {
+    let hint_matches = model_type_hint
+        .map(|t| t.starts_with("gemma4"))
+        .unwrap_or(false);
+    let model_type_matches = config
+        .get("model_type")
+        .and_then(|v| v.as_str())
+        .map(|t| t.starts_with("gemma4"))
+        .unwrap_or(false);
+    let architecture_matches = config
+        .get("architectures")
+        .and_then(|v| v.as_array())
+        .map(|arches| {
+            arches.iter().any(|a| {
+                a.as_str()
+                    .map(|s| s.contains("Gemma4") || s.contains("Gemma4Unified"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+
+    hint_matches || model_type_matches || architecture_matches
+}
+
+fn gemma4_image_token_count(
+    width: u32,
+    height: u32,
+    patch_size: u32,
+    pooling_kernel_size: u32,
+    max_soft_tokens: usize,
+) -> usize {
+    if width == 0
+        || height == 0
+        || patch_size == 0
+        || pooling_kernel_size == 0
+        || max_soft_tokens == 0
+    {
+        return 0;
+    }
+
+    let patch_size_f = f64::from(patch_size);
+    let pooling = u64::from(pooling_kernel_size);
+    let unit = u64::from(patch_size) * pooling;
+    let max_patches = max_soft_tokens as f64 * (pooling * pooling) as f64;
+    let num_patches_orig = (f64::from(height) / patch_size_f) * (f64::from(width) / patch_size_f);
+    if num_patches_orig <= 0.0 {
+        return 0;
+    }
+
+    let scale = (max_patches / num_patches_orig).sqrt();
+    let target_h = std::cmp::max(
+        unit,
+        ((f64::from(height) * scale / unit as f64).floor() as u64) * unit,
+    );
+    let target_w = std::cmp::max(
+        unit,
+        ((f64::from(width) * scale / unit as f64).floor() as u64) * unit,
+    );
+    let num_patches = (target_h / u64::from(patch_size)) * (target_w / u64::from(patch_size));
+    let num_soft = num_patches / (pooling * pooling);
+    std::cmp::min(num_soft as usize, max_soft_tokens)
 }
 
 /// Resolve the image-placeholder token id by delegating to lightseek's
@@ -339,6 +496,62 @@ mod tests {
     //! smg matcher change shows up here instead of as a silent runtime
     //! fallback to text-prefix-only routing.
     use super::*;
+
+    fn gemma4_config(max_soft_tokens: usize) -> String {
+        serde_json::json!({
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "model_type": "gemma4_unified",
+            "image_token_id": 258880,
+            "vision_config": {
+                "patch_size": 16,
+                "pooling_kernel_size": 3,
+                "num_soft_tokens": max_soft_tokens
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn gemma4_fallback_counter_uses_unified_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), gemma4_config(280)).unwrap();
+
+        let counter = LightseekMmCounter::try_new(
+            "google/gemma-4-12B-it",
+            Some("gemma4_unified"),
+            dir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(counter.count_tokens(64, 64), 256);
+        assert_eq!(counter.count_tokens(1000, 1000), 256);
+    }
+
+    #[test]
+    fn gemma4_fallback_counter_respects_max_soft_tokens_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), gemma4_config(70)).unwrap();
+
+        let counter = LightseekMmCounter::try_new(
+            "google/gemma-4-12B-it",
+            Some("gemma4_unified"),
+            dir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(counter.count_tokens(900, 3), 70);
+        assert_eq!(counter.count_tokens(4000, 2), 70);
+    }
+
+    #[test]
+    fn gemma4_routing_tokens_read_config_image_token_id() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), gemma4_config(280)).unwrap();
+
+        let tokens = resolve_routing_tokens("google/gemma-4-12B-it", dir.path());
+
+        assert_eq!(tokens.chat_placeholder_token_id, Some(258880));
+    }
 
     #[test]
     fn image_processor_registry_resolves_qwen3vl_via_path_substring() {

--- a/recipes/gemma-4-12b/Dockerfile
+++ b/recipes/gemma-4-12b/Dockerfile
@@ -20,14 +20,15 @@
 #      (Same approach as recipes/nemotron-3-nano-omni/Dockerfile.)
 #
 # Build (from the repo root):
-#   docker build -t <registry>/gemma4-12b-vllm:latest \
+#   docker build --platform=linux/arm64 \
+#                -t <registry>/gemma4-12b-vllm:latest \
 #                -f recipes/gemma-4-12b/Dockerfile \
-#                --build-arg VLLM_PR_REF=<PR#44429 head SHA from Phase 1> \
-#                recipes/gemma-4-12b
+#                .
 #
 # Override defaults with --build-arg, e.g.:
 #   --build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0
-#   --build-arg DYNAMO_VERSION=1.2.0.dev20260427
+#   --build-arg DYNAMO_VERSION=1.2.0.post1
+#   --build-arg VLLM_PR_SHA=25f921b008768712e99611cc5d942178637359c3
 #   --build-arg TRANSFORMERS_REF=d3f05911abb216047a00aba79c8543c73633db05
 #
 # ALTERNATIVE (offline / reproducible): instead of cloning the PR here, build a
@@ -108,10 +109,16 @@ RUN pip install --no-cache-dir \
       msgpack msgspec prometheus-client pyzmq
 
 # 3c. Multimodal runtime extras (image today; librosa/soundfile/av cover the
-#     audio/video paths for the deferred follow-up).
+#     audio/video paths for the deferred follow-up). numpy/pillow are also used
+#     by the bundled JSONL benchmark generator.
 RUN pip install --no-cache-dir \
       blake3 librosa soundfile uvloop \
-      av ftfy nvtx sentencepiece
+      av ftfy nvtx sentencepiece \
+      "numpy<3" pillow
+
+# Benchmark dataset generator used by data-gen/generate-datasets-job.yaml.
+# Keep the build context at the repo root and copy only this small directory.
+COPY benchmarks/multimodal/jsonl /workspace/benchmarks/multimodal/jsonl
 
 # Sanity-check at build time that the architecture and processor resolve.
 RUN python3 -c "import transformers.models.gemma4_unified; \

--- a/recipes/gemma-4-12b/Dockerfile
+++ b/recipes/gemma-4-12b/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1.10.0
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Custom runtime image for google/gemma-4-12B-it on Dynamo.
+#
+# google/gemma-4-12B-it is a unified, encoder-free decoder
+# (architectures: ["Gemma4UnifiedForConditionalGeneration"], model_type:
+# gemma4_unified). Released vLLM does NOT yet support this architecture; it is
+# added by the (currently unmerged) vLLM PR #44429 — a pure-Python change
+# (one model file + a registry line), no CUDA kernels. We therefore layer:
+#
+#   1. vLLM built from PR #44429 (pinned SHA), reusing the precompiled kernels
+#      from the upstream base image's vLLM build (VLLM_USE_PRECOMPILED=1), so
+#      only the Python sources are (re)installed — no kernel compile.
+#   2. transformers from a `main` commit that ships transformers.models.gemma4_unified.
+#   3. The ai-dynamo Python package (dynamo.frontend, dynamo.vllm, ...) from
+#      https://pypi.nvidia.com/ai-dynamo/ with --no-deps, plus its Rust _core
+#      extension wheel (ai-dynamo-runtime) and the multimodal runtime extras.
+#      (Same approach as recipes/nemotron-3-nano-omni/Dockerfile.)
+#
+# Build (from the repo root):
+#   docker build -t <registry>/gemma4-12b-vllm:latest \
+#                -f recipes/gemma-4-12b/Dockerfile \
+#                --build-arg VLLM_PR_REF=<PR#44429 head SHA from Phase 1> \
+#                recipes/gemma-4-12b
+#
+# Override defaults with --build-arg, e.g.:
+#   --build-arg BASE_IMAGE=vllm/vllm-openai:v0.22.0
+#   --build-arg DYNAMO_VERSION=1.2.0.dev20260427
+#   --build-arg TRANSFORMERS_REF=d3f05911abb216047a00aba79c8543c73633db05
+#
+# ALTERNATIVE (offline / reproducible): instead of cloning the PR here, build a
+# wheel in ~/vllm (`VLLM_USE_PRECOMPILED=1 uv build --wheel`) and COPY it in:
+#   COPY dist/vllm-*.whl /tmp/   &&   pip install --no-deps /tmp/vllm-*.whl
+# See README.md "Build the Container".
+
+# Align BASE_IMAGE's vLLM minor with PR #44429's base (it targets vLLM main,
+# post-0.22.0). The base supplies CUDA/torch/system libs; VLLM_USE_PRECOMPILED
+# pulls the matching precompiled vLLM wheel for the pinned commit.
+ARG BASE_IMAGE="vllm/vllm-openai:v0.22.0"
+# MUST be >= the release carrying Dynamo's gemma4 tool-call/reasoning parsers
+# (added 2026-04-30, PR #8852). 1.2.0.post1 is the matching 0.22-era release;
+# older wheels (e.g. 1.2.0.dev20260427) reject `--dyn-tool-call-parser gemma4`.
+# Avoid 1.3.0.dev* here unless BASE_IMAGE's vLLM is bumped to match.
+ARG DYNAMO_VERSION="1.2.0.post1"
+# PR #44429 is fetched via its head ref, then checked out at a pinned commit for
+# reproducibility. VLLM_PR_SHA must be an ancestor of (or equal to) the fetched
+# ref tip; override both if the PR is force-pushed past this commit.
+ARG VLLM_PR_REF="refs/pull/44429/head"
+ARG VLLM_PR_SHA="25f921b008768712e99611cc5d942178637359c3"
+# transformers `main` commit that ships transformers.models.gemma4_unified.
+ARG TRANSFORMERS_REF="d3f05911abb216047a00aba79c8543c73633db05"
+
+FROM ${BASE_IMAGE}
+USER root
+
+ARG DYNAMO_VERSION
+ARG VLLM_PR_REF
+ARG VLLM_PR_SHA
+ARG TRANSFORMERS_REF
+
+# Build tooling needed to clone + install vLLM from source. git for the clone;
+# the precompiled path skips the CUDA kernel compile.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git \
+        jq \
+        sox \
+        libsox-fmt-all \
+    && rm -rf /var/lib/apt/lists/*
+
+# 1. vLLM from PR #44429 — pure-Python arch addition. VLLM_USE_PRECOMPILED=1
+#    reuses precompiled kernels (downloads the matching wheel for the commit),
+#    so this installs Python sources only — no long ARM kernel build.
+#    If no precompiled wheel exists for this commit/arch, drop the env var to
+#    fall back to a full source build (slow but correct on the GH200).
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    set -eux; \
+    git clone https://github.com/vllm-project/vllm.git /opt/vllm-src; \
+    cd /opt/vllm-src; \
+    git fetch origin "${VLLM_PR_REF}:gemma4-unified-pr44429"; \
+    git checkout "${VLLM_PR_SHA}"; \
+    VLLM_USE_PRECOMPILED=1 pip install .; \
+    rm -rf /opt/vllm-src
+
+# 2. transformers carrying models/gemma4_unified (config/processor/modeling).
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip install --no-cache-dir \
+      "transformers @ git+https://github.com/huggingface/transformers@${TRANSFORMERS_REF}"
+
+# 3a. ai-dynamo Python package with --no-deps so the PR vLLM / torch / cuda
+#     stack installed above is preserved (ai-dynamo[vllm] would otherwise try to
+#     re-pin vllm), and so we skip nixl/ray that an aggregated single-GPU recipe
+#     does not need.
+RUN pip install --no-cache-dir --no-deps \
+      --extra-index-url https://pypi.nvidia.com \
+      ai-dynamo==${DYNAMO_VERSION}
+
+# 3b. ai-dynamo's core deps + the Rust _core extension wheel (ai-dynamo-runtime)
+#     the Python package imports natively. kubernetes/pydantic pinned to
+#     ai-dynamo's declared compatibility ranges.
+RUN pip install --no-cache-dir \
+      --extra-index-url https://pypi.nvidia.com \
+      ai-dynamo-runtime==${DYNAMO_VERSION} \
+      "kubernetes<33.0.0,>=32.0.1" \
+      "pydantic<2.13" "pydantic-settings<2.13.0" \
+      msgpack msgspec prometheus-client pyzmq
+
+# 3c. Multimodal runtime extras (image today; librosa/soundfile/av cover the
+#     audio/video paths for the deferred follow-up).
+RUN pip install --no-cache-dir \
+      blake3 librosa soundfile uvloop \
+      av ftfy nvtx sentencepiece
+
+# Sanity-check at build time that the architecture and processor resolve.
+RUN python3 -c "import transformers.models.gemma4_unified; \
+from vllm.model_executor.models.registry import ModelRegistry as R; \
+assert 'Gemma4UnifiedForConditionalGeneration' in R.get_supported_archs(), \
+'Gemma4UnifiedForConditionalGeneration missing from vLLM registry'; \
+print('OK: gemma4_unified arch + transformers module present')"
+
+# The base image ships flashinfer-jit-cache 0.6.11.post2 while PR #44429's vLLM
+# pulls flashinfer 0.6.12; vLLM's exact-match version check then aborts model
+# inspection ("Gemma4UnifiedForConditionalGeneration failed to be inspected").
+# The delta is patch-level and generation is verified correct, so bypass the
+# check. (If you prefer a hard pin, align flashinfer-jit-cache to the flashinfer
+# version instead and drop this.)
+ENV FLASHINFER_DISABLE_VERSION_CHECK=1
+
+# vllm/vllm-openai's default ENTRYPOINT runs `vllm serve`; reset it so the
+# image behaves as a plain dynamo runtime image.
+ENTRYPOINT ["/bin/bash"]

--- a/recipes/gemma-4-12b/README.md
+++ b/recipes/gemma-4-12b/README.md
@@ -1,0 +1,239 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Gemma 4 12B (text + image)
+
+Serves [google/gemma-4-12B-it](https://huggingface.co/google/gemma-4-12B-it) using
+vLLM with an aggregated Dynamo deployment.
+
+`google/gemma-4-12B-it` is a unified, **encoder-free** decoder
+(`architectures: ["Gemma4UnifiedForConditionalGeneration"]`, `model_type:
+gemma4_unified`): text, image, and audio inputs project directly into a single
+decoder-only transformer with no separate vision/audio encoder.
+
+Released vLLM does not yet ship this architecture — it is added by vLLM
+**PR [#44429](https://github.com/vllm-project/vllm/pull/44429)** (pure-Python: one
+model file + a registry line, no CUDA kernels). This recipe builds a custom
+container that layers that PR's vLLM, a `transformers` build carrying
+`models/gemma4_unified`, and the `ai-dynamo` wheel
+(from <https://pypi.nvidia.com/ai-dynamo/>) onto an upstream vLLM image — no Rust
+toolchain.
+
+> **Scope:** text + image is verified here. **Audio input is deferred** — native
+> audio rides the normal token path in vLLM, but accepting `audio_url` parts
+> through Dynamo's frontend/preprocessor needs additional work (tracked as a
+> follow-up). See [Notes](#notes).
+
+## Results
+
+Measured on a single **GH200 (96 GB, aarch64)**, aggregated, TP=1,
+`--max-model-len 32768`, `--gpu-memory-utilization 0.85`. Benchmark: `aiperf`
+0.6.0, **256 requests, concurrency 32**, 1 image/request (512×512, 8-image pool),
+~11 input text tokens, 150 output tokens (`min=max=150, ignore_eos`). 256/256
+requests succeeded.
+
+| Metric | avg | p50 | p99 |
+|--------|----:|----:|----:|
+| Output token throughput (tok/s) | **1,616** | — | — |
+| Request throughput (req/s) | **11.06** | — | — |
+| Time to First Token (ms) | 385 | 379 | 573 |
+| Inter-Token Latency (ms) | 17.2 | 16.8 | 21.9 |
+| Request Latency (ms) | 2,874 | 2,866 | 3,102 |
+| Per-user output (tok/s/user) | 58.4 | 59.6 | 62.5 |
+
+> Local single-container verification run (docker, file-KV discovery), using
+> inlined base64 images to avoid network-fetch flakiness. The canonical k8s
+> benchmark (`vllm/agg/perf.yaml` + `data-gen/`) uses 1000 requests, concurrency
+> 64, and the COCO http image pool — expect higher absolute throughput at that
+> concurrency. Numbers here establish a correctness-backed baseline, not a tuned
+> peak.
+
+## Topology
+
+| Role | Replicas | GPUs/replica | Notes |
+|------|----------|--------------|-------|
+| Frontend | 1 | 0 | Dynamo frontend with prefix-hash KV routing |
+| vLLM worker | 1 | 1 | Text + image inputs (encoder-free) |
+
+## Prerequisites
+
+- A Kubernetes cluster with the [Dynamo Operator](../../docs/kubernetes/README.md) installed
+- One NVIDIA GPU per worker replica
+- Shared PVC storage for the Hugging Face model cache
+- Hugging Face access to the gated `google/gemma-4-12B-it`
+
+## Step 1: Build the Container
+
+```bash
+docker build \
+  --platform=linux/arm64 \
+  -t <your-registry>/gemma4-12b-vllm:latest \
+  -f recipes/gemma-4-12b/Dockerfile \
+  recipes/gemma-4-12b
+docker push <your-registry>/gemma4-12b-vllm:latest
+```
+
+> **Pin `--platform` to your target arch.** On an aarch64 host (e.g. GH200) where
+> QEMU binfmt is registered, Docker may otherwise resolve the base image to
+> `linux/amd64` and build the whole image under emulation (including pulling the
+> *amd64* precompiled vLLM wheel), producing an image whose binaries can't run
+> natively. `--platform=linux/arm64` forces the arm64 base + the arm64 wheel.
+> The PR commit is pinned in the Dockerfile (`VLLM_PR_SHA`); override with
+> `--build-arg VLLM_PR_SHA=<sha>` if needed.
+
+Useful build args:
+
+- `VLLM_PR_REF=<sha>` — pin PR #44429 to a commit (default: live `refs/pull/44429/head`).
+- `TRANSFORMERS_REF=<sha>` — pin the `transformers` `main` commit that ships `models/gemma4_unified`.
+- `BASE_IMAGE=<image>` — upstream vLLM base (default `vllm/vllm-openai:v0.22.0`); align its vLLM minor with PR #44429's base.
+- `DYNAMO_VERSION=<version>` — pin an `ai-dynamo` release/nightly from <https://pypi.nvidia.com/ai-dynamo/>.
+
+If no aarch64 precompiled vLLM wheel exists for the pinned commit, edit the
+Dockerfile to drop `VLLM_USE_PRECOMPILED=1` (full source build — slow but
+correct on a GH200), or build a wheel in `~/vllm` and `COPY` it in (see the
+Dockerfile header).
+
+## Step 2: Download the Model
+
+```bash
+export NAMESPACE=<your-namespace>
+kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
+
+# First edit storageClassName in model-cache.yaml for your cluster.
+kubectl apply -f recipes/gemma-4-12b/model-cache/model-cache.yaml -n ${NAMESPACE}
+
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN=<your-hf-token> -n ${NAMESPACE}
+
+kubectl apply -f recipes/gemma-4-12b/model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=complete job/model-download -n ${NAMESPACE} --timeout=3600s
+```
+
+## Step 3: Deploy
+
+Edit `vllm/agg/deploy.yaml` and replace `<your-registry>/gemma4-12b-vllm:latest`
+with your built image, then:
+
+```bash
+kubectl apply -f recipes/gemma-4-12b/vllm/agg/deploy.yaml -n ${NAMESPACE}
+kubectl get pods -n ${NAMESPACE} -l nvidia.com/dynamo-graph-deployment-name=gemma4-12b-agg -w
+```
+
+## Step 4: Test
+
+```bash
+kubectl port-forward svc/gemma4-12b-agg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+Text:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-4-12B-it",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 128
+  }'
+```
+
+Image:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-4-12B-it",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "image_url", "image_url": {"url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/inpaint.png"}},
+        {"type": "text", "text": "Describe what is in this image."}
+      ]
+    }],
+    "max_tokens": 256
+  }'
+```
+
+## Local (no Kubernetes) bring-up
+
+The same image runs directly under Docker — useful on a single GPU box:
+
+```bash
+IMG=<your-registry>/gemma4-12b-vllm:latest
+docker run --gpus all --rm -it -p 8000:8000 -e HF_TOKEN=$HF_TOKEN "$IMG" bash -lc '
+  python3 -m dynamo.frontend --http-port 8000 &
+  exec python3 -m dynamo.vllm \
+    --model google/gemma-4-12B-it --enable-multimodal --tensor-parallel-size 1 \
+    --dyn-tool-call-parser gemma4 --dyn-reasoning-parser gemma4'
+```
+
+Then use the same `curl` calls against `http://localhost:8000`.
+
+## Benchmark
+
+```bash
+# 1. Generate the text+image dataset (writes to the perf-cache PVC).
+kubectl apply -f recipes/gemma-4-12b/data-gen/generate-datasets-job.yaml -n ${NAMESPACE}
+
+# 2. Deploy + run the benchmark.
+NAMESPACE=${NAMESPACE} recipes/gemma-4-12b/vllm/agg/run-benchmark.sh
+kubectl logs -f gemma4-12b-agg-benchmark -n ${NAMESPACE}
+```
+
+To benchmark locally instead, generate the dataset with
+`benchmarks/multimodal/jsonl/main.py` and point `aiperf profile --url
+http://localhost:8000` at the Docker deployment above (see `perf.yaml` for the
+exact flags).
+
+## Key Configuration Notes
+
+- `--enable-multimodal` enables image input.
+- `--dyn-tool-call-parser gemma4` / `--dyn-reasoning-parser gemma4` enable Gemma 4
+  tool-call and reasoning parsing (already shipped in Dynamo, architecture-agnostic).
+  For tool-calling prompts, also pass `--custom-jinja-template
+  examples/chat_templates/gemma4_tool.jinja` (mount it into the image, since this
+  recipe image does not vendor the Dynamo `examples/` tree).
+- No embedding cache: Gemma 4 is encoder-free, so there is no separate encoder
+  output to cache or transfer (unlike `qwen3-vl-30b`).
+- The frontend uses `--router-mode kv --no-kv-events` (prefix-hash KV routing
+  without backend KV events).
+
+## Notes
+
+- **Aggregated only — disaggregated E/PD is NOT supported for this model.**
+  Gemma 4 is encoder-free: image patches project directly inside the decoder, so
+  there is no separable vision-encoder stage to run on a standalone encode worker
+  and NIXL-transfer to prefill. Do **not** set `--route-to-encoder` /
+  `--disaggregation-mode=encode` for this recipe — Dynamo's encode worker calls
+  `load_vision_model().visual`, which an encoder-free model does not have. In
+  aggregated mode Dynamo passes the image straight to vLLM, which generates the
+  embeddings internally (`handlers.py`: *"Without encode worker, the embedding
+  will be generated internally by vLLM."*). Prefill/decode (KV-transfer) disagg
+  would still be valid, but is out of scope for this recipe.
+- **Audio is deferred.** Gemma 4 accepts audio natively, but Dynamo's
+  frontend/preprocessor does not yet accept `audio_url` request parts. The image
+  installs `librosa`/`soundfile`/`av` so the runtime is ready once that lands.
+- **Upstream tracking.** vLLM PR #44429 is unmerged. Once it merges and a
+  `transformers` release ships `models/gemma4_unified`, repin the Dockerfile to a
+  released vLLM/transformers and drop the from-source install.
+
+## File Layout
+
+```text
+recipes/gemma-4-12b/
+  README.md
+  Dockerfile
+  model-cache/
+    model-cache.yaml
+    model-download.yaml
+  data-gen/
+    generate-datasets-job.yaml
+  vllm/
+    agg/
+      deploy.yaml
+      perf.yaml
+      run-benchmark.sh
+```

--- a/recipes/gemma-4-12b/README.md
+++ b/recipes/gemma-4-12b/README.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Gemma 4 12B (text + image)
+# Gemma 4 12B (text + image + audio)
 
 Serves [google/gemma-4-12B-it](https://huggingface.co/google/gemma-4-12B-it) using
 vLLM with an aggregated Dynamo deployment.
@@ -21,10 +21,8 @@ container that layers that PR's vLLM, a `transformers` build carrying
 (from <https://pypi.nvidia.com/ai-dynamo/>) onto an upstream vLLM image — no Rust
 toolchain.
 
-> **Scope:** text + image is verified here. **Audio input is deferred** — native
-> audio rides the normal token path in vLLM, but accepting `audio_url` parts
-> through Dynamo's frontend/preprocessor needs additional work (tracked as a
-> follow-up). See [Notes](#notes).
+> **Scope:** text, image, and audio chat inputs are verified locally. The
+> benchmark below is image-only.
 
 ## Results
 
@@ -55,7 +53,7 @@ requests succeeded.
 | Role | Replicas | GPUs/replica | Notes |
 |------|----------|--------------|-------|
 | Frontend | 1 | 0 | Dynamo frontend with prefix-hash KV routing |
-| vLLM worker | 1 | 1 | Text + image inputs (encoder-free) |
+| vLLM worker | 1 | 1 | Text, image, and audio inputs (encoder-free) |
 
 ## Prerequisites
 
@@ -71,7 +69,7 @@ docker build \
   --platform=linux/arm64 \
   -t <your-registry>/gemma4-12b-vllm:latest \
   -f recipes/gemma-4-12b/Dockerfile \
-  recipes/gemma-4-12b
+  .
 docker push <your-registry>/gemma4-12b-vllm:latest
 ```
 
@@ -85,7 +83,8 @@ docker push <your-registry>/gemma4-12b-vllm:latest
 
 Useful build args:
 
-- `VLLM_PR_REF=<sha>` — pin PR #44429 to a commit (default: live `refs/pull/44429/head`).
+- `VLLM_PR_REF=<ref>` — PR #44429 ref to fetch (default: `refs/pull/44429/head`).
+- `VLLM_PR_SHA=<sha>` — exact PR commit to check out after fetching.
 - `TRANSFORMERS_REF=<sha>` — pin the `transformers` `main` commit that ships `models/gemma4_unified`.
 - `BASE_IMAGE=<image>` — upstream vLLM base (default `vllm/vllm-openai:v0.22.0`); align its vLLM minor with PR #44429's base.
 - `DYNAMO_VERSION=<version>` — pin an `ai-dynamo` release/nightly from <https://pypi.nvidia.com/ai-dynamo/>.
@@ -157,17 +156,54 @@ curl http://localhost:8000/v1/chat/completions \
   }'
 ```
 
+Audio:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-4-12B-it",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What is in this audio?"},
+        {"type": "audio_url", "audio_url": {"url": "<HTTPS-or-data-URI WAV/MP3>"}}
+      ]
+    }],
+    "max_tokens": 128
+  }'
+```
+
 ## Local (no Kubernetes) bring-up
 
 The same image runs directly under Docker — useful on a single GPU box:
 
 ```bash
 IMG=<your-registry>/gemma4-12b-vllm:latest
-docker run --gpus all --rm -it -p 8000:8000 -e HF_TOKEN=$HF_TOKEN "$IMG" bash -lc '
-  python3 -m dynamo.frontend --http-port 8000 &
-  exec python3 -m dynamo.vllm \
-    --model google/gemma-4-12B-it --enable-multimodal --tensor-parallel-size 1 \
-    --dyn-tool-call-parser gemma4 --dyn-reasoning-parser gemma4'
+docker run --gpus all --rm -it -p 8000:8000 \
+  --entrypoint /bin/bash \
+  -e HF_TOKEN="${HF_TOKEN}" \
+  -e DYN_DISCOVERY_BACKEND=file \
+  -e DYN_FILE_KV=/tmp/dynamo-gemma4-kv \
+  -e DYN_REQUEST_PLANE=tcp \
+  -e DYN_EVENT_PLANE=zmq \
+  "$IMG" -lc '
+    set -euo pipefail
+    rm -rf "${DYN_FILE_KV}"
+    python3 -m dynamo.frontend --router-mode kv --no-kv-events --http-port 8000 &
+    frontend_pid=$!
+    trap "kill ${frontend_pid} 2>/dev/null || true" EXIT
+    python3 -m dynamo.vllm \
+      --model google/gemma-4-12B-it \
+      --served-model-name google/gemma-4-12B-it \
+      --enable-multimodal \
+      --tensor-parallel-size 1 \
+      --gpu-memory-utilization 0.85 \
+      --max-model-len 32768 \
+      --enable-prefix-caching \
+      --no-enable-log-requests \
+      --dyn-tool-call-parser gemma4 \
+      --dyn-reasoning-parser gemma4'
 ```
 
 Then use the same `curl` calls against `http://localhost:8000`.
@@ -177,6 +213,8 @@ Then use the same `curl` calls against `http://localhost:8000`.
 ```bash
 # 1. Generate the text+image dataset (writes to the perf-cache PVC).
 kubectl apply -f recipes/gemma-4-12b/data-gen/generate-datasets-job.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=complete job/gemma4-12b-generate-datasets -n ${NAMESPACE} --timeout=3600s
+kubectl logs job/gemma4-12b-generate-datasets -n ${NAMESPACE}
 
 # 2. Deploy + run the benchmark.
 NAMESPACE=${NAMESPACE} recipes/gemma-4-12b/vllm/agg/run-benchmark.sh
@@ -190,7 +228,7 @@ exact flags).
 
 ## Key Configuration Notes
 
-- `--enable-multimodal` enables image input.
+- `--enable-multimodal` enables multimodal input.
 - `--dyn-tool-call-parser gemma4` / `--dyn-reasoning-parser gemma4` enable Gemma 4
   tool-call and reasoning parsing (already shipped in Dynamo, architecture-agnostic).
   For tool-calling prompts, also pass `--custom-jinja-template
@@ -213,9 +251,10 @@ exact flags).
   embeddings internally (`handlers.py`: *"Without encode worker, the embedding
   will be generated internally by vLLM."*). Prefill/decode (KV-transfer) disagg
   would still be valid, but is out of scope for this recipe.
-- **Audio is deferred.** Gemma 4 accepts audio natively, but Dynamo's
-  frontend/preprocessor does not yet accept `audio_url` request parts. The image
-  installs `librosa`/`soundfile`/`av` so the runtime is ready once that lands.
+- **MM-aware KV routing:** Gemma 4 Unified generation works without a separate
+  encode worker. Dynamo needs Gemma 4-specific routing-side image-token counting
+  to make the Rust/lightseek MM-aware KV router distinguish image content; with
+  older images it falls back to normal text-prefix KV routing.
 - **Upstream tracking.** vLLM PR #44429 is unmerged. Once it merges and a
   `transformers` release ships `models/gemma4_unified`, repin the Dockerfile to a
   released vLLM/transformers and drop the from-source install.

--- a/recipes/gemma-4-12b/data-gen/generate-datasets-job.yaml
+++ b/recipes/gemma-4-12b/data-gen/generate-datasets-job.yaml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Generates a single-turn text+image JSONL dataset for the Gemma 4 12B benchmark.
-# Replace the image reference with your built recipe image (it ships the
-# benchmarks/multimodal/jsonl generator) or any image that contains it.
+# Replace the image reference with your built recipe image. The Dockerfile copies
+# the benchmarks/multimodal/jsonl generator into /workspace.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/recipes/gemma-4-12b/data-gen/generate-datasets-job.yaml
+++ b/recipes/gemma-4-12b/data-gen/generate-datasets-job.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Generates a single-turn text+image JSONL dataset for the Gemma 4 12B benchmark.
+# Replace the image reference with your built recipe image (it ships the
+# benchmarks/multimodal/jsonl generator) or any image that contains it.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gemma4-12b-generate-datasets
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: generate-datasets
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+        - name: generate-datasets
+          image: <your-registry>/gemma4-12b-vllm:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+
+              GENERATOR_MAIN="/workspace/benchmarks/multimodal/jsonl/main.py"
+              OUTPUT_DIR="/perf-cache/datasets"
+
+              if [[ ! -f "${GENERATOR_MAIN}" ]]; then
+                echo "Generator not found at ${GENERATOR_MAIN}"
+                echo "If your image does not vendor benchmarks/, mount the Dynamo repo or"
+                echo "run benchmarks/multimodal/jsonl/main.py from a checkout instead."
+                exit 1
+              fi
+
+              mkdir -p "${OUTPUT_DIR}"
+
+              python3 "${GENERATOR_MAIN}" \
+                -n 1000 \
+                --images-per-request 1 \
+                --images-pool 200 \
+                --user-text-tokens 400 \
+                --image-mode http \
+                --image-dir /perf-cache/images \
+                -o "${OUTPUT_DIR}/gemma4_12b_1000req_1img_pool200.jsonl"
+
+              echo "Dataset generation complete in ${OUTPUT_DIR}"
+          volumeMounts:
+            - name: perf-cache
+              mountPath: /perf-cache
+      volumes:
+        - name: perf-cache
+          persistentVolumeClaim:
+            claimName: perf-cache

--- a/recipes/gemma-4-12b/model-cache/model-cache.yaml
+++ b/recipes/gemma-4-12b/model-cache/model-cache.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: "your-storage-class-name"

--- a/recipes/gemma-4-12b/model-cache/model-cache.yaml
+++ b/recipes/gemma-4-12b/model-cache/model-cache.yaml
@@ -11,3 +11,15 @@ spec:
     requests:
       storage: 100Gi
   storageClassName: "your-storage-class-name"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: perf-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: "your-storage-class-name"

--- a/recipes/gemma-4-12b/model-cache/model-download.yaml
+++ b/recipes/gemma-4-12b/model-cache/model-download.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: google/gemma-4-12B-it
+            - name: HF_HOME
+              value: /model-store
+            # Uses up to 64 GB RAM for XET buffers; set "0" on low-memory nodes (8 GB cap): https://huggingface.co/docs/hub/en/xet/using-xet-storage#download-buffers
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.11.0
+              hf download "$MODEL_NAME"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "64Gi"
+            limits:
+              cpu: "8"
+              memory: "64Gi"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-store
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/recipes/gemma-4-12b/vllm/agg/deploy.yaml
+++ b/recipes/gemma-4-12b/vllm/agg/deploy.yaml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Gemma 4 12B aggregated vLLM deployment (text + image).
+#
+# Prerequisites:
+#   - Dynamo Platform installed
+#   - Model weights downloaded into the model-cache PVC
+#   - Container built from recipes/gemma-4-12b/Dockerfile (carries vLLM PR #44429
+#     + transformers with models/gemma4_unified)
+#   - HF_TOKEN secret created (gated model):
+#       kubectl create secret generic hf-token-secret \
+#         --from-literal=HF_TOKEN=<your-token> -n <namespace>
+#
+# Replace image references before applying:
+#   <your-registry>/gemma4-12b-vllm:latest
+#
+# Gemma 4 is encoder-free (image patches project directly into the decoder), so
+# this recipe intentionally OMITS the multimodal-embedding-cache / NIXL
+# embedding-transfer block used by tower-based VLMs (e.g. qwen3-vl) — there is
+# no separate encoder output to cache or transfer.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: gemma4-12b-agg
+spec:
+  backendFramework: vllm
+  pvcs:
+    - name: model-cache
+      create: false
+  services:
+    Frontend:
+      componentType: frontend
+      envFromSecret: hf-token-secret
+      replicas: 1
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /model-store
+      extraPodSpec:
+        mainContainer:
+          image: <your-registry>/gemma4-12b-vllm:latest
+          imagePullPolicy: IfNotPresent
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 1800
+            failureThreshold: 60
+          env:
+            - name: HF_HOME
+              value: /model-store
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - >-
+              exec python3 -m dynamo.frontend
+              --router-mode kv
+              --no-kv-events
+              --http-port 8000
+
+    VllmWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          gpu: "1"
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /model-store
+      sharedMemory:
+        size: 16Gi
+      extraPodSpec:
+        mainContainer:
+          image: <your-registry>/gemma4-12b-vllm:latest
+          imagePullPolicy: IfNotPresent
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 120
+          env:
+            - name: HF_HOME
+              value: /model-store
+            # Permit the COCO http:// image URLs in the multimodal benchmark dataset.
+            - name: DYN_MM_ALLOW_INTERNAL
+              value: "1"
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - >-
+              exec python3 -m dynamo.vllm
+              --model google/gemma-4-12B-it
+              --served-model-name google/gemma-4-12B-it
+              --enable-multimodal
+              --tensor-parallel-size 1
+              --gpu-memory-utilization 0.85
+              --max-model-len 32768
+              --enable-prefix-caching
+              --no-enable-log-requests
+              --dyn-tool-call-parser gemma4
+              --dyn-reasoning-parser gemma4

--- a/recipes/gemma-4-12b/vllm/agg/perf.yaml
+++ b/recipes/gemma-4-12b/vllm/agg/perf.yaml
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# aiperf benchmark pod for the Gemma 4 12B aggregated deployment.
+# Assumes the dataset from data-gen/generate-datasets-job.yaml exists on the
+# perf-cache PVC, and the gemma4-12b-agg deployment is Ready.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gemma4-12b-agg-benchmark
+  labels:
+    app: benchmark
+spec:
+  containers:
+    - name: benchmark
+      image: python:3.11
+      command:
+        - /bin/bash
+        - -lc
+        - |
+          set -euo pipefail
+          ulimit -n 1048576
+          ulimit -u 65536
+
+          apt update && apt install -y tmux curl jq
+          pip install aiperf==0.6.0
+
+          echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models..."
+          until curl -s "http://${FRONTEND}:8000/v1/models" | jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' >/dev/null 2>&1; do
+            echo "[$(date '+%H:%M:%S')] Model not ready, retrying in 5s..."
+            sleep 5
+          done
+          echo "Model '${MODEL_NAME}' is ready."
+
+          INPUT_FILE="${DATASET_DIR}/gemma4_12b_1000req_1img_pool200.jsonl"
+          if [ ! -f "${INPUT_FILE}" ]; then
+            echo "Dataset not found: ${INPUT_FILE}"
+            exit 1
+          fi
+
+          RUN_DIR="${ARTIFACT_BASE_DIR}/agg"
+          mkdir -p "${RUN_DIR}"
+
+          echo "Running benchmark ..."
+          aiperf profile \
+            --model "${MODEL_NAME}" \
+            --input-file "${INPUT_FILE}" \
+            --custom-dataset-type single_turn \
+            --url "http://${FRONTEND}:8000" \
+            --streaming \
+            --ui-type none \
+            --request-count "${REQUEST_COUNT}" \
+            --concurrency "${CONCURRENCY}" \
+            --request-rate-mode constant \
+            --warmup-request-count "${WARMUP_REQUEST_COUNT}" \
+            --artifact-dir "${RUN_DIR}" \
+            --extra-inputs "max_tokens:${MAX_TOKENS}" \
+            --extra-inputs "min_tokens:${MAX_TOKENS}" \
+            --extra-inputs "ignore_eos:true"
+
+          echo "Run complete. Artifacts in ${RUN_DIR}"
+          sleep 3600
+      env:
+        - name: MODEL_NAME
+          value: google/gemma-4-12B-it
+        - name: FRONTEND
+          value: gemma4-12b-agg-frontend
+        - name: MAX_TOKENS
+          value: "150"
+        - name: REQUEST_COUNT
+          value: "1000"
+        - name: CONCURRENCY
+          value: "64"
+        - name: WARMUP_REQUEST_COUNT
+          value: "3"
+        - name: DATASET_DIR
+          value: /perf-cache/datasets
+        - name: ARTIFACT_BASE_DIR
+          value: /perf-cache/artifacts/gemma4_12b/agg
+      resources:
+        requests:
+          cpu: "8"
+          memory: 16Gi
+        limits:
+          cpu: "16"
+          memory: 32Gi
+      volumeMounts:
+        - name: perf-cache
+          mountPath: /perf-cache
+  volumes:
+    - name: perf-cache
+      persistentVolumeClaim:
+        claimName: perf-cache
+  restartPolicy: Never

--- a/recipes/gemma-4-12b/vllm/agg/run-benchmark.sh
+++ b/recipes/gemma-4-12b/vllm/agg/run-benchmark.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy the Gemma 4 12B aggregated graph, wait for it to be Ready, then launch
+# the aiperf benchmark pod.
+#
+# Usage:
+#   NAMESPACE=dynamo ./run-benchmark.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+NAMESPACE="${NAMESPACE:-dynamo}"
+
+echo "==> Applying deployment"
+kubectl apply -f "${SCRIPT_DIR}/deploy.yaml" -n "${NAMESPACE}"
+
+echo "==> Waiting for worker to be ready..."
+kubectl wait --for=condition=Ready \
+  dynamographdeployment/gemma4-12b-agg \
+  -n "${NAMESPACE}" --timeout=1800s
+
+# Delete old benchmark pod if it exists.
+kubectl delete pod gemma4-12b-agg-benchmark \
+  -n "${NAMESPACE}" --ignore-not-found
+
+echo "==> Launching benchmark pod"
+kubectl apply -f "${SCRIPT_DIR}/perf.yaml" -n "${NAMESPACE}"
+
+echo "==> Benchmark pod launched"
+echo "    Monitor with: kubectl logs -f gemma4-12b-agg-benchmark -n ${NAMESPACE}"

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -349,6 +349,34 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         },
         extra_vllm_args=["--dtype", "bfloat16"],
     ),
+    # google/gemma-4-12B-it — unified, encoder-free text+image+audio decoder
+    # (Gemma4UnifiedForConditionalGeneration), served by recipes/gemma-4-12b on a
+    # vLLM PR #44429 image. Skipped in standard CI until that PR merges and the
+    # runtime base ships gemma4_unified: the stock CI image cannot load this
+    # architecture, and the 12B (~24 GiB bf16 weights + activations) needs a
+    # ≥40 GiB GPU rather than the small pre_merge runners that host the E2B
+    # variant above. Run manually against the recipe image — see
+    # recipes/gemma-4-12b/README.md.
+    MultimodalModelProfile(
+        name="google/gemma-4-12B-it",
+        short_name="gemma4-12b-it",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[
+                    pytest.mark.skip(
+                        reason="Requires vLLM PR #44429 "
+                        "(Gemma4UnifiedForConditionalGeneration) image and a "
+                        "≥40 GiB GPU; see recipes/gemma-4-12b."
+                    ),
+                    pytest.mark.post_merge,
+                ],
+                timeout_s=900,
+                profiled_vram_gib=28.0,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+        },
+        extra_vllm_args=["--dtype", "bfloat16"],
+    ),
     # [gluo NOTE] LLaVA 1.5 7B is big model and require at least 3 GPUs to run.
     # We may use less GPUs by squeezing the model onto 2 GPUs.
     #

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from tests.utils.multimodal import (
@@ -363,15 +365,17 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[
-                    pytest.mark.skip(
+                    pytest.mark.skipif(
+                        not os.environ.get("DYN_GEMMA4_12B_MANUAL_ENABLED"),
                         reason="Requires vLLM PR #44429 "
                         "(Gemma4UnifiedForConditionalGeneration) image and a "
-                        "≥40 GiB GPU; see recipes/gemma-4-12b."
+                        ">=40 GiB GPU; set DYN_GEMMA4_12B_MANUAL_ENABLED=1 "
+                        "and see recipes/gemma-4-12b."
                     ),
                     pytest.mark.post_merge,
                 ],
                 timeout_s=900,
-                profiled_vram_gib=28.0,
+                profiled_vram_gib=40.0,
                 tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
         },


### PR DESCRIPTION
## Summary
- add Gemma 4 multimodal image token counting fallback for MM-aware KV routing
- update Gemma 4 12B recipe docs/manifests for text, image, and audio unified multimodal serving
- gate the manual vLLM Gemma 4 profile behind an explicit env var

## Validation
- `cargo fmt --check -p dynamo-llm`
- `CUDARC_CUDA_VERSION=13010 cargo test -p dynamo-llm --no-default-features --features lightseek-mm -- --nocapture`
- Python compile checks for Gemma 4 recipe/test helpers
- YAML parse checks for Gemma 4 recipe manifests
- Local Docker smoke: text, image, and audio chat inputs
- Kubernetes smoke on local k3s GPU cluster: text, image, and audio chat inputs through Dynamo frontend
- Kubernetes AIPerf image-chat run: 64/64 completed, 0 errors, 6.76 req/s, 432.43 output tok/s, TTFT avg 276.66 ms

## Notes
This branch is stacked on the unmerged Gemma 4 12B recipe work, so it includes that base history.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemma 4 12B multimodal inference with vLLM, including text, image, and audio processing capabilities.
  * Added Docker container recipe and Kubernetes deployment manifests for running Gemma 4 in aggregated mode.

* **Documentation**
  * Added comprehensive deployment guide covering local Docker and Kubernetes workflows for serving Gemma 4 12B.
  * Added benchmarking tooling and instructions for performance profiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->