### PR TITLE
fix(gms): refresh vLLM KV wake state

### DIFF
--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -387,14 +387,9 @@ class GMSWorker(Worker):
                 ensure_scratch_disabled(kv_cache_manager)
             kv_cache_manager.reallocate_all_handles(tag="kv_cache")
             kv_cache_manager.remap_all_vas()
+            self.model_runner.post_kv_cache_wake_up()
             if was_scratch:
                 self._register_kv_caches_with_nixl()
-
-            # Reinitialize FP8 KV scales if needed
-            if self.cache_config.cache_dtype.startswith("fp8") and hasattr(
-                self.model_runner, "init_fp8_kv_scales"
-            ):
-                self.model_runner.init_fp8_kv_scales()
 
     def _register_kv_caches_with_nixl(self) -> None:
         """Fire the NixlConnector KV-cache registration after deferred KV swap.


### PR DESCRIPTION
## Summary

Align Dynamo's vLLM GMS KV-cache wake path with upstream vLLM:

- Call `self.model_runner.post_kv_cache_wake_up()` after GMS remaps KV cache VAs.
- Remove Dynamo's separate explicit `init_fp8_kv_scales()` block from `GMSWorker.wake_up()`.

Dynamo's GMS worker bypasses vLLM's native CuMem allocator wake path and remaps KV cache VAs through GMS directly. After `kv_cache_manager.remap_all_vas()`, we still need to run vLLM's model-runner post-wake hook.

## Why

Inter-pod GMS failover with shadow engines could wake successfully, but the first inference after wake failed in vLLM block-table preparation:

```text
vllm/v1/worker/gpu/model_runner.py -> prepare_attn()
vllm/v1/worker/gpu/block_table.py -> gather_block_tables()
_gather_block_tables_kernel
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

This reproduced with `--enforce-eager`, so it was not caused by CUDA graph capture. Upstream vLLM's native `GPUWorker.wake_up()` calls `model_runner.post_kv_cache_wake_up()` after waking the allocator when KV cache is included. GMS needs the equivalent call after its own KV remap path.

Current upstream vLLM does not keep a separate FP8 reinit block in `GPUWorker.wake_up()`. The V1 model runner's `post_kv_cache_wake_up()` calls `init_fp8_kv_scales()`, while the V2 model runner's hook refreshes block-table layout tensors. Keeping Dynamo's old explicit FP8 block after the hook would duplicate the V1 path and diverge from upstream worker semantics.

## Validation

Whitespace:

```bash
git diff --check
```

Result: clean.

Diagnostic cluster validation performed while investigating this issue showed that adding the post-wake hook removes the post-wake block-table illegal memory access for Qwen/Qwen3-0.6B TP=8 vLLM inter-pod GMS failover. Larger/full-KV failover validation found an additional scratch-memory-accounting issue, which is intentionally split into a separate PR.

## Notes

- This PR is draft while the companion scratch-memory-accounting PR is split out.
- AI assistance was used to investigate, patch, and validate this change. A human submitter should review every changed line and re-run the relevant tests before marking this PR ready.
