### PR TITLE
fix(renderer): accept deepseek_v32 model_type for V3.2 native formatter

### DIFF
--- a/lib/renderer/src/template.rs
+++ b/lib/renderer/src/template.rs
@@ -163,7 +163,9 @@ fn is_deepseek_v3_2_non_exp(model_type_lower: &Option<String>, display_name_lowe
         && display_name_lower.contains("v3.2")
         && !display_name_lower.contains("exp");
     match model_type_lower.as_deref() {
-        Some("deepseek_v3_2") => !display_name_lower.contains("exp"),
+        // HF ships `deepseek_v32` (no underscore between 3 and 2); Dynamo's
+        // internal/tool-parser key is `deepseek_v3_2`. Accept both.
+        Some("deepseek_v3_2" | "deepseek_v32") => !display_name_lower.contains("exp"),
         Some(_) => false,
         None => name_match,
     }
@@ -281,6 +283,13 @@ mod detection_tests {
         assert!(is_deepseek_v3_2_non_exp(&v3_2, "deepseek-v3.2"));
         // V3.2-Exp is a separate model family; suppress even via config.
         assert!(!is_deepseek_v3_2_non_exp(&v3_2, "deepseek-v3.2-exp"));
+
+        // The actual HF config.json spelling has no underscore between 3 and 2
+        // (`deepseek_v32`). It must trigger identically to the internal key.
+        let hf_real = Some("deepseek_v32".to_string());
+        assert!(is_deepseek_v3_2_non_exp(&hf_real, "whatever"));
+        assert!(is_deepseek_v3_2_non_exp(&hf_real, "deepseek-v3.2-nvfp4"));
+        assert!(!is_deepseek_v3_2_non_exp(&hf_real, "deepseek-v3.2-exp"));
 
         // Other config types lose regardless of display name.
         let other = Some("deepseek_v4".to_string());


### PR DESCRIPTION
#### Overview
On Dynamo v1.2.0 the worker never registers DeepSeek-V3.2 (`deepseek-ai/DeepSeek-V3.2`, `nvidia/DeepSeek-V3.2-NVFP4`) with the frontend, so `/v1/models` is empty and chat requests 404. v1.1.0 worked. 

Root cause: the native-formatter detection added in `5cef9b62`(#8670) keys off `config.json` `model_type` and only accepts the literal `"deepseek_v3_2"`, but these models ship `"deepseek_v32"` (no underscore between 3 and 2). The non-matching value hits the `Some(_) => false` arm, suppresses the display-name fallback, and the request falls through to the HF Jinja path, which fails because V3.2 ships no `chat_template`. This PR accepts both spellings.

**Repro:**
```
# deploy deepseek-ai/DeepSeek-V3.2 on v1.2.0
curl http://<frontend>/v1/models
```

**Before:**
```
$ curl .../v1/models
{"object":"list","data":[]}

worker log:
ERROR dynamo_llm::discovery::watcher
  build_routed_pipeline: PromptFormatter.from_mdc:
  chat_template field is required in the
  tokenizer_config.json file
```

**After:**
```
$ curl .../v1/models
{"object":"list","data":[{"id":"deepseek-ai/DeepSeek-V3.2", ...}]}
# native V3.2 Rust formatter activates; no chat_template needed
```

#### Details
`is_deepseek_v3_2_non_exp` now matches both `deepseek_v3_2` and `deepseek_v32`. The `Some(_) => false` suppression and display-name fallback are unchanged. Added a test feeding the real HF string `deepseek_v32`; prior tests only used the internal spelling, which is why CI stayed green through the regression.

#### Where should the reviewer start?
`is_deepseek_v3_2_non_exp` in `lib/renderer/src/template.rs`. The one-arm match change is the whole fix.

#### Related Issues
- Resolves #10278


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of DeepSeek V3.2 non-Experimental models to support multiple tokenizer configuration formats, improving compatibility and ensuring consistent model recognition across different implementations.

* **Tests**
  * Updated test coverage to validate model detection across various configuration formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->