### PR TITLE
fix(frontend): keep EOS token text out of content when tool parser preserves special tokens

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -782,6 +782,21 @@ class SglangStreamingPostProcessor:
         # Preserve special tokens when a tool call parser is active so
         # delimiter tokens (e.g. <|tool_call|>) remain visible to the parser.
         self._skip_special_tokens = tool_call_parser is None
+        # EOS ids to filter from the decode stream when special tokens are
+        # preserved. With ``skip_special_tokens=False`` the engine's
+        # terminating EOS would otherwise detokenize into user-visible text
+        # at the tail of ``content`` (e.g. a trailing "<|im_end|>") whenever
+        # the model answers in plain text while a tool parser is active.
+        # Neither the reasoning nor the tool parser consumes the EOS, so it
+        # is dropped at the id level before decoding — streaming-chunk safe,
+        # and cannot strip legitimate text that merely resembles the EOS
+        # string.
+        _eos = getattr(tokenizer, "eos_token_id", None)
+        if _eos is None:
+            _eos = []
+        elif isinstance(_eos, int):
+            _eos = [_eos]
+        self._eos_token_ids = frozenset(_eos)
         self._is_json_array_parser = isinstance(tool_call_parser, JsonArrayParser)
 
         self._all_token_ids: list[int] = []
@@ -856,6 +871,9 @@ class SglangStreamingPostProcessor:
         """
         raw_ids = engine_response.get("token_ids")
         token_ids = raw_ids if isinstance(raw_ids, list) else list(raw_ids or [])
+        # Drop EOS ids before incremental decode — see __init__.
+        if not self._skip_special_tokens and self._eos_token_ids:
+            token_ids = [t for t in token_ids if t not in self._eos_token_ids]
         finish_reason = engine_response.get("finish_reason")
 
         delta_text = self._incremental_decode(token_ids) if token_ids else ""

--- a/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_tool_calls.py
@@ -586,3 +586,71 @@ class TestJsonArrayParserReparse:  # FRONTEND.4 — JSON-array parser reparse pa
         # No tool calls, plain content preserved, no crash.
         tc = (choice or {}).get("delta", {}).get("tool_calls", [])
         assert tc == []
+
+
+# ---------------------------------------------------------------------------
+# EOS token text must not leak into content
+# ---------------------------------------------------------------------------
+
+
+class TestEosTokenTextNotLeaked:
+    """With a tool parser active, special tokens are preserved for the
+    parser's delimiters (``skip_special_tokens=False``), so the engine's
+    terminating EOS id would otherwise detokenize into user-visible text at
+    the tail of ``content`` whenever the model answers in plain text instead
+    of calling a tool. The post-processor must drop EOS ids before decoding.
+    """
+
+    ANSWER = "The capital of France is Paris."
+
+    def _collect_content(self, results):
+        return "".join((r.get("delta", {}) or {}).get("content") or "" for r in results)
+
+    def _drive(self, tokenizer, batches):
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=FunctionCallParser(tools=TOOLS, tool_call_parser="hermes"),
+            reasoning_parser=None,
+            sglang_tools=TOOLS,
+        )
+        results = []
+        for i, batch in enumerate(batches):
+            choice = post.process_output(
+                {
+                    "token_ids": batch,
+                    "finish_reason": "stop" if i == len(batches) - 1 else None,
+                }
+            )
+            if choice:
+                results.append(choice)
+        return results
+
+    def test_plain_answer_with_trailing_eos(self, tokenizer):
+        """EOS arriving in the same chunk as the final text tokens."""
+        ids = tokenizer.encode(self.ANSWER) + [tokenizer.eos_token_id]
+        content = self._collect_content(self._drive(tokenizer, [ids]))
+        assert tokenizer.eos_token not in content
+        assert "Paris" in content
+
+    def test_eos_alone_in_final_chunk(self, tokenizer):
+        """Streaming shape: EOS id arrives by itself with the finish flag."""
+        ids = tokenizer.encode(self.ANSWER)
+        content = self._collect_content(
+            self._drive(tokenizer, [ids[:3], ids[3:], [tokenizer.eos_token_id]])
+        )
+        assert tokenizer.eos_token not in content
+        assert "Paris" in content
+
+    def test_tool_call_parsing_unaffected(self, tokenizer):
+        """Dropping EOS ids must not disturb tool-call markup parsing."""
+        text = (
+            '<tool_call>\n{"name": "get_weather", '
+            '"arguments": {"city": "Paris"}}\n</tool_call>'
+        )
+        ids = tokenizer.encode(text) + [tokenizer.eos_token_id]
+        results = self._drive(tokenizer, [ids])
+        tc = _extract_tool_calls(results)
+        assert len(tc) == 1
+        assert tc[0]["function"]["name"] == "get_weather"
+        assert json.loads(tc[0]["function"]["arguments"]) == {"city": "Paris"}
+        assert tokenizer.eos_token not in self._collect_content(results)


### PR DESCRIPTION
## Summary

When the frontend runs with `--dyn-chat-processor sglang` and a tool-call parser is configured, `SglangStreamingPostProcessor` decodes engine token ids with `skip_special_tokens=False` so the parser's delimiter tokens stay visible. As a side effect, the engine's terminating EOS id is detokenized into user-visible text at the tail of `content` whenever the model answers in plain text instead of calling a tool — e.g. responses ending in a literal `<|im_end|>`.

**Deterministic repro:** offer tools in the request, ask a question the model answers directly (`tool_choice: auto`). The final content chunk carries the decoded EOS string. Reproduces in streaming and non-streaming (both are assembled from the same `process_output` chunks).

## Fix

Drop EOS ids from the id stream before incremental decode (active only when special tokens are preserved, i.e. a tool parser is configured):

- **Id-level, not text-level**: a text-suffix strip can straddle SSE chunk boundaries and could remove legitimate text that merely resembles the EOS string; filtering ids has neither problem.
- Runs **before** the reasoning/tool parsers, so they see clean text.
- No behavior change when `skip_special_tokens=True` (no tool parser): HF decode already drops the EOS there.

## Tests

Three cases added to `test_sglang_tool_calls.py` (existing Qwen3-0.6B tokenizer + hermes parser fixtures):
- plain answer with trailing EOS in the same chunk → no EOS text in content
- EOS arriving alone in the final chunk (streaming shape) → clean
- tool-call markup + EOS → tool call still parsed correctly, content clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Prior art in this repo

Both other frontend paths already handle this correctly, so this change brings the sglang chat-processor path in line:

- **Rust preprocessor path**: `lib/llm/src/backend.rs` checks each token id against `hidden_stop_ids` (system EOS ids + user `stop_token_ids`) and returns `None` as the token text on match — id-level interception before any text is emitted, independent of `skip_special_tokens`. This PR applies the same technique.
- **vLLM chat-processor path**: embeds vLLM's own `OutputProcessor`/incremental detokenizer in the frontend, inheriting vLLM's native stop handling.

## Known limitations / possible follow-ups

- This filters the tokenizer's primary `eos_token_id`. The Rust path filters the model card's full `eos_token_ids` set plus request `stop_token_ids`; plumbing that set into `SglangStreamingPostProcessor` would also cover multi-EOS models and user token stops (the preprocessor already computes both).
- Model-emitted special tokens mid-stream (other than stop ids) still decode to visible text when a tool parser is active — unavoidable without per-parser knowledge of which special ids are parser delimiters, since blanket-filtering `all_special_ids` would delete the markup the parsers exist to read.
- Matched stop *strings* (request `stop` param) are not trimmed on this path either (sglang-native trims them in `DetokenizerManager.trim_matched_stop` via the scheduler's `matched_stop`); covering that frontend-side would need the worker payload to carry which stop fired, like the Rust path's `stop_reason`.
