### PR TITLE
chore(deps): bump to vLLM 0.22.1

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -47,7 +47,7 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.22.0-ubuntu2404
+    runtime_image_tag: v0.22.1-ubuntu2404
   xpu:
     base_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
     runtime_image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo
@@ -57,7 +57,7 @@ vllm:
     base_image: ubuntu
     runtime_image: vllm/vllm-openai-cpu
     base_image_tag: 22.04
-    runtime_image_tag: v0.22.0
+    runtime_image_tag: v0.22.1
   flashinf_ref: v0.6.8.post1
   vllm_omni_ref: "v0.21.0rc1"
   nixl_ref: v1.1.0

--- a/container/deps/vllm/protected_packages.txt
+++ b/container/deps/vllm/protected_packages.txt
@@ -11,7 +11,7 @@ vllm
 transformers
 tokenizers
 # vLLM-Omni (v0.21.0rc1) may require a newer safetensors than the upstream
-# vLLM 0.22.0 image ships, so safetensors is intentionally left unfrozen here.
+# vLLM 0.22.1 image ships, so safetensors is intentionally left unfrozen here.
 # safetensors
 msgspec
 flashinfer-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]==1.1.0",
-    "vllm[flashinfer,runai,otel]==0.22.0",
+    "vllm[flashinfer,runai,otel]==0.22.1",
     # vllm-omni is not part of ai-dynamo[vllm]: container builds inherit the
     # framework stack from vllm/vllm-openai, and pip/uv dependency resolution
     # for omni can override the vLLM torch stack.


### PR DESCRIPTION
Patch release off 0.22.0. No internal API changes, so just need to bump the requirements files (pyproject toml, container/ files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vllm dependency to version 0.22.1
  * Updated container image versions to 0.22.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->