### PR TITLE
chore(planner): remove unused load_metric_samples config

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -89,7 +89,6 @@ class SLAPlannerDefaults(BasePlannerDefaults):
         16  # must be a perfect square; total buckets across input axes
     )
     load_scaling_down_sensitivity = 80  # 0-100
-    load_metric_samples = 10  # number of samples per interval
     load_min_observations = 5  # cold start threshold
     prefill_scale_up_queue_tokens = None
     prefill_scale_down_queue_tokens = None

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -612,7 +612,6 @@ class PlannerConfig(BaseModel):
             "optimization_target='load'. Accepts 0-100."
         ),
     )
-    load_metric_samples: int = SLAPlannerDefaults.load_metric_samples
     load_min_observations: int = SLAPlannerDefaults.load_min_observations
 
     # Advisory mode: compute and log decisions without executing scaling

--- a/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_based_scaling.py
@@ -726,7 +726,6 @@ class TestRefreshWorkerInfoFromConnector:
                 max_num_fpm_samples=50,
                 fpm_sample_bucket_size=16,
                 load_scaling_down_sensitivity=80,
-                load_metric_samples=10,
                 load_min_observations=5,
             )
             planner = NativePlannerBase(None, config)

--- a/components/src/dynamo/planner/tests/unit/test_metric_publication.py
+++ b/components/src/dynamo/planner/tests/unit/test_metric_publication.py
@@ -72,7 +72,6 @@ def _make_planner(prometheus_enabled: bool = True) -> NativePlannerBase:
             max_num_fpm_samples=50,
             fpm_sample_bucket_size=16,
             load_scaling_down_sensitivity=80,
-            load_metric_samples=10,
             load_min_observations=5,
         )
         planner = NativePlannerBase(None, config)

--- a/docs/components/planner/planner-guide.md
+++ b/docs/components/planner/planner-guide.md
@@ -123,7 +123,6 @@ features:
 | `max_num_fpm_samples` | int | `64` | Maximum retained FPM observations for online tuning or regression. |
 | `fpm_sample_bucket_size` | int | `16` | Number of buckets for observation retirement (must be a perfect square). |
 | `load_scaling_down_sensitivity` | int | `80` | Scale-down sensitivity 0–100 (0=never, 100=aggressive). |
-| `load_metric_samples` | int | `10` | Number of metric samples to collect per decision. |
 | `load_min_observations` | int | `5` | Minimum observations before making scaling decisions. |
 
 ### General Settings

--- a/docs/components/planner/planner-guide.zh-CN.md
+++ b/docs/components/planner/planner-guide.zh-CN.md
@@ -123,7 +123,6 @@ features:
 | `max_num_fpm_samples` | int | `64` | 为在线调优或回归保留的 FPM 观测最大数量。 |
 | `fpm_sample_bucket_size` | int | `16` | 用于观测淘汰的 bucket 数量（必须是完全平方数）。 |
 | `load_scaling_down_sensitivity` | int | `80` | 缩容敏感度 0-100（0=永不，100=激进）。 |
-| `load_metric_samples` | int | `10` | 每次决策要收集的指标样本数。 |
 | `load_min_observations` | int | `5` | 做出扩缩容决策前所需的最少观测数。 |
 
 ### 通用设置


### PR DESCRIPTION
## Summary
- remove the unused `load_metric_samples` planner config/default
- stop documenting `load_metric_samples` in the planner guide
- remove stale test config arguments

## Tests
- `PYTHONPATH=/home/hongkuanz/Projects/dynamo-remove-load-metric-samples/components/src /home/hongkuanz/Projects/dynamo/.venv/bin/python -m pytest components/src/dynamo/planner/tests/unit/test_metric_publication.py components/src/dynamo/planner/tests/unit/test_load_based_scaling.py`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated load-metric sampling configuration parameter
  * Updated planner configuration with refined load-scaling parameters

* **Tests**
  * Synchronized unit test configurations to reflect planner parameter updates

* **Documentation**
  * Updated planner configuration guide (English and Chinese) with current settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->