### PR TITLE
chore: require lazy Python logging formatting in CodeRabbit reviews

### DIFF
--- a/.ai/python-guidelines.md
+++ b/.ai/python-guidelines.md
@@ -121,7 +121,7 @@ except json.JSONDecodeError:
 try:
     result = something()
 except Exception as e:
-    logger.error(f"Failed: {e}")
+    logger.error("Failed: %s", e)
     raise
 ```
 
@@ -270,6 +270,29 @@ for line in lines:
 # GOOD -- O(n) with join
 result = "\n".join(lines)
 ```
+
+### Use lazy formatting for log messages
+
+**Always flag** f-strings and other eagerly formatted strings passed to Python
+logging calls (`logging.*` or `logger.*`). Formatting the message before the
+logging call runs wastes CPU and can serialize large request payloads even when
+the log level is disabled. Pass a static format string and arguments separately
+so the logging framework performs interpolation only when it emits the message.
+
+```python
+# BAD -- request is serialized even when debug logging is disabled; flag this
+logger.debug(f"Request: {request}")
+logging.info("Worker %s started" % worker_id)
+logger.warning("Retrying {}".format(request_id))
+
+# GOOD -- logging interpolates only when the message is emitted
+logger.debug("Request: %s", request)
+logging.info("Worker %s started", worker_id)
+logger.warning("Retrying %s", request_id)
+```
+
+If constructing a log argument is itself expensive, guard that work with the
+appropriate `logger.isEnabledFor(...)` check or log a compact summary instead.
 
 ### Late-binding closures in loops
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,7 +28,10 @@ reviews:
       enabled: false
   path_instructions:
     - path: "**/*.py"
-      instructions: "Review against .ai/python-guidelines.md"
+      instructions: |
+        Review against .ai/python-guidelines.md.
+        Always flag eagerly formatted log messages, including f-strings passed
+        to logging.* or logger.* calls. Require lazy %s placeholder arguments.
     - path: "**/tests/**/*.py"
       instructions: "Review against .ai/pytest-guidelines.md"
     - path: "**/tests/**/*.py"


### PR DESCRIPTION
#### Overview:

Teach CodeRabbit to flag eagerly formatted Python log messages during review. Logging calls should pass static format strings with `%s` placeholders and separate arguments so disabled log levels do not pay interpolation or serialization costs.

#### Details:

- Expand the Python CodeRabbit path instruction to explicitly flag eager formatting in `logging.*` and `logger.*` calls.
- Add a mandatory Python guideline covering f-strings, `.format()`, and `%` interpolation passed directly to logging calls.
- Update the broad exception example to demonstrate lazy logging formatting.

#### Where should the reviewer start?

- `.coderabbit.yaml`
- `.ai/python-guidelines.md`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #10298

#### Validation:

- `git diff --check -- .coderabbit.yaml .ai/python-guidelines.md`
- Parsed `.coderabbit.yaml` with PyYAML and asserted the new Python path instruction.
- `pre-commit run check-yaml --files .coderabbit.yaml`
- `pre-commit run codespell --files .coderabbit.yaml .ai/python-guidelines.md`
- `pre-commit run trailing-whitespace --files .coderabbit.yaml .ai/python-guidelines.md`

The repository-wide `pytest-marker-report` pre-commit hook was skipped for the commit because collection from a clean `main` worktree currently fails under local Python 3.10 when existing code imports `typing.Required`, which requires Python 3.11+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python logging guidelines with best practices for lazy message formatting to improve performance and code consistency.

* **Chores**
  * Enhanced code review configuration to enforce lazy logging standards across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->