### PR TITLE
feat(llm): add per-request Mooncake trace capture [DYN-3181]

### DIFF
--- a/benchmarks/agent_trace/README.md
+++ b/benchmarks/agent_trace/README.md
@@ -55,6 +55,11 @@ absolute `timestamp` from Dynamo's request-arrival time and no `session_id`.
 Stable trace `input_sequence_hashes` are compacted to Mooncake `hash_ids`
 during conversion.
 
+The same CLI also accepts context-free `dynamo.request.trace.v1` files emitted
+by `DYN_REQUEST_TRACE=1`. Request traces can be converted to ordinary Mooncake
+rows, but are rejected with `--agentic` because they intentionally omit agent
+context and tool events.
+
 Mooncake replay intentionally ignores non-replay request fields such as
 `finish_reason_metadata`. Use the Perfetto converter when you want to inspect
 whether a request stopped for tool calls, hit a backend stop reason, or emitted

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -58,6 +58,7 @@ For detailed setup instructions and configuration, see [Prometheus + Grafana Set
 | [Operator Metrics (Kubernetes)](../kubernetes/observability/operator-metrics.md) | Operator controller and webhook metrics for Kubernetes | N/A (configured via Helm) |
 | [Health Checks](health-checks.md) | Component health monitoring and readiness probes | `DYN_SYSTEM_PORT`†, `DYN_SYSTEM_STARTING_HEALTH_STATUS`, `DYN_SYSTEM_HEALTH_PATH`, `DYN_SYSTEM_LIVE_PATH`, `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS` |
 | [Tracing](tracing.md) | Distributed tracing with OpenTelemetry and Tempo | `DYN_LOGGING_JSONL`†, `OTEL_EXPORT_ENABLED`†, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`†, `OTEL_SERVICE_NAME`† |
+| [Request Replay Tracing](request-tracing.md) | Per-request JSONL capture for Mooncake replay | `DYN_REQUEST_TRACE`, `DYN_REQUEST_TRACE_OUTPUT_PATH` |
 | [Logging](logging.md) | Structured logging and OTLP log export to Loki | `DYN_LOGGING_JSONL`†, `DYN_LOG`, `DYN_LOG_USE_LOCAL_TZ`, `DYN_LOGGING_CONFIG_PATH`, `OTEL_SERVICE_NAME`†, `OTEL_EXPORT_ENABLED`†, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`†, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`† |
 
 **Variables marked with † are shared across multiple observability systems.**

--- a/docs/observability/request-tracing.md
+++ b/docs/observability/request-tracing.md
@@ -1,0 +1,118 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Request Replay Tracing
+subtitle: Capture live chat and completion traffic for Mooncake replay
+---
+
+Request replay tracing records one compact `request_end` row for each supported
+Rust OpenAI chat or completion request. It does not require agent context and
+does not record prompts, responses, tool calls, session identifiers, or agent
+metadata.
+
+Enable the default rotating gzip sink:
+
+```bash
+export DYN_REQUEST_TRACE=1
+```
+
+This writes `/tmp/dynamo-request-trace.NNNNNN.jsonl.gz`. To choose another
+segment prefix:
+
+```bash
+export DYN_REQUEST_TRACE=1
+export DYN_REQUEST_TRACE_OUTPUT_PATH=/mnt/captures/run-42/request-trace
+```
+
+## Configuration
+
+| Variable | Default when enabled | Description |
+| --- | --- | --- |
+| `DYN_REQUEST_TRACE` | unset | Truthy master switch. |
+| `DYN_REQUEST_TRACE_SINKS` | `jsonl_gz` | Comma-separated `jsonl`, `jsonl_gz`, or `stderr`. |
+| `DYN_REQUEST_TRACE_OUTPUT_PATH` | `/tmp/dynamo-request-trace` | Literal JSONL path or gzip segment prefix. |
+| `DYN_REQUEST_TRACE_CAPACITY` | `1024` | Best-effort in-process broadcast capacity. |
+| `DYN_REQUEST_TRACE_JSONL_BUFFER_BYTES` | `1048576` | JSONL or gzip batching threshold. |
+| `DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS` | `1000` | Periodic flush interval. |
+| `DYN_REQUEST_TRACE_JSONL_GZ_ROLL_BYTES` | `268435456` | Gzip roll threshold in uncompressed bytes. |
+| `DYN_REQUEST_TRACE_JSONL_GZ_ROLL_LINES` | unset | Optional gzip roll threshold in records. |
+
+The bus and sinks use the same best-effort delivery behavior as agent tracing.
+A slow sink can report lag and drop records. Validate captured row counts before
+using a trace as a complete workload.
+
+## Record Shape
+
+```json
+{
+  "schema": "dynamo.request.trace.v1",
+  "event_type": "request_end",
+  "event_time_unix_ms": 1777312801000,
+  "request": {
+    "request_id": "dynamo-request-id",
+    "request_received_ms": 1777312800000,
+    "output_tokens": 16,
+    "replay": {
+      "trace_block_size": 64,
+      "input_length": 128,
+      "input_sequence_hashes": [
+        14879255164371896291,
+        274632075616497421
+      ]
+    }
+  }
+}
+```
+
+`input_sequence_hashes` are Dynamo's sequence-aware rolling hashes. The
+Mooncake converter maps them to compact `hash_ids`; they are not copied
+verbatim into the Mooncake output.
+
+For a canceled response stream, `output_tokens` is the final partial OSL
+observed after the inner response stream has been dropped.
+
+## Supported Requests
+
+Initial coverage is the Rust OpenAI chat-completions and completions paths.
+Each row must represent one replay request, so tracing skips:
+
+- `n > 1`
+- `best_of > 1`
+- `prompt_embeds`
+- Multimodal inputs
+- Requests without a tracker or usable KV cache block size
+
+Skipped requests produce a structured warning and no partial replay row.
+
+## Convert And Replay
+
+The existing converter accepts both `dynamo.agent.trace.v1` and
+`dynamo.request.trace.v1`:
+
+```bash
+cargo run -p dynamo-bench --bin agent_trace_to_mooncake -- \
+  --input-path /tmp/dynamo-request-trace.*.jsonl.gz \
+  --output-file /tmp/dynamo-request-trace.mooncake.jsonl
+```
+
+Do not pass `--agentic` for request traces; they intentionally contain no agent
+context. The converter rejects unknown schema versions.
+
+Use the trace block size printed by the converter for both trace parsing and
+the mock engine:
+
+```bash
+TRACE_BLOCK_SIZE=64
+.venv/bin/python -m dynamo.replay /tmp/dynamo-request-trace.mooncake.jsonl \
+  --trace-format mooncake \
+  --trace-block-size "${TRACE_BLOCK_SIZE}" \
+  --replay-mode offline \
+  --router-mode kv_router \
+  --num-workers 4 \
+  --extra-engine-args "{\"block_size\":${TRACE_BLOCK_SIZE}}" \
+  --report-json /tmp/dynamo-request-trace.replay-report.json
+```
+
+`DYN_REQUEST_TRACE` is independent of `DYN_AGENT_TRACE`. Enabling both emits
+separate files while sharing request completion notification and replay-hash
+computation.

--- a/lib/bench/agent_trace_to_mooncake.rs
+++ b/lib/bench/agent_trace_to_mooncake.rs
@@ -37,6 +37,9 @@ fn main() -> Result<()> {
     let output_path = expand_user_path(&args.output_file);
 
     let loaded = load_agent_trace_records(&input_paths)?;
+    if args.agentic {
+        loaded.ensure_agentic_compatible()?;
+    }
     let tool_summary = summarize_tools(&loaded.tools);
     let mut writer = MooncakeJsonlWriter::create(&output_path, None)?;
 

--- a/lib/bench/src/agent_trace/agentic.rs
+++ b/lib/bench/src/agent_trace/agentic.rs
@@ -14,6 +14,7 @@ use super::load::{LoadedAgentTrace, RequestEntry, ToolEntry};
 pub fn build_agentic_mooncake_rows(
     mut loaded: LoadedAgentTrace,
 ) -> Result<(usize, Vec<AgenticMooncakeRow>)> {
+    loaded.ensure_agentic_compatible()?;
     let global_start_ms = loaded
         .requests
         .iter()
@@ -464,6 +465,7 @@ mod tests {
                 contextual_request("r2", "root", None, 1_300, 1_400, vec![11, 22]),
             ],
             tools: vec![tool("root", "call-1", "ls", 1_150, 1_250)],
+            contains_request_trace: false,
         };
 
         let (_, rows) = build_agentic_mooncake_rows(loaded).unwrap();
@@ -484,6 +486,22 @@ mod tests {
     }
 
     #[test]
+    fn agentic_converter_rejects_request_trace_schema() {
+        let loaded = LoadedAgentTrace {
+            requests: vec![request("r1", 1_000, 1_100, vec![11])],
+            tools: Vec::new(),
+            contains_request_trace: true,
+        };
+
+        let error = build_agentic_mooncake_rows(loaded).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("cannot be converted with --agentic")
+        );
+    }
+
+    #[test]
     fn agentic_converter_attaches_parallel_tool_events_with_union_wait() {
         let loaded = LoadedAgentTrace {
             requests: vec![
@@ -497,6 +515,7 @@ mod tests {
                 tool("root", "call-2", "read", 1_150, 1_250),
                 tool("root", "call-3", "find", 1_200, 1_250),
             ],
+            contains_request_trace: false,
         };
 
         let (_, rows) = build_agentic_mooncake_rows(loaded).unwrap();
@@ -521,6 +540,7 @@ mod tests {
                 contextual_request("parent-2", "root", None, 1_500, 1_600, vec![11, 22]),
             ],
             tools: Vec::new(),
+            contains_request_trace: false,
         };
 
         let (_, rows) = build_agentic_mooncake_rows(loaded).unwrap();
@@ -543,6 +563,7 @@ mod tests {
                 contextual_request("child-2", "child", Some("root-b"), 1_200, 1_300, vec![22]),
             ],
             tools: Vec::new(),
+            contains_request_trace: false,
         };
 
         let err = build_agentic_mooncake_rows(loaded).unwrap_err();
@@ -560,6 +581,7 @@ mod tests {
                 contextual_request("parent-3", "root", None, 2_000, 2_100, vec![11, 22, 33]),
             ],
             tools: Vec::new(),
+            contains_request_trace: false,
         };
 
         let (_, rows) = build_agentic_mooncake_rows(loaded).unwrap();

--- a/lib/bench/src/agent_trace/load.rs
+++ b/lib/bench/src/agent_trace/load.rs
@@ -3,9 +3,11 @@
 
 //! Source-format records and JSONL/gz loader.
 //!
-//! Local subset of `dynamo.agent.trace.v1`; the canonical producer-side schema
-//! lives in `lib/llm/src/agents/trace/types.rs`.
+//! Local subset of the supported Dynamo request trace schemas. Canonical
+//! producer-side schemas live in `lib/llm/src/agents/trace/types.rs` and
+//! `lib/llm/src/request_trace/types.rs`.
 
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -17,6 +19,7 @@ use serde_json::Value;
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct AgentTraceRecord {
+    pub(crate) schema: TraceSchema,
     pub(crate) event_type: String,
     pub(crate) event_time_unix_ms: u64,
     #[serde(default)]
@@ -25,6 +28,14 @@ pub(crate) struct AgentTraceRecord {
     pub(crate) request: Option<AgentRequestMetrics>,
     #[serde(default)]
     pub(crate) tool: Option<AgentToolEventMetrics>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub(crate) enum TraceSchema {
+    #[serde(rename = "dynamo.agent.trace.v1")]
+    AgentV1,
+    #[serde(rename = "dynamo.request.trace.v1")]
+    RequestV1,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -104,12 +115,25 @@ pub struct ToolEntry {
 pub struct LoadedAgentTrace {
     pub requests: Vec<RequestEntry>,
     pub tools: Vec<ToolEntry>,
+    pub contains_request_trace: bool,
+}
+
+impl LoadedAgentTrace {
+    pub fn ensure_agentic_compatible(&self) -> Result<()> {
+        if self.contains_request_trace {
+            bail!(
+                "dynamo.request.trace.v1 records do not contain agent context and cannot be converted with --agentic"
+            );
+        }
+        Ok(())
+    }
 }
 
 /// Records other than `request_end` / `tool_end` / `tool_error` are skipped.
 /// Errors if no `request_end` rows were found.
 pub fn load_agent_trace_records(paths: &[PathBuf]) -> Result<LoadedAgentTrace> {
     let mut loaded = LoadedAgentTrace::default();
+    let mut request_ids = HashSet::new();
 
     for path in paths {
         let reader = open_trace_reader(path)?;
@@ -125,14 +149,34 @@ pub fn load_agent_trace_records(paths: &[PathBuf]) -> Result<LoadedAgentTrace> {
             else {
                 continue;
             };
+            if record.schema == TraceSchema::RequestV1 {
+                loaded.contains_request_trace = true;
+                if record.event_type != "request_end" {
+                    bail!(
+                        "request trace schema only supports request_end, got {} at {}:{}",
+                        record.event_type,
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+            }
             if record.event_type == "request_end" {
-                loaded.requests.push(request_entry(record).with_context(|| {
+                let entry = request_entry(record).with_context(|| {
                     format!(
                         "invalid request_end at {}:{}",
                         path.display(),
                         line_index + 1
                     )
-                })?);
+                })?;
+                if !request_ids.insert(entry.request.request_id.clone()) {
+                    bail!(
+                        "duplicate request_id {} at {}:{}",
+                        entry.request.request_id,
+                        path.display(),
+                        line_index + 1
+                    );
+                }
+                loaded.requests.push(entry);
             } else if matches!(record.event_type.as_str(), "tool_end" | "tool_error") {
                 let terminal_event = record.event_type.clone();
                 if let Some(tool) = tool_entry(record, terminal_event) {
@@ -169,6 +213,7 @@ fn parse_trace_record(line: &str) -> Result<Option<AgentTraceRecord>> {
 }
 
 fn request_entry(record: AgentTraceRecord) -> Result<RequestEntry> {
+    let schema = record.schema;
     let request = record
         .request
         .ok_or_else(|| anyhow!("request_end record is missing request payload"))?;
@@ -179,12 +224,23 @@ fn request_entry(record: AgentTraceRecord) -> Result<RequestEntry> {
     if replay.trace_block_size == 0 {
         bail!("request replay trace_block_size must be greater than 0");
     }
-    if replay.input_sequence_hashes.len() * replay.trace_block_size < replay.input_length {
+    let expected_hashes = replay.input_length.div_ceil(replay.trace_block_size);
+    if replay.input_sequence_hashes.len() != expected_hashes {
         bail!(
-            "input_length {} exceeds replay hash capacity {}",
+            "input_length {} with trace_block_size {} requires exactly {} replay hashes, got {}",
             replay.input_length,
-            replay.input_sequence_hashes.len() * replay.trace_block_size
+            replay.trace_block_size,
+            expected_hashes,
+            replay.input_sequence_hashes.len()
         );
+    }
+    if schema == TraceSchema::RequestV1 {
+        if request.request_received_ms.is_none() {
+            bail!("request trace is missing request_received_ms");
+        }
+        if request.output_tokens.is_none() {
+            bail!("request trace is missing output_tokens");
+        }
     }
 
     let (start_ms, end_ms) = request_times(record.event_time_unix_ms, &request);
@@ -198,6 +254,9 @@ fn request_entry(record: AgentTraceRecord) -> Result<RequestEntry> {
 }
 
 fn tool_entry(record: AgentTraceRecord, terminal_event: String) -> Option<ToolEntry> {
+    if record.schema != TraceSchema::AgentV1 {
+        return None;
+    }
     let context = record.agent_context?;
     let tool = record.tool?;
     let end_ms = tool
@@ -264,6 +323,10 @@ pub(crate) fn saturating_i64(value: u64) -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
     use super::*;
 
     #[test]
@@ -277,5 +340,93 @@ mod tests {
         };
 
         assert_eq!(request_times(1_250, &request), (1_000, 1_250));
+    }
+
+    #[test]
+    fn loads_context_free_request_trace() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1100,"request":{{"request_id":"req-1","request_received_ms":1000,"output_tokens":4,"replay":{{"trace_block_size":2,"input_length":3,"input_sequence_hashes":[11,22]}}}}}}"#
+        )
+        .unwrap();
+
+        let loaded = load_agent_trace_records(&[file.path().to_path_buf()]).unwrap();
+        assert!(loaded.contains_request_trace);
+        assert_eq!(loaded.requests.len(), 1);
+        assert!(loaded.requests[0].agent_context.is_none());
+        assert_eq!(loaded.requests[0].start_ms, 1_000);
+        assert_eq!(loaded.requests[0].end_ms, 1_100);
+    }
+
+    #[test]
+    fn rejects_unknown_trace_schema() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"schema":"dynamo.request.trace.v2","event_type":"request_end","event_time_unix_ms":1100,"request":{{"request_id":"req-1","request_received_ms":1000,"output_tokens":4,"replay":{{"trace_block_size":2,"input_length":2,"input_sequence_hashes":[11]}}}}}}"#
+        )
+        .unwrap();
+
+        let error = load_agent_trace_records(&[file.path().to_path_buf()]).unwrap_err();
+        assert!(error.to_string().contains("failed to parse"));
+        assert!(format!("{error:#}").contains("unknown variant `dynamo.request.trace.v2`"));
+    }
+
+    #[test]
+    fn request_trace_requires_arrival_time_and_output_length() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1100,"request":{{"request_id":"req-1","replay":{{"trace_block_size":2,"input_length":2,"input_sequence_hashes":[11]}}}}}}"#
+        )
+        .unwrap();
+
+        let error = load_agent_trace_records(&[file.path().to_path_buf()]).unwrap_err();
+        assert!(format!("{error:#}").contains("request trace is missing request_received_ms"));
+    }
+
+    #[test]
+    fn rejects_duplicate_request_ids() {
+        let mut file = NamedTempFile::new().unwrap();
+        for _ in 0..2 {
+            writeln!(
+                file,
+                r#"{{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1100,"request":{{"request_id":"req-1","request_received_ms":1000,"output_tokens":4,"replay":{{"trace_block_size":2,"input_length":2,"input_sequence_hashes":[11]}}}}}}"#
+            )
+            .unwrap();
+        }
+
+        let error = load_agent_trace_records(&[file.path().to_path_buf()]).unwrap_err();
+        assert!(error.to_string().contains("duplicate request_id req-1"));
+    }
+
+    #[test]
+    fn rejects_extra_replay_hashes() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{"schema":"dynamo.request.trace.v1","event_type":"request_end","event_time_unix_ms":1100,"request":{{"request_id":"req-1","request_received_ms":1000,"output_tokens":4,"replay":{{"trace_block_size":2,"input_length":2,"input_sequence_hashes":[11,22]}}}}}}"#
+        )
+        .unwrap();
+
+        let error = load_agent_trace_records(&[file.path().to_path_buf()]).unwrap_err();
+        assert!(format!("{error:#}").contains("requires exactly 1 replay hashes, got 2"));
+    }
+
+    #[test]
+    fn request_trace_is_rejected_for_agentic_conversion() {
+        let loaded = LoadedAgentTrace {
+            requests: Vec::new(),
+            tools: Vec::new(),
+            contains_request_trace: true,
+        };
+
+        let error = loaded.ensure_agentic_compatible().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("cannot be converted with --agentic")
+        );
     }
 }

--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -4,6 +4,7 @@
 //! Dynamo LLM integration helpers for agent trace records.
 
 use std::collections::HashMap;
+#[cfg(test)]
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -12,6 +13,7 @@ use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::pipeline::Context;
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::transports::event_plane::EventSubscriber;
+#[cfg(test)]
 use futures::{Stream, StreamExt};
 use parking_lot::Mutex;
 
@@ -238,7 +240,7 @@ pub(crate) struct AgentTraceRequestEndState {
     pub request_model: String,
     pub request_tracker: Option<Arc<RequestTracker>>,
     pub x_request_id: Option<String>,
-    pub replay_metrics: Option<AgentReplayMetrics>,
+    pub replay_metrics: Option<Arc<AgentReplayMetrics>>,
     pub finish_reason_metadata: SharedFinishReasonMetadata,
 }
 
@@ -246,7 +248,7 @@ pub(crate) fn build_agent_trace_request_end_state(
     common_request: &PreprocessedRequest,
     tracker: &Option<Arc<RequestTracker>>,
     context: &Context<()>,
-    trace_block_size: usize,
+    replay_metrics: Option<Arc<AgentReplayMetrics>>,
 ) -> Option<AgentTraceRequestEndState> {
     if !super::is_enabled() {
         return None;
@@ -265,11 +267,12 @@ pub(crate) fn build_agent_trace_request_end_state(
         request_model: common_request.model.clone(),
         request_tracker: tracker.clone(),
         x_request_id,
-        replay_metrics: super::request_replay_metrics(&common_request.token_ids, trace_block_size),
+        replay_metrics,
         finish_reason_metadata: SharedFinishReasonMetadata::default(),
     })
 }
 
+#[cfg(test)]
 pub(crate) fn finish_reason_metadata_handle(
     trace_state: &Option<AgentTraceRequestEndState>,
 ) -> Option<SharedFinishReasonMetadata> {
@@ -298,7 +301,7 @@ pub(crate) fn record_backend_finish_reason_metadata(
     );
 }
 
-fn record_chat_finish_reason_metadata(
+pub(crate) fn record_chat_finish_reason_metadata(
     finish_reason_metadata: &SharedFinishReasonMetadata,
     response: &Annotated<NvCreateChatCompletionStreamResponse>,
 ) {
@@ -343,7 +346,7 @@ fn completion_finish_reason_to_finish_reason(
     }
 }
 
-fn record_completion_finish_reason_metadata(
+pub(crate) fn record_completion_finish_reason_metadata(
     finish_reason_metadata: &SharedFinishReasonMetadata,
     response: &Annotated<NvCreateCompletionResponse>,
 ) {
@@ -368,6 +371,43 @@ fn snapshot_finish_reason_metadata(
     finish_reason_metadata.lock().snapshot()
 }
 
+pub(crate) fn emit_agent_trace_request_end(
+    trace_state: AgentTraceRequestEndState,
+    request_id: String,
+) {
+    let AgentTraceRequestEndState {
+        agent_context,
+        request_model,
+        request_tracker,
+        x_request_id,
+        replay_metrics,
+        finish_reason_metadata,
+    } = trace_state;
+
+    if request_tracker.is_none() {
+        tracing::warn!(
+            request_id,
+            "agent_context present but request tracker is missing; emitting partial trace"
+        );
+    }
+    let mut metrics = super::request_metrics(
+        request_id,
+        x_request_id,
+        request_model,
+        request_tracker.as_deref(),
+    );
+    metrics.replay = replay_metrics.map(into_owned_replay_metrics);
+    metrics.finish_reason_metadata = snapshot_finish_reason_metadata(&finish_reason_metadata);
+    super::emit_request_end(agent_context, metrics);
+}
+
+pub(crate) fn into_owned_replay_metrics(
+    replay_metrics: Arc<AgentReplayMetrics>,
+) -> AgentReplayMetrics {
+    Arc::try_unwrap(replay_metrics).unwrap_or_else(|shared| shared.as_ref().clone())
+}
+
+#[cfg(test)]
 pub(crate) fn wrap_agent_trace_request_end_stream<Resp>(
     stream: Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>,
     trace_state: Option<AgentTraceRequestEndState>,
@@ -376,40 +416,19 @@ pub(crate) fn wrap_agent_trace_request_end_stream<Resp>(
 where
     Resp: Send + 'static,
 {
-    let Some(AgentTraceRequestEndState {
-        agent_context,
-        request_model,
-        request_tracker,
-        x_request_id,
-        replay_metrics,
-        finish_reason_metadata,
-    }) = trace_state
-    else {
+    let Some(trace_state) = trace_state else {
         return stream;
     };
 
     let (stream, done_fut) = crate::telemetry::stream::notify_on_completion(stream);
     tokio::spawn(async move {
         done_fut.await;
-        if request_tracker.is_none() {
-            tracing::warn!(
-                request_id,
-                "agent_context present but request tracker is missing; emitting partial trace"
-            );
-        }
-        let mut metrics = super::request_metrics(
-            request_id,
-            x_request_id,
-            request_model,
-            request_tracker.as_deref(),
-        );
-        metrics.replay = replay_metrics;
-        metrics.finish_reason_metadata = snapshot_finish_reason_metadata(&finish_reason_metadata);
-        super::emit_request_end(agent_context, metrics);
+        emit_agent_trace_request_end(trace_state, request_id);
     });
     stream
 }
 
+#[cfg(test)]
 pub(crate) fn wrap_agent_trace_chat_request_end_stream(
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
     trace_state: Option<AgentTraceRequestEndState>,
@@ -426,6 +445,7 @@ pub(crate) fn wrap_agent_trace_chat_request_end_stream(
     wrap_agent_trace_request_end_stream(Box::pin(stream), trace_state, request_id)
 }
 
+#[cfg(test)]
 pub(crate) fn wrap_agent_trace_completion_request_end_stream(
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>,
     trace_state: Option<AgentTraceRequestEndState>,

--- a/lib/llm/src/agents/trace/mod.rs
+++ b/lib/llm/src/agents/trace/mod.rs
@@ -16,15 +16,15 @@ use crate::telemetry::bus::TelemetryBus;
 pub use config::{AgentTracePolicy, is_enabled, policy};
 pub use integration::SharedFinishReasonMetadata;
 pub(crate) use integration::{
-    build_agent_trace_request_end_state, finish_reason_metadata_handle,
-    record_backend_finish_reason_metadata, record_llm_metric_tokens, request_metrics,
-    start_tool_event_ingest_from_policy, wrap_agent_trace_chat_request_end_stream,
-    wrap_agent_trace_completion_request_end_stream,
+    AgentTraceRequestEndState, build_agent_trace_request_end_state, emit_agent_trace_request_end,
+    into_owned_replay_metrics, record_backend_finish_reason_metadata,
+    record_chat_finish_reason_metadata, record_completion_finish_reason_metadata,
+    record_llm_metric_tokens, request_metrics, start_tool_event_ingest_from_policy,
 };
 pub(crate) use record::validate_tool_record;
 pub use record::{emit_request_end, publish_tool_record};
 pub use relay::AgentToolEventRelay;
-pub(crate) use replay::request_replay_metrics;
+pub(crate) use replay::replay_metrics;
 pub use types::{
     AgentReplayMetrics, AgentRequestMetrics, AgentToolEvent, AgentToolStatus, AgentTraceRecord,
     ChoiceFinishReasonMetadata, FinishReasonMetadata, ToolCallMetadata, TraceEventSource,

--- a/lib/llm/src/agents/trace/replay.rs
+++ b/lib/llm/src/agents/trace/replay.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Replay-oriented request hash capture for agent traces.
+//! Replay-oriented request hash capture for live traces.
 
 use bytemuck::cast_slice;
 use dynamo_kv_router::protocols::{
@@ -14,18 +14,11 @@ use crate::protocols::TokenIdType;
 
 use super::AgentReplayMetrics;
 
-pub(crate) fn request_replay_metrics(
+pub(crate) fn replay_metrics(
     token_ids: &[TokenIdType],
     trace_block_size: usize,
 ) -> Option<AgentReplayMetrics> {
-    let policy = super::policy();
-    if !policy.enabled || !policy.replay_hashes_enabled {
-        return None;
-    }
     if trace_block_size == 0 {
-        tracing::warn!(
-            "agent trace replay hashes requested but model KV cache block size is unavailable"
-        );
         return None;
     }
 
@@ -45,9 +38,8 @@ pub(crate) fn input_sequence_hashes(
         "agent trace replay block size must be positive"
     );
 
-    // TODO(replay): move this token-id -> sequence-hash helper into a shared
-    // crate with the router/mocker hash path. Agent tracing, Mooncake export,
-    // and replay should not each carry subtly different block hash logic.
+    // Keep this identical to the router/mocker sequence-aware hashing path so
+    // replay preserves shared-prefix identity.
     let block_size = trace_block_size as u32;
     let mut block_hashes =
         compute_block_hash_for_seq(token_ids, block_size, BlockHashOptions::default());
@@ -66,6 +58,8 @@ fn partial_local_block_hash(tokens: &[TokenIdType]) -> LocalBlockHash {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::input_sequence_hashes;
 
     #[test]
@@ -92,5 +86,20 @@ mod tests {
     #[test]
     fn empty_input_has_empty_sequence_hashes() {
         assert!(input_sequence_hashes(&[], 64).is_empty());
+    }
+
+    #[test]
+    fn long_input_hashes_cover_every_token() {
+        let tokens = (0..131_072_u32).collect::<Vec<_>>();
+        let started = Instant::now();
+        let hashes = input_sequence_hashes(&tokens, 64);
+        eprintln!(
+            "hashed {} input tokens into {} sequence hashes in {:?}",
+            tokens.len(),
+            hashes.len(),
+            started.elapsed()
+        );
+
+        assert_eq!(hashes.len(), tokens.len() / 64);
     }
 }

--- a/lib/llm/src/entrypoint/input.rs
+++ b/lib/llm/src/entrypoint/input.rs
@@ -98,6 +98,9 @@ pub async fn run_input(
     in_opt: Input,
     engine_config: super::EngineConfig,
 ) -> anyhow::Result<()> {
+    if let Err(e) = crate::request_trace::init_from_env_with_shutdown(drt.child_token()).await {
+        tracing::warn!(error = %e, "Request trace initialization failed; continuing without trace sink");
+    }
     if let Err(e) = crate::agents::trace::init_from_env_with_shutdown(drt.child_token()).await {
         tracing::warn!(error = %e, "Agent trace initialization failed; continuing without trace sink");
     }

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -32,6 +32,7 @@ pub mod preprocessor;
 pub mod protocols;
 pub mod recorder;
 pub mod request_template;
+pub mod request_trace;
 pub mod telemetry;
 pub use dynamo_tokenizers as tokenizers;
 pub use dynamo_tokenizers::{file_json_field, log_json_err};

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2874,7 +2874,7 @@ impl
         )?;
 
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
-        let trace_state = crate::agents::trace::build_agent_trace_request_end_state(
+        let trace_state = crate::request_trace::build_request_end_trace_state(
             &common_request,
             &tracker,
             &context,
@@ -2882,7 +2882,7 @@ impl
         );
         let trace_tokens_enabled = trace_state.is_some();
         let trace_finish_reason_metadata =
-            crate::agents::trace::finish_reason_metadata_handle(&trace_state);
+            crate::request_trace::finish_reason_metadata_handle(&trace_state);
 
         // Attach the timing tracker to the request so downstream components can record metrics
         common_request.tracker = tracker;
@@ -2959,7 +2959,7 @@ impl
             &self.tokenizer,
         );
 
-        let final_stream = crate::agents::trace::wrap_agent_trace_chat_request_end_stream(
+        let final_stream = crate::request_trace::wrap_chat_request_end_stream(
             final_stream,
             trace_state,
             request_id,
@@ -3036,7 +3036,7 @@ impl
 
         let mut common_request = builder.build()?;
 
-        let trace_state = crate::agents::trace::build_agent_trace_request_end_state(
+        let trace_state = crate::request_trace::build_request_end_trace_state(
             &common_request,
             &tracker,
             &context,
@@ -3044,7 +3044,7 @@ impl
         );
         let trace_tokens_enabled = trace_state.is_some();
         let trace_finish_reason_metadata =
-            crate::agents::trace::finish_reason_metadata_handle(&trace_state);
+            crate::request_trace::finish_reason_metadata_handle(&trace_state);
 
         // Attach the timing tracker to the request so downstream components can record metrics
         common_request.tracker = tracker;
@@ -3083,7 +3083,7 @@ impl
             trace_finish_reason_metadata,
         );
 
-        let stream = crate::agents::trace::wrap_agent_trace_completion_request_end_stream(
+        let stream = crate::request_trace::wrap_completion_request_end_stream(
             Box::pin(stream),
             trace_state,
             request_id,

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::OnceLock;
+
+use dynamo_runtime::config::{
+    env_is_truthy, environment_names::llm::request_trace as env_request_trace,
+};
+
+use crate::telemetry::parse_sink_names;
+
+const DEFAULT_CAPACITY: usize = 1024;
+const DEFAULT_JSONL_BUFFER_BYTES: usize = 1024 * 1024;
+const DEFAULT_JSONL_FLUSH_INTERVAL_MS: u64 = 1000;
+const DEFAULT_JSONL_GZ_ROLL_BYTES: u64 = 256 * 1024 * 1024;
+
+const DEFAULT_SINK: &str = "jsonl_gz";
+const DEFAULT_OUTPUT_PATH: &str = "/tmp/dynamo-request-trace";
+
+#[derive(Clone, Debug)]
+pub struct RequestTracePolicy {
+    pub enabled: bool,
+    pub sinks: Vec<String>,
+    pub output_path: Option<String>,
+    pub capacity: usize,
+    pub jsonl_buffer_bytes: usize,
+    pub jsonl_flush_interval_ms: u64,
+    pub jsonl_gz_roll_bytes: u64,
+    pub jsonl_gz_roll_lines: Option<u64>,
+}
+
+static POLICY: OnceLock<RequestTracePolicy> = OnceLock::new();
+
+fn load_from_env() -> RequestTracePolicy {
+    let enabled = env_is_truthy(env_request_trace::DYN_REQUEST_TRACE);
+    let sinks = std::env::var(env_request_trace::DYN_REQUEST_TRACE_SINKS)
+        .ok()
+        .map(|value| parse_sink_names(&value))
+        .unwrap_or_else(|| {
+            if enabled {
+                vec![DEFAULT_SINK.to_string()]
+            } else {
+                Vec::new()
+            }
+        });
+    let output_path = std::env::var(env_request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| enabled.then(|| DEFAULT_OUTPUT_PATH.to_string()));
+    let capacity = std::env::var(env_request_trace::DYN_REQUEST_TRACE_CAPACITY)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CAPACITY);
+    let jsonl_buffer_bytes = std::env::var(env_request_trace::DYN_REQUEST_TRACE_JSONL_BUFFER_BYTES)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_JSONL_BUFFER_BYTES);
+    let jsonl_flush_interval_ms =
+        std::env::var(env_request_trace::DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_JSONL_FLUSH_INTERVAL_MS);
+    let jsonl_gz_roll_bytes =
+        std::env::var(env_request_trace::DYN_REQUEST_TRACE_JSONL_GZ_ROLL_BYTES)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_JSONL_GZ_ROLL_BYTES);
+    let jsonl_gz_roll_lines =
+        std::env::var(env_request_trace::DYN_REQUEST_TRACE_JSONL_GZ_ROLL_LINES)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0);
+
+    RequestTracePolicy {
+        enabled,
+        sinks,
+        output_path,
+        capacity,
+        jsonl_buffer_bytes,
+        jsonl_flush_interval_ms,
+        jsonl_gz_roll_bytes,
+        jsonl_gz_roll_lines,
+    }
+}
+
+pub fn policy() -> &'static RequestTracePolicy {
+    POLICY.get_or_init(load_from_env)
+}
+
+pub fn is_enabled() -> bool {
+    policy().enabled
+}
+
+#[cfg(test)]
+mod tests {
+    use dynamo_runtime::config::environment_names::llm::request_trace as env_request_trace;
+
+    use super::load_from_env;
+
+    #[test]
+    #[serial_test::serial]
+    fn master_switch_enables_default_sink_and_path() {
+        temp_env::with_vars(
+            [
+                (env_request_trace::DYN_REQUEST_TRACE, Some("1")),
+                (env_request_trace::DYN_REQUEST_TRACE_SINKS, None),
+                (env_request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH, None),
+            ],
+            || {
+                let policy = load_from_env();
+                assert!(policy.enabled);
+                assert_eq!(policy.sinks, vec!["jsonl_gz".to_string()]);
+                assert_eq!(
+                    policy.output_path.as_deref(),
+                    Some("/tmp/dynamo-request-trace")
+                );
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn master_switch_yields_to_overrides() {
+        temp_env::with_vars(
+            [
+                (env_request_trace::DYN_REQUEST_TRACE, Some("1")),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_SINKS,
+                    Some("jsonl,stderr"),
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH,
+                    Some("/tmp/custom-request-trace"),
+                ),
+                (
+                    env_request_trace::DYN_REQUEST_TRACE_JSONL_GZ_ROLL_LINES,
+                    Some("10"),
+                ),
+            ],
+            || {
+                let policy = load_from_env();
+                assert_eq!(
+                    policy.sinks,
+                    vec!["jsonl".to_string(), "stderr".to_string()]
+                );
+                assert_eq!(
+                    policy.output_path.as_deref(),
+                    Some("/tmp/custom-request-trace")
+                );
+                assert_eq!(policy.jsonl_gz_roll_lines, Some(10));
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disabled_by_default() {
+        temp_env::with_vars(
+            [
+                (env_request_trace::DYN_REQUEST_TRACE, None::<&str>),
+                (env_request_trace::DYN_REQUEST_TRACE_SINKS, None),
+                (env_request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH, None),
+            ],
+            || {
+                let policy = load_from_env();
+                assert!(!policy.enabled);
+                assert!(policy.sinks.is_empty());
+                assert!(policy.output_path.is_none());
+            },
+        );
+    }
+}

--- a/lib/llm/src/request_trace/integration.rs
+++ b/lib/llm/src/request_trace/integration.rs
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use dynamo_runtime::pipeline::Context;
+use dynamo_runtime::protocols::annotated::Annotated;
+use futures::{Stream, StreamExt};
+
+use crate::agents::trace::{
+    AgentReplayMetrics, AgentTraceRequestEndState, SharedFinishReasonMetadata,
+};
+use crate::protocols::common::preprocessor::PreprocessedRequest;
+use crate::protocols::common::timing::RequestTracker;
+use crate::protocols::openai::{
+    chat_completions::NvCreateChatCompletionStreamResponse, completions::NvCreateCompletionResponse,
+};
+
+struct RequestTraceRequestEndState {
+    request_tracker: Arc<RequestTracker>,
+    replay_metrics: Arc<AgentReplayMetrics>,
+}
+
+pub(crate) struct RequestEndTraceState {
+    agent: Option<AgentTraceRequestEndState>,
+    request: Option<RequestTraceRequestEndState>,
+}
+
+impl RequestEndTraceState {
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.agent.is_some() || self.request.is_some()
+    }
+}
+
+fn request_trace_rejection(common_request: &PreprocessedRequest) -> Option<&'static str> {
+    if common_request.prompt_embeds.is_some() {
+        return Some("prompt embeddings are not supported");
+    }
+    if common_request.multi_modal_data.is_some() {
+        return Some("multimodal inputs are not supported");
+    }
+    if common_request.sampling_options.n.unwrap_or(1) > 1 {
+        return Some("multiple output choices are not supported");
+    }
+    if common_request.sampling_options.best_of.unwrap_or(1) > 1 {
+        return Some("best_of greater than one is not supported");
+    }
+    None
+}
+
+fn shared_replay_metrics(
+    request_trace_supported: bool,
+    agent_replay_enabled: bool,
+    token_ids: &[crate::protocols::TokenIdType],
+    trace_block_size: usize,
+) -> Option<Arc<AgentReplayMetrics>> {
+    if trace_block_size == 0 || (!request_trace_supported && !agent_replay_enabled) {
+        return None;
+    }
+    crate::agents::trace::replay_metrics(token_ids, trace_block_size).map(Arc::new)
+}
+
+pub(crate) fn build_request_end_trace_state(
+    common_request: &PreprocessedRequest,
+    tracker: &Option<Arc<RequestTracker>>,
+    context: &Context<()>,
+    trace_block_size: usize,
+) -> Option<RequestEndTraceState> {
+    let request_trace_enabled = super::is_enabled();
+    let agent_trace_enabled =
+        crate::agents::trace::is_enabled() && common_request.agent_context.is_some();
+
+    if !request_trace_enabled && !agent_trace_enabled {
+        return None;
+    }
+
+    let request_id = context.id();
+    let request_trace_supported = request_trace_enabled
+        && match request_trace_rejection(common_request) {
+            Some(reason) => {
+                tracing::warn!(
+                    %request_id,
+                    reason,
+                    "request trace skipped because the request cannot be represented as one Mooncake row"
+                );
+                false
+            }
+            None => true,
+        };
+    let request_trace_supported = request_trace_supported
+        && if tracker.is_none() {
+            tracing::warn!(
+                %request_id,
+                "request trace skipped because the request tracker is unavailable"
+            );
+            false
+        } else {
+            true
+        };
+    let request_trace_supported = request_trace_supported
+        && if trace_block_size == 0 {
+            tracing::warn!(
+                %request_id,
+                "request trace skipped because the KV cache block size is unavailable"
+            );
+            false
+        } else {
+            true
+        };
+
+    let agent_replay_enabled =
+        agent_trace_enabled && crate::agents::trace::policy().replay_hashes_enabled;
+    if agent_replay_enabled && trace_block_size == 0 {
+        tracing::warn!(
+            %request_id,
+            "agent trace replay hashes requested but model KV cache block size is unavailable"
+        );
+    }
+
+    let replay_metrics = shared_replay_metrics(
+        request_trace_supported,
+        agent_replay_enabled,
+        &common_request.token_ids,
+        trace_block_size,
+    );
+
+    let agent = crate::agents::trace::build_agent_trace_request_end_state(
+        common_request,
+        tracker,
+        context,
+        agent_replay_enabled
+            .then(|| replay_metrics.clone())
+            .flatten(),
+    );
+    let request = request_trace_supported
+        .then(|| {
+            Some(RequestTraceRequestEndState {
+                request_tracker: tracker.clone()?,
+                replay_metrics: replay_metrics.clone()?,
+            })
+        })
+        .flatten();
+
+    let state = RequestEndTraceState { agent, request };
+    state.is_enabled().then_some(state)
+}
+
+pub(crate) fn finish_reason_metadata_handle(
+    trace_state: &Option<RequestEndTraceState>,
+) -> Option<SharedFinishReasonMetadata> {
+    trace_state
+        .as_ref()
+        .and_then(|state| state.agent.as_ref())
+        .map(|state| state.finish_reason_metadata.clone())
+}
+
+fn wrap_request_end_stream<Resp>(
+    stream: Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>,
+    trace_state: Option<RequestEndTraceState>,
+    request_id: String,
+) -> Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>
+where
+    Resp: Send + 'static,
+{
+    let Some(trace_state) = trace_state else {
+        return stream;
+    };
+
+    let (stream, done) = crate::telemetry::stream::notify_on_completion(stream);
+    tokio::spawn(async move {
+        done.await;
+        if let Some(request_state) = trace_state.request {
+            super::record::emit_request_end(
+                request_id.clone(),
+                &request_state.request_tracker,
+                crate::agents::trace::into_owned_replay_metrics(request_state.replay_metrics),
+            );
+        }
+        if let Some(agent_state) = trace_state.agent {
+            crate::agents::trace::emit_agent_trace_request_end(agent_state, request_id);
+        }
+    });
+    stream
+}
+
+pub(crate) fn wrap_chat_request_end_stream(
+    stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
+    trace_state: Option<RequestEndTraceState>,
+    request_id: String,
+) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
+    let Some(finish_reason_metadata) = finish_reason_metadata_handle(&trace_state) else {
+        return wrap_request_end_stream(stream, trace_state, request_id);
+    };
+
+    let stream = stream.map(move |response| {
+        crate::agents::trace::record_chat_finish_reason_metadata(
+            &finish_reason_metadata,
+            &response,
+        );
+        response
+    });
+    wrap_request_end_stream(Box::pin(stream), trace_state, request_id)
+}
+
+pub(crate) fn wrap_completion_request_end_stream(
+    stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>,
+    trace_state: Option<RequestEndTraceState>,
+    request_id: String,
+) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>> {
+    let Some(finish_reason_metadata) = finish_reason_metadata_handle(&trace_state) else {
+        return wrap_request_end_stream(stream, trace_state, request_id);
+    };
+
+    let stream = stream.map(move |response| {
+        crate::agents::trace::record_completion_finish_reason_metadata(
+            &finish_reason_metadata,
+            &response,
+        );
+        response
+    });
+    wrap_request_end_stream(Box::pin(stream), trace_state, request_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use std::task::{Context as TaskContext, Poll};
+    use std::time::{Duration, Instant};
+
+    use super::*;
+    use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
+    use crate::request_trace::BUS;
+
+    struct TrackerDropStream {
+        tracker: Arc<RequestTracker>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Stream for TrackerDropStream {
+        type Item = Annotated<NvCreateCompletionResponse>;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for TrackerDropStream {
+        fn drop(&mut self) {
+            self.tracker.record_osl(9);
+            self.tracker.record_finish();
+            self.dropped.store(true, Ordering::Release);
+        }
+    }
+
+    fn preprocessed_request(sampling_options: SamplingOptions) -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("test-model".to_string())
+            .token_ids(vec![1, 2, 3])
+            .stop_conditions(StopConditions::default())
+            .sampling_options(sampling_options)
+            .output_options(OutputOptions::default())
+            .eos_token_ids(vec![])
+            .annotations(vec![])
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn rejects_unsupported_request_shapes() {
+        let mut multi_choice = preprocessed_request(SamplingOptions {
+            n: Some(2),
+            ..Default::default()
+        });
+        assert_eq!(
+            request_trace_rejection(&multi_choice),
+            Some("multiple output choices are not supported")
+        );
+
+        multi_choice.sampling_options.n = Some(1);
+        multi_choice.sampling_options.best_of = Some(2);
+        assert_eq!(
+            request_trace_rejection(&multi_choice),
+            Some("best_of greater than one is not supported")
+        );
+
+        multi_choice.sampling_options.best_of = Some(1);
+        multi_choice.prompt_embeds = Some("embedding".to_string());
+        assert_eq!(
+            request_trace_rejection(&multi_choice),
+            Some("prompt embeddings are not supported")
+        );
+
+        multi_choice.prompt_embeds = None;
+        multi_choice.multi_modal_data = Some(Default::default());
+        assert_eq!(
+            request_trace_rejection(&multi_choice),
+            Some("multimodal inputs are not supported")
+        );
+    }
+
+    #[test]
+    fn replay_hashing_is_disabled_when_unused_and_shared_when_both_need_it() {
+        assert!(shared_replay_metrics(false, false, &[1, 2, 3], 2).is_none());
+
+        let replay = shared_replay_metrics(true, true, &[1, 2, 3], 2).unwrap();
+        let request_replay = replay.clone();
+        let agent_replay = replay.clone();
+        assert!(Arc::ptr_eq(&request_replay, &agent_replay));
+        assert_eq!(replay.input_sequence_hashes.len(), 2);
+    }
+
+    #[test]
+    fn long_isl_hashing_reports_mode_costs_without_threshold() {
+        let token_ids = (0..131_072_u32).collect::<Vec<_>>();
+
+        let started = Instant::now();
+        let disabled = shared_replay_metrics(false, false, &token_ids, 64);
+        let disabled_elapsed = started.elapsed();
+
+        let started = Instant::now();
+        let request_only = shared_replay_metrics(true, false, &token_ids, 64).unwrap();
+        let request_elapsed = started.elapsed();
+
+        let started = Instant::now();
+        let both = shared_replay_metrics(true, true, &token_ids, 64).unwrap();
+        let both_elapsed = started.elapsed();
+
+        eprintln!(
+            "long-ISL replay hashing: disabled={disabled_elapsed:?}, request_only={request_elapsed:?}, both={both_elapsed:?}"
+        );
+        assert!(disabled.is_none());
+        assert_eq!(request_only.input_sequence_hashes.len(), 2_048);
+        assert_eq!(
+            request_only.input_sequence_hashes,
+            both.input_sequence_hashes
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_reads_tracker_after_inner_stream_drop() {
+        BUS.init(16);
+        let mut receiver = BUS.subscribe();
+        let tracker = Arc::new(RequestTracker::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let state = RequestEndTraceState {
+            agent: None,
+            request: Some(RequestTraceRequestEndState {
+                request_tracker: tracker.clone(),
+                replay_metrics: Arc::new(AgentReplayMetrics {
+                    trace_block_size: 2,
+                    input_length: 2,
+                    input_sequence_hashes: vec![11],
+                }),
+            }),
+        };
+        let stream = TrackerDropStream {
+            tracker,
+            dropped: dropped.clone(),
+        };
+
+        let wrapped =
+            wrap_request_end_stream(Box::pin(stream), Some(state), "req-drop".to_string());
+        drop(wrapped);
+
+        let record = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let record = receiver.recv().await.unwrap();
+                if record.request.request_id == "req-drop" {
+                    break record;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(dropped.load(Ordering::Acquire));
+        assert_eq!(record.request.output_tokens, 9);
+    }
+}

--- a/lib/llm/src/request_trace/mod.rs
+++ b/lib/llm/src/request_trace/mod.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod config;
+mod integration;
+mod record;
+pub mod sink;
+pub mod types;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::telemetry::bus::TelemetryBus;
+
+pub use config::{RequestTracePolicy, is_enabled, policy};
+pub(crate) use integration::{
+    build_request_end_trace_state, finish_reason_metadata_handle, wrap_chat_request_end_stream,
+    wrap_completion_request_end_stream,
+};
+pub use types::{
+    RequestTraceEventType, RequestTraceMetrics, RequestTraceRecord, RequestTraceSchema,
+};
+
+static BUS: TelemetryBus<RequestTraceRecord> = TelemetryBus::new();
+
+pub async fn init_from_env_with_shutdown(shutdown: CancellationToken) -> anyhow::Result<()> {
+    let policy = policy();
+    if !policy.enabled {
+        return Ok(());
+    }
+
+    BUS.init(policy.capacity);
+    sink::spawn_workers_from_env(shutdown).await?;
+    tracing::info!(
+        capacity = policy.capacity,
+        sinks = ?policy.sinks,
+        "Request trace initialized"
+    );
+    Ok(())
+}
+
+pub fn publish(record: RequestTraceRecord) {
+    BUS.publish(record);
+}
+
+pub fn subscribe() -> tokio::sync::broadcast::Receiver<RequestTraceRecord> {
+    BUS.subscribe()
+}

--- a/lib/llm/src/request_trace/record.rs
+++ b/lib/llm/src/request_trace/record.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::agents::trace::AgentReplayMetrics;
+use crate::protocols::common::timing::RequestTracker;
+
+use super::{
+    RequestTraceEventType, RequestTraceMetrics, RequestTraceRecord, RequestTraceSchema, publish,
+};
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+pub(crate) fn emit_request_end(
+    request_id: String,
+    tracker: &RequestTracker,
+    replay: AgentReplayMetrics,
+) {
+    let request_received_ms = tracker.request_received_epoch_ms();
+    let event_time_unix_ms = tracker
+        .total_time_ms()
+        .map_or_else(unix_time_ms, |elapsed| {
+            request_received_ms.saturating_add(elapsed.max(0.0).round() as u64)
+        });
+
+    publish(RequestTraceRecord {
+        schema: RequestTraceSchema::V1,
+        event_type: RequestTraceEventType::RequestEnd,
+        event_time_unix_ms,
+        request: RequestTraceMetrics {
+            request_id,
+            request_received_ms,
+            output_tokens: tracker.osl_tokens(),
+            replay,
+        },
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::request_trace::BUS;
+
+    #[tokio::test]
+    async fn emits_tracker_timing_lengths_and_hashes() {
+        BUS.init(16);
+        let mut rx = BUS.subscribe();
+        let tracker = RequestTracker::new();
+        tracker.record_osl(7);
+        tracker.record_finish();
+
+        emit_request_end(
+            "req-1".to_string(),
+            &tracker,
+            AgentReplayMetrics {
+                trace_block_size: 2,
+                input_length: 3,
+                input_sequence_hashes: vec![11, 22],
+            },
+        );
+
+        let record = loop {
+            let record = rx.recv().await.unwrap();
+            if record.request.request_id == "req-1" {
+                break record;
+            }
+        };
+        assert_eq!(record.request.request_id, "req-1");
+        assert_eq!(record.request.output_tokens, 7);
+        assert_eq!(
+            record.request.request_received_ms,
+            tracker.request_received_epoch_ms()
+        );
+        assert!(record.event_time_unix_ms >= record.request.request_received_ms);
+        assert_eq!(record.request.replay.input_length, 3);
+    }
+}

--- a/lib/llm/src/request_trace/sink.rs
+++ b/lib/llm/src/request_trace/sink.rs
@@ -1,0 +1,314 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+
+use anyhow::{Context as _, anyhow};
+use async_trait::async_trait;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+use crate::telemetry::jsonl::{JsonlSinkOptions, JsonlWriter};
+use crate::telemetry::jsonl_gz::{JsonlGzipSinkOptions, JsonlGzipWriter};
+
+use super::{RequestTracePolicy, RequestTraceRecord, config};
+
+static WORKERS_STARTED: AtomicBool = AtomicBool::new(false);
+
+#[async_trait]
+pub trait RequestTraceSink: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn emit(&self, record: &RequestTraceRecord);
+}
+
+pub struct StderrRequestTraceSink;
+
+#[async_trait]
+impl RequestTraceSink for StderrRequestTraceSink {
+    fn name(&self) -> &'static str {
+        "stderr"
+    }
+
+    async fn emit(&self, record: &RequestTraceRecord) {
+        match serde_json::to_string(record) {
+            Ok(json) => tracing::info!(
+                target = "dynamo_llm::request_trace",
+                log_type = "request_trace",
+                record = %json,
+                "request_trace"
+            ),
+            Err(error) => tracing::warn!("request trace serialization failed: {error}"),
+        }
+    }
+}
+
+pub struct JsonlRequestTraceSink {
+    writer: JsonlWriter<RequestTraceRecord>,
+}
+
+impl JsonlRequestTraceSink {
+    pub async fn new(path: String, options: JsonlSinkOptions) -> anyhow::Result<Self> {
+        let writer = JsonlWriter::new(path.clone(), options)
+            .await
+            .with_context(|| format!("opening jsonl request trace sink at {path}"))?;
+        Ok(Self { writer })
+    }
+
+    async fn from_policy(policy: &RequestTracePolicy) -> anyhow::Result<Self> {
+        let path = policy.output_path.clone().ok_or_else(|| {
+            anyhow!(
+                "{} must be set when {} includes jsonl",
+                dynamo_runtime::config::environment_names::llm::request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH,
+                dynamo_runtime::config::environment_names::llm::request_trace::DYN_REQUEST_TRACE_SINKS
+            )
+        })?;
+        Self::new(
+            path,
+            JsonlSinkOptions {
+                buffer_bytes: policy.jsonl_buffer_bytes,
+                flush_interval: Duration::from_millis(policy.jsonl_flush_interval_ms.max(1)),
+            },
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl RequestTraceSink for JsonlRequestTraceSink {
+    fn name(&self) -> &'static str {
+        "jsonl"
+    }
+
+    async fn emit(&self, record: &RequestTraceRecord) {
+        if self.writer.send(record.clone()).await.is_err() {
+            tracing::warn!("request trace jsonl sink closed; dropping record");
+        }
+    }
+}
+
+pub struct JsonlGzipRequestTraceSink {
+    writer: JsonlGzipWriter<RequestTraceRecord>,
+}
+
+impl JsonlGzipRequestTraceSink {
+    pub async fn new(path: String, options: JsonlGzipSinkOptions) -> anyhow::Result<Self> {
+        let writer = JsonlGzipWriter::new(path.clone(), options)
+            .await
+            .with_context(|| format!("opening gzip jsonl request trace sink at {path}"))?;
+        Ok(Self { writer })
+    }
+
+    async fn from_policy(policy: &RequestTracePolicy) -> anyhow::Result<Self> {
+        let path = policy.output_path.clone().ok_or_else(|| {
+            anyhow!(
+                "{} must be set when {} includes jsonl_gz",
+                dynamo_runtime::config::environment_names::llm::request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH,
+                dynamo_runtime::config::environment_names::llm::request_trace::DYN_REQUEST_TRACE_SINKS
+            )
+        })?;
+        Self::new(
+            path,
+            JsonlGzipSinkOptions {
+                buffer_bytes: policy.jsonl_buffer_bytes,
+                flush_interval: Duration::from_millis(policy.jsonl_flush_interval_ms.max(1)),
+                roll_uncompressed_bytes: policy.jsonl_gz_roll_bytes,
+                roll_lines: policy.jsonl_gz_roll_lines,
+            },
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl RequestTraceSink for JsonlGzipRequestTraceSink {
+    fn name(&self) -> &'static str {
+        "jsonl_gz"
+    }
+
+    async fn emit(&self, record: &RequestTraceRecord) {
+        if self.writer.send(record.clone()).await.is_err() {
+            tracing::warn!("request trace jsonl_gz sink closed; dropping record");
+        }
+    }
+}
+
+async fn parse_sinks_from_env() -> anyhow::Result<Vec<Arc<dyn RequestTraceSink>>> {
+    let policy = config::policy();
+    let mut sinks: Vec<Arc<dyn RequestTraceSink>> = Vec::new();
+    for name in &policy.sinks {
+        match name.as_str() {
+            "stderr" => sinks.push(Arc::new(StderrRequestTraceSink)),
+            "jsonl" => sinks.push(Arc::new(JsonlRequestTraceSink::from_policy(policy).await?)),
+            "jsonl_gz" => sinks.push(Arc::new(
+                JsonlGzipRequestTraceSink::from_policy(policy).await?,
+            )),
+            other => tracing::warn!(%other, "request trace: unknown sink ignored"),
+        }
+    }
+    Ok(sinks)
+}
+
+pub async fn spawn_workers_from_env(shutdown: CancellationToken) -> anyhow::Result<()> {
+    if WORKERS_STARTED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    if let Err(error) = spawn_workers(shutdown).await {
+        WORKERS_STARTED.store(false, Ordering::Release);
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn spawn_workers(shutdown: CancellationToken) -> anyhow::Result<()> {
+    let sinks = parse_sinks_from_env().await?;
+    let sink_count = sinks.len();
+    for sink in sinks {
+        let name = sink.name();
+        let mut receiver: broadcast::Receiver<RequestTraceRecord> = super::subscribe();
+        let worker_shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = worker_shutdown.cancelled() => {
+                        loop {
+                            match receiver.try_recv() {
+                                Ok(record) => sink.emit(&record).await,
+                                Err(broadcast::error::TryRecvError::Lagged(count)) => tracing::warn!(
+                                    sink = name,
+                                    dropped = count,
+                                    "request trace bus lagged during shutdown; dropped records"
+                                ),
+                                Err(
+                                    broadcast::error::TryRecvError::Empty
+                                    | broadcast::error::TryRecvError::Closed
+                                ) => break,
+                            }
+                        }
+                        return;
+                    }
+                    message = receiver.recv() => {
+                        match message {
+                            Ok(record) => sink.emit(&record).await,
+                            Err(broadcast::error::RecvError::Lagged(count)) => tracing::warn!(
+                                sink = name,
+                                dropped = count,
+                                "request trace bus lagged; dropped records"
+                            ),
+                            Err(broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    tracing::info!(sinks = sink_count, "Request trace sinks ready");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use flate2::read::MultiGzDecoder;
+    use tempfile::tempdir;
+
+    use crate::agents::trace::AgentReplayMetrics;
+    use crate::telemetry::jsonl_gz::segment_path;
+
+    use super::*;
+    use crate::request_trace::{RequestTraceEventType, RequestTraceMetrics, RequestTraceSchema};
+
+    fn sample_record() -> RequestTraceRecord {
+        RequestTraceRecord {
+            schema: RequestTraceSchema::V1,
+            event_type: RequestTraceEventType::RequestEnd,
+            event_time_unix_ms: 1_100,
+            request: RequestTraceMetrics {
+                request_id: "req-123".to_string(),
+                request_received_ms: 1_000,
+                output_tokens: 7,
+                replay: AgentReplayMetrics {
+                    trace_block_size: 2,
+                    input_length: 3,
+                    input_sequence_hashes: vec![11, 22],
+                },
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn jsonl_sink_writes_request_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace.jsonl");
+        let sink = JsonlRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlSinkOptions {
+                buffer_bytes: 128,
+                flush_interval: Duration::from_millis(10),
+            },
+        )
+        .await
+        .unwrap();
+
+        sink.emit(&sample_record()).await;
+
+        let mut content = String::new();
+        for _ in 0..100 {
+            content = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+            if content.contains("\"request_id\":\"req-123\"") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(content.contains("\"schema\":\"dynamo.request.trace.v1\""));
+        assert!(!content.contains("agent_context"));
+        assert!(!content.contains("\"tool\""));
+    }
+
+    #[tokio::test]
+    async fn gzip_sink_writes_and_rolls_request_records() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("request_trace");
+        let sink = JsonlGzipRequestTraceSink::new(
+            path.display().to_string(),
+            JsonlGzipSinkOptions {
+                buffer_bytes: 1,
+                flush_interval: Duration::from_secs(60),
+                roll_uncompressed_bytes: 1024 * 1024,
+                roll_lines: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+        sink.emit(&sample_record()).await;
+        sink.emit(&sample_record()).await;
+
+        for index in 0..2 {
+            let segment = segment_path(&path, index);
+            let mut content = String::new();
+            for _ in 0..100 {
+                if segment.exists() {
+                    let bytes = std::fs::read(&segment).unwrap();
+                    let mut decoder = MultiGzDecoder::new(bytes.as_slice());
+                    decoder.read_to_string(&mut content).unwrap();
+                    if content.contains("\"request_id\":\"req-123\"") {
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            assert!(content.contains("\"request_id\":\"req-123\""));
+        }
+    }
+}

--- a/lib/llm/src/request_trace/types.rs
+++ b/lib/llm/src/request_trace/types.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::agents::trace::AgentReplayMetrics;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequestTraceRecord {
+    pub schema: RequestTraceSchema,
+    pub event_type: RequestTraceEventType,
+    pub event_time_unix_ms: u64,
+    pub request: RequestTraceMetrics,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RequestTraceSchema {
+    #[serde(rename = "dynamo.request.trace.v1")]
+    V1,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RequestTraceEventType {
+    #[serde(rename = "request_end")]
+    RequestEnd,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequestTraceMetrics {
+    pub request_id: String,
+    pub request_received_ms: u64,
+    pub output_tokens: u64,
+    pub replay: AgentReplayMetrics,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_trace_has_only_replay_fields() {
+        let record = RequestTraceRecord {
+            schema: RequestTraceSchema::V1,
+            event_type: RequestTraceEventType::RequestEnd,
+            event_time_unix_ms: 1_100,
+            request: RequestTraceMetrics {
+                request_id: "req-1".to_string(),
+                request_received_ms: 1_000,
+                output_tokens: 4,
+                replay: AgentReplayMetrics {
+                    trace_block_size: 2,
+                    input_length: 4,
+                    input_sequence_hashes: vec![11, 22],
+                },
+            },
+        };
+
+        let value = serde_json::to_value(record).unwrap();
+        assert_eq!(value["schema"], "dynamo.request.trace.v1");
+        assert_eq!(value["event_type"], "request_end");
+        assert!(value.get("agent_context").is_none());
+        assert!(value.get("tool").is_none());
+        assert!(value["request"].get("model").is_none());
+        assert!(value["request"].get("finish_reason_metadata").is_none());
+        assert!(value["request"].get("payload").is_none());
+    }
+}

--- a/lib/llm/src/telemetry/stream.rs
+++ b/lib/llm/src/telemetry/stream.rs
@@ -11,16 +11,20 @@ type CompletionStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 type DoneFuture = Pin<Box<dyn std::future::Future<Output = ()> + Send>>;
 
 struct PassThroughWithCompletion<S> {
-    inner: S,
+    inner: Option<S>,
     done_tx: Option<oneshot::Sender<()>>,
 }
 
 impl<S> PassThroughWithCompletion<S> {
     fn new(inner: S, done_tx: oneshot::Sender<()>) -> Self {
         Self {
-            inner,
+            inner: Some(inner),
             done_tx: Some(done_tx),
         }
+    }
+
+    fn drop_inner(&mut self) {
+        drop(self.inner.take());
     }
 
     fn notify_done(&mut self) {
@@ -32,6 +36,7 @@ impl<S> PassThroughWithCompletion<S> {
 
 impl<S> Drop for PassThroughWithCompletion<S> {
     fn drop(&mut self) {
+        self.drop_inner();
         self.notify_done();
     }
 }
@@ -43,8 +48,12 @@ where
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match Pin::new(&mut self.inner).poll_next(cx) {
+        let Some(inner) = self.inner.as_mut() else {
+            return Poll::Ready(None);
+        };
+        match Pin::new(inner).poll_next(cx) {
             Poll::Ready(None) => {
+                self.drop_inner();
                 self.notify_done();
                 Poll::Ready(None)
             }
@@ -71,9 +80,34 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::pin::Pin;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use std::task::{Context, Poll};
+
     use futures::{StreamExt, stream};
 
     use super::notify_on_completion;
+
+    struct DropMarker {
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Release);
+        }
+    }
+
+    impl futures::Stream for DropMarker {
+        type Item = ();
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Pending
+        }
+    }
 
     #[tokio::test]
     async fn notifies_when_stream_is_dropped_before_exhaustion() {
@@ -88,5 +122,18 @@ mod tests {
         assert_eq!(wrapped.next().await, Some(1));
         assert_eq!(wrapped.next().await, None);
         done.await;
+    }
+
+    #[tokio::test]
+    async fn drops_inner_stream_before_notifying() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (wrapped, done) = notify_on_completion(DropMarker {
+            dropped: dropped.clone(),
+        });
+
+        drop(wrapped);
+        done.await;
+
+        assert!(dropped.load(Ordering::Acquire));
     }
 }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -421,6 +421,40 @@ pub mod llm {
         pub const DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC: &str =
             "DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC";
     }
+
+    /// Per-request replay trace configuration
+    pub mod request_trace {
+        /// Master switch. Truthy enables per-request replay tracing.
+        pub const DYN_REQUEST_TRACE: &str = "DYN_REQUEST_TRACE";
+
+        /// Request trace sink selection. Comma-separated values: stderr,jsonl,jsonl_gz.
+        pub const DYN_REQUEST_TRACE_SINKS: &str = "DYN_REQUEST_TRACE_SINKS";
+
+        /// Local output path for request trace records.
+        ///
+        /// For `jsonl`, this is the literal file path. For `jsonl_gz`, this is the
+        /// segment prefix used to derive `<prefix>.<index>.jsonl.gz` files.
+        pub const DYN_REQUEST_TRACE_OUTPUT_PATH: &str = "DYN_REQUEST_TRACE_OUTPUT_PATH";
+
+        /// In-process trace bus capacity.
+        pub const DYN_REQUEST_TRACE_CAPACITY: &str = "DYN_REQUEST_TRACE_CAPACITY";
+
+        /// JSONL sink buffer size in bytes.
+        pub const DYN_REQUEST_TRACE_JSONL_BUFFER_BYTES: &str =
+            "DYN_REQUEST_TRACE_JSONL_BUFFER_BYTES";
+
+        /// JSONL sink periodic flush interval in milliseconds.
+        pub const DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS: &str =
+            "DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS";
+
+        /// Rotating gzip JSONL sink roll threshold in uncompressed bytes.
+        pub const DYN_REQUEST_TRACE_JSONL_GZ_ROLL_BYTES: &str =
+            "DYN_REQUEST_TRACE_JSONL_GZ_ROLL_BYTES";
+
+        /// Rotating gzip JSONL sink roll threshold in record lines.
+        pub const DYN_REQUEST_TRACE_JSONL_GZ_ROLL_LINES: &str =
+            "DYN_REQUEST_TRACE_JSONL_GZ_ROLL_LINES";
+    }
 }
 
 /// Model loading and caching environment variables
@@ -670,6 +704,14 @@ mod tests {
             llm::agent_trace::DYN_AGENT_TRACE_REPLAY_HASHES,
             llm::agent_trace::DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT,
             llm::agent_trace::DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC,
+            llm::request_trace::DYN_REQUEST_TRACE,
+            llm::request_trace::DYN_REQUEST_TRACE_SINKS,
+            llm::request_trace::DYN_REQUEST_TRACE_OUTPUT_PATH,
+            llm::request_trace::DYN_REQUEST_TRACE_CAPACITY,
+            llm::request_trace::DYN_REQUEST_TRACE_JSONL_BUFFER_BYTES,
+            llm::request_trace::DYN_REQUEST_TRACE_JSONL_FLUSH_INTERVAL_MS,
+            llm::request_trace::DYN_REQUEST_TRACE_JSONL_GZ_ROLL_BYTES,
+            llm::request_trace::DYN_REQUEST_TRACE_JSONL_GZ_ROLL_LINES,
             // Model
             model::model_express::MODEL_EXPRESS_URL,
             model::model_express::MODEL_EXPRESS_CACHE_PATH,


### PR DESCRIPTION
Adds independent per-request replay tracing for Rust OpenAI chat and completion serving, including rolling sequence hashes and accurate partial OSL on cancellation. Extends the existing agent trace converter to accept the context-free request schema for Mooncake replay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added request replay tracing capability for offline request simulation, enabled via `DYN_REQUEST_TRACE` environment variable
  * Added configurable trace sinks (stderr, JSONL, gzipped JSONL) with flexible output paths and rolling strategies
  * Request traces can be converted to replay format and used for benchmarking

* **Documentation**
  * Added comprehensive request replay tracing guide with configuration and usage examples

* **Validation**
  * Added compatibility checks preventing conversion of context-free request traces when agentic mode is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->