### PR TITLE
ci: add frontend perf PR guard

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -57,6 +57,16 @@ on:
       gpu_test_markers:
         required: true
         type: string
+      run_frontend_perf_pr_guard:
+        description: 'Whether to run the CPU-pinned frontend performance PR guard'
+        required: false
+        type: boolean
+        default: false
+      frontend_perf_guard_baseline:
+        description: 'Optional baseline JSON/CSV path inside the test image for frontend perf comparisons'
+        required: false
+        type: string
+        default: ''
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -226,6 +236,54 @@ jobs:
       source_ref: ${{ inputs.source_ref }}
       image_tag_suffix: ${{ inputs.image_tag_suffix }}
     secrets: inherit
+
+  frontend-perf-pr-guard:
+    name: frontend perf pr guard
+    needs: image
+    if: ${{ inputs.run_frontend_perf_pr_guard }}
+    runs-on: prod-tester-amd-v2
+    container:
+      image: ${{ vars.RUNNERS_REGISTRY }}/ai-dynamo/dynamo:${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}-${{ needs.image.outputs.target_tag_plain }}${{ (inputs.cuda_version != '' && !startsWith(inputs.cuda_version, '13.')) && format('-cuda{0}', startsWith(inputs.cuda_version, '12.') && '12' || inputs.cuda_version) || '' }}${{ inputs.image_tag_suffix }}-test
+      env:
+        HOME: /__w/dynamo/dynamo
+        USER: dynamo
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Run CPU-pinned frontend perf guard
+        working-directory: /workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v aiperf >/dev/null 2>&1 && ! python3 -c "import aiperf" >/dev/null 2>&1; then
+            if command -v uv >/dev/null 2>&1; then
+              uv pip install --requirement container/deps/requirements.benchmark.txt
+            else
+              python3 -m pip install --requirement container/deps/requirements.benchmark.txt
+            fi
+          fi
+
+          OUTPUT_DIR="${RUNNER_TEMP}/frontend-perf-pr-guard"
+          BASELINE_ARGS=()
+          if [[ -n "${{ inputs.frontend_perf_guard_baseline }}" ]]; then
+            BASELINE_ARGS=(--baseline "${{ inputs.frontend_perf_guard_baseline }}")
+          fi
+
+          python3 benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run \
+            --output-dir "${OUTPUT_DIR}" \
+            --report-json "${OUTPUT_DIR}/pr_guard_report.json" \
+            --summary-file "${OUTPUT_DIR}/pr_guard_summary.md" \
+            "${BASELINE_ARGS[@]}"
+
+      - name: Upload frontend perf guard artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: frontend-perf-pr-guard-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/frontend-perf-pr-guard
+          if-no-files-found: ignore
 
   gpu:
     name: test

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -257,15 +257,24 @@ jobs:
         run: |
           set -euo pipefail
 
+          OUTPUT_DIR="${RUNNER_TEMP}/frontend-perf-pr-guard"
+          mkdir -p "${OUTPUT_DIR}"
+
           if ! command -v aiperf >/dev/null 2>&1 && ! python3 -c "import aiperf" >/dev/null 2>&1; then
+            AIPERF_VENV="${RUNNER_TEMP}/frontend-perf-tools"
             if command -v uv >/dev/null 2>&1; then
-              uv pip install --requirement container/deps/requirements.benchmark.txt
+              uv venv "${AIPERF_VENV}" --python "$(command -v python3)"
+              UV_CACHE_DIR="${RUNNER_TEMP}/uv-cache" uv pip install \
+                --python "${AIPERF_VENV}/bin/python" \
+                --requirement container/deps/requirements.benchmark.txt
             else
-              python3 -m pip install --requirement container/deps/requirements.benchmark.txt
+              python3 -m venv "${AIPERF_VENV}"
+              "${AIPERF_VENV}/bin/python" -m pip install \
+                --requirement container/deps/requirements.benchmark.txt
             fi
+            export PATH="${AIPERF_VENV}/bin:${PATH}"
           fi
 
-          OUTPUT_DIR="${RUNNER_TEMP}/frontend-perf-pr-guard"
           BASELINE_ARGS=()
           if [[ -n "${{ inputs.frontend_perf_guard_baseline }}" ]]; then
             BASELINE_ARGS=(--baseline "${{ inputs.frontend_perf_guard_baseline }}")

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -259,20 +259,24 @@ jobs:
 
           OUTPUT_DIR="${RUNNER_TEMP}/frontend-perf-pr-guard"
           mkdir -p "${OUTPUT_DIR}"
+          DYNAMO_PYTHON="$(command -v python3)"
 
           if ! command -v aiperf >/dev/null 2>&1 && ! python3 -c "import aiperf" >/dev/null 2>&1; then
             AIPERF_VENV="${RUNNER_TEMP}/frontend-perf-tools"
+            AIPERF_BIN_DIR="${RUNNER_TEMP}/frontend-perf-bin"
             if command -v uv >/dev/null 2>&1; then
-              uv venv "${AIPERF_VENV}" --python "$(command -v python3)"
+              uv venv "${AIPERF_VENV}" --python "${DYNAMO_PYTHON}"
               UV_CACHE_DIR="${RUNNER_TEMP}/uv-cache" uv pip install \
                 --python "${AIPERF_VENV}/bin/python" \
                 --requirement container/deps/requirements.benchmark.txt
             else
-              python3 -m venv "${AIPERF_VENV}"
+              "${DYNAMO_PYTHON}" -m venv "${AIPERF_VENV}"
               "${AIPERF_VENV}/bin/python" -m pip install \
                 --requirement container/deps/requirements.benchmark.txt
             fi
-            export PATH="${AIPERF_VENV}/bin:${PATH}"
+            mkdir -p "${AIPERF_BIN_DIR}"
+            ln -sf "${AIPERF_VENV}/bin/aiperf" "${AIPERF_BIN_DIR}/aiperf"
+            export PATH="${AIPERF_BIN_DIR}:${PATH}"
           fi
 
           BASELINE_ARGS=()
@@ -280,7 +284,7 @@ jobs:
             BASELINE_ARGS=(--baseline "${{ inputs.frontend_perf_guard_baseline }}")
           fi
 
-          python3 benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run \
+          "${DYNAMO_PYTHON}" benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run \
             --output-dir "${OUTPUT_DIR}" \
             --report-json "${OUTPUT_DIR}/pr_guard_report.json" \
             --summary-file "${OUTPUT_DIR}/pr_guard_summary.md" \

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -254,6 +254,8 @@ jobs:
       - name: Run CPU-pinned frontend perf guard
         working-directory: /workspace
         shell: bash
+        env:
+          FRONTEND_PERF_GUARD_BASELINE: ${{ inputs.frontend_perf_guard_baseline }}
         run: |
           set -euo pipefail
 
@@ -280,8 +282,8 @@ jobs:
           fi
 
           BASELINE_ARGS=()
-          if [[ -n "${{ inputs.frontend_perf_guard_baseline }}" ]]; then
-            BASELINE_ARGS=(--baseline "${{ inputs.frontend_perf_guard_baseline }}")
+          if [[ -n "${FRONTEND_PERF_GUARD_BASELINE}" ]]; then
+            BASELINE_ARGS=(--baseline "${FRONTEND_PERF_GUARD_BASELINE}")
           fi
 
           "${DYNAMO_PYTHON}" benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run \

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -263,24 +263,6 @@ jobs:
           mkdir -p "${OUTPUT_DIR}"
           DYNAMO_PYTHON="$(command -v python3)"
 
-          if ! command -v aiperf >/dev/null 2>&1 && ! python3 -c "import aiperf" >/dev/null 2>&1; then
-            AIPERF_VENV="${RUNNER_TEMP}/frontend-perf-tools"
-            AIPERF_BIN_DIR="${RUNNER_TEMP}/frontend-perf-bin"
-            if command -v uv >/dev/null 2>&1; then
-              uv venv "${AIPERF_VENV}" --python "${DYNAMO_PYTHON}"
-              UV_CACHE_DIR="${RUNNER_TEMP}/uv-cache" uv pip install \
-                --python "${AIPERF_VENV}/bin/python" \
-                --requirement container/deps/requirements.benchmark.txt
-            else
-              "${DYNAMO_PYTHON}" -m venv "${AIPERF_VENV}"
-              "${AIPERF_VENV}/bin/python" -m pip install \
-                --requirement container/deps/requirements.benchmark.txt
-            fi
-            mkdir -p "${AIPERF_BIN_DIR}"
-            ln -sf "${AIPERF_VENV}/bin/aiperf" "${AIPERF_BIN_DIR}/aiperf"
-            export PATH="${AIPERF_BIN_DIR}:${PATH}"
-          fi
-
           BASELINE_ARGS=()
           if [[ -n "${FRONTEND_PERF_GUARD_BASELINE}" ]]; then
             BASELINE_ARGS=(--baseline "${FRONTEND_PERF_GUARD_BASELINE}")

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -528,6 +528,7 @@ jobs:
       cpu_parallel_test_markers: 'pre_merge and parallel and not (vllm or sglang or trtllm) and (gpu_0)'
       cpu_sequential_test_markers: 'pre_merge and not parallel and not (vllm or sglang or trtllm) and (gpu_0)'
       gpu_test_markers: 'pre_merge and none and gpu_1'
+      run_frontend_perf_pr_guard: ${{ needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.frontend == 'true' || needs.changed-files.outputs.benchmarks == 'true' }}
     secrets: inherit
 
   # ============================================================================

--- a/benchmarks/frontend/scripts/ci/README.md
+++ b/benchmarks/frontend/scripts/ci/README.md
@@ -41,6 +41,19 @@ coarse regression thresholds:
 - ITL p50 rises more than 20%;
 - ITL p99 rises more than 35%.
 
+## Baseline Storage
+
+The guard does not have a hard-coded baseline location. `--export-baseline`
+writes a JSON file to the path passed on the command line, and `--baseline`
+reads that same format back from the path passed to the guard.
+
+The PR workflow currently leaves `frontend_perf_guard_baseline` empty, so the
+guard runs in sanity-only mode and uploads the candidate results as the
+`frontend-perf-pr-guard-${run_id}-${run_attempt}` artifact. When baseline gating
+is enabled, store a runner-specific baseline JSON at a path available inside the
+test image or checked-out workspace and pass that path through
+`frontend_perf_guard_baseline`.
+
 ## Create A Baseline Candidate
 
 Run on the same runner class that will execute the PR guard:

--- a/benchmarks/frontend/scripts/ci/README.md
+++ b/benchmarks/frontend/scripts/ci/README.md
@@ -1,0 +1,55 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Frontend Perf PR Guard
+
+`frontend_perf_pr_guard.py` is a small CI wrapper around the existing frontend
+benchmark sweep. It is intended to catch large frontend regressions before a PR
+merges.
+
+The guard partitions the runner's allowed CPU set deterministically:
+
+- the frontend is pinned to the first allowed CPU;
+- mocker, aiperf, etcd, and NATS are pinned to all remaining allowed CPUs.
+
+The default benchmark uses the in-repo TinyLlama tokenizer fixture, materialized
+under the run output with a minimal chat template, so the run is offline and
+does not depend on HuggingFace cache state.
+
+## Local Dry Run
+
+```bash
+python3 benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run --dry-run
+```
+
+## CI Run
+
+```bash
+python3 benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run \
+  --output-dir /tmp/frontend-perf-pr-guard \
+  --baseline /path/to/runner-specific-baseline.json
+```
+
+Without `--baseline`, the guard runs in sanity-only mode and checks that the run
+completed with non-zero core metrics. With a baseline, it fails on the default
+coarse regression thresholds:
+
+- request throughput drops more than 15%;
+- output token throughput drops more than 15%;
+- TTFT p50 rises more than 25%;
+- TTFT p99 rises more than 35%;
+- ITL p50 rises more than 20%;
+- ITL p99 rises more than 35%.
+
+## Create A Baseline Candidate
+
+Run on the same runner class that will execute the PR guard:
+
+```bash
+python3 benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py run \
+  --output-dir /tmp/frontend-perf-pr-guard \
+  --export-baseline /tmp/frontend-perf-pr-guard-baseline.json
+```
+
+Baseline files are CPU and runner dependent. Keep separate baselines for
+different runner labels or CPU allocations.

--- a/benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py
+++ b/benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py
@@ -218,12 +218,19 @@ def evaluate(
     for key, row in candidate.items():
         if row.get("status") != "ok":
             issues.append(f"{key}: run status is {row.get('status')!r}")
-        for metric in ("req_per_sec", "output_tok_per_sec", "ttft_p50_ms"):
+        for metric in (
+            "req_per_sec",
+            "output_tok_per_sec",
+            "ttft_p50_ms",
+            "ttft_p99_ms",
+            "itl_p50_ms",
+            "itl_p99_ms",
+        ):
             if to_float(row.get(metric)) <= 0:
                 issues.append(f"{key}: {metric} is missing or non-positive")
 
     baseline: dict[str, dict[str, object]] = {}
-    if baseline_path:
+    if baseline_path is not None:
         if baseline_path.exists():
             baseline = load_points(baseline_path)
         elif require_baseline:
@@ -319,7 +326,7 @@ def markdown_report(report: dict[str, object]) -> str:
     lines = ["# Frontend Perf PR Guard", ""]
     lines.append(f"Result: {'PASS' if report['ok'] else 'FAIL'}")
     lines.append(f"Results CSV: `{report['result_csv']}`")
-    if report.get("baseline"):
+    if report.get("baseline") is not None:
         lines.append(f"Baseline: `{report['baseline']}`")
     lines.append("")
 
@@ -382,12 +389,12 @@ def write_reports(args: argparse.Namespace, report: dict[str, object]) -> None:
         args.report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
 
     markdown = markdown_report(report)
-    if args.summary_file:
+    if args.summary_file is not None:
         args.summary_file.parent.mkdir(parents=True, exist_ok=True)
         args.summary_file.write_text(markdown)
 
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
-    if step_summary:
+    if step_summary is not None and step_summary != "":
         with open(step_summary, "a") as f:
             f.write(markdown)
 

--- a/benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py
+++ b/benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-pinned frontend performance PR guard.
+
+This is intentionally small and CI-oriented: it runs a fixed frontend/mocker
+benchmark point through the existing sweep runner, then compares the resulting
+CSV against an optional baseline captured on the same runner class.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPT_DIR.parents[2]
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "artifacts" / "frontend_perf_pr_guard"
+DEFAULT_MODEL = (
+    REPO_ROOT / "lib" / "llm" / "tests" / "data" / "sample-models" / "TinyLlama_v1.1"
+)
+DEFAULT_CHAT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{{ message['role'] + ': ' + message['content'] + eos_token }}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}{{ 'assistant: ' }}{% endif %}"
+)
+KEY_FIELDS = ("backend", "tokenizer", "concurrency", "isl", "osl", "workers")
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    min_req_per_sec_ratio: float = 0.85
+    min_output_tok_per_sec_ratio: float = 0.85
+    max_ttft_p50_ratio: float = 1.25
+    max_ttft_p99_ratio: float = 1.35
+    max_itl_p50_ratio: float = 1.20
+    max_itl_p99_ratio: float = 1.35
+
+
+def parse_cpu_list(value: str) -> list[int]:
+    cpus: set[int] = set()
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_s, end_s = part.split("-", 1)
+            start, end = int(start_s), int(end_s)
+            if end < start:
+                raise ValueError(f"invalid CPU range: {part}")
+            cpus.update(range(start, end + 1))
+        else:
+            cpus.add(int(part))
+    return sorted(cpus)
+
+
+def format_cpu_list(cpus: Iterable[int]) -> str:
+    ordered = sorted(cpus)
+    if not ordered:
+        return ""
+
+    ranges: list[str] = []
+    start = prev = ordered[0]
+    for cpu in ordered[1:]:
+        if cpu == prev + 1:
+            prev = cpu
+            continue
+        ranges.append(f"{start}-{prev}" if start != prev else str(start))
+        start = prev = cpu
+    ranges.append(f"{start}-{prev}" if start != prev else str(start))
+    return ",".join(ranges)
+
+
+def allowed_cpus() -> list[int]:
+    if hasattr(os, "sched_getaffinity"):
+        return sorted(os.sched_getaffinity(0))
+
+    status = Path("/proc/self/status")
+    if status.exists():
+        for line in status.read_text().splitlines():
+            if line.startswith("Cpus_allowed_list:"):
+                return parse_cpu_list(line.split(":", 1)[1].strip())
+
+    return list(range(os.cpu_count() or 1))
+
+
+def cpu_partition(min_cpus: int) -> tuple[str, str, list[int]]:
+    cpus = allowed_cpus()
+    if len(cpus) < min_cpus:
+        raise RuntimeError(
+            f"frontend perf guard requires at least {min_cpus} allowed CPUs; "
+            f"runner only exposes {len(cpus)} ({format_cpu_list(cpus)})"
+        )
+    return str(cpus[0]), format_cpu_list(cpus[1:]), cpus
+
+
+def row_key(row: dict[str, object]) -> str:
+    return "|".join(str(row[field]) for field in KEY_FIELDS)
+
+
+def to_float(value: object) -> float:
+    if value in (None, ""):
+        return 0.0
+    return float(value)
+
+
+def normalize_row(row: dict[str, object]) -> dict[str, object]:
+    normalized = dict(row)
+    for field in ("concurrency", "isl", "osl", "workers"):
+        normalized[field] = int(normalized[field])
+    for field in (
+        "req_per_sec",
+        "output_tok_per_sec",
+        "ttft_p50_ms",
+        "ttft_p99_ms",
+        "itl_p50_ms",
+        "itl_p99_ms",
+        "duration_sec",
+    ):
+        normalized[field] = to_float(normalized.get(field))
+    return normalized
+
+
+def load_csv(path: Path) -> dict[str, dict[str, object]]:
+    rows: dict[str, dict[str, object]] = {}
+    with path.open(newline="") as f:
+        for row in csv.DictReader(f):
+            normalized = normalize_row(row)
+            rows[row_key(normalized)] = normalized
+    return rows
+
+
+def load_points(path: Path) -> dict[str, dict[str, object]]:
+    if path.suffix == ".csv":
+        return load_csv(path)
+
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        points = data
+    else:
+        points = data.get("points", [])
+    rows: dict[str, dict[str, object]] = {}
+    for row in points:
+        normalized = normalize_row(row)
+        rows[row_key(normalized)] = normalized
+    return rows
+
+
+def export_baseline(
+    rows: dict[str, dict[str, object]],
+    path: Path,
+    frontend_cpuset: str,
+    load_cpuset: str,
+    allowed: list[int],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "host": socket.gethostname(),
+        "allowed_cpus": format_cpu_list(allowed),
+        "frontend_cpuset": frontend_cpuset,
+        "load_cpuset": load_cpuset,
+        "key_fields": KEY_FIELDS,
+        "points": list(rows.values()),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def compare_metric(
+    issues: list[str],
+    key: str,
+    metric: str,
+    baseline: float,
+    candidate: float,
+    ratio: float,
+    lower_is_worse: bool,
+) -> None:
+    if baseline <= 0:
+        return
+    actual_ratio = candidate / baseline
+    if lower_is_worse and actual_ratio < ratio:
+        issues.append(
+            f"{key}: {metric} dropped to {actual_ratio:.2%} of baseline "
+            f"({candidate:.2f} vs {baseline:.2f})"
+        )
+    elif not lower_is_worse and actual_ratio > ratio:
+        issues.append(
+            f"{key}: {metric} rose to {actual_ratio:.2%} of baseline "
+            f"({candidate:.2f} vs {baseline:.2f})"
+        )
+
+
+def evaluate(
+    result_csv: Path,
+    baseline_path: Path | None,
+    thresholds: Thresholds,
+    require_baseline: bool,
+) -> tuple[bool, dict[str, object]]:
+    candidate = load_csv(result_csv)
+    issues: list[str] = []
+    notes: list[str] = []
+
+    if not candidate:
+        issues.append(f"no result rows found in {result_csv}")
+
+    for key, row in candidate.items():
+        if row.get("status") != "ok":
+            issues.append(f"{key}: run status is {row.get('status')!r}")
+        for metric in ("req_per_sec", "output_tok_per_sec", "ttft_p50_ms"):
+            if to_float(row.get(metric)) <= 0:
+                issues.append(f"{key}: {metric} is missing or non-positive")
+
+    baseline: dict[str, dict[str, object]] = {}
+    if baseline_path:
+        if baseline_path.exists():
+            baseline = load_points(baseline_path)
+        elif require_baseline:
+            issues.append(f"required baseline does not exist: {baseline_path}")
+        else:
+            notes.append(
+                f"baseline not found; running sanity-only guard: {baseline_path}"
+            )
+    elif require_baseline:
+        issues.append("--require-baseline was set, but no --baseline was provided")
+    else:
+        notes.append("no baseline supplied; running sanity-only guard")
+
+    if baseline:
+        common = sorted(set(candidate) & set(baseline))
+        if not common:
+            issues.append("baseline exists, but no points match the candidate run")
+
+        missing = sorted(set(candidate) - set(baseline))
+        for key in missing:
+            issues.append(f"{key}: missing from baseline")
+
+        for key in common:
+            b = baseline[key]
+            c = candidate[key]
+            compare_metric(
+                issues,
+                key,
+                "req_per_sec",
+                to_float(b.get("req_per_sec")),
+                to_float(c.get("req_per_sec")),
+                thresholds.min_req_per_sec_ratio,
+                lower_is_worse=True,
+            )
+            compare_metric(
+                issues,
+                key,
+                "output_tok_per_sec",
+                to_float(b.get("output_tok_per_sec")),
+                to_float(c.get("output_tok_per_sec")),
+                thresholds.min_output_tok_per_sec_ratio,
+                lower_is_worse=True,
+            )
+            compare_metric(
+                issues,
+                key,
+                "ttft_p50_ms",
+                to_float(b.get("ttft_p50_ms")),
+                to_float(c.get("ttft_p50_ms")),
+                thresholds.max_ttft_p50_ratio,
+                lower_is_worse=False,
+            )
+            compare_metric(
+                issues,
+                key,
+                "ttft_p99_ms",
+                to_float(b.get("ttft_p99_ms")),
+                to_float(c.get("ttft_p99_ms")),
+                thresholds.max_ttft_p99_ratio,
+                lower_is_worse=False,
+            )
+            compare_metric(
+                issues,
+                key,
+                "itl_p50_ms",
+                to_float(b.get("itl_p50_ms")),
+                to_float(c.get("itl_p50_ms")),
+                thresholds.max_itl_p50_ratio,
+                lower_is_worse=False,
+            )
+            compare_metric(
+                issues,
+                key,
+                "itl_p99_ms",
+                to_float(b.get("itl_p99_ms")),
+                to_float(c.get("itl_p99_ms")),
+                thresholds.max_itl_p99_ratio,
+                lower_is_worse=False,
+            )
+
+    report = {
+        "ok": not issues,
+        "result_csv": str(result_csv),
+        "baseline": str(baseline_path) if baseline_path else None,
+        "candidate_points": list(candidate.values()),
+        "issues": issues,
+        "notes": notes,
+    }
+    return not issues, report
+
+
+def markdown_report(report: dict[str, object]) -> str:
+    lines = ["# Frontend Perf PR Guard", ""]
+    lines.append(f"Result: {'PASS' if report['ok'] else 'FAIL'}")
+    lines.append(f"Results CSV: `{report['result_csv']}`")
+    if report.get("baseline"):
+        lines.append(f"Baseline: `{report['baseline']}`")
+    lines.append("")
+
+    notes = report.get("notes") or []
+    if notes:
+        lines.append("## Notes")
+        lines.extend(f"- {note}" for note in notes)
+        lines.append("")
+
+    issues = report.get("issues") or []
+    if issues:
+        lines.append("## Issues")
+        lines.extend(f"- {issue}" for issue in issues)
+        lines.append("")
+
+    points = report.get("candidate_points") or []
+    if points:
+        lines.append("## Candidate Points")
+        lines.append("| Key | Req/s | Tok/s | TTFT p50 | TTFT p99 | ITL p50 | Status |")
+        lines.append("|---|---:|---:|---:|---:|---:|---|")
+        for row in points:
+            key = row_key(row)
+            lines.append(
+                f"| `{key}` | {to_float(row.get('req_per_sec')):.2f} | "
+                f"{to_float(row.get('output_tok_per_sec')):.1f} | "
+                f"{to_float(row.get('ttft_p50_ms')):.1f} | "
+                f"{to_float(row.get('ttft_p99_ms')):.1f} | "
+                f"{to_float(row.get('itl_p50_ms')):.1f} | {row.get('status')} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def thresholds_from_args(args: argparse.Namespace) -> Thresholds:
+    return Thresholds(
+        min_req_per_sec_ratio=1.0 - args.max_req_per_sec_drop_pct / 100.0,
+        min_output_tok_per_sec_ratio=1.0 - args.max_output_tok_per_sec_drop_pct / 100.0,
+        max_ttft_p50_ratio=1.0 + args.max_ttft_p50_rise_pct / 100.0,
+        max_ttft_p99_ratio=1.0 + args.max_ttft_p99_rise_pct / 100.0,
+        max_itl_p50_ratio=1.0 + args.max_itl_p50_rise_pct / 100.0,
+        max_itl_p99_ratio=1.0 + args.max_itl_p99_rise_pct / 100.0,
+    )
+
+
+def add_check_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--baseline", type=Path, default=None)
+    parser.add_argument("--require-baseline", action="store_true")
+    parser.add_argument("--max-req-per-sec-drop-pct", type=float, default=15.0)
+    parser.add_argument("--max-output-tok-per-sec-drop-pct", type=float, default=15.0)
+    parser.add_argument("--max-ttft-p50-rise-pct", type=float, default=25.0)
+    parser.add_argument("--max-ttft-p99-rise-pct", type=float, default=35.0)
+    parser.add_argument("--max-itl-p50-rise-pct", type=float, default=20.0)
+    parser.add_argument("--max-itl-p99-rise-pct", type=float, default=35.0)
+    parser.add_argument("--summary-file", type=Path, default=None)
+    parser.add_argument("--report-json", type=Path, default=None)
+
+
+def write_reports(args: argparse.Namespace, report: dict[str, object]) -> None:
+    if args.report_json:
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    markdown = markdown_report(report)
+    if args.summary_file:
+        args.summary_file.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_file.write_text(markdown)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(markdown)
+
+    print(markdown)
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    ok, report = evaluate(
+        args.results_csv,
+        args.baseline,
+        thresholds_from_args(args),
+        args.require_baseline,
+    )
+    write_reports(args, report)
+    return 0 if ok else 1
+
+
+def _same_path(left: str | Path, right: str | Path) -> bool:
+    try:
+        return Path(left).resolve() == Path(right).resolve()
+    except OSError:
+        return Path(left) == Path(right)
+
+
+def materialize_default_chat_model(output_dir: Path, dry_run: bool) -> Path:
+    """Create a chat-capable TinyLlama fixture under the run output directory."""
+    target = output_dir / "model-fixtures" / "tinyllama-chat"
+    if dry_run:
+        return target
+
+    target.mkdir(parents=True, exist_ok=True)
+    for src in DEFAULT_MODEL.iterdir():
+        if src.name == "tokenizer_config.json":
+            continue
+        dst = target / src.name
+        if dst.exists():
+            continue
+        try:
+            os.symlink(src, dst)
+        except OSError:
+            shutil.copy2(src, dst)
+
+    tokenizer_config = json.loads((DEFAULT_MODEL / "tokenizer_config.json").read_text())
+    tokenizer_config["chat_template"] = DEFAULT_CHAT_TEMPLATE
+    (target / "tokenizer_config.json").write_text(
+        json.dumps(tokenizer_config, indent=2, sort_keys=True) + "\n"
+    )
+    return target
+
+
+def resolve_model_arg(args: argparse.Namespace, output_dir: Path) -> str:
+    if _same_path(args.model, DEFAULT_MODEL):
+        return str(materialize_default_chat_model(output_dir, args.dry_run))
+    return args.model
+
+
+def build_sweep_command(
+    args: argparse.Namespace, output_dir: Path, model: str
+) -> list[str]:
+    return [
+        sys.executable,
+        str(SCRIPT_DIR / "sweep_runner.py"),
+        "--mode",
+        "local",
+        "--backend",
+        "mocker",
+        "--model",
+        model,
+        "--tokenizers",
+        args.tokenizers,
+        "--concurrency",
+        str(args.concurrency),
+        "--isl",
+        str(args.isl),
+        "--osl",
+        str(args.osl),
+        "--workers",
+        str(args.workers),
+        "--benchmark-duration",
+        str(args.benchmark_duration),
+        "--speedup-ratio",
+        str(args.speedup_ratio),
+        "--output-dir",
+        str(output_dir),
+        "--cooldown",
+        "0",
+        "--no-report",
+        "--",
+        "--skip-bpf",
+        "--skip-nsys",
+        "--skip-flamegraph",
+        "--skip-perf",
+    ]
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    output_dir = args.output_dir.resolve()
+    model = resolve_model_arg(args, output_dir)
+    frontend_cpuset, load_cpuset, allowed = cpu_partition(args.min_cpus)
+    record_processors = args.aiperf_record_processors or len(
+        parse_cpu_list(load_cpuset)
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FRONTEND_CPUSET": frontend_cpuset,
+            "LOAD_CPUSET": load_cpuset,
+            "INFRA_CPUSET": load_cpuset,
+            "AIPERF_RECORD_PROCESSORS": str(record_processors),
+            "AIPERF_WORKERS_MAX": str(args.concurrency),
+            "DYN_RUNTIME_NUM_WORKER_THREADS": str(args.frontend_runtime_threads),
+            "DYN_RUNTIME_MAX_BLOCKING_THREADS": str(args.frontend_max_blocking_threads),
+            "DYN_COMPUTE_THREADS": str(args.frontend_compute_threads),
+            "TOKENIZERS_PARALLELISM": args.tokenizers_parallelism,
+        }
+    )
+
+    cmd = build_sweep_command(args, output_dir, model)
+    print(f"Allowed CPUs:  {format_cpu_list(allowed)}")
+    print(f"Frontend CPU:  {frontend_cpuset}")
+    print(f"Load CPUs:     {load_cpuset}")
+    if _same_path(args.model, DEFAULT_MODEL):
+        print(f"Model fixture: {model}")
+    print(f"Sweep command: {' '.join(cmd)}")
+
+    if args.dry_run:
+        return 0
+
+    completed = subprocess.run(cmd, cwd=SCRIPT_DIR, env=env)
+    if completed.returncode != 0:
+        return completed.returncode
+
+    result_csv = output_dir / "results.csv"
+    if args.export_baseline and result_csv.exists():
+        rows = load_csv(result_csv)
+        export_baseline(
+            rows, args.export_baseline, frontend_cpuset, load_cpuset, allowed
+        )
+
+    check_args = argparse.Namespace(
+        results_csv=result_csv,
+        baseline=args.baseline,
+        require_baseline=args.require_baseline,
+        max_req_per_sec_drop_pct=args.max_req_per_sec_drop_pct,
+        max_output_tok_per_sec_drop_pct=args.max_output_tok_per_sec_drop_pct,
+        max_ttft_p50_rise_pct=args.max_ttft_p50_rise_pct,
+        max_ttft_p99_rise_pct=args.max_ttft_p99_rise_pct,
+        max_itl_p50_rise_pct=args.max_itl_p50_rise_pct,
+        max_itl_p99_rise_pct=args.max_itl_p99_rise_pct,
+        summary_file=args.summary_file or output_dir / "pr_guard_summary.md",
+        report_json=args.report_json or output_dir / "pr_guard_report.json",
+    )
+    return cmd_check(check_args)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run the pinned sweep and check it")
+    run_parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    run_parser.add_argument("--export-baseline", type=Path, default=None)
+    run_parser.add_argument("--min-cpus", type=int, default=4)
+    run_parser.add_argument("--model", default=str(DEFAULT_MODEL))
+    run_parser.add_argument("--tokenizers", default="hf")
+    run_parser.add_argument("--concurrency", type=int, default=128)
+    run_parser.add_argument("--isl", type=int, default=1024)
+    run_parser.add_argument("--osl", type=int, default=128)
+    run_parser.add_argument("--workers", type=int, default=2)
+    run_parser.add_argument("--benchmark-duration", type=int, default=60)
+    run_parser.add_argument("--speedup-ratio", type=float, default=1_000_000.0)
+    run_parser.add_argument("--frontend-runtime-threads", type=int, default=1)
+    run_parser.add_argument("--frontend-compute-threads", type=int, default=1)
+    run_parser.add_argument("--frontend-max-blocking-threads", type=int, default=8)
+    run_parser.add_argument("--aiperf-record-processors", type=int, default=0)
+    run_parser.add_argument("--tokenizers-parallelism", default="false")
+    run_parser.add_argument("--dry-run", action="store_true")
+    add_check_args(run_parser)
+    run_parser.set_defaults(func=cmd_run)
+
+    check_parser = subparsers.add_parser("check", help="Check an existing results.csv")
+    check_parser.add_argument("results_csv", type=Path)
+    add_check_args(check_parser)
+    check_parser.set_defaults(func=cmd_check)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py
+++ b/benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import math
 import os
 import shutil
 import socket
@@ -113,6 +114,11 @@ def to_float(value: object) -> float:
     if value in (None, ""):
         return 0.0
     return float(value)
+
+
+def is_positive_finite(value: object) -> bool:
+    metric = to_float(value)
+    return math.isfinite(metric) and metric > 0
 
 
 def normalize_row(row: dict[str, object]) -> dict[str, object]:
@@ -226,8 +232,10 @@ def evaluate(
             "itl_p50_ms",
             "itl_p99_ms",
         ):
-            if to_float(row.get(metric)) <= 0:
-                issues.append(f"{key}: {metric} is missing or non-positive")
+            if not is_positive_finite(row.get(metric)):
+                issues.append(
+                    f"{key}: {metric} is missing, non-finite, or non-positive"
+                )
 
     baseline: dict[str, dict[str, object]] = {}
     if baseline_path is not None:

--- a/benchmarks/frontend/scripts/run_perf.sh
+++ b/benchmarks/frontend/scripts/run_perf.sh
@@ -299,6 +299,12 @@ INFRA_TASKSET=()
 [[ -n "$LOAD_CPUSET" ]] && LOAD_TASKSET=(taskset -c "$LOAD_CPUSET")
 [[ -n "$INFRA_CPUSET" ]] && INFRA_TASKSET=(taskset -c "$INFRA_CPUSET")
 
+tcp_port_open() {
+    local host="$1"
+    local port="$2"
+    (exec 3<>"/dev/tcp/${host}/${port}") >/dev/null 2>&1
+}
+
 # ─── Tracked PIDs for cleanup ───────────────────────────────────────────────
 ALL_PIDS=()      # everything we need to kill on exit
 CAPTURE_PIDS=()  # capture processes we wait for
@@ -362,13 +368,14 @@ if ! curl -sf http://localhost:2379/health >/dev/null 2>&1; then
     if command -v etcd &>/dev/null; then
         echo "  etcd not running — starting it..."
         ETCD_DATA_DIR=$(mktemp -d)
+        ETCD_LOG="$OUTPUT_DIR/logs/etcd.log"
         "${INFRA_TASKSET[@]}" etcd --data-dir="$ETCD_DATA_DIR" \
              --listen-client-urls=http://localhost:2379 \
              --advertise-client-urls=http://localhost:2379 \
              --listen-peer-urls=http://localhost:2380 \
              --initial-advertise-peer-urls=http://localhost:2380 \
              --initial-cluster=default=http://localhost:2380 \
-             > /dev/null 2>&1 &
+             > "$ETCD_LOG" 2>&1 &
         ETCD_PID=$!
         for i in $(seq 1 30); do
             if curl -sf http://localhost:2379/health >/dev/null 2>&1; then
@@ -377,7 +384,9 @@ if ! curl -sf http://localhost:2379/health >/dev/null 2>&1; then
             fi
             sleep 1
             if [[ $i -eq 30 ]]; then
-                echo "ERROR: etcd failed to start after 30s"; exit 1
+                echo "ERROR: etcd failed to start after 30s"
+                tail -n 80 "$ETCD_LOG" || true
+                exit 1
             fi
         done
     else
@@ -388,19 +397,27 @@ else
 fi
 
 # NATS
-if ! nc -z localhost 4222 2>/dev/null; then
+if ! tcp_port_open localhost 4222; then
     if command -v nats-server &>/dev/null; then
         echo "  nats-server not running — starting it..."
-        "${INFRA_TASKSET[@]}" nats-server > /dev/null 2>&1 &
+        NATS_LOG="$OUTPUT_DIR/logs/nats-server.log"
+        "${INFRA_TASKSET[@]}" nats-server > "$NATS_LOG" 2>&1 &
         NATS_PID=$!
         for i in $(seq 1 30); do
-            if nc -z localhost 4222 2>/dev/null; then
+            if tcp_port_open localhost 4222; then
                 echo "  nats-server ready (PID $NATS_PID)"
                 break
             fi
+            if ! kill -0 "$NATS_PID" 2>/dev/null; then
+                echo "ERROR: nats-server exited before it became ready"
+                tail -n 80 "$NATS_LOG" || true
+                exit 1
+            fi
             sleep 1
             if [[ $i -eq 30 ]]; then
-                echo "ERROR: nats-server failed to start after 30s"; exit 1
+                echo "ERROR: nats-server failed to start after 30s"
+                tail -n 80 "$NATS_LOG" || true
+                exit 1
             fi
         done
     else

--- a/benchmarks/frontend/scripts/run_perf.sh
+++ b/benchmarks/frontend/scripts/run_perf.sh
@@ -64,6 +64,14 @@ BENCHMARK_DURATION="${BENCHMARK_DURATION:-}"  # aiperf --benchmark-duration (sec
 REQUEST_RATE="${REQUEST_RATE:-}"              # aiperf --request-rate (requests/sec)
 WARMUP_DURATION="${WARMUP_DURATION:-}"        # aiperf --warmup-duration (seconds)
 WARMUP_COUNT="${WARMUP_COUNT:-}"              # aiperf --warmup-request-count
+AIPERF_RECORD_PROCESSORS="${AIPERF_RECORD_PROCESSORS:-32}"
+AIPERF_WORKERS_MAX="${AIPERF_WORKERS_MAX:-}"
+
+# Optional CPU affinity controls. These are intentionally environment-only so
+# the regular benchmark CLI stays compact while CI can pin roles deterministically.
+FRONTEND_CPUSET="${FRONTEND_CPUSET:-}"
+LOAD_CPUSET="${LOAD_CPUSET:-}"
+INFRA_CPUSET="${INFRA_CPUSET:-${LOAD_CPUSET}}"
 
 # Opt-out flags
 SKIP_BPF=false
@@ -213,6 +221,8 @@ echo "╚═══════════════════════�
 echo ""
 echo "Output:    $OUTPUT_DIR"
 echo "Tokenizer: ${TOKENIZER_BACKEND:-hf (default)}"
+[[ -n "$FRONTEND_CPUSET" ]] && echo "Frontend CPU set: $FRONTEND_CPUSET"
+[[ -n "$LOAD_CPUSET" ]] && echo "Load CPU set:     $LOAD_CPUSET"
 echo ""
 
 # ─── Pre-flight: detect available tools ──────────────────────────────────────
@@ -267,12 +277,27 @@ if ! command -v jq &>/dev/null; then
 fi
 echo "  jq:         available"
 
+if [[ -n "$FRONTEND_CPUSET" || -n "$LOAD_CPUSET" || -n "$INFRA_CPUSET" ]]; then
+    if ! command -v taskset &>/dev/null; then
+        echo "ERROR: CPU affinity requested, but taskset was not found in PATH"
+        exit 1
+    fi
+    echo "  taskset:    available"
+fi
+
 if ! command -v aiperf &>/dev/null && ! python3 -c "import aiperf" 2>/dev/null; then
     echo "ERROR: aiperf not found. Install: pip install git+https://github.com/ai-dynamo/aiperf.git"
     exit 1
 fi
 echo "  aiperf:     available"
 echo ""
+
+FRONTEND_TASKSET=()
+LOAD_TASKSET=()
+INFRA_TASKSET=()
+[[ -n "$FRONTEND_CPUSET" ]] && FRONTEND_TASKSET=(taskset -c "$FRONTEND_CPUSET")
+[[ -n "$LOAD_CPUSET" ]] && LOAD_TASKSET=(taskset -c "$LOAD_CPUSET")
+[[ -n "$INFRA_CPUSET" ]] && INFRA_TASKSET=(taskset -c "$INFRA_CPUSET")
 
 # ─── Tracked PIDs for cleanup ───────────────────────────────────────────────
 ALL_PIDS=()      # everything we need to kill on exit
@@ -337,7 +362,7 @@ if ! curl -sf http://localhost:2379/health >/dev/null 2>&1; then
     if command -v etcd &>/dev/null; then
         echo "  etcd not running — starting it..."
         ETCD_DATA_DIR=$(mktemp -d)
-        etcd --data-dir="$ETCD_DATA_DIR" \
+        "${INFRA_TASKSET[@]}" etcd --data-dir="$ETCD_DATA_DIR" \
              --listen-client-urls=http://localhost:2379 \
              --advertise-client-urls=http://localhost:2379 \
              --listen-peer-urls=http://localhost:2380 \
@@ -366,7 +391,7 @@ fi
 if ! nc -z localhost 4222 2>/dev/null; then
     if command -v nats-server &>/dev/null; then
         echo "  nats-server not running — starting it..."
-        nats-server > /dev/null 2>&1 &
+        "${INFRA_TASKSET[@]}" nats-server > /dev/null 2>&1 &
         NATS_PID=$!
         for i in $(seq 1 30); do
             if nc -z localhost 4222 2>/dev/null; then
@@ -409,7 +434,7 @@ for MN in "${MODEL_NAMES[@]}"; do
         fi
 
         MN_SAFE="${MN//\//_}"
-        HF_HUB_OFFLINE=1 DYN_SYSTEM_PORT=$WORKER_PORT DYN_EVENT_PLANE="$EVENT_PLANE" python -m dynamo.mocker "${MOCKER_ARGS[@]}" \
+        "${LOAD_TASKSET[@]}" env HF_HUB_OFFLINE=1 DYN_SYSTEM_PORT=$WORKER_PORT DYN_EVENT_PLANE="$EVENT_PLANE" python -m dynamo.mocker "${MOCKER_ARGS[@]}" \
             > "$OUTPUT_DIR/logs/mocker_${MN_SAFE}_${i}.log" 2>&1 &
         ALL_PIDS+=($!)
         echo "  Worker $WORKER_IDX ($MN #$i): PID ${ALL_PIDS[-1]}, port $WORKER_PORT"
@@ -455,7 +480,7 @@ fi
 
 if [[ "$HAS_NSYS" == true ]]; then
     echo "  (under nsys profiling)"
-    env "${FRONTEND_ENV[@]}" \
+    "${FRONTEND_TASKSET[@]}" env "${FRONTEND_ENV[@]}" \
         "$NSYS_CMD" profile \
         --trace=osrt,nvtx \
         --sample=cpu \
@@ -485,7 +510,7 @@ if [[ "$HAS_NSYS" == true ]]; then
     echo "  nsys wrapper PID: $NSYS_WRAPPER_PID"
     echo "  Frontend PID: $FRONTEND_PID"
 else
-    env "${FRONTEND_ENV[@]}" python -m dynamo.frontend \
+    "${FRONTEND_TASKSET[@]}" env "${FRONTEND_ENV[@]}" python -m dynamo.frontend \
         > "$OUTPUT_DIR/logs/frontend.log" 2>&1 &
     FRONTEND_PID=$!
     ALL_PIDS+=($FRONTEND_PID)
@@ -692,6 +717,11 @@ echo "--- Running aiperf load ---"
 echo "  concurrency=$CONCURRENCY  requests=${NUM_REQUESTS:-auto}  isl=$ISL  osl=$OSL"
 [[ -n "$BENCHMARK_DURATION" ]] && echo "  benchmark-duration=${BENCHMARK_DURATION}s"
 [[ -n "$REQUEST_RATE" ]] && echo "  request-rate=${REQUEST_RATE} req/s"
+[[ -n "$LOAD_CPUSET" ]] && echo "  load-cpuset=$LOAD_CPUSET"
+
+if [[ -z "$AIPERF_WORKERS_MAX" ]]; then
+    AIPERF_WORKERS_MAX="$CONCURRENCY"
+fi
 
 # Build load-control args: prefer --benchmark-duration (time-based) over
 # --request-count (count-based) so each run gets a consistent measurement
@@ -751,7 +781,7 @@ for _AIPERF_MODEL in "${_AIPERF_MODELS[@]}"; do
         _AIPERF_TOK_ARGS=(--tokenizer "$MODEL")
     fi
 
-    HF_HUB_OFFLINE=1 aiperf profile --artifact-dir "$AIPERF_ARTIFACT_DIR" \
+    "${LOAD_TASKSET[@]}" env HF_HUB_OFFLINE=1 aiperf profile --artifact-dir "$AIPERF_ARTIFACT_DIR" \
         --model "$_AIPERF_MODEL" \
         "${_AIPERF_TOK_ARGS[@]}" \
         --endpoint-type chat \
@@ -772,8 +802,8 @@ for _AIPERF_MODEL in "${_AIPERF_MODELS[@]}"; do
         "${_WARMUP_ARGS[@]}" \
         --num-dataset-entries 12800 \
         --random-seed 100 \
-        --workers-max "$CONCURRENCY" \
-        --record-processors 32 \
+        --workers-max "$AIPERF_WORKERS_MAX" \
+        --record-processors "$AIPERF_RECORD_PROCESSORS" \
         --ui simple || echo "WARNING: aiperf failed for model ${_AIPERF_MODEL}"
 done
 
@@ -914,6 +944,11 @@ cat > "$OUTPUT_DIR/config.json" <<EOF
   "osl": $OSL,
   "capture_duration": $CAPTURE_DURATION,
   "frontend_pid": $FRONTEND_PID,
+  "frontend_cpuset": "${FRONTEND_CPUSET:-}",
+  "load_cpuset": "${LOAD_CPUSET:-}",
+  "infra_cpuset": "${INFRA_CPUSET:-}",
+  "aiperf_record_processors": $AIPERF_RECORD_PROCESSORS,
+  "aiperf_workers_max": $AIPERF_WORKERS_MAX,
   "has_nsys": $HAS_NSYS,
   "has_perf": $HAS_PERF,
   "has_bpf": $HAS_BPF,

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -12,16 +12,19 @@ FROM ${BASE_IMAGE} AS test_image
 # Install test dependencies on top of runtime image
 USER root
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
+    --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     --mount=type=cache,target=/root/.cache/uv,sharing=shared \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     if [ -n "$VIRTUAL_ENV" ]; then \
         uv pip install \
-            --requirement /tmp/requirements.test.txt; \
+            --requirement /tmp/requirements.test.txt \
+            --requirement /tmp/requirements.benchmark.txt; \
     else \
         pip install --break-system-packages \
-            --requirement /tmp/requirements.test.txt; \
+            --requirement /tmp/requirements.test.txt \
+            --requirement /tmp/requirements.benchmark.txt; \
     fi
 
 USER dynamo

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -12,20 +12,33 @@ FROM ${BASE_IMAGE} AS test_image
 # Install test dependencies on top of runtime image
 USER root
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
-    --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     --mount=type=cache,target=/root/.cache/uv,sharing=shared \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     if [ -n "$VIRTUAL_ENV" ]; then \
         uv pip install \
-            --requirement /tmp/requirements.test.txt \
-            --requirement /tmp/requirements.benchmark.txt; \
+            --requirement /tmp/requirements.test.txt; \
     else \
         pip install --break-system-packages \
-            --requirement /tmp/requirements.test.txt \
-            --requirement /tmp/requirements.benchmark.txt; \
+            --requirement /tmp/requirements.test.txt; \
     fi
+
+RUN --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
+    --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    export UV_CACHE_DIR=/root/.cache/uv PIP_CACHE_DIR=/root/.cache/pip && \
+    if command -v uv >/dev/null 2>&1; then \
+        uv venv /opt/dynamo/benchmark-tools --python python3 && \
+        uv pip install \
+            --python /opt/dynamo/benchmark-tools/bin/python \
+            --requirement /tmp/requirements.benchmark.txt; \
+    else \
+        python3 -m venv /opt/dynamo/benchmark-tools && \
+        /opt/dynamo/benchmark-tools/bin/python -m pip install \
+            --requirement /tmp/requirements.benchmark.txt; \
+    fi && \
+    ln -sf /opt/dynamo/benchmark-tools/bin/aiperf /usr/local/bin/aiperf
 
 USER dynamo
 


### PR DESCRIPTION
## Summary

- add a CPU-pinned frontend performance PR guard around the existing local frontend sweep
- pin frontend to one allowed CPU and mocker/aiperf/infra to the remaining CPUs via `run_perf.sh`
- add a gated draftable CI job and artifact upload for guard results

## Validation

- `bash -n benchmarks/frontend/scripts/run_perf.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile benchmarks/frontend/scripts/ci/frontend_perf_pr_guard.py`
- workflow YAML parse for `.github/workflows/dynamo-pipeline.yml` and `.github/workflows/pr.yaml`
- local guard run passed:
  - output: `/tmp/frontend-perf-pr-guard-local-run4`
  - `79.90 req/s`, `10550 output tok/s`, `TTFT p50 947.8ms`, `TTFT p99 1652.6ms`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced frontend performance PR guard that validates performance metrics against baselines in the CI pipeline
  * Added CPU affinity support to pin frontend and supporting services during performance testing
  * New configurable parameters for worker and processor management in performance benchmarks

* **Documentation**
  * Added comprehensive guide for frontend performance testing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->