### PR TITLE
fix: remove failover requirement for inter-pod GMS

### DIFF
--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -32,20 +32,18 @@ type VLLMBackend struct {
 func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
 	// The inter-pod GMS layout (with or without failover) requires the engine
 	// to load weights from the dedicated GMS weight-server pod rather than
-	// from disk. --load-format gms and DYN_VLLM_GMS_SHADOW_MODE activate the
-	// vLLM-side GMS client path and apply to both standalone inter-pod GMS
-	// and inter-pod GMS + failover; the "shadow mode" name is a vLLM upstream
-	// naming convention, not a statement about whether shadow pods are
-	// present.
+	// from disk.
 	if component.IsInterPodGMSEnabled() {
 		if !containerHasArg(container, "--load-format", "gms") {
 			injectFlagsIntoContainerCommand(container, "--load-format gms", false, "vllm")
 		}
-		// DYN_VLLM_GMS_SHADOW_MODE is a vLLM-engine-specific switch (activates
-		// the vLLM-side GMS client path for shadow weight loading). It is
-		// injected here — in the vLLM backend — rather than in the backend-
-		// agnostic GMS helpers so non-vLLM backends do not inherit a stray,
-		// meaningless env var if/when inter-pod GMS is extended to them.
+	}
+
+	if component.IsInterPodGMSEnabled() && component.IsInterPodFailoverEnabled() {
+		// DYN_VLLM_GMS_SHADOW_MODE activates vLLM's standby/failover behavior
+		// on top of --load-format gms. Standalone inter-pod GMS should not set
+		// it: those engines are active clients of the dedicated GMS weight
+		// server, not shadow engines waiting for failover activation.
 		container.Env = append(container.Env, corev1.EnvVar{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"})
 	}
 

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -37,14 +37,13 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 		if !containerHasArg(container, "--load-format", "gms") {
 			injectFlagsIntoContainerCommand(container, "--load-format gms", false, "vllm")
 		}
-	}
-
-	if component.IsInterPodGMSEnabled() && component.IsInterPodFailoverEnabled() {
-		// DYN_VLLM_GMS_SHADOW_MODE activates vLLM's standby/failover behavior
-		// on top of --load-format gms. Standalone inter-pod GMS should not set
-		// it: those engines are active clients of the dedicated GMS weight
-		// server, not shadow engines waiting for failover activation.
-		container.Env = append(container.Env, corev1.EnvVar{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"})
+		if component.IsInterPodFailoverEnabled() {
+			// DYN_VLLM_GMS_SHADOW_MODE activates vLLM's standby/failover behavior
+			// on top of --load-format gms. Standalone inter-pod GMS should not set
+			// it: those engines are active clients of the dedicated GMS weight
+			// server, not shadow engines waiting for failover activation.
+			container.Env = append(container.Env, corev1.EnvVar{Name: "DYN_VLLM_GMS_SHADOW_MODE", Value: "true"})
+		}
 	}
 
 	isMultinode := numberOfNodes > 1

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -996,59 +996,82 @@ func TestShouldUseMpBackend(t *testing.T) {
 	}
 }
 
-// TestVLLMBackend_UpdateContainer_InterPodGMS asserts that when the inter-pod
-// GMS layout is enabled (gpuMemoryService.mode=interPod, with or without
-// failover), the vLLM backend is the one responsible for injecting both the
-// --load-format=gms flag and the DYN_VLLM_GMS_SHADOW_MODE env var. These are
-// vLLM-runtime switches and must live in the backend adapter, not in the
-// backend-agnostic GMS helpers (see gmsEngineEnvVars).
+// TestVLLMBackend_UpdateContainer_InterPodGMS asserts that standalone
+// inter-pod GMS and inter-pod GMS failover share the same GMS load path, but
+// only failover enables vLLM's shadow/standby behavior.
 func TestVLLMBackend_UpdateContainer_InterPodGMS(t *testing.T) {
-	backend := &VLLMBackend{}
-	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
-		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
-			Enabled: true,
-			Mode:    v1alpha1.GMSModeInterPod,
+	tests := []struct {
+		name            string
+		component       *v1alpha1.DynamoComponentDeploymentSharedSpec
+		wantShadowMode  bool
+		wantLoadFormat  bool
+		shadowModeCount int
+	}{
+		{
+			name: "standalone inter-pod GMS injects load-format only",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    v1alpha1.GMSModeInterPod,
+				},
+			},
+			wantLoadFormat: true,
 		},
-		Failover: &v1alpha1.FailoverSpec{
-			Enabled: true,
-			Mode:    v1alpha1.GMSModeInterPod,
+		{
+			name: "inter-pod GMS failover injects load-format and shadow mode",
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    v1alpha1.GMSModeInterPod,
+				},
+				Failover: &v1alpha1.FailoverSpec{
+					Enabled: true,
+					Mode:    v1alpha1.GMSModeInterPod,
+				},
+			},
+			wantLoadFormat:  true,
+			wantShadowMode:  true,
+			shadowModeCount: 1,
 		},
-	})
-	container := &corev1.Container{
-		Command: []string{"python3"},
-		Args:    []string{"-m", "dynamo.vllm"},
 	}
 
-	backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
-
-	// --load-format gms flag must be injected into the container args.
-	joined := ""
-	for _, a := range container.Args {
-		joined += " " + a
-	}
-	if !reflect.DeepEqual(containerHasArg(container, "--load-format", "gms"), true) {
-		t.Errorf("expected --load-format gms to be injected; got args=%q", joined)
-	}
-
-	// DYN_VLLM_GMS_SHADOW_MODE must be set exactly once.
-	count := 0
-	for _, e := range container.Env {
-		if e.Name == "DYN_VLLM_GMS_SHADOW_MODE" {
-			count++
-			if e.Value != "true" {
-				t.Errorf("DYN_VLLM_GMS_SHADOW_MODE value = %q, want %q", e.Value, "true")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &VLLMBackend{}
+			component := betaComponent(t, tt.component)
+			container := &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.vllm"},
 			}
-		}
-	}
-	if count != 1 {
-		t.Errorf("DYN_VLLM_GMS_SHADOW_MODE env var count = %d, want 1", count)
+
+			backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
+
+			if got := containerHasArg(container, "--load-format", "gms"); got != tt.wantLoadFormat {
+				t.Errorf("containerHasArg(--load-format gms) = %v, want %v; args=%v", got, tt.wantLoadFormat, container.Args)
+			}
+
+			count := 0
+			for _, e := range container.Env {
+				if e.Name == "DYN_VLLM_GMS_SHADOW_MODE" {
+					count++
+					if e.Value != "true" {
+						t.Errorf("DYN_VLLM_GMS_SHADOW_MODE value = %q, want %q", e.Value, "true")
+					}
+				}
+			}
+			if count != tt.shadowModeCount {
+				t.Errorf("DYN_VLLM_GMS_SHADOW_MODE env var count = %d, want %d", count, tt.shadowModeCount)
+			}
+			if got := count > 0; got != tt.wantShadowMode {
+				t.Errorf("DYN_VLLM_GMS_SHADOW_MODE present = %v, want %v", got, tt.wantShadowMode)
+			}
+		})
 	}
 }
 
 // TestVLLMBackend_UpdateContainer_NoInterPodGMS asserts the complementary
-// invariant: when inter-pod GMS failover is NOT enabled, the vLLM backend
-// must not inject the GMS-specific env var (it is meaningless outside the
-// inter-pod layout).
+// invariant: when inter-pod GMS is not enabled, the vLLM backend must not
+// inject the inter-pod GMS load path or shadow/standby mode.
 func TestVLLMBackend_UpdateContainer_NoInterPodGMS(t *testing.T) {
 	backend := &VLLMBackend{}
 	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{})
@@ -1059,6 +1082,9 @@ func TestVLLMBackend_UpdateContainer_NoInterPodGMS(t *testing.T) {
 
 	backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
 
+	if containerHasArg(container, "--load-format", "gms") {
+		t.Errorf("--load-format gms must not be injected when inter-pod GMS is disabled")
+	}
 	for _, e := range container.Env {
 		if e.Name == "DYN_VLLM_GMS_SHADOW_MODE" {
 			t.Errorf("DYN_VLLM_GMS_SHADOW_MODE must not be injected when inter-pod GMS is disabled")

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -344,10 +344,10 @@ func (v *DynamoGraphDeploymentValidator) validateService(ctx context.Context, se
 	}
 
 	// The inter-pod GMS layout is currently implemented only for vLLM (the
-	// engine relies on vLLM-specific runtime hooks like --load-format gms and
-	// DYN_VLLM_GMS_SHADOW_MODE that activate the GMS client path). Fail fast
-	// at admission rather than producing a broken deployment when another or
-	// no backend is configured — an empty BackendFramework means the operator
+	// engine relies on vLLM-specific runtime hooks like --load-format gms; the
+	// failover variant additionally enables vLLM shadow mode). Fail fast at
+	// admission rather than producing a broken deployment when another or no
+	// backend is configured — an empty BackendFramework means the operator
 	// cannot confirm the engine speaks vLLM, which is a hard prerequisite for
 	// inter-pod GMS (both standalone and with failover).
 	if service.IsInterPodGMSEnabled() &&


### PR DESCRIPTION
## Summary

Remove the implicit failover/shadow-mode requirement from standalone inter-pod GMS.

Inter-pod GMS can be used without shadow-engine failover, for example to restart an inference engine and reconnect to a still-running GMS weight server without reloading weights. In that standalone layout, the vLLM engine should load weights through GMS, but it should not enter shadow/standby failover mode.

This PR updates the operator so:

- standalone `gpuMemoryService.mode=interPod` still injects `--load-format gms`
- standalone inter-pod GMS no longer injects `DYN_VLLM_GMS_SHADOW_MODE=true`
- inter-pod GMS failover still injects both `--load-format gms` and `DYN_VLLM_GMS_SHADOW_MODE=true`
- tests now explicitly cover standalone inter-pod GMS vs. inter-pod failover behavior

## Why this is not duplicating an existing PR

Checked open PRs with:

```bash
gh pr list --repo ai-dynamo/dynamo --state open --search 'DYN_VLLM_GMS_SHADOW_MODE inter-pod GMS' --limit 20
gh pr list --repo ai-dynamo/dynamo --state open --search 'gms shadow mode standalone inter-pod' --limit 20
gh pr list --repo ai-dynamo/dynamo --state open --search 'interpod GMS failover shadow mode' --limit 20
gh pr list --repo ai-dynamo/dynamo --state open --search 'DYN_VLLM_GMS_SHADOW_MODE' --limit 20
gh pr list --repo ai-dynamo/dynamo --state open --search 'standalone inter-pod GMS' --limit 20
```

The only result was #8833 (`feat: wire GMS checkpoint restore flow`), which is about checkpoint restore and does not address standalone inter-pod GMS shadow-mode injection.

## Tests

```bash
cd deploy/operator
go test ./internal/dynamo -run 'TestVLLMBackend_UpdateContainer_(InterPodGMS|NoInterPodGMS)$'
```

Result:

```text
ok  	github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo	0.017s
```

```bash
cd deploy/operator
go test ./internal/dynamo
```

Result:

```text
ok  	github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo	0.141s
```

## AI assistance

AI assistance was used to inspect the operator code paths, make this focused change, and draft/update the PR description. The submitted changes should be reviewed by a human before merge.
