### PR TITLE
feat(llm): per-worker ZMQ KV-event source registration on KvRouter

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -726,6 +726,83 @@ where
         self.block_size
     }
 
+    /// Subscribe directly to a worker's native ZMQ KV-cache event stream (e.g. a
+    /// vanilla vLLM started with `--kv-events-config`) and feed decoded events
+    /// into this router's indexer, stamped with `worker_id`.
+    ///
+    /// Dynamo workers normally bridge their vLLM KV events onto the event plane
+    /// and the router subscribes there; the external (GIE) EPP has no such
+    /// bridge, so it connects to each pod's ZMQ PUB socket directly. Events are
+    /// re-hashed from their `token_ids` by the normalizer, so a worker's actual
+    /// cached prefixes match the query-side block hashes and yield precise
+    /// overlap — complementing (not replacing) predict-on-route bookkeeping.
+    ///
+    /// The listener reconnects with backoff until the returned token is
+    /// cancelled (e.g. when the pod is removed). Returns that cancellation token.
+    pub fn register_worker_kv_events(
+        &self,
+        worker_id: protocols::WorkerId,
+        zmq_endpoint: String,
+        zmq_topic: String,
+    ) -> tokio_util::sync::CancellationToken {
+        let token = self.cancellation_token.child_token();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<protocols::PlacementEvent>();
+        let block_size = self.block_size;
+
+        // Pump decoded placement events into this router's indexer. Run them
+        // through the same refcount-correct dedup the batched NATS path uses,
+        // so duplicate vLLM store/remove events don't evict blocks from the
+        // routing index before the worker actually evicts them.
+        let indexer = self.indexer.clone();
+        let pump_token = token.clone();
+        tokio::spawn(async move {
+            let mut dedup = publisher::PerWorkerDedup::new();
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = pump_token.cancelled() => break,
+                    maybe = rx.recv() => match maybe {
+                        Some(event) => {
+                            if let Some(router_event) = dedup.process(event) {
+                                indexer.apply_event(router_event).await;
+                            }
+                        }
+                        None => break,
+                    },
+                }
+            }
+        });
+
+        // Connect (and reconnect with backoff) to the worker's ZMQ PUB socket.
+        let listen_token = token.clone();
+        tokio::spawn(async move {
+            let next_event_id = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+            while !listen_token.is_cancelled() {
+                publisher::start_zmq_listener(
+                    zmq_endpoint.clone(),
+                    zmq_topic.clone(),
+                    worker_id,
+                    tx.clone(),
+                    listen_token.clone(),
+                    block_size,
+                    next_event_id.clone(),
+                    None, // image_token_id: not applicable for the per-pod path
+                )
+                .await;
+                if listen_token.is_cancelled() {
+                    break;
+                }
+                // Listener returned (connect failure or stream end) — back off.
+                tokio::select! {
+                    _ = listen_token.cancelled() => break,
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {}
+                }
+            }
+        });
+
+        token
+    }
+
     /// Compute the overlap blocks for a given token sequence and worker.
     /// This queries the indexer to find the effective weighted cache hit.
     pub async fn get_overlap_blocks(

--- a/lib/llm/src/kv_router/publisher/dedup.rs
+++ b/lib/llm/src/kv_router/publisher/dedup.rs
@@ -5,7 +5,8 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 
 use dynamo_kv_router::protocols::{
-    ExternalSequenceBlockHash, KvCacheRemoveData, KvCacheStoreData, StorageTier,
+    ExternalSequenceBlockHash, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
+    PlacementEvent, RouterEvent, StorageTier,
 };
 
 /// Reference-counting filter that deduplicates KV cache events.
@@ -88,5 +89,49 @@ impl EventDedupFilter {
     /// must reset all refcounts to stay consistent.
     pub(super) fn clear(&mut self) {
         self.per_rank_tier.clear();
+    }
+}
+
+/// Per-worker dedup for the direct (non-NATS) per-pod ZMQ KV-event path.
+///
+/// vLLM can emit duplicate store/remove events; applying them straight to the
+/// indexer corrupts block refcounts (a remove could fire before the worker
+/// actually evicts the block). This wraps [`EventDedupFilter`] so the per-pod
+/// path (`KvRouter::register_worker_kv_events`) gets the same refcount-correct
+/// dedup the batched NATS path already applies.
+pub(crate) struct PerWorkerDedup {
+    filter: EventDedupFilter,
+}
+
+impl PerWorkerDedup {
+    pub(crate) fn new() -> Self {
+        Self {
+            filter: EventDedupFilter::new(),
+        }
+    }
+
+    /// Apply dedup to a decoded placement event and return the `RouterEvent`
+    /// to index, or `None` when the event is fully filtered (duplicate remove)
+    /// or carries no local-worker placement.
+    pub(crate) fn process(&mut self, mut event: PlacementEvent) -> Option<RouterEvent> {
+        let dp_rank = event.event.dp_rank;
+        let tier = event.placement.tier;
+        // Take the data out to dedup (`filter_remove` consumes it), then restore.
+        let data = std::mem::replace(&mut event.event.data, KvCacheEventData::Cleared);
+        let new_data = match data {
+            KvCacheEventData::Stored(store) => {
+                self.filter.track_store(dp_rank, tier, &store);
+                KvCacheEventData::Stored(store)
+            }
+            KvCacheEventData::Removed(remove) => {
+                KvCacheEventData::Removed(self.filter.filter_remove(dp_rank, tier, remove)?)
+            }
+            KvCacheEventData::Cleared => {
+                self.filter.clear();
+                KvCacheEventData::Cleared
+            }
+        };
+        event.event.data = new_data;
+        event.into_router_event()
     }
 }

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -38,12 +38,12 @@ mod zmq_listener;
 use batching::BatchingState;
 #[cfg(test)]
 use dedup::EventDedupFilter;
+pub(crate) use dedup::PerWorkerDedup;
 #[cfg(test)]
 use event_processor::run_event_processor_loop;
 use event_processor::{start_event_processor, start_event_processor_jetstream};
 use sinks::EventPlanePublisher;
 pub use worker_metrics::WorkerMetricsPublisher;
-pub(crate) use dedup::PerWorkerDedup;
 pub(crate) use zmq_listener::start_zmq_listener;
 
 const MAX_BATCHING_TIMEOUT_MS: u64 = 15_000;

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -43,7 +43,8 @@ use event_processor::run_event_processor_loop;
 use event_processor::{start_event_processor, start_event_processor_jetstream};
 use sinks::EventPlanePublisher;
 pub use worker_metrics::WorkerMetricsPublisher;
-use zmq_listener::start_zmq_listener;
+pub(crate) use dedup::PerWorkerDedup;
+pub(crate) use zmq_listener::start_zmq_listener;
 
 const MAX_BATCHING_TIMEOUT_MS: u64 = 15_000;
 pub const DEFAULT_BATCHING_TIMEOUT_MS: Option<u64> = None;

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -15,7 +15,7 @@ use crate::kv_router::metrics::kv_publisher_metrics;
 use crate::utils::zmq::{connect_sub_socket, multipart_message};
 
 #[allow(clippy::too_many_arguments)]
-pub(super) async fn start_zmq_listener(
+pub(crate) async fn start_zmq_listener(
     zmq_endpoint: String,
     zmq_topic: String,
     worker_id: WorkerId,


### PR DESCRIPTION
#### Overview:

feat(llm): per-worker ZMQ KV-event source registration on KvRouter

#### Details:

Add KvRouter::register_worker_kv_events(worker_id, zmq_endpoint, topic): spawns a reconnecting zmq_listener (now pub(crate)) that decodes a worker native vLLM-format KV events and feeds them into this router indexer stamped with worker_id. Lets a Gateway-API EPP with no worker-side event-plane bridge subscribe to each pod ZMQ stream directly.

#### Where should the reviewer start?

review the changes 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---
Part of the **Native GAIE Support** roadmap — see the DEP proposal in #10336 (`docs/proposals/native-gaie-support.md`). Tracked in Linear under project *Native GAIE Support in Dynamo*.