### PR TITLE
add support for sgl self benchmarking

### DIFF
--- a/components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py
+++ b/components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py
@@ -12,8 +12,13 @@ Order (highest → lowest):
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import msgspec
 import pytest
 
+from dynamo.common.forward_pass_metrics import (
+    ForwardPassMetrics,
+    ScheduledRequestMetrics,
+)
 from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
 from dynamo.planner.config.defaults import SubComponentType
 from dynamo.planner.config.parallelization import PickedParallelConfig
@@ -251,3 +256,35 @@ class TestEndpointDiscoveryWait:
         )
 
         assert got is False
+
+
+class TestBenchmarkExtraction:
+    def test_prefill_kv_read_point_preserves_fpm_kv_tokens(self):
+        fpm = ForwardPassMetrics(
+            wall_time=0.012,
+            scheduled_requests=ScheduledRequestMetrics(
+                num_prefill_requests=1,
+                sum_prefill_tokens=128,
+                sum_prefill_kv_tokens=512,
+            ),
+        )
+        benchmark_data = {
+            "results": [
+                {
+                    "point": {
+                        "point_type": "prefill",
+                        "isl": 640,
+                        "kv_read_tokens": 512,
+                    },
+                    "fpms": [msgspec.to_builtins(fpm)],
+                }
+            ]
+        }
+
+        fpms = pm._extract_fpms_from_benchmark(
+            benchmark_data, SubComponentType.PREFILL
+        )
+
+        assert len(fpms) == 1
+        assert fpms[0].scheduled_requests.sum_prefill_tokens == 128
+        assert fpms[0].scheduled_requests.sum_prefill_kv_tokens == 512

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -17,6 +17,7 @@ try:
         _inject_mocker_aic_args,
         build_aic_interpolation_spec,
         build_aic_perf_model_spec,
+        enable_sglang_benchmark_mode,
         enable_vllm_benchmark_mode,
     )
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
@@ -526,3 +527,73 @@ class TestEnableVllmBenchmarkMode:
         assert (
             _benchmark_mode(cfg["spec"]["services"]["VllmPrefillWorker"]) == "prefill"
         )
+
+
+class TestEnableSGLangBenchmarkMode:
+    def test_disagg_sets_prefill_and_decode(self):
+        cfg = {
+            "spec": {
+                "services": {
+                    "Frontend": {},
+                    "prefill": {},
+                    "decode": {},
+                }
+            }
+        }
+        enable_sglang_benchmark_mode(cfg)
+        services = cfg["spec"]["services"]
+        assert _benchmark_mode(services["prefill"]) == "prefill"
+        assert _benchmark_mode(services["decode"]) == "decode"
+        assert "env" not in services["Frontend"].get("extraPodSpec", {}).get(
+            "mainContainer", {}
+        )
+
+    def test_agg_sets_single_decode_worker(self):
+        cfg = {"spec": {"services": {"Frontend": {}, "decode": {}}}}
+        enable_sglang_benchmark_mode(cfg)
+        assert _benchmark_mode(cfg["spec"]["services"]["decode"]) == "agg"
+
+    def test_idempotent_replaces_existing_value(self):
+        cfg = {
+            "spec": {
+                "services": {
+                    "decode": {
+                        "extraPodSpec": {
+                            "mainContainer": {
+                                "env": [
+                                    {"name": "SOMETHING_ELSE", "value": "keep"},
+                                    {"name": "DYN_BENCHMARK_MODE", "value": "wrong"},
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        enable_sglang_benchmark_mode(cfg)
+        env = cfg["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"]["env"]
+        names = [e["name"] for e in env]
+        assert names.count("DYN_BENCHMARK_MODE") == 1
+        assert _benchmark_mode(cfg["spec"]["services"]["decode"]) == "agg"
+        assert {"name": "SOMETHING_ELSE", "value": "keep"} in env
+
+    def test_preserves_unrelated_service_keys(self):
+        cfg = {
+            "spec": {
+                "services": {
+                    "prefill": {
+                        "extraPodSpec": {
+                            "mainContainer": {
+                                "image": "nvcr.io/foo:1.0",
+                                "args": ["--model-path", "x"],
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        enable_sglang_benchmark_mode(cfg)
+        mc = cfg["spec"]["services"]["prefill"]["extraPodSpec"]["mainContainer"]
+        assert mc["image"] == "nvcr.io/foo:1.0"
+        assert mc["args"] == ["--model-path", "x"]
+        assert _benchmark_mode(cfg["spec"]["services"]["prefill"]) == "prefill"

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -26,6 +26,7 @@ from dynamo.common.utils.paths import get_workspace_dir
 from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
 from dynamo.planner.config.backend_components import (
     MockerComponentName,
+    SGLangComponentName,
     VllmComponentName,
 )
 from dynamo.planner.config.parallelization import (
@@ -83,7 +84,7 @@ def assemble_final_config(
     """Apply Dynamo features to the picked DGD config via composable layers.
 
     1. **Mocker** — swap the base to the mocker DGD template if enabled.
-    2. **vLLM self-benchmark** — when the resolved backend is vLLM, set
+    2. **backend self-benchmark** — when the resolved backend supports it, set
        ``DYN_BENCHMARK_MODE`` on each worker so the ``get_perf_metrics``
        endpoint is populated at runtime. The planner consumes this as
        priority 1 of its bootstrap chain, superseding AIC and files.
@@ -121,11 +122,13 @@ def assemble_final_config(
     else:
         base = dgd_config
 
-    # Step 2: for vLLM deployments, turn on the per-worker self-benchmark so
+    # Step 2: for supported backends, turn on the per-worker self-benchmark so
     # the get_perf_metrics endpoint is available to the planner. Mocker
     # workers don't use DYN_BENCHMARK_MODE, so skip when mocker is active.
     if not mocker and resolved_backend == "vllm":
         enable_vllm_benchmark_mode(base)
+    elif not mocker and resolved_backend == "sglang":
+        enable_sglang_benchmark_mode(base)
 
     # Steps 3-4: layer features, collecting ConfigMaps
     config_maps: list[dict] = []
@@ -169,19 +172,35 @@ def _vllm_worker_roles() -> dict[str, str]:
     }
 
 
-def enable_vllm_benchmark_mode(config_dict: dict) -> None:
-    """Set ``DYN_BENCHMARK_MODE`` on every vLLM worker in *config_dict*.
+def _sglang_worker_roles(config_dict: dict) -> dict[str, str]:
+    """Canonical SGLang DGD service name → DYN_BENCHMARK_MODE role.
 
-    Mutates ``config_dict`` in place. Each recognised worker service
-    (``VllmPrefillWorker`` / ``VllmDecodeWorker`` / ``VllmWorker``) gets the
-    mode matching its role so its startup self-benchmark publishes
-    ForwardPassMetrics via the ``get_perf_metrics`` endpoint.
-
-    Idempotent: if ``DYN_BENCHMARK_MODE`` is already set (e.g. via user
-    overrides) the existing entry is replaced with the role-correct value.
+    SGLang uses short service names. In disaggregated configs, both
+    ``prefill`` and ``decode`` exist; in aggregated configs, ``decode`` is
+    the single worker service, so benchmark it in ``agg`` mode.
     """
     services = config_dict.get("spec", {}).get("services", {})
-    for svc_name, mode in _vllm_worker_roles().items():
+    if not isinstance(services, dict):
+        return {}
+
+    roles: dict[str, str] = {}
+    prefill = SGLangComponentName.prefill_worker_k8s_name
+    decode = SGLangComponentName.decode_worker_k8s_name
+    if prefill in services:
+        roles[prefill] = "prefill"
+    if decode in services:
+        roles[decode] = "decode" if prefill in services else "agg"
+    return roles
+
+
+def _set_benchmark_mode_env(
+    config_dict: dict, worker_roles: dict[str, str], backend_label: str
+) -> None:
+    services = config_dict.get("spec", {}).get("services", {})
+    if not isinstance(services, dict):
+        return
+
+    for svc_name, mode in worker_roles.items():
         svc = services.get(svc_name)
         if svc is None:
             continue
@@ -197,10 +216,35 @@ def enable_vllm_benchmark_mode(config_dict: dict) -> None:
         ]
         env_list.append({"name": "DYN_BENCHMARK_MODE", "value": mode})
         logger.info(
-            "Enabled vLLM self-benchmark on service %s (DYN_BENCHMARK_MODE=%s)",
+            "Enabled %s self-benchmark on service %s (DYN_BENCHMARK_MODE=%s)",
+            backend_label,
             svc_name,
             mode,
         )
+
+
+def enable_vllm_benchmark_mode(config_dict: dict) -> None:
+    """Set ``DYN_BENCHMARK_MODE`` on every vLLM worker in *config_dict*.
+
+    Mutates ``config_dict`` in place. Each recognised worker service
+    (``VllmPrefillWorker`` / ``VllmDecodeWorker`` / ``VllmWorker``) gets the
+    mode matching its role so its startup self-benchmark publishes
+    ForwardPassMetrics via the ``get_perf_metrics`` endpoint.
+
+    Idempotent: if ``DYN_BENCHMARK_MODE`` is already set (e.g. via user
+    overrides) the existing entry is replaced with the role-correct value.
+    """
+    _set_benchmark_mode_env(config_dict, _vllm_worker_roles(), "vLLM")
+
+
+def enable_sglang_benchmark_mode(config_dict: dict) -> None:
+    """Set ``DYN_BENCHMARK_MODE`` on every SGLang worker in *config_dict*.
+
+    Mutates ``config_dict`` in place. Disaggregated configs set ``prefill`` and
+    ``decode`` separately; aggregated configs set the single ``decode`` worker
+    to ``agg``.
+    """
+    _set_benchmark_mode_env(config_dict, _sglang_worker_roles(config_dict), "SGLang")
 
 
 def generate_mocker_config(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -30,6 +30,7 @@ from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.sglang._compat import enable_disjoint_streaming_output
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
+from dynamo.sglang.benchmark import apply_benchmark_env
 
 configure_dynamo_logging()
 PREFILL_DECODE_DISAGGREGATION_MODE = "pd"
@@ -334,6 +335,7 @@ async def parse_args(args: list[str]) -> Config:
     dynamo_config.validate_multimodal_topology()
 
     parsed_args = sglang_only_parser.parse_args(unknown)
+    apply_benchmark_env(parsed_args, unknown)
 
     # Clean up temp file if created
     if temp_config_file and os.path.exists(temp_config_file):

--- a/components/src/dynamo/sglang/benchmark.py
+++ b/components/src/dynamo/sglang/benchmark.py
@@ -134,26 +134,32 @@ async def wait_and_load_benchmark(server_args: Any) -> dict[str, Any]:
             stem, ext = os.path.splitext(str(base_path))
             rank_paths.append(Path(f"{stem}_dp{dp_rank}{ext}"))
 
+    expected_model = getattr(server_args, "model_path", None)
     logger.info(
         "Waiting for SGLang self-benchmark to complete (files: %s, timeout: %ds)",
         rank_paths,
         timeout,
     )
     deadline = time.monotonic() + timeout
-    for path in rank_paths:
-        while not path.exists():
-            if time.monotonic() > deadline:
-                raise TimeoutError(
-                    f"SGLang self-benchmark did not complete within {timeout}s. "
-                    f"Missing: {path}"
-                )
-            await asyncio.sleep(0.1)
+    loaded: list[tuple[int, dict[str, Any]]] = []
+    for i, path in enumerate(rank_paths):
+        data = await _await_completed_result(path, deadline, timeout, expected_model)
+        loaded.append((dp_start + i, data))
+
+    # The producer stamps every rank file with the current run_id and, at
+    # startup, rewrites it to an invalid "running" sentinel, so a stale file
+    # from a previous (possibly crashed) run is never accepted. As a final
+    # cross-rank guard, all merged rank files must agree on the run_id.
+    run_ids = {d.get("run_id") for _, d in loaded if d.get("run_id")}
+    if len(run_ids) > 1:
+        logger.warning(
+            "SGLang self-benchmark rank files have mismatched run_ids %s; "
+            "results may combine different runs",
+            run_ids,
+        )
 
     merged: dict[str, Any] = {}
-    for i, path in enumerate(rank_paths):
-        with open(path) as f:
-            data = json.load(f)
-        dp_rank = dp_start + i
+    for i, (dp_rank, data) in enumerate(loaded):
         if i == 0:
             merged = data
             for result in merged.get("results", []):
@@ -164,11 +170,70 @@ async def wait_and_load_benchmark(server_args: Any) -> dict[str, Any]:
             merged.setdefault("results", []).extend(data.get("results", []))
 
     logger.info(
-        "SGLang self-benchmark complete, %d point(s) across %d rank(s)",
+        "SGLang self-benchmark complete (run_id=%s), %d point(s) across %d rank(s)",
+        merged.get("run_id"),
         len(merged.get("results", [])),
         len(rank_paths),
     )
     return merged
+
+
+async def _await_completed_result(
+    path: Path, deadline: float, timeout: int, expected_model: Any
+) -> dict[str, Any]:
+    """Poll until ``path`` holds a COMPLETED self-benchmark result.
+
+    The producer writes an invalid "running" sentinel at startup and atomically
+    replaces it with the completed results when the sweep finishes, so we wait
+    for ``status == "complete"`` rather than mere file existence; otherwise we
+    would accept the in-progress sentinel (or a stale prior-run file).
+    """
+    while True:
+        data = _read_json(path)
+        if data is not None and _is_completed_result(data):
+            _warn_on_model_mismatch(path, data, expected_model)
+            return data
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"SGLang self-benchmark did not complete within {timeout}s. "
+                f"Incomplete or missing: {path}"
+            )
+        await asyncio.sleep(0.1)
+
+
+def _read_json(path: Path) -> Optional[dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        # Mid-write or transiently unreadable; treat as not-ready and retry.
+        return None
+
+
+def _is_completed_result(data: dict[str, Any]) -> bool:
+    status = data.get("status")
+    if status == "complete":
+        return data.get("valid", True) is not False
+    # Backward compatibility with producers that predate the status field.
+    return status is None and "results" in data
+
+
+def _warn_on_model_mismatch(
+    path: Path, data: dict[str, Any], expected_model: Any
+) -> None:
+    if expected_model is None:
+        return
+    actual = data.get("identity", {}).get("model_path")
+    if actual is not None and actual != expected_model:
+        logger.warning(
+            "SGLang self-benchmark file %s was produced for model %r but this "
+            "worker serves %r; results may be stale or misrouted",
+            path,
+            actual,
+            expected_model,
+        )
 
 
 def _apply_int_env(

--- a/components/src/dynamo/sglang/benchmark.py
+++ b/components/src/dynamo/sglang/benchmark.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from dynamo.sglang.capacity import local_dp_rank_bounds
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BENCHMARK_OUTPUT_PATH = "/tmp/benchmark_results.json"
+
+
+def apply_benchmark_env(parsed_args: Any, cli_args: list[str]) -> None:
+    """Map Dynamo benchmark env vars onto native SGLang benchmark args."""
+
+    mode = os.environ.get("DYN_BENCHMARK_MODE")
+    if mode and getattr(parsed_args, "benchmark_mode", None) is None:
+        if mode not in {"prefill", "decode", "agg"}:
+            raise ValueError(
+                "DYN_BENCHMARK_MODE must be one of: prefill, decode, agg; "
+                f"got {mode!r}"
+            )
+        parsed_args.benchmark_mode = mode
+
+    _apply_int_env(
+        parsed_args,
+        cli_args,
+        "benchmark_prefill_granularity",
+        "--benchmark-prefill-granularity",
+        "DYN_BENCHMARK_PREFILL_GRANULARITY",
+    )
+    _apply_int_env(
+        parsed_args,
+        cli_args,
+        "benchmark_decode_length_granularity",
+        "--benchmark-decode-length-granularity",
+        "DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY",
+    )
+    _apply_int_env(
+        parsed_args,
+        cli_args,
+        "benchmark_decode_batch_granularity",
+        "--benchmark-decode-batch-granularity",
+        "DYN_BENCHMARK_DECODE_BATCH_GRANULARITY",
+    )
+    _apply_int_env(
+        parsed_args,
+        cli_args,
+        "benchmark_warmup_iterations",
+        "--benchmark-warmup-iterations",
+        "DYN_BENCHMARK_WARMUP_ITERATIONS",
+    )
+    _apply_int_env(
+        parsed_args,
+        cli_args,
+        "benchmark_timeout",
+        "--benchmark-timeout",
+        "DYN_BENCHMARK_TIMEOUT",
+    )
+
+    output_path = os.environ.get("DYN_BENCHMARK_OUTPUT_PATH")
+    if output_path and not _has_cli_flag(cli_args, "--benchmark-output-path"):
+        parsed_args.benchmark_output_path = output_path
+
+
+def prepare_benchmark_output_path(server_args: Any, worker_id: object) -> None:
+    """Make the default benchmark output path unique per worker instance."""
+
+    if getattr(server_args, "benchmark_mode", None) is None:
+        return
+    if (
+        getattr(server_args, "benchmark_output_path", None)
+        != _DEFAULT_BENCHMARK_OUTPUT_PATH
+    ):
+        return
+    short_id = str(worker_id)[-8:]
+    server_args.benchmark_output_path = f"/tmp/benchmark_results_{short_id}.json"
+
+
+def benchmark_config(server_args: Any) -> Optional[dict[str, Any]]:
+    mode = getattr(server_args, "benchmark_mode", None)
+    if mode is None:
+        return None
+    return {
+        "mode": mode,
+        "prefill_isl_granularity": getattr(
+            server_args, "benchmark_prefill_granularity", 16
+        ),
+        "decode_length_granularity": getattr(
+            server_args, "benchmark_decode_length_granularity", 6
+        ),
+        "decode_batch_size_granularity": getattr(
+            server_args, "benchmark_decode_batch_granularity", 6
+        ),
+        "warmup_iterations": getattr(server_args, "benchmark_warmup_iterations", 5),
+        "output_path": getattr(
+            server_args, "benchmark_output_path", _DEFAULT_BENCHMARK_OUTPUT_PATH
+        ),
+        "timeout": getattr(server_args, "benchmark_timeout", 300),
+    }
+
+
+async def wait_and_load_benchmark(server_args: Any) -> dict[str, Any]:
+    cfg = benchmark_config(server_args)
+    if cfg is None:
+        return {"status": "error", "message": "benchmark mode is not enabled"}
+
+    base_path = Path(cfg["output_path"])
+    timeout = int(cfg.get("timeout", 300))
+    dp_start, dp_end = local_dp_rank_bounds(server_args)
+    rank_paths = []
+    for dp_rank in range(dp_start, dp_end):
+        if dp_rank == 0:
+            rank_paths.append(base_path)
+        else:
+            stem, ext = os.path.splitext(str(base_path))
+            rank_paths.append(Path(f"{stem}_dp{dp_rank}{ext}"))
+
+    logger.info(
+        "Waiting for SGLang self-benchmark to complete (files: %s, timeout: %ds)",
+        rank_paths,
+        timeout,
+    )
+    deadline = time.monotonic() + timeout
+    for path in rank_paths:
+        while not path.exists():
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"SGLang self-benchmark did not complete within {timeout}s. "
+                    f"Missing: {path}"
+                )
+            await asyncio.sleep(0.1)
+
+    merged: dict[str, Any] = {}
+    for i, path in enumerate(rank_paths):
+        with open(path) as f:
+            data = json.load(f)
+        dp_rank = dp_start + i
+        if i == 0:
+            merged = data
+            for result in merged.get("results", []):
+                result.setdefault("point", {})["dp_rank"] = dp_rank
+        else:
+            for result in data.get("results", []):
+                result.setdefault("point", {})["dp_rank"] = dp_rank
+            merged.setdefault("results", []).extend(data.get("results", []))
+
+    logger.info(
+        "SGLang self-benchmark complete, %d point(s) across %d rank(s)",
+        len(merged.get("results", [])),
+        len(rank_paths),
+    )
+    return merged
+
+
+def _apply_int_env(
+    parsed_args: Any, cli_args: list[str], attr: str, flag: str, env_var: str
+) -> None:
+    raw = os.environ.get(env_var)
+    if raw is not None and not _has_cli_flag(cli_args, flag):
+        setattr(parsed_args, attr, int(raw))
+
+
+def _has_cli_flag(args: list[str], flag: str) -> bool:
+    return any(arg == flag or arg.startswith(f"{flag}=") for arg in args)

--- a/components/src/dynamo/sglang/benchmark.py
+++ b/components/src/dynamo/sglang/benchmark.py
@@ -40,6 +40,13 @@ def apply_benchmark_env(parsed_args: Any, cli_args: list[str]) -> None:
     _apply_int_env(
         parsed_args,
         cli_args,
+        "benchmark_prefill_kv_read_granularity",
+        "--benchmark-prefill-kv-read-granularity",
+        "DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY",
+    )
+    _apply_int_env(
+        parsed_args,
+        cli_args,
         "benchmark_decode_length_granularity",
         "--benchmark-decode-length-granularity",
         "DYN_BENCHMARK_DECODE_LENGTH_GRANULARITY",
@@ -93,6 +100,9 @@ def benchmark_config(server_args: Any) -> Optional[dict[str, Any]]:
         "mode": mode,
         "prefill_isl_granularity": getattr(
             server_args, "benchmark_prefill_granularity", 16
+        ),
+        "prefill_kv_read_granularity": getattr(
+            server_args, "benchmark_prefill_kv_read_granularity", 1
         ),
         "decode_length_granularity": getattr(
             server_args, "benchmark_decode_length_granularity", 6

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -15,6 +15,7 @@ from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
+from dynamo.sglang.benchmark import wait_and_load_benchmark
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangHealthCheckPayload,
@@ -69,6 +70,12 @@ async def init_decode(
                 "a different IPC path than the relay would subscribe to."
             )
             server_args.enable_forward_pass_metrics = False
+        if getattr(server_args, "benchmark_mode", None) is not None:
+            logging.warning(
+                "SGLang self-benchmark disabled in snapshot mode: the engine was "
+                "created before Dynamo could assign a benchmark output path."
+            )
+            server_args.benchmark_mode = None
     else:
         set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
         start_time = time.time()
@@ -87,8 +94,11 @@ async def init_decode(
     list_loras_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.list_loras"
     )
+    perf_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.get_perf_metrics"
+    )
 
-    shutdown_endpoints[:] = [generate_endpoint]
+    shutdown_endpoints[:] = [generate_endpoint, perf_endpoint]
 
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
@@ -115,6 +125,9 @@ async def init_decode(
         enable_frontend_decoding=dynamo_args.frontend_decoding,
     )
     handler.register_engine_routes(runtime)
+
+    if getattr(server_args, "benchmark_mode", None) is not None:
+        handler._benchmark_results = await wait_and_load_benchmark(server_args)
 
     if config.serving_mode == DisaggregationMode.DECODE:
         health_check_payload = SglangDisaggHealthCheckPayload(
@@ -158,6 +171,10 @@ async def init_decode(
             ),
             list_loras_endpoint.serve_endpoint(
                 handler.list_loras,
+                metrics_labels=metrics_labels,
+            ),
+            perf_endpoint.serve_endpoint(
+                handler.get_perf_metrics,
                 metrics_labels=metrics_labels,
             ),
             register_model_with_readiness_gate(
@@ -216,6 +233,12 @@ async def init_prefill(
                 "a different IPC path than the relay would subscribe to."
             )
             server_args.enable_forward_pass_metrics = False
+        if getattr(server_args, "benchmark_mode", None) is not None:
+            logging.warning(
+                "SGLang self-benchmark disabled in snapshot mode: the engine was "
+                "created before Dynamo could assign a benchmark output path."
+            )
+            server_args.benchmark_mode = None
     else:
         set_forward_pass_metrics_worker_id(server_args, generate_endpoint)
         start_time = time.time()
@@ -234,8 +257,11 @@ async def init_prefill(
     list_loras_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.list_loras"
     )
+    perf_endpoint = runtime.endpoint(
+        f"{dynamo_args.namespace}.{dynamo_args.component}.get_perf_metrics"
+    )
 
-    shutdown_endpoints[:] = [generate_endpoint]
+    shutdown_endpoints[:] = [generate_endpoint, perf_endpoint]
 
     publisher, metrics_task, metrics_labels = await setup_sgl_metrics(
         engine, config, generate_endpoint
@@ -249,6 +275,10 @@ async def init_prefill(
     if server_args.node_rank >= 1:
         await handle_non_leader_node(engine, publisher, metrics_task)
         return
+
+    benchmark_results = None
+    if getattr(server_args, "benchmark_mode", None) is not None:
+        benchmark_results = await wait_and_load_benchmark(server_args)
 
     try:
         await _warmup_prefill_engine(engine, server_args)
@@ -264,6 +294,7 @@ async def init_prefill(
     handler = PrefillWorkerHandler(
         engine, config, publisher, generate_endpoint, shutdown_event
     )
+    handler._benchmark_results = benchmark_results
     handler.register_engine_routes(runtime)
 
     health_check_payload = SglangPrefillHealthCheckPayload(engine).to_dict()
@@ -288,6 +319,10 @@ async def init_prefill(
             ),
             list_loras_endpoint.serve_endpoint(
                 handler.list_loras,
+                metrics_labels=metrics_labels,
+            ),
+            perf_endpoint.serve_endpoint(
+                handler.get_perf_metrics,
                 metrics_labels=metrics_labels,
             ),
             register_model_with_readiness_gate(

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -26,6 +26,7 @@ from dynamo.llm import KvEventPublisher, WorkerMetricsPublisher
 from dynamo.runtime import Endpoint
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import Config
+from dynamo.sglang.benchmark import prepare_benchmark_output_path
 from dynamo.sglang.capacity import kv_metrics_block_values, local_dp_rank_bounds
 
 
@@ -45,7 +46,14 @@ def set_forward_pass_metrics_worker_id(
     import tempfile
 
     server_args.forward_pass_metrics_worker_id = str(generate_endpoint.connection_id())
-    ipc_path = tempfile.NamedTemporaryFile(delete=False).name
+    prepare_benchmark_output_path(
+        server_args, server_args.forward_pass_metrics_worker_id
+    )
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        ipc_path = tmp.name
+    finally:
+        tmp.close()
     server_args.forward_pass_metrics_ipc_name = f"ipc://{ipc_path}"
 
 

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -666,6 +666,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         self.enable_session_radix_cache = getattr(
             config.server_args, "enable_session_radix_cache", False
         )
+        self._benchmark_results: Optional[dict[str, Any]] = None
 
         if engine is not None:
             self.input_param_manager = InputParamManager(
@@ -899,6 +900,15 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             "message": f"Weight version updated to {req.new_version}",
             "new_version": req.new_version,
         }
+
+    async def get_perf_metrics(self, request: Optional[Dict[str, Any]] = None):
+        """Return startup self-benchmark results, or an error if unavailable."""
+
+        del request
+        if self._benchmark_results is None:
+            yield {"status": "error", "message": "no benchmark data"}
+        else:
+            yield self._benchmark_results
 
     def register_engine_routes(self, runtime: DistributedRuntime) -> None:
         """Register all engine routes for this handler.

--- a/components/src/dynamo/sglang/tests/test_sglang_benchmark.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_benchmark.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 from dynamo.sglang.args import parse_args
+from dynamo.sglang.benchmark import benchmark_config
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
 pytestmark = [
@@ -27,6 +28,7 @@ async def test_benchmark_mode_enabled_from_env(monkeypatch, mock_sglang_cli):
     """Dynamo should map benchmark env vars onto native SGLang args."""
     monkeypatch.setenv("DYN_BENCHMARK_MODE", "prefill")
     monkeypatch.setenv("DYN_BENCHMARK_PREFILL_GRANULARITY", "32")
+    monkeypatch.setenv("DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY", "4")
     monkeypatch.setenv("DYN_BENCHMARK_TIMEOUT", "17")
     mock_sglang_cli("--model", "Qwen/Qwen3-0.6B")
 
@@ -34,23 +36,29 @@ async def test_benchmark_mode_enabled_from_env(monkeypatch, mock_sglang_cli):
     assert config.server_args.benchmark_mode == "prefill"
     assert config.server_args.enable_forward_pass_metrics is True
     assert config.server_args.benchmark_prefill_granularity == 32
+    assert config.server_args.benchmark_prefill_kv_read_granularity == 4
     assert config.server_args.benchmark_timeout == 17
+    assert benchmark_config(config.server_args)["prefill_kv_read_granularity"] == 4
 
 
 @pytest.mark.asyncio
 async def test_benchmark_cli_overrides_env(monkeypatch, mock_sglang_cli):
     """Explicit SGLang benchmark CLI flags should win over Dynamo env defaults."""
     monkeypatch.setenv("DYN_BENCHMARK_MODE", "prefill")
+    monkeypatch.setenv("DYN_BENCHMARK_PREFILL_KV_READ_GRANULARITY", "4")
     monkeypatch.setenv("DYN_BENCHMARK_TIMEOUT", "17")
     mock_sglang_cli(
         "--model",
         "Qwen/Qwen3-0.6B",
         "--benchmark-mode",
         "decode",
+        "--benchmark-prefill-kv-read-granularity",
+        "9",
         "--benchmark-timeout",
         "23",
     )
 
     config = await parse_args(sys.argv[1:])
     assert config.server_args.benchmark_mode == "decode"
+    assert config.server_args.benchmark_prefill_kv_read_granularity == 9
     assert config.server_args.benchmark_timeout == 23

--- a/components/src/dynamo/sglang/tests/test_sglang_benchmark.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_benchmark.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SGLang self-benchmark adapter wiring."""
+
+import sys
+
+import pytest
+
+from dynamo.sglang.args import parse_args
+from dynamo.sglang.tests.conftest import make_cli_args_fixture
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.profiled_vram_gib(0),
+    pytest.mark.pre_merge,
+    pytest.mark.filterwarnings("ignore:.*torch.jit.script_method.*:DeprecationWarning"),
+]
+
+mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
+
+
+@pytest.mark.asyncio
+async def test_benchmark_mode_enabled_from_env(monkeypatch, mock_sglang_cli):
+    """Dynamo should map benchmark env vars onto native SGLang args."""
+    monkeypatch.setenv("DYN_BENCHMARK_MODE", "prefill")
+    monkeypatch.setenv("DYN_BENCHMARK_PREFILL_GRANULARITY", "32")
+    monkeypatch.setenv("DYN_BENCHMARK_TIMEOUT", "17")
+    mock_sglang_cli("--model", "Qwen/Qwen3-0.6B")
+
+    config = await parse_args(sys.argv[1:])
+    assert config.server_args.benchmark_mode == "prefill"
+    assert config.server_args.enable_forward_pass_metrics is True
+    assert config.server_args.benchmark_prefill_granularity == 32
+    assert config.server_args.benchmark_timeout == 17
+
+
+@pytest.mark.asyncio
+async def test_benchmark_cli_overrides_env(monkeypatch, mock_sglang_cli):
+    """Explicit SGLang benchmark CLI flags should win over Dynamo env defaults."""
+    monkeypatch.setenv("DYN_BENCHMARK_MODE", "prefill")
+    monkeypatch.setenv("DYN_BENCHMARK_TIMEOUT", "17")
+    mock_sglang_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--benchmark-mode",
+        "decode",
+        "--benchmark-timeout",
+        "23",
+    )
+
+    config = await parse_args(sys.argv[1:])
+    assert config.server_args.benchmark_mode == "decode"
+    assert config.server_args.benchmark_timeout == 23

--- a/components/src/dynamo/sglang/tests/test_sglang_benchmark.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_benchmark.py
@@ -3,12 +3,17 @@
 
 """Unit tests for SGLang self-benchmark adapter wiring."""
 
+import asyncio
+import json
+import logging
 import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from dynamo.sglang.args import parse_args
-from dynamo.sglang.benchmark import benchmark_config
+from dynamo.sglang.benchmark import benchmark_config, wait_and_load_benchmark
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
 pytestmark = [
@@ -62,3 +67,174 @@ async def test_benchmark_cli_overrides_env(monkeypatch, mock_sglang_cli):
     assert config.server_args.benchmark_mode == "decode"
     assert config.server_args.benchmark_prefill_kv_read_granularity == 9
     assert config.server_args.benchmark_timeout == 23
+
+
+# ---- result handoff consumer (wait_and_load_benchmark) ----
+#
+# The producer (SGLang scheduler) rewrites the result file to an invalid
+# ``status: running`` sentinel at startup and atomically replaces it with the
+# completed results when the sweep finishes. The consumer must wait for
+# ``status == "complete"`` rather than mere file existence, or it would accept
+# the in-progress sentinel (or a stale prior-run file) and mark the worker ready
+# prematurely.
+
+
+def _server_args(
+    output_path: Path, *, timeout: int = 5, model: str = "test-model", **overrides
+):
+    args = SimpleNamespace(
+        benchmark_mode="agg",
+        benchmark_output_path=str(output_path),
+        benchmark_timeout=timeout,
+        model_path=model,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _complete(run_id="run-1", model="test-model", results=None):
+    return {
+        "schema_version": 1,
+        "scope": "local_diagnostics",
+        "status": "complete",
+        "valid": True,
+        "run_id": run_id,
+        "identity": {"model_path": model},
+        "results": results
+        if results is not None
+        else [{"point": {"point_type": "prefill", "isl": 8}, "fpms": []}],
+    }
+
+
+def _sentinel(run_id="run-1", model="test-model"):
+    return {
+        "schema_version": 1,
+        "scope": "local_diagnostics",
+        "status": "running",
+        "valid": False,
+        "run_id": run_id,
+        "identity": {"model_path": model},
+        "message": "Self-benchmark is running; previous results are invalid.",
+    }
+
+
+def _write(path: Path, payload: dict):
+    path.write_text(json.dumps(payload))
+
+
+@pytest.mark.asyncio
+async def test_returns_error_when_benchmark_mode_disabled(tmp_path):
+    server_args = _server_args(tmp_path / "results.json")
+    server_args.benchmark_mode = None
+
+    result = await wait_and_load_benchmark(server_args)
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_waits_past_running_sentinel_until_complete(tmp_path):
+    output_path = tmp_path / "results.json"
+    # The file already exists as the in-progress sentinel before the sweep ends.
+    _write(output_path, _sentinel(run_id="run-7"))
+    server_args = _server_args(output_path, timeout=5)
+
+    async def finish_after_delay():
+        await asyncio.sleep(0.05)
+        _write(output_path, _complete(run_id="run-7"))
+
+    writer = asyncio.create_task(finish_after_delay())
+    merged = await wait_and_load_benchmark(server_args)
+    await writer
+
+    assert merged["status"] == "complete"
+    assert merged["run_id"] == "run-7"
+    assert len(merged["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_running_sentinel_alone_times_out(tmp_path):
+    # A benchmark that never completes (e.g. a multi-rank finish-sync deadlock)
+    # leaves the file stuck at status=running; existence must NOT satisfy us.
+    output_path = tmp_path / "results.json"
+    _write(output_path, _sentinel())
+    server_args = _server_args(output_path, timeout=0)
+
+    with pytest.raises(TimeoutError):
+        await wait_and_load_benchmark(server_args)
+
+
+@pytest.mark.asyncio
+async def test_missing_file_times_out(tmp_path):
+    server_args = _server_args(tmp_path / "results.json", timeout=0)
+
+    with pytest.raises(TimeoutError):
+        await wait_and_load_benchmark(server_args)
+
+
+@pytest.mark.asyncio
+async def test_warns_on_model_mismatch_but_still_loads(tmp_path, caplog):
+    output_path = tmp_path / "results.json"
+    _write(output_path, _complete(model="some-other-model"))
+    server_args = _server_args(output_path, model="test-model")
+
+    with caplog.at_level(logging.WARNING, logger="dynamo.sglang.benchmark"):
+        merged = await wait_and_load_benchmark(server_args)
+
+    assert merged["status"] == "complete"
+    assert "some-other-model" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_backward_compat_file_without_status_field(tmp_path):
+    # Producers predating the status field write only results; still accept them.
+    output_path = tmp_path / "results.json"
+    _write(output_path, {"results": [{"point": {"point_type": "decode"}, "fpms": []}]})
+    server_args = _server_args(output_path)
+
+    merged = await wait_and_load_benchmark(server_args)
+
+    assert len(merged["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_merges_results_across_dp_ranks(tmp_path):
+    base = tmp_path / "results.json"
+    dp1 = tmp_path / "results_dp1.json"
+    _write(
+        base,
+        _complete(run_id="same", results=[{"point": {"point_type": "prefill"}, "fpms": []}]),
+    )
+    _write(
+        dp1,
+        _complete(run_id="same", results=[{"point": {"point_type": "decode"}, "fpms": []}]),
+    )
+    server_args = _server_args(
+        base, dp_size=2, enable_dp_attention=True, nnodes=1, node_rank=0
+    )
+
+    merged = await wait_and_load_benchmark(server_args)
+
+    assert len(merged["results"]) == 2
+    dp_ranks = {r["point"]["dp_rank"] for r in merged["results"]}
+    assert dp_ranks == {0, 1}
+
+
+@pytest.mark.asyncio
+async def test_warns_on_run_id_mismatch_across_dp_ranks(tmp_path, caplog):
+    # A leftover dp-rank file from a previous run (different run_id) must surface
+    # as a warning rather than being silently merged in as valid data.
+    base = tmp_path / "results.json"
+    dp1 = tmp_path / "results_dp1.json"
+    _write(base, _complete(run_id="run-A"))
+    _write(dp1, _complete(run_id="run-B"))
+    server_args = _server_args(
+        base, dp_size=2, enable_dp_attention=True, nnodes=1, node_rank=0
+    )
+
+    with caplog.at_level(logging.WARNING, logger="dynamo.sglang.benchmark"):
+        merged = await wait_and_load_benchmark(server_args)
+
+    assert len(merged["results"]) == 2
+    assert "mismatched run_ids" in caplog.text

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -59,6 +59,19 @@ def test_set_forward_pass_metrics_worker_id_uses_endpoint_identity():
     assert server_args.forward_pass_metrics_ipc_name.startswith("ipc://")
 
 
+def test_set_forward_pass_metrics_worker_id_sets_benchmark_output_path():
+    server_args = SimpleNamespace(
+        enable_forward_pass_metrics=True,
+        benchmark_mode="decode",
+        benchmark_output_path="/tmp/benchmark_results.json",
+    )
+    endpoint = SimpleNamespace(connection_id=lambda: "worker-9")
+
+    set_forward_pass_metrics_worker_id(server_args, endpoint)
+
+    assert server_args.benchmark_output_path == "/tmp/benchmark_results_worker-9.json"
+
+
 def test_set_forward_pass_metrics_worker_id_is_noop_when_disabled():
     server_args = SimpleNamespace(enable_forward_pass_metrics=False)
     endpoint = SimpleNamespace(connection_id=lambda: "endpoint-9")


### PR DESCRIPTION
#### Overview:

Add Dynamo support for SGLang self-benchmarking.

#### Details:

When benchmark mode is requested, Dynamo now maps the benchmark env/config onto the corresponding SGLang server args, starts SGLang with self-benchmarking enabled, waits for the generated benchmark output, and exposes the collected ForwardPassMetrics through the worker `get_perf_metrics` endpoint.

This lets Dynamo’s planner use SGLang startup benchmark data as an initial performance signal before falling back to profiler-generated data.

#### Where should the reviewer start?

Start with `components/src/dynamo/sglang/benchmark.py` for the env/config bridge and benchmark result loading, then `components/src/dynamo/sglang/init_llm.py` for where startup waits for benchmark completion before serving endpoints.

The corresponding SGLang implementation is in https://github.com/sgl-project/sglang/pull/27311, especially `self_benchmark.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended per-worker startup self-benchmarking to SGLang backend alongside vLLM support
  * Added performance metrics endpoint for exposing real-time worker performance data
  * Benchmark behavior now configurable through environment variables and CLI argument overrides
  * Automatic benchmark result collection and cross-worker synchronization in distributed settings

* **Tests**
  * Added comprehensive test coverage for SGLang benchmark configuration and result handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->