### PR TITLE
fix(mm-routing): fix Phi-3 splice helper — drop roundtrip, remove mid-BOS

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1333,34 +1333,16 @@ impl OpenAIPreprocessor {
     }
 
     /// Build routing-side tokens for Phi-3-vision's `<|image_N|>` numbered
-    /// placeholder template so the router's per-block hashes match the
-    /// worker's BlockStored events byte-for-byte.
+    /// placeholder template. Mirrors vLLM's text-substitute path: split the
+    /// formatted prompt at each `<|image_N|>` text boundary, encode each
+    /// segment, insert one `find_token_id` slot (outer loop expands to N
+    /// copies), prepend a single leading BOS.
     ///
-    /// **Family contract — Phi-3-only.** The encode-decode roundtrip +
-    /// per-segment BOS pattern here is specific to Phi-3's HF processor
-    /// (and any future `LlamaTokenizer`-family with `<|image_{n}|>`
-    /// placeholders): the processor splits the prompt at `<|image_N|>` and
-    /// tokenizes each segment with `add_special_tokens=true`, prefixing
-    /// every segment (including the first) with a fresh BOS, and decodes-
-    /// then-re-encodes across special-token boundaries, which inserts
-    /// whitespace after each special token and bumps the SentencePiece
-    /// prefix token (e.g. 29871 `▁` -> 259 `▁▁` for `<|user|>\n`). Both
-    /// effects are reproduced here.
-    ///
-    /// Caller is `gather_mm_exact_routing_info`, which gates on
-    /// `placeholder_tpl.contains("{n}")`. The `routing_prepend_bos`
-    /// requirement below acts as the family guard: a future model with a
-    /// `{n}`-style placeholder but no BOS prepend (i.e. not a
-    /// LlamaTokenizer-family) would not benefit from this roundtrip and
-    /// could silently produce wrong block hashes, so we bail and let the
-    /// caller fall back to text-prefix routing.
-    ///
-    /// Returns one `find_token_id` per image; the caller's expansion loop
-    /// multiplies them to the per-image patch count. Leading BOS is
-    /// emitted here as the first element of the returned vector — the
-    /// caller does NOT prepend its own BOS when this helper succeeds.
-    /// Returns `None` (caller falls back to text-prefix routing) when the
-    /// family guard trips or on any tokenize/decode failure.
+    /// `<|image_1|>` is not a vocabulary token in Phi-3-vision so it
+    /// BPE-shatters. Splitting the original string directly avoids the
+    /// SentencePiece `▁`-prefix drift that a roundtrip encode/decode introduces.
+    /// `routing_prepend_bos` being set (add_bos_token=true) is the family guard;
+    /// returns `None` to fall back to text-prefix routing if not satisfied.
     #[cfg(feature = "lightseek-mm")]
     fn splice_phi3_numbered_placeholders_at_token_level(
         &self,
@@ -1369,21 +1351,7 @@ impl OpenAIPreprocessor {
         find_token_id: crate::protocols::TokenIdType,
         expected_count: usize,
     ) -> Option<Vec<crate::protocols::TokenIdType>> {
-        // Family guard: the encode-decode roundtrip + per-segment BOS
-        // semantics are LlamaTokenizer-family-specific. `routing_prepend_bos`
-        // is set iff the model declares `add_bos_token: true` in
-        // tokenizer_config.json, which is the marker for that family.
         let bos = self.routing_prepend_bos?;
-
-        // Encode-decode roundtrip mirrors vLLM's text-substitute fallback,
-        // which is what the Phi-3 worker actually hashes on.
-        let prompt_owned: String = self
-            .tokenizer
-            .encode(prompt)
-            .ok()
-            .and_then(|enc| self.tokenizer.decode(enc.token_ids(), false).ok())
-            .map(Into::into)?;
-        let prompt: &str = &prompt_owned;
 
         let mut byte_ranges: Vec<(usize, usize)> = Vec::with_capacity(expected_count);
         let mut search_from = 0usize;
@@ -1396,20 +1364,12 @@ impl OpenAIPreprocessor {
             search_from = end;
         }
 
-        // Leading BOS is emitted here so the caller's general-purpose
-        // BOS-prepend path can skip when this helper produced the
-        // normalized tokens (avoids the prior split-brain where leading
-        // BOS was pushed by the caller and mid/suffix BOS pushed here).
         let mut result: Vec<crate::protocols::TokenIdType> = vec![bos];
         let mut prev_end = 0usize;
         for &(ph_start, ph_end) in byte_ranges.iter() {
-            let seg = &prompt[prev_end..ph_start];
-            let seg_enc = self.tokenizer.encode(seg).ok()?;
+            let seg_enc = self.tokenizer.encode(&prompt[prev_end..ph_start]).ok()?;
             result.extend_from_slice(seg_enc.token_ids());
             result.push(find_token_id);
-            // Mid-prompt segments get a fresh BOS — Phi-3's HF processor
-            // tokenizes each segment with add_special_tokens=true.
-            result.push(bos);
             prev_end = ph_end;
         }
         let suffix_enc = self.tokenizer.encode(&prompt[prev_end..]).ok()?;

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -259,16 +259,15 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # leaves slim headroom on a 24 GiB box. If first post_merge
             # run OOMs, drop to one worker (NUM_WORKERS=1) or move to
             # gpu_2 with one worker per GPU.
+            # Temporarily pre_merge to validate the splice-helper fix for
+            # Phi-3's numbered image placeholders (PR #TODO). Move back to
+            # post_merge once CI confirms the kv_hit_rate gate passes.
             "agg_router": TopologyConfig(
-                marks=[pytest.mark.post_merge],
+                marks=[pytest.mark.pre_merge],
                 timeout_s=500,
                 profiled_vram_gib=22.0,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
                 env={"SINGLE_GPU": "true"},
-                # cached_tokens-asserting payload proves MM-aware routing
-                # engaged (2nd identical request hits the warm worker's KV
-                # cache); a silent regression to text-prefix-only routing
-                # would still return "green" but 0 cached tokens.
                 tests=[
                     MmCase(
                         payload=make_image_payload_cached_tokens(


### PR DESCRIPTION
## Summary

Fixes `tests/serve/test_vllm.py::test_serve_deployment[mm_agg_router_phi3-vision-2]` failing with `router_kv_hit_rate: mean over R2+ (0.000)`.

**Root cause:** `<|image_1|>` is not a vocabulary token in Phi-3-vision (only `<|image|>` ID 32044 exists). The splice helper's encode→decode roundtrip caused SentencePiece to insert `▁` space prefixes at `\n` boundaries, so `\n<|image_1|>` decoded to `\n <|image_1|>`. This shifted segment boundaries, adding a spurious space token (29871) to the routing sequence — making every block 0 hash diverge from what vLLM stored → 0.000 hit rate across all retries.

**Fix (`lib/llm/src/preprocessor.rs`):**
- Drop the 7-line roundtrip encode/decode — search `<|image_N|>` in the original formatted-prompt string directly
- Drop `result.push(bos)` — vLLM's text-substitute path doesn't re-tokenise each segment independently, so no per-segment BOS after the image patches

**Validation (`tests/serve/multimodal_profiles/vllm.py`):**
- Temporarily promote `mm_agg_router_phi3-vision` from `post_merge` → `pre_merge` so this PR's CI confirms the `kv_hit_rate >= 0.9` gate passes. Will move back to `post_merge` in a follow-up once green.

## Test plan
- [ ] `mm_agg_router_phi3-vision-2` pre_merge CI passes with `router_kv_hit_rate >= 0.9`
- [ ] Qwen3-VL-2B `agg_router` pre_merge still passes (fast path unaffected)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Phi-3 vision model's image token routing behavior and sequencing for more efficient handling of image placeholders, with fallback support for text-prefix routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->