### PR TITLE
docs: fix broken deployment-guide links in root READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Most inference engines optimize a single GPU or a single node. Dynamo is the **o
 
 ### New in 1.0
 
-- **Zero-config deploy ([DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide/dgdr-reference))** *(beta):* Specify model, HW, and SLA in one YAML — AIConfigurator auto-profiles the workload, Planner optimizes the topology, and Dynamo deploys
+- **Zero-config deploy ([DGDR](docs/kubernetes/dgdr.md))** *(beta):* Specify model, HW, and SLA in one YAML — AIConfigurator auto-profiles the workload, Planner optimizes the topology, and Dynamo deploys
 - **Agentic inference:** Per-request hints for latency priority, expected output length, and cache pinning TTL. [LangChain](https://docs.langchain.com/oss/python/integrations/chat/nvidia_ai_endpoints#use-with-nvidia-dynamo) + [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit) integrations
 - **Multimodal E/P/D:** Disaggregated encode/prefill/decode with embedding cache — 30% faster TTFT on image workloads
 - **Video generation:** Native [FastVideo](https://github.com/hao-ai-lab/FastVideo) + [SGLang Diffusion](https://lmsys.org/blog/2026-02-16-sglang-diffusion-advanced-optimizations/) support — real-time 1080p on single B200
@@ -157,7 +157,7 @@ Then start the frontend and a worker as shown above. See the [full installation 
 
 ### Option C: Kubernetes (recommended)
 
-For production multi-node clusters, install the [Dynamo Platform](https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide) and deploy with a single manifest:
+For production multi-node clusters, install the [Dynamo Platform](docs/kubernetes/model-deployment-guide.md) and deploy with a single manifest:
 
 ```yaml
 # Zero-config deploy: specify model + SLA, Dynamo handles the rest
@@ -276,7 +276,7 @@ To quickly setup both: `docker compose -f dev/docker-compose.yml up -d`
 - **[Support Matrix](https://docs.nvidia.com/dynamo/resources/support-matrix)** — Hardware, OS, CUDA, and backend versions
 - **[Feature Matrix](https://docs.nvidia.com/dynamo/resources/feature-matrix)** — Detailed backend compatibility
 - **[Release Artifacts](https://docs.nvidia.com/dynamo/resources/release-artifacts)** — Containers, wheels, Helm charts
-- **[Service Discovery](https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide/service-discovery)** — K8s-native vs etcd vs file-based discovery
+- **[Service Discovery](docs/kubernetes/service-discovery.md)** — K8s-native vs etcd vs file-based discovery
 - **[Benchmarking Guide](https://docs.nvidia.com/dynamo/user-guides/benchmarking)** — Compare deployment topologies with AIPerf
 
 <!-- Reference links for Feature Compatibility Matrix -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,7 +100,7 @@ limitations under the License.
 
 ### 1.0 新功能
 
-- **零配置部署（[DGDR](https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide/dgdr-reference)）** *(beta)：* 在一个 YAML 中指定模型、硬件和 SLA；AIConfigurator 自动分析工作负载，Planner 优化拓扑，然后由 Dynamo 完成部署
+- **零配置部署（[DGDR](docs/kubernetes/dgdr.md)）** *(beta)：* 在一个 YAML 中指定模型、硬件和 SLA；AIConfigurator 自动分析工作负载，Planner 优化拓扑，然后由 Dynamo 完成部署
 - **Agentic inference：** 按请求提供延迟优先级、预期输出长度和缓存固定 TTL 等提示。集成 [LangChain](https://docs.langchain.com/oss/python/integrations/chat/nvidia_ai_endpoints#use-with-nvidia-dynamo) + [NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit)
 - **多模态 E/P/D：** 带 embedding cache 的分离式 encode/prefill/decode；图像工作负载 TTFT 快 30%
 - **视频生成：** 原生支持 [FastVideo](https://github.com/hao-ai-lab/FastVideo) + [SGLang Diffusion](https://lmsys.org/blog/2026-02-16-sglang-diffusion-advanced-optimizations/)；单张 B200 上实现实时 1080p
@@ -143,7 +143,7 @@ uv pip install --prerelease=allow "ai-dynamo[sglang]"   # 或 [vllm]
 
 ### 选项 C：Kubernetes（推荐）
 
-对于生产级多节点集群，安装 [Dynamo Platform](https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide)，并使用单个 manifest 部署：
+对于生产级多节点集群，安装 [Dynamo Platform](docs/kubernetes/model-deployment-guide.md)，并使用单个 manifest 部署：
 
 ```yaml
 # 零配置部署：指定模型 + SLA，剩余工作由 Dynamo 处理
@@ -262,7 +262,7 @@ Dynamo 使用 TCP 进行组件间通信。在 Kubernetes 上，原生资源（[C
 - **[支持矩阵](https://docs.nvidia.com/dynamo/resources/support-matrix)** — 硬件、操作系统、CUDA 和后端版本
 - **[功能矩阵](https://docs.nvidia.com/dynamo/resources/feature-matrix)** — 详细后端兼容性
 - **[发布产物](https://docs.nvidia.com/dynamo/resources/release-artifacts)** — 容器、wheel、Helm chart
-- **[服务发现](https://docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide/service-discovery)** — K8s 原生、etcd 与基于文件的服务发现对比
+- **[服务发现](docs/kubernetes/service-discovery.md)** — K8s 原生、etcd 与基于文件的服务发现对比
 - **[基准测试指南](https://docs.nvidia.com/dynamo/user-guides/benchmarking)** — 使用 AIPerf 比较部署拓扑
 
 <!-- Reference links for Feature Compatibility Matrix -->


### PR DESCRIPTION
## Summary

The published `docs.nvidia.com/dynamo/kubernetes-deployment/deployment-guide` pages were removed from the docs site and now return 404, which is failing the **lychee** "Docs link check" on `main` (and every open PR). This points the three affected links in both root READMEs at their in-repo sources instead:

- `kubernetes-deployment/deployment-guide` → `docs/kubernetes/model-deployment-guide.md`
- `.../deployment-guide/dgdr-reference` → `docs/kubernetes/dgdr.md`
- `.../deployment-guide/service-discovery` → `docs/kubernetes/service-discovery.md`

Relative in-repo links resolve on GitHub, pass the link check, and won't break again when the published docs site restructures. This matches the README's existing relative-link usage (e.g. the Service Discovery link already used a relative path elsewhere in the file).

## Changes

- `README.md` — 3 links (lines 104, 160, 279)
- `README.zh-CN.md` — 3 links (lines 103, 146, 265)

## Test plan

- [x] `grep` confirms no `kubernetes-deployment/deployment-guide` URLs remain
- [x] All three relative targets exist in-repo
- [ ] lychee "Docs link check" passes in CI
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->