### PR TITLE
fix: Fix flaky TestVllmIndexersSync timeouts

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -474,7 +474,7 @@ def _test_remote_indexer_decisions(
     async def wait_for_worker_ids(endpoint, expected_num_workers: int) -> list[int]:
         client = await endpoint.client()
 
-        for _ in range(120):
+        for _ in range(300):
             worker_ids = sorted(set(client.instance_ids()))
             if len(worker_ids) >= expected_num_workers:
                 return worker_ids
@@ -496,7 +496,7 @@ def _test_remote_indexer_decisions(
         )
         record_client = await record_endpoint.client()
 
-        for _ in range(120):
+        for _ in range(600):
             query_ids = set(query_client.instance_ids())
             record_ids = set(record_client.instance_ids())
 
@@ -535,7 +535,7 @@ def _test_remote_indexer_decisions(
                 router_predicted_ttl_secs=router_predicted_ttl_secs,
             )
             last_error: Exception | None = None
-            for _ in range(60):
+            for _ in range(300):
                 runtime = get_runtime(
                     store_backend=store_backend, request_plane=request_plane
                 )
@@ -3254,7 +3254,7 @@ def _test_disagg_direct_mode(
 
         async def wait_for_models():
             models_url = f"{frontend_url}/v1/models"
-            for _ in range(120):
+            for _ in range(300):
                 try:
                     async with aiohttp.ClientSession() as session:
                         async with session.get(models_url) as response:
@@ -3286,7 +3286,7 @@ def _test_disagg_direct_mode(
             prefill_client = await prefill_endpoint.client()
             decode_client = await decode_endpoint.client()
 
-            for _ in range(60):
+            for _ in range(600):
                 p_ids = prefill_client.instance_ids()
                 d_ids = decode_client.instance_ids()
                 if p_ids and d_ids:

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -260,7 +260,7 @@ async def wait_for_frontend_ready(
 async def poll_for_worker_instances(
     endpoint,
     expected_num_workers: int,
-    max_wait_time: int = 60,
+    max_wait_time: int = 300,
 ) -> list[int]:
     """Poll the endpoint's discovery client until the expected number of worker instances appear.
 
@@ -347,7 +347,7 @@ async def wait_for_workers_ready(
 async def wait_for_indexer_workers_active(
     indexer_url: str,
     expected_workers: dict[int, dict[int, str]],
-    timeout_s: float = 30.0,
+    timeout_s: float = 120.0,
 ) -> None:
     """Wait until the standalone indexer reports all ZMQ listeners as active."""
     if not expected_workers:

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -376,7 +376,7 @@ class VLLMProcess(ManagedEngineProcessMixin):
                 process.__enter__()
 
                 new_worker_id = None
-                for _ in range(120):
+                for _ in range(600):
                     ids = set(client.instance_ids())
                     new = ids - known_ids
                     if new:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a633bb65-485e-4fe5-b55d-f5b02e526abe","source":"chat","resourceId":"3d4f4ec6-1dc8-462d-8189-07aa5171931e","workflowId":"9f572ad1-373e-440a-b8d3-1295875c6d11","codeChangeId":"9f572ad1-373e-440a-b8d3-1295875c6d11","sourceType":"test-optimization"} -->
#### Overview:

Fixing `test_vllm_indexers_sync[nats_core]` • [View in Test Optimization](https://us3.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fai-dynamo%2Fdynamo%22+%40test.name%3A%22test_vllm_indexers_sync%5Bnats_core%5D%22&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%221f642b967c295115%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D)

Fix flaky test `test_vllm_indexers_sync[nats_core]` by increasing worker registration and model discovery timeouts.

#### Details:
The test was failing with `RuntimeError: Timed out waiting for vLLM worker 0 to register (known_ids=set())`. This is because vLLM model loading can take significantly longer (up to 150s or more) than the previous 60s timeout, especially on contended CI runners.

This PR:
- Increases the worker registration polling timeout in `VLLMProcess.launch_workers_with_indexer` from 60s to 300s.
- Increases the default timeout in `poll_for_worker_instances` from 60s to 300s.
- Increases the default timeout in `wait_for_indexer_workers_active` from 30s to 120s.
- Increases various discovery and registration timeouts in `tests/router/common.py` from 60s/120s to 300s.

#### Where should the reviewer start?
- [tests/router/test_router_e2e_with_vllm.py](#removed-for-safety)
- [tests/router/helper.py](#removed-for-safety)
- [tests/router/common.py](#removed-for-safety)

#### Related Issues:
- Relates to flaky test report for `test_vllm_indexers_sync[nats_core]`

#### Impact:
Fixes a flaky test with 9.7% flake rate and 29 hours of CI time wasted.

<a name="removed-for-safety"></a>
> **_NOTE:_** some AI-generated links and images were removed to ensure safety.

---

PR by Bits - [View session in Datadog](https://us3.datadoghq.com/code/3d4f4ec6-1dc8-462d-8189-07aa5171931e)

Comment @datadog to request changes