### PR TITLE
docs(ext-proc): GIE-packaged Dynamo worker examples (vLLM + SGLang)

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/dynamo-worker/dynamo-sglang.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/dynamo-worker/dynamo-sglang.yaml
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# GIE-packaged Dynamo SGLang worker — proves a vanilla EPP routes to a SGLang
+# Dynamo worker (incl. precise KV) exactly like vLLM. SGLang's own
+# sglang.srt.disaggregation.kv_events.ZmqEventPublisher emits vLLM-format KV
+# events; bind it to 0.0.0.0:5557 so the EPP can subscribe (NO translation shim).
+# Reuses ServiceAccount epp-dynamo-sa + Role epp-dynamo-disc (already applied).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: epp-dynamo-sglang
+  namespace: mkhadkevich-dev
+  labels: { app: epp-dynamo-sglang, owner: claude-epp }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: epp-dynamo-sglang } }
+  template:
+    metadata:
+      labels: { app: epp-dynamo-sglang, owner: claude-epp }
+    spec:
+      serviceAccountName: epp-dynamo-sa
+      tolerations:
+      - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      containers:
+      # --- Dynamo SGLang worker (engine + vLLM-format KV events) ---
+      - name: worker
+        image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0
+        command: ["python3", "-m", "dynamo.sglang"]
+        args:
+        - --model-path
+        - Qwen/Qwen3-0.6B
+        - --served-model-name
+        - Qwen/Qwen3-0.6B
+        - --page-size
+        - "16"
+        - --tp
+        - "1"
+        - --trust-remote-code
+        - --skip-tokenizer-init
+        - --discovery-backend
+        - file
+        - --request-plane
+        - tcp
+        - --mem-fraction-static
+        - "0.45"
+        - --kv-events-config
+        - '{"publisher":"zmq","endpoint":"tcp://*:5557"}'
+        env:
+        - { name: DYN_FILE_KV, value: /shared/dynamo-kv }
+        - { name: DYN_NAMESPACE, value: epp-dynamo-sg }
+        - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
+        - { name: POD_NAMESPACE, valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
+        - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+        - { name: POD_UID, valueFrom: { fieldRef: { fieldPath: metadata.uid } } }
+        ports:
+        - { name: kv-events, containerPort: 5557 }
+        volumeMounts:
+        - { name: disc, mountPath: /shared }
+        resources:
+          limits: { nvidia.com/gpu: "1" }
+          requests: { nvidia.com/gpu: "1" }
+      # --- Dynamo frontend (per-pod OpenAI HTTP; tokenizes for the worker) ---
+      - name: frontend
+        image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+        command: ["python3", "-m", "dynamo.frontend"]
+        # Gate the HTTP server on at least one registered worker so the
+        # readiness probe can't pass before the colocated worker registers.
+        args: ["--http-port=8000", "--discovery-backend=file", "--request-plane=tcp", "--router-min-initial-workers=1"]
+        env:
+        - { name: DYN_FILE_KV, value: /shared/dynamo-kv }
+        - { name: DYN_NAMESPACE, value: epp-dynamo-sg }
+        - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
+        - { name: POD_NAMESPACE, valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
+        - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+        - { name: POD_UID, valueFrom: { fieldRef: { fieldPath: metadata.uid } } }
+        ports:
+        - { name: http, containerPort: 8000 }
+        volumeMounts:
+        - { name: disc, mountPath: /shared }
+        readinessProbe:
+          httpGet: { path: /health, port: 8000 }
+          initialDelaySeconds: 50
+          periodSeconds: 10
+          failureThreshold: 90
+      volumes:
+      - { name: disc, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: epp-dynamo-sglang
+  namespace: mkhadkevich-dev
+  labels: { app: epp-dynamo-sglang, owner: claude-epp }
+spec:
+  selector: { app: epp-dynamo-sglang }
+  ports:
+  - { name: http, port: 8000, targetPort: 8000 }
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata: { name: epp-dynamo-sglang-pool, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+spec:
+  selector:
+    matchLabels: { app: epp-dynamo-sglang }
+  targetPorts:
+  - { number: 8000 }
+  endpointPickerRef:
+    name: epp-vanilla-epp
+    port: { number: 9002 }
+    failureMode: FailOpen
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata: { name: epp-dynamo-sglang-route, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+spec:
+  parentRefs:
+  - { name: inference-gateway, namespace: agentgateway-system }
+  hostnames:
+  - epp-dynamo-sglang.local
+  rules:
+  - backendRefs:
+    - { group: inference.networking.k8s.io, kind: InferencePool, name: epp-dynamo-sglang-pool }

--- a/deploy/inference-gateway/ext-proc/examples/dynamo-worker/dynamo-vllm.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/dynamo-worker/dynamo-vllm.yaml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# GIE-packaged Dynamo vLLM worker: a Dynamo worker pod that presents the
+# standard Gateway API Inference Extension (InferencePool) interface so any GAIE
+# Endpoint Picker can route to it like a stock `vllm serve` pod.
+#   - frontend container  -> per-pod OpenAI HTTP on :8000 (gateway target)
+#   - worker container    -> vLLM engine; emits vLLM-NATIVE KV events on :5557
+#                            (endpoint bound 0.0.0.0 so the EPP can SUB too)
+#   - kubernetes discovery (DynamoWorkerMetadata CRD) wires frontend<->worker
+# Distinct names (epp-dynamo-*) to avoid colliding with gms-bulwark work.
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: epp-dynamo-sa, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: epp-dynamo-disc, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+rules:
+- apiGroups: ["nvidia.com"]
+  resources: ["dynamoworkermetadatas", "dynamomodels"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: epp-dynamo-disc, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: epp-dynamo-disc }
+subjects:
+- { kind: ServiceAccount, name: epp-dynamo-sa, namespace: mkhadkevich-dev }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: epp-dynamo-vllm
+  namespace: mkhadkevich-dev
+  labels: { app: epp-dynamo-vllm, owner: claude-epp }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: epp-dynamo-vllm } }
+  template:
+    metadata:
+      labels: { app: epp-dynamo-vllm, owner: claude-epp }
+    spec:
+      serviceAccountName: epp-dynamo-sa
+      tolerations:
+      - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      containers:
+      # --- Dynamo vLLM worker (engine + native KV events) ---
+      - name: worker
+        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+        command: ["python3", "-m", "dynamo.vllm"]
+        args:
+        - --model=Qwen/Qwen3-0.6B
+        - --discovery-backend=file
+        - --request-plane=tcp
+        - --enable-prefix-caching
+        - --gpu-memory-utilization=0.45
+        - --max-model-len=8192
+        - --kv-events-config={"enable_kv_cache_events":true,"endpoint":"tcp://0.0.0.0:5557"}
+        env:
+        - { name: DYN_DISCOVERY_BACKEND, value: file }
+        - { name: DYN_FILE_KV, value: /shared/dynamo-kv }
+        - { name: DYN_NAMESPACE, value: epp-dynamo }
+        - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
+        - { name: POD_NAMESPACE, valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
+        - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+        - { name: POD_UID, valueFrom: { fieldRef: { fieldPath: metadata.uid } } }
+        ports:
+        - { name: kv-events, containerPort: 5557 }
+        volumeMounts:
+        - { name: disc, mountPath: /shared }
+        resources:
+          limits: { nvidia.com/gpu: "1" }
+          requests: { nvidia.com/gpu: "1" }
+      # --- Dynamo frontend (per-pod OpenAI HTTP) ---
+      - name: frontend
+        image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.0
+        command: ["python3", "-m", "dynamo.frontend"]
+        # Gate the HTTP server on at least one registered worker so the
+        # readiness probe can't pass before the colocated worker registers.
+        args: ["--http-port=8000", "--discovery-backend=file", "--request-plane=tcp", "--router-min-initial-workers=1"]
+        env:
+        - { name: DYN_DISCOVERY_BACKEND, value: file }
+        - { name: DYN_FILE_KV, value: /shared/dynamo-kv }
+        - { name: DYN_NAMESPACE, value: epp-dynamo }
+        - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
+        - { name: POD_NAMESPACE, valueFrom: { fieldRef: { fieldPath: metadata.namespace } } }
+        - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+        - { name: POD_UID, valueFrom: { fieldRef: { fieldPath: metadata.uid } } }
+        ports:
+        - { name: http, containerPort: 8000 }
+        volumeMounts:
+        - { name: disc, mountPath: /shared }
+        readinessProbe:
+          httpGet: { path: /health, port: 8000 }
+          initialDelaySeconds: 40
+          periodSeconds: 10
+          failureThreshold: 60
+      volumes:
+      - { name: disc, emptyDir: {} }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: epp-dynamo-vllm
+  namespace: mkhadkevich-dev
+  labels: { app: epp-dynamo-vllm, owner: claude-epp }
+spec:
+  selector: { app: epp-dynamo-vllm }
+  ports:
+  - { name: http, port: 8000, targetPort: 8000 }

--- a/deploy/inference-gateway/ext-proc/examples/dynamo-worker/topology.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/dynamo-worker/topology.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# GIE topology pointing at GIE-packaged Dynamo vLLM workers (epp-dynamo-vllm).
+# Reuses the same EPP (epp-vanilla-epp Service -> epp-build pod); relaunch the
+# EPP with DYN_EPP_INFERENCE_POOL=epp-dynamo-pool so it discovers these pods.
+# Proves a vanilla-mode EPP routes to Dynamo workers exactly like vanilla vLLM.
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata: { name: epp-dynamo-pool, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+spec:
+  selector:
+    matchLabels: { app: epp-dynamo-vllm }
+  targetPorts:
+  - { number: 8000 }
+  endpointPickerRef:
+    name: epp-vanilla-epp
+    port: { number: 9002 }
+    failureMode: FailOpen
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata: { name: epp-dynamo-route, namespace: mkhadkevich-dev, labels: { owner: claude-epp } }
+spec:
+  parentRefs:
+  - { name: inference-gateway, namespace: agentgateway-system }
+  hostnames:
+  - epp-dynamo.local
+  rules:
+  - backendRefs:
+    - { group: inference.networking.k8s.io, kind: InferencePool, name: epp-dynamo-pool }


### PR DESCRIPTION
#### Overview:

docs(ext-proc): GIE-packaged Dynamo worker examples (vLLM + SGLang)

#### Details:

Add examples/dynamo-worker with dynamo-vllm.yaml, dynamo-sglang.yaml and topology.yaml: a Dynamo worker plus frontend co-located in one pod (file discovery, no NATS), the engine KV-event publisher bound to 0.0.0.0:5557, plus an InferencePool and route so a native EPP routes to them with precise KV. SGLang and TRT-LLM need no translation shim (they already emit the vLLM ZMQ wire format).

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---
Part of the **Native GAIE Support** roadmap — see the DEP proposal in #10336 (`docs/proposals/native-gaie-support.md`). Tracked in Linear under project *Native GAIE Support in Dynamo*.