### PR TITLE
feat: add anchor-heavy steady-state benchmark

### DIFF
--- a/lib/bench/Cargo.toml
+++ b/lib/bench/Cargo.toml
@@ -44,6 +44,11 @@ name = "active_sequences_bench"
 path = "kv_router/active_sequences_bench.rs"
 harness = false
 
+[[bench]]
+name = "anchor_heavy_bench"
+path = "kv_router/anchor_heavy_bench.rs"
+harness = false
+
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -100,6 +100,21 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 4
 ```
 
+### Anchor-heavy Stored-event steady state
+
+This synthetic benchmark isolates the BSI anchor-dedup path. It warms stable workers with one boundary-crossing `Stored` event each, then repeatedly stores new suffix continuations under the same already-installed anchors. There are no `Cleared` or `remove_worker` operations, so the output exposes `ensure_worker_anchor` reuse cost directly via Stored-event throughput, p99, and anchor install/reuse counts.
+
+```bash
+cargo bench --package dynamo-bench --bench anchor_heavy_bench -- \
+  --workers 1024 \
+  --events 100000 \
+  --submit-tasks 4 \
+  --num-shards 2 \
+  --num-event-workers-per-shard 4 \
+  --prefix-depth 2 \
+  --suffix-blocks 4
+```
+
 ### Peak throughput sweep
 
 **CRTC baseline — sweep:**

--- a/lib/bench/kv_router/anchor_heavy_bench.rs
+++ b/lib/bench/kv_router/anchor_heavy_bench.rs
@@ -14,6 +14,7 @@ use dynamo_kv_router::{
     BranchShardedIndexer, ConcurrentRadixTreeCompressed, LocalBlockHash, ThreadPoolIndexer,
 };
 use tokio::sync::Barrier;
+use tokio_util::sync::CancellationToken;
 
 type Bsi = BranchShardedIndexer<ThreadPoolIndexer<ConcurrentRadixTreeCompressed>>;
 
@@ -187,16 +188,19 @@ async fn main() -> anyhow::Result<()> {
     }
     indexer.flush().await;
 
-    let barrier = Arc::new(Barrier::new(args.submit_tasks + 1));
+    let ready_barrier = Arc::new(Barrier::new(args.submit_tasks + 1));
+    let start_signal = CancellationToken::new();
     let mut tasks = Vec::with_capacity(args.submit_tasks);
     for task_idx in 0..args.submit_tasks {
         let args = args.clone();
         let indexer = Arc::clone(&indexer);
-        let barrier = Arc::clone(&barrier);
+        let ready_barrier = Arc::clone(&ready_barrier);
+        let start_signal = start_signal.clone();
         let range = task_range(args.events, task_idx, args.submit_tasks);
         tasks.push(tokio::spawn(async move {
             let mut latencies_ns = Vec::with_capacity(range.len());
-            barrier.wait().await;
+            ready_barrier.wait().await;
+            start_signal.cancelled().await;
             for event_idx in range {
                 let worker_id = (event_idx % args.workers) as u64;
                 let event_id = args.workers as u64 + event_idx as u64;
@@ -215,8 +219,9 @@ async fn main() -> anyhow::Result<()> {
         }));
     }
 
-    barrier.wait().await;
+    ready_barrier.wait().await;
     let started_at = minstant::Instant::now();
+    start_signal.cancel();
 
     let mut latencies_ns = Vec::with_capacity(args.events);
     for task in tasks {

--- a/lib/bench/kv_router/anchor_heavy_bench.rs
+++ b/lib/bench/kv_router/anchor_heavy_bench.rs
@@ -83,6 +83,9 @@ impl Args {
         if self.suffix_blocks == 0 {
             anyhow::bail!("--suffix-blocks must be at least 1");
         }
+        if self.block_size == 0 {
+            anyhow::bail!("--block-size must be at least 1");
+        }
         Ok(())
     }
 

--- a/lib/bench/kv_router/anchor_heavy_bench.rs
+++ b/lib/bench/kv_router/anchor_heavy_bench.rs
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use clap::Parser;
+use dynamo_kv_router::indexer::KvIndexerInterface;
+use dynamo_kv_router::protocols::{
+    ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+    KvCacheStoredBlockData, RouterEvent, compute_seq_hash_for_block,
+};
+use dynamo_kv_router::{
+    BranchShardedIndexer, ConcurrentRadixTreeCompressed, LocalBlockHash, ThreadPoolIndexer,
+};
+use tokio::sync::Barrier;
+
+type Bsi = BranchShardedIndexer<ThreadPoolIndexer<ConcurrentRadixTreeCompressed>>;
+
+#[derive(Parser, Debug, Clone)]
+#[clap(
+    version,
+    about = "Anchor-heavy BSI steady-state Stored-event benchmark"
+)]
+struct Args {
+    /// Number of stable workers to warm and reuse during the measured phase.
+    #[clap(long, default_value = "1024")]
+    workers: usize,
+
+    /// Number of Stored events measured after warm-up.
+    #[clap(long, default_value = "100000")]
+    events: usize,
+
+    /// Number of concurrent submitter tasks issuing Stored events.
+    #[clap(long, default_value = "4")]
+    submit_tasks: usize,
+
+    /// Number of independent CRTC shards.
+    #[clap(long, default_value = "2")]
+    num_shards: usize,
+
+    /// Number of OS event-worker threads per shard.
+    #[clap(long, default_value = "4")]
+    num_event_workers_per_shard: usize,
+
+    /// Routing depth before suffixes are dispatched to a shard.
+    #[clap(long, default_value = "2")]
+    prefix_depth: usize,
+
+    /// KV block size used by the indexer.
+    #[clap(long, default_value = "32")]
+    block_size: u32,
+
+    /// Number of suffix blocks beyond prefix_depth in each Stored event.
+    #[clap(long, default_value = "4")]
+    suffix_blocks: usize,
+
+    /// Ignored - passed by cargo bench harness.
+    #[arg(long, hide = true)]
+    bench: bool,
+}
+
+impl Args {
+    fn validate(&self) -> anyhow::Result<()> {
+        if self.workers == 0 {
+            anyhow::bail!("--workers must be at least 1");
+        }
+        if self.events == 0 {
+            anyhow::bail!("--events must be at least 1");
+        }
+        if self.submit_tasks == 0 {
+            anyhow::bail!("--submit-tasks must be at least 1");
+        }
+        if self.num_shards == 0 {
+            anyhow::bail!("--num-shards must be at least 1");
+        }
+        if self.num_event_workers_per_shard == 0 {
+            anyhow::bail!("--num-event-workers-per-shard must be at least 1");
+        }
+        if self.prefix_depth == 0 {
+            anyhow::bail!("--prefix-depth must be at least 1");
+        }
+        if self.suffix_blocks == 0 {
+            anyhow::bail!("--suffix-blocks must be at least 1");
+        }
+        Ok(())
+    }
+
+    fn blocks_per_event(&self) -> usize {
+        self.prefix_depth + self.suffix_blocks
+    }
+}
+
+fn make_indexer(args: &Args) -> Arc<Bsi> {
+    let shards = (0..args.num_shards)
+        .map(|_| {
+            ThreadPoolIndexer::new(
+                ConcurrentRadixTreeCompressed::new(),
+                args.num_event_workers_per_shard,
+                args.block_size,
+            )
+        })
+        .collect();
+    Arc::new(BranchShardedIndexer::new_with_options(
+        shards,
+        args.prefix_depth,
+        args.block_size,
+    ))
+}
+
+fn sequence_hashes(args: &Args, worker_id: u64, event_idx: u64) -> Vec<LocalBlockHash> {
+    let mut hashes = Vec::with_capacity(args.blocks_per_event());
+
+    for depth in 0..args.prefix_depth {
+        hashes.push(LocalBlockHash(46 + depth as u64));
+    }
+
+    let suffix_seed = 1_000_000_000u64
+        .wrapping_add(worker_id.wrapping_mul(65_537))
+        .wrapping_add(event_idx.wrapping_mul(1_048_573));
+    for suffix_idx in 0..args.suffix_blocks {
+        hashes.push(LocalBlockHash(suffix_seed.wrapping_add(suffix_idx as u64)));
+    }
+
+    hashes
+}
+
+fn stored_event(args: &Args, worker_id: u64, event_id: u64, event_idx: u64) -> RouterEvent {
+    let local_hashes = sequence_hashes(args, worker_id, event_idx);
+    let seq_hashes = compute_seq_hash_for_block(&local_hashes);
+    let blocks = local_hashes
+        .iter()
+        .zip(seq_hashes.iter())
+        .map(|(&tokens_hash, &block_hash)| KvCacheStoredBlockData {
+            tokens_hash,
+            block_hash: ExternalSequenceBlockHash(block_hash),
+            mm_extra_info: None,
+        })
+        .collect();
+
+    RouterEvent::new(
+        worker_id,
+        KvCacheEvent {
+            event_id,
+            dp_rank: 0,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: None,
+                blocks,
+            }),
+        },
+    )
+}
+
+fn task_range(events: usize, task_idx: usize, tasks: usize) -> Range<usize> {
+    let base = events / tasks;
+    let extra = events % tasks;
+    let start = task_idx * base + task_idx.min(extra);
+    let len = base + usize::from(task_idx < extra);
+    start..start + len
+}
+
+fn percentile_us(mut latencies_ns: Vec<u64>, pct: usize) -> f64 {
+    if latencies_ns.is_empty() {
+        return 0.0;
+    }
+    latencies_ns.sort_unstable();
+    let idx = (latencies_ns.len().saturating_sub(1) * pct) / 100;
+    latencies_ns[idx] as f64 / 1000.0
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    args.validate()?;
+
+    let indexer = make_indexer(&args);
+
+    println!("Warming {} stable workers...", args.workers);
+    for worker_id in 0..args.workers {
+        indexer
+            .apply_event(stored_event(&args, worker_id as u64, worker_id as u64, 0))
+            .await;
+    }
+    indexer.flush().await;
+
+    let barrier = Arc::new(Barrier::new(args.submit_tasks + 1));
+    let mut tasks = Vec::with_capacity(args.submit_tasks);
+    for task_idx in 0..args.submit_tasks {
+        let args = args.clone();
+        let indexer = Arc::clone(&indexer);
+        let barrier = Arc::clone(&barrier);
+        let range = task_range(args.events, task_idx, args.submit_tasks);
+        tasks.push(tokio::spawn(async move {
+            let mut latencies_ns = Vec::with_capacity(range.len());
+            barrier.wait().await;
+            for event_idx in range {
+                let worker_id = (event_idx % args.workers) as u64;
+                let event_id = args.workers as u64 + event_idx as u64;
+                let start = minstant::Instant::now();
+                indexer
+                    .apply_event(stored_event(
+                        &args,
+                        worker_id,
+                        event_id,
+                        event_idx as u64 + 1,
+                    ))
+                    .await;
+                latencies_ns.push(start.elapsed().as_nanos() as u64);
+            }
+            latencies_ns
+        }));
+    }
+
+    barrier.wait().await;
+    let started_at = minstant::Instant::now();
+
+    let mut latencies_ns = Vec::with_capacity(args.events);
+    for task in tasks {
+        latencies_ns.extend(task.await?);
+    }
+    indexer.flush().await;
+
+    let elapsed = started_at.elapsed();
+    let elapsed_secs = elapsed.as_secs_f64().max(1e-9);
+    let event_throughput = args.events as f64 / elapsed_secs;
+    let block_throughput = (args.events * args.blocks_per_event()) as f64 / elapsed_secs;
+    let p99_us = percentile_us(latencies_ns, 99);
+    let metrics = indexer.metrics_snapshot();
+
+    println!();
+    println!("Anchor-heavy BSI Stored-event benchmark");
+    println!("workers: {}", args.workers);
+    println!("stored events: {}", args.events);
+    println!("blocks per event: {}", args.blocks_per_event());
+    println!("submit tasks: {}", args.submit_tasks);
+    println!(
+        "config: {} shards x {} event workers, prefix_depth={}",
+        args.num_shards, args.num_event_workers_per_shard, args.prefix_depth
+    );
+    println!("elapsed: {:.3}s", elapsed_secs);
+    println!("stored-event throughput: {:.0} events/s", event_throughput);
+    println!(
+        "stored-block throughput: {:.0} block events/s",
+        block_throughput
+    );
+    println!("apply_event p99: {:.1}us", p99_us);
+    println!("anchor installs: {}", metrics.anchor_installs);
+    println!("anchor reuses: {}", metrics.anchor_reuses);
+    println!("remove broadcasts: {}", metrics.remove_broadcasts);
+
+    Ok(())
+}

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -27,13 +27,13 @@ use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
-#[cfg(feature = "bench")]
-use super::ShardedIndexerMetrics;
 use super::shard_handle::AsyncShardHandle;
 use super::{
     AnchorCapableSyncIndexer, AnchorRef, AnchorTask, KvIndexerInterface, KvRouterError,
     ShardSizeSnapshot, ThreadPoolIndexer,
 };
+#[cfg(feature = "bench")]
+use super::{ShardedIndexerMetrics, ShardedIndexerMetricsSnapshot};
 use crate::protocols::*;
 
 type WorkerRoutingLookup = DashMap<ExternalSequenceBlockHash, BlockRoutingEntry, FxBuildHasher>;
@@ -471,6 +471,36 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
             (worker.worker_id == worker_id).then_some(worker)
         }));
         workers
+    }
+
+    #[cfg(feature = "bench")]
+    pub fn metrics_snapshot(&self) -> ShardedIndexerMetricsSnapshot {
+        ShardedIndexerMetricsSnapshot {
+            find_match_dispatches: self
+                .metrics
+                .counters
+                .find_match_dispatches
+                .load(Ordering::Relaxed),
+            find_match_early_returns: self
+                .metrics
+                .counters
+                .find_match_early_returns
+                .load(Ordering::Relaxed),
+            anchor_installs: self
+                .metrics
+                .counters
+                .anchor_installs
+                .load(Ordering::Relaxed),
+            anchor_reuses: self.metrics.counters.anchor_reuses.load(Ordering::Relaxed),
+            remove_broadcasts: self
+                .metrics
+                .counters
+                .remove_broadcasts
+                .load(Ordering::Relaxed),
+            timing_calls: self.metrics.timing.calls.load(Ordering::Relaxed),
+            routing_ns: self.metrics.timing.routing_ns.load(Ordering::Relaxed),
+            shard_ns: self.metrics.timing.shard_ns.load(Ordering::Relaxed),
+        }
     }
 
     fn rewritten_store_event(

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -123,6 +123,19 @@ impl ShardedIndexerMetrics {
     }
 }
 
+#[cfg(feature = "bench")]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ShardedIndexerMetricsSnapshot {
+    pub find_match_dispatches: u64,
+    pub find_match_early_returns: u64,
+    pub anchor_installs: u64,
+    pub anchor_reuses: u64,
+    pub remove_broadcasts: u64,
+    pub timing_calls: u64,
+    pub routing_ns: u64,
+    pub shard_ns: u64,
+}
+
 /// Metrics for the KV Indexer.
 #[derive(Clone)]
 #[cfg_attr(not(feature = "metrics"), derive(Default))]


### PR DESCRIPTION
#### Overview:

Add an anchor-heavy steady-state benchmark for BSI. 

#### Details:

The benchmark warms stable workers, then runs boundary-crossing `Stored` events with already-installed anchors and no cleanup/removes, reporting throughput, p99, and anchor install/reuse counts.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new benchmark suite to measure indexer performance under anchor-heavy steady-state conditions with configurable parameters including worker counts and shard configurations.
  * Added metrics snapshot capabilities to capture and report detailed performance statistics, including throughput, latency percentiles, and anchor operation metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->