### PR TITLE
docs(ext-proc): vanilla-vLLM InferencePool example (gateway + EPP)

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm/topology.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm/topology.yaml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Inference Gateway (GAIE) topology for vanilla vLLM + native Dynamo EPP.
+#   client -> Gateway -> HTTPRoute -> InferencePool -> (ext_proc) EPP
+#                                            |-> selects vanilla vLLM pods
+#
+# No metadata.namespace is set on any object — apply the directory into a
+# namespace of your choosing:
+#   kubectl -n <namespace> apply -f deploy/inference-gateway/ext-proc/examples/vanilla-vllm/
+#
+# The EPP runs as its own Deployment (below) in external/GAIE mode against the
+# InferencePool. Set EPP_IMAGE to the published EPP artifact (or one built from
+# deploy/inference-gateway/ext-proc).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: epp-vanilla-epp, labels: { owner: claude-epp } }
+---
+# External mode discovers pool endpoints via a pod reflector and resolves the
+# InferencePool; replica-sync (optional) also watches EndpointSlices.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: epp-vanilla-epp, labels: { owner: claude-epp } }
+rules:
+- { apiGroups: [""], resources: [pods], verbs: [get, list, watch] }
+- { apiGroups: ["discovery.k8s.io"], resources: [endpointslices], verbs: [get, list, watch] }
+- { apiGroups: ["inference.networking.k8s.io"], resources: [inferencepools], verbs: [get, list, watch] }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: epp-vanilla-epp, labels: { owner: claude-epp } }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: epp-vanilla-epp }
+subjects:
+- { kind: ServiceAccount, name: epp-vanilla-epp }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: epp-vanilla-epp, labels: { owner: claude-epp, app: epp-vanilla-epp } }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: epp-vanilla-epp } }
+  template:
+    metadata: { labels: { app: epp-vanilla-epp, owner: claude-epp } }
+    spec:
+      serviceAccountName: epp-vanilla-epp
+      containers:
+      - name: epp
+        image: ${EPP_IMAGE}  # published EPP artifact (built from deploy/inference-gateway/ext-proc)
+        args: ["dynamo-ext-proc"]
+        ports:
+        - { name: grpc-ext-proc, containerPort: 9002 }
+        - { name: health, containerPort: 9003 }
+        env:
+        - { name: DYN_EPP_EXTERNAL, value: "true" }
+        - { name: DYN_DISCOVERY_BACKEND, value: "mem" }
+        - { name: DYN_EPP_INFERENCE_POOL, value: "epp-vanilla-pool" }
+        - { name: DYN_MODEL_NAME, value: "Qwen/Qwen3-0.6B" }
+        - { name: DYN_KV_CACHE_BLOCK_SIZE, value: "16" }
+        - { name: DYN_EPP_PREFIX_MODE, value: "precise" }
+        - { name: DYN_EPP_TOKENIZE_URL, value: "http://127.0.0.1:8790/tokenize" }
+        - { name: DYN_EPP_KV_EVENTS, value: "true" }
+        - { name: DYN_EPP_KV_EVENT_PORT, value: "5557" }
+        - { name: DYN_SECURE_SERVING, value: "true" }
+        - { name: POD_NAMESPACE, valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
+        readinessProbe: { tcpSocket: { port: 9003 }, initialDelaySeconds: 5, periodSeconds: 5 }
+      # Tokenizer sidecar (precise mode): same binary in DYN_TOKENIZER_ONLY mode,
+      # exact-parity tokens with no GPU. Swap for a transformers or vLLM
+      # /tokenize proxy if preferred.
+      - name: tokenizer
+        image: ${EPP_IMAGE}
+        args: ["dynamo-ext-proc"]
+        env:
+        - { name: DYN_TOKENIZER_ONLY, value: "true" }
+        - { name: DYN_MODEL_NAME, value: "Qwen/Qwen3-0.6B" }
+        - { name: DYN_TOKENIZER_HOST, value: "127.0.0.1" }
+        - { name: DYN_TOKENIZER_PORT, value: "8790" }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: epp-vanilla-epp, labels: { owner: claude-epp } }
+spec:
+  selector: { app: epp-vanilla-epp }
+  ports:
+  - { name: grpc-ext-proc, port: 9002, targetPort: 9002, appProtocol: http2 }
+  - { name: health, port: 9003, targetPort: 9003 }
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata: { name: epp-vanilla-pool, labels: { owner: claude-epp } }
+spec:
+  selector:
+    matchLabels: { app: epp-vanilla-vllm }
+  targetPorts:
+  - { number: 8000 }
+  endpointPickerRef:
+    name: epp-vanilla-epp
+    port: { number: 9002 }
+    failureMode: FailOpen
+# No own Gateway: attach our route (cross-namespace parentRef) to a shared
+# gateway, with a unique hostname to disambiguate from other routes.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata: { name: epp-vanilla-route, labels: { owner: claude-epp } }
+spec:
+  parentRefs:
+  - { name: inference-gateway, namespace: agentgateway-system }
+  hostnames:
+  - epp-vanilla.local
+  rules:
+  - backendRefs:
+    - { group: inference.networking.k8s.io, kind: InferencePool, name: epp-vanilla-pool }

--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm/vllm.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm/vllm.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Vanilla `vllm serve` deployment (stock vllm/vllm-openai image, no Dynamo runtime).
+# The native Dynamo EPP routes to these pods in external mode (worker tokenizes).
+# Each pod is a single-rank endpoint; scale data parallelism by adding replicas
+# (more endpoints in the pool) — the standard vLLM external-LB DP pattern, where
+# each DP rank is its own endpoint. (A single endpoint fanning out to multiple
+# internal DP ranks is not per-rank routable from the gateway.)
+# Distinct names (epp-vanilla-*) to avoid colliding with gms-bulwark-* work.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: epp-vanilla-vllm
+  labels: { app: epp-vanilla-vllm, owner: claude-epp }
+spec:
+  replicas: 2
+  # maxSurge:0 so the rolling restart never needs a 3rd GPU (replace in place).
+  strategy:
+    type: RollingUpdate
+    rollingUpdate: { maxSurge: 0, maxUnavailable: 1 }
+  selector:
+    matchLabels: { app: epp-vanilla-vllm }
+  template:
+    metadata:
+      labels: { app: epp-vanilla-vllm, owner: claude-epp }
+    spec:
+      # Tolerate ONLY the standard GPU taint so we land on a free, non-reserved
+      # GPU node. We deliberately do NOT tolerate reserved-by/dra/gms-bench/etc.
+      tolerations:
+      - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      containers:
+      - name: vllm
+        image: vllm/vllm-openai:latest
+        command: ["vllm","serve","Qwen/Qwen3-0.6B"]
+        args:
+        - --port=8000
+        - --enable-prefix-caching
+        - --gpu-memory-utilization=0.45
+        - --max-model-len=8192
+        # Publish native KV-cache events over ZMQ (PUB binds tcp://*:5557) so the
+        # EPP can consume them for precise prefix-cache-aware routing (Task #5).
+        - '--kv-events-config={"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}'
+        ports:
+        - { name: http, containerPort: 8000 }
+        - { name: kv-events, containerPort: 5557 }
+        resources:
+          limits: { nvidia.com/gpu: "1" }
+          requests: { nvidia.com/gpu: "1" }
+        readinessProbe:
+          httpGet: { path: /health, port: 8000 }
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 60
+        startupProbe:
+          httpGet: { path: /health, port: 8000 }
+          periodSeconds: 10
+          failureThreshold: 120
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: epp-vanilla-vllm
+  labels: { app: epp-vanilla-vllm, owner: claude-epp }
+spec:
+  selector: { app: epp-vanilla-vllm }
+  ports:
+  - { name: http, port: 8000, targetPort: 8000 }


### PR DESCRIPTION
#### Overview:

docs(ext-proc): vanilla-vLLM InferencePool example (gateway + EPP topology)

#### Details:

Add examples/vanilla-vllm with vllm.yaml and topology.yaml: a stock vllm/vllm-openai Deployment plus the GAIE topology (InferencePool, EPP Service, cross-namespace HTTPRoute) the native EPP routes through in external mode.


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---
Part of the **Native GAIE Support** roadmap — see the DEP proposal in #10336 (`docs/proposals/native-gaie-support.md`). Tracked in Linear under project *Native GAIE Support in Dynamo*.