### PR TITLE
fix(container): preserve C/C++ toolchain in vllm-runtime codec purge (nemotron-ultra)

### DIFF
--- a/container/deps/vllm/validate_torch_compile_smoke.py
+++ b/container/deps/vllm/validate_torch_compile_smoke.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Build-time regression guard for the host C/C++ toolchain.
+
+torch.inductor / Triton JIT-compile kernels at *runtime* by shelling out to a
+host compiler (``cc``/``gcc``/``g++`` + ``make``). When that toolchain is absent
+the failure only surfaces on the first compile inside a live worker -- exactly
+how QA hit ``InductorError: Failed to find C compiler`` in the 1.3.0 release
+image after an over-broad ``apt-get autoremove`` swept gcc out of the codec
+purge. This probe reproduces that path during the image build so a missing
+toolchain aborts the build instead of shipping.
+
+It runs CPU-only (no GPU at build time): the inductor CPU backend codegens a
+fused kernel and compiles it with g++, which is the same compiler-discovery path
+the GPU runtime exercises. ``suppress_errors = False`` forces a compiler error to
+raise rather than silently fall back to eager.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+
+REQUIRED_TOOLS = ("cc", "gcc", "g++", "make")
+
+
+def _check_tools() -> None:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise RuntimeError(
+            "missing host compiler toolchain required by torch.inductor/Triton "
+            f"runtime JIT: {', '.join(missing)}. Something removed it after the "
+            "vLLM base image was built (check the ffmpeg/codec purge step)."
+        )
+
+
+def _check_torch_compile() -> None:
+    import torch
+    import torch._dynamo as dynamo
+
+    dynamo.config.suppress_errors = False
+
+    @torch.compile(backend="inductor", fullgraph=True)
+    def f(x: "torch.Tensor") -> "torch.Tensor":
+        return (x * 2 + 1).relu()
+
+    out = f(torch.randn(64))
+    assert out.shape == (64,), out.shape
+
+
+def main() -> int:
+    _check_tools()
+    _check_torch_compile()
+    print("torch.compile CPU inductor smoke OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -117,30 +117,42 @@ RUN --mount=type=bind,source=./container/deps/vllm/patches/v0.22.0/ultra,target=
 {% endif %}
 
 # The upstream vllm/vllm-openai base image ships a GPL/GPL-3.0 ffmpeg built
-# against libx264/libx265/libmp3lame. Purge that entire apt codec stack and
-# replace it with the LGPL-only in-tree ffmpeg built in wheel_builder
-# (--disable-gpl --disable-nonfree; H.264 via NVENC, VP9 via libvpx). PyAV,
-# torchaudio, torchvision, soundfile and Pillow all bundle their own libraries
-# and do not link the system ffmpeg/codecs, so removing them is safe. dpkg-query
-# keeps the purge robust across base-image/arch version suffixes (e.g.
-# libavcodec58 vs 60), and autoremove then sweeps the now-orphaned media deps.
+# against libx264/libx265/libmp3lame. Purge ONLY the explicitly-named ffmpeg +
+# codec packages and replace them with the LGPL-only in-tree ffmpeg built in
+# wheel_builder (--disable-gpl --disable-nonfree; H.264 via NVENC, VP9 via
+# libvpx). PyAV, torchaudio, torchvision, soundfile and Pillow all bundle their
+# own libraries and do not link the system ffmpeg/codecs, so removing them is
+# safe. dpkg-query keeps the match robust across base-image/arch version
+# suffixes (e.g. libavcodec58 vs 60).
 #
-# CRITICAL: the base image marks the CUDA math libs (libcublas/libcusolver/
-# libcusparse) auto-installed, and the torch wheels here ship NO bundled cublas
-# — torch loads the system copies. A bare autoremove would delete them and break
-# GPU inference, so pin every CUDA/NVIDIA lib as manually-installed first.
+# This grep is the COMPLETE, auditable set of what leaves the image: there is
+# deliberately NO apt-get autoremove, so the removal can never cascade into
+# unrelated auto-installed packages. That matters because the base image marks
+# both the gcc/g++/make toolchain (which torch.inductor/Triton JIT shell out to
+# at runtime) and the CUDA math libs (libcublas/libcusolver/libcusparse — the
+# torch wheels here ship no bundled cublas and load the system copies) as
+# auto-installed. A bare `autoremove --purge` sweeps all of those as "orphaned",
+# which is what broke runtime JIT (missing C compiler) in the 1.3.0 rc image.
+# Any LGPL/BSD media libs left orphaned by the named purge (libva, libvdpau,
+# ...) are license-clean dead weight, not a compliance issue.
 RUN set -eux; \
-    keep=$(dpkg-query -W -f='${Package}\n' 2>/dev/null \
-        | grep -E '^(libcu|libnv|libnccl|cuda)' || true); \
-    if [ -n "$keep" ]; then apt-mark manual $keep >/dev/null; fi; \
     purge=$(dpkg-query -W -f='${Package}\n' 2>/dev/null \
         | grep -E '^(ffmpeg|libav[a-z]|libsw[a-z]|libpostproc|libx264|libx265|libmp3lame|libaom|libdav1d|libvpx|libtheora|libvorbis|libopus|libsoxr)' \
         || true); \
     if [ -n "$purge" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get purge -y $purge; \
     fi; \
-    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y --purge; \
     rm -rf /var/lib/apt/lists/*
+
+{% if device == "cuda" %}
+# Regression guard for the codec purge above: torch.inductor/Triton JIT shell
+# out to a host C/C++ compiler at runtime, so a missing toolchain only surfaces
+# on the first compile in production. Reproduce that compile path at build time
+# (CPU-only, the same minimal probe QA runs) so a missing compiler aborts the
+# build instead of shipping.
+RUN --mount=type=bind,source=./container/deps/vllm/validate_torch_compile_smoke.py,target=/tmp/validate_torch_compile_smoke.py,readonly \
+    python3 /tmp/validate_torch_compile_smoke.py
+{% endif %}
 
 # Copy the LGPL ffmpeg from wheel_builder: versioned shared libs (libav*.so*,
 # libsw*.so*) plus the LGPL CLI binary that imageio/diffusers target via


### PR DESCRIPTION
## Problem

QA caught Triton JIT compilation failing in the **prod released** `vllm-runtime:1.3.0-nemotron-ultra-dev.1` container (but not the staging `…-pr.10234` image):

```
torch._inductor.exc.InductorError: RuntimeError: Failed to find C compiler.
Please specify via CC environment variable or set triton.knobs.build.impl.
```

The released image is missing `cc`, `gcc`, `g++`, `clang`, `make`; the staging image has them.

## Root cause

The GPL→LGPL ffmpeg fix (#10313) added a blanket `apt-get autoremove -y --purge` after purging the base image's GPL codec stack. `autoremove` removes **every** auto-installed orphan system-wide — not just the codec deps — and the `vllm/vllm-openai` base marks the `gcc`/`g++`/`cc`/`make` toolchain as auto-installed. Nothing manually-installed declares an apt-level dependency on it, so `autoremove` swept it out of the final image.

`torch.inductor`/Triton JIT-compile kernels **at runtime** by shelling out to a host C compiler, so the loss only surfaced on the first compile in a live worker — which is why the build succeeded but QA hit `InvalidCxxCompiler` at runtime. The pre-#10313 staging image had no `autoremove`, so its toolchain survived.

## Fix

- **Drop the blanket `autoremove`.** The explicitly-named `grep` purge is now the complete, auditable removal set and can never cascade into unrelated packages. The `apt-mark manual` CUDA pin only existed to survive `autoremove`, so it becomes dead code and is removed too. Any LGPL/BSD media libs left orphaned (`libva`, `libvdpau`, …) are license-clean dead weight, not a compliance issue.
- **Add a build-time regression guard** (`container/deps/vllm/validate_torch_compile_smoke.py`, CUDA-gated): a `cc/gcc/g++/make` presence check plus the same minimal CPU `torch.compile(backend="inductor")` probe QA ran, with `suppress_errors=False` so a missing compiler **aborts the build** instead of shipping.

## Verification

- Rendered all three targets via `container/render.py`: cuda13.0 / cuda12.9 have the explicit purge + smoke guard and **zero** `autoremove` commands; cpu has the purge fix and (correctly) no guard.
- Pending on this PR: the vllm cuda13 container build, after which I'll pull the image and confirm the toolchain is present and the smoke guard passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->