### PR TITLE
docs: update related issues guidance in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,23 @@
-#### Overview:
+## Overview:
 
 <!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
 
-#### Details:
+## Details:
 
 <!-- Describe the changes made in this PR. -->
 
-#### Where should the reviewer start?
+## Where should the reviewer start?
 
 <!-- call out specific files that should be looked at closely -->
 
-#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
+## Related Issues
 
-- closes #xxx
+> ⚠️ **This section is required.** Choose one path below and delete the other.
+
+**🔗 This PR is linked to an issue:**
+<!-- Replace XXXX with the real issue number e.g. for Single issue  → Closes #8480
+     Multiple issues → Closes #8480, Closes #8481 -->
+- Closes #XXXX
+
+**🚫 This PR is NOT linked to an issue** _(docs, chore, refactor)_:
+- [ ] Confirmed — no related issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,9 +15,16 @@
 > ⚠️ **This section is required.** Choose one path below and delete the other.
 
 **🔗 This PR is linked to an issue:**
-<!-- Replace XXXX with the real issue number e.g. for Single issue  → Closes #8480
-     Multiple issues → Closes #8480, Closes #8481 -->
+<!-- Replace XXXX with the real issue number e.g.
+     Single issue  → Closes #8480
+     Multiple issues → Closes #8480, Closes #8481
+
+     Use `Relates to #XXXX` when this PR references, depends on,
+     or partially addresses an issue. This links the PR to the issue
+     but does not automatically close it.
+-->
+
 - Closes #XXXX
 
-**🚫 This PR is NOT linked to an issue** _(docs, chore, refactor)_:
+**🚫 This PR is NOT linked to an issue**:
 - [ ] Confirmed — no related issue


### PR DESCRIPTION
Overview:

Updated the “Related Issues” section of the PR template to clarify that PRs resolving issues should include a GitHub closing keyword with the issue ID, such as Closes #XXXX, Fixes #XXXX, or Resolves #XXXX.

Details:

Added guidance distinguishing between closing references and non-closing references. PR authors should use GitHub closing keywords when the PR should automatically close an issue after merge, and use a non-closing reference such as Relates to #XXXX when the PR only references, depends on, or partially addresses an issue.

Where should the reviewer start?

Review the updated “Related Issues” section in the PR template to confirm the wording clearly explains when to use closing keywords versus non-closing issue references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request template with revised guidance structure and formatting, including numbered sections and emoji-driven issue linking options to streamline the contribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->