### PR TITLE
chore: keep CodeRabbit rule ownership in Python guidelines

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,10 +28,7 @@ reviews:
       enabled: false
   path_instructions:
     - path: "**/*.py"
-      instructions: |
-        Review against .ai/python-guidelines.md.
-        Always flag eagerly formatted log messages, including f-strings passed
-        to logging.* or logger.* calls. Require lazy %s placeholder arguments.
+      instructions: "Review against .ai/python-guidelines.md"
     - path: "**/tests/**/*.py"
       instructions: "Review against .ai/pytest-guidelines.md"
     - path: "**/tests/**/*.py"


### PR DESCRIPTION
#### Overview:

Remove duplicated lazy logging rule text from `.coderabbit.yaml` now that the full rule is documented in `.ai/python-guidelines.md`.

#### Details:

- Keep the Python path instruction focused on routing reviews to `.ai/python-guidelines.md`.
- Leave the detailed lazy logging policy and examples in the guideline file as the single source of truth.

#### Where should the reviewer start?

- `.coderabbit.yaml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #10305

#### Validation:

- `git diff --check -- .coderabbit.yaml`
- Parsed `.coderabbit.yaml` with PyYAML and asserted the Python instruction value.
- `pre-commit run check-yaml --files .coderabbit.yaml`
- `pre-commit run trailing-whitespace --files .coderabbit.yaml`

The repository-wide `pytest-marker-report` pre-commit hook was skipped for the commit because collection from a clean `main` worktree currently fails under local Python 3.10 when existing code imports `typing.Required`, which requires Python 3.11+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to streamline code review guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->