### PR TITLE
fix: Harmony parser fixes from main

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -162,6 +162,8 @@ class TrtllmLLMEngine(LLMEngine):
         elif self.max_seq_len is not None:
             sampling_params.max_tokens = max(1, self.max_seq_len - len(token_ids))
 
+        # TODO: mirror visible/hidden stop-token handling from the disagg
+        # path (handler_base.py) into a shared helper. See PR #9778.
         ignore_eos = stop_conditions.get("ignore_eos")
         if ignore_eos:
             sampling_params.ignore_eos = ignore_eos

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -38,7 +38,7 @@ from prometheus_client import CollectorRegistry
 from dynamo.common.utils.prometheus import LLMBackendMetrics
 from dynamo.llm import FpmDirectPublisher, KvEventPublisher, WorkerMetricsPublisher
 
-logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 # Create a dedicated registry for dynamo_component metrics
 # This ensures these metrics are isolated and can be exposed via their own callback
@@ -219,7 +219,7 @@ class ZmqKvEventPublisher:
             timestamp = time.time()
             batch = [timestamp, [event], attention_dp_rank]
             event_type = event.get("type", "Unknown")
-            logging.debug(
+            logger.debug(
                 f"TensorRT-LLM: ZMQ publisher sending {event_type} event (dp_rank={attention_dp_rank}) to {self.zmq_endpoint}"
             )
 
@@ -650,7 +650,7 @@ class Publisher:
         def handle_stat(stat):
             kv_active_blocks = stat["kvCacheStats"]["usedNumBlocks"]
             kv_total_blocks = stat["kvCacheStats"]["maxNumBlocks"]
-            logging.debug(f"Publishing stats: kv_active_blocks: {kv_active_blocks}")
+            logger.debug(f"Publishing stats: kv_active_blocks: {kv_active_blocks}")
             # TRT-LLM doesn't use data parallelism currently (dp_rank=None for NATS, "0" for Prometheus)
             assert self.metrics_publisher is not None
             self.metrics_publisher.publish(None, kv_used_blocks=kv_active_blocks)
@@ -776,7 +776,7 @@ class Publisher:
         return True
 
     def _handle_kv_event(self, event):
-        logging.debug(f"KV cache event received: {event}")
+        logger.debug(f"KV cache event received: {event}")
         # drop the events that is not emitted from the global attention layer.
         if self.should_drop_event(event):
             return
@@ -858,7 +858,7 @@ class Publisher:
             # Default to 0 for backwards compatibility with older TRT-LLM versions
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
-            logging.debug(
+            logger.debug(
                 f"publish stored event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, token_ids: {token_ids}, num_block_tokens: {num_block_tokens}, block_hashes: {block_hashes}, lora_name: {lora_name}, parent_hash: {parent_hash}"
             )
             # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
@@ -900,7 +900,7 @@ class Publisher:
                 if block_hash is None:
                     continue
                 if block_hash in self.partial_block_hashes:
-                    logging.debug(
+                    logger.debug(
                         f"Skipping removing block hash {block_hash} since it is a partial block"
                     )
                     self.partial_block_hashes.remove(block_hash)
@@ -910,7 +910,7 @@ class Publisher:
             # Get attention_dp_rank from event (TRT-LLM includes this in KVCacheEvent)
             attention_dp_rank = event.get("attention_dp_rank", 0)
 
-            logging.debug(
+            logger.debug(
                 f"publish removed event: engine_event_id: {event_id}, attention_dp_rank: {attention_dp_rank}, block_hashes: {removed_block_hashes}"
             )
             # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -18,6 +18,7 @@ import dataclasses
 import logging
 import os
 import re
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
@@ -941,6 +942,19 @@ class HandlerBase(BaseGenerativeHandler):
         """
         logging.debug(f"Request: {request}")
 
+        # [TTFT-TRACE] Per-request timing checkpoints. epoch_ms is wall-clock so
+        # logs from prefill+decode workers can be aligned offline; perf_counter
+        # is monotonic and used for relative deltas within a worker.
+        ttft_mode = self.disaggregation_mode.value
+        ttft_req_id = context.id()
+        ttft_t_handler = time.perf_counter()
+        logging.info(
+            "[TTFT-TRACE] mode=%s request_id=%s stage=handler_received epoch_ms=%d",
+            ttft_mode,
+            ttft_req_id,
+            int(time.time() * 1000),
+        )
+
         # Additional metrics: request type detection
         metrics_collector = self.additional_metrics
 
@@ -971,8 +985,14 @@ class HandlerBase(BaseGenerativeHandler):
             except Exception as e:
                 logging.warning("Additional metrics (request type): %s", e)
 
+        # [TTFT-TRACE] sub-stage timing within the handler prep block.
+        # Each "*_ms" is the elapsed time for that single sub-stage.
+        ttft_t_prep_stage = time.perf_counter()
+
         # Normalize OpenAI format to TRT-LLM internal format
         self._normalize_request_format(request)
+        ttft_normalize_ms = (time.perf_counter() - ttft_t_prep_stage) * 1000.0
+        ttft_t_prep_stage = time.perf_counter()
 
         # Setup disaggregated params based on PREFILL/DECODE mode
         (
@@ -980,11 +1000,15 @@ class HandlerBase(BaseGenerativeHandler):
             ep_disaggregated_params,
             epd_metadata,
         ) = self._setup_disaggregated_params_for_mode(request, ep_disaggregated_params)
+        ttft_setup_disagg_ms = (time.perf_counter() - ttft_t_prep_stage) * 1000.0
+        ttft_t_prep_stage = time.perf_counter()
 
         # Prepare input for generation (handles multimodal/text flows)
         processed_input = await self._prepare_input_for_generation(
             request, embeddings, ep_disaggregated_params, epd_metadata
         )
+        ttft_prepare_input_ms = (time.perf_counter() - ttft_t_prep_stage) * 1000.0
+        ttft_t_prep_stage = time.perf_counter()
 
         # Check if there is an error in the publisher error queue
         publishers_error = (
@@ -1101,7 +1125,38 @@ class HandlerBase(BaseGenerativeHandler):
         # Priority is a float in [0.0, 1.0]; health checks use 1.0. Default is 0.5.
         priority = request.get("priority", DEFAULT_REQUEST_PRIORITY)
 
+        # [TTFT-TRACE] sampling/trace block is everything from end of
+        # _prepare_input_for_generation to here (sampling params override,
+        # output_options, max_tokens/min_tokens/stop_tokens, trace_headers,
+        # scheduling_params, priority).
+        ttft_sampling_trace_ms = (time.perf_counter() - ttft_t_prep_stage) * 1000.0
+
         try:
+            # [TTFT-TRACE] Right before request enters TRT-LLM engine.
+            ttft_t_pre_engine = time.perf_counter()
+            logging.info(
+                "[TTFT-TRACE] mode=%s request_id=%s stage=pre_engine_generate_async "
+                "prep_ms=%.3f epoch_ms=%d",
+                ttft_mode,
+                ttft_req_id,
+                (ttft_t_pre_engine - ttft_t_handler) * 1000.0,
+                int(time.time() * 1000),
+            )
+            # [TTFT-TRACE] Per-sub-stage breakdown of prep_ms. Use this to
+            # identify which prep sub-stage dominates (e.g. multimodal
+            # extract showing up in prepare_input_ms, or sampling override
+            # showing up in sampling_trace_ms).
+            logging.info(
+                "[TTFT-TRACE] mode=%s request_id=%s stage=prep_breakdown "
+                "normalize_ms=%.3f setup_disagg_ms=%.3f prepare_input_ms=%.3f "
+                "sampling_trace_ms=%.3f",
+                ttft_mode,
+                ttft_req_id,
+                ttft_normalize_ms,
+                ttft_setup_disagg_ms,
+                ttft_prepare_input_ms,
+                ttft_sampling_trace_ms,
+            )
             # NEW: Updated engine call to include multimodal data
             generation_result = self.engine.llm.generate_async(
                 inputs=processed_input,  # Use the correctly extracted inputs
@@ -1111,6 +1166,14 @@ class HandlerBase(BaseGenerativeHandler):
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
                 priority=priority,
+            )
+            ttft_t_post_async_call = time.perf_counter()
+            logging.info(
+                "[TTFT-TRACE] mode=%s request_id=%s stage=post_engine_generate_async_call "
+                "submit_ms=%.3f",
+                ttft_mode,
+                ttft_req_id,
+                (ttft_t_post_async_call - ttft_t_pre_engine) * 1000.0,
             )
 
             # In disagg decode mode, wrap abort() to defer until first token
@@ -1122,10 +1185,29 @@ class HandlerBase(BaseGenerativeHandler):
             )
 
             # Monitor for cancellation triggers and cancel by calling abort()
+            ttft_engine_first_response_logged = False
+            ttft_first_yield_logged = False
             async with self._cancellation_monitor(
                 abort_guard or generation_result, context
             ):
                 async for res in generation_result:
+                    # [TTFT-TRACE] First response from engine. For PREFILL mode this
+                    # is the prefill-complete signal; for DECODE mode it is the
+                    # engine's first decode-step output (KV transfer + first forward
+                    # pass complete).
+                    if not ttft_engine_first_response_logged:
+                        ttft_engine_first_response_logged = True
+                        ttft_t_first_engine_resp = time.perf_counter()
+                        logging.info(
+                            "[TTFT-TRACE] mode=%s request_id=%s "
+                            "stage=engine_first_response "
+                            "engine_ms=%.3f total_ms_since_handler=%.3f epoch_ms=%d",
+                            ttft_mode,
+                            ttft_req_id,
+                            (ttft_t_first_engine_resp - ttft_t_pre_engine) * 1000.0,
+                            (ttft_t_first_engine_resp - ttft_t_handler) * 1000.0,
+                            int(time.time() * 1000),
+                        )
                     # Signal first token to deferred abort guard
                     if abort_guard is not None:
                         abort_guard.signal_first_token()
@@ -1222,6 +1304,27 @@ class HandlerBase(BaseGenerativeHandler):
                                 "prompt_tokens_details": prompt_tokens_details,
                             }
 
+                        # [TTFT-TRACE] First chunk with tokens yielded back to the
+                        # router. For decode this is when the first token leaves
+                        # this worker; for prefill it is the single prefill
+                        # response carrying disaggregated_params.
+                        if not ttft_first_yield_logged and out.get("token_ids"):
+                            ttft_first_yield_logged = True
+                            ttft_t_first_yield = time.perf_counter()
+                            logging.info(
+                                "[TTFT-TRACE] mode=%s request_id=%s "
+                                "stage=first_chunk_yielded "
+                                "engine_to_yield_ms=%.3f "
+                                "total_ms_since_handler=%.3f epoch_ms=%d "
+                                "num_tokens=%d",
+                                ttft_mode,
+                                ttft_req_id,
+                                (ttft_t_first_yield - ttft_t_first_engine_resp)
+                                * 1000.0,
+                                (ttft_t_first_yield - ttft_t_handler) * 1000.0,
+                                int(time.time() * 1000),
+                                len(out.get("token_ids", [])),
+                            )
                         # Yield the chunk to the client and update the token
                         # count for this output choice.
                         yield out

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1074,18 +1074,35 @@ class HandlerBase(BaseGenerativeHandler):
                 dynamic_default = max(1, self.max_seq_len - input_length)
                 sampling_params.max_tokens = dynamic_default
 
-        ignore_eos = request["stop_conditions"].get("ignore_eos")
-        if ignore_eos:
-            sampling_params.ignore_eos = ignore_eos
+        stop_conditions = request["stop_conditions"]
+        ignore_eos = stop_conditions.get("ignore_eos")
+        visible_stop_token_ids = set(
+            stop_conditions.get("stop_token_ids_visible") or []
+        )
+        # TRT-LLM PyTorch backend has no per-token "visible stop" hook, so
+        # visible stop tokens (e.g. Harmony's `<|call|>` for gpt-oss) are
+        # stripped before Dynamo sees them. Force `ignore_eos=True` to disable
+        # engine-side stopping and let backend.rs (`VisibleStopTokenDetected` /
+        # `HiddenStopTokenDetected`) own all stopping.
+        #
+        # TODO: revisit once TRT-LLM exposes a per-token visible-stop hook.
+        if ignore_eos or visible_stop_token_ids:
+            sampling_params.ignore_eos = True
 
-        min_tokens = request["stop_conditions"].get("min_tokens")
+        min_tokens = stop_conditions.get("min_tokens")
         if min_tokens:
             sampling_params.min_tokens = min_tokens
 
-        stop_token_ids = request["stop_conditions"].get("stop_token_ids_hidden")
+        stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
         if stop_token_ids:
             existing = sampling_params.stop_token_ids or []
-            sampling_params.stop_token_ids = list(set(existing).union(stop_token_ids))
+            engine_stop_token_ids = set(existing).union(stop_token_ids)
+            engine_stop_token_ids.difference_update(visible_stop_token_ids)
+            sampling_params.stop_token_ids = list(engine_stop_token_ids)
+        elif visible_stop_token_ids and sampling_params.stop_token_ids:
+            sampling_params.stop_token_ids = list(
+                set(sampling_params.stop_token_ids) - visible_stop_token_ids
+            )
 
         # TODO: Instead of True, we should use streaming from the request.
         # However, currently dynamo run does not send streaming in the request.

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import time
 from collections.abc import AsyncGenerator
 from typing import Optional
 
@@ -138,6 +139,15 @@ class PrefillHandler(HandlerBase):
         """
         logging.debug(f"Prefill Request ID: {context.id()}")
         logging.debug(f"PrefillHandler.generate received request: {request}")
+        # [TTFT-TRACE] Prefill worker RPC entry — measured against
+        # frontend-side prefill_dispatch epoch_ms to compute network + RPC
+        # overhead before the request reaches the engine.
+        logging.info(
+            "[TTFT-TRACE] mode=prefill request_id=%s stage=worker_rpc_entry "
+            "epoch_ms=%d",
+            context.id(),
+            int(time.time() * 1000),
+        )
         embeddings_tensor = None
         ep_disaggregated_params = None
 
@@ -216,6 +226,17 @@ class DecodeHandler(HandlerBase):
         If disaggregated_params is present, prefill was done. Otherwise generate normally.
         """
         logging.debug(f"Decode Request ID: {context.id()}")
+        # [TTFT-TRACE] Decode worker RPC entry — this is "decode worker
+        # consumed the decode request" in the TTFT decomposition. Diff
+        # against frontend's decode_dispatch epoch_ms to measure RPC + queue
+        # overhead, and against this worker's engine_first_response to
+        # isolate KV-transfer + first-decode-step latency.
+        logging.info(
+            "[TTFT-TRACE] mode=decode request_id=%s stage=worker_rpc_entry "
+            "epoch_ms=%d",
+            context.id(),
+            int(time.time() * 1000),
+        )
 
         disaggregated_params = request.get("disaggregated_params")
         if disaggregated_params:

--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -262,6 +262,13 @@ impl
                             // System EOS token - no stop_reason (user didn't request this stop)
                             (Some(FinishReason::Stop), None)
                         }
+                        Some(StopTrigger::VisibleStopTokenDetected(token_id)) => {
+                            // Token stop included in output.
+                            (
+                                Some(FinishReason::Stop),
+                                Some(StopReason::Int((*token_id).into())),
+                            )
+                        }
                         Some(StopTrigger::HiddenStopSequenceDetected(seq)) => {
                             // User-provided stop sequence (hidden from output)
                             (
@@ -435,6 +442,9 @@ pub struct Decoder {
     // minimum number of tokens have been generated
     hidden_stop_ids: HashSet<TokenIdType>,
 
+    // single tokens that if found in the response will trigger a stop condition and be returned
+    visible_stop_ids: HashSet<TokenIdType>,
+
     // text sequences that if found in the response will trigger a stop condition after the
     // minimum number of tokens have been generated (excluded from output)
     hidden_stop_sequences: Vec<String>,
@@ -461,6 +471,7 @@ pub struct Decoder {
 pub enum StopTrigger {
     MaxTokensLimit,
     HiddenStopTokenDetected(TokenIdType),
+    VisibleStopTokenDetected(TokenIdType),
     HiddenStopSequenceDetected(String),
     VisibleStopSequenceDetected(String),
 }
@@ -507,6 +518,12 @@ impl Decoder {
             .iter()
             .copied()
             .collect();
+        let visible_stop_ids: HashSet<TokenIdType> = stop_condition
+            .stop_token_ids_visible
+            .unwrap_or_default()
+            .iter()
+            .copied()
+            .collect();
 
         // Categorize stop sequences based on include_stop_str_in_output:
         // - When true: user-provided stop sequences go to visible (included in output)
@@ -529,6 +546,7 @@ impl Decoder {
             decode_stream,
             tracker,
             hidden_stop_ids,
+            visible_stop_ids,
             hidden_stop_sequences,
             visible_stop_sequences,
             min_tokens: stop_condition.min_tokens.unwrap_or(0),
@@ -563,6 +581,14 @@ impl Decoder {
         // stop conditions to not apply until the minimum number of tokens have been generated
         if self.generated_tokens < self.min_tokens {
             return Ok(StepResult::ok(token));
+        }
+
+        // Check token stops. Visible token IDs are included in output.
+        if self.visible_stop_ids.contains(&token_id) {
+            return Ok(StepResult::with_stop_trigger(
+                token,
+                StopTrigger::VisibleStopTokenDetected(token_id),
+            ));
         }
 
         // check for hidden stop tokens - eos takes precedence

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1191,6 +1191,21 @@ async fn chat_completions(
 
     let request_id = request.id().to_string();
 
+    // [TTFT-TRACE] Very first line of the axum chat_completions handler.
+    // Pair this with `preprocessor_entered` to isolate validation +
+    // engine-lookup overhead, and with the tracker's request_received epoch
+    // (captured later when the response_generator is built) to measure the
+    // pre-tracker portion of the handler.
+    tracing::info!(
+        request_id = %request_id,
+        epoch_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0),
+        endpoint = "chat_completions",
+        "[TTFT-TRACE] stage=http_handler_entered"
+    );
+
     // Determine streaming mode early
     // todo - decide on default
     let streaming = request.inner.stream.unwrap_or(false);
@@ -1316,6 +1331,12 @@ async fn chat_completions(
         let reasoning_dispatch_enabled = state.streaming_reasoning_dispatch_enabled();
         let mut reasoning_buffer: HashMap<u32, String> = HashMap::new();
         let mut dispatched_tool_ids: HashSet<String> = HashSet::new();
+        // [TTFT-TRACE] Track when the first SSE Event is generated for this
+        // request. This is the closest signal in user space to "first byte
+        // about to go on the wire to the client" (axum's Sse layer flushes
+        // each Event individually).
+        let mut first_sse_emitted = false;
+        let trace_request_id_sse = request_id.clone();
 
         // flat_map lets us optionally prepend extra SSE events before each regular chunk:
         //   - `event: tool_call_dispatch`  — complete tool call detected early (tool dispatch)
@@ -1350,6 +1371,20 @@ async fn chat_completions(
                 Ok(Some(ev)) => events.push(Ok(ev)),
                 Ok(None) => {}
                 Err(e) => events.push(Err(e)),
+            }
+            // [TTFT-TRACE] Fire once when the first SSE event for this
+            // request leaves this flat_map. Includes both data events and
+            // any side-channel events.
+            if !first_sse_emitted && !events.is_empty() {
+                first_sse_emitted = true;
+                tracing::info!(
+                    request_id = %trace_request_id_sse,
+                    epoch_ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0),
+                    "[TTFT-TRACE] stage=first_sse_chunk_emitted"
+                );
             }
             stream::iter(events)
         });

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -9,7 +9,10 @@ use tokio::sync::OwnedSemaphorePermit;
 use tracing::Instrument;
 
 use dynamo_kv_router::protocols::{BlockExtraInfo, WorkerId};
-use dynamo_runtime::{pipeline::SingleIn, protocols::maybe_error::MaybeError};
+use dynamo_runtime::{
+    pipeline::{AsyncEngineContextProvider, SingleIn},
+    protocols::maybe_error::MaybeError,
+};
 
 use super::{InnerPrefillRouter, PrefillError, PrefillResolveDecision, PrefillRouter};
 use crate::protocols::common::{
@@ -131,6 +134,18 @@ impl PrefillRouter {
         // Clone tracker before request is consumed by generate_to_worker.
         // Used to record prefill_complete_time for KV transfer latency metric.
         let tracker = request.tracker.clone();
+        // [TTFT-TRACE] capture request_id from the context before request is
+        // consumed by generate_to_worker.
+        let trace_request_id = request.context().id().to_string();
+        tracing::info!(
+            request_id = %trace_request_id,
+            target_worker = ?target_worker,
+            epoch_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            "[TTFT-TRACE] stage=prefill_rpc_send"
+        );
         let mut prefill_response = router
             .generate_to_worker(request, target_worker)
             .await
@@ -157,6 +172,19 @@ impl PrefillRouter {
         if let Some(ref tracker) = tracker {
             tracker.record_prefill_complete();
         }
+        // [TTFT-TRACE] First prefill response received from the prefill worker
+        // (= prefill engine finished + RPC return). Pair this with the
+        // matching prefill worker's `engine_first_response` log to isolate
+        // prefill→frontend network/RPC overhead.
+        tracing::info!(
+            request_id = %trace_request_id,
+            target_worker = ?target_worker,
+            epoch_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            "[TTFT-TRACE] stage=prefill_rpc_first_response"
+        );
 
         if let Some(err) = first_output.err() {
             return Err(PrefillError::PrefillError(
@@ -233,8 +261,41 @@ impl PrefillRouter {
         // Capture current span to propagate trace context to the spawned task
         let span = tracing::Span::current();
 
+        // [TTFT-TRACE] Capture request_id and the tokio::spawn dispatch time
+        // here so we can measure scheduling latency between spawn() and the
+        // future body actually running. This is the bootstrap path's only
+        // user of spawn_prefill_task and the gap matters under high
+        // concurrency.
+        let trace_request_id = prefill_request.context().id().to_string();
+        let spawn_requested_epoch_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        tracing::info!(
+            request_id = %trace_request_id,
+            target_worker = ?target_worker,
+            epoch_ms = spawn_requested_epoch_ms,
+            "[TTFT-TRACE] stage=prefill_spawn_requested"
+        );
+
         tokio::spawn(
             async move {
+                // [TTFT-TRACE] Spawned future just started executing.
+                // Diff against spawn_requested_epoch_ms = tokio task-queue
+                // latency for this prefill RPC.
+                let spawn_started_epoch_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0);
+                tracing::info!(
+                    request_id = %trace_request_id,
+                    target_worker = ?target_worker,
+                    epoch_ms = spawn_started_epoch_ms,
+                    spawn_queue_ms = spawn_started_epoch_ms
+                        .saturating_sub(spawn_requested_epoch_ms),
+                    "[TTFT-TRACE] stage=prefill_spawn_started"
+                );
+
                 match Self::execute_prefill(
                     router,
                     prefill_request,

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -3,9 +3,20 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use tokio_util::sync::CancellationToken;
+
+/// [TTFT-TRACE] helper — wall-clock epoch ms used to align TTFT trace logs
+/// across processes (frontend, prefill worker, decode worker).
+#[inline]
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 use dynamo_kv_router::PrefillLoadEstimator;
 use dynamo_runtime::{
@@ -110,6 +121,14 @@ impl
         let tracker = req.tracker.as_ref().unwrap();
         let prefill_phase_barrier = tracker.set_phase(RequestPhase::Prefill).await;
 
+        // [TTFT-TRACE] PrefillRouter entry.
+        tracing::info!(
+            request_id = %request_id,
+            request_received_epoch_ms = tracker.request_received_epoch_ms(),
+            epoch_ms = unix_now_ms(),
+            "[TTFT-TRACE] stage=prefill_router_entry"
+        );
+
         // Prepare prefill request with max_tokens = 1 (clone after tracker is set)
         let mut prefill_req = req.clone();
         prefill_req.stop_conditions.max_tokens = Some(1);
@@ -128,10 +147,29 @@ impl
             ));
         }
 
-        let prefill_result = match self
+        // [TTFT-TRACE] Wrap resolve_prefill_worker to measure worker
+        // selection time (KV chooser / find_best_match or peek_next_worker
+        // plus bootstrap-endpoint lookup).
+        let resolve_start_ms = unix_now_ms();
+        let resolve_decision = self
             .resolve_prefill_worker(&prefill_req, preselected_worker)
-            .await
-        {
+            .await;
+        let resolve_end_ms = unix_now_ms();
+        let resolved_kind = match &resolve_decision {
+            PrefillResolveDecision::Resolved { .. } => "resolved",
+            PrefillResolveDecision::Unavailable => "unavailable",
+            PrefillResolveDecision::NotActivated => "not_activated",
+            PrefillResolveDecision::NoBootstrapEndpoint => "no_bootstrap_endpoint",
+        };
+        tracing::info!(
+            request_id = %request_id,
+            resolve_ms = resolve_end_ms.saturating_sub(resolve_start_ms),
+            decision = resolved_kind,
+            epoch_ms = resolve_end_ms,
+            "[TTFT-TRACE] stage=prefill_worker_resolved"
+        );
+
+        let prefill_result = match resolve_decision {
             PrefillResolveDecision::Resolved {
                 worker_id,
                 dp_rank,
@@ -150,6 +188,19 @@ impl
                 routing.prefill_worker_id = Some(worker_id);
                 routing.dp_rank = dp_rank;
                 prefill_req.bootstrap_info = Some(bootstrap_info.clone());
+
+                // [TTFT-TRACE] Prefill worker chosen + bootstrap info ready;
+                // about to spawn prefill RPC. This is the closest the
+                // frontend gets to "prefill dispatched" in the bootstrap path.
+                tracing::info!(
+                    request_id = %request_id,
+                    worker_id = worker_id,
+                    dp_rank = ?dp_rank,
+                    bootstrap_room = bootstrap_info.bootstrap_room,
+                    epoch_ms = unix_now_ms(),
+                    path = "bootstrap",
+                    "[TTFT-TRACE] stage=prefill_dispatch"
+                );
 
                 // NVBugs 5969206: Do NOT link prefill as child of engine context.
                 // Kill propagation tears down the RPC transport, interrupting NIXL
@@ -177,6 +228,15 @@ impl
                 // Drop the phase barrier because we wait for prefill completion in this task,
                 // so there is no race with set_phase(Decode) below.
                 drop(prefill_phase_barrier);
+
+                // [TTFT-TRACE] About to enter blocking prefill path (no bootstrap).
+                tracing::info!(
+                    request_id = %request_id,
+                    preselected_worker = ?preselected_worker,
+                    epoch_ms = unix_now_ms(),
+                    path = "blocking",
+                    "[TTFT-TRACE] stage=prefill_dispatch"
+                );
 
                 // NVBugs 5969206: Do NOT link prefill as child (same rationale as bootstrap path).
                 let prefill_context = Context::with_id(prefill_req, request_id.clone());
@@ -213,6 +273,21 @@ impl
             Ok(outcome) => {
                 tracing::debug!("Prefill completed, proceeding to decode");
 
+                // [TTFT-TRACE] Prefill has returned to the router (in bootstrap
+                // path: only the spawn handshake has completed; in blocking
+                // path: prefill body has finished and prefill_complete_time
+                // has been recorded by execute_prefill).
+                let outcome_kind = match outcome {
+                    PrefillOutcome::Bootstrap(_) => "bootstrap",
+                    PrefillOutcome::Completed(_) => "completed",
+                };
+                tracing::info!(
+                    request_id = %request_id,
+                    outcome = outcome_kind,
+                    epoch_ms = unix_now_ms(),
+                    "[TTFT-TRACE] stage=prefill_returned_to_router"
+                );
+
                 // Set phase to Decode for the decode request.
                 // In bootstrap path, this blocks until the spawned prefill task releases its
                 // phase barrier after routing completes, ensuring correct worker attribution.
@@ -243,6 +318,15 @@ impl
                 let existing_override = decode_req.router_config_override.take();
                 decode_req.router_config_override =
                     Some(build_decode_router_override(existing_override));
+
+                // [TTFT-TRACE] About to hand the decode request to the next
+                // operator (the decode KvPushRouter). This is "frontend sends
+                // decode request" in the TTFT decomposition.
+                tracing::info!(
+                    request_id = %request_id,
+                    epoch_ms = unix_now_ms(),
+                    "[TTFT-TRACE] stage=decode_dispatch_to_next_operator"
+                );
 
                 // Map the modified request through with preserved context
                 let decode_request = context.map(|_| decode_req);

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -93,6 +93,23 @@ impl RequestGuard {
         if !self.first_response_received {
             self.first_response_received = true;
             self.dispatch_guard.take();
+            // [TTFT-TRACE] First RPC response back from the worker (any
+            // payload, not necessarily tokens). Matches the worker-side
+            // engine_first_response log when paired by request_id.
+            let phase = self
+                .tracker
+                .as_ref()
+                .map(|t| t.phase().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            tracing::info!(
+                request_id = %self.context_id,
+                phase = %phase,
+                epoch_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+                "[TTFT-TRACE] stage=kv_push_router_first_response"
+            );
         }
 
         if !self.prefill_marked {
@@ -130,6 +147,24 @@ impl RequestGuard {
                         .time_to_first_token_seconds
                         .observe(ttft / 1000.0);
                 }
+                // [TTFT-TRACE] First token-bearing response. ttft_ms is from
+                // request_received, which is the canonical TTFT.
+                tracing::info!(
+                    request_id = %self.context_id,
+                    phase = %tracker.phase(),
+                    ttft_ms = tracker.ttft_ms(),
+                    prefill_wait_ms = tracker.prefill_wait_time_ms(),
+                    prefill_time_ms = tracker.prefill_time_ms(),
+                    kv_transfer_estimated_ms = tracker
+                        .kv_transfer_estimated_latency_secs()
+                        .map(|s| s * 1000.0),
+                    new_tokens = new_tokens,
+                    epoch_ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0),
+                    "[TTFT-TRACE] stage=kv_push_router_first_token"
+                );
             }
             self.first_token_recorded = true;
         }
@@ -525,6 +560,13 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
 
         let block_size = self.chooser.block_size() as usize;
+        // [TTFT-TRACE] Time the worker-selection call (KV chooser
+        // find_best_match or pinned-worker resolution). Pair against
+        // kv_push_router_dispatch to isolate selection vs dispatch.
+        let select_start_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
         let selection = self
             .select_worker(&context_id, &request, phase, is_query_only)
             .instrument(tracing::info_span!("kv_router.select_worker"))
@@ -537,6 +579,19 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             cached_tokens,
             scheduler_tracked,
         } = selection;
+        let select_end_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        tracing::info!(
+            request_id = %context_id,
+            worker_id = instance_id,
+            dp_rank = dp_rank,
+            phase = ?phase,
+            select_ms = select_end_ms.saturating_sub(select_start_ms),
+            epoch_ms = select_end_ms,
+            "[TTFT-TRACE] stage=kv_push_router_worker_selected"
+        );
 
         // In approximate mode (use_kv_events=false), record the routing decision
         // so the indexer can track cache state based on routing decisions.
@@ -680,6 +735,23 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             deferred_close,
             dispatched: false,
         };
+
+        // [TTFT-TRACE] About to RPC-dispatch the request to the selected
+        // worker. For decode phase, this is "frontend sends decode request to
+        // decode worker"; for prefill phase, it's the dispatch into the
+        // prefill worker from KvPushRouter (paired with PrefillRouter's
+        // prefill_rpc_send / prefill_dispatch).
+        tracing::info!(
+            request_id = %context_id,
+            worker_id = instance_id,
+            dp_rank = dp_rank,
+            phase = ?phase,
+            epoch_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            "[TTFT-TRACE] stage=kv_push_router_dispatch"
+        );
 
         let mut response_stream = self
             .inner

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -694,9 +694,24 @@ impl OpenAIPreprocessor {
             Cow::Borrowed(prompt)
         };
         let encoding = self.tokenizer.encode(prompt.as_ref())?;
+        let tokenize_ms = encode_start.elapsed().as_secs_f64() * 1000.0;
         if let Some(t) = tracker {
             t.record_tokenize_latency(encode_start.elapsed());
         }
+        // [TTFT-TRACE] HF tokenizer encode finished. This is the actual
+        // tokenize cost; chat-template rendering happens upstream in
+        // preprocess_request and is captured by the
+        // preprocessor_entered → tokenize_done delta together with any
+        // request-shape conversion.
+        tracing::info!(
+            tokenize_ms = tokenize_ms,
+            num_tokens = encoding.token_ids().len(),
+            epoch_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            "[TTFT-TRACE] stage=tokenize_done"
+        );
         Ok(encoding)
     }
 
@@ -895,6 +910,10 @@ impl OpenAIPreprocessor {
             usage_chunk_sent: bool,
             finished: bool,
             trace_tokens_enabled: bool,
+            // [TTFT-TRACE] Fires once when the first chunk with tokens is
+            // converted to the public response type. This is the closest
+            // user-space signal to "first token detokenized on the frontend".
+            first_detokenize_logged: bool,
         }
 
         let state = State {
@@ -907,6 +926,7 @@ impl OpenAIPreprocessor {
             usage_chunk_sent: false,
             finished: false,
             trace_tokens_enabled,
+            first_detokenize_logged: false,
         };
 
         // transform the common response stream into a chat response stream
@@ -969,6 +989,25 @@ impl OpenAIPreprocessor {
                             })
                             .map_err(|e| e.to_string())
                     });
+
+                    // [TTFT-TRACE] First chunk with tokens just got
+                    // detokenized + assembled into the public response
+                    // shape. Diff against kv_push_router_first_token to
+                    // measure detokenize + parse overhead, and against
+                    // first_sse_chunk_emitted to measure remaining
+                    // postprocessor + SSE-convert cost.
+                    if !inner.first_detokenize_logged && chunk_tokens > 0 {
+                        inner.first_detokenize_logged = true;
+                        tracing::info!(
+                            request_id = inner.context.id(),
+                            chunk_tokens = chunk_tokens,
+                            epoch_ms = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_millis() as u64)
+                                .unwrap_or(0),
+                            "[TTFT-TRACE] stage=first_chunk_detokenized"
+                        );
+                    }
 
                     // Create LLM metrics annotation with prefill/decode worker info from tracker.
                     // Worker types are stored at routing time to avoid expensive MDC lookup.
@@ -1456,6 +1495,20 @@ impl
         // Preserve original inbound streaming flag before any internal overrides
         let request_id = context.id().to_string();
         let original_stream_flag = request.inner.stream.unwrap_or(false);
+
+        // [TTFT-TRACE] OpenAIPreprocessor entered — pair with
+        // `http_handler_entered` to measure HTTP validation + engine-lookup
+        // overhead, and pair with the tracker's request_received epoch (set
+        // ~30 lines below at response_generator construction) to measure the
+        // sub-stages.
+        tracing::info!(
+            request_id = %request_id,
+            epoch_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0),
+            "[TTFT-TRACE] stage=preprocessor_entered"
+        );
 
         // Build audit handle (None if no DYN_AUDIT_SINKS)
         let mut audit_handle = crate::audit::handle::create_handle(&request, &request_id);

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -46,7 +46,9 @@ use crate::protocols::common::preprocessor::{
 use crate::protocols::common::timing::RequestTracker;
 use crate::tokenizers::Encoding;
 
-use dynamo_parsers::{ReasoningParser, ReasoningParserType};
+use dynamo_parsers::{
+    ReasoningParser, ReasoningParserType, tool_calling::parsers::get_tool_parser_map,
+};
 use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, ResponseStream};
 use dynamo_runtime::pipeline::{
     AsyncEngineContext, Error, ManyOut, Operator, SingleIn, async_trait,
@@ -54,6 +56,7 @@ use dynamo_runtime::pipeline::{
 use dynamo_runtime::protocols::annotated::{Annotated, AnnotationsProvider};
 
 use crate::protocols::{
+    TokenIdType,
     common::{OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider},
     openai::{
         DeltaGeneratorExt,
@@ -293,21 +296,44 @@ impl OpenAIPreprocessor {
         builder.model(request.model());
 
         let mut stop_conditions = request.extract_stop_conditions()?;
+        let eos_token_ids = self.model_info.eos_token_ids();
+        let hidden_eos_token_ids = eos_token_ids.clone();
         if let Some(stop_tokens) = &mut stop_conditions.stop_token_ids_hidden {
-            for eos_token in self.model_info.eos_token_ids() {
-                if !stop_tokens.contains(&eos_token) {
-                    stop_tokens.push(eos_token);
+            for eos_token_id in hidden_eos_token_ids {
+                if !stop_tokens.contains(&eos_token_id) {
+                    stop_tokens.push(eos_token_id);
                 }
             }
         } else {
-            stop_conditions.stop_token_ids_hidden = Some(self.model_info.eos_token_ids());
+            stop_conditions.stop_token_ids_hidden = Some(hidden_eos_token_ids);
+        }
+        // Some tool-call parsers terminate on a token that is also a model
+        // EOS (e.g. Harmony's `<|call|>` for gpt-oss). Left in the hidden
+        // set, the engine stops AND strips it, so the parser sees a
+        // truncated envelope and drops the call. Move such tokens to the
+        // visible set so the engine still stops on them but the token
+        // survives into output for the parser to consume. See PR #9778.
+        let mut visible_tool_parser_end_token_ids = Vec::new();
+        if let Some(stop_tokens) = &mut stop_conditions.stop_token_ids_hidden {
+            visible_tool_parser_end_token_ids =
+                self.remove_tool_parser_end_tokens_from_hidden_stops(request, stop_tokens)?;
+        }
+        if !visible_tool_parser_end_token_ids.is_empty() {
+            let visible_stops = stop_conditions
+                .stop_token_ids_visible
+                .get_or_insert_with(Vec::new);
+            for token_id in visible_tool_parser_end_token_ids {
+                if !visible_stops.contains(&token_id) {
+                    visible_stops.push(token_id);
+                }
+            }
         }
 
         // apply ignore eos if not already set
         stop_conditions.apply_ignore_eos();
 
         if !stop_conditions.ignore_eos.unwrap_or(false) {
-            builder.eos_token_ids(self.model_info.eos_token_ids());
+            builder.eos_token_ids(eos_token_ids);
         }
 
         builder.stop_conditions(stop_conditions);
@@ -370,6 +396,81 @@ impl OpenAIPreprocessor {
         builder.mm_processor_kwargs(request.mm_processor_kwargs().cloned());
 
         Ok(builder)
+    }
+
+    fn remove_tool_parser_end_tokens_from_hidden_stops<R: OAIChatLikeRequest>(
+        &self,
+        request: &R,
+        hidden_stop_token_ids: &mut Vec<TokenIdType>,
+    ) -> Result<Vec<TokenIdType>> {
+        let has_tools = request
+            .tools()
+            .as_ref()
+            .and_then(|tools| tools.len())
+            .is_some_and(|len| len > 0);
+        let tool_choice_none = request
+            .tool_choice()
+            .as_ref()
+            .and_then(|tool_choice| tool_choice.as_str())
+            == Some("none");
+
+        if !Self::should_keep_tool_parser_end_tokens_visible(has_tools, tool_choice_none) {
+            return Ok(Vec::new());
+        }
+
+        let Some(tool_call_parser) = self.tool_call_parser.as_deref().filter(|p| !p.is_empty())
+        else {
+            return Ok(Vec::new());
+        };
+        let Some(tool_call_config) = get_tool_parser_map().get(tool_call_parser) else {
+            return Ok(Vec::new());
+        };
+
+        let mut visible_stop_token_ids = Vec::new();
+        for end_token in tool_call_config.parser_config.tool_call_end_tokens() {
+            if end_token.is_empty() {
+                continue;
+            }
+            let encoded = self.tokenizer.encode(&end_token).with_context(|| {
+                format!(
+                    "Failed to encode tool-call end token {end_token:?} for parser {tool_call_parser:?}"
+                )
+            })?;
+            let was_hidden_eos =
+                Self::remove_single_token_marker(hidden_stop_token_ids, encoded.token_ids());
+            if !was_hidden_eos {
+                tracing::debug!(
+                    token_ids = ?encoded.token_ids(),
+                    end_token,
+                    parser = tool_call_parser,
+                    "Tool-call end token was not a single hidden EOS token"
+                );
+                continue;
+            }
+            if let [token_id] = encoded.token_ids()
+                && !visible_stop_token_ids.contains(token_id)
+            {
+                visible_stop_token_ids.push(*token_id);
+            }
+        }
+
+        Ok(visible_stop_token_ids)
+    }
+
+    fn should_keep_tool_parser_end_tokens_visible(has_tools: bool, tool_choice_none: bool) -> bool {
+        has_tools && !tool_choice_none
+    }
+
+    fn remove_single_token_marker(
+        hidden_eos_token_ids: &mut Vec<TokenIdType>,
+        marker_token_ids: &[TokenIdType],
+    ) -> bool {
+        let [marker_token_id] = marker_token_ids else {
+            return false;
+        };
+        let before = hidden_eos_token_ids.len();
+        hidden_eos_token_ids.retain(|token_id| token_id != marker_token_id);
+        hidden_eos_token_ids.len() != before
     }
 
     pub fn apply_template<

--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -56,6 +56,133 @@ fn remove_known_non_jinja2_tags(template: &str) -> String {
         .replace("{% endgeneration %}", "")
 }
 
+/// Normalize common Python/Jinja dict method calls that are ambiguous in minijinja.
+///
+/// JSON schemas commonly use an `items` key for array item definitions. In
+/// minijinja, `foo.items()` can resolve `items` as a map entry before the
+/// pycompat method callback sees it, causing "object is not callable" for
+/// templates that iterate OpenAI tool schemas. The `items` filter gives the same
+/// map iteration behavior without colliding with schema keys.
+fn normalize_dict_method_calls(template: &str) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+
+    while i < template.len() {
+        if template[i..].starts_with("{#") {
+            let Some(end) = find_tag_end(template, i + 2, "#}") else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            out.push_str(&template[i..end]);
+            i = end;
+        } else if template[i..].starts_with("{{") {
+            let Some(end) = find_tag_end(template, i + 2, "}}") else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            out.push_str("{{");
+            out.push_str(&normalize_jinja_code_segment(&template[i + 2..end - 2]));
+            out.push_str("}}");
+            i = end;
+        } else if template[i..].starts_with("{%") {
+            let Some(end) = find_tag_end(template, i + 2, "%}") else {
+                out.push_str(&template[i..]);
+                break;
+            };
+            let inner = &template[i + 2..end - 2];
+            if is_jinja_block_name(inner, "raw") {
+                if let Some(raw_end) = find_raw_block_end(template, end) {
+                    out.push_str(&template[i..raw_end]);
+                    i = raw_end;
+                } else {
+                    out.push_str(&template[i..]);
+                    break;
+                }
+            } else {
+                out.push_str("{%");
+                out.push_str(&normalize_jinja_code_segment(inner));
+                out.push_str("%}");
+                i = end;
+            }
+        } else {
+            let ch = template[i..].chars().next().expect("valid char boundary");
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+
+    out
+}
+
+fn find_tag_end(template: &str, start: usize, close: &str) -> Option<usize> {
+    template[start..]
+        .find(close)
+        .map(|relative| start + relative + close.len())
+}
+
+fn find_raw_block_end(template: &str, start: usize) -> Option<usize> {
+    let mut i = start;
+    while let Some(relative_open) = template[i..].find("{%") {
+        let open = i + relative_open;
+        let end = find_tag_end(template, open + 2, "%}")?;
+        if is_jinja_block_name(&template[open + 2..end - 2], "endraw") {
+            return Some(end);
+        }
+        i = end;
+    }
+    None
+}
+
+fn is_jinja_block_name(inner: &str, name: &str) -> bool {
+    let trimmed = inner.trim_start();
+    let trimmed = trimmed
+        .strip_prefix('-')
+        .or_else(|| trimmed.strip_prefix('+'))
+        .unwrap_or(trimmed)
+        .trim_start();
+    let Some(rest) = trimmed.strip_prefix(name) else {
+        return false;
+    };
+    rest.chars()
+        .next()
+        .is_none_or(|ch| ch.is_whitespace() || ch == '-' || ch == '+')
+}
+
+fn normalize_jinja_code_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    let mut i = 0;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    while i < segment.len() {
+        let ch = segment[i..].chars().next().expect("valid char boundary");
+
+        if let Some(q) = quote {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == q {
+                quote = None;
+            }
+            i += ch.len_utf8();
+        } else if ch == '\'' || ch == '"' {
+            quote = Some(ch);
+            out.push(ch);
+            i += ch.len_utf8();
+        } else if segment[i..].starts_with(".items()") {
+            out.push_str("|items");
+            i += ".items()".len();
+        } else {
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+
+    out
+}
+
 impl JinjaEnvironment {
     fn env(self) -> Environment<'static> {
         self.env
@@ -121,7 +248,8 @@ impl HfTokenizerConfigJsonFormatter {
                     supports_add_generation_prompt = Some(true);
                 }
                 // Remove known non-standard tags before validation (they don't affect output)
-                let template_cleaned = remove_known_non_jinja2_tags(x);
+                let template_cleaned =
+                    normalize_dict_method_calls(&remove_known_non_jinja2_tags(x));
                 env.add_template_owned("default", template_cleaned.clone())?;
                 env.add_template_owned("tool_use", template_cleaned)?;
             }
@@ -146,7 +274,8 @@ impl HfTokenizerConfigJsonFormatter {
                             supports_add_generation_prompt = Some(false);
                         }
                         // Remove known non-standard tags before validation (they don't affect output)
-                        let template_cleaned = remove_known_non_jinja2_tags(v);
+                        let template_cleaned =
+                            normalize_dict_method_calls(&remove_known_non_jinja2_tags(v));
                         env.add_template_owned(k.to_string(), template_cleaned)?;
                     }
                 }
@@ -214,5 +343,98 @@ mod tests {
         let template = "Start {% generation %}Part 1{% endgeneration %} middle {% generation %}Part 2{% endgeneration %}";
         let result = remove_known_non_jinja2_tags(template);
         assert_eq!(result, "Start Part 1 middle Part 2");
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_rewrites_items_method() {
+        let template = "{% for k, v in tool.parameters.properties.items() %}{{ k }}{% endfor %}";
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(
+            result,
+            "{% for k, v in tool.parameters.properties|items %}{{ k }}{% endfor %}"
+        );
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_rewrites_expression_items_method() {
+        let template = "{{ tool.parameters.properties.items() }}";
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(result, "{{ tool.parameters.properties|items }}");
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_preserves_literal_text() {
+        let template = "Do not rewrite literal .items() text.";
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(result, template);
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_preserves_comments_raw_and_strings() {
+        let template = concat!(
+            "{# comment .items() #}",
+            "{% raw %}{{ tool.parameters.properties.items() }}{% endraw %}",
+            "{{ '.items()' }}",
+            "{{ \".items()\" }}",
+        );
+        let result = normalize_dict_method_calls(template);
+        assert_eq!(result, template);
+    }
+
+    #[test]
+    fn test_normalize_dict_method_calls_avoids_schema_items_collision() {
+        let template = normalize_dict_method_calls(
+            "{% for param_name, param_spec in tool.parameters.properties.items() %}{{ param_name }}={{ param_spec.type }};{% endfor %}",
+        );
+
+        let mut env = Environment::new();
+        env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+        env.add_template("t", &template).unwrap();
+
+        let tool = json!({
+            "parameters": {
+                "properties": {
+                    "items": {"type": "array", "items": {"type": "object"}},
+                    "message": {"type": "string"}
+                }
+            }
+        });
+
+        let out = env
+            .get_template("t")
+            .unwrap()
+            .render(context! { tool => tool })
+            .unwrap();
+
+        assert!(out.contains("items=array;"));
+        assert!(out.contains("message=string;"));
+    }
+
+    #[test]
+    fn test_minijinja_parses_midchain_dotted_integer_lookup() {
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": r#"{{ m.content.0.type }} {{ "1.5.10" }}"#,
+        }))
+        .unwrap();
+
+        let formatter =
+            HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap();
+
+        let result = formatter
+            .env
+            .get_template("default")
+            .unwrap()
+            .render(context! {
+                m => json!({
+                    "content": [
+                        {
+                            "type": "tool_reference"
+                        }
+                    ]
+                })
+            })
+            .unwrap();
+
+        assert_eq!(result, "tool_reference 1.5.10");
     }
 }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -32,6 +32,28 @@ use crate::protocols::openai::common_ext::CommonExt;
 // ---------------------------------------------------------------------------
 // Conversion: AnthropicCreateMessageRequest -> NvCreateChatCompletionRequest
 // ---------------------------------------------------------------------------
+fn push_system_message(content: String, messages: &mut Vec<ChatCompletionRequestMessage>) {
+    messages.push(ChatCompletionRequestMessage::System(
+        ChatCompletionRequestSystemMessage {
+            content: ChatCompletionRequestSystemMessageContent::Text(content),
+            name: None,
+        },
+    ));
+}
+
+fn system_message_content(content: &AnthropicMessageContent) -> String {
+    match content {
+        AnthropicMessageContent::Text { content } => content.clone(),
+        AnthropicMessageContent::Blocks { content } => content
+            .iter()
+            .filter_map(|block| match block {
+                AnthropicContentBlock::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    }
+}
 impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
     type Error = anyhow::Error;
 
@@ -40,19 +62,16 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
 
         // Prepend system message if present
         if let Some(system_content) = &req.system {
-            messages.push(ChatCompletionRequestMessage::System(
-                ChatCompletionRequestSystemMessage {
-                    content: ChatCompletionRequestSystemMessageContent::Text(
-                        system_content.text.clone(),
-                    ),
-                    name: None,
-                },
-            ));
+            push_system_message(system_content.text.clone(), &mut messages);
         }
 
         // Convert each Anthropic message
         for msg in &req.messages {
             match (&msg.role, &msg.content) {
+                // System messages may appear in messages[] from agent clients.
+                (AnthropicRole::System, content) => {
+                    push_system_message(system_message_content(content), &mut messages);
+                }
                 // User with plain text
                 (AnthropicRole::User, AnthropicMessageContent::Text { content }) => {
                     messages.push(ChatCompletionRequestMessage::User(
@@ -631,6 +650,48 @@ mod tests {
         ));
         assert!(matches!(
             &chat_req.inner.messages[1],
+            ChatCompletionRequestMessage::User(_)
+        ));
+    }
+
+    #[test]
+    fn test_message_level_system_role_conversion() {
+        let json = r#"{
+            "model": "test-model",
+            "max_tokens": 100,
+            "messages": [
+                {"role": "user", "content": "Hi"},
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "Keep answers short."},
+                        {"type": "text", "text": "Use the available shell."}
+                    ]
+                },
+                {"role": "user", "content": "List files"}
+            ]
+        }"#;
+
+        let req: AnthropicCreateMessageRequest = serde_json::from_str(json).unwrap();
+        assert!(matches!(req.messages[1].role, AnthropicRole::System));
+
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        assert_eq!(chat_req.inner.messages.len(), 3);
+        assert!(matches!(
+            &chat_req.inner.messages[0],
+            ChatCompletionRequestMessage::User(_)
+        ));
+        match &chat_req.inner.messages[1] {
+            ChatCompletionRequestMessage::System(system) => match &system.content {
+                ChatCompletionRequestSystemMessageContent::Text(text) => {
+                    assert_eq!(text, "Keep answers short.\nUse the available shell.");
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected system message, got {other:?}"),
+        }
+        assert!(matches!(
+            &chat_req.inner.messages[2],
             ChatCompletionRequestMessage::User(_)
         ));
     }

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -237,7 +237,11 @@ pub struct StopConditions {
     /// The returned output will not contain the stop strings.
     pub stop: Option<Vec<String>>,
 
-    /// List of tokens that stop the generation when they are
+    /// List of tokens that stop generation when they are generated.
+    /// The returned output WILL contain the stop tokens.
+    pub stop_token_ids_visible: Option<Vec<TokenIdType>>,
+
+    /// List of hidden/system tokens that stop generation when they are
     /// generated. The returned output will NOT contain the stop tokens.
     pub stop_token_ids_hidden: Option<Vec<TokenIdType>>,
 
@@ -259,6 +263,7 @@ impl StopConditions {
     pub fn apply_ignore_eos(&mut self) {
         if self.ignore_eos.unwrap_or(false) {
             self.stop = None;
+            self.stop_token_ids_visible = None;
             self.stop_token_ids_hidden = None;
         }
     }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -190,6 +190,7 @@ impl<T: OpenAIStopConditionsProvider> StopConditionsProvider for T {
             max_tokens,
             min_tokens,
             stop,
+            stop_token_ids_visible: None,
             stop_token_ids_hidden: None,
             ignore_eos,
             max_thinking_tokens,

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1904,17 +1904,11 @@ mod tests {
         let jail = JailedStream::builder().tool_call_parser("harmony").build();
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have at least one output containing the parsed tool call.
+        // Should have at least one output containing both analysis text and parsed tool call
         assert!(!results.is_empty());
 
-        // Recipientless analysis is pure reasoning, not visible content. The
-        // harmony tool parser no longer surfaces it as `content` (in the full
-        // pipeline the reasoning parser routes it to `reasoning_content`); here
-        // the jail runs standalone, so the analysis prose is simply dropped from
-        // content. Verify it does NOT leak into content — this is the contract
-        // change that stops Harmony analysis reasoning from polluting response
-        // text. (Was previously asserted to appear in content.)
-        let leaks_analysis_text = results.iter().any(|r| {
+        // Verify the analysis text appears as content in one of the outputs
+        let has_analysis_text = results.iter().any(|r| {
             r.data
                 .as_ref()
                 .and_then(|d| d.inner.choices.first())
@@ -1925,10 +1919,7 @@ mod tests {
                 })
                 .unwrap_or(false)
         });
-        assert!(
-            !leaks_analysis_text,
-            "recipientless analysis reasoning must not leak into content"
-        );
+        assert!(has_analysis_text, "Should contain extracted analysis text");
 
         // Verify a tool call was parsed with expected name and args
         let tool_call_idx = results

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -1904,11 +1904,17 @@ mod tests {
         let jail = JailedStream::builder().tool_call_parser("harmony").build();
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should have at least one output containing both analysis text and parsed tool call
+        // Should have at least one output containing the parsed tool call.
         assert!(!results.is_empty());
 
-        // Verify the analysis text appears as content in one of the outputs
-        let has_analysis_text = results.iter().any(|r| {
+        // Recipientless analysis is pure reasoning, not visible content. The
+        // harmony tool parser no longer surfaces it as `content` (in the full
+        // pipeline the reasoning parser routes it to `reasoning_content`); here
+        // the jail runs standalone, so the analysis prose is simply dropped from
+        // content. Verify it does NOT leak into content — this is the contract
+        // change that stops Harmony analysis reasoning from polluting response
+        // text. (Was previously asserted to appear in content.)
+        let leaks_analysis_text = results.iter().any(|r| {
             r.data
                 .as_ref()
                 .and_then(|d| d.inner.choices.first())
@@ -1919,7 +1925,10 @@ mod tests {
                 })
                 .unwrap_or(false)
         });
-        assert!(has_analysis_text, "Should contain extracted analysis text");
+        assert!(
+            !leaks_analysis_text,
+            "recipientless analysis reasoning must not leak into content"
+        );
 
         // Verify a tool call was parsed with expected name and args
         let tool_call_idx = results

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -7,9 +7,8 @@ use crate::ParserResult;
 use crate::ReasoningParser;
 
 use openai_harmony::StreamableParser;
-use openai_harmony::chat::{Content, Message, TextContent};
+use openai_harmony::chat::TextContent;
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, chat::Role, load_harmony_encoding};
-use regex::Regex;
 
 ///// Static initialization of harmony encoder to not affect performance every time a parser is created
 /// This is because load_harmony_encoding downloads some tiktoken files into a directory and we don't want to do this every time we create a parser.
@@ -17,18 +16,6 @@ use std::sync::OnceLock;
 
 static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::Error>> =
     OnceLock::new();
-static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
-static HARMONY_ANALYSIS_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
-const HARMONY_CALL_MARKER: &str = "<|call|>";
-const HARMONY_SPECIAL_TOKENS: &[&str] = &[
-    "<|start|>",
-    "<|end|>",
-    "<|return|>",
-    "<|channel|>",
-    "<|constrain|>",
-    "<|message|>",
-    "<|call|>",
-];
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
     GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
@@ -47,19 +34,6 @@ fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
 
 pub struct GptOssReasoningParser {
     parser: StreamableParser,
-    pending_text: String,
-    pending_tool_call_text: String,
-    emitted_reasoning_text: bool,
-    insert_reasoning_separator: bool,
-    emitted_normal_text: bool,
-    insert_normal_separator: bool,
-    /// Channel/recipient of the directed tool call currently being streamed.
-    /// Persisted across chunks because the `<|call|>` terminator can arrive in a
-    /// later chunk than the one that resolved the recipient (and `<|call|>` resets
-    /// the live parser state), so the `<|call|>`-chunk envelope reconstruction
-    /// would otherwise lose the channel/recipient. Cleared once the call is emitted.
-    last_directed_channel: Option<String>,
-    last_directed_recipient: Option<String>,
 }
 
 /// Implement Debug for GptOssReasoningParser separately because StreamableParser does not implement Debug
@@ -88,44 +62,7 @@ impl GptOssReasoningParser {
                 return Err(anyhow::anyhow!("Failed to load Harmony encoding: {e}"));
             }
         };
-        Ok(Self {
-            parser,
-            pending_text: String::new(),
-            pending_tool_call_text: String::new(),
-            emitted_reasoning_text: false,
-            insert_reasoning_separator: false,
-            emitted_normal_text: false,
-            insert_normal_separator: false,
-            last_directed_channel: None,
-            last_directed_recipient: None,
-        })
-    }
-
-    // Inherent method (the f1999 `ReasoningParser` trait does not declare
-    // `finish_reasoning_stream`). The serving pipeline never calls it; it exists
-    // for the streaming unit tests to flush any held-back trailing content, so
-    // it reads as dead code on a non-test build.
-    #[allow(dead_code)]
-    fn finish_reasoning_stream(&mut self) -> ParserResult {
-        self.pending_tool_call_text.clear();
-        self.last_directed_channel = None;
-        self.last_directed_recipient = None;
-        let pending = std::mem::take(&mut self.pending_text);
-        if pending.is_empty() {
-            return ParserResult::default();
-        }
-
-        match self.parser.current_channel().as_deref() {
-            Some("analysis") => ParserResult {
-                normal_text: String::new(),
-                reasoning_text: pending,
-            },
-            Some("final") | Some("commentary") => ParserResult {
-                normal_text: pending,
-                reasoning_text: String::new(),
-            },
-            _ => ParserResult::default(),
-        }
+        Ok(Self { parser })
     }
 }
 
@@ -136,231 +73,18 @@ fn encode_text_to_tokens(text: &str) -> anyhow::Result<Vec<u32>> {
     Ok(enc.tokenizer().encode_with_special_tokens(text))
 }
 
-fn harmony_call_token_ids() -> Option<&'static [u32]> {
-    let ids = HARMONY_CALL_TOKEN_IDS.get_or_init(|| {
-        get_harmony_encoding()
-            .as_ref()
-            .map(|enc| {
-                enc.tokenizer()
-                    .encode_with_special_tokens(HARMONY_CALL_MARKER)
-            })
-            .unwrap_or_default()
-    });
-    if ids.is_empty() {
-        None
-    } else {
-        Some(ids.as_slice())
-    }
-}
-
-/// Token id(s) for the harmony `<|call|>` terminator.
-///
-/// `<|call|>` is simultaneously the harmony tool-call terminator the parser
-/// requires AND a gpt-oss EOS token. Pipelines that hide EOS tokens from the
-/// decoded output (e.g. the preprocessor's stop-condition handling) must keep
-/// these ids visible when the harmony tool-call parser is active — otherwise the
-/// terminator is stripped before the parser sees it and tool calls are silently
-/// dropped. Empty if the harmony encoding is unavailable.
-///
-/// Unused on this base: its caller is the preprocessor stop-token integration,
-/// which is part of the separate stop-token work not included in this
-/// parser-only patch.
-#[allow(dead_code)]
-pub fn harmony_terminator_token_ids() -> Vec<u32> {
-    harmony_call_token_ids()
-        .map(|ids| ids.to_vec())
-        .unwrap_or_default()
-}
-
-fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
-    !marker_ids.is_empty()
-        && marker_ids.len() <= token_ids.len()
-        && token_ids
-            .windows(marker_ids.len())
-            .any(|window| window == marker_ids)
-}
-
-fn harmony_analysis_block_regex() -> &'static Regex {
-    HARMONY_ANALYSIS_BLOCK_REGEX.get_or_init(|| {
-        // Match ONLY recipientless analysis reasoning blocks (the CoT channel).
-        // Requiring `<|message|>` to immediately follow `analysis` (no `.*?`
-        // gap) ensures that `analysis to=functions.X code<|message|>…` tool-call
-        // envelopes are NOT stripped — they must survive into normal_text so
-        // the downstream harmony tool-call jail can recover them.
-        Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>.*?(?:<\|call\|>|<\|end\|>|\z)",
-        )
-            .expect("harmony analysis block regex")
-    })
-}
-
-fn input_contains_call_marker(
-    text: &str,
-    token_ids: &[u32],
-    caller_supplied_token_ids: bool,
-) -> bool {
-    if !token_ids.is_empty()
-        && let Some(call_ids) = harmony_call_token_ids()
-    {
-        return token_ids_contain_sequence(token_ids, call_ids);
-    }
-
-    !caller_supplied_token_ids && text.contains(HARMONY_CALL_MARKER)
-}
-
-fn raw_input_text_for_tool_parser(
-    text: &str,
-    token_ids: &[u32],
-    caller_supplied_token_ids: bool,
-) -> String {
-    if caller_supplied_token_ids && let Ok(enc) = get_harmony_encoding() {
-        return enc.tokenizer().decode_utf8(token_ids).unwrap_or_default();
-    }
-
-    text.to_string()
-}
-
-fn split_incomplete_harmony_suffix(text: &str) -> (&str, &str) {
-    let hold_len = HARMONY_SPECIAL_TOKENS
-        .iter()
-        .flat_map(|token| (1..token.len()).map(|idx| &token[..idx]))
-        .filter(|prefix| text.ends_with(*prefix))
-        .map(str::len)
-        .max()
-        .unwrap_or(0);
-
-    text.split_at(text.len() - hold_len)
-}
-
-fn contains_directed_harmony_function_call(text: &str) -> bool {
-    (text.contains("<|channel|>commentary to=functions.")
-        || text.contains("<|channel|>analysis to=functions."))
-        && text.contains(HARMONY_CALL_MARKER)
-}
-
-fn strip_analysis_blocks_for_tool_handoff(text: &str) -> String {
-    harmony_analysis_block_regex()
-        .replace_all(text, "")
-        .into_owned()
-}
-
-fn append_separated(target: &mut String, text: &str) {
-    if text.is_empty() {
-        return;
-    }
-    if !target.is_empty() {
-        target.push('\n');
-    }
-    target.push_str(text);
-}
-
-fn append_text_content(target: &mut String, content: &[Content]) {
-    for item in content {
-        if let Content::Text(TextContent { text }) = item {
-            append_separated(target, text);
-        }
-    }
-}
-
-fn append_message_by_channel(reasoning_text: &mut String, normal_text: &mut String, msg: &Message) {
-    match msg.channel.as_deref() {
-        // Analysis WITHOUT a recipient is chain-of-thought reasoning.
-        // Analysis WITH a functions recipient is a (malformed) tool call whose
-        // payload is handed off via strip_analysis_blocks_for_tool_handoff —
-        // do not also surface it as reasoning_content.
-        Some("analysis") if msg.recipient.is_none() => {
-            append_text_content(reasoning_text, &msg.content)
-        }
-        Some("final") => append_text_content(normal_text, &msg.content),
-        Some("commentary") if msg.recipient.is_none() => {
-            append_text_content(normal_text, &msg.content)
-        }
-        _ => {}
-    }
-}
-
-fn append_current_by_channel(
-    reasoning_text: &mut String,
-    normal_text: &mut String,
-    channel: Option<String>,
-    current: String,
-) {
-    match channel.as_deref() {
-        Some("analysis") => append_separated(reasoning_text, &current),
-        Some("final") => append_separated(normal_text, &current),
-        Some("commentary") => append_separated(normal_text, &current),
-        _ => {}
-    }
-}
-
-fn is_visible_normal_channel(channel: Option<&str>, recipient: Option<&str>) -> bool {
-    matches!(channel, Some("final"))
-        || (matches!(channel, Some("commentary")) && recipient.is_none())
-}
-
-fn starts_directed_harmony_tool_call(text: &str) -> bool {
-    text.contains("<|channel|>commentary to=functions.")
-        || text.contains("<|channel|>analysis to=functions.")
-}
-
-/// Reconstruct the complete harmony envelope for the directed tool call that
-/// just terminated, by decoding the cumulative parser token buffer from its
-/// last `<|channel|>` token to the end.
-///
-/// This is the canonical handoff to the downstream tool-call jail: it always
-/// starts exactly at the tool call's `<|channel|>` token, so it (a) survives a
-/// channel header that was split across streaming chunks, and (b) excludes any
-/// leading `<|end|>` / text from a preceding reasoning message that raw
-/// per-chunk accumulation would otherwise prepend (and leak).
-///
-/// Returns `None` when the captured channel is not a directed tool call, when
-/// the harmony encoding is unavailable, or when no `<|channel|>` token is found.
-fn reconstruct_directed_envelope(
-    parser: &StreamableParser,
-    channel: Option<&str>,
-    recipient: Option<&str>,
-) -> Option<String> {
-    let ch = channel?;
-    let is_tool_ch = ch == "commentary"
-        || (ch == "analysis" && recipient.is_some_and(|r| r.starts_with("functions.")));
-    if !is_tool_ch {
-        return None;
-    }
-    let Ok(enc) = get_harmony_encoding() else {
-        return None;
-    };
-    let tokens = parser.tokens();
-    let channel_token_id = enc
-        .tokenizer()
-        .encode_with_special_tokens("<|channel|>")
-        .last()
-        .copied()?;
-    let last_channel_idx = tokens.iter().rposition(|t| *t == channel_token_id)?;
-    let decoded = enc
-        .tokenizer()
-        .decode_utf8(&tokens[last_channel_idx..])
-        .unwrap_or_default();
-    if decoded.is_empty() {
-        None
-    } else {
-        Some(decoded)
-    }
-}
-
 impl ReasoningParser for GptOssReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
-        let caller_supplied_token_ids = !token_ids.is_empty();
-        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            encoded_tokens = match encode_text_to_tokens(text) {
+            let encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            encoded_tokens.as_slice()
+            &encoded_tokens.to_vec()
         } else {
             token_ids
         };
@@ -383,42 +107,70 @@ impl ReasoningParser for GptOssReasoningParser {
         let output_msgs = parser.messages();
         tracing::debug!("Parser has {} output messages", output_msgs.len());
 
-        let mut reasoning_text = String::new();
-        let mut normal_text = String::new();
-        for msg in output_msgs {
-            append_message_by_channel(&mut reasoning_text, &mut normal_text, msg);
-        }
+        match output_msgs.len() {
+            0 => {
+                tracing::debug!("No output messages, using current content");
+                let current = parser.current_content().unwrap_or_default();
+                tracing::debug!("Current content length: {}", current.len());
+                ParserResult {
+                    normal_text: String::new(),
+                    reasoning_text: current,
+                }
+            }
+            1 => {
+                tracing::debug!("Single output message detected");
+                let mut reasoning_text = String::new();
+                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
+                    output_msgs[0].content.first()
+                {
+                    reasoning_text.push_str(text);
+                    tracing::debug!("Extracted reasoning text length: {}", reasoning_text.len());
+                }
+                let current = parser.current_content().unwrap_or_default();
+                tracing::debug!("Current content length: {}", current.len());
+                ParserResult {
+                    normal_text: current,
+                    reasoning_text,
+                }
+            }
+            _ => {
+                tracing::debug!("Multiple output messages detected: {}", output_msgs.len());
+                let mut reasoning_text = String::new();
+                let mut normal_text = String::new();
 
-        let current = parser.current_content().unwrap_or_default();
-        let current_channel = parser.current_channel();
-        if current_channel.as_deref() != Some("commentary") || parser.current_recipient().is_none()
-        {
-            append_current_by_channel(
-                &mut reasoning_text,
-                &mut normal_text,
-                current_channel,
-                current,
-            );
-        }
+                // Loop until second last message
+                for (i, parse_msg) in output_msgs.iter().take(output_msgs.len() - 1).enumerate() {
+                    tracing::debug!("Processing reasoning message {}", i + 1);
+                    if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
+                        parse_msg.content.first()
+                    {
+                        reasoning_text.push_str(text);
+                        tracing::debug!("Added {} chars to reasoning text", text.len());
+                    }
+                }
 
-        let raw_input_text =
-            raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
-        if contains_directed_harmony_function_call(&raw_input_text) {
-            // The serving pipeline feeds reasoning normal_text into the Harmony
-            // tool parser. Keep directed commentary envelopes intact so tool
-            // calls are not silently dropped.
-            normal_text = strip_analysis_blocks_for_tool_handoff(&raw_input_text);
-        }
+                let last_msg = &output_msgs[output_msgs.len() - 1];
+                tracing::debug!("Processing final message");
 
-        tracing::debug!(
-            "Final result - normal_text: {} chars, reasoning_text: {} chars",
-            normal_text.len(),
-            reasoning_text.len()
-        );
+                // Handle the last message
+                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
+                    last_msg.content.first()
+                {
+                    normal_text.push_str(text);
+                    tracing::debug!("Added {} chars to normal text", text.len());
+                }
 
-        ParserResult {
-            normal_text,
-            reasoning_text,
+                tracing::debug!(
+                    "Final result - normal_text: {} chars, reasoning_text: {} chars",
+                    normal_text.len(),
+                    reasoning_text.len()
+                );
+
+                ParserResult {
+                    normal_text,
+                    reasoning_text,
+                }
+            }
         }
     }
 
@@ -427,34 +179,16 @@ impl ReasoningParser for GptOssReasoningParser {
         text: &str,
         token_ids: &[u32],
     ) -> ParserResult {
-        let caller_supplied_token_ids = !token_ids.is_empty();
-        let text_to_process;
-        let text = if caller_supplied_token_ids {
-            text
-        } else {
-            self.pending_text.push_str(text);
-            let combined = std::mem::take(&mut self.pending_text);
-            let (ready, pending) = split_incomplete_harmony_suffix(&combined);
-            self.pending_text.push_str(pending);
-            text_to_process = ready.to_string();
-            text_to_process.as_str()
-        };
-
-        if text.is_empty() && token_ids.is_empty() {
-            return ParserResult::default();
-        }
-
-        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            encoded_tokens = match encode_text_to_tokens(text) {
+            let encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            encoded_tokens.as_slice()
+            &encoded_tokens.to_vec()
         } else {
             token_ids
         };
@@ -470,150 +204,31 @@ impl ReasoningParser for GptOssReasoningParser {
                 token_ids.len(),
                 token_id
             );
-            let previous_channel = parser.current_channel();
-            let previous_recipient = parser.current_recipient();
             if let Err(e) = parser.process(*token_id) {
                 tracing::warn!("Harmony parse error for token_id {token_id}: {e}");
                 return ParserResult::default();
             }
-            let current_channel = parser.current_channel();
-            let current_recipient = parser.current_recipient();
-
-            // Persist directed tool-call context before `<|call|>` can reset it.
-            // This is stored on `self` (not a local) because the `<|call|>`
-            // terminator can arrive in a later chunk than the one that resolved
-            // the recipient — e.g. for short responses split into tiny chunks the
-            // `<|call|>` token can be the first token of its own chunk, by which
-            // point the live parser recipient is already gone.
-            if let (Some(ch), Some(rec)) = (&current_channel, &current_recipient)
-                && (ch.as_str() == "commentary" || ch.as_str() == "analysis")
-                && rec.starts_with("functions.")
-            {
-                self.last_directed_channel = current_channel.clone();
-                self.last_directed_recipient = current_recipient.clone();
-            }
-
-            if previous_channel.as_deref() != Some("analysis")
-                && current_channel.as_deref() == Some("analysis")
-                && self.emitted_reasoning_text
-            {
-                self.insert_reasoning_separator = true;
-            }
-
-            if is_visible_normal_channel(current_channel.as_deref(), current_recipient.as_deref())
-                && !is_visible_normal_channel(
-                    previous_channel.as_deref(),
-                    previous_recipient.as_deref(),
-                )
-                && self.emitted_normal_text
-            {
-                self.insert_normal_separator = true;
-            }
 
             if let (Some(delta), Some(channel)) = (
                 parser.last_content_delta().unwrap_or_default(),
-                current_channel,
+                parser.current_channel(),
             ) {
-                // `last_content_delta` only exposes the newest token slice, so directed
-                // commentary still falls through to the raw handoff path for tool parsing.
+                // `last_content_delta` only exposes the newest token slice, so we forward
+                // `final`/`analysis` chunks immediately; commentary is reconstructed in the
+                // fallback path below because it needs the stripped metadata.
+                let current_recipient = parser.current_recipient();
                 match channel.as_str() {
-                    "final" => {
-                        if self.insert_normal_separator {
-                            normal_delta.push('\n');
-                            self.insert_normal_separator = false;
-                        }
-                        normal_delta.push_str(&delta);
-                        self.emitted_normal_text = true;
-                    }
-                    "analysis" => {
-                        // Analysis WITHOUT a recipient is reasoning content.
-                        // Analysis WITH a functions recipient is a (malformed)
-                        // tool call — its payload is handed off via normal_delta
-                        // below; do not also surface it as reasoning_content.
-                        if current_recipient.is_none() {
-                            if self.insert_reasoning_separator {
-                                reasoning_delta.push('\n');
-                                self.insert_reasoning_separator = false;
-                            }
-                            reasoning_delta.push_str(&delta);
-                            self.emitted_reasoning_text = true;
-                        }
-                    }
-                    "commentary" => {
-                        if current_recipient.is_none() {
-                            if self.insert_normal_separator {
-                                normal_delta.push('\n');
-                                self.insert_normal_separator = false;
-                            }
-                            normal_delta.push_str(&delta);
-                            self.emitted_normal_text = true;
-                        }
-                    }
+                    "final" => normal_delta.push_str(&delta),
+                    // Recipientless analysis is reasoning. Analysis WITH a
+                    // functions recipient is a (malformed) tool call — defer it
+                    // to the reconstruction path below (like commentary) so its
+                    // payload reaches the tool parser instead of polluting
+                    // reasoning_content.
+                    "analysis" if current_recipient.is_none() => reasoning_delta.push_str(&delta),
+                    "analysis" => {}
+                    "commentary" => {}
                     _ => {}
                 }
-            }
-        }
-
-        let has_call_marker =
-            input_contains_call_marker(text, token_ids, caller_supplied_token_ids);
-        let raw_input_text = if has_call_marker
-            || !self.pending_tool_call_text.is_empty()
-            || starts_directed_harmony_tool_call(text)
-        {
-            Some(raw_input_text_for_tool_parser(
-                text,
-                token_ids,
-                caller_supplied_token_ids,
-            ))
-        } else {
-            None
-        };
-
-        if let Some(raw_input_text) = raw_input_text {
-            // Streaming feeds the downstream Harmony tool parser through
-            // `normal_text`. This is an internal handoff, not visible-content
-            // semantics: directed commentary/analysis tool payloads must become
-            // tool calls, not assistant `content`.
-            if has_call_marker {
-                // The tool call terminated in this chunk. Reconstruct the complete,
-                // clean envelope from the cumulative parser token buffer (it starts
-                // exactly at the tool call's `<|channel|>` token). This both handles
-                // a channel header that was split across chunks AND supersedes any
-                // raw text accumulated in `pending_tool_call_text` — which can carry
-                // a leading `<|end|>` (and other markup) from a preceding reasoning
-                // message that would otherwise leak into `response_text`.
-                //
-                // `parser.current_channel()` is None here because `<|call|>` resets
-                // the parser state, so we use the channel/recipient persisted on
-                // `self` during the per-token loop (possibly from a prior chunk).
-                let reconstructed = reconstruct_directed_envelope(
-                    parser,
-                    self.last_directed_channel.as_deref(),
-                    self.last_directed_recipient.as_deref(),
-                );
-                match reconstructed {
-                    Some(env) => {
-                        self.pending_tool_call_text.clear();
-                        normal_delta.push_str(&env);
-                    }
-                    None if !self.pending_tool_call_text.is_empty() => {
-                        // Fallback: no clean reconstruction available; flush the
-                        // accumulated raw text plus this chunk.
-                        self.pending_tool_call_text.push_str(&raw_input_text);
-                        normal_delta.push_str(&std::mem::take(&mut self.pending_tool_call_text));
-                    }
-                    None => normal_delta.push_str(&raw_input_text),
-                }
-                // The directed tool call terminated; clear the persisted context so
-                // the next call (or trailing reasoning) starts fresh.
-                self.last_directed_channel = None;
-                self.last_directed_recipient = None;
-            } else if !self.pending_tool_call_text.is_empty()
-                || starts_directed_harmony_tool_call(&raw_input_text)
-            {
-                // Mid tool call, terminator not yet seen: keep accumulating as a
-                // fallback (e.g. truncated streams that never emit `<|call|>`).
-                self.pending_tool_call_text.push_str(&raw_input_text);
             }
         }
 
@@ -630,35 +245,72 @@ impl ReasoningParser for GptOssReasoningParser {
         }
 
         if let Some(channel) = parser.current_channel() {
+            // A directed tool call (functions recipient) on EITHER the canonical
+            // commentary channel or the malformed analysis channel is recovered
+            // the same way: reconstruct the envelope from the token buffer so the
+            // downstream tool parser receives the channel/recipient/constraint
+            // metadata together with the payload.
             let is_directed_tool_call = channel == "commentary"
                 || (channel == "analysis"
                     && parser
                         .current_recipient()
                         .as_deref()
                         .is_some_and(|r| r.starts_with("functions.")));
-
             if is_directed_tool_call {
-                // We are mid directed-tool-call (channel + functions recipient) but
-                // produced no delta this chunk. Emit NOTHING here:
-                //
-                //  * A complete tool call is reconstructed in full — header, message
-                //    and `<|call|>` together — from the cumulative token buffer on
-                //    the `<|call|>` chunk (the `has_call_marker` branch above). Any
-                //    emission here would be a redundant partial: a bare header (when
-                //    a chunk boundary lands at `<|message|>`) or a header-less body
-                //    fragment, neither of which the downstream jail can assemble into
-                //    a tool call — they only leak raw harmony markup into
-                //    `response_text`.
-                //  * A truncated tool call that never emits `<|call|>` has no complete
-                //    envelope to recover, so emitting its partial header would leak
-                //    too. Suppressing loses nothing recoverable.
-                tracing::debug!(
-                    "In directed tool-call channel ({channel}); suppressing partial mid-stream \
-                     content (complete envelope is recovered on the <|call|> chunk)"
-                );
-            } else if channel != "analysis" {
-                // Pure analysis reasoning (no recipient) is expected to be silent here —
-                // it was already emitted to reasoning_delta in the per-token loop.
+                tracing::debug!("In directed tool-call channel, recovering full content");
+                // If we're in the commentary channel, we should return raw token content and recover content that has been consumed by the parser
+                // so that the tool parser can process it properly
+                if let Ok(enc) = get_harmony_encoding() {
+                    let current_content = parser.current_content().unwrap_or_default();
+                    let mut final_text = text.to_string();
+
+                    // Restore commentary metadata consumed by the parser so the tool-call parser can
+                    // process it correctly.
+                    //
+                    // Example:
+                    //   Before parsing:
+                    //   "<|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{\"format\":\"celsius\",\"location\":\"San Francisco\"}<|call|>"
+                    //   After parsing, the header is stripped, so we must reconstruct it:
+                    //   "<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>"
+                    //
+                    // This ensures downstream tool-call parsing receives the channel, target, and
+                    // constraint metadata together with the message payload.
+
+                    // Recovery should only happen once, and only when `current_content` is empty.
+                    if current_content.is_empty() {
+                        let tokens = parser.tokens();
+
+                        // Get the token id for " <|channel|>"
+                        let channel_token_id = enc
+                            .tokenizer()
+                            .encode_with_special_tokens("<|channel|>")
+                            .last()
+                            .copied();
+
+                        // Find the last occurrence of the <|channel|> token (id 20005) in the tokens vector
+                        let last_channel_token_idx = channel_token_id
+                            .and_then(|token_id| {
+                                tokens.iter().rposition(|token| *token == token_id)
+                            })
+                            .unwrap_or(0);
+
+                        // Then get the generated text from the last <|channel|> to the end of parser.tokens()
+                        let end_token_idx = parser.tokens().len();
+                        // Use Harmony's decode_utf8 to decode tokens into text
+                        let generated_text = enc
+                            .tokenizer()
+                            .decode_utf8(&parser.tokens()[last_channel_token_idx..end_token_idx])
+                            .unwrap_or_default();
+
+                        final_text = generated_text;
+                    }
+
+                    return ParserResult {
+                        normal_text: final_text,
+                        reasoning_text: String::new(),
+                    };
+                }
+            } else {
                 tracing::warn!("Shouldn't be delta content after in channel: {}", channel);
             }
         }
@@ -671,7 +323,7 @@ impl ReasoningParser for GptOssReasoningParser {
 mod tests {
     use super::*;
 
-    #[test] // REASONING.batch.2.c, TOOLCALLING.harmony.1
+    #[test] // REASONING.batch.1, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis<|message|>The user asks a simple factual question: capital of Brazil. The answer is Brasília. No additional explanation needed.<|end|><|start|>assistant<|channel|>final<|message|>The capital of Brazil is Brasília.";
@@ -683,64 +335,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.batch.4
-    fn test_gpt_oss_final_channel_without_analysis_is_normal_text() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let result = parser.detect_and_parse_reasoning("<|channel|>final<|message|>answer", &[]);
-        assert_eq!(result.reasoning_text, "");
-        assert_eq!(result.normal_text, "answer");
-    }
-
-    #[test] // REASONING.batch.6.a
-    fn test_gpt_oss_multiple_analysis_spans_join_before_final() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let text = "<|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done";
-        let result = parser.detect_and_parse_reasoning(text, &[]);
-        assert_eq!(result.reasoning_text, "first\nsecond");
-        assert_eq!(result.normal_text, "done");
-    }
-
-    #[test]
-    fn test_gpt_oss_directed_commentary_is_tool_parser_handoff() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let text = "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
-        let result = parser.detect_and_parse_reasoning(text, &[]);
-        assert_eq!(result.reasoning_text, "think");
-        assert_eq!(
-            result.normal_text,
-            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
-        );
-    }
-
-    #[test]
-    fn test_gpt_oss_analysis_call_does_not_swallow_commentary_handoff() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let text = "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
-        let result = parser.detect_and_parse_reasoning(text, &[]);
-        // An analysis-channel message WITH a `to=functions.` recipient is a
-        // (malformed) directed tool call, not chain-of-thought: its args are NOT
-        // leaked to reasoning_text.
-        assert_eq!(result.reasoning_text, "");
-        // Both directed tool-call envelopes (the analysis `search` call and the
-        // commentary `get_weather` call) plus the final message are handed off
-        // intact to the downstream tool-call jail — the analysis call no longer
-        // swallows or strips the commentary handoff.
-        assert_eq!(
-            result.normal_text,
-            "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
-        );
-    }
-
-    #[test]
-    fn test_gpt_oss_recipientless_commentary_is_normal_text() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let text = "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant<|channel|>final<|message|>Done.";
-        let result = parser.detect_and_parse_reasoning(text, &[]);
-        assert_eq!(result.reasoning_text, "");
-        assert_eq!(result.normal_text, "I will check that.\nDone.");
-    }
-
-    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
+    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let chunks = vec![
@@ -764,107 +359,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3.b
-    fn test_gpt_oss_reasoning_parser_streaming_split_end_marker() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let chunks = vec![
-            "<|channel|>analysis<|message|>thinking<|e",
-            "nd|><|start|>assistant<|channel|>final<|message|>answer",
-        ];
-        let mut reasoning_text_incr = String::new();
-        let mut normal_text_incr = String::new();
-        for chunk in chunks {
-            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
-            normal_text_incr.push_str(&result.normal_text);
-            reasoning_text_incr.push_str(&result.reasoning_text);
-        }
-        assert_eq!(reasoning_text_incr, "thinking");
-        assert_eq!(normal_text_incr, "answer");
-    }
-
-    #[test]
-    fn test_gpt_oss_reasoning_parser_streaming_flushes_pending_suffix_on_finish() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let result = parser.parse_reasoning_streaming_incremental(
-            "<|channel|>analysis<|message|>thinking<|e",
-            &[],
-        );
-        let finish = parser.finish_reasoning_stream();
-        assert_eq!(result.reasoning_text, "thinking");
-        assert_eq!(finish.reasoning_text, "<|e");
-        assert_eq!(finish.normal_text, "");
-        let finish = parser.finish_reasoning_stream();
-        assert_eq!(finish.reasoning_text, "");
-        assert_eq!(finish.normal_text, "");
-
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let result = parser
-            .parse_reasoning_streaming_incremental("<|channel|>final<|message|>answer<|e", &[]);
-        let finish = parser.finish_reasoning_stream();
-        assert_eq!(result.normal_text, "answer");
-        assert_eq!(finish.normal_text, "<|e");
-        assert_eq!(finish.reasoning_text, "");
-    }
-
-    #[test] // REASONING.stream.2.b
-    fn test_gpt_oss_reasoning_parser_streaming_multiple_analysis_spans() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let chunks = vec![
-            "<|channel|>analysis<|message|>first<|end|><|start|>assistant",
-            "<|channel|>analysis<|message|>second<|end|><|start|>assistant",
-            "<|channel|>final<|message|>done",
-        ];
-        let mut reasoning_text_incr = String::new();
-        let mut normal_text_incr = String::new();
-        for chunk in chunks {
-            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
-            normal_text_incr.push_str(&result.normal_text);
-            reasoning_text_incr.push_str(&result.reasoning_text);
-        }
-        assert_eq!(reasoning_text_incr, "first\nsecond");
-        assert_eq!(normal_text_incr, "done");
-    }
-
-    #[test]
-    fn test_gpt_oss_reasoning_parser_streaming_recipientless_commentary() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let chunks = vec![
-            "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant",
-            "<|channel|>final<|message|>Done.",
-        ];
-        let mut reasoning_text_incr = String::new();
-        let mut normal_text_incr = String::new();
-        for chunk in chunks {
-            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
-            normal_text_incr.push_str(&result.normal_text);
-            reasoning_text_incr.push_str(&result.reasoning_text);
-        }
-        assert_eq!(reasoning_text_incr, "");
-        assert_eq!(normal_text_incr, "I will check that.\nDone.");
-    }
-
-    #[test]
-    fn test_gpt_oss_reasoning_parser_streaming_split_directed_commentary() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let chunks = vec![
-            "<|channel|>commentary to=functions.get_",
-            "weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>",
-        ];
-        let mut reasoning_text_incr = String::new();
-        let mut normal_text_incr = String::new();
-        for chunk in chunks {
-            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
-            normal_text_incr.push_str(&result.normal_text);
-            reasoning_text_incr.push_str(&result.reasoning_text);
-        }
-        assert_eq!(reasoning_text_incr, "");
-        assert_eq!(
-            normal_text_incr,
-            "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>"
-        );
-    }
-
-    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
+    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_chunked() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let enc = get_harmony_encoding()
@@ -893,7 +388,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.batch.3.a, TOOLCALLING.harmony.1
+    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_variable_length_chunks() {
         let text = "<|channel|>analysis<|message|>User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>{}";
         let enc = get_harmony_encoding()
@@ -915,13 +410,11 @@ mod tests {
                 reasoning_text_incr,
                 "User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function."
             );
-            // This input is a TRUNCATED tool call: it ends at `<|message|>{}` with
-            // no `<|call|>` terminator. A complete directed tool call is handed off
-            // to the jail in one piece (header + body + `<|call|>`) on the `<|call|>`
-            // chunk; without a terminator there is no complete envelope to recover,
-            // so the streaming parser emits no normal_text rather than leaking a
-            // partial `<|channel|>…<|message|>` header.
-            assert_eq!(normal_text_incr, "");
+            // [gluo TODO] missing "<|start|>assistant" and "{}" from original message
+            assert_eq!(
+                normal_text_incr,
+                "<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>"
+            );
         }
 
         // Send token in chunks (chunking obtained from actual model output)
@@ -955,32 +448,10 @@ mod tests {
                 reasoning_text_incr,
                 "User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function."
             );
-            // Truncated tool call (no `<|call|>`): no complete envelope to recover,
-            // so no normal_text is emitted (see the token-by-token block above).
-            assert_eq!(normal_text_incr, "");
+            assert_eq!(
+                normal_text_incr,
+                "<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>"
+            );
         }
-    }
-
-    // NOTE: the corpus-characterization tests that ran captured dynamo.trtllm
-    // output through this parser (`reasoning_characterize_corpus_markup_leak`,
-    // `reasoning_parser_leaks_harmony_markup`) are intentionally omitted here —
-    // they `include_str!` private capture data that cannot be shared. The
-    // malformed analysis-channel frame they exercised is covered synthetically
-    // by `test_gpt_oss_analysis_call_does_not_swallow_commentary_handoff` and
-    // the control test below.
-
-    /// Control: a well-formed analysis+final stream splits cleanly with no
-    /// markup in either field (harness/encoding sanity).
-    #[test]
-    fn reasoning_control_wellformed_no_markup() {
-        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
-        let text = "<|channel|>analysis<|message|>Think about it.<|end|><|start|>assistant<|channel|>final<|message|>Answer.";
-        let r = parser.detect_and_parse_reasoning(text, &[]);
-        assert_eq!(r.reasoning_text, "Think about it.");
-        assert_eq!(r.normal_text, "Answer.");
-        assert!(
-            !r.reasoning_text.contains("<|") && !r.normal_text.contains("<|"),
-            "well-formed stream must not retain markup"
-        );
     }
 }

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -217,14 +217,19 @@ impl ReasoningParser for GptOssReasoningParser {
                 // `final`/`analysis` chunks immediately; commentary is reconstructed in the
                 // fallback path below because it needs the stripped metadata.
                 let current_recipient = parser.current_recipient();
+                let is_functions_recipient = current_recipient
+                    .as_deref()
+                    .is_some_and(|r| r.starts_with("functions."));
                 match channel.as_str() {
                     "final" => normal_delta.push_str(&delta),
-                    // Recipientless analysis is reasoning. Analysis WITH a
-                    // functions recipient is a (malformed) tool call — defer it
-                    // to the reconstruction path below (like commentary) so its
-                    // payload reaches the tool parser instead of polluting
-                    // reasoning_content.
-                    "analysis" if current_recipient.is_none() => reasoning_delta.push_str(&delta),
+                    // Analysis is reasoning UNLESS it carries a `functions.*`
+                    // recipient — that is a (malformed) directed tool call, which
+                    // we defer to the reconstruction path below (like commentary)
+                    // so its payload reaches the tool parser. Recipientless
+                    // analysis AND analysis directed at non-functions recipients
+                    // (e.g. `to=python`/`to=browser.*` built-in tools) are kept as
+                    // reasoning_content rather than dropped.
+                    "analysis" if !is_functions_recipient => reasoning_delta.push_str(&delta),
                     "analysis" => {}
                     "commentary" => {}
                     _ => {}

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -322,7 +322,7 @@ fn reconstruct_directed_envelope(
 ) -> Option<String> {
     let ch = channel?;
     let is_tool_ch = ch == "commentary"
-        || (ch == "analysis" && recipient.map_or(false, |r| r.starts_with("functions.")));
+        || (ch == "analysis" && recipient.is_some_and(|r| r.starts_with("functions.")));
     if !is_tool_ch {
         return None;
     }
@@ -485,13 +485,12 @@ impl ReasoningParser for GptOssReasoningParser {
             // the recipient — e.g. for short responses split into tiny chunks the
             // `<|call|>` token can be the first token of its own chunk, by which
             // point the live parser recipient is already gone.
-            if let (Some(ch), Some(rec)) = (&current_channel, &current_recipient) {
-                if (ch.as_str() == "commentary" || ch.as_str() == "analysis")
-                    && rec.starts_with("functions.")
-                {
-                    self.last_directed_channel = current_channel.clone();
-                    self.last_directed_recipient = current_recipient.clone();
-                }
+            if let (Some(ch), Some(rec)) = (&current_channel, &current_recipient)
+                && (ch.as_str() == "commentary" || ch.as_str() == "analysis")
+                && rec.starts_with("functions.")
+            {
+                self.last_directed_channel = current_channel.clone();
+                self.last_directed_recipient = current_recipient.clone();
             }
 
             if previous_channel.as_deref() != Some("analysis")
@@ -636,7 +635,7 @@ impl ReasoningParser for GptOssReasoningParser {
                     && parser
                         .current_recipient()
                         .as_deref()
-                        .map_or(false, |r| r.starts_with("functions.")));
+                        .is_some_and(|r| r.starts_with("functions.")));
 
             if is_directed_tool_call {
                 // We are mid directed-tool-call (channel + functions recipient) but

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -7,8 +7,9 @@ use crate::ParserResult;
 use crate::ReasoningParser;
 
 use openai_harmony::StreamableParser;
-use openai_harmony::chat::TextContent;
+use openai_harmony::chat::{Content, Message, TextContent};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, chat::Role, load_harmony_encoding};
+use regex::Regex;
 
 ///// Static initialization of harmony encoder to not affect performance every time a parser is created
 /// This is because load_harmony_encoding downloads some tiktoken files into a directory and we don't want to do this every time we create a parser.
@@ -16,6 +17,18 @@ use std::sync::OnceLock;
 
 static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::Error>> =
     OnceLock::new();
+static HARMONY_CALL_TOKEN_IDS: OnceLock<Vec<u32>> = OnceLock::new();
+static HARMONY_ANALYSIS_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
+const HARMONY_CALL_MARKER: &str = "<|call|>";
+const HARMONY_SPECIAL_TOKENS: &[&str] = &[
+    "<|start|>",
+    "<|end|>",
+    "<|return|>",
+    "<|channel|>",
+    "<|constrain|>",
+    "<|message|>",
+    "<|call|>",
+];
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
     GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
@@ -34,6 +47,19 @@ fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
 
 pub struct GptOssReasoningParser {
     parser: StreamableParser,
+    pending_text: String,
+    pending_tool_call_text: String,
+    emitted_reasoning_text: bool,
+    insert_reasoning_separator: bool,
+    emitted_normal_text: bool,
+    insert_normal_separator: bool,
+    /// Channel/recipient of the directed tool call currently being streamed.
+    /// Persisted across chunks because the `<|call|>` terminator can arrive in a
+    /// later chunk than the one that resolved the recipient (and `<|call|>` resets
+    /// the live parser state), so the `<|call|>`-chunk envelope reconstruction
+    /// would otherwise lose the channel/recipient. Cleared once the call is emitted.
+    last_directed_channel: Option<String>,
+    last_directed_recipient: Option<String>,
 }
 
 /// Implement Debug for GptOssReasoningParser separately because StreamableParser does not implement Debug
@@ -62,7 +88,44 @@ impl GptOssReasoningParser {
                 return Err(anyhow::anyhow!("Failed to load Harmony encoding: {e}"));
             }
         };
-        Ok(Self { parser })
+        Ok(Self {
+            parser,
+            pending_text: String::new(),
+            pending_tool_call_text: String::new(),
+            emitted_reasoning_text: false,
+            insert_reasoning_separator: false,
+            emitted_normal_text: false,
+            insert_normal_separator: false,
+            last_directed_channel: None,
+            last_directed_recipient: None,
+        })
+    }
+
+    // Inherent method (the f1999 `ReasoningParser` trait does not declare
+    // `finish_reasoning_stream`). The serving pipeline never calls it; it exists
+    // for the streaming unit tests to flush any held-back trailing content, so
+    // it reads as dead code on a non-test build.
+    #[allow(dead_code)]
+    fn finish_reasoning_stream(&mut self) -> ParserResult {
+        self.pending_tool_call_text.clear();
+        self.last_directed_channel = None;
+        self.last_directed_recipient = None;
+        let pending = std::mem::take(&mut self.pending_text);
+        if pending.is_empty() {
+            return ParserResult::default();
+        }
+
+        match self.parser.current_channel().as_deref() {
+            Some("analysis") => ParserResult {
+                normal_text: String::new(),
+                reasoning_text: pending,
+            },
+            Some("final") | Some("commentary") => ParserResult {
+                normal_text: pending,
+                reasoning_text: String::new(),
+            },
+            _ => ParserResult::default(),
+        }
     }
 }
 
@@ -73,18 +136,231 @@ fn encode_text_to_tokens(text: &str) -> anyhow::Result<Vec<u32>> {
     Ok(enc.tokenizer().encode_with_special_tokens(text))
 }
 
+fn harmony_call_token_ids() -> Option<&'static [u32]> {
+    let ids = HARMONY_CALL_TOKEN_IDS.get_or_init(|| {
+        get_harmony_encoding()
+            .as_ref()
+            .map(|enc| {
+                enc.tokenizer()
+                    .encode_with_special_tokens(HARMONY_CALL_MARKER)
+            })
+            .unwrap_or_default()
+    });
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids.as_slice())
+    }
+}
+
+/// Token id(s) for the harmony `<|call|>` terminator.
+///
+/// `<|call|>` is simultaneously the harmony tool-call terminator the parser
+/// requires AND a gpt-oss EOS token. Pipelines that hide EOS tokens from the
+/// decoded output (e.g. the preprocessor's stop-condition handling) must keep
+/// these ids visible when the harmony tool-call parser is active — otherwise the
+/// terminator is stripped before the parser sees it and tool calls are silently
+/// dropped. Empty if the harmony encoding is unavailable.
+///
+/// Unused on this base: its caller is the preprocessor stop-token integration,
+/// which is part of the separate stop-token work not included in this
+/// parser-only patch.
+#[allow(dead_code)]
+pub fn harmony_terminator_token_ids() -> Vec<u32> {
+    harmony_call_token_ids()
+        .map(|ids| ids.to_vec())
+        .unwrap_or_default()
+}
+
+fn token_ids_contain_sequence(token_ids: &[u32], marker_ids: &[u32]) -> bool {
+    !marker_ids.is_empty()
+        && marker_ids.len() <= token_ids.len()
+        && token_ids
+            .windows(marker_ids.len())
+            .any(|window| window == marker_ids)
+}
+
+fn harmony_analysis_block_regex() -> &'static Regex {
+    HARMONY_ANALYSIS_BLOCK_REGEX.get_or_init(|| {
+        // Match ONLY recipientless analysis reasoning blocks (the CoT channel).
+        // Requiring `<|message|>` to immediately follow `analysis` (no `.*?`
+        // gap) ensures that `analysis to=functions.X code<|message|>…` tool-call
+        // envelopes are NOT stripped — they must survive into normal_text so
+        // the downstream harmony tool-call jail can recover them.
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>.*?(?:<\|call\|>|<\|end\|>|\z)",
+        )
+            .expect("harmony analysis block regex")
+    })
+}
+
+fn input_contains_call_marker(
+    text: &str,
+    token_ids: &[u32],
+    caller_supplied_token_ids: bool,
+) -> bool {
+    if !token_ids.is_empty()
+        && let Some(call_ids) = harmony_call_token_ids()
+    {
+        return token_ids_contain_sequence(token_ids, call_ids);
+    }
+
+    !caller_supplied_token_ids && text.contains(HARMONY_CALL_MARKER)
+}
+
+fn raw_input_text_for_tool_parser(
+    text: &str,
+    token_ids: &[u32],
+    caller_supplied_token_ids: bool,
+) -> String {
+    if caller_supplied_token_ids && let Ok(enc) = get_harmony_encoding() {
+        return enc.tokenizer().decode_utf8(token_ids).unwrap_or_default();
+    }
+
+    text.to_string()
+}
+
+fn split_incomplete_harmony_suffix(text: &str) -> (&str, &str) {
+    let hold_len = HARMONY_SPECIAL_TOKENS
+        .iter()
+        .flat_map(|token| (1..token.len()).map(|idx| &token[..idx]))
+        .filter(|prefix| text.ends_with(*prefix))
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+
+    text.split_at(text.len() - hold_len)
+}
+
+fn contains_directed_harmony_function_call(text: &str) -> bool {
+    (text.contains("<|channel|>commentary to=functions.")
+        || text.contains("<|channel|>analysis to=functions."))
+        && text.contains(HARMONY_CALL_MARKER)
+}
+
+fn strip_analysis_blocks_for_tool_handoff(text: &str) -> String {
+    harmony_analysis_block_regex()
+        .replace_all(text, "")
+        .into_owned()
+}
+
+fn append_separated(target: &mut String, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    if !target.is_empty() {
+        target.push('\n');
+    }
+    target.push_str(text);
+}
+
+fn append_text_content(target: &mut String, content: &[Content]) {
+    for item in content {
+        if let Content::Text(TextContent { text }) = item {
+            append_separated(target, text);
+        }
+    }
+}
+
+fn append_message_by_channel(reasoning_text: &mut String, normal_text: &mut String, msg: &Message) {
+    match msg.channel.as_deref() {
+        // Analysis WITHOUT a recipient is chain-of-thought reasoning.
+        // Analysis WITH a functions recipient is a (malformed) tool call whose
+        // payload is handed off via strip_analysis_blocks_for_tool_handoff —
+        // do not also surface it as reasoning_content.
+        Some("analysis") if msg.recipient.is_none() => {
+            append_text_content(reasoning_text, &msg.content)
+        }
+        Some("final") => append_text_content(normal_text, &msg.content),
+        Some("commentary") if msg.recipient.is_none() => {
+            append_text_content(normal_text, &msg.content)
+        }
+        _ => {}
+    }
+}
+
+fn append_current_by_channel(
+    reasoning_text: &mut String,
+    normal_text: &mut String,
+    channel: Option<String>,
+    current: String,
+) {
+    match channel.as_deref() {
+        Some("analysis") => append_separated(reasoning_text, &current),
+        Some("final") => append_separated(normal_text, &current),
+        Some("commentary") => append_separated(normal_text, &current),
+        _ => {}
+    }
+}
+
+fn is_visible_normal_channel(channel: Option<&str>, recipient: Option<&str>) -> bool {
+    matches!(channel, Some("final"))
+        || (matches!(channel, Some("commentary")) && recipient.is_none())
+}
+
+fn starts_directed_harmony_tool_call(text: &str) -> bool {
+    text.contains("<|channel|>commentary to=functions.")
+        || text.contains("<|channel|>analysis to=functions.")
+}
+
+/// Reconstruct the complete harmony envelope for the directed tool call that
+/// just terminated, by decoding the cumulative parser token buffer from its
+/// last `<|channel|>` token to the end.
+///
+/// This is the canonical handoff to the downstream tool-call jail: it always
+/// starts exactly at the tool call's `<|channel|>` token, so it (a) survives a
+/// channel header that was split across streaming chunks, and (b) excludes any
+/// leading `<|end|>` / text from a preceding reasoning message that raw
+/// per-chunk accumulation would otherwise prepend (and leak).
+///
+/// Returns `None` when the captured channel is not a directed tool call, when
+/// the harmony encoding is unavailable, or when no `<|channel|>` token is found.
+fn reconstruct_directed_envelope(
+    parser: &StreamableParser,
+    channel: Option<&str>,
+    recipient: Option<&str>,
+) -> Option<String> {
+    let ch = channel?;
+    let is_tool_ch = ch == "commentary"
+        || (ch == "analysis" && recipient.map_or(false, |r| r.starts_with("functions.")));
+    if !is_tool_ch {
+        return None;
+    }
+    let Ok(enc) = get_harmony_encoding() else {
+        return None;
+    };
+    let tokens = parser.tokens();
+    let channel_token_id = enc
+        .tokenizer()
+        .encode_with_special_tokens("<|channel|>")
+        .last()
+        .copied()?;
+    let last_channel_idx = tokens.iter().rposition(|t| *t == channel_token_id)?;
+    let decoded = enc
+        .tokenizer()
+        .decode_utf8(&tokens[last_channel_idx..])
+        .unwrap_or_default();
+    if decoded.is_empty() {
+        None
+    } else {
+        Some(decoded)
+    }
+}
+
 impl ReasoningParser for GptOssReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, token_ids: &[u32]) -> ParserResult {
+        let caller_supplied_token_ids = !token_ids.is_empty();
+        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            let encoded_tokens = match encode_text_to_tokens(text) {
+            encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            &encoded_tokens.to_vec()
+            encoded_tokens.as_slice()
         } else {
             token_ids
         };
@@ -107,70 +383,42 @@ impl ReasoningParser for GptOssReasoningParser {
         let output_msgs = parser.messages();
         tracing::debug!("Parser has {} output messages", output_msgs.len());
 
-        match output_msgs.len() {
-            0 => {
-                tracing::debug!("No output messages, using current content");
-                let current = parser.current_content().unwrap_or_default();
-                tracing::debug!("Current content length: {}", current.len());
-                ParserResult {
-                    normal_text: String::new(),
-                    reasoning_text: current,
-                }
-            }
-            1 => {
-                tracing::debug!("Single output message detected");
-                let mut reasoning_text = String::new();
-                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                    output_msgs[0].content.first()
-                {
-                    reasoning_text.push_str(text);
-                    tracing::debug!("Extracted reasoning text length: {}", reasoning_text.len());
-                }
-                let current = parser.current_content().unwrap_or_default();
-                tracing::debug!("Current content length: {}", current.len());
-                ParserResult {
-                    normal_text: current,
-                    reasoning_text,
-                }
-            }
-            _ => {
-                tracing::debug!("Multiple output messages detected: {}", output_msgs.len());
-                let mut reasoning_text = String::new();
-                let mut normal_text = String::new();
+        let mut reasoning_text = String::new();
+        let mut normal_text = String::new();
+        for msg in output_msgs {
+            append_message_by_channel(&mut reasoning_text, &mut normal_text, msg);
+        }
 
-                // Loop until second last message
-                for (i, parse_msg) in output_msgs.iter().take(output_msgs.len() - 1).enumerate() {
-                    tracing::debug!("Processing reasoning message {}", i + 1);
-                    if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                        parse_msg.content.first()
-                    {
-                        reasoning_text.push_str(text);
-                        tracing::debug!("Added {} chars to reasoning text", text.len());
-                    }
-                }
+        let current = parser.current_content().unwrap_or_default();
+        let current_channel = parser.current_channel();
+        if current_channel.as_deref() != Some("commentary") || parser.current_recipient().is_none()
+        {
+            append_current_by_channel(
+                &mut reasoning_text,
+                &mut normal_text,
+                current_channel,
+                current,
+            );
+        }
 
-                let last_msg = &output_msgs[output_msgs.len() - 1];
-                tracing::debug!("Processing final message");
+        let raw_input_text =
+            raw_input_text_for_tool_parser(text, token_ids, caller_supplied_token_ids);
+        if contains_directed_harmony_function_call(&raw_input_text) {
+            // The serving pipeline feeds reasoning normal_text into the Harmony
+            // tool parser. Keep directed commentary envelopes intact so tool
+            // calls are not silently dropped.
+            normal_text = strip_analysis_blocks_for_tool_handoff(&raw_input_text);
+        }
 
-                // Handle the last message
-                if let Some(openai_harmony::chat::Content::Text(TextContent { text })) =
-                    last_msg.content.first()
-                {
-                    normal_text.push_str(text);
-                    tracing::debug!("Added {} chars to normal text", text.len());
-                }
+        tracing::debug!(
+            "Final result - normal_text: {} chars, reasoning_text: {} chars",
+            normal_text.len(),
+            reasoning_text.len()
+        );
 
-                tracing::debug!(
-                    "Final result - normal_text: {} chars, reasoning_text: {} chars",
-                    normal_text.len(),
-                    reasoning_text.len()
-                );
-
-                ParserResult {
-                    normal_text,
-                    reasoning_text,
-                }
-            }
+        ParserResult {
+            normal_text,
+            reasoning_text,
         }
     }
 
@@ -179,16 +427,34 @@ impl ReasoningParser for GptOssReasoningParser {
         text: &str,
         token_ids: &[u32],
     ) -> ParserResult {
+        let caller_supplied_token_ids = !token_ids.is_empty();
+        let text_to_process;
+        let text = if caller_supplied_token_ids {
+            text
+        } else {
+            self.pending_text.push_str(text);
+            let combined = std::mem::take(&mut self.pending_text);
+            let (ready, pending) = split_incomplete_harmony_suffix(&combined);
+            self.pending_text.push_str(pending);
+            text_to_process = ready.to_string();
+            text_to_process.as_str()
+        };
+
+        if text.is_empty() && token_ids.is_empty() {
+            return ParserResult::default();
+        }
+
+        let encoded_tokens;
         let token_ids = if token_ids.is_empty() {
             // WAR: Since we are moving to just text based reasoning parsing, converting to token_ids now using harmony encoding
-            let encoded_tokens = match encode_text_to_tokens(text) {
+            encoded_tokens = match encode_text_to_tokens(text) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     tracing::warn!("Failed to encode Harmony tokens: {err}");
                     return ParserResult::default();
                 }
             };
-            &encoded_tokens.to_vec()
+            encoded_tokens.as_slice()
         } else {
             token_ids
         };
@@ -204,24 +470,151 @@ impl ReasoningParser for GptOssReasoningParser {
                 token_ids.len(),
                 token_id
             );
+            let previous_channel = parser.current_channel();
+            let previous_recipient = parser.current_recipient();
             if let Err(e) = parser.process(*token_id) {
                 tracing::warn!("Harmony parse error for token_id {token_id}: {e}");
                 return ParserResult::default();
             }
+            let current_channel = parser.current_channel();
+            let current_recipient = parser.current_recipient();
+
+            // Persist directed tool-call context before `<|call|>` can reset it.
+            // This is stored on `self` (not a local) because the `<|call|>`
+            // terminator can arrive in a later chunk than the one that resolved
+            // the recipient — e.g. for short responses split into tiny chunks the
+            // `<|call|>` token can be the first token of its own chunk, by which
+            // point the live parser recipient is already gone.
+            if let (Some(ch), Some(rec)) = (&current_channel, &current_recipient) {
+                if (ch.as_str() == "commentary" || ch.as_str() == "analysis")
+                    && rec.starts_with("functions.")
+                {
+                    self.last_directed_channel = current_channel.clone();
+                    self.last_directed_recipient = current_recipient.clone();
+                }
+            }
+
+            if previous_channel.as_deref() != Some("analysis")
+                && current_channel.as_deref() == Some("analysis")
+                && self.emitted_reasoning_text
+            {
+                self.insert_reasoning_separator = true;
+            }
+
+            if is_visible_normal_channel(current_channel.as_deref(), current_recipient.as_deref())
+                && !is_visible_normal_channel(
+                    previous_channel.as_deref(),
+                    previous_recipient.as_deref(),
+                )
+                && self.emitted_normal_text
+            {
+                self.insert_normal_separator = true;
+            }
 
             if let (Some(delta), Some(channel)) = (
                 parser.last_content_delta().unwrap_or_default(),
-                parser.current_channel(),
+                current_channel,
             ) {
-                // `last_content_delta` only exposes the newest token slice, so we forward
-                // `final`/`analysis` chunks immediately; commentary is reconstructed in the
-                // fallback path below because it needs the stripped metadata.
+                // `last_content_delta` only exposes the newest token slice, so directed
+                // commentary still falls through to the raw handoff path for tool parsing.
                 match channel.as_str() {
-                    "final" => normal_delta.push_str(&delta),
-                    "analysis" => reasoning_delta.push_str(&delta),
-                    "commentary" => {}
+                    "final" => {
+                        if self.insert_normal_separator {
+                            normal_delta.push('\n');
+                            self.insert_normal_separator = false;
+                        }
+                        normal_delta.push_str(&delta);
+                        self.emitted_normal_text = true;
+                    }
+                    "analysis" => {
+                        // Analysis WITHOUT a recipient is reasoning content.
+                        // Analysis WITH a functions recipient is a (malformed)
+                        // tool call — its payload is handed off via normal_delta
+                        // below; do not also surface it as reasoning_content.
+                        if current_recipient.is_none() {
+                            if self.insert_reasoning_separator {
+                                reasoning_delta.push('\n');
+                                self.insert_reasoning_separator = false;
+                            }
+                            reasoning_delta.push_str(&delta);
+                            self.emitted_reasoning_text = true;
+                        }
+                    }
+                    "commentary" => {
+                        if current_recipient.is_none() {
+                            if self.insert_normal_separator {
+                                normal_delta.push('\n');
+                                self.insert_normal_separator = false;
+                            }
+                            normal_delta.push_str(&delta);
+                            self.emitted_normal_text = true;
+                        }
+                    }
                     _ => {}
                 }
+            }
+        }
+
+        let has_call_marker =
+            input_contains_call_marker(text, token_ids, caller_supplied_token_ids);
+        let raw_input_text = if has_call_marker
+            || !self.pending_tool_call_text.is_empty()
+            || starts_directed_harmony_tool_call(text)
+        {
+            Some(raw_input_text_for_tool_parser(
+                text,
+                token_ids,
+                caller_supplied_token_ids,
+            ))
+        } else {
+            None
+        };
+
+        if let Some(raw_input_text) = raw_input_text {
+            // Streaming feeds the downstream Harmony tool parser through
+            // `normal_text`. This is an internal handoff, not visible-content
+            // semantics: directed commentary/analysis tool payloads must become
+            // tool calls, not assistant `content`.
+            if has_call_marker {
+                // The tool call terminated in this chunk. Reconstruct the complete,
+                // clean envelope from the cumulative parser token buffer (it starts
+                // exactly at the tool call's `<|channel|>` token). This both handles
+                // a channel header that was split across chunks AND supersedes any
+                // raw text accumulated in `pending_tool_call_text` — which can carry
+                // a leading `<|end|>` (and other markup) from a preceding reasoning
+                // message that would otherwise leak into `response_text`.
+                //
+                // `parser.current_channel()` is None here because `<|call|>` resets
+                // the parser state, so we use the channel/recipient persisted on
+                // `self` during the per-token loop (possibly from a prior chunk).
+                let reconstructed = reconstruct_directed_envelope(
+                    parser,
+                    self.last_directed_channel.as_deref(),
+                    self.last_directed_recipient.as_deref(),
+                );
+                match reconstructed {
+                    Some(env) => {
+                        self.pending_tool_call_text.clear();
+                        normal_delta.push_str(&env);
+                    }
+                    None if !self.pending_tool_call_text.is_empty() => {
+                        // Fallback: no clean reconstruction available; flush the
+                        // accumulated raw text plus this chunk.
+                        self.pending_tool_call_text.push_str(&raw_input_text);
+                        normal_delta.push_str(&std::mem::take(&mut self.pending_tool_call_text));
+                    }
+                    None => normal_delta.push_str(&raw_input_text),
+                }
+                // The directed tool call terminated; clear the persisted context so
+                // the next call (or trailing reasoning) starts fresh.
+                self.last_directed_channel = None;
+                self.last_directed_recipient = None;
+            } else if !self.pending_tool_call_text.is_empty()
+                || starts_directed_harmony_tool_call(&raw_input_text)
+            {
+                // Mid tool call, terminator not yet seen: keep accumulating as a
+                // fallback (e.g. truncated streams that never emit `<|call|>`).
+                self.pending_tool_call_text.push_str(&raw_input_text);
             }
         }
 
@@ -238,61 +631,35 @@ impl ReasoningParser for GptOssReasoningParser {
         }
 
         if let Some(channel) = parser.current_channel() {
-            if channel == "commentary" {
-                tracing::debug!("In commentary channel, recovering full content");
-                // If we're in the commentary channel, we should return raw token content and recover content that has been consumed by the parser
-                // so that the tool parser can process it properly
-                if let Ok(enc) = get_harmony_encoding() {
-                    let current_content = parser.current_content().unwrap_or_default();
-                    let mut final_text = text.to_string();
+            let is_directed_tool_call = channel == "commentary"
+                || (channel == "analysis"
+                    && parser
+                        .current_recipient()
+                        .as_deref()
+                        .map_or(false, |r| r.starts_with("functions.")));
 
-                    // Restore commentary metadata consumed by the parser so the tool-call parser can
-                    // process it correctly.
-                    //
-                    // Example:
-                    //   Before parsing:
-                    //   "<|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{\"format\":\"celsius\",\"location\":\"San Francisco\"}<|call|>"
-                    //   After parsing, the header is stripped, so we must reconstruct it:
-                    //   "<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>"
-                    //
-                    // This ensures downstream tool-call parsing receives the channel, target, and
-                    // constraint metadata together with the message payload.
-
-                    // Recovery should only happen once, and only when `current_content` is empty.
-                    if current_content.is_empty() {
-                        let tokens = parser.tokens();
-
-                        // Get the token id for " <|channel|>"
-                        let channel_token_id = enc
-                            .tokenizer()
-                            .encode_with_special_tokens("<|channel|>")
-                            .last()
-                            .copied();
-
-                        // Find the last occurrence of the <|channel|> token (id 20005) in the tokens vector
-                        let last_channel_token_idx = channel_token_id
-                            .and_then(|token_id| {
-                                tokens.iter().rposition(|token| *token == token_id)
-                            })
-                            .unwrap_or(0);
-
-                        // Then get the generated text from the last <|channel|> to the end of parser.tokens()
-                        let end_token_idx = parser.tokens().len();
-                        // Use Harmony's decode_utf8 to decode tokens into text
-                        let generated_text = enc
-                            .tokenizer()
-                            .decode_utf8(&parser.tokens()[last_channel_token_idx..end_token_idx])
-                            .unwrap_or_default();
-
-                        final_text = generated_text;
-                    }
-
-                    return ParserResult {
-                        normal_text: final_text,
-                        reasoning_text: String::new(),
-                    };
-                }
-            } else {
+            if is_directed_tool_call {
+                // We are mid directed-tool-call (channel + functions recipient) but
+                // produced no delta this chunk. Emit NOTHING here:
+                //
+                //  * A complete tool call is reconstructed in full — header, message
+                //    and `<|call|>` together — from the cumulative token buffer on
+                //    the `<|call|>` chunk (the `has_call_marker` branch above). Any
+                //    emission here would be a redundant partial: a bare header (when
+                //    a chunk boundary lands at `<|message|>`) or a header-less body
+                //    fragment, neither of which the downstream jail can assemble into
+                //    a tool call — they only leak raw harmony markup into
+                //    `response_text`.
+                //  * A truncated tool call that never emits `<|call|>` has no complete
+                //    envelope to recover, so emitting its partial header would leak
+                //    too. Suppressing loses nothing recoverable.
+                tracing::debug!(
+                    "In directed tool-call channel ({channel}); suppressing partial mid-stream \
+                     content (complete envelope is recovered on the <|call|> chunk)"
+                );
+            } else if channel != "analysis" {
+                // Pure analysis reasoning (no recipient) is expected to be silent here —
+                // it was already emitted to reasoning_delta in the per-token loop.
                 tracing::warn!("Shouldn't be delta content after in channel: {}", channel);
             }
         }
@@ -305,7 +672,7 @@ impl ReasoningParser for GptOssReasoningParser {
 mod tests {
     use super::*;
 
-    #[test] // REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let text = "<|channel|>analysis<|message|>The user asks a simple factual question: capital of Brazil. The answer is Brasília. No additional explanation needed.<|end|><|start|>assistant<|channel|>final<|message|>The capital of Brazil is Brasília.";
@@ -317,7 +684,64 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.batch.4
+    fn test_gpt_oss_final_channel_without_analysis_is_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser.detect_and_parse_reasoning("<|channel|>final<|message|>answer", &[]);
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "answer");
+    }
+
+    #[test] // REASONING.batch.6.a
+    fn test_gpt_oss_multiple_analysis_spans_join_before_final() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>first<|end|><|start|>assistant<|channel|>analysis<|message|>second<|end|><|start|>assistant<|channel|>final<|message|>done";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "first\nsecond");
+        assert_eq!(result.normal_text, "done");
+    }
+
+    #[test]
+    fn test_gpt_oss_directed_commentary_is_tool_parser_handoff() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "think");
+        assert_eq!(
+            result.normal_text,
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+        );
+    }
+
+    #[test]
+    fn test_gpt_oss_analysis_call_does_not_swallow_commentary_handoff() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        // An analysis-channel message WITH a `to=functions.` recipient is a
+        // (malformed) directed tool call, not chain-of-thought: its args are NOT
+        // leaked to reasoning_text.
+        assert_eq!(result.reasoning_text, "");
+        // Both directed tool-call envelopes (the analysis `search` call and the
+        // commentary `get_weather` call) plus the final message are handed off
+        // intact to the downstream tool-call jail — the analysis call no longer
+        // swallows or strips the commentary handoff.
+        assert_eq!(
+            result.normal_text,
+            "<|channel|>analysis to=functions.search <|constrain|>json<|message|>{\"q\":\"x\"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|><|start|>assistant<|channel|>final<|message|>It is sunny."
+        );
+    }
+
+    #[test]
+    fn test_gpt_oss_recipientless_commentary_is_normal_text() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant<|channel|>final<|message|>Done.";
+        let result = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "I will check that.\nDone.");
+    }
+
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let chunks = vec![
@@ -341,7 +765,107 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.stream.3.b
+    fn test_gpt_oss_reasoning_parser_streaming_split_end_marker() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis<|message|>thinking<|e",
+            "nd|><|start|>assistant<|channel|>final<|message|>answer",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "thinking");
+        assert_eq!(normal_text_incr, "answer");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_flushes_pending_suffix_on_finish() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser.parse_reasoning_streaming_incremental(
+            "<|channel|>analysis<|message|>thinking<|e",
+            &[],
+        );
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(result.reasoning_text, "thinking");
+        assert_eq!(finish.reasoning_text, "<|e");
+        assert_eq!(finish.normal_text, "");
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(finish.reasoning_text, "");
+        assert_eq!(finish.normal_text, "");
+
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let result = parser
+            .parse_reasoning_streaming_incremental("<|channel|>final<|message|>answer<|e", &[]);
+        let finish = parser.finish_reasoning_stream();
+        assert_eq!(result.normal_text, "answer");
+        assert_eq!(finish.normal_text, "<|e");
+        assert_eq!(finish.reasoning_text, "");
+    }
+
+    #[test] // REASONING.stream.2.b
+    fn test_gpt_oss_reasoning_parser_streaming_multiple_analysis_spans() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>analysis<|message|>first<|end|><|start|>assistant",
+            "<|channel|>analysis<|message|>second<|end|><|start|>assistant",
+            "<|channel|>final<|message|>done",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "first\nsecond");
+        assert_eq!(normal_text_incr, "done");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_recipientless_commentary() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>commentary<|message|>I will check that.<|end|><|start|>assistant",
+            "<|channel|>final<|message|>Done.",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert_eq!(normal_text_incr, "I will check that.\nDone.");
+    }
+
+    #[test]
+    fn test_gpt_oss_reasoning_parser_streaming_split_directed_commentary() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let chunks = vec![
+            "<|channel|>commentary to=functions.get_",
+            "weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>",
+        ];
+        let mut reasoning_text_incr = String::new();
+        let mut normal_text_incr = String::new();
+        for chunk in chunks {
+            let result = parser.parse_reasoning_streaming_incremental(chunk, &[]);
+            normal_text_incr.push_str(&result.normal_text);
+            reasoning_text_incr.push_str(&result.reasoning_text);
+        }
+        assert_eq!(reasoning_text_incr, "");
+        assert_eq!(
+            normal_text_incr,
+            "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"city\":\"SF\"}<|call|>"
+        );
+    }
+
+    #[test] // REASONING.stream.2.a, REASONING.batch.2.c, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_chunked() {
         let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
         let enc = get_harmony_encoding()
@@ -370,7 +894,7 @@ mod tests {
         );
     }
 
-    #[test] // REASONING.stream.3, REASONING.batch.1, PARSER.harmony.1
+    #[test] // REASONING.batch.3.a, TOOLCALLING.harmony.1
     fn test_gpt_oss_reasoning_parser_streaming_variable_length_chunks() {
         let text = "<|channel|>analysis<|message|>User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>{}";
         let enc = get_harmony_encoding()
@@ -392,11 +916,13 @@ mod tests {
                 reasoning_text_incr,
                 "User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function."
             );
-            // [gluo TODO] missing "<|start|>assistant" and "{}" from original message
-            assert_eq!(
-                normal_text_incr,
-                "<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>"
-            );
+            // This input is a TRUNCATED tool call: it ends at `<|message|>{}` with
+            // no `<|call|>` terminator. A complete directed tool call is handed off
+            // to the jail in one piece (header + body + `<|call|>`) on the `<|call|>`
+            // chunk; without a terminator there is no complete envelope to recover,
+            // so the streaming parser emits no normal_text rather than leaking a
+            // partial `<|channel|>…<|message|>` header.
+            assert_eq!(normal_text_incr, "");
         }
 
         // Send token in chunks (chunking obtained from actual model output)
@@ -430,10 +956,32 @@ mod tests {
                 reasoning_text_incr,
                 "User asks: \"Hey, quick check: is everything up and running?\" We should check system health using the provided function get_system_health. Use function."
             );
-            assert_eq!(
-                normal_text_incr,
-                "<|channel|>commentary to=functions.get_system_health <|constrain|>json<|message|>"
-            );
+            // Truncated tool call (no `<|call|>`): no complete envelope to recover,
+            // so no normal_text is emitted (see the token-by-token block above).
+            assert_eq!(normal_text_incr, "");
         }
+    }
+
+    // NOTE: the corpus-characterization tests that ran captured dynamo.trtllm
+    // output through this parser (`reasoning_characterize_corpus_markup_leak`,
+    // `reasoning_parser_leaks_harmony_markup`) are intentionally omitted here —
+    // they `include_str!` private capture data that cannot be shared. The
+    // malformed analysis-channel frame they exercised is covered synthetically
+    // by `test_gpt_oss_analysis_call_does_not_swallow_commentary_handoff` and
+    // the control test below.
+
+    /// Control: a well-formed analysis+final stream splits cleanly with no
+    /// markup in either field (harness/encoding sanity).
+    #[test]
+    fn reasoning_control_wellformed_no_markup() {
+        let mut parser = GptOssReasoningParser::new().expect("Failed to create parser");
+        let text = "<|channel|>analysis<|message|>Think about it.<|end|><|start|>assistant<|channel|>final<|message|>Answer.";
+        let r = parser.detect_and_parse_reasoning(text, &[]);
+        assert_eq!(r.reasoning_text, "Think about it.");
+        assert_eq!(r.normal_text, "Answer.");
+        assert!(
+            !r.reasoning_text.contains("<|") && !r.normal_text.contains("<|"),
+            "well-formed stream must not retain markup"
+        );
     }
 }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -417,14 +417,13 @@ pub async fn parse_tool_calls_harmony_complete(
                     arguments: args_json,
                 },
             });
-        } else if channel == Some("commentary")
-            && recipient.is_empty()
-            && !(has_recipientless_commentary_call
-                && (message.content_type.as_deref() == Some("<|constrain|>json")
-                    || content_looks_like_json(&message.content)))
+        } else if channel == Some("final")
+            || (channel == Some("commentary")
+                && recipient.is_empty()
+                && !(has_recipientless_commentary_call
+                    && (message.content_type.as_deref() == Some("<|constrain|>json")
+                        || content_looks_like_json(&message.content))))
         {
-            push_harmony_text(&mut normal_text, &message.content);
-        } else if channel == Some("final") {
             push_harmony_text(&mut normal_text, &message.content);
         }
     }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -2,272 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ToolDefinition;
+use super::super::json::base_json_parser::try_repair_truncated_json;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
-use openai_harmony::chat::{Content, Role};
+use openai_harmony::chat::{Content::Text, Role};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding};
-use regex::{Captures, Regex};
+use regex::Regex;
 use serde_json::Value;
 use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
-static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
-static COMMENTARY_HEADER_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
-static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
-static FINAL_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
-static MESSAGE_CALL_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
-static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
 /// input — alternative on this path is silent-drop. Worst case is missing
-/// a call, never fabricating one: Harmony tool calls must end with `<|call|>`.
-///
-/// Matches tool calls on either `commentary` or `analysis` channel: the model
-/// emits ~47% of tool calls on the `analysis` channel with a bare `code`
-/// constraint marker instead of `<|constrain|>json`. The `.*?` non-greedy span
-/// between the recipient and `<|message|>` already tolerates any constraint
-/// marker form (`code`, `<|constrain|>json`, or nothing).
+/// a call, never fabricating one (full structural signature required).
 fn commentary_block_regex() -> &'static Regex {
     COMMENTARY_BLOCK_REGEX.get_or_init(|| {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
         // Between name and `<|message|>` we tolerate optional
-        // `<|constrain|>json`, bare `code`, or nothing (non-greedy `.*?`).
-        // Args must end at `<|call|>`, the required Harmony tool-call stop token.
+        // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
+        // Args end at either `<|call|>` (normal close) or end-of-string
+        // (`\z`, the bare-envelope PARSER.batch.5 variant where the model never
+        // emitted `<|call|>` before EOS / max_tokens).
+        // A `to=functions.X` recipient is the real tool-call signal regardless of
+        // channel: gpt-oss/trtllm emits a large fraction of calls on the
+        // `analysis` channel (with a bare `code` constraint) instead of the
+        // canonical `commentary`. Match either; the `.*?` already tolerates the
+        // optional ` code` / ` <|constrain|>json` between recipient and message.
         Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>(?:commentary|analysis) to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
+            r"(?s)<\|channel\|>(?:commentary|analysis) to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
         )
         .expect("commentary block regex")
     })
 }
 
-fn commentary_block_cleanup_regex() -> &'static Regex {
-    COMMENTARY_BLOCK_CLEANUP_REGEX.get_or_init(|| {
-        Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*?<\|message\|>.*?(?:<\|call\|>|\z)",
-        )
-        .expect("commentary block cleanup regex")
-    })
-}
-
-fn commentary_header_cleanup_regex() -> &'static Regex {
-    COMMENTARY_HEADER_CLEANUP_REGEX.get_or_init(|| {
-        Regex::new(
-            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*\z",
-        )
-        .expect("commentary header cleanup regex")
-    })
-}
-
-fn analysis_block_cleanup_regex() -> &'static Regex {
-    ANALYSIS_BLOCK_CLEANUP_REGEX.get_or_init(|| {
-        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>(?P<body>.*?)(?:<\|end\|>|\z)")
-            .expect("analysis block cleanup regex")
-    })
-}
-
-fn final_block_cleanup_regex() -> &'static Regex {
-    FINAL_BLOCK_CLEANUP_REGEX.get_or_init(|| {
-        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>final<\|message\|>(?P<body>.*?)(?:<\|return\|>|<\|end\|>|\z)")
-            .expect("final block cleanup regex")
-    })
-}
-
-fn message_call_cleanup_regex() -> &'static Regex {
-    MESSAGE_CALL_CLEANUP_REGEX.get_or_init(|| {
-        Regex::new(r"(?s)<\|message\|>.*?(?:<\|call\|>|\z)").expect("message call cleanup regex")
-    })
-}
-
-fn special_token_regex() -> &'static Regex {
-    SPECIAL_TOKEN_REGEX.get_or_init(|| {
-        Regex::new(r"<\|(?:start|channel|constrain|message|call|end|return)\|>")
-            .expect("special token cleanup regex")
-    })
-}
-
-fn push_unique(items: &mut Vec<String>, item: String) {
-    if !items.iter().any(|existing| existing == &item) {
-        items.push(item);
-    }
-}
-
-fn record_special_tokens(text: &str, items: &mut Vec<String>) {
-    for m in special_token_regex().find_iter(text) {
-        push_unique(items, format!("special_token:{}", m.as_str()));
-    }
-}
-
-fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> String {
-    let mut stripped = Vec::new();
-
-    let cleaned = commentary_block_cleanup_regex()
-        .replace_all(text, |caps: &Captures<'_>| {
-            record_special_tokens(&caps[0], &mut stripped);
-            let item = match caps.name("name").map(|m| m.as_str()) {
-                Some(name) => format!("commentary_tool_call:functions.{name}"),
-                None => "commentary_tool_call:missing_recipient".to_string(),
-            };
-            push_unique(&mut stripped, item);
-            ""
-        })
-        .into_owned();
-
-    let cleaned = commentary_header_cleanup_regex()
-        .replace_all(&cleaned, |caps: &Captures<'_>| {
-            record_special_tokens(&caps[0], &mut stripped);
-            let item = match caps.name("name").map(|m| m.as_str()) {
-                Some(name) => format!("commentary_tool_call_without_message:functions.{name}"),
-                None => "commentary_tool_call_without_message:missing_recipient".to_string(),
-            };
-            push_unique(&mut stripped, item);
-            ""
-        })
-        .into_owned();
-
-    let cleaned = analysis_block_cleanup_regex()
-        .replace_all(&cleaned, |caps: &Captures<'_>| {
-            record_special_tokens(&caps[0], &mut stripped);
-            push_unique(&mut stripped, "analysis_envelope".to_string());
-            ""
-        })
-        .into_owned();
-
-    let cleaned = final_block_cleanup_regex()
-        .replace_all(&cleaned, |caps: &Captures<'_>| {
-            record_special_tokens(&caps[0], &mut stripped);
-            push_unique(&mut stripped, "final_envelope".to_string());
-            caps.name("body")
-                .map(|m| m.as_str())
-                .unwrap_or_default()
-                .to_string()
-        })
-        .into_owned();
-
-    let cleaned = message_call_cleanup_regex()
-        .replace_all(&cleaned, |caps: &Captures<'_>| {
-            record_special_tokens(&caps[0], &mut stripped);
-            push_unique(&mut stripped, "message_call_payload".to_string());
-            ""
-        })
-        .into_owned();
-
-    let cleaned = special_token_regex()
-        .replace_all(&cleaned, |caps: &Captures<'_>| {
-            push_unique(&mut stripped, format!("special_token:{}", &caps[0]));
-            ""
-        })
-        .into_owned();
-
-    if stripped.is_empty() {
-        return text.to_string();
-    }
-
-    let cleaned = cleaned.trim().to_string();
-
-    tracing::warn!(
-        family = "harmony",
-        reason,
-        stripped = ?stripped,
-        original_len = text.len(),
-        cleaned_len = cleaned.len(),
-        "stripped harmony protocol content from normal_text"
-    );
-
-    cleaned
-}
-
-fn normal_text_after_parse_failure(text: &str, reason: &'static str) -> String {
-    let cleaned = strip_harmony_protocol_from_normal_text(text, reason);
-    if cleaned == text && !text.trim().is_empty() {
-        tracing::warn!(
-            family = "harmony",
-            reason,
-            original_len = text.len(),
-            "dropped bare text without a Harmony final/commentary message"
-        );
-        String::new()
-    } else {
-        cleaned
-    }
-}
-
-fn serialize_harmony_arguments(raw_args: &str) -> String {
-    let trimmed = raw_args.trim();
-    match serde_json::from_str::<Value>(trimmed) {
-        Ok(value) => serde_json::to_string(&value).unwrap_or_else(|_| trimmed.to_string()),
-        Err(_) => trimmed.to_string(),
-    }
-}
-
-fn push_harmony_text(out: &mut String, content: &[Content]) {
-    for item in content {
-        if let Content::Text(text) = item {
-            out.push_str(&text.text);
-        }
-    }
-}
-
-fn content_looks_like_json(content: &[Content]) -> bool {
-    content.iter().any(|item| match item {
-        Content::Text(text) => {
-            matches!(text.text.trim_start().as_bytes().first(), Some(b'{' | b'['))
-        }
-        _ => false,
-    })
-}
-
-fn contains_recipientless_commentary_call(text: &str) -> bool {
-    let channel_marker = "<|channel|>commentary";
-    let message_marker = "<|message|>";
-    let call_marker = "<|call|>";
-    let boundaries = ["<|end|>", "<|return|>", "<|start|>", "<|channel|>"];
-
-    let mut remaining = text;
-    while let Some(channel_start) = remaining.find(channel_marker) {
-        let after_channel = &remaining[channel_start + channel_marker.len()..];
-        let Some(message_start) = after_channel.find(message_marker) else {
-            return false;
-        };
-
-        let header = &after_channel[..message_start];
-        let after_message = &after_channel[message_start + message_marker.len()..];
-        remaining = after_message;
-
-        if header
-            .split_whitespace()
-            .any(|part| part.starts_with("to="))
-        {
-            continue;
-        }
-
-        let Some(call_start) = after_message.find(call_marker) else {
-            continue;
-        };
-
-        let next_boundary = boundaries
-            .iter()
-            .filter_map(|boundary| after_message.find(boundary))
-            .min();
-
-        match next_boundary {
-            Some(boundary) if call_start >= boundary => {}
-            _ => return true,
-        };
-    }
-
-    false
-}
-
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
 /// (truncated JSON, multiple back-to-back commentary blocks, etc.).
 /// Returns (calls, residual_text) where residual_text is everything not
-/// consumed by a matched commentary block — preserved so non-tool user-visible
-/// spans aren't dropped.
+/// consumed by a matched commentary block — preserved so analysis prose and
+/// non-tool suffixes aren't dropped.
 fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
     let mut residual = String::new();
     let mut cursor = 0;
-    for cap in commentary_block_regex().captures_iter(text) {
+    for (i, cap) in commentary_block_regex().captures_iter(text).enumerate() {
         let m = cap.get(0).expect("regex match has full span");
         residual.push_str(&text[cursor..m.start()]);
         cursor = m.end();
@@ -277,10 +55,17 @@ fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
         if name.is_empty() {
             continue;
         }
-        let args_json = serialize_harmony_arguments(raw_args);
-        let call_idx = out.len() + 1;
+        let args_json = match serde_json::from_str::<Value>(raw_args) {
+            Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
+            Err(_) => match try_repair_truncated_json(raw_args)
+                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
+            {
+                Some(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
+                None => raw_args.to_string(),
+            },
+        };
         out.push(ToolCallResponse {
-            id: format!("call-{call_idx}"),
+            id: format!("call-{}", i + 1),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name: name.to_string(),
@@ -320,9 +105,9 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// or token-by-token streaming, making it more efficient for complete chunks.
 ///
 /// # Arguments
-/// * `text` - The full Harmony-format string to be parsed, including required Harmony stop tokens.
+/// * `text` - The full Harmony-format string to be parsed, excluding any trailing stop tokens.
 ///   Example:
-///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>`
+///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}`
 /// * `_config` - Parser configuration (currently unused but kept for API consistency)
 ///
 /// # Returns
@@ -330,15 +115,14 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// * `Err(e)` - If parsing fails due to encoding or tokenization errors
 pub async fn parse_tool_calls_harmony_complete(
     text: &str,
-    _config: &JsonParserConfig,
+    config: &JsonParserConfig,
     _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let enc = match get_harmony_encoding().await.as_ref() {
         Ok(e) => e,
         Err(e) => {
             tracing::debug!("Failed to load harmony encoding: {e}. Tool calls will not be parsed.");
-            let normal_text = normal_text_after_parse_failure(text, "harmony_encoding_unavailable");
-            return Ok((vec![], Some(normal_text)));
+            return Ok((vec![], Some(text.to_string())));
         }
     };
 
@@ -350,29 +134,24 @@ pub async fn parse_tool_calls_harmony_complete(
             tracing::debug!(
                 "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
-            // Recovery: harmony rejects parallel commentary blocks even when
-            // every call is explicitly closed. Only EOF/truncated recovery is
-            // gated, so streaming jails do not synthesize incomplete calls.
-            // Harmony differs from generic JSON/XML recovery: a tool call is
-            // complete only once `<|call|>` is present. Do not synthesize a
-            // call from EOF; that would diverge from vLLM/openai_harmony.
-            let (calls, residual) = extract_calls_via_regex(text);
-            if !calls.is_empty() {
-                let normal_text =
-                    strip_harmony_protocol_from_normal_text(&residual, "regex_recovery_residual");
-                return Ok((calls, Some(normal_text)));
+            // Recovery: harmony rejects parallel commentary blocks and
+            // truncated JSON. Gated on `allow_eof_recovery` so streaming
+            // jails (where the tokenizer often rejects mid-chunk before all
+            // tokens have arrived) don't extract a partial call.
+            if config.allow_eof_recovery {
+                let (calls, residual) = extract_calls_via_regex(text);
+                if !calls.is_empty() {
+                    return Ok((calls, Some(residual)));
+                }
             }
-            let normal_text =
-                normal_text_after_parse_failure(text, "parse_failed_no_recovered_calls");
-            return Ok((vec![], Some(normal_text)));
+            return Ok((vec![], Some(text.to_string())));
         }
     };
 
+    let mut normal_text = String::new();
+
     let mut res = Vec::with_capacity(messages.len());
     let mut call_idx = 0; // Index of the tool call
-    let mut normal_text = String::new();
-    let has_tool_call_stop = text.contains("<|call|>");
-    let has_recipientless_commentary_call = contains_recipientless_commentary_call(text);
 
     for message in messages.iter() {
         if message.author.role != Role::Assistant {
@@ -382,15 +161,12 @@ pub async fn parse_tool_calls_harmony_complete(
         let channel = message.channel.as_deref();
         let recipient = message.recipient.as_deref().unwrap_or_default();
 
-        // A `to=functions.NAME` recipient is the definitive signal of a tool
-        // call, regardless of channel label. The model emits tool calls on both
-        // `commentary` (canonical) and `analysis` (malformed-but-common) channels.
-        let is_tool_channel = channel == Some("commentary") || channel == Some("analysis");
-        if is_tool_channel && recipient.starts_with("functions.") {
-            if !has_tool_call_stop {
-                continue;
-            }
-
+        // A directed call (to=functions.*) is a tool call regardless of channel.
+        // gpt-oss/trtllm emits many calls on the `analysis` channel instead of
+        // the canonical `commentary`; key on the recipient, not the label.
+        let is_directed_tool_call = recipient.starts_with("functions.")
+            && matches!(channel, Some("commentary") | Some("analysis"));
+        if is_directed_tool_call {
             let Some(fname) = message
                 .recipient
                 .as_ref()
@@ -401,33 +177,49 @@ pub async fn parse_tool_calls_harmony_complete(
                 continue;
             };
 
-            let Some(args_json) = message.content.first().and_then(|content| match content {
-                Content::Text(text) => Some(serialize_harmony_arguments(&text.text)),
-                _ => None,
-            }) else {
-                continue;
+            let args = match message.content.first() {
+                Some(Text(text)) => {
+                    let trimmed = text.text.trim();
+                    match serde_json::from_str::<Value>(trimmed) {
+                        Ok(value) => value,
+                        Err(_) if config.allow_eof_recovery => {
+                            // Truncation recovery: balance unclosed strings /
+                            // braces (max_tokens / EOS pattern) and retry.
+                            // Gated so streaming early-exit doesn't extract
+                            // a partial call with synthesized closers.
+                            try_repair_truncated_json(trimmed)
+                                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
+                                .unwrap_or(Value::Null)
+                        }
+                        Err(_) => Value::Null,
+                    }
+                }
+                _ => {
+                    Value::Null // Set args to null if it's not a text content
+                }
             };
-
-            call_idx += 1;
-            res.push(ToolCallResponse {
-                id: format!("call-{}", call_idx),
-                tp: ToolCallType::Function,
-                function: CalledFunction {
-                    name: fname.to_string(),
-                    arguments: args_json,
-                },
+            // Add tool call to result if args is valid JSON
+            if !args.is_null() {
+                call_idx += 1;
+                res.push(ToolCallResponse {
+                    id: format!("call-{}", call_idx),
+                    tp: ToolCallType::Function,
+                    function: CalledFunction {
+                        name: fname.to_string(),
+                        // Safety: `Value::Object` is always valid JSON, so serialization cannot fail
+                        arguments: serde_json::to_string(&args).unwrap(),
+                    },
+                });
+            }
+        // Handle reasoning(analysis) channel
+        } else if channel == Some("analysis") {
+            normal_text.push_str(match &message.content[0] {
+                Text(t) => &t.text,
+                _ => "",
             });
-        } else if channel == Some("final")
-            || (channel == Some("commentary")
-                && recipient.is_empty()
-                && !(has_recipientless_commentary_call
-                    && (message.content_type.as_deref() == Some("<|constrain|>json")
-                        || content_looks_like_json(&message.content))))
-        {
-            push_harmony_text(&mut normal_text, &message.content);
         }
     }
-    Ok((res, Some(normal_text)))
+    Ok((res, Some(normal_text.to_string())))
 }
 
 pub fn detect_tool_call_start_harmony(
@@ -438,14 +230,6 @@ pub fn detect_tool_call_start_harmony(
     let trimmed = chunk.trim();
     if trimmed.is_empty() {
         return false;
-    }
-
-    let has_complete_end_token = config
-        .tool_call_end_tokens
-        .iter()
-        .any(|token| !token.is_empty() && trimmed.contains(token));
-    if has_complete_end_token {
-        return true;
     }
 
     if strict {
@@ -519,10 +303,9 @@ mod tests {
         (call.function.name, args)
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
-    #[tokio::test] // TOOLCALLING.batch.1, TOOLCALLING.harmony.2
+    #[tokio::test] // PARSER.batch.1, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_complete_basic() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}<|call|>"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
@@ -534,27 +317,28 @@ mod tests {
         assert_eq!(args["format"], "celsius");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
-    #[tokio::test] // TOOLCALLING.batch.4, TOOLCALLING.harmony.2
+    #[tokio::test] // PARSER.batch.4, PARSER.harmony.2
     async fn test_parse_tools_harmony_without_start_token() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("".to_string()));
+        assert_eq!(normal_content, Some(text.trim().to_string()));
         assert_eq!(tool_calls.len(), 0);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
-    #[tokio::test] // TOOLCALLING.batch.7, TOOLCALLING.batch.8, TOOLCALLING.harmony.2
+    #[tokio::test] // PARSER.batch.7, PARSER.batch.8, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_with_multi_args() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("".to_string()));
+        assert_eq!(
+            normal_content,
+            Some("Need to use function get_current_weather.".to_string())
+        );
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -562,102 +346,48 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
-    #[tokio::test] // TOOLCALLING.batch.8, TOOLCALLING.batch.8, TOOLCALLING.harmony.2
+    #[tokio::test] // PARSER.batch.8, PARSER.batch.8, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_with_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("".to_string()));
+        assert_eq!(
+            normal_content,
+            Some("Need to use function get_current_weather.".to_string())
+        );
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
         assert_eq!(args["location"], "San Francisco");
     }
 
-    #[tokio::test] // TOOLCALLING.batch.3 — gpt-oss
-    async fn test_parse_harmony_bare_text_without_final_message_is_dropped() {
-        let text = "Hello, how can I help you today?";
-        let (tool_calls, normal_content) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-        assert!(tool_calls.is_empty());
-        assert_eq!(normal_content, Some("".to_string()));
-    }
-
-    #[tokio::test] // TOOLCALLING.batch.3 — gpt-oss
-    async fn test_parse_harmony_final_message_returns_normal_text() {
-        let text = r#"<|channel|>final<|message|>Hello, how can I help you today?<|return|>"#;
-        let (tool_calls, normal_content) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-        assert!(tool_calls.is_empty());
-        assert_eq!(
-            normal_content,
-            Some("Hello, how can I help you today?".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_tool_only_keeps_final_as_normal_text() {
-        let text = r#"<|channel|>analysis<|message|>Need to check weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>final<|message|>I checked the weather.<|return|>"#;
-        let (tool_calls, normal_content) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-        assert_eq!(tool_calls.len(), 1);
-        assert_eq!(normal_content, Some("I checked the weather.".to_string()));
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_drops_directed_non_function_commentary() {
-        let text = r#"<|start|>assistant<|channel|>commentary to=browser.search <|constrain|>json<|message|>{"query":"secret weather"}<|call|><|start|>assistant<|channel|>final<|message|>Done.<|return|>"#;
-        let (tool_calls, normal_content) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-
-        assert!(tool_calls.is_empty());
-        let normal = normal_content.unwrap_or_default();
-        assert_eq!(normal, "Done.");
-        assert!(!normal.contains("secret weather"));
-        assert!(!normal.contains("browser.search"));
-        assert!(!normal.contains("<|channel|>"));
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_drops_recipientless_tool_call_payload() {
-        let text = r#"<|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>final<|message|>Done.<|return|>"#;
-        let (tool_calls, normal_content) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-
-        assert!(tool_calls.is_empty());
-        let normal = normal_content.unwrap_or_default();
-        assert_eq!(normal, "Done.");
-        assert!(!normal.contains("NYC"));
-        assert!(!normal.contains("<|channel|>"));
-    }
-
-    // Harmony's strict tokenizer rejects two back-to-back commentary
-    // blocks, so EOF recovery falls back to regex extraction and pins that
-    // both calls are surfaced without leaking the raw envelopes.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.2.yaml.
-    #[tokio::test] // TOOLCALLING.batch.2 — gpt-oss
+    // Harmony's `<|call|>` plays the role of an outer end-token. When
+    // max_tokens fires before it lands, the existing `analysis ... <|end|>`
+    // envelope still gives the parser enough context to recover the call —
+    // this test pins that recovery behavior. The bare-envelope variant
+    // (no preceding analysis block) currently does NOT recover, but adding
+    // a test for that is a parser-change discussion.
+    // Pin current behavior on two back-to-back commentary blocks. The
+    // harmony parser today does NOT extract both calls — the second
+    // `<|start|>assistant<|channel|>commentary` block is left in normal
+    // content. Same failure class as PARSER.batch.5: parser drops in-flight work,
+    // customer sees HTTP 200 with fewer tool_calls than the model emitted.
+    // Promoting this to recovery is a parser change.
+    #[tokio::test] // PARSER.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
-        let (tool_calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
+        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+            text,
+            &JsonParserConfig {
+                allow_eof_recovery: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(tool_calls.len(), 2);
         let (n0, a0) = extract_name_and_args(tool_calls[0].clone());
         let (n1, a1) = extract_name_and_args(tool_calls[1].clone());
@@ -667,22 +397,11 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
-    #[tokio::test] // TOOLCALLING.batch.4 — gpt-oss
-    async fn test_parse_harmony_malformed_json_preserves_raw_arguments() {
-        let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>"#;
-        let (tool_calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-        assert_eq!(tool_calls.len(), 1);
-        assert_eq!(tool_calls[0].function.name, "get_weather");
-        assert_eq!(tool_calls[0].function.arguments, "not json at all");
-    }
-
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
-    #[tokio::test] // TOOLCALLING.batch.4 — gpt-oss
-    async fn test_parse_harmony_unterminated_json_preserves_raw_arguments() {
+    // Pin current behavior on truncated JSON args. harmony today drops the
+    // call entirely rather than falling back to a string-form arguments or
+    // surfacing an explicit error.
+    #[tokio::test] // PARSER.batch.4 — gpt-oss
+    async fn test_parse_harmony_truncated_json_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
         let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
             text,
@@ -695,18 +414,18 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(tool_calls.len(), 1);
-        assert_eq!(tool_calls[0].function.name, "get_weather");
-        assert_eq!(tool_calls[0].function.arguments, r#"{"location":"NYC"#);
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
     }
 
-    // Bare-envelope TOOLCALLING.batch.5: no preceding `analysis` block, no `<|call|>`
-    // at the end. Harmony requires the explicit call stop token, so fallback
-    // must not accept EOS as a synthetic close.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml.
-    #[tokio::test] // TOOLCALLING.batch.5 — gpt-oss
-    async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
+    // Bare-envelope PARSER.batch.5: no preceding `analysis` block, no `<|call|>`
+    // at the end. harmony's tokenizer rejects this; the regex fallback
+    // accepts EOS as a synthetic close.
+    #[tokio::test] // PARSER.batch.5 — gpt-oss
+    async fn test_parse_harmony_bare_envelope_no_call_token_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
-        let (tool_calls, normal) = parse_tool_calls_harmony_complete(
+        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
             text,
             &JsonParserConfig {
                 allow_eof_recovery: true,
@@ -716,15 +435,17 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(tool_calls.is_empty());
-        assert_eq!(normal, Some("".to_string()));
+        assert_eq!(tool_calls.len(), 1);
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
     }
 
-    // The regex fallback must preserve user-visible non-tool spans (prose before
-    // the call and suffix after `<|call|>`) as `normal_text`, not zero them.
+    // The regex fallback must preserve any non-tool spans (prose before
+    // the call, suffix after `<|call|>`) as `normal_text`, not zero them.
     #[tokio::test]
     async fn test_parse_harmony_regex_fallback_preserves_residual_text() {
-        let text = r#"PREFIX <|channel|>analysis<|message|>Need a tool.<|end|><|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
+        let text = r#"PREFIX <|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
         let (tool_calls, normal) = parse_tool_calls_harmony_complete(
             text,
             &JsonParserConfig {
@@ -745,78 +466,21 @@ mod tests {
             normal.contains("SUFFIX"),
             "normal must keep suffix: {normal:?}"
         );
-        assert!(
-            !normal.contains("Need a tool."),
-            "normal must not expose Harmony analysis text: {normal:?}"
-        );
-        assert!(
-            !normal.contains("<|start|>"),
-            "normal must not leak harmony start token: {normal:?}"
-        );
-        assert!(
-            !normal.contains("assistant"),
-            "normal must not leak harmony assistant marker: {normal:?}"
-        );
     }
 
-    #[tokio::test]
-    async fn test_parse_harmony_parse_failure_strips_protocol_from_normal_text() {
-        let text = r#"Before <|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
-        let (tool_calls, normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-        assert!(tool_calls.is_empty());
-        let normal = normal.unwrap_or_default();
-        assert_eq!(normal, "Before  After");
-        for token in [
-            "<|start|>",
-            "<|channel|>",
-            "<|constrain|>",
-            "<|message|>",
-            "<|call|>",
-        ] {
-            assert!(
-                !normal.contains(token),
-                "normal_text must not leak {token}: {normal:?}"
-            );
-        }
-        assert!(
-            !normal.contains("commentary"),
-            "normal_text must not leak tool-call metadata: {normal:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_parse_failure_strips_analysis_body() {
-        let text = r#"Before <|channel|>analysis<|message|>Need to call get_weather.<|end|><|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
-        let (tool_calls, normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
-        assert!(tool_calls.is_empty());
-        let normal = normal.unwrap_or_default();
-        assert_eq!(normal, "Before  After");
-        assert!(
-            !normal.contains("<|channel|>"),
-            "normal_text must not leak Harmony protocol tokens: {normal:?}"
-        );
-        assert!(
-            !normal.contains("Need to call get_weather."),
-            "normal_text must not expose Harmony analysis text: {normal:?}"
-        );
-    }
-
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml, tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
-    #[tokio::test] // TOOLCALLING.batch.4, TOOLCALLING.batch.5, TOOLCALLING.harmony.2
+    #[tokio::test] // PARSER.batch.4, PARSER.batch.5, PARSER.harmony.2
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("".to_string()));
-        assert!(tool_calls.is_empty());
+        assert_eq!(normal_content, Some("We need to call get_weather function. The user asks \"What's the weather like in San Francisco in Celsius?\" So location: \"San Francisco, CA\" unit: \"celsius\". Let's call function.".to_string()));
+        assert_eq!(tool_calls.len(), 1);
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "San Francisco, CA");
+        assert_eq!(args["unit"], "celsius");
     }
 
     /// Parser-level invariant: the harmony parser is byte-stable — it
@@ -827,19 +491,19 @@ mod tests {
     /// cross-parser finish_reason mapping work-item (tracked separately).
     #[tokio::test]
     async fn test_harmony_parser_output_independent_of_upstream_finish() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
         assert_eq!(tool_calls.len(), 1);
     }
 
-    /// TOOLCALLING.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
+    /// PARSER.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
     /// the function name.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.6.yaml.
-    #[tokio::test] // TOOLCALLING.batch.6 — gpt-oss
+    #[tokio::test] // PARSER.batch.6 — gpt-oss
     async fn test_parse_harmony_empty_args() {
-        let text = r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}<|call|>"#;
+        let text =
+            r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
@@ -849,13 +513,12 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
-    /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
+    /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls. Unlike the
     /// XML/JSON parsers (which trim whitespace down to `Some("")`), the
     /// harmony parser passes the input verbatim through to normal_text —
     /// pin that distinction here.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
-    #[tokio::test] // TOOLCALLING.batch.9 — gpt-oss
+    #[tokio::test] // PARSER.batch.9 — gpt-oss
     async fn test_parse_harmony_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
             let (tool_calls, normal) =
@@ -876,12 +539,11 @@ mod tests {
         }
     }
 
-    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice). Two
+    /// PARSER.batch.10 — duplicate calls (same function name twice). Two
     /// back-to-back commentary blocks for the same function. Pin
     /// parser-level behavior — both calls returned with distinct ids
     /// and distinct args.
-    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
-    #[tokio::test] // TOOLCALLING.batch.10 — gpt-oss
+    #[tokio::test] // PARSER.batch.10 — gpt-oss
     async fn test_parse_harmony_duplicate_calls_same_name() {
         let text = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"LA"}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
@@ -935,25 +597,7 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[tokio::test]
-    async fn test_parse_harmony_orphan_call_marker_does_not_leak() {
-        let config = JsonParserConfig {
-            tool_call_start_tokens: vec!["<|start|>assistant<|channel|>commentary".to_string()],
-            tool_call_end_tokens: vec!["<|call|>".to_string()],
-            ..Default::default()
-        };
-
-        assert!(detect_tool_call_start_harmony("<|call|>", &config, false));
-        assert!(detect_tool_call_start_harmony("<|call|>", &config, true));
-
-        let (tool_calls, normal) = parse_tool_calls_harmony_complete("<|call|>", &config, None)
-            .await
-            .unwrap();
-        assert!(tool_calls.is_empty());
-        assert_eq!(normal, Some("".to_string()));
-    }
-
-    #[test] // helper, TOOLCALLING.stream.3
+    #[test] // helper, PARSER.stream.3
     fn test_detect_tool_call_start_harmony_partial_tokens() {
         // Test partial token detection for streaming scenarios
         let config = JsonParserConfig {
@@ -989,96 +633,5 @@ mod detect_parser_tests {
             !detect_tool_call_start_harmony("xyz", &config, true),
             "'xyz' should not be detected in strict mode"
         );
-    }
-
-    // --- analysis-channel tool-call recovery (the gpt-oss-120b malformed form) ---
-
-    #[tokio::test]
-    async fn test_parse_harmony_analysis_code_tool_call_recovered() {
-        // Exact form emitted by the gpt-oss-120b worker: channel=analysis, constraint=code.
-        let text =
-            r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>"#;
-        let (calls, normal) =
-            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
-                .await
-                .expect("parser should not error");
-        assert_eq!(calls.len(), 1, "analysis/code tool call must be recovered");
-        assert_eq!(calls[0].function.name, "grep");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["pattern"], "foo");
-        assert_eq!(
-            normal,
-            Some("".to_string()),
-            "no markup should leak into normal_text"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_analysis_no_constraint_tool_call_recovered() {
-        // analysis channel with no constraint marker at all.
-        let text = r#"<|channel|>analysis to=functions.bash<|message|>{"command":"ls"}<|call|>"#;
-        let (calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
-                .await
-                .expect("parser should not error");
-        assert_eq!(
-            calls.len(),
-            1,
-            "analysis tool call without constraint must be recovered"
-        );
-        assert_eq!(calls[0].function.name, "bash");
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_recipientless_analysis_is_not_tool_call() {
-        // Recipientless analysis is pure reasoning — must never become a tool call
-        // and must not leak markup into normal_text.
-        let text = r#"<|channel|>analysis<|message|>Let me think about grep.<|end|><|channel|>final<|message|>Done.<|return|>"#;
-        let (calls, normal) =
-            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
-                .await
-                .expect("parser should not error");
-        assert!(
-            calls.is_empty(),
-            "recipientless analysis must not produce a tool call"
-        );
-        assert_eq!(
-            normal,
-            Some("Done.".to_string()),
-            "only the final-channel text should appear in normal_text"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_analysis_tool_call_without_stop_drops() {
-        // Analysis tool call missing the required <|call|> terminator must be dropped.
-        let text = r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}"#;
-        let (calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
-                .await
-                .expect("parser should not error");
-        assert!(
-            calls.is_empty(),
-            "analysis tool call without <|call|> terminator must be dropped"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_parse_harmony_analysis_tool_call_then_final() {
-        // Reasoning block + analysis tool call + final answer: one tool call recovered,
-        // normal_text = only the final-channel content.
-        let text = concat!(
-            "<|channel|>analysis<|message|>think<|end|>",
-            "<|start|>assistant<|channel|>analysis to=functions.get_weather code<|message|>",
-            r#"{"location":"NYC"}<|call|>"#,
-            "<|start|>assistant<|channel|>final<|message|>Checked.<|return|>",
-        );
-        let (calls, normal) =
-            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
-                .await
-                .expect("parser should not error");
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(normal, Some("Checked.".to_string()));
     }
 }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -2,45 +2,272 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ToolDefinition;
-use super::super::json::base_json_parser::try_repair_truncated_json;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
-use openai_harmony::chat::{Content::Text, Role};
+use openai_harmony::chat::{Content, Role};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding};
-use regex::Regex;
+use regex::{Captures, Regex};
 use serde_json::Value;
 use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMMENTARY_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static COMMENTARY_HEADER_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static ANALYSIS_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static FINAL_BLOCK_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static MESSAGE_CALL_CLEANUP_REGEX: OnceLock<Regex> = OnceLock::new();
+static SPECIAL_TOKEN_REGEX: OnceLock<Regex> = OnceLock::new();
 
 /// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
 /// input — alternative on this path is silent-drop. Worst case is missing
-/// a call, never fabricating one (full structural signature required).
+/// a call, never fabricating one: Harmony tool calls must end with `<|call|>`.
+///
+/// Matches tool calls on either `commentary` or `analysis` channel: the model
+/// emits ~47% of tool calls on the `analysis` channel with a bare `code`
+/// constraint marker instead of `<|constrain|>json`. The `.*?` non-greedy span
+/// between the recipient and `<|message|>` already tolerates any constraint
+/// marker form (`code`, `<|constrain|>json`, or nothing).
 fn commentary_block_regex() -> &'static Regex {
     COMMENTARY_BLOCK_REGEX.get_or_init(|| {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
         // Between name and `<|message|>` we tolerate optional
-        // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
-        // Args end at either `<|call|>` (normal close) or end-of-string
-        // (`\z`, the bare-envelope PARSER.batch.5 variant where the model never
-        // emitted `<|call|>` before EOS / max_tokens).
+        // `<|constrain|>json`, bare `code`, or nothing (non-greedy `.*?`).
+        // Args must end at `<|call|>`, the required Harmony tool-call stop token.
         Regex::new(
-            r"(?s)<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>(?:commentary|analysis) to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
         )
         .expect("commentary block regex")
     })
 }
 
+fn commentary_block_cleanup_regex() -> &'static Regex {
+    COMMENTARY_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*?<\|message\|>.*?(?:<\|call\|>|\z)",
+        )
+        .expect("commentary block cleanup regex")
+    })
+}
+
+fn commentary_header_cleanup_regex() -> &'static Regex {
+    COMMENTARY_HEADER_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(
+            r"(?s)(?:<\|start\|>assistant)?<\|channel\|>commentary(?:\s+to=functions\.(?P<name>[\w.\-]+))?.*\z",
+        )
+        .expect("commentary header cleanup regex")
+    })
+}
+
+fn analysis_block_cleanup_regex() -> &'static Regex {
+    ANALYSIS_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>analysis<\|message\|>(?P<body>.*?)(?:<\|end\|>|\z)")
+            .expect("analysis block cleanup regex")
+    })
+}
+
+fn final_block_cleanup_regex() -> &'static Regex {
+    FINAL_BLOCK_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)(?:<\|start\|>assistant)?<\|channel\|>final<\|message\|>(?P<body>.*?)(?:<\|return\|>|<\|end\|>|\z)")
+            .expect("final block cleanup regex")
+    })
+}
+
+fn message_call_cleanup_regex() -> &'static Regex {
+    MESSAGE_CALL_CLEANUP_REGEX.get_or_init(|| {
+        Regex::new(r"(?s)<\|message\|>.*?(?:<\|call\|>|\z)").expect("message call cleanup regex")
+    })
+}
+
+fn special_token_regex() -> &'static Regex {
+    SPECIAL_TOKEN_REGEX.get_or_init(|| {
+        Regex::new(r"<\|(?:start|channel|constrain|message|call|end|return)\|>")
+            .expect("special token cleanup regex")
+    })
+}
+
+fn push_unique(items: &mut Vec<String>, item: String) {
+    if !items.iter().any(|existing| existing == &item) {
+        items.push(item);
+    }
+}
+
+fn record_special_tokens(text: &str, items: &mut Vec<String>) {
+    for m in special_token_regex().find_iter(text) {
+        push_unique(items, format!("special_token:{}", m.as_str()));
+    }
+}
+
+fn strip_harmony_protocol_from_normal_text(text: &str, reason: &'static str) -> String {
+    let mut stripped = Vec::new();
+
+    let cleaned = commentary_block_cleanup_regex()
+        .replace_all(text, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("commentary_tool_call:functions.{name}"),
+                None => "commentary_tool_call:missing_recipient".to_string(),
+            };
+            push_unique(&mut stripped, item);
+            ""
+        })
+        .into_owned();
+
+    let cleaned = commentary_header_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            let item = match caps.name("name").map(|m| m.as_str()) {
+                Some(name) => format!("commentary_tool_call_without_message:functions.{name}"),
+                None => "commentary_tool_call_without_message:missing_recipient".to_string(),
+            };
+            push_unique(&mut stripped, item);
+            ""
+        })
+        .into_owned();
+
+    let cleaned = analysis_block_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "analysis_envelope".to_string());
+            ""
+        })
+        .into_owned();
+
+    let cleaned = final_block_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "final_envelope".to_string());
+            caps.name("body")
+                .map(|m| m.as_str())
+                .unwrap_or_default()
+                .to_string()
+        })
+        .into_owned();
+
+    let cleaned = message_call_cleanup_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            record_special_tokens(&caps[0], &mut stripped);
+            push_unique(&mut stripped, "message_call_payload".to_string());
+            ""
+        })
+        .into_owned();
+
+    let cleaned = special_token_regex()
+        .replace_all(&cleaned, |caps: &Captures<'_>| {
+            push_unique(&mut stripped, format!("special_token:{}", &caps[0]));
+            ""
+        })
+        .into_owned();
+
+    if stripped.is_empty() {
+        return text.to_string();
+    }
+
+    let cleaned = cleaned.trim().to_string();
+
+    tracing::warn!(
+        family = "harmony",
+        reason,
+        stripped = ?stripped,
+        original_len = text.len(),
+        cleaned_len = cleaned.len(),
+        "stripped harmony protocol content from normal_text"
+    );
+
+    cleaned
+}
+
+fn normal_text_after_parse_failure(text: &str, reason: &'static str) -> String {
+    let cleaned = strip_harmony_protocol_from_normal_text(text, reason);
+    if cleaned == text && !text.trim().is_empty() {
+        tracing::warn!(
+            family = "harmony",
+            reason,
+            original_len = text.len(),
+            "dropped bare text without a Harmony final/commentary message"
+        );
+        String::new()
+    } else {
+        cleaned
+    }
+}
+
+fn serialize_harmony_arguments(raw_args: &str) -> String {
+    let trimmed = raw_args.trim();
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value) => serde_json::to_string(&value).unwrap_or_else(|_| trimmed.to_string()),
+        Err(_) => trimmed.to_string(),
+    }
+}
+
+fn push_harmony_text(out: &mut String, content: &[Content]) {
+    for item in content {
+        if let Content::Text(text) = item {
+            out.push_str(&text.text);
+        }
+    }
+}
+
+fn content_looks_like_json(content: &[Content]) -> bool {
+    content.iter().any(|item| match item {
+        Content::Text(text) => {
+            matches!(text.text.trim_start().as_bytes().first(), Some(b'{' | b'['))
+        }
+        _ => false,
+    })
+}
+
+fn contains_recipientless_commentary_call(text: &str) -> bool {
+    let channel_marker = "<|channel|>commentary";
+    let message_marker = "<|message|>";
+    let call_marker = "<|call|>";
+    let boundaries = ["<|end|>", "<|return|>", "<|start|>", "<|channel|>"];
+
+    let mut remaining = text;
+    while let Some(channel_start) = remaining.find(channel_marker) {
+        let after_channel = &remaining[channel_start + channel_marker.len()..];
+        let Some(message_start) = after_channel.find(message_marker) else {
+            return false;
+        };
+
+        let header = &after_channel[..message_start];
+        let after_message = &after_channel[message_start + message_marker.len()..];
+        remaining = after_message;
+
+        if header
+            .split_whitespace()
+            .any(|part| part.starts_with("to="))
+        {
+            continue;
+        }
+
+        let Some(call_start) = after_message.find(call_marker) else {
+            continue;
+        };
+
+        let next_boundary = boundaries
+            .iter()
+            .filter_map(|boundary| after_message.find(boundary))
+            .min();
+
+        match next_boundary {
+            Some(boundary) if call_start >= boundary => {}
+            _ => return true,
+        };
+    }
+
+    false
+}
+
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
 /// (truncated JSON, multiple back-to-back commentary blocks, etc.).
 /// Returns (calls, residual_text) where residual_text is everything not
-/// consumed by a matched commentary block — preserved so analysis prose and
-/// non-tool suffixes aren't dropped.
+/// consumed by a matched commentary block — preserved so non-tool user-visible
+/// spans aren't dropped.
 fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
     let mut residual = String::new();
     let mut cursor = 0;
-    for (i, cap) in commentary_block_regex().captures_iter(text).enumerate() {
+    for cap in commentary_block_regex().captures_iter(text) {
         let m = cap.get(0).expect("regex match has full span");
         residual.push_str(&text[cursor..m.start()]);
         cursor = m.end();
@@ -50,17 +277,10 @@ fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
         if name.is_empty() {
             continue;
         }
-        let args_json = match serde_json::from_str::<Value>(raw_args) {
-            Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-            Err(_) => match try_repair_truncated_json(raw_args)
-                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
-            {
-                Some(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
-                None => raw_args.to_string(),
-            },
-        };
+        let args_json = serialize_harmony_arguments(raw_args);
+        let call_idx = out.len() + 1;
         out.push(ToolCallResponse {
-            id: format!("call-{}", i + 1),
+            id: format!("call-{call_idx}"),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name: name.to_string(),
@@ -100,9 +320,9 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// or token-by-token streaming, making it more efficient for complete chunks.
 ///
 /// # Arguments
-/// * `text` - The full Harmony-format string to be parsed, excluding any trailing stop tokens.
+/// * `text` - The full Harmony-format string to be parsed, including required Harmony stop tokens.
 ///   Example:
-///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}`
+///   `<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>`
 /// * `_config` - Parser configuration (currently unused but kept for API consistency)
 ///
 /// # Returns
@@ -110,14 +330,15 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// * `Err(e)` - If parsing fails due to encoding or tokenization errors
 pub async fn parse_tool_calls_harmony_complete(
     text: &str,
-    config: &JsonParserConfig,
+    _config: &JsonParserConfig,
     _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let enc = match get_harmony_encoding().await.as_ref() {
         Ok(e) => e,
         Err(e) => {
             tracing::debug!("Failed to load harmony encoding: {e}. Tool calls will not be parsed.");
-            return Ok((vec![], Some(text.to_string())));
+            let normal_text = normal_text_after_parse_failure(text, "harmony_encoding_unavailable");
+            return Ok((vec![], Some(normal_text)));
         }
     };
 
@@ -129,24 +350,29 @@ pub async fn parse_tool_calls_harmony_complete(
             tracing::debug!(
                 "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
-            // Recovery: harmony rejects parallel commentary blocks and
-            // truncated JSON. Gated on `allow_eof_recovery` so streaming
-            // jails (where the tokenizer often rejects mid-chunk before all
-            // tokens have arrived) don't extract a partial call.
-            if config.allow_eof_recovery {
-                let (calls, residual) = extract_calls_via_regex(text);
-                if !calls.is_empty() {
-                    return Ok((calls, Some(residual)));
-                }
+            // Recovery: harmony rejects parallel commentary blocks even when
+            // every call is explicitly closed. Only EOF/truncated recovery is
+            // gated, so streaming jails do not synthesize incomplete calls.
+            // Harmony differs from generic JSON/XML recovery: a tool call is
+            // complete only once `<|call|>` is present. Do not synthesize a
+            // call from EOF; that would diverge from vLLM/openai_harmony.
+            let (calls, residual) = extract_calls_via_regex(text);
+            if !calls.is_empty() {
+                let normal_text =
+                    strip_harmony_protocol_from_normal_text(&residual, "regex_recovery_residual");
+                return Ok((calls, Some(normal_text)));
             }
-            return Ok((vec![], Some(text.to_string())));
+            let normal_text =
+                normal_text_after_parse_failure(text, "parse_failed_no_recovered_calls");
+            return Ok((vec![], Some(normal_text)));
         }
     };
 
-    let mut normal_text = String::new();
-
     let mut res = Vec::with_capacity(messages.len());
     let mut call_idx = 0; // Index of the tool call
+    let mut normal_text = String::new();
+    let has_tool_call_stop = text.contains("<|call|>");
+    let has_recipientless_commentary_call = contains_recipientless_commentary_call(text);
 
     for message in messages.iter() {
         if message.author.role != Role::Assistant {
@@ -156,8 +382,16 @@ pub async fn parse_tool_calls_harmony_complete(
         let channel = message.channel.as_deref();
         let recipient = message.recipient.as_deref().unwrap_or_default();
 
-        // Handle commentary channel
-        if channel == Some("commentary") && recipient.starts_with("functions.") {
+        // A `to=functions.NAME` recipient is the definitive signal of a tool
+        // call, regardless of channel label. The model emits tool calls on both
+        // `commentary` (canonical) and `analysis` (malformed-but-common) channels.
+        let is_tool_channel =
+            channel == Some("commentary") || channel == Some("analysis");
+        if is_tool_channel && recipient.starts_with("functions.") {
+            if !has_tool_call_stop {
+                continue;
+            }
+
             let Some(fname) = message
                 .recipient
                 .as_ref()
@@ -168,49 +402,34 @@ pub async fn parse_tool_calls_harmony_complete(
                 continue;
             };
 
-            let args = match message.content.first() {
-                Some(Text(text)) => {
-                    let trimmed = text.text.trim();
-                    match serde_json::from_str::<Value>(trimmed) {
-                        Ok(value) => value,
-                        Err(_) if config.allow_eof_recovery => {
-                            // Truncation recovery: balance unclosed strings /
-                            // braces (max_tokens / EOS pattern) and retry.
-                            // Gated so streaming early-exit doesn't extract
-                            // a partial call with synthesized closers.
-                            try_repair_truncated_json(trimmed)
-                                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
-                                .unwrap_or(Value::Null)
-                        }
-                        Err(_) => Value::Null,
-                    }
-                }
-                _ => {
-                    Value::Null // Set args to null if it's not a text content
-                }
+            let Some(args_json) = message.content.first().and_then(|content| match content {
+                Content::Text(text) => Some(serialize_harmony_arguments(&text.text)),
+                _ => None,
+            }) else {
+                continue;
             };
-            // Add tool call to result if args is valid JSON
-            if !args.is_null() {
-                call_idx += 1;
-                res.push(ToolCallResponse {
-                    id: format!("call-{}", call_idx),
-                    tp: ToolCallType::Function,
-                    function: CalledFunction {
-                        name: fname.to_string(),
-                        // Safety: `Value::Object` is always valid JSON, so serialization cannot fail
-                        arguments: serde_json::to_string(&args).unwrap(),
-                    },
-                });
-            }
-        // Handle reasoning(analysis) channel
-        } else if channel == Some("analysis") {
-            normal_text.push_str(match &message.content[0] {
-                Text(t) => &t.text,
-                _ => "",
+
+            call_idx += 1;
+            res.push(ToolCallResponse {
+                id: format!("call-{}", call_idx),
+                tp: ToolCallType::Function,
+                function: CalledFunction {
+                    name: fname.to_string(),
+                    arguments: args_json,
+                },
             });
+        } else if channel == Some("commentary")
+            && recipient.is_empty()
+            && !(has_recipientless_commentary_call
+                && (message.content_type.as_deref() == Some("<|constrain|>json")
+                    || content_looks_like_json(&message.content)))
+        {
+            push_harmony_text(&mut normal_text, &message.content);
+        } else if channel == Some("final") {
+            push_harmony_text(&mut normal_text, &message.content);
         }
     }
-    Ok((res, Some(normal_text.to_string())))
+    Ok((res, Some(normal_text)))
 }
 
 pub fn detect_tool_call_start_harmony(
@@ -221,6 +440,14 @@ pub fn detect_tool_call_start_harmony(
     let trimmed = chunk.trim();
     if trimmed.is_empty() {
         return false;
+    }
+
+    let has_complete_end_token = config
+        .tool_call_end_tokens
+        .iter()
+        .any(|token| !token.is_empty() && trimmed.contains(token));
+    if has_complete_end_token {
+        return true;
     }
 
     if strict {
@@ -294,9 +521,10 @@ mod tests {
         (call.function.name, args)
     }
 
-    #[tokio::test] // PARSER.batch.1, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.1 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
+    #[tokio::test] // TOOLCALLING.batch.1, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_complete_basic() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"format":"celsius","location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
@@ -308,28 +536,27 @@ mod tests {
         assert_eq!(args["format"], "celsius");
     }
 
-    #[tokio::test] // PARSER.batch.4, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.d in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4, TOOLCALLING.harmony.2
     async fn test_parse_tools_harmony_without_start_token() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some(text.trim().to_string()));
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 0);
     }
 
-    #[tokio::test] // PARSER.batch.7, PARSER.batch.8, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.7.d, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.7.yaml, tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
+    #[tokio::test] // TOOLCALLING.batch.7, TOOLCALLING.batch.8, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_with_multi_args() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco", "unit":"fahrenheit"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
@@ -337,48 +564,102 @@ mod tests {
         assert_eq!(args["unit"], "fahrenheit");
     }
 
-    #[tokio::test] // PARSER.batch.8, PARSER.batch.8, PARSER.harmony.2
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
+    #[tokio::test] // TOOLCALLING.batch.8, TOOLCALLING.batch.8, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_with_normal_text() {
         let text = r#"<|channel|>analysis<|message|>Need to use function get_current_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"San Francisco"}<|call|>"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            normal_content,
-            Some("Need to use function get_current_weather.".to_string())
-        );
+        assert_eq!(normal_content, Some("".to_string()));
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_current_weather");
         assert_eq!(args["location"], "San Francisco");
     }
 
-    // Harmony's `<|call|>` plays the role of an outer end-token. When
-    // max_tokens fires before it lands, the existing `analysis ... <|end|>`
-    // envelope still gives the parser enough context to recover the call —
-    // this test pins that recovery behavior. The bare-envelope variant
-    // (no preceding analysis block) currently does NOT recover, but adding
-    // a test for that is a parser-change discussion.
-    // Pin current behavior on two back-to-back commentary blocks. The
-    // harmony parser today does NOT extract both calls — the second
-    // `<|start|>assistant<|channel|>commentary` block is left in normal
-    // content. Same failure class as PARSER.batch.5: parser drops in-flight work,
-    // customer sees HTTP 200 with fewer tool_calls than the model emitted.
-    // Promoting this to recovery is a parser change.
-    #[tokio::test] // PARSER.batch.2 — gpt-oss
+    #[tokio::test] // TOOLCALLING.batch.3 — gpt-oss
+    async fn test_parse_harmony_bare_text_without_final_message_is_dropped() {
+        let text = "Hello, how can I help you today?";
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal_content, Some("".to_string()));
+    }
+
+    #[tokio::test] // TOOLCALLING.batch.3 — gpt-oss
+    async fn test_parse_harmony_final_message_returns_normal_text() {
+        let text = r#"<|channel|>final<|message|>Hello, how can I help you today?<|return|>"#;
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(
+            normal_content,
+            Some("Hello, how can I help you today?".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_tool_only_keeps_final_as_normal_text() {
+        let text = r#"<|channel|>analysis<|message|>Need to check weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>final<|message|>I checked the weather.<|return|>"#;
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(normal_content, Some("I checked the weather.".to_string()));
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_drops_directed_non_function_commentary() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=browser.search <|constrain|>json<|message|>{"query":"secret weather"}<|call|><|start|>assistant<|channel|>final<|message|>Done.<|return|>"#;
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+
+        assert!(tool_calls.is_empty());
+        let normal = normal_content.unwrap_or_default();
+        assert_eq!(normal, "Done.");
+        assert!(!normal.contains("secret weather"));
+        assert!(!normal.contains("browser.search"));
+        assert!(!normal.contains("<|channel|>"));
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_drops_recipientless_tool_call_payload() {
+        let text = r#"<|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>final<|message|>Done.<|return|>"#;
+        let (tool_calls, normal_content) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+
+        assert!(tool_calls.is_empty());
+        let normal = normal_content.unwrap_or_default();
+        assert_eq!(normal, "Done.");
+        assert!(!normal.contains("NYC"));
+        assert!(!normal.contains("<|channel|>"));
+    }
+
+    // Harmony's strict tokenizer rejects two back-to-back commentary
+    // blocks, so EOF recovery falls back to regex extraction and pins that
+    // both calls are surfaced without leaking the raw envelopes.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.2.b in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.2.yaml.
+    #[tokio::test] // TOOLCALLING.batch.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
-        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
-            text,
-            &JsonParserConfig {
-                allow_eof_recovery: true,
-                ..Default::default()
-            },
-            None,
-        )
-        .await
-        .unwrap();
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
         assert_eq!(tool_calls.len(), 2);
         let (n0, a0) = extract_name_and_args(tool_calls[0].clone());
         let (n1, a1) = extract_name_and_args(tool_calls[1].clone());
@@ -388,11 +669,22 @@ mod tests {
         assert_eq!(a1["y"], 2);
     }
 
-    // Pin current behavior on truncated JSON args. harmony today drops the
-    // call entirely rather than falling back to a string-form arguments or
-    // surfacing an explicit error.
-    #[tokio::test] // PARSER.batch.4 — gpt-oss
-    async fn test_parse_harmony_truncated_json_recovers() {
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4 — gpt-oss
+    async fn test_parse_harmony_malformed_json_preserves_raw_arguments() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>"#;
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, "not json at all");
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.4.b in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.4.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4 — gpt-oss
+    async fn test_parse_harmony_unterminated_json_preserves_raw_arguments() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
         let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
             text,
@@ -405,18 +697,18 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
+        assert_eq!(tool_calls[0].function.name, "get_weather");
+        assert_eq!(tool_calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
-    // Bare-envelope PARSER.batch.5: no preceding `analysis` block, no `<|call|>`
-    // at the end. harmony's tokenizer rejects this; the regex fallback
-    // accepts EOS as a synthetic close.
-    #[tokio::test] // PARSER.batch.5 — gpt-oss
-    async fn test_parse_harmony_bare_envelope_no_call_token_recovers() {
+    // Bare-envelope TOOLCALLING.batch.5: no preceding `analysis` block, no `<|call|>`
+    // at the end. Harmony requires the explicit call stop token, so fallback
+    // must not accept EOS as a synthetic close.
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml.
+    #[tokio::test] // TOOLCALLING.batch.5 — gpt-oss
+    async fn test_parse_harmony_bare_envelope_no_call_token_drops() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
-        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete(
             text,
             &JsonParserConfig {
                 allow_eof_recovery: true,
@@ -426,17 +718,15 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "NYC");
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal, Some("".to_string()));
     }
 
-    // The regex fallback must preserve any non-tool spans (prose before
-    // the call, suffix after `<|call|>`) as `normal_text`, not zero them.
+    // The regex fallback must preserve user-visible non-tool spans (prose before
+    // the call and suffix after `<|call|>`) as `normal_text`, not zero them.
     #[tokio::test]
     async fn test_parse_harmony_regex_fallback_preserves_residual_text() {
-        let text = r#"PREFIX <|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
+        let text = r#"PREFIX <|channel|>analysis<|message|>Need a tool.<|end|><|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
         let (tool_calls, normal) = parse_tool_calls_harmony_complete(
             text,
             &JsonParserConfig {
@@ -457,21 +747,78 @@ mod tests {
             normal.contains("SUFFIX"),
             "normal must keep suffix: {normal:?}"
         );
+        assert!(
+            !normal.contains("Need a tool."),
+            "normal must not expose Harmony analysis text: {normal:?}"
+        );
+        assert!(
+            !normal.contains("<|start|>"),
+            "normal must not leak harmony start token: {normal:?}"
+        );
+        assert!(
+            !normal.contains("assistant"),
+            "normal must not leak harmony assistant marker: {normal:?}"
+        );
     }
 
-    #[tokio::test] // PARSER.batch.4, PARSER.batch.5, PARSER.harmony.2
+    #[tokio::test]
+    async fn test_parse_harmony_parse_failure_strips_protocol_from_normal_text() {
+        let text = r#"Before <|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
+        let (tool_calls, normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        let normal = normal.unwrap_or_default();
+        assert_eq!(normal, "Before  After");
+        for token in [
+            "<|start|>",
+            "<|channel|>",
+            "<|constrain|>",
+            "<|message|>",
+            "<|call|>",
+        ] {
+            assert!(
+                !normal.contains(token),
+                "normal_text must not leak {token}: {normal:?}"
+            );
+        }
+        assert!(
+            !normal.contains("commentary"),
+            "normal_text must not leak tool-call metadata: {normal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_parse_failure_strips_analysis_body() {
+        let text = r#"Before <|channel|>analysis<|message|>Need to call get_weather.<|end|><|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"<|call|> After"#;
+        let (tool_calls, normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert!(tool_calls.is_empty());
+        let normal = normal.unwrap_or_default();
+        assert_eq!(normal, "Before  After");
+        assert!(
+            !normal.contains("<|channel|>"),
+            "normal_text must not leak Harmony protocol tokens: {normal:?}"
+        );
+        assert!(
+            !normal.contains("Need to call get_weather."),
+            "normal_text must not expose Harmony analysis text: {normal:?}"
+        );
+    }
+
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.5.a, TOOLCALLING.batch.8.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.5.yaml, tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.8.yaml.
+    #[tokio::test] // TOOLCALLING.batch.4, TOOLCALLING.batch.5, TOOLCALLING.harmony.2
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
         let (tool_calls, normal_content) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(normal_content, Some("We need to call get_weather function. The user asks \"What's the weather like in San Francisco in Celsius?\" So location: \"San Francisco, CA\" unit: \"celsius\". Let's call function.".to_string()));
-        assert_eq!(tool_calls.len(), 1);
-        let (name, args) = extract_name_and_args(tool_calls[0].clone());
-        assert_eq!(name, "get_weather");
-        assert_eq!(args["location"], "San Francisco, CA");
-        assert_eq!(args["unit"], "celsius");
+        assert_eq!(normal_content, Some("".to_string()));
+        assert!(tool_calls.is_empty());
     }
 
     /// Parser-level invariant: the harmony parser is byte-stable — it
@@ -482,19 +829,19 @@ mod tests {
     /// cross-parser finish_reason mapping work-item (tracked separately).
     #[tokio::test]
     async fn test_harmony_parser_output_independent_of_upstream_finish() {
-        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
         assert_eq!(tool_calls.len(), 1);
     }
 
-    /// PARSER.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
+    /// TOOLCALLING.batch.6 — empty args. A no-arg harmony call (`{}`) must still surface
     /// the function name.
-    #[tokio::test] // PARSER.batch.6 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.6.a in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.6.yaml.
+    #[tokio::test] // TOOLCALLING.batch.6 — gpt-oss
     async fn test_parse_harmony_empty_args() {
-        let text =
-            r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}"#;
+        let text = r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
             .await
             .unwrap();
@@ -504,12 +851,13 @@ mod tests {
         assert_eq!(args, serde_json::json!({}));
     }
 
-    /// PARSER.batch.9 — empty / null content variants. Truly-empty (zero bytes)
+    /// TOOLCALLING.batch.9 — empty / null content variants. Truly-empty (zero bytes)
     /// and whitespace-only inputs must yield no tool calls. Unlike the
     /// XML/JSON parsers (which trim whitespace down to `Some("")`), the
     /// harmony parser passes the input verbatim through to normal_text —
     /// pin that distinction here.
-    #[tokio::test] // PARSER.batch.9 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.9 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
+    #[tokio::test] // TOOLCALLING.batch.9 — gpt-oss
     async fn test_parse_harmony_empty_and_whitespace_inputs() {
         for input in &["", " ", "\n", "\t\n  \t"] {
             let (tool_calls, normal) =
@@ -530,11 +878,12 @@ mod tests {
         }
     }
 
-    /// PARSER.batch.10 — duplicate calls (same function name twice). Two
+    /// TOOLCALLING.batch.10 — duplicate calls (same function name twice). Two
     /// back-to-back commentary blocks for the same function. Pin
     /// parser-level behavior — both calls returned with distinct ids
     /// and distinct args.
-    #[tokio::test] // PARSER.batch.10 — gpt-oss
+    // DEPRECATED(parser-fixture-duplicate): Duplicate of YAML fixture coverage: TOOLCALLING.batch.10 in tests/parity/toolcalling/fixtures/harmony/TOOLCALLING.batch.yaml.
+    #[tokio::test] // TOOLCALLING.batch.10 — gpt-oss
     async fn test_parse_harmony_duplicate_calls_same_name() {
         let text = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"LA"}<|call|>"#;
         let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
@@ -588,7 +937,25 @@ mod detect_parser_tests {
         assert!(result);
     }
 
-    #[test] // helper, PARSER.stream.3
+    #[tokio::test]
+    async fn test_parse_harmony_orphan_call_marker_does_not_leak() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<|start|>assistant<|channel|>commentary".to_string()],
+            tool_call_end_tokens: vec!["<|call|>".to_string()],
+            ..Default::default()
+        };
+
+        assert!(detect_tool_call_start_harmony("<|call|>", &config, false));
+        assert!(detect_tool_call_start_harmony("<|call|>", &config, true));
+
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete("<|call|>", &config, None)
+            .await
+            .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal, Some("".to_string()));
+    }
+
+    #[test] // helper, TOOLCALLING.stream.3
     fn test_detect_tool_call_start_harmony_partial_tokens() {
         // Test partial token detection for streaming scenarios
         let config = JsonParserConfig {
@@ -624,5 +991,90 @@ mod detect_parser_tests {
             !detect_tool_call_start_harmony("xyz", &config, true),
             "'xyz' should not be detected in strict mode"
         );
+    }
+
+    // --- analysis-channel tool-call recovery (the gpt-oss-120b malformed form) ---
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_code_tool_call_recovered() {
+        // Exact form emitted by the gpt-oss-120b worker: channel=analysis, constraint=code.
+        let text = r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>"#;
+        let (calls, normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert_eq!(calls.len(), 1, "analysis/code tool call must be recovered");
+        assert_eq!(calls[0].function.name, "grep");
+        let args: serde_json::Value =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["pattern"], "foo");
+        assert_eq!(
+            normal,
+            Some("".to_string()),
+            "no markup should leak into normal_text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_no_constraint_tool_call_recovered() {
+        // analysis channel with no constraint marker at all.
+        let text =
+            r#"<|channel|>analysis to=functions.bash<|message|>{"command":"ls"}<|call|>"#;
+        let (calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert_eq!(calls.len(), 1, "analysis tool call without constraint must be recovered");
+        assert_eq!(calls[0].function.name, "bash");
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_recipientless_analysis_is_not_tool_call() {
+        // Recipientless analysis is pure reasoning — must never become a tool call
+        // and must not leak markup into normal_text.
+        let text = r#"<|channel|>analysis<|message|>Let me think about grep.<|end|><|channel|>final<|message|>Done.<|return|>"#;
+        let (calls, normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert!(calls.is_empty(), "recipientless analysis must not produce a tool call");
+        assert_eq!(
+            normal,
+            Some("Done.".to_string()),
+            "only the final-channel text should appear in normal_text"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_tool_call_without_stop_drops() {
+        // Analysis tool call missing the required <|call|> terminator must be dropped.
+        let text = r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}"#;
+        let (calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert!(
+            calls.is_empty(),
+            "analysis tool call without <|call|> terminator must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_analysis_tool_call_then_final() {
+        // Reasoning block + analysis tool call + final answer: one tool call recovered,
+        // normal_text = only the final-channel content.
+        let text = concat!(
+            "<|channel|>analysis<|message|>think<|end|>",
+            "<|start|>assistant<|channel|>analysis to=functions.get_weather code<|message|>",
+            r#"{"location":"NYC"}<|call|>"#,
+            "<|start|>assistant<|channel|>final<|message|>Checked.<|return|>",
+        );
+        let (calls, normal) =
+            parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
+                .await
+                .expect("parser should not error");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(normal, Some("Checked.".to_string()));
     }
 }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -385,8 +385,7 @@ pub async fn parse_tool_calls_harmony_complete(
         // A `to=functions.NAME` recipient is the definitive signal of a tool
         // call, regardless of channel label. The model emits tool calls on both
         // `commentary` (canonical) and `analysis` (malformed-but-common) channels.
-        let is_tool_channel =
-            channel == Some("commentary") || channel == Some("analysis");
+        let is_tool_channel = channel == Some("commentary") || channel == Some("analysis");
         if is_tool_channel && recipient.starts_with("functions.") {
             if !has_tool_call_stop {
                 continue;
@@ -998,15 +997,15 @@ mod detect_parser_tests {
     #[tokio::test]
     async fn test_parse_harmony_analysis_code_tool_call_recovered() {
         // Exact form emitted by the gpt-oss-120b worker: channel=analysis, constraint=code.
-        let text = r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>"#;
+        let text =
+            r#"<|channel|>analysis to=functions.grep code<|message|>{"pattern":"foo"}<|call|>"#;
         let (calls, normal) =
             parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
                 .await
                 .expect("parser should not error");
         assert_eq!(calls.len(), 1, "analysis/code tool call must be recovered");
         assert_eq!(calls[0].function.name, "grep");
-        let args: serde_json::Value =
-            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["pattern"], "foo");
         assert_eq!(
             normal,
@@ -1018,13 +1017,16 @@ mod detect_parser_tests {
     #[tokio::test]
     async fn test_parse_harmony_analysis_no_constraint_tool_call_recovered() {
         // analysis channel with no constraint marker at all.
-        let text =
-            r#"<|channel|>analysis to=functions.bash<|message|>{"command":"ls"}<|call|>"#;
+        let text = r#"<|channel|>analysis to=functions.bash<|message|>{"command":"ls"}<|call|>"#;
         let (calls, _normal) =
             parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
                 .await
                 .expect("parser should not error");
-        assert_eq!(calls.len(), 1, "analysis tool call without constraint must be recovered");
+        assert_eq!(
+            calls.len(),
+            1,
+            "analysis tool call without constraint must be recovered"
+        );
         assert_eq!(calls[0].function.name, "bash");
     }
 
@@ -1037,7 +1039,10 @@ mod detect_parser_tests {
             parse_tool_calls_harmony_complete(text, &JsonParserConfig::default(), None)
                 .await
                 .expect("parser should not error");
-        assert!(calls.is_empty(), "recipientless analysis must not produce a tool call");
+        assert!(
+            calls.is_empty(),
+            "recipientless analysis must not produce a tool call"
+        );
         assert_eq!(
             normal,
             Some("Done.".to_string()),

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -232,6 +232,14 @@ pub fn detect_tool_call_start_harmony(
         return false;
     }
 
+    let has_complete_end_token = config
+        .tool_call_end_tokens
+        .iter()
+        .any(|token| !token.is_empty() && trimmed.contains(token));
+    if has_complete_end_token {
+        return true;
+    }
+
     if strict {
         // Check for complete start tokens first
         let has_complete_token = config
@@ -595,6 +603,24 @@ mod detect_parser_tests {
         };
         let result = detect_tool_call_start_harmony(text, &config, false);
         assert!(result);
+    }
+
+    #[tokio::test]
+    async fn test_parse_harmony_orphan_call_marker_does_not_leak() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<|start|>assistant<|channel|>commentary".to_string()],
+            tool_call_end_tokens: vec!["<|call|>".to_string()],
+            ..Default::default()
+        };
+
+        assert!(detect_tool_call_start_harmony("<|call|>", &config, false));
+        assert!(detect_tool_call_start_harmony("<|call|>", &config, true));
+
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete("<|call|>", &config, None)
+            .await
+            .unwrap();
+        assert!(tool_calls.is_empty());
+        assert_eq!(normal, Some("".to_string()));
     }
 
     #[test] // helper, PARSER.stream.3

--- a/lib/protocols/src/types/anthropic.rs
+++ b/lib/protocols/src/types/anthropic.rs
@@ -214,6 +214,9 @@ pub struct AnthropicMessage {
 pub enum AnthropicRole {
     User,
     Assistant,
+    /// Compatibility for clients that place system instructions in `messages[]`
+    /// instead of the top-level `system` field.
+    System,
 }
 
 /// Message content -- either a plain string or an array of content blocks.
@@ -807,6 +810,7 @@ impl AnthropicCountTokensRequest {
             total_len += match msg.role {
                 AnthropicRole::User => 4,
                 AnthropicRole::Assistant => 9,
+                AnthropicRole::System => 6,
             };
             // Count content
             match &msg.content {


### PR DESCRIPTION
#### Overview:

Only pulling in changes from #10366. These changes have to be mapped back onto the `feat/bench_x` branch as `main` has drifted too far from the state of this branch.

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details

Confirmed offline that this fix removes the tool leaking on the benchmark
```
+-------------------------------------------------+----------------------------+-----------------+
| Metric                                          | This run (4137999-trtllm)  | Buggy baseline  |
+-------------------------------------------------+----------------------------+-----------------+
| Harmony markup <|...|> in response_text         | 0 / 1172 (0.0%)            | ~22%            |
| to=functions. envelopes leaked                  | 0                          | hundreds        |
| <|channel|>analysis to=functions. (the bug)     | 0                          | ~half of calls  |
| <|message|> / <|call|> leaked                   | 0 / 0                      | present         |
| bare-JSON args leaked (markup-stripped failure) | 0                          | --              |
| success / non-empty                             | 1172 / 1172                | --              |
+-------------------------------------------------+----------------------------+-----------------+
```
<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

Related Issues: DIS-2194