### PR TITLE
fix(bindings): propagate Python exception HTTP status through the boundary

### DIFF
--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -40,7 +40,7 @@ use pythonize::{depythonize, pythonize};
 
 use crate::ModelInput;
 use crate::context::Context as PyContext;
-use crate::errors::py_exception_to_backend_error;
+use crate::errors::{extract_http_like_error, py_exception_to_backend_error};
 use crate::llm::kv::KvEventPublisher as PyKvEventPublisher;
 use crate::to_pyerr;
 
@@ -1192,6 +1192,17 @@ fn py_err_to_dynamo(err: PyErr) -> DynamoError {
     let (backend, message) = Python::with_gil(|py| {
         if let Some(mapped) = py_exception_to_backend_error(py, &err) {
             return mapped;
+        }
+        // See engine.rs::process_item — emit JSON-shaped message so the OpenAI
+        // frontend can read the status code instead of defaulting to 500.
+        if let Some((code, message)) = extract_http_like_error(py, &err) {
+            let backend = if (400..500).contains(&code) {
+                BackendError::InvalidArgument
+            } else {
+                BackendError::Unknown
+            };
+            let json_msg = serde_json::json!({ "message": message, "code": code }).to_string();
+            return (backend, json_msg);
         }
         let backend = if err.is_instance_of::<pyo3::exceptions::PyValueError>(py)
             || err.is_instance_of::<pyo3::exceptions::PyTypeError>(py)

--- a/lib/bindings/python/rust/engine.rs
+++ b/lib/bindings/python/rust/engine.rs
@@ -22,7 +22,7 @@ pub use dynamo_runtime::{
 };
 
 use super::context::{Context, callable_accepts_kwarg};
-use super::errors::py_exception_to_backend_error;
+use super::errors::{extract_http_like_error, py_exception_to_backend_error};
 
 /// Add bindings from this crate to the provided module
 pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -308,6 +308,28 @@ where
                     DynamoError::builder()
                         .error_type(ErrorType::Backend(backend_err))
                         .message(message)
+                        .build(),
+                );
+            }
+
+            // openai.rs::extract_backend_error_if_present parses the DynamoError
+            // message as JSON {message, code}; emit that shape so the HTTP status
+            // survives instead of defaulting to 500.
+            if let Some((code, message)) = extract_http_like_error(py, &e) {
+                let backend_err = if (400..500).contains(&code) {
+                    BackendError::InvalidArgument
+                } else {
+                    BackendError::Unknown
+                };
+                let json_msg = serde_json::json!({
+                    "message": message,
+                    "code": code,
+                })
+                .to_string();
+                return ResponseProcessingError::Dynamo(
+                    DynamoError::builder()
+                        .error_type(ErrorType::Backend(backend_err))
+                        .message(json_msg)
                         .build(),
                 );
             }

--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -106,6 +106,12 @@ define_dynamo_exceptions!(
 /// Read `(code, message)` off a Python exception carrying an HTTP-style
 /// status. Accepts `.code` (matches [`HttpError`] in `http.rs`) or `.status`
 /// (matches `dynamo.common.http.HttpStatusError`) plus `.message`.
+///
+/// SECURITY: `.message` is forwarded verbatim to clients on 4xx responses
+/// (HTTP protocol contract). Python callers must ensure it contains no
+/// internal state, file paths, traceback strings, or backend identifiers.
+/// Non-4xx codes (including 5xx) are sanitized downstream — the original
+/// message survives in server logs only.
 pub fn extract_http_like_error(py: Python<'_>, err: &PyErr) -> Option<(u16, String)> {
     let value = err.value(py);
     let code = value

--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -102,3 +102,22 @@ define_dynamo_exceptions!(
     (EngineShutdown, BackendError::EngineShutdown),
     (StreamIncomplete, BackendError::StreamIncomplete),
 );
+
+/// Read `(code, message)` off a Python exception carrying an HTTP-style
+/// status. Accepts `.code` (matches [`HttpError`] in `http.rs`) or `.status`
+/// (matches `dynamo.common.http.HttpStatusError`) plus `.message`.
+pub fn extract_http_like_error(py: Python<'_>, err: &PyErr) -> Option<(u16, String)> {
+    let value = err.value(py);
+    let code = value
+        .getattr("code")
+        .ok()
+        .and_then(|a| a.extract::<u16>().ok())
+        .or_else(|| {
+            value
+                .getattr("status")
+                .ok()
+                .and_then(|a| a.extract::<u16>().ok())
+        })?;
+    let message = value.getattr("message").ok()?.extract::<String>().ok()?;
+    Some((code, message))
+}

--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -39,6 +39,7 @@ class _StatusLikeError(Exception):
         self.status = status
         self.message = message
 
+
 pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,

--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -27,7 +27,17 @@ from dynamo.llm import HttpAsyncEngine, HttpError, HttpService
 from dynamo.runtime import DistributedRuntime
 
 MSG_CONTAINS_ERROR = "This message contains an 400error."
+MSG_CONTAINS_STATUS_ERROR = "This message contains a 415 status error."
 MSG_CONTAINS_INTERNAL_ERROR = "This message contains an internal server error."
+
+
+class _StatusLikeError(Exception):
+    """Mimics dynamo.common.http.HttpStatusError's .status + .message shape."""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(f"HTTP {status}: {message}")
+        self.status = status
+        self.message = message
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -58,6 +68,8 @@ class MockHttpEngine:
 
         if MSG_CONTAINS_ERROR.lower() in user_message.lower():
             raise HttpError(code=400, message=MSG_CONTAINS_ERROR)
+        elif MSG_CONTAINS_STATUS_ERROR.lower() in user_message.lower():
+            raise _StatusLikeError(status=415, message=MSG_CONTAINS_STATUS_ERROR)
         elif MSG_CONTAINS_INTERNAL_ERROR.lower() in user_message.lower():
             raise ValueError("Simulated internal error")
 
@@ -165,11 +177,9 @@ async def test_chat_completion_success(http_server):
 @pytest.mark.parametrize(
     "msg_to_code",
     [
-        (MSG_CONTAINS_ERROR, 500),  # # TODO: should be 400, but currently 500
-        (
-            MSG_CONTAINS_INTERNAL_ERROR,
-            500,
-        ),  # Placeholder for future internal error test
+        (MSG_CONTAINS_ERROR, 400),
+        (MSG_CONTAINS_STATUS_ERROR, 415),
+        (MSG_CONTAINS_INTERNAL_ERROR, 500),
     ],
 )
 @pytest.mark.forked
@@ -189,5 +199,7 @@ async def test_chat_completion_http_error(http_server, msg_to_code: tuple[str, i
             error_json = await response.json()
             if msg_to_code[0] == MSG_CONTAINS_ERROR:
                 assert MSG_CONTAINS_ERROR in str(error_json)
+            elif msg_to_code[0] == MSG_CONTAINS_STATUS_ERROR:
+                assert MSG_CONTAINS_STATUS_ERROR in str(error_json)
             elif msg_to_code[0] == MSG_CONTAINS_INTERNAL_ERROR:
                 assert "simulated internal error" in str(error_json).lower()

--- a/tests/frontend/http_status_propagation_worker.py
+++ b/tests/frontend/http_status_propagation_worker.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Worker for the HTTP-status-propagation e2e test. Raises a duck-typed
+`.status=415` exception so the test can assert the status survives the wire."""
+
+from __future__ import annotations
+
+import asyncio
+
+import uvloop
+
+from dynamo.llm import ModelInput, ModelType, register_model
+from dynamo.runtime import DistributedRuntime
+from tests.frontend.test_http_status_propagation import (
+    ENDPOINT_PATH,
+    EXPECTED_MESSAGE,
+    EXPECTED_STATUS,
+    MODEL_NAME,
+)
+from tests.utils.constants import QWEN
+
+
+class _StatusLikeError(Exception):
+    """Duck-typed `.status` + `.message` — same shape as
+    `dynamo.common.http.HttpStatusError`."""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(f"HTTP {status}: {message}")
+        self.status = status
+        self.message = message
+
+
+async def generate(request, context):
+    raise _StatusLikeError(status=EXPECTED_STATUS, message=EXPECTED_MESSAGE)
+    yield  # unreachable; needed to make this an async generator
+
+
+async def main():
+    runtime = DistributedRuntime(asyncio.get_running_loop(), "etcd", "tcp")
+    endpoint = runtime.endpoint(ENDPOINT_PATH)
+    await register_model(
+        ModelInput.Tokens,
+        ModelType.Chat,
+        endpoint,
+        QWEN,
+        model_name=MODEL_NAME,
+    )
+    await endpoint.serve_endpoint(generate)
+
+
+if __name__ == "__main__":
+    uvloop.run(main())

--- a/tests/frontend/test_http_status_propagation.py
+++ b/tests/frontend/test_http_status_propagation.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end check that an HTTP status raised inside a Python engine
+propagates through the wire transport to the frontend's HTTP response.
+
+Launches a real worker + frontend subprocess pair, posts one
+chat-completions request, asserts the response is 415 — proving the
+boundary fix survives the TCP/etcd request plane, not just the
+in-process pipeline."""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+import requests
+
+from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
+from tests.utils.port_utils import ServicePorts
+
+MODEL_NAME = "test-http-status-prop"
+ENDPOINT_PATH = "test.http_status_prop.generate"
+EXPECTED_STATUS = 415
+EXPECTED_MESSAGE = "unsupported-media-via-wire"
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+    pytest.mark.gpu_0,
+]
+
+
+class _WorkerProcess(ManagedProcess):
+    def __init__(self, request, *, frontend_port: int) -> None:
+        super().__init__(
+            command=["python3", "-m", "tests.frontend.http_status_propagation_worker"],
+            health_check_urls=[
+                (f"http://localhost:{frontend_port}/v1/models", self._model_listed)
+            ],
+            timeout=60,
+            display_output=True,
+            terminate_all_matching_process_names=False,
+            straggler_commands=["-m tests.frontend.http_status_propagation_worker"],
+            log_dir=f"{request.node.name}_worker",
+        )
+
+    @staticmethod
+    def _model_listed(response: requests.Response) -> bool:
+        try:
+            if response.status_code != 200:
+                return False
+            data = response.json()
+        except (ValueError, KeyError):
+            return False
+        return any(m.get("id") == MODEL_NAME for m in data.get("data", []))
+
+
+@pytest.fixture(scope="function")
+def services(
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports: ServicePorts,
+) -> Generator[int, None, None]:
+    _ = runtime_services_dynamic_ports
+    frontend_port = dynamo_dynamic_ports.frontend_port
+    with DynamoFrontendProcess(
+        request,
+        frontend_port=frontend_port,
+        extra_args=["--discovery-backend", "etcd", "--request-plane", "tcp"],
+        terminate_all_matching_process_names=False,
+    ):
+        with _WorkerProcess(request, frontend_port=frontend_port):
+            yield frontend_port
+
+
+def test_http_status_propagates_through_wire(services: int) -> None:
+    response = requests.post(
+        f"http://localhost:{services}/v1/chat/completions",
+        json={
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        timeout=30,
+    )
+    assert response.status_code == EXPECTED_STATUS, response.text
+    assert EXPECTED_MESSAGE in response.text


### PR DESCRIPTION
## What this PR does

PR #10281 (merged 2026-06-04) added explicit `HttpStatusError(415)` handling in `ImageLoader` so unsupported image formats like SVG would return HTTP 415 instead of 500. The fix is correct at the Python layer — but the status never reaches the client.

The Python→Rust boundary in `lib/bindings/python` stringifies HTTP-status-carrying exceptions on the way through. The OpenAI frontend parses `DynamoError` messages as JSON `{message, code}` to recover the status; when it sees a plain string it defaults to HTTP 500.

Net effect on main today: any client sending an SVG to a multimodal worker still gets HTTP 500. The user-facing behavior #10281 promised isn't delivered.

This PR completes the fix:

- Adds `extract_http_like_error` in `errors.rs` — duck-typed: matches `.code` (used by `dynamo.llm.HttpError`) or `.status` (used by `dynamo.common.http.HttpStatusError`) plus `.message`.
- Calls it from `process_item` (streaming-response handler) and `py_err_to_dynamo` (request-side error mapper). Both serialize as JSON `{message, code}` so the frontend reads the correct status.
- 4xx codes map to `BackendError::InvalidArgument`; non-4xx fall back to `BackendError::Unknown`. Frontend turns the JSON code into the outgoing HTTP status.

Also closes the pre-existing `# TODO: should be 400, but currently 500` in `test_http_server.py` — same bug, different exception class (`dynamo.llm.HttpError`).

## Tests

Updated `test_http_server.py::test_chat_completion_http_error`:

- The pre-existing `(MSG_CONTAINS_ERROR, 500)  # TODO: should be 400` case is flipped to expect 400.
- New `_StatusLikeError(status=415)` case exercises the `.status` path used by `dynamo.common.http.HttpStatusError`.
- The negative case (`ValueError` → 500) stays unchanged: the boundary doesn't invent a status code when the exception didn't carry one.

Before fix: 2/3 cases FAIL with HTTP 500.
After fix: 4/4 (incl. success path) pass; no regression in the existing 15 `test_image_loader.py` tests from #10281.

## Verification

Built + tested in \`dynamo:vllm-0.22-release-1.2\` container:
- \`cargo fmt --check\` clean
- \`cargo clippy --all-targets -- -D warnings\` clean
- Full \`test_http_server.py\` passes (4/4)

## Background

Caught by dynamo-ops's review on #10281: https://github.com/ai-dynamo/dynamo/pull/10281#discussion_r3359534881 — the review flagged that the boundary strips the status; this PR is the boundary-side fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced HTTP error detection in exception handling to properly extract status codes and messages
  * Improved error response formatting with correct status code classification (4xx vs other errors)

* **Tests**
  * Added test coverage for HTTP error detection and response formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->