### PR TITLE
fix(kv-router): harden cancellation and replica sync

### DIFF
--- a/components/src/dynamo/router/CLAUDE.md
+++ b/components/src/dynamo/router/CLAUDE.md
@@ -101,7 +101,8 @@ logic but do not share the same serialization, RPC, or process boundaries.
 | `__main__.py` | Standalone Python router service |
 | `../thunderagent_router/__main__.py` | Custom registered router facade |
 | `../../../../lib/llm/src/entrypoint/input/common.rs` | Builds embedded Rust routing pipelines |
-| `../../../../lib/llm/src/kv_router/push_router.rs` | Worker selection and router-side tracker updates |
+| `../../../../lib/llm/src/kv_router/push_router.rs` | Routed-generation orchestration and router-side tracker updates |
+| `../../../../lib/llm/src/kv_router/push_router/selection.rs` | Worker selection, pinned routing, and sticky-worker validation |
 | `../../../../lib/llm/src/protocols/common/preprocessor.rs` | `PreprocessedRequest`; tracker is `#[serde(skip)]` |
 | `../../../../lib/bindings/python/rust/llm/routed_engine.rs` | Python processor -> embedded Rust pipeline bridge |
 | `../../../../lib/bindings/python/rust/llm/kv.rs` | Binding-level router used by standalone/custom Python routers |

--- a/lib/kv-router/src/scheduling/CLAUDE.md
+++ b/lib/kv-router/src/scheduling/CLAUDE.md
@@ -6,8 +6,9 @@ from projected load into sequence-state booking.
 ## Guardrails
 
 - `SchedulerQueue::admit_one` is the canonical admission path: compute projected
-  load, select worker, respond, then book state. Do not bypass this for normal
-  scheduling.
+  load, select worker, skip booking if the response receiver is closed, then
+  book state before responding. Failed response delivery must roll back the
+  booking. Do not bypass this for normal scheduling.
 - Do not remove or weaken `admission_gate` without proving selection plus
   booking remains serialized enough to avoid oversubscription regressions.
 - Potential-load projection must go through

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -568,7 +568,7 @@ impl<
     }
 
     /// Run the full scheduling pipeline for a single request:
-    /// compute potential load -> select worker -> respond -> book via add_request.
+    /// compute potential load -> select worker -> book tracked state -> respond.
     fn admit_one(&self, mut request: SchedulingRequest, decay_now: Instant) {
         let (decode_blocks, prefill_tokens) = self.slots.potential_blocks_and_tokens_at(
             request.token_seq.as_deref(),
@@ -598,18 +598,22 @@ impl<
             }
         };
 
-        request.respond(Ok(SchedulingResponse {
+        let response = SchedulingResponse {
             best_worker: selection.worker,
             effective_overlap_blocks: selection.effective_overlap_blocks,
             cached_tokens: selection.cached_tokens,
-        }));
+        };
 
         if !request.update_states {
+            request.respond(Ok(response));
             return;
         }
 
-        let Some(request_id) = request.maybe_request_id else {
+        let Some(request_id) = request.maybe_request_id.clone() else {
             tracing::error!("No request_id provided to add_request to the slot tracker");
+            request.respond(Err(KvSchedulerError::BookingFailed(
+                "tracked scheduling request did not include a request_id".to_string(),
+            )));
             return;
         };
 
@@ -619,19 +623,46 @@ impl<
             request.track_prefill_tokens,
         );
 
-        if let Err(e) = self.slots.add_request(
-            SequenceRequest {
-                request_id: request_id.clone(),
-                token_sequence: request.token_seq,
-                track_prefill_tokens: request.track_prefill_tokens,
-                expected_output_tokens: request.expected_output_tokens,
-                prefill_load_hint,
-                worker: selection.worker,
-                lora_name: request.lora_name.clone(),
-            },
-            Instant::now(),
-        ) {
-            tracing::warn!("Failed to add request {request_id}: {e}");
+        let sequence_request = SequenceRequest {
+            request_id,
+            token_sequence: request.token_seq.take(),
+            track_prefill_tokens: request.track_prefill_tokens,
+            expected_output_tokens: request.expected_output_tokens,
+            prefill_load_hint,
+            worker: selection.worker,
+            lora_name: request.lora_name.take(),
+        };
+        self.book_and_respond(request, sequence_request, response);
+    }
+
+    fn book_and_respond(
+        &self,
+        mut request: SchedulingRequest,
+        sequence_request: SequenceRequest,
+        response: SchedulingResponse,
+    ) {
+        if request.response_is_closed() {
+            tracing::debug!(
+                request_id = %sequence_request.request_id,
+                "Skipping scheduler booking for cancelled request"
+            );
+            return;
+        }
+
+        let request_id = sequence_request.request_id.clone();
+        if let Err(error) = self.slots.add_request(sequence_request, Instant::now()) {
+            tracing::warn!(%request_id, %error, "Failed to book scheduler state");
+            request.respond(Err(KvSchedulerError::BookingFailed(error.to_string())));
+            return;
+        }
+
+        if request.respond(Ok(response)) {
+            return;
+        }
+
+        tracing::debug!(%request_id, "Rolling back undelivered scheduler booking");
+        if let Err(error) = self.slots.free(&request_id, Instant::now()) {
+            tracing::error!(%request_id, %error, "Failed to roll back scheduler booking");
         }
     }
 
@@ -744,9 +775,12 @@ mod tests {
 
     use super::*;
     use crate::config::RouterQueueDepthByMissingIslTier;
-    use crate::protocols::{RouterBackpressureReason, WorkerSelectionResult, WorkerWithDpRank};
+    use crate::protocols::{
+        ActiveLoad, ActiveSequenceEvent, RouterBackpressureReason, WorkerSelectionResult,
+        WorkerWithDpRank,
+    };
     use crate::scheduling::types::KvSchedulerError;
-    use crate::sequences::ActiveSequencesMultiWorker;
+    use crate::sequences::{ActiveSequencesMultiWorker, SequencePublisher};
     use crate::test_utils::{NoopSequencePublisher, SimpleWorkerConfig};
     use crate::{DefaultWorkerSelector, WorkerSelector};
 
@@ -767,6 +801,28 @@ mod tests {
         ) -> anyhow::Result<Duration> {
             Ok(self.duration)
         }
+    }
+
+    type SchedulingResponseReceiver =
+        tokio::sync::oneshot::Receiver<Result<SchedulingResponse, KvSchedulerError>>;
+
+    struct DropResponseOnLoadPublisher {
+        response_rx: Arc<StdMutex<Option<SchedulingResponseReceiver>>>,
+    }
+
+    impl SequencePublisher for DropResponseOnLoadPublisher {
+        fn publish_event(
+            &self,
+            _event: &ActiveSequenceEvent,
+        ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send {
+            std::future::ready(Ok(()))
+        }
+
+        fn publish_load(&self, _load: ActiveLoad) {
+            self.response_rx.lock().unwrap().take();
+        }
+
+        fn observe_load(&self, _: &WorkerWithDpRank, _: &str, _: usize, _: usize) {}
     }
 
     #[derive(Default)]
@@ -1223,6 +1279,71 @@ mod tests {
             resp_tx: Some(tx),
         };
         (req, rx)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cancelled_pending_request_is_not_booked() {
+        let isl = 512;
+        let (queue, slots) = make_queue(1, 16, isl, Some(0.0));
+
+        let (first, first_rx) = make_request("first", isl);
+        queue.enqueue(first).await;
+        first_rx
+            .await
+            .expect("first response sender dropped")
+            .expect("first request should be scheduled");
+
+        let (cancelled, cancelled_rx) = make_request("cancelled", isl);
+        queue.enqueue(cancelled).await;
+        assert_eq!(queue.pending_count(), 1);
+        drop(cancelled_rx);
+
+        slots.free(&"first".to_string(), decay_now()).unwrap();
+        queue.update().await;
+
+        assert_eq!(queue.pending_count(), 0);
+        slots.assert_completely_drained(decay_now());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_failed_response_delivery_rolls_back_booking() {
+        let isl = 512;
+        let response_rx = Arc::new(StdMutex::new(None));
+        let publisher = DropResponseOnLoadPublisher {
+            response_rx: Arc::clone(&response_rx),
+        };
+        let slots = Arc::new(ActiveSequencesMultiWorker::new(
+            publisher,
+            16,
+            HashMap::from([(0, (0, 1))]),
+            false,
+            0,
+            "test",
+        ));
+        let (_cfg_tx, cfg_rx) = watch::channel(HashMap::from([(
+            0,
+            SimpleWorkerConfig {
+                max_num_batched_tokens: Some(isl as u64),
+                ..Default::default()
+            },
+        )]));
+        let queue = SchedulerQueue::new(
+            Arc::clone(&slots),
+            cfg_rx,
+            None,
+            RouterQueueDepthTiers::unbounded_cap(),
+            16,
+            DefaultWorkerSelector::new(None, "test"),
+            FcfsPolicy,
+            None,
+        );
+
+        let (request, receiver) = make_request("delivery-race", isl);
+        *response_rx.lock().unwrap() = Some(receiver);
+        queue.enqueue(request).await;
+
+        assert!(response_rx.lock().unwrap().is_none());
+        slots.assert_completely_drained(decay_now());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -63,6 +63,9 @@ pub enum KvSchedulerError {
     #[error("endpoint subscriber shutdown")]
     SubscriberShutdown,
 
+    #[error("failed to book scheduler state: {0}")]
+    BookingFailed(String),
+
     #[error("failed to initialize event publisher: {0}")]
     InitFailed(String),
 }
@@ -248,13 +251,19 @@ impl SchedulingRequest {
         self.isl_tokens.div_ceil(block_size as usize) as u64
     }
 
-    pub fn respond(&mut self, result: Result<SchedulingResponse, KvSchedulerError>) {
+    pub(crate) fn response_is_closed(&self) -> bool {
+        self.resp_tx.as_ref().is_none_or(|tx| tx.is_closed())
+    }
+
+    pub fn respond(&mut self, result: Result<SchedulingResponse, KvSchedulerError>) -> bool {
         let Some(tx) = self.resp_tx.take() else {
             tracing::error!("respond called multiple times on same request");
-            return;
+            return false;
         };
         if tx.send(result).is_err() {
-            tracing::error!("failed to send response to requestor");
+            tracing::debug!("requestor dropped scheduling response");
+            return false;
         }
+        true
     }
 }

--- a/lib/kv-router/src/sequences/mod.rs
+++ b/lib/kv-router/src/sequences/mod.rs
@@ -6,6 +6,7 @@ pub mod multi_worker;
 mod prefill_tracker;
 mod prompt_membership_trie;
 mod prompt_registry;
+mod replica_sync;
 mod request_maps;
 pub mod single;
 mod topology;

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -15,6 +15,9 @@ use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -55,6 +58,13 @@ pub trait SequencePublisher: Send + Sync {
     /// Fire-and-forget publish of an [`ActiveLoad`] metric payload.
     fn publish_load(&self, load: ActiveLoad);
 
+    /// Fire-and-forget publish of a batch of [`ActiveLoad`] metric payloads.
+    fn publish_load_batch(&self, loads: Vec<ActiveLoad>) {
+        for load in loads {
+            self.publish_load(load);
+        }
+    }
+
     /// Record per-worker load in Prometheus gauges.
     fn observe_load(
         &self,
@@ -71,6 +81,14 @@ pub trait SequenceSubscriber: Send {
     fn next_event(
         &mut self,
     ) -> impl Future<Output = Option<anyhow::Result<ActiveSequenceEvent>>> + Send;
+
+    /// Poll for an event that is already ready without waiting.
+    fn poll_next_event(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
+        Poll::Pending
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -117,13 +135,15 @@ pub struct SequenceRequest {
 /// Generic over `P: SequencePublisher` to decouple from runtime-specific event transport
 /// and metrics infrastructure.
 pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
-    workers: RwLock<WorkerTable>,
-    request_index: RequestIndex,
-    prompt_registry: PromptRegistry,
+    pub(super) workers: RwLock<WorkerTable>,
+    pub(super) request_index: RequestIndex,
+    pub(super) prompt_registry: PromptRegistry,
     block_size: usize,
-    router_id: u64,
-    publisher: Arc<P>,
+    pub(super) router_id: u64,
+    pub(super) publisher: Arc<P>,
     remote_state_updates: watch::Sender<()>,
+    #[cfg(test)]
+    remote_state_update_count: AtomicUsize,
     replica_sync: bool,
     worker_type: &'static str,
 }
@@ -153,6 +173,8 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             router_id,
             publisher: Arc::new(publisher),
             remote_state_updates,
+            #[cfg(test)]
+            remote_state_update_count: AtomicUsize::new(0),
             replica_sync,
             worker_type,
         }
@@ -211,21 +233,29 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         load: WorkerLoadSnapshot,
         decay_now: Instant,
     ) {
+        let active_load = self.observe_worker_load_snapshot(worker, load, decay_now);
+        self.publisher.publish_load(active_load);
+    }
+
+    pub(super) fn observe_worker_load_snapshot(
+        &self,
+        worker: WorkerWithDpRank,
+        load: WorkerLoadSnapshot,
+        decay_now: Instant,
+    ) -> ActiveLoad {
         let active_blocks = load.active_blocks;
         let active_tokens = load.active_tokens(decay_now);
 
         self.publisher
             .observe_load(&worker, self.worker_type, active_blocks, active_tokens);
 
-        let active_load = ActiveLoad {
+        ActiveLoad {
             worker_id: worker.worker_id,
             dp_rank: worker.dp_rank,
             active_decode_blocks: Some(active_blocks as u64),
             active_prefill_tokens: Some(active_tokens as u64),
             kv_used_blocks: None,
-        };
-
-        self.publisher.publish_load(active_load);
+        }
     }
 
     fn spawn_publish_event(&self, event: ActiveSequenceEvent) {
@@ -255,151 +285,16 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.remote_state_updates.subscribe()
     }
 
-    /// Spawn a background task that subscribes to replica-sync events from peer routers
-    /// and applies them to the local state.
-    pub fn start_replica_sync<S: SequenceSubscriber + 'static>(
-        self: &Arc<Self>,
-        subscriber: S,
-        cancel_token: CancellationToken,
-    ) {
-        let this = Arc::clone(self);
-        tokio::spawn(async move {
-            if let Err(e) = this.run_replica_sync(subscriber, cancel_token).await {
-                tracing::error!("Error in active sequences events subscription: {}", e);
-            }
-        });
+    pub(super) fn notify_remote_state_update(&self) {
+        #[cfg(test)]
+        self.remote_state_update_count
+            .fetch_add(1, Ordering::Relaxed);
+        let _ = self.remote_state_updates.send(());
     }
 
-    async fn run_replica_sync<S: SequenceSubscriber>(
-        &self,
-        mut subscriber: S,
-        cancel_token: CancellationToken,
-    ) -> anyhow::Result<()> {
-        loop {
-            tokio::select! {
-                result = subscriber.next_event() => {
-                    let Some(result) = result else {
-                        break;
-                    };
-
-                    let Ok(event) = result else {
-                        tracing::error!(
-                            "Error receiving active sequence event: {}",
-                            result.unwrap_err()
-                        );
-                        continue;
-                    };
-
-                    if event.router_id == self.router_id {
-                        continue;
-                    }
-
-                    // TODO: ActiveSequenceEvent does not carry prompt-load decay timestamps yet.
-                    // Peer routers still approximate decay anchoring with local receive time.
-                    let decay_now = Instant::now();
-                    let mut remote_capacity_changed = false;
-                    // TODO: Extract a reusable single-event apply method with structured errors
-                    // and lazy or strict worker admission. Native sync assumes discovery plus lazy
-                    // registration; standalone transports must reject stale adds after removal.
-                    match &event.data {
-                        ActiveSequenceEventData::AddRequest {
-                            token_sequence,
-                            track_prefill_tokens,
-                            expected_output_tokens,
-                            prefill_load_hint,
-                        } => {
-                            self.ensure_worker_registered(event.worker);
-                            let table = self.workers.read();
-                            if let Some(&idx) = table.index.get(&event.worker) {
-                                self.request_index.set_request(
-                                    event.request_id.clone(),
-                                    event.worker,
-                                    event.lora_name.clone(),
-                                );
-                                let (expired_request_ids, load) = {
-                                    let slot = &table.slots[idx];
-                                    let mut seq = slot.sequences.write();
-                                    let outcome = seq.add_request_with_prefill_tracking(
-                                        event.request_id.clone(),
-                                        token_sequence.clone(),
-                                        *expected_output_tokens,
-                                        *track_prefill_tokens,
-                                        *prefill_load_hint,
-                                        decay_now,
-                                    );
-                                    let load = seq.worker_load_snapshot();
-                                    self.prompt_registry.apply_membership_delta_and_load(
-                                        event.worker,
-                                        &slot.trie_lookup,
-                                        outcome.membership_delta,
-                                        load,
-                                    );
-                                    (outcome.expired_request_ids, load)
-                                };
-                                drop(table);
-                                self.request_index.remove_requests(expired_request_ids.iter());
-                                self.publish_worker_load_snapshot(event.worker, load, decay_now);
-                                continue;
-                            } else {
-                                tracing::warn!(
-                                    "Worker {:?} not found, cannot process AddRequest",
-                                    event.worker
-                                );
-                            }
-                        }
-                        ActiveSequenceEventData::Free => {
-                            if let Some(worker) = self.request_index.remove_request(&event.request_id) {
-                                let table = self.workers.read();
-                                if let Some(&idx) = table.index.get(&worker) {
-                                    let load = {
-                                        let slot = &table.slots[idx];
-                                        let mut seq = slot.sequences.write();
-                                        let delta = seq.free(&event.request_id, decay_now);
-                                        let load = seq.worker_load_snapshot();
-                                        self.prompt_registry.apply_membership_delta_and_load(
-                                            worker,
-                                            &slot.trie_lookup,
-                                            delta,
-                                            load,
-                                        );
-                                        load
-                                    };
-                                    drop(table);
-                                    self.publish_worker_load_snapshot(worker, load, decay_now);
-                                    remote_capacity_changed = true;
-                                }
-                            }
-                        }
-                        ActiveSequenceEventData::MarkPrefillCompleted => {
-                            let worker = self.request_index.worker_for(&event.request_id);
-                            if let Some(worker) = worker {
-                                let table = self.workers.read();
-                                if let Some(&idx) = table.index.get(&worker) {
-                                    {
-                                        let mut seq = table.slots[idx].sequences.write();
-                                        seq.mark_prefill_completed(&event.request_id, decay_now);
-                                        let load = seq.worker_load_snapshot();
-                                        self.prompt_registry.replace_worker_load_state(worker, load);
-                                    }
-                                    drop(table);
-                                    remote_capacity_changed = true;
-                                }
-                            }
-                        }
-                    }
-
-                    if remote_capacity_changed {
-                        let _ = self.remote_state_updates.send(());
-                    }
-                }
-                _ = cancel_token.cancelled() => {
-                    tracing::debug!("Subscription task cancelled");
-                    break;
-                }
-            }
-        }
-
-        Ok(())
+    #[cfg(test)]
+    fn remote_state_update_count(&self) -> usize {
+        self.remote_state_update_count.load(Ordering::Relaxed)
     }
 
     /// Register externally-provided workers (e.g. from EPP) in the slot tracker,
@@ -749,7 +644,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         });
     }
 
-    fn ensure_worker_registered(&self, worker: WorkerWithDpRank) {
+    pub(super) fn ensure_worker_registered(&self, worker: WorkerWithDpRank) {
         if self.workers.read().index.contains_key(&worker) {
             return;
         }
@@ -980,9 +875,11 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 mod tests {
     use std::collections::{HashMap, VecDeque};
     use std::future::{self, Future};
+    use std::sync::Mutex;
     use std::time::Duration;
 
     use rustc_hash::FxHashMap;
+    use tokio::sync::mpsc;
 
     use super::*;
     use crate::protocols::{
@@ -1111,6 +1008,170 @@ mod tests {
             &mut self,
         ) -> impl Future<Output = Option<anyhow::Result<ActiveSequenceEvent>>> + Send {
             future::ready(self.events.pop_front())
+        }
+
+        fn poll_next_event(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
+            Poll::Ready(self.events.pop_front())
+        }
+    }
+
+    struct ChannelSubscriber {
+        rx: mpsc::UnboundedReceiver<anyhow::Result<ActiveSequenceEvent>>,
+    }
+
+    impl SequenceSubscriber for ChannelSubscriber {
+        async fn next_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
+            self.rx.recv().await
+        }
+
+        fn poll_next_event(
+            &mut self,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
+            self.rx.poll_recv(cx)
+        }
+    }
+
+    struct CancelOnPollSubscriber {
+        event: Option<anyhow::Result<ActiveSequenceEvent>>,
+        cancel_token: CancellationToken,
+    }
+
+    impl SequenceSubscriber for CancelOnPollSubscriber {
+        fn next_event(
+            &mut self,
+        ) -> impl Future<Output = Option<anyhow::Result<ActiveSequenceEvent>>> + Send {
+            future::ready(self.event.take())
+        }
+
+        fn poll_next_event(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
+            self.cancel_token.cancel();
+            Poll::Pending
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingPublisherState {
+        single_loads: Mutex<Vec<ActiveLoad>>,
+        load_batches: Mutex<Vec<Vec<ActiveLoad>>>,
+        observations: Mutex<Vec<(WorkerWithDpRank, usize, usize)>>,
+    }
+
+    impl RecordingPublisherState {
+        fn load_batches(&self) -> Vec<Vec<ActiveLoad>> {
+            self.load_batches.lock().unwrap().clone()
+        }
+
+        fn clear(&self) {
+            self.single_loads.lock().unwrap().clear();
+            self.load_batches.lock().unwrap().clear();
+            self.observations.lock().unwrap().clear();
+        }
+    }
+
+    struct RecordingPublisher {
+        state: Arc<RecordingPublisherState>,
+    }
+
+    impl SequencePublisher for RecordingPublisher {
+        fn publish_event(
+            &self,
+            _event: &ActiveSequenceEvent,
+        ) -> impl Future<Output = anyhow::Result<()>> + Send {
+            future::ready(Ok(()))
+        }
+
+        fn publish_load(&self, load: ActiveLoad) {
+            self.state.single_loads.lock().unwrap().push(load);
+        }
+
+        fn publish_load_batch(&self, loads: Vec<ActiveLoad>) {
+            self.state.load_batches.lock().unwrap().push(loads);
+        }
+
+        fn observe_load(
+            &self,
+            worker: &WorkerWithDpRank,
+            _worker_type: &str,
+            blocks: usize,
+            tokens: usize,
+        ) {
+            self.state
+                .observations
+                .lock()
+                .unwrap()
+                .push((*worker, blocks, tokens));
+        }
+    }
+
+    fn make_recording_sequences(
+        workers: HashMap<u64, (u32, u32)>,
+    ) -> (
+        ActiveSequencesMultiWorker<RecordingPublisher>,
+        Arc<RecordingPublisherState>,
+    ) {
+        let state = Arc::new(RecordingPublisherState::default());
+        let sequences = ActiveSequencesMultiWorker::new(
+            RecordingPublisher {
+                state: Arc::clone(&state),
+            },
+            4,
+            workers,
+            true,
+            0,
+            "test",
+        );
+        (sequences, state)
+    }
+
+    fn replica_add(
+        request_id: impl Into<String>,
+        worker: WorkerWithDpRank,
+        token_sequence: Vec<SequenceHash>,
+    ) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker,
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(token_sequence),
+                track_prefill_tokens: true,
+                expected_output_tokens: None,
+                prefill_load_hint: tracking_hint(12),
+            },
+            router_id: 99,
+            lora_name: None,
+        }
+    }
+
+    fn replica_free(
+        request_id: impl Into<String>,
+        payload_worker: WorkerWithDpRank,
+    ) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: payload_worker,
+            data: ActiveSequenceEventData::Free,
+            router_id: 99,
+            lora_name: None,
+        }
+    }
+
+    fn replica_mark(
+        request_id: impl Into<String>,
+        payload_worker: WorkerWithDpRank,
+    ) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: payload_worker,
+            data: ActiveSequenceEventData::MarkPrefillCompleted,
+            router_id: 99,
+            lora_name: None,
         }
     }
 
@@ -1586,6 +1647,222 @@ mod tests {
             Instant::now(),
         );
         assert_eq!(actual, expected);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_coalesces_latest_load_wake_and_cleanup() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        let subscriber = VecSubscriber {
+            events: VecDeque::from(vec![
+                Ok(replica_add("req-1", worker, vec![1, 2, 3])),
+                Ok(replica_add("req-2", worker, vec![4, 5, 6])),
+                Ok(replica_mark("req-2", worker)),
+                Ok(replica_free("req-1", worker)),
+            ]),
+        };
+
+        sequences
+            .run_replica_sync(subscriber, CancellationToken::new())
+            .await
+            .unwrap();
+
+        let batches = publisher.load_batches();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(batches[0][0].worker_id, worker.worker_id);
+        assert_eq!(batches[0][0].dp_rank, worker.dp_rank);
+        assert_eq!(batches[0][0].active_decode_blocks, Some(3));
+        assert_eq!(batches[0][0].active_prefill_tokens, Some(0));
+        assert_eq!(sequences.remote_state_update_count(), 1);
+        assert_eq!(sequences.prompt_registry.cleanup_attempts(), 1);
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-2".to_string()),
+            Some(worker)
+        );
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-1".to_string()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn replica_sync_mark_only_batch_does_not_publish_load() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(replica_add("req-1", worker, vec![1, 2, 3]))]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        publisher.clear();
+        let wake_count_before = sequences.remote_state_update_count();
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![
+                        Ok(replica_mark("req-1", worker)),
+                        Ok(replica_mark("req-1", worker)),
+                    ]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(publisher.load_batches().is_empty());
+        assert_eq!(sequences.remote_state_update_count(), wake_count_before + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_free_uses_canonical_worker_for_collapsed_load() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let wrong_payload_worker = WorkerWithDpRank::new(2, 0);
+        let (sequences, publisher) = make_recording_sequences(HashMap::from([
+            (1_u64, (0_u32, 1_u32)),
+            (2_u64, (0_u32, 1_u32)),
+        ]));
+        let subscriber = VecSubscriber {
+            events: VecDeque::from(vec![
+                Ok(replica_add("req-1", worker, vec![1, 2, 3])),
+                Ok(replica_free("req-1", wrong_payload_worker)),
+            ]),
+        };
+
+        sequences
+            .run_replica_sync(subscriber, CancellationToken::new())
+            .await
+            .unwrap();
+
+        let batches = publisher.load_batches();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(batches[0][0].worker_id, worker.worker_id);
+        assert_eq!(batches[0][0].dp_rank, worker.dp_rank);
+        assert_eq!(batches[0][0].active_decode_blocks, Some(0));
+        assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(0));
+        assert_eq!(
+            sequences
+                .active_blocks()
+                .get(&wrong_payload_worker)
+                .copied(),
+            Some(0)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_batch_cap_splits_deferred_side_effects() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        let events = (0..300)
+            .map(|i| Ok(replica_add(format!("req-{i}"), worker, vec![i])))
+            .collect();
+
+        sequences
+            .run_replica_sync(VecSubscriber { events }, CancellationToken::new())
+            .await
+            .unwrap();
+
+        let batches = publisher.load_batches();
+        assert_eq!(batches.len(), 2);
+        assert!(batches.iter().all(|batch| batch.len() == 1));
+        assert_eq!(sequences.prompt_registry.cleanup_attempts(), 2);
+        assert_eq!(sequences.remote_state_update_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn replica_sync_flushes_sparse_event_without_waiting_for_another() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let state = Arc::new(RecordingPublisherState::default());
+        let sequences = Arc::new(ActiveSequencesMultiWorker::new(
+            RecordingPublisher {
+                state: Arc::clone(&state),
+            },
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+        ));
+        let (tx, rx) = mpsc::unbounded_channel();
+        let cancel_token = CancellationToken::new();
+        sequences.start_replica_sync(ChannelSubscriber { rx }, cancel_token.clone());
+
+        tx.send(Ok(replica_add("req-1", worker, vec![1, 2, 3])))
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_millis(250), async {
+            loop {
+                if state.load_batches.lock().unwrap().len() == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn replica_sync_receive_error_flushes_applied_prefix() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        let subscriber = VecSubscriber {
+            events: VecDeque::from(vec![
+                Ok(replica_add("req-1", worker, vec![1, 2, 3])),
+                Err(anyhow::anyhow!("synthetic receive error")),
+            ]),
+        };
+
+        sequences
+            .run_replica_sync(subscriber, CancellationToken::new())
+            .await
+            .unwrap();
+
+        let batches = publisher.load_batches();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-1".to_string()),
+            Some(worker)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_cancellation_flushes_applied_prefix() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        let cancel_token = CancellationToken::new();
+        let subscriber = CancelOnPollSubscriber {
+            event: Some(Ok(replica_add("req-1", worker, vec![1, 2, 3]))),
+            cancel_token: cancel_token.clone(),
+        };
+
+        sequences
+            .run_replica_sync(subscriber, cancel_token)
+            .await
+            .unwrap();
+
+        let batches = publisher.load_batches();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-1".to_string()),
+            Some(worker)
+        );
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -8,6 +8,8 @@ use rustc_hash::FxHashSet;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::collections::HashMap;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::time::Instant;
 
 use super::PrefillTokenDeltas;
@@ -45,6 +47,8 @@ pub(super) struct PromptRegistry {
     // never existed atomically and make a suboptimal routing choice.
     membership: PromptMembershipTrie,
     loads: DashMap<WorkerWithDpRank, WorkerLoadSnapshot, FxBuildHasher>,
+    #[cfg(test)]
+    cleanup_attempts: AtomicUsize,
 }
 
 impl Default for PromptRegistry {
@@ -52,6 +56,8 @@ impl Default for PromptRegistry {
         Self {
             membership: PromptMembershipTrie::new(),
             loads: DashMap::with_hasher(FxBuildHasher),
+            #[cfg(test)]
+            cleanup_attempts: AtomicUsize::new(0),
         }
     }
 }
@@ -80,6 +86,17 @@ impl PromptRegistry {
         delta: PromptMembershipDelta,
         load: WorkerLoadSnapshot,
     ) {
+        self.apply_membership_delta_and_load_without_cleanup(worker, lookup, delta, load);
+        self.maybe_cleanup();
+    }
+
+    pub(super) fn apply_membership_delta_and_load_without_cleanup(
+        &self,
+        worker: WorkerWithDpRank,
+        lookup: &Arc<parking_lot::RwLock<WorkerLookup>>,
+        delta: PromptMembershipDelta,
+        load: WorkerLoadSnapshot,
+    ) {
         for remove in delta.removes {
             self.membership.remove_chain(worker, lookup, &remove.hashes);
         }
@@ -88,7 +105,17 @@ impl PromptRegistry {
                 .store_chain(worker, lookup, store.parent, &store.hashes);
         }
         self.loads.insert(worker, load);
+    }
+
+    pub(super) fn maybe_cleanup(&self) {
+        #[cfg(test)]
+        self.cleanup_attempts.fetch_add(1, Ordering::Relaxed);
         self.membership.maybe_cleanup();
+    }
+
+    #[cfg(test)]
+    pub(super) fn cleanup_attempts(&self) -> usize {
+        self.cleanup_attempts.load(Ordering::Relaxed)
     }
 
     pub(super) fn apply_topology_change(&self, change: WorkerTopologyChange) {

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::poll_fn;
+use std::sync::Arc;
+use std::task::Poll;
+
+use rustc_hash::FxHashMap;
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+use super::multi_worker::{ActiveSequencesMultiWorker, SequencePublisher, SequenceSubscriber};
+use super::prompt_registry::WorkerLoadSnapshot;
+use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
+
+const MAX_REPLICA_BATCH_EVENTS: usize = 256;
+const MAX_REPLICA_BATCH_DURATION: Duration = Duration::from_millis(1);
+
+#[derive(Default)]
+struct ReplicaBatchEffects {
+    worker_loads: FxHashMap<WorkerWithDpRank, PendingLoadPublication>,
+    wake_scheduler: bool,
+    cleanup_prompt_trie: bool,
+}
+
+struct PendingLoadPublication {
+    latest_load: WorkerLoadSnapshot,
+    publish: bool,
+}
+
+impl ReplicaBatchEffects {
+    fn record_worker_load(
+        &mut self,
+        worker: WorkerWithDpRank,
+        load: WorkerLoadSnapshot,
+        publish: bool,
+    ) {
+        self.worker_loads
+            .entry(worker)
+            .and_modify(|pending| {
+                pending.latest_load = load;
+                pending.publish |= publish;
+            })
+            .or_insert(PendingLoadPublication {
+                latest_load: load,
+                publish,
+            });
+    }
+}
+
+impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
+    /// Spawn a background task that subscribes to replica-sync events from peer routers
+    /// and applies them to the local state.
+    pub fn start_replica_sync<S: SequenceSubscriber + 'static>(
+        self: &Arc<Self>,
+        subscriber: S,
+        cancel_token: CancellationToken,
+    ) {
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(error) = this.run_replica_sync(subscriber, cancel_token).await {
+                tracing::error!("Error in active sequences events subscription: {error}");
+            }
+        });
+    }
+
+    pub(super) async fn run_replica_sync<S: SequenceSubscriber>(
+        &self,
+        mut subscriber: S,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<()> {
+        let mut effects = ReplicaBatchEffects::default();
+
+        loop {
+            let result = tokio::select! {
+                result = subscriber.next_event() => result,
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Subscription task cancelled");
+                    break;
+                }
+            };
+
+            let Some(result) = result else {
+                break;
+            };
+            let Ok(event) = result else {
+                tracing::error!(
+                    "Error receiving active sequence event: {}",
+                    result.unwrap_err()
+                );
+                continue;
+            };
+
+            let batch_start = Instant::now();
+            let mut batch_events = 0;
+            let mut exit_after_flush = false;
+            let mut yield_after_flush = false;
+            let mut next_event = Some(event);
+
+            loop {
+                let event = next_event
+                    .take()
+                    .expect("replica batch event must be present");
+                self.apply_replica_event(event, &mut effects);
+                batch_events += 1;
+
+                if cancel_token.is_cancelled() {
+                    exit_after_flush = true;
+                    break;
+                }
+
+                if batch_events >= MAX_REPLICA_BATCH_EVENTS
+                    || batch_start.elapsed() >= MAX_REPLICA_BATCH_DURATION
+                {
+                    yield_after_flush = true;
+                    break;
+                }
+
+                match poll_fn(|cx| Poll::Ready(subscriber.poll_next_event(cx))).await {
+                    Poll::Ready(Some(Ok(event))) => next_event = Some(event),
+                    Poll::Ready(Some(Err(error))) => {
+                        tracing::error!("Error receiving active sequence event: {error}");
+                        break;
+                    }
+                    Poll::Ready(None) => {
+                        exit_after_flush = true;
+                        break;
+                    }
+                    Poll::Pending => break,
+                }
+            }
+
+            self.flush_replica_batch_effects(&mut effects);
+
+            if exit_after_flush {
+                break;
+            }
+            if yield_after_flush {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_replica_event(&self, event: ActiveSequenceEvent, effects: &mut ReplicaBatchEffects) {
+        let ActiveSequenceEvent {
+            request_id,
+            worker: event_worker,
+            data,
+            router_id,
+            lora_name,
+        } = event;
+
+        if router_id == self.router_id {
+            return;
+        }
+
+        // ActiveSequenceEvent does not carry prompt-load decay timestamps yet.
+        // Peer routers still approximate decay anchoring with local receive time.
+        let decay_now = Instant::now();
+
+        match data {
+            ActiveSequenceEventData::AddRequest {
+                token_sequence,
+                track_prefill_tokens,
+                expected_output_tokens,
+                prefill_load_hint,
+            } => {
+                self.ensure_worker_registered(event_worker);
+                let table = self.workers.read();
+                let Some(&idx) = table.index.get(&event_worker) else {
+                    tracing::warn!(
+                        "Worker {:?} not found, cannot process AddRequest",
+                        event_worker
+                    );
+                    return;
+                };
+
+                self.request_index
+                    .set_request(request_id.clone(), event_worker, lora_name);
+                let (expired_request_ids, load) = {
+                    let slot = &table.slots[idx];
+                    let mut seq = slot.sequences.write();
+                    let outcome = seq.add_request_with_prefill_tracking(
+                        request_id,
+                        token_sequence,
+                        expected_output_tokens,
+                        track_prefill_tokens,
+                        prefill_load_hint,
+                        decay_now,
+                    );
+                    let load = seq.worker_load_snapshot();
+                    self.prompt_registry
+                        .apply_membership_delta_and_load_without_cleanup(
+                            event_worker,
+                            &slot.trie_lookup,
+                            outcome.membership_delta,
+                            load,
+                        );
+                    (outcome.expired_request_ids, load)
+                };
+                drop(table);
+                self.request_index
+                    .remove_requests(expired_request_ids.iter());
+                effects.record_worker_load(event_worker, load, true);
+                effects.cleanup_prompt_trie = true;
+            }
+            ActiveSequenceEventData::Free => {
+                let Some(worker) = self.request_index.remove_request(&request_id) else {
+                    return;
+                };
+                let table = self.workers.read();
+                let Some(&idx) = table.index.get(&worker) else {
+                    return;
+                };
+                let load = {
+                    let slot = &table.slots[idx];
+                    let mut seq = slot.sequences.write();
+                    let delta = seq.free(&request_id, decay_now);
+                    let load = seq.worker_load_snapshot();
+                    self.prompt_registry
+                        .apply_membership_delta_and_load_without_cleanup(
+                            worker,
+                            &slot.trie_lookup,
+                            delta,
+                            load,
+                        );
+                    load
+                };
+                drop(table);
+                effects.record_worker_load(worker, load, true);
+                effects.wake_scheduler = true;
+                effects.cleanup_prompt_trie = true;
+            }
+            ActiveSequenceEventData::MarkPrefillCompleted => {
+                let Some(worker) = self.request_index.worker_for(&request_id) else {
+                    return;
+                };
+                let table = self.workers.read();
+                let Some(&idx) = table.index.get(&worker) else {
+                    return;
+                };
+                let load = {
+                    let mut seq = table.slots[idx].sequences.write();
+                    seq.mark_prefill_completed(&request_id, decay_now);
+                    let load = seq.worker_load_snapshot();
+                    self.prompt_registry.replace_worker_load_state(worker, load);
+                    load
+                };
+                drop(table);
+                effects.record_worker_load(worker, load, false);
+                effects.wake_scheduler = true;
+            }
+        }
+    }
+
+    fn flush_replica_batch_effects(&self, effects: &mut ReplicaBatchEffects) {
+        let decay_now = Instant::now();
+        let mut active_loads = Vec::with_capacity(effects.worker_loads.len());
+        for (worker, pending) in effects.worker_loads.drain() {
+            if pending.publish {
+                active_loads.push(self.observe_worker_load_snapshot(
+                    worker,
+                    pending.latest_load,
+                    decay_now,
+                ));
+            }
+        }
+        if !active_loads.is_empty() {
+            self.publisher.publish_load_batch(active_loads);
+        }
+
+        if std::mem::take(&mut effects.wake_scheduler) {
+            self.notify_remote_state_update();
+        }
+        if std::mem::take(&mut effects.cleanup_prompt_trie) {
+            self.prompt_registry.maybe_cleanup();
+        }
+    }
+}

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -1,22 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, future::Future, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_kv_router::{
-    RouterConfigOverride,
-    indexer::RoutingDecisionHashes,
-    protocols::{BlockExtraInfo, RoutingConstraints, TokensWithHashes, WorkerId, WorkerWithDpRank},
-    scheduling::{RoutingEligibility, WorkerEligibilityError},
-};
+use dynamo_kv_router::protocols::{TokensWithHashes, WorkerWithDpRank};
 use dynamo_runtime::{
-    dynamo_nvtx_range,
-    error::{DynamoError, ErrorType as DynamoErrorType},
     metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
     pipeline::{
-        AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
-        ResponseStream, SingleIn, async_trait,
+        AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, PushRouter, ResponseStream,
+        SingleIn, async_trait,
     },
     protocols::annotated::Annotated,
 };
@@ -26,111 +19,25 @@ use tracing::Instrument;
 
 use crate::{
     kv_router::{
-        FindBestMatchOutcome, KvRouter,
-        metrics::RouterRequestMetrics,
-        sticky::coordinator::{StickySessionCoordinator, sticky_allowed_for_phase},
+        KvRouter, metrics::RouterRequestMetrics, sticky::coordinator::StickySessionCoordinator,
     },
     preprocessor::PreprocessedRequest,
-    protocols::{
-        TokenIdType,
-        common::{llm_backend::LLMEngineOutput, preprocessor::RoutingHints, timing::RequestPhase},
-    },
+    protocols::common::{llm_backend::LLMEngineOutput, timing::RequestPhase},
 };
 
+mod cancellation;
 mod request_guard;
+mod selection;
 
+use cancellation::{cancel_on_stop, cancelled_error};
 use request_guard::RequestGuard;
+use selection::{RoutingRequestParts, WorkerSelection};
 
 pub struct KvPushRouter {
     inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     pub chooser: Arc<KvRouter>,
     /// Sticky session routing. Lazily activated when requests carry session_control.
     pub(super) sticky: Arc<StickySessionCoordinator>,
-}
-
-/// Result of worker selection containing instance ID, dp_rank, and overlap amount.
-struct WorkerSelection {
-    instance_id: u64,
-    dp_rank: u32,
-    overlap_amount: u32,
-    effective_overlap_blocks: f64,
-    cached_tokens: usize,
-    routing_hashes: Option<RoutingDecisionHashes>,
-    /// Whether the scheduler is tracking this request (add_request or
-    /// find_best_match_details with update_states=true was called).
-    scheduler_tracked: bool,
-}
-
-// NOTE: In KV router mode, worker selection is DP-rank precise. A pinned
-// worker without a concrete dp_rank is invalid unless the worker owns exactly
-// one rank and can be resolved unambiguously. Rank 0 is a real rank, not an
-// unset sentinel. Do not coerce unresolved ranks to 0.
-fn resolve_pinned_worker_rank(
-    worker_id: WorkerId,
-    requested_dp_rank: Option<u32>,
-    unique_dp_rank: Option<u32>,
-) -> Result<WorkerWithDpRank, Error> {
-    let Some(dp_rank) = requested_dp_rank.or(unique_dp_rank) else {
-        return Err(anyhow::anyhow!(
-            "Pinned worker {worker_id} requires an explicit dp_rank because it has multiple or unknown DP ranks"
-        ));
-    };
-
-    Ok(WorkerWithDpRank::new(worker_id, dp_rank))
-}
-
-#[derive(Clone, Copy)]
-struct RoutingRequestParts<'a> {
-    token_ids: &'a [TokenIdType],
-    block_mm_infos: Option<&'a [Option<BlockExtraInfo>]>,
-}
-
-impl<'a> RoutingRequestParts<'a> {
-    fn new(request: &'a PreprocessedRequest) -> Self {
-        let (token_ids, block_mm_infos) = request.block_mm_routing_info();
-        Self {
-            token_ids,
-            block_mm_infos,
-        }
-    }
-}
-
-fn cancelled_error(context_id: &str) -> Error {
-    DynamoError::builder()
-        .error_type(DynamoErrorType::Cancelled)
-        .message(format!("Request {context_id} was cancelled"))
-        .build()
-        .into()
-}
-
-async fn cancel_on_stop<T>(
-    context: &dyn AsyncEngineContext,
-    context_id: &str,
-    operation: impl Future<Output = T>,
-) -> Result<T, Error> {
-    tokio::pin!(operation);
-    tokio::select! {
-        biased;
-
-        // Keep completed ownership-bearing results so their normal cleanup can run.
-        result = &mut operation => Ok(result),
-        _ = context.stopped() => Err(cancelled_error(context_id)),
-    }
-}
-
-struct BestMatchArgs<'a> {
-    context_id: &'a str,
-    routing_parts: RoutingRequestParts<'a>,
-    router_config_override: Option<&'a RouterConfigOverride>,
-    update_states: bool,
-    return_routing_hashes: bool,
-    lora_name: Option<String>,
-    priority_jump: f64,
-    expected_output_tokens: Option<u32>,
-    pinned_worker: Option<WorkerWithDpRank>,
-    allowed_worker_ids: Option<HashSet<WorkerId>>,
-    routing_constraints: RoutingConstraints,
-    scheduler_tracked: bool,
 }
 
 impl KvPushRouter {
@@ -151,244 +58,6 @@ impl KvPushRouter {
             chooser,
             sticky,
         }
-    }
-
-    async fn select_best_match(&self, args: BestMatchArgs<'_>) -> Result<WorkerSelection, Error> {
-        let outcome = self
-            .chooser
-            .find_best_match_details(
-                Some(args.context_id),
-                args.routing_parts.token_ids,
-                args.routing_parts.block_mm_infos,
-                args.router_config_override,
-                args.update_states,
-                args.return_routing_hashes,
-                args.lora_name,
-                args.priority_jump,
-                args.expected_output_tokens,
-                args.pinned_worker,
-                args.allowed_worker_ids,
-                args.routing_constraints,
-            )
-            .await?;
-
-        match outcome {
-            FindBestMatchOutcome::Routed {
-                worker,
-                overlap_blocks,
-                effective_overlap_blocks,
-                cached_tokens,
-                routing_hashes,
-            } => Ok(WorkerSelection {
-                instance_id: worker.worker_id,
-                dp_rank: worker.dp_rank,
-                overlap_amount: overlap_blocks,
-                effective_overlap_blocks,
-                cached_tokens,
-                routing_hashes,
-                scheduler_tracked: args.scheduler_tracked,
-            }),
-            FindBestMatchOutcome::Backpressure {
-                reason,
-                queued_isl_tokens,
-                max_queued_isl_tokens,
-            } => Err(DynamoError::builder()
-                .error_type(DynamoErrorType::ResourceExhausted)
-                .message(format!(
-                    "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
-                ))
-                .build()
-                .into()),
-        }
-    }
-
-    /// Select a worker for the request, either using an exact phase-specific pin
-    /// or by finding the best KV overlap match.
-    async fn select_worker(
-        &self,
-        context_id: &str,
-        request: &PreprocessedRequest,
-        routing_parts: RoutingRequestParts<'_>,
-        phase: RequestPhase,
-        is_query_only: bool,
-        sticky_worker: Option<WorkerWithDpRank>,
-    ) -> Result<WorkerSelection, Error> {
-        let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
-        let routing = request.routing.as_ref();
-        let lora_name = routing.and_then(|r| r.lora_name.clone());
-        let priority_jump = routing.and_then(|r| r.priority_jump).unwrap_or(0.0);
-        let expected_output_tokens = routing.and_then(|r| r.expected_output_tokens);
-        let allowed_worker_ids = routing.and_then(|r| r.allowed_worker_ids.clone());
-        let return_routing_hashes =
-            !is_query_only && self.chooser.indexer().records_routing_decisions();
-        let routing_constraints = routing
-            .and_then(|r| r.routing_constraints.clone())
-            .unwrap_or_default();
-        let sticky_pin = sticky_worker.map(|worker| (worker.worker_id, Some(worker.dp_rank)));
-        let Some((pinned_worker_id, requested_dp_rank)) =
-            pinned_worker_hint(phase, routing).or(sticky_pin)
-        else {
-            let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
-            let selection = self
-                .select_best_match(BestMatchArgs {
-                    context_id,
-                    routing_parts,
-                    router_config_override: request.router_config_override.as_ref(),
-                    update_states: !is_query_only,
-                    return_routing_hashes,
-                    lora_name,
-                    priority_jump,
-                    expected_output_tokens,
-                    pinned_worker: None,
-                    allowed_worker_ids,
-                    routing_constraints: routing_constraints.clone(),
-                    scheduler_tracked: !is_query_only,
-                })
-                .await?;
-
-            if !is_query_only {
-                let total_blocks = routing_parts
-                    .token_ids
-                    .len()
-                    .div_ceil(self.chooser.block_size() as usize);
-                // tests/utils/router_logs.py parses the structured fields on this event.
-                tracing::debug!(
-                    request_id = %context_id,
-                    worker_id = selection.instance_id,
-                    dp_rank = selection.dp_rank,
-                    overlap_blocks = selection.overlap_amount,
-                    total_blocks = total_blocks,
-                    "[ROUTING] Best: worker_{} dp_rank={} with {}/{} blocks overlap",
-                    selection.instance_id,
-                    selection.dp_rank,
-                    selection.overlap_amount,
-                    total_blocks,
-                );
-            }
-
-            return Ok(selection);
-        };
-
-        let pinned_worker = resolve_pinned_worker_rank(
-            pinned_worker_id,
-            requested_dp_rank,
-            self.chooser.unique_dp_rank_for_worker(pinned_worker_id),
-        )?;
-        {
-            let configs = self.chooser.workers_with_configs.borrow();
-            let eligibility = RoutingEligibility::new(
-                allowed_worker_ids.as_ref(),
-                None,
-                Some(pinned_worker),
-                &routing_constraints,
-            );
-            if let Err(error) = eligibility.validate_worker_rank(&configs, pinned_worker) {
-                return Err(anyhow::anyhow!(
-                    "Pinned worker {} dp_rank {} is not eligible: {error}",
-                    pinned_worker.worker_id,
-                    pinned_worker.dp_rank
-                ));
-            }
-        }
-
-        tracing::debug!(
-            worker_id = pinned_worker.worker_id,
-            dp_rank = pinned_worker.dp_rank,
-            ?phase,
-            "Routing to specified worker"
-        );
-
-        self.select_best_match(BestMatchArgs {
-            context_id,
-            routing_parts,
-            router_config_override: request.router_config_override.as_ref(),
-            update_states: !is_query_only,
-            return_routing_hashes,
-            lora_name,
-            priority_jump,
-            expected_output_tokens,
-            pinned_worker: Some(pinned_worker),
-            allowed_worker_ids,
-            routing_constraints,
-            scheduler_tracked: !is_query_only,
-        })
-        .await
-    }
-
-    fn sticky_worker_ineligibility_for_phase(
-        &self,
-        request: &PreprocessedRequest,
-        phase: RequestPhase,
-        worker: WorkerWithDpRank,
-    ) -> Option<WorkerEligibilityError> {
-        let routing = request.routing.as_ref()?;
-        if !sticky_allowed_for_phase(phase, Some(routing)) {
-            return None;
-        }
-
-        let default_constraints = RoutingConstraints::default();
-        let routing_constraints = routing
-            .routing_constraints
-            .as_ref()
-            .unwrap_or(&default_constraints);
-        let configs = self.chooser.workers_with_configs.borrow();
-        let eligibility = RoutingEligibility::new(
-            routing.allowed_worker_ids.as_ref(),
-            None,
-            Some(worker),
-            routing_constraints,
-        );
-        eligibility.validate_worker_rank(&configs, worker).err()
-    }
-
-    pub(crate) fn unbind_ineligible_sticky_worker_for_phase(
-        &self,
-        context_id: &str,
-        request: &PreprocessedRequest,
-        phase: RequestPhase,
-        worker: WorkerWithDpRank,
-    ) -> bool {
-        let Some(reason) = self.sticky_worker_ineligibility_for_phase(request, phase, worker)
-        else {
-            return false;
-        };
-
-        let Some((session_id, _binding)) = self.sticky.unbind_for_phase(request, phase) else {
-            return false;
-        };
-        tracing::warn!(
-            request_id = %context_id,
-            %session_id,
-            worker_id = worker.worker_id,
-            dp_rank = worker.dp_rank,
-            reason = %reason,
-            "Sticky worker is no longer eligible; removing session affinity"
-        );
-        true
-    }
-
-    pub(crate) async fn validate_sticky_worker_for_phase(
-        &self,
-        context_id: &str,
-        request: &PreprocessedRequest,
-        phase: RequestPhase,
-        worker: WorkerWithDpRank,
-    ) -> Result<WorkerWithDpRank, Error> {
-        let routing_parts = RoutingRequestParts::new(request);
-        let selection = self
-            .select_worker(
-                context_id,
-                request,
-                routing_parts,
-                phase,
-                true,
-                Some(worker),
-            )
-            .await?;
-        Ok(WorkerWithDpRank::new(
-            selection.instance_id,
-            selection.dp_rank,
-        ))
     }
 }
 
@@ -697,35 +366,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
     }
 }
 
-/// Extract a phase-specific (worker_id, dp_rank) pin from routing hints.
-///
-/// Returns `Some((worker_id, optional_dp_rank))` when the request should be
-/// pinned to a particular worker, or `None` when the normal KV-overlap
-/// selection path should be used.
-fn pinned_worker_hint(
-    phase: RequestPhase,
-    routing: Option<&RoutingHints>,
-) -> Option<(u64, Option<u32>)> {
-    let routing = routing?;
-    match phase {
-        RequestPhase::Prefill => {
-            let worker_id = routing.prefill_worker_id.or(routing.backend_instance_id)?;
-            let dp_rank = routing.prefill_dp_rank.or(routing.dp_rank);
-            Some((worker_id, dp_rank))
-        }
-        RequestPhase::Decode => {
-            let worker_id = routing.decode_worker_id.or(routing.backend_instance_id)?;
-            let dp_rank = routing.dp_rank;
-            Some((worker_id, dp_rank))
-        }
-        RequestPhase::Aggregated => {
-            let worker_id = routing.backend_instance_id?;
-            let dp_rank = routing.dp_rank;
-            Some((worker_id, dp_rank))
-        }
-    }
-}
-
 /// A direct routing wrapper for `RouterMode::Direct`.
 ///
 /// This wraps a `PushRouter` and reads worker IDs from each request's routing hints,
@@ -768,149 +408,5 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         tracing::debug!(worker_id = worker_id, "Direct routing to specified worker");
 
         self.inner.direct(request, worker_id).await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        collections::{HashMap, HashSet},
-        future::Future,
-        pin::Pin,
-        sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
-        },
-        task::{Context, Poll},
-    };
-
-    use dynamo_kv_router::{
-        protocols::{RoutingConstraints, WorkerWithDpRank},
-        scheduling::{RoutingEligibility, WorkerEligibilityError},
-    };
-    use dynamo_runtime::{
-        error::{DynamoError, ErrorType},
-        pipeline::{AsyncEngineContext, context::Controller},
-    };
-
-    use super::{cancel_on_stop, pinned_worker_hint, resolve_pinned_worker_rank};
-    use crate::local_model::runtime_config::ModelRuntimeConfig;
-    use crate::protocols::common::{preprocessor::RoutingHints, timing::RequestPhase};
-
-    struct PendingUntilDropped(Arc<AtomicBool>);
-
-    impl Future for PendingUntilDropped {
-        type Output = ();
-
-        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-            Poll::Pending
-        }
-    }
-
-    impl Drop for PendingUntilDropped {
-        fn drop(&mut self) {
-            self.0.store(true, Ordering::SeqCst);
-        }
-    }
-
-    #[tokio::test]
-    async fn cancel_on_stop_drops_pending_operation() {
-        let context = Controller::new("cancelled-request".to_string());
-        context.stop();
-        let dropped = Arc::new(AtomicBool::new(false));
-
-        let error = cancel_on_stop(&context, context.id(), PendingUntilDropped(dropped.clone()))
-            .await
-            .unwrap_err();
-
-        let error = error
-            .downcast_ref::<DynamoError>()
-            .expect("cancellation should return DynamoError");
-        assert_eq!(error.error_type(), ErrorType::Cancelled);
-        assert!(dropped.load(Ordering::SeqCst));
-    }
-
-    #[test]
-    fn resolve_pinned_worker_rank_uses_explicit_rank_including_zero() {
-        let worker = resolve_pinned_worker_rank(7, Some(0), Some(3)).unwrap();
-        assert_eq!(worker.worker_id, 7);
-        assert_eq!(worker.dp_rank, 0);
-    }
-
-    #[test]
-    fn resolve_pinned_worker_rank_uses_unique_rank_when_unset() {
-        let worker = resolve_pinned_worker_rank(7, None, Some(3)).unwrap();
-        assert_eq!(worker.worker_id, 7);
-        assert_eq!(worker.dp_rank, 3);
-    }
-
-    #[test]
-    fn resolve_pinned_worker_rank_rejects_unresolved_rank() {
-        let error = resolve_pinned_worker_rank(7, None, None)
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("requires an explicit dp_rank"));
-    }
-
-    #[test]
-    fn pinned_worker_hint_prefill_uses_prefill_worker_before_backend() {
-        let routing = RoutingHints {
-            backend_instance_id: Some(1),
-            prefill_worker_id: Some(2),
-            dp_rank: Some(3),
-            prefill_dp_rank: Some(4),
-            ..Default::default()
-        };
-
-        let hint = pinned_worker_hint(RequestPhase::Prefill, Some(&routing));
-        assert_eq!(hint, Some((2, Some(4))));
-    }
-
-    #[test]
-    fn pinned_worker_hint_decode_uses_decode_worker_before_backend() {
-        let routing = RoutingHints {
-            backend_instance_id: Some(1),
-            decode_worker_id: Some(5),
-            dp_rank: Some(6),
-            ..Default::default()
-        };
-
-        let hint = pinned_worker_hint(RequestPhase::Decode, Some(&routing));
-        assert_eq!(hint, Some((5, Some(6))));
-    }
-
-    #[test]
-    fn pinned_worker_hint_aggregated_uses_backend_worker() {
-        let routing = RoutingHints {
-            backend_instance_id: Some(9),
-            dp_rank: Some(7),
-            ..Default::default()
-        };
-
-        let hint = pinned_worker_hint(RequestPhase::Aggregated, Some(&routing));
-        assert_eq!(hint, Some((9, Some(7))));
-    }
-
-    #[test]
-    fn sticky_validation_style_ignores_transient_overload() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let configs = HashMap::from([(7, ModelRuntimeConfig::default())]);
-        let constraints = RoutingConstraints::default();
-        let overloaded = HashSet::from([7]);
-        let scheduling_eligibility =
-            RoutingEligibility::new(None, Some(&overloaded), Some(worker), &constraints);
-        let sticky_eligibility = RoutingEligibility::new(None, None, Some(worker), &constraints);
-
-        assert_eq!(
-            scheduling_eligibility
-                .validate_worker_rank(&configs, worker)
-                .err(),
-            Some(WorkerEligibilityError::WorkerOverloaded { worker_id: 7 })
-        );
-        assert!(
-            sticky_eligibility
-                .validate_worker_rank(&configs, worker)
-                .is_ok()
-        );
     }
 }

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -330,8 +330,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         .await??;
         // direct() succeeded — mark dispatched so record_metrics() fires.
         // If direct() returned Err above, guard drops here with dispatched=false
-        // → RequestGuard::Drop fires → chooser.free() + deferred_close.execute()
-        //   but record_metrics() is suppressed (no backend work was done).
+        // and suppresses metrics; its nested RequestCleanup then frees scheduler
+        // state and executes the deferred close action.
         guard.mark_dispatched();
         let stream_context = response_stream.context();
         let context_for_monitoring = stream_context.clone();

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, future::Future, sync::Arc};
 
 use anyhow::Result;
 use dynamo_kv_router::{
@@ -13,10 +13,10 @@ use dynamo_kv_router::{
 use dynamo_runtime::{
     dynamo_nvtx_range,
     error::{DynamoError, ErrorType as DynamoErrorType},
-    metrics::frontend_perf::{STAGE_DISPATCH, STAGE_ROUTE, StageGuard},
+    metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
     pipeline::{
-        AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, PushRouter, ResponseStream,
-        SingleIn, async_trait,
+        AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
+        ResponseStream, SingleIn, async_trait,
     },
     protocols::annotated::Annotated,
 };
@@ -28,21 +28,18 @@ use crate::{
     kv_router::{
         FindBestMatchOutcome, KvRouter,
         metrics::RouterRequestMetrics,
-        sticky::{
-            coordinator::{StickySessionCoordinator, sticky_allowed_for_phase},
-            lifecycle::SessionCloseAction,
-        },
+        sticky::coordinator::{StickySessionCoordinator, sticky_allowed_for_phase},
     },
     preprocessor::PreprocessedRequest,
     protocols::{
         TokenIdType,
-        common::{
-            llm_backend::LLMEngineOutput,
-            preprocessor::RoutingHints,
-            timing::{RequestPhase, RequestTracker},
-        },
+        common::{llm_backend::LLMEngineOutput, preprocessor::RoutingHints, timing::RequestPhase},
     },
 };
+
+mod request_guard;
+
+use request_guard::RequestGuard;
 
 pub struct KvPushRouter {
     inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
@@ -98,6 +95,29 @@ impl<'a> RoutingRequestParts<'a> {
     }
 }
 
+fn cancelled_error(context_id: &str) -> Error {
+    DynamoError::builder()
+        .error_type(DynamoErrorType::Cancelled)
+        .message(format!("Request {context_id} was cancelled"))
+        .build()
+        .into()
+}
+
+async fn cancel_on_stop<T>(
+    context: &dyn AsyncEngineContext,
+    context_id: &str,
+    operation: impl Future<Output = T>,
+) -> Result<T, Error> {
+    tokio::pin!(operation);
+    tokio::select! {
+        biased;
+
+        // Keep completed ownership-bearing results so their normal cleanup can run.
+        result = &mut operation => Ok(result),
+        _ = context.stopped() => Err(cancelled_error(context_id)),
+    }
+}
+
 struct BestMatchArgs<'a> {
     context_id: &'a str,
     routing_parts: RoutingRequestParts<'a>,
@@ -111,201 +131,6 @@ struct BestMatchArgs<'a> {
     allowed_worker_ids: Option<HashSet<WorkerId>>,
     routing_constraints: RoutingConstraints,
     scheduler_tracked: bool,
-}
-
-/// Drop guard that manages the full lifecycle of a routed request:
-/// per-item tracking (prefill, first token, output blocks) and final cleanup (free + metrics).
-///
-/// In the happy path, `finish().await` runs cleanup inline in the async context.
-/// If the stream is dropped early (e.g., client disconnect, consumer drop), the
-/// `Drop` impl fires and spawns a task to call `free()`.
-struct RequestGuard {
-    chooser: Arc<KvRouter>,
-    scheduler_tracked: bool,
-    context_id: String,
-    tracker: Option<Arc<RequestTracker>>,
-    request_metrics: Arc<RouterRequestMetrics>,
-    cumulative_osl: usize,
-    metrics_recorded: bool,
-    freed: bool,
-    prefill_marked: bool,
-    first_token_recorded: bool,
-    first_response_received: bool,
-    dispatch_guard: Option<StageGuard>,
-    track_output_blocks: bool,
-    current_total_blocks: usize,
-    isl_tokens: usize,
-    block_size: usize,
-    expected_output_tokens: Option<u32>,
-    /// Deferred session close action (fires after generation completes)
-    deferred_close: Option<SessionCloseAction>,
-    /// True once inner.direct() has returned Ok — guards record_metrics() so
-    /// that a dispatch failure does not emit metrics for a request that never
-    /// reached the backend (spurious requests_total increment, OSL histogram
-    /// zeros, premature tracker.record_finish()).
-    dispatched: bool,
-}
-
-impl RequestGuard {
-    async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
-        // End dispatch stage on first response from backend (any item, not just tokens).
-        if !self.first_response_received {
-            self.first_response_received = true;
-            self.dispatch_guard.take();
-        }
-
-        if !self.prefill_marked {
-            let has_tokens = item
-                .data
-                .as_ref()
-                .map(|d| !d.token_ids.is_empty())
-                .unwrap_or(false);
-            if has_tokens {
-                if self.scheduler_tracked
-                    && let Err(e) = self.chooser.mark_prefill_completed(&self.context_id).await
-                {
-                    tracing::warn!(
-                        "Failed to mark prefill completed for request {}: {e}",
-                        self.context_id
-                    );
-                }
-                self.prefill_marked = true;
-            }
-        }
-
-        let new_tokens = item.data.as_ref().map(|d| d.token_ids.len()).unwrap_or(0);
-
-        if !self.first_token_recorded && new_tokens > 0 {
-            if let Some(ref tracker) = self.tracker {
-                tracker.record_first_token();
-                // Record decode-phase first token for KV transfer latency metric.
-                // In disaggregated serving, first_token_time is locked by the prefill phase,
-                // so we need a separate timestamp for the decode worker's first token.
-                if tracker.phase() == RequestPhase::Decode {
-                    tracker.record_decode_first_token();
-                }
-                if let Some(ttft) = tracker.ttft_ms() {
-                    self.request_metrics
-                        .time_to_first_token_seconds
-                        .observe(ttft / 1000.0);
-                }
-            }
-            self.first_token_recorded = true;
-        }
-
-        self.cumulative_osl += new_tokens;
-
-        if self.track_output_blocks {
-            let new_total_blocks =
-                (self.isl_tokens + self.cumulative_osl).div_ceil(self.block_size);
-            if new_total_blocks > self.current_total_blocks {
-                let decay_fraction = self
-                    .expected_output_tokens
-                    .map(|eot| (1.0 - (self.cumulative_osl as f64 / eot.max(1) as f64)).max(0.0));
-                if let Err(e) = self
-                    .chooser
-                    .add_output_block(&self.context_id, decay_fraction)
-                {
-                    tracing::warn!(
-                        "Failed to add output block for request {}: {e}",
-                        self.context_id
-                    );
-                }
-
-                if let Some(ref tracker) = self.tracker {
-                    tracker.record_osl(self.cumulative_osl);
-                    tracker.record_finish();
-                    if let Some(avg_itl) = tracker.avg_itl_ms() {
-                        self.request_metrics
-                            .inter_token_latency_seconds
-                            .observe(avg_itl / 1000.0);
-                    }
-                }
-
-                self.current_total_blocks = new_total_blocks;
-            }
-        }
-    }
-
-    async fn finish(&mut self) {
-        self.record_metrics();
-        if self.scheduler_tracked
-            && let Err(e) = self.chooser.free(&self.context_id).await
-        {
-            tracing::warn!("Failed to free request {}: {e}", self.context_id);
-        }
-        self.freed = true;
-
-        // Take to prevent double-fire from Drop
-        if let Some(close) = self.deferred_close.take() {
-            close.execute(&self.context_id);
-        }
-    }
-
-    fn record_metrics(&mut self) {
-        // Skip metrics for requests that never reached the backend (dispatch
-        // failure before direct() returned Ok). Recording here would emit
-        // spurious requests_total increments and OSL-histogram zeros.
-        if self.metrics_recorded || !self.dispatched {
-            return;
-        }
-        self.metrics_recorded = true;
-        if let Some(ref tracker) = self.tracker {
-            tracker.record_finish();
-            tracker.record_osl(self.cumulative_osl);
-            // Observe KV transfer estimated latency (disaggregated paths)
-            if let Some(latency) = tracker.kv_transfer_estimated_latency_secs() {
-                self.request_metrics
-                    .kv_transfer_estimated_latency_seconds
-                    .observe(latency);
-            }
-        }
-        // Only record output sequence length for requests that actually
-        // produced output tokens. Recording zero for failed/cancelled requests
-        // would corrupt histogram averages (sum/count) and percentiles.
-        // Failures are already tracked by requests_total.
-        if self.cumulative_osl > 0 {
-            self.request_metrics
-                .output_sequence_tokens
-                .observe(self.cumulative_osl as f64);
-        }
-        self.request_metrics.requests_total.inc();
-    }
-}
-
-impl Drop for RequestGuard {
-    fn drop(&mut self) {
-        self.record_metrics();
-
-        let deferred_close = self.deferred_close.take();
-        let needs_free = !self.freed && self.scheduler_tracked;
-
-        if deferred_close.is_none() && !needs_free {
-            return;
-        }
-
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            tracing::warn!(
-                "No tokio runtime for drop guard cleanup of request {}",
-                self.context_id
-            );
-            return;
-        };
-
-        // Mirror finish(): free the scheduler slot first, then fire the
-        // deferred session close so the worker's KV isn't released while
-        // generation teardown is still in progress.
-        let chooser = self.chooser.clone();
-        let context_id = self.context_id.clone();
-        handle.spawn(async move {
-            if needs_free && let Err(e) = chooser.free(&context_id).await {
-                tracing::warn!("Failed to free request {context_id} (drop guard): {e}");
-            }
-            if let Some(close) = deferred_close {
-                close.execute(&context_id);
-            }
-        });
-    }
 }
 
 impl KvPushRouter {
@@ -625,53 +450,77 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             }
             worker => worker,
         };
-        let selection = match self
-            .select_worker(
-                &context_id,
-                &request,
-                routing_parts,
-                phase,
-                is_query_only,
-                sticky_worker,
-            )
-            .instrument(tracing::info_span!("kv_router.select_worker"))
-            .await
-        {
-            Ok(selection) => {
-                if sticky_worker.is_some() && !is_query_only {
-                    self.sticky.refresh_worker_for_phase(&request, phase);
-                }
-                selection
-            }
-            Err(error) if sticky_worker.is_some() => {
-                if let Some(worker) = sticky_worker {
-                    let unbound = self.unbind_ineligible_sticky_worker_for_phase(
-                        &context_id,
-                        &request,
-                        phase,
-                        worker,
-                    );
-                    tracing::warn!(
-                        request_id = %context_id,
-                        worker_id = worker.worker_id,
-                        dp_rank = worker.dp_rank,
-                        error = %error,
-                        unbound_due_to_ineligibility = unbound,
-                        "Sticky worker routing failed; falling back to normal routing"
-                    );
-                }
-                self.select_worker(
+        let request_context = request.context().clone();
+        let mut selection_future = Box::pin(async {
+            match self
+                .select_worker(
                     &context_id,
                     &request,
                     routing_parts,
                     phase,
                     is_query_only,
-                    None,
+                    sticky_worker,
                 )
-                .instrument(tracing::info_span!("kv_router.select_worker_fallback"))
-                .await?
+                .instrument(tracing::info_span!("kv_router.select_worker"))
+                .await
+            {
+                Ok(selection) => {
+                    if sticky_worker.is_some() && !is_query_only {
+                        self.sticky.refresh_worker_for_phase(&request, phase);
+                    }
+                    Ok(selection)
+                }
+                Err(error) if sticky_worker.is_some() => {
+                    if let Some(worker) = sticky_worker {
+                        let unbound = self.unbind_ineligible_sticky_worker_for_phase(
+                            &context_id,
+                            &request,
+                            phase,
+                            worker,
+                        );
+                        tracing::warn!(
+                            request_id = %context_id,
+                            worker_id = worker.worker_id,
+                            dp_rank = worker.dp_rank,
+                            error = %error,
+                            unbound_due_to_ineligibility = unbound,
+                            "Sticky worker routing failed; falling back to normal routing"
+                        );
+                    }
+                    self.select_worker(
+                        &context_id,
+                        &request,
+                        routing_parts,
+                        phase,
+                        is_query_only,
+                        None,
+                    )
+                    .instrument(tracing::info_span!("kv_router.select_worker_fallback"))
+                    .await
+                }
+                Err(error) => Err(error),
             }
-            Err(error) => return Err(error),
+        });
+        let selection_result = tokio::select! {
+            biased;
+
+            _ = request_context.stopped() => None,
+            result = &mut selection_future => Some(result),
+        };
+        drop(selection_future);
+
+        let selection = match selection_result {
+            Some(result) => result?,
+            None => {
+                if !is_query_only && let Err(error) = self.chooser.free(&context_id).await {
+                    tracing::warn!(
+                        request_id = %context_id,
+                        %error,
+                        "Failed to free scheduler state after cancellation during worker selection"
+                    );
+                }
+                return Err(cancelled_error(&context_id));
+            }
         };
         let WorkerSelection {
             instance_id,
@@ -683,12 +532,23 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             scheduler_tracked,
         } = selection;
 
+        // Tracked selection books scheduler state, so own its cleanup before any later await.
+        let mut guard = RequestGuard::new(
+            self.chooser.clone(),
+            context_id.clone(),
+            &request,
+            scheduler_tracked,
+        );
+
         if should_record {
             let worker = WorkerWithDpRank::new(instance_id, dp_rank);
             let record_result = if let Some(hashes) = routing_hashes {
-                self.chooser
-                    .record_routing_decision_hashes(hashes, worker)
-                    .await
+                cancel_on_stop(
+                    request_context.as_ref(),
+                    &context_id,
+                    self.chooser.record_routing_decision_hashes(hashes, worker),
+                )
+                .await?
             } else {
                 let lora_name = request.routing.as_ref().and_then(|r| r.lora_name.clone());
                 let mut tokens_with_hashes = TokensWithHashes::new(
@@ -702,9 +562,13 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 if let Some(lora_name) = lora_name {
                     tokens_with_hashes = tokens_with_hashes.with_lora_name(lora_name);
                 }
-                self.chooser
-                    .record_routing_decision(tokens_with_hashes, worker)
-                    .await
+                cancel_on_stop(
+                    request_context.as_ref(),
+                    &context_id,
+                    self.chooser
+                        .record_routing_decision(tokens_with_hashes, worker),
+                )
+                .await?
             };
             if let Err(e) = record_result {
                 tracing::warn!(
@@ -718,8 +582,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         }
 
         // Record routing metrics on tracker and observe ISL + prefill start.
-        let request_metrics =
-            RouterRequestMetrics::from_component(self.chooser.client().endpoint.component());
         if let Some(ref tracker) = request.tracker {
             let isl_blocks = routing_parts.token_ids.len().div_ceil(block_size);
             tracker.record_kv_hit(effective_overlap_blocks, isl_blocks);
@@ -727,10 +589,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             tracker.record_worker(instance_id, Some(dp_rank), self.chooser.worker_type());
             tracker.record_router_queue_depth(self.chooser.pending_count());
             if let Some(hit_rate) = tracker.kv_hit_rate() {
-                request_metrics.kv_hit_rate.observe(hit_rate);
+                guard.request_metrics().kv_hit_rate.observe(hit_rate);
             }
         }
-        request_metrics
+        guard
+            .request_metrics()
             .input_sequence_tokens
             .observe(request.token_ids.len() as f64);
 
@@ -761,84 +624,46 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // End route stage — worker has been selected and routing metrics recorded.
         // Dispatch stage starts immediately so there is no gap between stages.
         drop(route_guard);
-        let stage_dispatch_guard = StageGuard::new(STAGE_DISPATCH, &phase_label);
-
-        // Dispatch to worker
-        let isl_tokens = request.token_ids.len();
-        let expected_output_tokens = request
-            .routing
-            .as_ref()
-            .and_then(|r| r.expected_output_tokens);
-        let track_output_blocks = self.chooser.kv_router_config().router_track_output_blocks;
-        let tracker = request.tracker.clone();
+        guard.start_dispatch(&phase_label);
 
         // Session lifecycle RPCs.
         // Fails fast if session_control.open is requested but the client can't be created.
         let worker = WorkerWithDpRank::new(instance_id, dp_rank);
-        let route_outcome = self.sticky.on_routed(&request, worker, &context_id).await?;
-        let deferred_close = route_outcome.deferred_close;
+        let route_outcome = cancel_on_stop(
+            request_context.as_ref(),
+            &context_id,
+            self.sticky.on_routed(&request, worker, &context_id),
+        )
+        .await??;
+        guard.set_deferred_close(route_outcome.deferred_close);
 
         let (mut backend_input, context) = request.into_parts();
         backend_input.routing_mut().dp_rank = Some(dp_rank);
         let updated_request = context.map(|_| backend_input);
 
         // Record prefill start right before pushing to backend (OnceLock: first call wins).
-        if let Some(ref tracker) = tracker {
-            tracker.record_prefill_start();
-        }
+        guard.record_prefill_start();
 
-        let chooser = self.chooser.clone();
-
-        // Build the guard BEFORE calling direct() so that its Drop covers the
-        // error path as well as the drop-before-first-poll path.
-        //
-        // Without this, if direct().await? below returns Err, both the
-        // scheduler slot (booked by find_best_match with update_states=true)
-        // and the SessionCloseAction (obtained above via on_routed) are leaked:
-        // SessionCloseAction has no Drop impl, so dropping it never sends the
-        // close_session RPC; chooser.free() is only called via RequestGuard::Drop.
-        //
-        // All guard fields are available here (deferred_close was just obtained;
-        // isl_tokens/block_size/tracker were set before request.into_parts()).
-        let mut guard = RequestGuard {
-            chooser: chooser.clone(),
-            scheduler_tracked,
-            context_id: context_id.clone(),
-            tracker: tracker.clone(),
-            request_metrics: request_metrics.clone(),
-            cumulative_osl: 0,
-            metrics_recorded: false,
-            freed: false,
-            prefill_marked: false,
-            first_token_recorded: false,
-            first_response_received: false,
-            dispatch_guard: Some(stage_dispatch_guard),
-            track_output_blocks: scheduler_tracked && track_output_blocks,
-            current_total_blocks: isl_tokens.div_ceil(block_size),
-            isl_tokens,
-            block_size,
-            expected_output_tokens,
-            deferred_close,
-            dispatched: false,
-        };
-
-        let mut response_stream = self
-            .inner
-            .direct(updated_request, instance_id)
-            .instrument(tracing::info_span!(
-                "kv_router.route_request",
-                request_id = %context_id,
-                worker_id = instance_id,
-                dp_rank = dp_rank,
-                overlap_blocks = overlap_amount,
-                phase = ?phase,
-            ))
-            .await?;
+        let mut response_stream = cancel_on_stop(
+            request_context.as_ref(),
+            &context_id,
+            self.inner
+                .direct(updated_request, instance_id)
+                .instrument(tracing::info_span!(
+                    "kv_router.route_request",
+                    request_id = %context_id,
+                    worker_id = instance_id,
+                    dp_rank = dp_rank,
+                    overlap_blocks = overlap_amount,
+                    phase = ?phase,
+                )),
+        )
+        .await??;
         // direct() succeeded — mark dispatched so record_metrics() fires.
         // If direct() returned Err above, guard drops here with dispatched=false
         // → RequestGuard::Drop fires → chooser.free() + deferred_close.execute()
         //   but record_metrics() is suppressed (no backend work was done).
-        guard.dispatched = true;
+        guard.mark_dispatched();
         let stream_context = response_stream.context();
         let context_for_monitoring = stream_context.clone();
 
@@ -948,16 +773,62 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        future::Future,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::{Context, Poll},
+    };
 
     use dynamo_kv_router::{
         protocols::{RoutingConstraints, WorkerWithDpRank},
         scheduling::{RoutingEligibility, WorkerEligibilityError},
     };
+    use dynamo_runtime::{
+        error::{DynamoError, ErrorType},
+        pipeline::{AsyncEngineContext, context::Controller},
+    };
 
-    use super::{pinned_worker_hint, resolve_pinned_worker_rank};
+    use super::{cancel_on_stop, pinned_worker_hint, resolve_pinned_worker_rank};
     use crate::local_model::runtime_config::ModelRuntimeConfig;
     use crate::protocols::common::{preprocessor::RoutingHints, timing::RequestPhase};
+
+    struct PendingUntilDropped(Arc<AtomicBool>);
+
+    impl Future for PendingUntilDropped {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for PendingUntilDropped {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_on_stop_drops_pending_operation() {
+        let context = Controller::new("cancelled-request".to_string());
+        context.stop();
+        let dropped = Arc::new(AtomicBool::new(false));
+
+        let error = cancel_on_stop(&context, context.id(), PendingUntilDropped(dropped.clone()))
+            .await
+            .unwrap_err();
+
+        let error = error
+            .downcast_ref::<DynamoError>()
+            .expect("cancellation should return DynamoError");
+        assert_eq!(error.error_type(), ErrorType::Cancelled);
+        assert!(dropped.load(Ordering::SeqCst));
+    }
 
     #[test]
     fn resolve_pinned_worker_rank_uses_explicit_rank_including_zero() {

--- a/lib/llm/src/kv_router/push_router/cancellation.rs
+++ b/lib/llm/src/kv_router/push_router/cancellation.rs
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+
+use dynamo_runtime::{
+    error::{DynamoError, ErrorType},
+    pipeline::{AsyncEngineContext, Error},
+};
+
+pub(super) fn cancelled_error(context_id: &str) -> Error {
+    DynamoError::builder()
+        .error_type(ErrorType::Cancelled)
+        .message(format!("Request {context_id} was cancelled"))
+        .build()
+        .into()
+}
+
+pub(super) async fn cancel_on_stop<T>(
+    context: &dyn AsyncEngineContext,
+    context_id: &str,
+    operation: impl Future<Output = T>,
+) -> Result<T, Error> {
+    tokio::pin!(operation);
+    tokio::select! {
+        biased;
+
+        // Preserve a simultaneously completed ownership-bearing result so its
+        // normal cleanup path runs instead of treating it as an unseen result.
+        result = &mut operation => Ok(result),
+        _ = context.stopped() => Err(cancelled_error(context_id)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::{Context, Poll},
+    };
+
+    use dynamo_runtime::{
+        error::{DynamoError, ErrorType},
+        pipeline::{AsyncEngineContext, context::Controller},
+    };
+
+    use super::cancel_on_stop;
+
+    struct PendingUntilDropped(Arc<AtomicBool>);
+
+    impl Future for PendingUntilDropped {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for PendingUntilDropped {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn drops_pending_operation_when_context_stops() {
+        let context = Controller::new("cancelled-request".to_string());
+        context.stop();
+        let dropped = Arc::new(AtomicBool::new(false));
+
+        let error = cancel_on_stop(&context, context.id(), PendingUntilDropped(dropped.clone()))
+            .await
+            .unwrap_err();
+
+        let error = error
+            .downcast_ref::<DynamoError>()
+            .expect("cancellation should return DynamoError");
+        assert_eq!(error.error_type(), ErrorType::Cancelled);
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+}

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -96,117 +96,57 @@ impl Drop for RequestCleanup {
     }
 }
 
-/// Tracks routed request metrics and owns cleanup for scheduler and session state.
-pub(super) struct RequestGuard {
-    cleanup: RequestCleanup,
+/// Owns request-scoped timing and metrics state.
+struct RequestObservability {
     tracker: Option<Arc<RequestTracker>>,
     request_metrics: Arc<RouterRequestMetrics>,
     cumulative_osl: usize,
     metrics_recorded: bool,
-    prefill_marked: bool,
     first_token_recorded: bool,
-    first_response_received: bool,
     dispatch_guard: Option<StageGuard>,
-    track_output_blocks: bool,
-    current_total_blocks: usize,
-    isl_tokens: usize,
-    block_size: usize,
-    expected_output_tokens: Option<u32>,
     dispatched: bool,
 }
 
-impl RequestGuard {
-    pub(super) fn new(
-        chooser: Arc<KvRouter>,
-        context_id: String,
-        request: &PreprocessedRequest,
-        scheduler_tracked: bool,
+impl RequestObservability {
+    fn new(
+        tracker: Option<Arc<RequestTracker>>,
+        request_metrics: Arc<RouterRequestMetrics>,
     ) -> Self {
-        // Snapshot request-scoped inputs now so the guard can outlive the
-        // PreprocessedRequest after it is moved into backend dispatch.
-        let block_size = chooser.block_size() as usize;
-        let isl_tokens = request.token_ids.len();
-        let expected_output_tokens = request
-            .routing
-            .as_ref()
-            .and_then(|routing| routing.expected_output_tokens);
-        let track_output_blocks =
-            scheduler_tracked && chooser.kv_router_config().router_track_output_blocks;
-        let request_metrics =
-            RouterRequestMetrics::from_component(chooser.client().endpoint.component());
-
         Self {
-            cleanup: RequestCleanup::new(chooser, context_id, scheduler_tracked),
-            tracker: request.tracker.clone(),
+            tracker,
             request_metrics,
             cumulative_osl: 0,
             metrics_recorded: false,
-            prefill_marked: false,
             first_token_recorded: false,
-            first_response_received: false,
             dispatch_guard: None,
-            track_output_blocks,
-            current_total_blocks: isl_tokens.div_ceil(block_size),
-            isl_tokens,
-            block_size,
-            expected_output_tokens,
             dispatched: false,
         }
     }
 
-    pub(super) fn request_metrics(&self) -> &RouterRequestMetrics {
+    fn request_metrics(&self) -> &RouterRequestMetrics {
         &self.request_metrics
     }
 
-    pub(super) fn start_dispatch(&mut self, phase_label: &str) {
+    fn start_dispatch(&mut self, phase_label: &str) {
         self.dispatch_guard = Some(StageGuard::new(STAGE_DISPATCH, phase_label));
     }
 
-    pub(super) fn set_deferred_close(&mut self, deferred_close: Option<SessionCloseAction>) {
-        self.cleanup.set_deferred_close(deferred_close);
-    }
-
-    pub(super) fn record_prefill_start(&self) {
+    fn record_prefill_start(&self) {
         if let Some(tracker) = &self.tracker {
             tracker.record_prefill_start();
         }
     }
 
-    pub(super) fn mark_dispatched(&mut self) {
+    fn mark_dispatched(&mut self) {
         self.dispatched = true;
     }
 
-    pub(super) async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
-        // The first backend response ends dispatch latency, even if it carries no tokens.
-        if !self.first_response_received {
-            self.first_response_received = true;
-            self.dispatch_guard.take();
-        }
+    fn observe_response(&mut self) {
+        // Taking the guard ends dispatch latency exactly once; later responses see None.
+        self.dispatch_guard.take();
+    }
 
-        if !self.prefill_marked {
-            let has_tokens = item
-                .data
-                .as_ref()
-                .is_some_and(|data| !data.token_ids.is_empty());
-            if has_tokens {
-                if self.cleanup.scheduler_tracked
-                    && let Err(error) = self
-                        .cleanup
-                        .chooser
-                        .mark_prefill_completed(&self.cleanup.context_id)
-                        .await
-                {
-                    tracing::warn!(
-                        request_id = %self.cleanup.context_id,
-                        %error,
-                        "Failed to mark prefill completed"
-                    );
-                }
-                self.prefill_marked = true;
-            }
-        }
-
-        let new_tokens = item.data.as_ref().map_or(0, |data| data.token_ids.len());
+    fn observe_tokens(&mut self, new_tokens: usize) {
         if !self.first_token_recorded && new_tokens > 0 {
             if let Some(tracker) = &self.tracker {
                 tracker.record_first_token();
@@ -223,48 +163,25 @@ impl RequestGuard {
         }
 
         self.cumulative_osl += new_tokens;
-        if !self.track_output_blocks {
-            return;
-        }
-
-        let new_total_blocks = (self.isl_tokens + self.cumulative_osl).div_ceil(self.block_size);
-        if new_total_blocks <= self.current_total_blocks {
-            return;
-        }
-
-        // Update scheduler load only when generation crosses a block boundary.
-        let decay_fraction = self
-            .expected_output_tokens
-            .map(|expected| (1.0 - self.cumulative_osl as f64 / expected.max(1) as f64).max(0.0));
-        if let Err(error) = self
-            .cleanup
-            .chooser
-            .add_output_block(&self.cleanup.context_id, decay_fraction)
-        {
-            tracing::warn!(
-                request_id = %self.cleanup.context_id,
-                %error,
-                "Failed to add output block"
-            );
-        }
-
-        if let Some(tracker) = &self.tracker {
-            tracker.record_osl(self.cumulative_osl);
-            tracker.record_finish();
-            if let Some(avg_itl) = tracker.avg_itl_ms() {
-                self.request_metrics
-                    .inter_token_latency_seconds
-                    .observe(avg_itl / 1000.0);
-            }
-        }
-
-        self.current_total_blocks = new_total_blocks;
     }
 
-    pub(super) async fn finish(&mut self) {
-        // Metrics must observe the completed request before cleanup releases its state.
-        self.record_metrics();
-        self.cleanup.finish().await;
+    fn cumulative_osl(&self) -> usize {
+        self.cumulative_osl
+    }
+
+    fn observe_output_block_boundary(&self) {
+        let Some(tracker) = &self.tracker else {
+            return;
+        };
+
+        // Refresh finish time at block boundaries so the streaming ITL sample stays current.
+        tracker.record_osl(self.cumulative_osl);
+        tracker.record_finish();
+        if let Some(avg_itl) = tracker.avg_itl_ms() {
+            self.request_metrics
+                .inter_token_latency_seconds
+                .observe(avg_itl / 1000.0);
+        }
     }
 
     fn record_metrics(&mut self) {
@@ -292,9 +209,175 @@ impl RequestGuard {
     }
 }
 
+struct OutputBlockUpdate {
+    decay_fraction: Option<f64>,
+}
+
+/// Tracks when streamed output grows into a new scheduler accounting block.
+struct OutputBlockTracker {
+    track_output_blocks: bool,
+    current_total_blocks: usize,
+    isl_tokens: usize,
+    block_size: usize,
+    expected_output_tokens: Option<u32>,
+}
+
+impl OutputBlockTracker {
+    fn new(
+        track_output_blocks: bool,
+        isl_tokens: usize,
+        block_size: usize,
+        expected_output_tokens: Option<u32>,
+    ) -> Self {
+        Self {
+            track_output_blocks,
+            current_total_blocks: isl_tokens.div_ceil(block_size),
+            isl_tokens,
+            block_size,
+            expected_output_tokens,
+        }
+    }
+
+    fn observe(&mut self, cumulative_osl: usize) -> Option<OutputBlockUpdate> {
+        if !self.track_output_blocks {
+            return None;
+        }
+
+        let new_total_blocks = (self.isl_tokens + cumulative_osl).div_ceil(self.block_size);
+        if new_total_blocks <= self.current_total_blocks {
+            return None;
+        }
+
+        // Advance before returning so a failed scheduler update preserves existing no-retry behavior.
+        self.current_total_blocks = new_total_blocks;
+        let decay_fraction = self
+            .expected_output_tokens
+            .map(|expected| (1.0 - cumulative_osl as f64 / expected.max(1) as f64).max(0.0));
+        Some(OutputBlockUpdate { decay_fraction })
+    }
+}
+
+/// Coordinates scheduler/session cleanup, observability, and streamed load tracking.
+pub(super) struct RequestGuard {
+    cleanup: RequestCleanup,
+    observability: RequestObservability,
+    output_blocks: OutputBlockTracker,
+    prefill_marked: bool,
+}
+
+impl RequestGuard {
+    pub(super) fn new(
+        chooser: Arc<KvRouter>,
+        context_id: String,
+        request: &PreprocessedRequest,
+        scheduler_tracked: bool,
+    ) -> Self {
+        // Snapshot request-scoped inputs now so the guard can outlive the
+        // PreprocessedRequest after it is moved into backend dispatch.
+        let block_size = chooser.block_size() as usize;
+        let isl_tokens = request.token_ids.len();
+        let expected_output_tokens = request
+            .routing
+            .as_ref()
+            .and_then(|routing| routing.expected_output_tokens);
+        let track_output_blocks =
+            scheduler_tracked && chooser.kv_router_config().router_track_output_blocks;
+        let request_metrics =
+            RouterRequestMetrics::from_component(chooser.client().endpoint.component());
+
+        Self {
+            cleanup: RequestCleanup::new(chooser, context_id, scheduler_tracked),
+            observability: RequestObservability::new(request.tracker.clone(), request_metrics),
+            output_blocks: OutputBlockTracker::new(
+                track_output_blocks,
+                isl_tokens,
+                block_size,
+                expected_output_tokens,
+            ),
+            prefill_marked: false,
+        }
+    }
+
+    pub(super) fn request_metrics(&self) -> &RouterRequestMetrics {
+        self.observability.request_metrics()
+    }
+
+    pub(super) fn start_dispatch(&mut self, phase_label: &str) {
+        self.observability.start_dispatch(phase_label);
+    }
+
+    pub(super) fn set_deferred_close(&mut self, deferred_close: Option<SessionCloseAction>) {
+        self.cleanup.set_deferred_close(deferred_close);
+    }
+
+    pub(super) fn record_prefill_start(&self) {
+        self.observability.record_prefill_start();
+    }
+
+    pub(super) fn mark_dispatched(&mut self) {
+        self.observability.mark_dispatched();
+    }
+
+    pub(super) async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
+        self.observability.observe_response();
+
+        if !self.prefill_marked {
+            let has_tokens = item
+                .data
+                .as_ref()
+                .is_some_and(|data| !data.token_ids.is_empty());
+            if has_tokens {
+                if self.cleanup.scheduler_tracked
+                    && let Err(error) = self
+                        .cleanup
+                        .chooser
+                        .mark_prefill_completed(&self.cleanup.context_id)
+                        .await
+                {
+                    tracing::warn!(
+                        request_id = %self.cleanup.context_id,
+                        %error,
+                        "Failed to mark prefill completed"
+                    );
+                }
+                self.prefill_marked = true;
+            }
+        }
+
+        let new_tokens = item.data.as_ref().map_or(0, |data| data.token_ids.len());
+        self.observability.observe_tokens(new_tokens);
+        let Some(update) = self
+            .output_blocks
+            .observe(self.observability.cumulative_osl())
+        else {
+            return;
+        };
+
+        if let Err(error) = self
+            .cleanup
+            .chooser
+            .add_output_block(&self.cleanup.context_id, update.decay_fraction)
+        {
+            tracing::warn!(
+                request_id = %self.cleanup.context_id,
+                %error,
+                "Failed to add output block"
+            );
+        }
+
+        self.observability.observe_output_block_boundary();
+    }
+
+    pub(super) async fn finish(&mut self) {
+        // Metrics must observe the completed request before cleanup releases its state.
+        self.observability.record_metrics();
+        self.cleanup.finish().await;
+    }
+}
+
 impl Drop for RequestGuard {
     fn drop(&mut self) {
         // RequestCleanup drops immediately afterward and performs resource cleanup.
-        self.record_metrics();
+        self.observability.record_metrics();
     }
 }

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use dynamo_runtime::{
+    metrics::frontend_perf::{STAGE_DISPATCH, StageGuard},
+    protocols::annotated::Annotated,
+};
+
+use crate::{
+    kv_router::{KvRouter, metrics::RouterRequestMetrics, sticky::lifecycle::SessionCloseAction},
+    preprocessor::PreprocessedRequest,
+    protocols::common::{
+        llm_backend::LLMEngineOutput,
+        timing::{RequestPhase, RequestTracker},
+    },
+};
+
+/// Owns resources that must be released even when routing setup or streaming is cancelled.
+struct RequestCleanup {
+    chooser: Arc<KvRouter>,
+    context_id: String,
+    scheduler_tracked: bool,
+    freed: bool,
+    deferred_close: Option<SessionCloseAction>,
+}
+
+impl RequestCleanup {
+    fn new(chooser: Arc<KvRouter>, context_id: String, scheduler_tracked: bool) -> Self {
+        Self {
+            chooser,
+            context_id,
+            scheduler_tracked,
+            freed: false,
+            deferred_close: None,
+        }
+    }
+
+    fn set_deferred_close(&mut self, deferred_close: Option<SessionCloseAction>) {
+        self.deferred_close = deferred_close;
+    }
+
+    async fn finish(&mut self) {
+        // Free scheduler state before closing the session so both explicit and
+        // drop cleanup preserve the same lifecycle ordering.
+        if self.scheduler_tracked
+            && let Err(error) = self.chooser.free(&self.context_id).await
+        {
+            tracing::warn!(
+                request_id = %self.context_id,
+                %error,
+                "Failed to free request"
+            );
+        }
+        self.freed = true;
+
+        if let Some(close) = self.deferred_close.take() {
+            close.execute(&self.context_id);
+        }
+    }
+}
+
+impl Drop for RequestCleanup {
+    fn drop(&mut self) {
+        // Drop cannot await, so transfer any unfinished cleanup into one task.
+        let deferred_close = self.deferred_close.take();
+        let needs_free = !self.freed && self.scheduler_tracked;
+        if deferred_close.is_none() && !needs_free {
+            return;
+        }
+
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            tracing::warn!(
+                request_id = %self.context_id,
+                "No tokio runtime for request cleanup"
+            );
+            return;
+        };
+
+        let chooser = self.chooser.clone();
+        let context_id = self.context_id.clone();
+        handle.spawn(async move {
+            // Match explicit finish ordering so session KV closes after scheduler cleanup.
+            if needs_free && let Err(error) = chooser.free(&context_id).await {
+                tracing::warn!(
+                    request_id = %context_id,
+                    %error,
+                    "Failed to free request from drop guard"
+                );
+            }
+            if let Some(close) = deferred_close {
+                close.execute(&context_id);
+            }
+        });
+    }
+}
+
+/// Tracks routed request metrics and owns cleanup for scheduler and session state.
+pub(super) struct RequestGuard {
+    cleanup: RequestCleanup,
+    tracker: Option<Arc<RequestTracker>>,
+    request_metrics: Arc<RouterRequestMetrics>,
+    cumulative_osl: usize,
+    metrics_recorded: bool,
+    prefill_marked: bool,
+    first_token_recorded: bool,
+    first_response_received: bool,
+    dispatch_guard: Option<StageGuard>,
+    track_output_blocks: bool,
+    current_total_blocks: usize,
+    isl_tokens: usize,
+    block_size: usize,
+    expected_output_tokens: Option<u32>,
+    dispatched: bool,
+}
+
+impl RequestGuard {
+    pub(super) fn new(
+        chooser: Arc<KvRouter>,
+        context_id: String,
+        request: &PreprocessedRequest,
+        scheduler_tracked: bool,
+    ) -> Self {
+        // Snapshot request-scoped inputs now so the guard can outlive the
+        // PreprocessedRequest after it is moved into backend dispatch.
+        let block_size = chooser.block_size() as usize;
+        let isl_tokens = request.token_ids.len();
+        let expected_output_tokens = request
+            .routing
+            .as_ref()
+            .and_then(|routing| routing.expected_output_tokens);
+        let track_output_blocks =
+            scheduler_tracked && chooser.kv_router_config().router_track_output_blocks;
+        let request_metrics =
+            RouterRequestMetrics::from_component(chooser.client().endpoint.component());
+
+        Self {
+            cleanup: RequestCleanup::new(chooser, context_id, scheduler_tracked),
+            tracker: request.tracker.clone(),
+            request_metrics,
+            cumulative_osl: 0,
+            metrics_recorded: false,
+            prefill_marked: false,
+            first_token_recorded: false,
+            first_response_received: false,
+            dispatch_guard: None,
+            track_output_blocks,
+            current_total_blocks: isl_tokens.div_ceil(block_size),
+            isl_tokens,
+            block_size,
+            expected_output_tokens,
+            dispatched: false,
+        }
+    }
+
+    pub(super) fn request_metrics(&self) -> &RouterRequestMetrics {
+        &self.request_metrics
+    }
+
+    pub(super) fn start_dispatch(&mut self, phase_label: &str) {
+        self.dispatch_guard = Some(StageGuard::new(STAGE_DISPATCH, phase_label));
+    }
+
+    pub(super) fn set_deferred_close(&mut self, deferred_close: Option<SessionCloseAction>) {
+        self.cleanup.set_deferred_close(deferred_close);
+    }
+
+    pub(super) fn record_prefill_start(&self) {
+        if let Some(tracker) = &self.tracker {
+            tracker.record_prefill_start();
+        }
+    }
+
+    pub(super) fn mark_dispatched(&mut self) {
+        self.dispatched = true;
+    }
+
+    pub(super) async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
+        // The first backend response ends dispatch latency, even if it carries no tokens.
+        if !self.first_response_received {
+            self.first_response_received = true;
+            self.dispatch_guard.take();
+        }
+
+        if !self.prefill_marked {
+            let has_tokens = item
+                .data
+                .as_ref()
+                .is_some_and(|data| !data.token_ids.is_empty());
+            if has_tokens {
+                if self.cleanup.scheduler_tracked
+                    && let Err(error) = self
+                        .cleanup
+                        .chooser
+                        .mark_prefill_completed(&self.cleanup.context_id)
+                        .await
+                {
+                    tracing::warn!(
+                        request_id = %self.cleanup.context_id,
+                        %error,
+                        "Failed to mark prefill completed"
+                    );
+                }
+                self.prefill_marked = true;
+            }
+        }
+
+        let new_tokens = item.data.as_ref().map_or(0, |data| data.token_ids.len());
+        if !self.first_token_recorded && new_tokens > 0 {
+            if let Some(tracker) = &self.tracker {
+                tracker.record_first_token();
+                if tracker.phase() == RequestPhase::Decode {
+                    tracker.record_decode_first_token();
+                }
+                if let Some(ttft) = tracker.ttft_ms() {
+                    self.request_metrics
+                        .time_to_first_token_seconds
+                        .observe(ttft / 1000.0);
+                }
+            }
+            self.first_token_recorded = true;
+        }
+
+        self.cumulative_osl += new_tokens;
+        if !self.track_output_blocks {
+            return;
+        }
+
+        let new_total_blocks = (self.isl_tokens + self.cumulative_osl).div_ceil(self.block_size);
+        if new_total_blocks <= self.current_total_blocks {
+            return;
+        }
+
+        // Update scheduler load only when generation crosses a block boundary.
+        let decay_fraction = self
+            .expected_output_tokens
+            .map(|expected| (1.0 - self.cumulative_osl as f64 / expected.max(1) as f64).max(0.0));
+        if let Err(error) = self
+            .cleanup
+            .chooser
+            .add_output_block(&self.cleanup.context_id, decay_fraction)
+        {
+            tracing::warn!(
+                request_id = %self.cleanup.context_id,
+                %error,
+                "Failed to add output block"
+            );
+        }
+
+        if let Some(tracker) = &self.tracker {
+            tracker.record_osl(self.cumulative_osl);
+            tracker.record_finish();
+            if let Some(avg_itl) = tracker.avg_itl_ms() {
+                self.request_metrics
+                    .inter_token_latency_seconds
+                    .observe(avg_itl / 1000.0);
+            }
+        }
+
+        self.current_total_blocks = new_total_blocks;
+    }
+
+    pub(super) async fn finish(&mut self) {
+        // Metrics must observe the completed request before cleanup releases its state.
+        self.record_metrics();
+        self.cleanup.finish().await;
+    }
+
+    fn record_metrics(&mut self) {
+        // A failed dispatch never reached the backend and must not count as a request.
+        if self.metrics_recorded || !self.dispatched {
+            return;
+        }
+        self.metrics_recorded = true;
+
+        if let Some(tracker) = &self.tracker {
+            tracker.record_finish();
+            tracker.record_osl(self.cumulative_osl);
+            if let Some(latency) = tracker.kv_transfer_estimated_latency_secs() {
+                self.request_metrics
+                    .kv_transfer_estimated_latency_seconds
+                    .observe(latency);
+            }
+        }
+        if self.cumulative_osl > 0 {
+            self.request_metrics
+                .output_sequence_tokens
+                .observe(self.cumulative_osl as f64);
+        }
+        self.request_metrics.requests_total.inc();
+    }
+}
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        // RequestCleanup drops immediately afterward and performs resource cleanup.
+        self.record_metrics();
+    }
+}

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -1,0 +1,452 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use dynamo_kv_router::{
+    RouterConfigOverride,
+    indexer::RoutingDecisionHashes,
+    protocols::{BlockExtraInfo, RoutingConstraints, WorkerId, WorkerWithDpRank},
+    scheduling::{RoutingEligibility, WorkerEligibilityError},
+};
+use dynamo_runtime::{
+    dynamo_nvtx_range,
+    error::{DynamoError, ErrorType},
+    pipeline::Error,
+};
+
+use crate::{
+    kv_router::{
+        FindBestMatchOutcome, push_router::KvPushRouter,
+        sticky::coordinator::sticky_allowed_for_phase,
+    },
+    preprocessor::PreprocessedRequest,
+    protocols::{
+        TokenIdType,
+        common::{preprocessor::RoutingHints, timing::RequestPhase},
+    },
+};
+
+pub(super) struct WorkerSelection {
+    pub(super) instance_id: u64,
+    pub(super) dp_rank: u32,
+    pub(super) overlap_amount: u32,
+    pub(super) effective_overlap_blocks: f64,
+    pub(super) cached_tokens: usize,
+    pub(super) routing_hashes: Option<RoutingDecisionHashes>,
+    pub(super) scheduler_tracked: bool,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct RoutingRequestParts<'a> {
+    pub(super) token_ids: &'a [TokenIdType],
+    pub(super) block_mm_infos: Option<&'a [Option<BlockExtraInfo>]>,
+}
+
+impl<'a> RoutingRequestParts<'a> {
+    pub(super) fn new(request: &'a PreprocessedRequest) -> Self {
+        let (token_ids, block_mm_infos) = request.block_mm_routing_info();
+        Self {
+            token_ids,
+            block_mm_infos,
+        }
+    }
+}
+
+struct BestMatchArgs<'a> {
+    context_id: &'a str,
+    routing_parts: RoutingRequestParts<'a>,
+    router_config_override: Option<&'a RouterConfigOverride>,
+    update_states: bool,
+    return_routing_hashes: bool,
+    lora_name: Option<String>,
+    priority_jump: f64,
+    expected_output_tokens: Option<u32>,
+    pinned_worker: Option<WorkerWithDpRank>,
+    allowed_worker_ids: Option<HashSet<WorkerId>>,
+    routing_constraints: RoutingConstraints,
+    scheduler_tracked: bool,
+}
+
+impl KvPushRouter {
+    async fn select_best_match(&self, args: BestMatchArgs<'_>) -> Result<WorkerSelection, Error> {
+        let outcome = self
+            .chooser
+            .find_best_match_details(
+                Some(args.context_id),
+                args.routing_parts.token_ids,
+                args.routing_parts.block_mm_infos,
+                args.router_config_override,
+                args.update_states,
+                args.return_routing_hashes,
+                args.lora_name,
+                args.priority_jump,
+                args.expected_output_tokens,
+                args.pinned_worker,
+                args.allowed_worker_ids,
+                args.routing_constraints,
+            )
+            .await?;
+
+        match outcome {
+            FindBestMatchOutcome::Routed {
+                worker,
+                overlap_blocks,
+                effective_overlap_blocks,
+                cached_tokens,
+                routing_hashes,
+            } => Ok(WorkerSelection {
+                instance_id: worker.worker_id,
+                dp_rank: worker.dp_rank,
+                overlap_amount: overlap_blocks,
+                effective_overlap_blocks,
+                cached_tokens,
+                routing_hashes,
+                scheduler_tracked: args.scheduler_tracked,
+            }),
+            FindBestMatchOutcome::Backpressure {
+                reason,
+                queued_isl_tokens,
+                max_queued_isl_tokens,
+            } => Err(DynamoError::builder()
+                .error_type(ErrorType::ResourceExhausted)
+                .message(format!(
+                    "router backpressure: {reason:?} (queued_isl_tokens={queued_isl_tokens}, max_queued_isl_tokens={max_queued_isl_tokens:?})"
+                ))
+                .build()
+                .into()),
+        }
+    }
+
+    /// Select a worker using either a phase-specific pin or KV overlap.
+    pub(super) async fn select_worker(
+        &self,
+        context_id: &str,
+        request: &PreprocessedRequest,
+        routing_parts: RoutingRequestParts<'_>,
+        phase: RequestPhase,
+        is_query_only: bool,
+        sticky_worker: Option<WorkerWithDpRank>,
+    ) -> Result<WorkerSelection, Error> {
+        let _nvtx_select = dynamo_nvtx_range!("route.select_worker");
+        let routing = request.routing.as_ref();
+        let lora_name = routing.and_then(|routing| routing.lora_name.clone());
+        let priority_jump = routing
+            .and_then(|routing| routing.priority_jump)
+            .unwrap_or(0.0);
+        let expected_output_tokens = routing.and_then(|routing| routing.expected_output_tokens);
+        let allowed_worker_ids = routing.and_then(|routing| routing.allowed_worker_ids.clone());
+        let return_routing_hashes =
+            !is_query_only && self.chooser.indexer().records_routing_decisions();
+        let routing_constraints = routing
+            .and_then(|routing| routing.routing_constraints.clone())
+            .unwrap_or_default();
+        let sticky_pin = sticky_worker.map(|worker| (worker.worker_id, Some(worker.dp_rank)));
+        let Some((pinned_worker_id, requested_dp_rank)) =
+            pinned_worker_hint(phase, routing).or(sticky_pin)
+        else {
+            let _nvtx_kv = dynamo_nvtx_range!("route.kv_match");
+            let selection = self
+                .select_best_match(BestMatchArgs {
+                    context_id,
+                    routing_parts,
+                    router_config_override: request.router_config_override.as_ref(),
+                    update_states: !is_query_only,
+                    return_routing_hashes,
+                    lora_name,
+                    priority_jump,
+                    expected_output_tokens,
+                    pinned_worker: None,
+                    allowed_worker_ids,
+                    routing_constraints: routing_constraints.clone(),
+                    scheduler_tracked: !is_query_only,
+                })
+                .await?;
+
+            if !is_query_only {
+                let total_blocks = routing_parts
+                    .token_ids
+                    .len()
+                    .div_ceil(self.chooser.block_size() as usize);
+                // tests/utils/router_logs.py parses the structured fields on this event.
+                tracing::debug!(
+                    request_id = %context_id,
+                    worker_id = selection.instance_id,
+                    dp_rank = selection.dp_rank,
+                    overlap_blocks = selection.overlap_amount,
+                    total_blocks,
+                    "[ROUTING] Best: worker_{} dp_rank={} with {}/{} blocks overlap",
+                    selection.instance_id,
+                    selection.dp_rank,
+                    selection.overlap_amount,
+                    total_blocks,
+                );
+            }
+
+            return Ok(selection);
+        };
+
+        let pinned_worker = resolve_pinned_worker_rank(
+            pinned_worker_id,
+            requested_dp_rank,
+            self.chooser.unique_dp_rank_for_worker(pinned_worker_id),
+        )?;
+        {
+            let configs = self.chooser.workers_with_configs.borrow();
+            let eligibility = RoutingEligibility::new(
+                allowed_worker_ids.as_ref(),
+                None,
+                Some(pinned_worker),
+                &routing_constraints,
+            );
+            if let Err(error) = eligibility.validate_worker_rank(&configs, pinned_worker) {
+                return Err(anyhow::anyhow!(
+                    "Pinned worker {} dp_rank {} is not eligible: {error}",
+                    pinned_worker.worker_id,
+                    pinned_worker.dp_rank
+                ));
+            }
+        }
+
+        tracing::debug!(
+            worker_id = pinned_worker.worker_id,
+            dp_rank = pinned_worker.dp_rank,
+            ?phase,
+            "Routing to specified worker"
+        );
+
+        self.select_best_match(BestMatchArgs {
+            context_id,
+            routing_parts,
+            router_config_override: request.router_config_override.as_ref(),
+            update_states: !is_query_only,
+            return_routing_hashes,
+            lora_name,
+            priority_jump,
+            expected_output_tokens,
+            pinned_worker: Some(pinned_worker),
+            allowed_worker_ids,
+            routing_constraints,
+            scheduler_tracked: !is_query_only,
+        })
+        .await
+    }
+
+    fn sticky_worker_ineligibility_for_phase(
+        &self,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+        worker: WorkerWithDpRank,
+    ) -> Option<WorkerEligibilityError> {
+        let routing = request.routing.as_ref()?;
+        if !sticky_allowed_for_phase(phase, Some(routing)) {
+            return None;
+        }
+
+        let default_constraints = RoutingConstraints::default();
+        let routing_constraints = routing
+            .routing_constraints
+            .as_ref()
+            .unwrap_or(&default_constraints);
+        let configs = self.chooser.workers_with_configs.borrow();
+        let eligibility = RoutingEligibility::new(
+            routing.allowed_worker_ids.as_ref(),
+            None,
+            Some(worker),
+            routing_constraints,
+        );
+        eligibility.validate_worker_rank(&configs, worker).err()
+    }
+
+    pub(crate) fn unbind_ineligible_sticky_worker_for_phase(
+        &self,
+        context_id: &str,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+        worker: WorkerWithDpRank,
+    ) -> bool {
+        let Some(reason) = self.sticky_worker_ineligibility_for_phase(request, phase, worker)
+        else {
+            return false;
+        };
+
+        let Some((session_id, _binding)) = self.sticky.unbind_for_phase(request, phase) else {
+            return false;
+        };
+        tracing::warn!(
+            request_id = %context_id,
+            %session_id,
+            worker_id = worker.worker_id,
+            dp_rank = worker.dp_rank,
+            reason = %reason,
+            "Sticky worker is no longer eligible; removing session affinity"
+        );
+        true
+    }
+
+    pub(crate) async fn validate_sticky_worker_for_phase(
+        &self,
+        context_id: &str,
+        request: &PreprocessedRequest,
+        phase: RequestPhase,
+        worker: WorkerWithDpRank,
+    ) -> Result<WorkerWithDpRank, Error> {
+        let routing_parts = RoutingRequestParts::new(request);
+        let selection = self
+            .select_worker(
+                context_id,
+                request,
+                routing_parts,
+                phase,
+                true,
+                Some(worker),
+            )
+            .await?;
+        Ok(WorkerWithDpRank::new(
+            selection.instance_id,
+            selection.dp_rank,
+        ))
+    }
+}
+
+fn resolve_pinned_worker_rank(
+    worker_id: WorkerId,
+    requested_dp_rank: Option<u32>,
+    unique_dp_rank: Option<u32>,
+) -> Result<WorkerWithDpRank, Error> {
+    let Some(dp_rank) = requested_dp_rank.or(unique_dp_rank) else {
+        return Err(anyhow::anyhow!(
+            "Pinned worker {worker_id} requires an explicit dp_rank because it has multiple or unknown DP ranks"
+        ));
+    };
+
+    Ok(WorkerWithDpRank::new(worker_id, dp_rank))
+}
+
+fn pinned_worker_hint(
+    phase: RequestPhase,
+    routing: Option<&RoutingHints>,
+) -> Option<(u64, Option<u32>)> {
+    let routing = routing?;
+    match phase {
+        RequestPhase::Prefill => {
+            let worker_id = routing.prefill_worker_id.or(routing.backend_instance_id)?;
+            let dp_rank = routing.prefill_dp_rank.or(routing.dp_rank);
+            Some((worker_id, dp_rank))
+        }
+        RequestPhase::Decode => {
+            let worker_id = routing.decode_worker_id.or(routing.backend_instance_id)?;
+            Some((worker_id, routing.dp_rank))
+        }
+        RequestPhase::Aggregated => {
+            let worker_id = routing.backend_instance_id?;
+            Some((worker_id, routing.dp_rank))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use dynamo_kv_router::{
+        protocols::{RoutingConstraints, WorkerWithDpRank},
+        scheduling::{RoutingEligibility, WorkerEligibilityError},
+    };
+
+    use super::{pinned_worker_hint, resolve_pinned_worker_rank};
+    use crate::{
+        local_model::runtime_config::ModelRuntimeConfig,
+        protocols::common::{preprocessor::RoutingHints, timing::RequestPhase},
+    };
+
+    #[test]
+    fn resolve_pinned_worker_rank_uses_explicit_rank_including_zero() {
+        let worker = resolve_pinned_worker_rank(7, Some(0), Some(3)).unwrap();
+        assert_eq!(worker.worker_id, 7);
+        assert_eq!(worker.dp_rank, 0);
+    }
+
+    #[test]
+    fn resolve_pinned_worker_rank_uses_unique_rank_when_unset() {
+        let worker = resolve_pinned_worker_rank(7, None, Some(3)).unwrap();
+        assert_eq!(worker.worker_id, 7);
+        assert_eq!(worker.dp_rank, 3);
+    }
+
+    #[test]
+    fn resolve_pinned_worker_rank_rejects_unresolved_rank() {
+        let error = resolve_pinned_worker_rank(7, None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("requires an explicit dp_rank"));
+    }
+
+    #[test]
+    fn pinned_worker_hint_prefill_uses_prefill_worker_before_backend() {
+        let routing = RoutingHints {
+            backend_instance_id: Some(1),
+            prefill_worker_id: Some(2),
+            dp_rank: Some(3),
+            prefill_dp_rank: Some(4),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Prefill, Some(&routing)),
+            Some((2, Some(4)))
+        );
+    }
+
+    #[test]
+    fn pinned_worker_hint_decode_uses_decode_worker_before_backend() {
+        let routing = RoutingHints {
+            backend_instance_id: Some(1),
+            decode_worker_id: Some(5),
+            dp_rank: Some(6),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Decode, Some(&routing)),
+            Some((5, Some(6)))
+        );
+    }
+
+    #[test]
+    fn pinned_worker_hint_aggregated_uses_backend_worker() {
+        let routing = RoutingHints {
+            backend_instance_id: Some(9),
+            dp_rank: Some(7),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            pinned_worker_hint(RequestPhase::Aggregated, Some(&routing)),
+            Some((9, Some(7)))
+        );
+    }
+
+    #[test]
+    fn sticky_validation_style_ignores_transient_overload() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let configs = HashMap::from([(7, ModelRuntimeConfig::default())]);
+        let constraints = RoutingConstraints::default();
+        let overloaded = HashSet::from([7]);
+        let scheduling_eligibility =
+            RoutingEligibility::new(None, Some(&overloaded), Some(worker), &constraints);
+        let sticky_eligibility = RoutingEligibility::new(None, None, Some(worker), &constraints);
+
+        assert_eq!(
+            scheduling_eligibility
+                .validate_worker_rank(&configs, worker)
+                .err(),
+            Some(WorkerEligibilityError::WorkerOverloaded { worker_id: 7 })
+        );
+        assert!(
+            sticky_eligibility
+                .validate_worker_rank(&configs, worker)
+                .is_ok()
+        );
+    }
+}

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -20,6 +20,7 @@ use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use super::metrics::WORKER_LOAD_METRICS;
 use crate::kv_router::{ACTIVE_SEQUENCES_SUBJECT, KV_METRICS_SUBJECT};
@@ -51,6 +52,21 @@ impl SequencePublisher for RuntimeSequencePublisher {
         });
     }
 
+    fn publish_load_batch(&self, loads: Vec<ActiveLoad>) {
+        let publisher = self.metrics_publisher.clone();
+        tokio::spawn(async move {
+            for load in loads {
+                if let Err(e) = publisher.publish(&load).await {
+                    tracing::trace!(
+                        "Failed to publish ActiveLoad to NATS for worker (id={}, dp_rank={}): {e:?}",
+                        load.worker_id,
+                        load.dp_rank
+                    );
+                }
+            }
+        });
+    }
+
     fn observe_load(
         &self,
         worker: &WorkerWithDpRank,
@@ -78,6 +94,18 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
         match self.inner.next().await? {
             Ok((_envelope, event)) => Some(Ok(event)),
             Err(e) => Some(Err(e)),
+        }
+    }
+
+    fn poll_next_event(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
+        match self.inner.poll_next(cx) {
+            Poll::Ready(Some(Ok((_envelope, event)))) => Poll::Ready(Some(Ok(event))),
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -770,13 +770,21 @@ pub struct TypedEventSubscriber<T> {
 impl<T: DeserializeOwned + Send + 'static> TypedEventSubscriber<T> {
     /// Get the next typed event with its envelope.
     pub async fn next(&mut self) -> Option<Result<(EventEnvelope, T)>> {
-        let envelope = self.stream.next().await?;
-        match envelope {
-            Ok(env) => match self.codec.decode_payload(&env.payload) {
-                Ok(typed) => Some(Ok((env, typed))),
-                Err(e) => Some(Err(e)),
-            },
-            Err(e) => Some(Err(e)),
+        std::future::poll_fn(|cx| self.poll_next(cx)).await
+    }
+
+    /// Poll for the next typed event.
+    pub fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<(EventEnvelope, T)>>> {
+        match self.stream.as_mut().poll_next(cx) {
+            Poll::Ready(Some(envelope)) => Poll::Ready(Some(match envelope {
+                Ok(env) => match self.codec.decode_payload(&env.payload) {
+                    Ok(typed) => Ok((env, typed)),
+                    Err(e) => Err(e),
+                },
+                Err(e) => Err(e),
+            })),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Batch replica-sync side effects while preserving delivered lifecycle-event order and the derived read DAG.
- Prevent ghost scheduler bookings by skipping cancelled queued requests and rolling back bookings when response delivery races with cancellation.
- Make push routing cancellation-aware during worker selection and pre-stream setup, with RAII cleanup for scheduler state and sticky-session closure.
- Split push-router cancellation, request lifecycle, and worker-selection logic into focused private modules.

## Validation

- `cargo test -p dynamo-llm --no-default-features kv_router::push_router --lib`
- `cargo clippy --no-default-features -- -D warnings` in `lib/llm`
- `cargo clippy --no-default-features -- -D warnings` in `lib/bindings/python`
- Replica-sync unit tests in `dynamo-kv-router`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replica synchronization support for multi-worker sequence management
  * Introduced batched load publishing for improved throughput
  * Enabled cancellation-aware worker selection logic

* **Improvements**
  * Enhanced request booking with automatic rollback on delivery failures
  * Improved cancellation propagation throughout request routing pipelines
  * Refined event polling mechanisms for better async handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->