### PR TITLE
feat(lora): allocation controller + slot-aware HRW + load estimator + metrics (1/3)

### DIFF
--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -15,7 +15,7 @@ use dynamo_runtime::{
     },
 };
 use prometheus::{
-    Encoder, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts,
+    Encoder, GaugeVec, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts,
 };
 use serde::Serialize;
 use std::{
@@ -114,6 +114,110 @@ pub fn register_worker_timing_metrics(registry: &Registry) -> Result<(), prometh
     registry.register(Box::new(WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE.clone()))?;
     registry.register(Box::new(WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE.clone()))?;
     registry.register(Box::new(WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE.clone()))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// LoRA allocation metrics (updated by LoraController each tick)
+// ---------------------------------------------------------------------------
+
+pub static LORA_REPLICA_FACTOR_GAUGE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            format!("dynamo_frontend_{}", frontend_service::LORA_REPLICA_FACTOR),
+            "Number of replicas allocated for a LoRA adapter",
+        ),
+        &["lora"],
+    )
+    .expect("Failed to create lora_replica_factor gauge")
+});
+
+pub static LORA_IS_ACTIVE_GAUGE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            format!("dynamo_frontend_{}", frontend_service::LORA_IS_ACTIVE),
+            "Whether a LoRA adapter is active (1) or inactive (0)",
+        ),
+        &["lora"],
+    )
+    .expect("Failed to create lora_is_active gauge")
+});
+
+pub static LORA_RAW_ARRIVAL_COUNT_GAUGE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            format!(
+                "dynamo_frontend_{}",
+                frontend_service::LORA_RAW_ARRIVAL_COUNT
+            ),
+            "Raw arrival count (windowed rate counter) for a LoRA adapter",
+        ),
+        &["lora"],
+    )
+    .expect("Failed to create lora_raw_arrival_count gauge")
+});
+
+pub static LORA_ESTIMATED_LOAD_GAUGE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            format!("dynamo_frontend_{}", frontend_service::LORA_ESTIMATED_LOAD),
+            "Estimated load (windowed request count) for a LoRA adapter",
+        ),
+        &["lora"],
+    )
+    .expect("Failed to create lora_estimated_load gauge")
+});
+
+pub static LORA_ACTIVE_REQUESTS_GAUGE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            format!("dynamo_frontend_{}", frontend_service::LORA_ACTIVE_REQUESTS),
+            "Number of in-flight requests for a LoRA adapter",
+        ),
+        &["lora"],
+    )
+    .expect("Failed to create lora_active_requests gauge")
+});
+
+pub static LORA_CHURN_LOADS_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        format!(
+            "dynamo_frontend_{}",
+            frontend_service::LORA_CHURN_LOADS_TOTAL
+        ),
+        "Total LoRA loads (new placements) this tick",
+    )
+    .expect("Failed to create lora_churn_loads gauge")
+});
+
+pub static LORA_CHURN_UNLOADS_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        format!(
+            "dynamo_frontend_{}",
+            frontend_service::LORA_CHURN_UNLOADS_TOTAL
+        ),
+        "Total LoRA unloads (removed placements) this tick",
+    )
+    .expect("Failed to create lora_churn_unloads gauge")
+});
+
+pub static LORA_OVERFLOW_COUNT_GAUGE: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        format!("dynamo_frontend_{}", frontend_service::LORA_OVERFLOW_COUNT),
+        "MCF solver overflow count (unplaceable replicas)",
+    )
+    .expect("Failed to create lora_overflow_count gauge")
+});
+
+pub fn register_lora_allocation_metrics(registry: &Registry) -> Result<(), prometheus::Error> {
+    registry.register(Box::new(LORA_REPLICA_FACTOR_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_IS_ACTIVE_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_RAW_ARRIVAL_COUNT_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_ESTIMATED_LOAD_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_ACTIVE_REQUESTS_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_CHURN_LOADS_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_CHURN_UNLOADS_GAUGE.clone()))?;
+    registry.register(Box::new(LORA_OVERFLOW_COUNT_GAUGE.clone()))?;
     Ok(())
 }
 

--- a/lib/llm/src/lora.rs
+++ b/lib/llm/src/lora.rs
@@ -10,6 +10,7 @@
 
 mod cache;
 pub mod config;
+pub mod controller;
 mod downloader;
 pub mod load_estimator;
 pub mod predictor;
@@ -18,11 +19,13 @@ mod source;
 pub mod state_tracker;
 
 pub use cache::LoRACache;
-pub use config::LoraAllocationConfig;
+pub use config::{LoraAllocationConfig, McfConfig};
+pub use controller::LoraController;
 pub use downloader::LoRADownloader;
 pub use load_estimator::{LoadEstimator, LoadEstimatorConfig};
 pub use routing::{
-    AllocationAlgorithmType, LoraAllocator, LoraReplicaConfig, LoraRoutingTable, RendezvousHasher,
+    AllocationAlgorithmType, LoraAllocator, LoraReplicaConfig, LoraRoutingTable,
+    McfPlacementResult, McfPlacementSolver, McfSolveParams, RendezvousHasher,
     create_lora_allocator,
 };
 pub use source::{LoRASource, LocalLoRASource, S3LoRASource};

--- a/lib/llm/src/lora/config.rs
+++ b/lib/llm/src/lora/config.rs
@@ -5,6 +5,8 @@
 
 use std::str::FromStr;
 
+use serde::{Deserialize, Serialize};
+
 use crate::lora::routing::AllocationAlgorithmType;
 use dynamo_runtime::config::environment_names::llm;
 
@@ -30,6 +32,45 @@ impl FromStr for PredictorType {
     }
 }
 
+/// Configuration for the Min-Cost Flow placement solver.
+///
+/// Read from the `DYN_LORA_MCF_CONFIG` env var as JSON. Omitted fields
+/// fall back to defaults via `#[serde(default)]`.
+///
+/// Example: `{"candidate_m":16,"gamma_load":2000,"beta_keep":500}`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct McfConfig {
+    /// Number of HRW top-M candidates per LoRA.
+    pub candidate_m: usize,
+    /// Preference weight for HRW rank ordering.
+    pub alpha_pref: i64,
+    /// Penalty weight for loading a new LoRA on a worker.
+    pub gamma_load: i64,
+    /// Reward weight for keeping a LoRA on its prior worker.
+    pub beta_keep: i64,
+    /// Cost assigned to the overflow dummy worker.
+    pub overflow_cost: i64,
+    /// Whether to allow overflow (soft infeasibility) or fail hard.
+    pub allow_overflow: bool,
+    /// Default churn weight per LoRA (uniform=1; can be per-adapter later).
+    pub churn_weight_default: i64,
+}
+
+impl Default for McfConfig {
+    fn default() -> Self {
+        Self {
+            candidate_m: 16,
+            alpha_pref: 1,
+            gamma_load: 1000,
+            beta_keep: 250,
+            overflow_cost: 1_000_000_000_000,
+            allow_overflow: true,
+            churn_weight_default: 1,
+        }
+    }
+}
+
 /// Configuration for the LoRA allocation controller.
 #[derive(Debug, Clone)]
 pub struct LoraAllocationConfig {
@@ -46,6 +87,8 @@ pub struct LoraAllocationConfig {
     pub predictor_type: PredictorType,
     /// EMA smoothing factor (alpha). Range [0.0, 1.0].
     pub ema_alpha: f64,
+    /// MCF-specific configuration (only used when algorithm = MinCostFlow).
+    pub mcf: McfConfig,
 }
 
 /// Minimum rate window (seconds).
@@ -62,6 +105,7 @@ impl Default for LoraAllocationConfig {
             buckets_per_second: 1,
             predictor_type: PredictorType::Ema,
             ema_alpha: 0.3,
+            mcf: McfConfig::default(),
         }
     }
 }
@@ -162,6 +206,20 @@ impl LoraAllocationConfig {
             .map(|a| a.clamp(0.0, 1.0))
             .unwrap_or(defaults.ema_alpha);
 
+        let mcf = std::env::var(llm::DYN_LORA_MCF_CONFIG)
+            .ok()
+            .and_then(|v| {
+                serde_json::from_str(&v)
+                    .map_err(|e| {
+                        tracing::warn!(
+                            "Failed to parse DYN_LORA_MCF_CONFIG JSON, using defaults: {e}"
+                        );
+                        e
+                    })
+                    .ok()
+            })
+            .unwrap_or_default();
+
         Self {
             enabled,
             algorithm,
@@ -171,6 +229,7 @@ impl LoraAllocationConfig {
             buckets_per_second,
             predictor_type,
             ema_alpha,
+            mcf,
         }
     }
 }
@@ -199,6 +258,39 @@ mod tests {
     fn test_effective_rate_window_uses_multiplier() {
         let config = LoraAllocationConfig::new(true, "hrw", 10, 2, 5).unwrap();
         assert_eq!(config.effective_rate_window_secs(), 50);
+    }
+
+    #[test]
+    fn test_mcf_config_defaults() {
+        let mcf = McfConfig::default();
+        assert_eq!(mcf.candidate_m, 16);
+        assert_eq!(mcf.alpha_pref, 1);
+        assert_eq!(mcf.gamma_load, 1000);
+        assert_eq!(mcf.beta_keep, 250);
+        assert!(mcf.allow_overflow);
+    }
+
+    #[test]
+    fn test_mcf_config_partial_json() {
+        let json = r#"{"candidate_m":32,"gamma_load":2000}"#;
+        let mcf: McfConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(mcf.candidate_m, 32);
+        assert_eq!(mcf.gamma_load, 2000);
+        // Omitted fields use defaults
+        assert_eq!(mcf.beta_keep, 250);
+        assert_eq!(mcf.alpha_pref, 1);
+    }
+
+    #[test]
+    fn test_mcf_algorithm_type_parsing() {
+        assert_eq!(
+            AllocationAlgorithmType::from_str("mcf").unwrap(),
+            AllocationAlgorithmType::MinCostFlow
+        );
+        assert_eq!(
+            AllocationAlgorithmType::from_str("min_cost_flow").unwrap(),
+            AllocationAlgorithmType::MinCostFlow
+        );
     }
 
     #[test]

--- a/lib/llm/src/lora/controller.rs
+++ b/lib/llm/src/lora/controller.rs
@@ -1,0 +1,1486 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! LoRA Allocation Controller
+//!
+//! Periodically recomputes LoRA allocations based on load estimates and cluster state.
+//! Uses batch load-fraction proportional allocation for active LoRAs, and deterministic
+//! HRW cold-start pinning for inactive LoRAs.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::kv_router::protocols::WorkerWithDpRank;
+use crate::lora::config::LoraAllocationConfig;
+use crate::lora::load_estimator::LoadEstimator;
+use crate::lora::routing::mcf_allocator::{
+    LoraInput, McfPlacementSolver, McfSolveParams, WorkerInput,
+};
+use crate::lora::routing::table::{LoraReplicaConfig, LoraRoutingTable};
+use crate::lora::routing::{AllocationAlgorithmType, LoraAllocator, create_lora_allocator};
+use crate::lora::state_tracker::LoraStateTracker;
+
+#[derive(Debug, Clone)]
+struct HysteresisState {
+    last_scale_down_tick: u64,
+}
+
+/// The LoRA allocation controller.
+///
+/// Runs a periodic background loop that:
+/// 1. Reads current load from `LoadEstimator`
+/// 2. Reads cluster topology from `LoraStateTracker`
+/// 3. Computes proportional replica counts for active LoRAs
+/// 4. Assigns deterministic HRW cold-start pins for inactive LoRAs
+/// 5. Updates the `LoraRoutingTable`
+pub struct LoraController {
+    config: LoraAllocationConfig,
+    allocator: Box<dyn LoraAllocator>,
+    routing_table: LoraRoutingTable,
+    state_tracker: LoraStateTracker,
+    load_estimator: Arc<LoadEstimator>,
+    hysteresis: HashMap<String, HysteresisState>,
+    tick: u64,
+    // MCF-specific state
+    mcf_solver: Option<McfPlacementSolver>,
+    prev_assignment: HashMap<String, HashSet<WorkerWithDpRank>>,
+    prev_workers: HashSet<WorkerWithDpRank>,
+    prev_worker_capacities: HashMap<WorkerWithDpRank, u32>,
+    prev_replica_counts: HashMap<String, usize>,
+}
+
+impl LoraController {
+    pub fn new(
+        config: LoraAllocationConfig,
+        routing_table: LoraRoutingTable,
+        state_tracker: LoraStateTracker,
+        load_estimator: Arc<LoadEstimator>,
+    ) -> Self {
+        let allocator = create_lora_allocator(config.algorithm);
+        let mcf_solver = if config.algorithm == AllocationAlgorithmType::MinCostFlow {
+            let params = McfSolveParams {
+                candidate_m: config.mcf.candidate_m,
+                alpha_pref: config.mcf.alpha_pref,
+                gamma_load: config.mcf.gamma_load,
+                beta_keep: config.mcf.beta_keep,
+                overflow_cost: config.mcf.overflow_cost,
+                allow_overflow: config.mcf.allow_overflow,
+            };
+            Some(McfPlacementSolver::new(params))
+        } else {
+            None
+        };
+        Self {
+            config,
+            allocator,
+            routing_table,
+            state_tracker,
+            load_estimator,
+            hysteresis: HashMap::new(),
+            tick: 0,
+            mcf_solver,
+            prev_assignment: HashMap::new(),
+            prev_workers: HashSet::new(),
+            prev_worker_capacities: HashMap::new(),
+            prev_replica_counts: HashMap::new(),
+        }
+    }
+
+    /// Start the controller background loop.
+    pub fn start(
+        config: LoraAllocationConfig,
+        routing_table: LoraRoutingTable,
+        state_tracker: LoraStateTracker,
+        load_estimator: Arc<LoadEstimator>,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let timestep = Duration::from_secs(config.timestep_secs);
+        let mut controller = Self::new(config, routing_table, state_tracker, load_estimator);
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(timestep);
+            tracing::info!(
+                timestep_secs = controller.config.timestep_secs,
+                algorithm = controller.allocator.name(),
+                "LoRA allocation controller started"
+            );
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::debug!("LoRA allocation controller shutting down");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        // A panic inside recompute must not silently kill the controller loop —
+                        // that would freeze all LoRA allocation for the process lifetime with no
+                        // restart and no alert. Catch it, log, and continue; the next tick
+                        // recomputes fresh from current cluster state (a partially-updated table
+                        // self-heals). `&mut controller` across the unwind boundary needs
+                        // AssertUnwindSafe.
+                        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            controller.recompute_allocations();
+                        }));
+                        if let Err(panic) = outcome {
+                            let msg = panic
+                                .downcast_ref::<&str>()
+                                .map(|s| s.to_string())
+                                .or_else(|| panic.downcast_ref::<String>().cloned())
+                                .unwrap_or_else(|| "unknown panic".to_string());
+                            tracing::error!(
+                                tick = controller.tick,
+                                panic = %msg,
+                                "LoRA allocation recompute panicked; skipping this tick and continuing"
+                            );
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    pub fn recompute_now(&mut self) {
+        self.recompute_allocations();
+    }
+
+    fn recompute_allocations(&mut self) {
+        self.tick += 1;
+
+        let workers = self.state_tracker.list_workers();
+        if workers.is_empty() {
+            // Cluster drained: every routing entry now points at gone workers. Leaving it would
+            // make the filter fall back to all-available (scatter) and the gauges show phantom
+            // allocations. Clear routing state and reset metrics instead of returning early.
+            tracing::debug!("No workers available; clearing stale LoRA routes and metrics");
+            self.clear_lora_routing_and_metrics();
+            return;
+        }
+
+        let total_slots = self.state_tracker.total_lora_slots() as usize;
+        if total_slots == 0 {
+            // Workers exist but report zero LoRA capacity, so there is nothing to (re)allocate.
+            // Don't wipe bounded routes wholesale (they'd drop to the filter's no-table scatter),
+            // but a route whose replica set has lost ALL its live workers (e.g. some workers were
+            // removed) WOULD scatter — the filter finds no live replica intersection and falls back
+            // to all available workers. Prune every entry against the live worker set: narrow to
+            // the live intersection, or rebind to a single deterministic live pin when none of its
+            // workers are live, so every LoRA keeps a bounded, live route. Then skip recompute.
+            let live: std::collections::HashSet<WorkerWithDpRank> =
+                workers.iter().copied().collect();
+            for (name, cfg) in self.routing_table.snapshot_configs() {
+                let live_set: Vec<WorkerWithDpRank> = cfg
+                    .replica_set
+                    .iter()
+                    .copied()
+                    .filter(|w| live.contains(w))
+                    .collect();
+                if live_set.is_empty() {
+                    // Deterministic HRW top-1, NOT self.allocator: the Random allocator returns
+                    // all workers regardless of replica_factor, which would re-scatter the dead
+                    // route instead of binding it to a single worker.
+                    let pin = crate::lora::routing::RendezvousHasher
+                        .compute_replica_set(&name, &workers, 1);
+                    if pin.is_empty() {
+                        self.routing_table.remove_lora(&name);
+                        self.hysteresis.remove(&name);
+                    } else if pin != cfg.replica_set {
+                        self.update_routing_entry(&name, pin.len(), pin, cfg.is_active);
+                    }
+                } else if live_set.len() != cfg.replica_set.len() {
+                    self.update_routing_entry(&name, live_set.len(), live_set, cfg.is_active);
+                }
+            }
+            // Refresh gauges from the pruned table so a narrowed/rebound route's replica_factor
+            // (and the other LoRA gauges) don't stay stale while capacity remains zero. No
+            // allocation ran this tick, so churn/overflow are zero.
+            let table_snapshot = self.routing_table.snapshot_configs();
+            let loads = self.load_estimator.get_current_load();
+            let raw_arrival_counts = self.load_estimator.get_raw_arrival_counts();
+            self.update_prometheus_metrics(&table_snapshot, &loads, &raw_arrival_counts);
+            crate::http::service::metrics::LORA_CHURN_LOADS_GAUGE.set(0);
+            crate::http::service::metrics::LORA_CHURN_UNLOADS_GAUGE.set(0);
+            crate::http::service::metrics::LORA_OVERFLOW_COUNT_GAUGE.set(0);
+            tracing::debug!(
+                "No LoRA slots available; pruned routes to live workers, skipping recompute"
+            );
+            return;
+        }
+
+        let worker_slot_usage = self.state_tracker.get_worker_slot_usage();
+        let loads = self.load_estimator.get_current_load();
+        let total_load: usize = loads.values().sum();
+
+        if !loads.is_empty() {
+            tracing::debug!(
+                tick = self.tick,
+                ?loads,
+                total_load,
+                "Load estimator snapshot"
+            );
+        }
+
+        // Collect all known LoRAs (from state tracker + from load estimator)
+        let mut seen: std::collections::HashSet<String> =
+            self.state_tracker.list_loras().into_iter().collect();
+        for lora_name in loads.keys() {
+            seen.insert(lora_name.clone());
+        }
+        // Sort for deterministic ordering across all router instances (REQ: deterministic
+        // placement). active/inactive/MCF inputs all derive from this order, and the
+        // largest-remainder tie-break below is by name, so every router converges identically.
+        let mut all_loras: Vec<String> = seen.into_iter().collect();
+        all_loras.sort();
+
+        let active_loras: Vec<(String, usize)> = all_loras
+            .iter()
+            .filter_map(|name| {
+                let load = loads.get(name).copied().unwrap_or(0);
+                if load > 0 {
+                    Some((name.clone(), load))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let inactive_loras: Vec<String> = all_loras
+            .iter()
+            .filter(|name| loads.get(*name).copied().unwrap_or(0) == 0)
+            .cloned()
+            .collect();
+
+        // Active LoRAs: load-fraction proportional allocation
+        let active_replica_counts = if !active_loras.is_empty() && total_load > 0 {
+            Self::compute_active_replica_counts(
+                &active_loras,
+                total_load,
+                total_slots,
+                workers.len(),
+            )
+        } else {
+            HashMap::new()
+        };
+
+        if self.mcf_solver.is_some() {
+            self.recompute_mcf(
+                &workers,
+                &all_loras,
+                &active_loras,
+                &inactive_loras,
+                &active_replica_counts,
+            );
+        } else {
+            self.recompute_per_lora(
+                &workers,
+                &inactive_loras,
+                &active_replica_counts,
+                &worker_slot_usage,
+            );
+        }
+
+        // Cleanup stale entries.
+        let known_set: std::collections::HashSet<&str> =
+            all_loras.iter().map(|s| s.as_str()).collect();
+        let live_workers: std::collections::HashSet<WorkerWithDpRank> =
+            workers.iter().copied().collect();
+
+        // Capacity-dropped active LoRAs: active (load>0) but truncated out of this tick's budget
+        // by the R3 cap, so they received no fresh allocation. Each must stay routable (REQ 7)
+        // without triggering uncontrolled loads that defeat the cap:
+        //   * If still warm somewhere (prior set ∩ loaded ∩ live non-empty), keep ONLY those
+        //     workers — routes to existing adapters with zero new loads. (Rewrites only when the
+        //     warm set shrank, so a still-warm dropped LoRA stays churn-free.)
+        //   * Otherwise (adapter evicted everywhere, OR a brand-new over-budget active LoRA with
+        //     no entry at all), pin it to a SINGLE deterministic slot-aware HRW worker. This bounds
+        //     the unavoidable load to one worker and is identical across router instances, instead
+        //     of removing the entry — which would scatter to all workers via the filter's no-table
+        //     path (returns all when nothing is loaded).
+        // Pin worker selection is slot-aware against this tick's PROJECTED usage (the in-budget
+        // HRW/MCF placements already written to the routing table, plus earlier dropped pins), so a
+        // pin never targets a slot already claimed this tick.
+        let dropped_active: Vec<&str> = active_loras
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .filter(|n| !active_replica_counts.contains_key(*n))
+            .collect();
+        if !dropped_active.is_empty() {
+            let dropped_set: std::collections::HashSet<&str> =
+                dropped_active.iter().copied().collect();
+            let caps = self.state_tracker.get_worker_capacities();
+            // Committed placements this tick, excluding the dropped LoRAs themselves (their entries
+            // are stale and re-decided below).
+            let mut projected: HashMap<WorkerWithDpRank, usize> = HashMap::new();
+            for (name, cfg) in self.routing_table.snapshot_configs() {
+                if dropped_set.contains(name.as_str()) {
+                    continue;
+                }
+                for w in &cfg.replica_set {
+                    *projected.entry(*w).or_insert(0) += 1;
+                }
+            }
+
+            for &name in &dropped_active {
+                let prior = self
+                    .routing_table
+                    .get_config(name)
+                    .map(|c| c.replica_set)
+                    .unwrap_or_default();
+                let loaded = self.state_tracker.get_loaded_workers(name);
+                let warm: Vec<WorkerWithDpRank> = prior
+                    .iter()
+                    .copied()
+                    .filter(|w| loaded.contains(w) && live_workers.contains(w))
+                    .collect();
+
+                let chosen = if !warm.is_empty() {
+                    warm
+                } else {
+                    let proj_usage: HashMap<WorkerWithDpRank, (usize, usize)> = workers
+                        .iter()
+                        .map(|w| {
+                            let used = projected.get(w).copied().unwrap_or(0);
+                            let cap = caps.get(w).copied().unwrap_or(0) as usize;
+                            (*w, (used, cap))
+                        })
+                        .collect();
+                    self.allocator
+                        .compute_replica_set_with_slots(name, &workers, 1, &proj_usage)
+                };
+
+                if chosen.is_empty() {
+                    self.routing_table.remove_lora(name);
+                    self.hysteresis.remove(name);
+                    continue;
+                }
+                // Charge the chosen workers so later dropped pins see them occupied.
+                for w in &chosen {
+                    *projected.entry(*w).or_insert(0) += 1;
+                }
+                // No-ops when nothing changed (still-warm, unchanged set) — keeps churn at zero.
+                self.update_routing_entry(name, chosen.len(), chosen, true);
+            }
+        }
+
+        let table_snapshot = self.routing_table.snapshot_configs();
+
+        for (name, _) in &table_snapshot {
+            if !known_set.contains(name.as_str()) {
+                self.routing_table.remove_lora(name);
+                self.hysteresis.remove(name);
+                tracing::debug!(lora = name, "Removed stale routing table entry");
+            }
+        }
+
+        // Re-snapshot after cleanup so the logs and Prometheus gauges below reflect the
+        // post-cleanup table and don't surface a stale LoRA for an extra tick (RF-1).
+        let table_snapshot = self.routing_table.snapshot_configs();
+
+        // Prune the load estimator of LoRAs that are no longer loaded (and any
+        // unknown/typo request names), bounding its memory over time (F12).
+        self.load_estimator.retain_known(&known_set);
+
+        tracing::debug!(
+            tick = self.tick,
+            active = active_loras.len(),
+            inactive = inactive_loras.len(),
+            total_workers = workers.len(),
+            total_slots = total_slots,
+            "Recompute complete"
+        );
+
+        if !table_snapshot.is_empty() {
+            tracing::debug!(
+                tick = self.tick,
+                entries = table_snapshot.len(),
+                "LoRA allocation table"
+            );
+            for (name, config) in &table_snapshot {
+                if known_set.contains(name.as_str()) {
+                    let worker_ids: Vec<u64> =
+                        config.replica_set.iter().map(|w| w.worker_id).collect();
+                    tracing::debug!(
+                        lora = name,
+                        replica_factor = config.replica_factor,
+                        workers = ?worker_ids,
+                        is_active = config.is_active,
+                        "  allocation"
+                    );
+                }
+            }
+        }
+
+        let raw_arrival_counts = self.load_estimator.get_raw_arrival_counts();
+        self.update_prometheus_metrics(&table_snapshot, &loads, &raw_arrival_counts);
+    }
+
+    /// Per-LoRA allocation path (HRW / Random): processes each LoRA independently.
+    fn recompute_per_lora(
+        &mut self,
+        workers: &[WorkerWithDpRank],
+        inactive_loras: &[String],
+        active_replica_counts: &HashMap<String, usize>,
+        worker_slot_usage: &HashMap<WorkerWithDpRank, (usize, usize)>,
+    ) {
+        // Track residual capacity across LoRAs within this tick so multiple active LoRAs
+        // are not all placed on the same "free" slots and exceed per-worker capacity (F7).
+        // Iterate in a deterministic (sorted) order so every router instance charges
+        // residual capacity identically and converges on the same placement.
+        let mut residual_usage = worker_slot_usage.clone();
+        let mut active_sorted: Vec<(&String, &usize)> = active_replica_counts.iter().collect();
+        active_sorted.sort_by(|a, b| a.0.cmp(b.0));
+
+        for (lora_name, desired_replicas) in active_sorted {
+            let current = self.routing_table.get_config(lora_name);
+            let current_replicas = current.as_ref().map(|c| c.replica_factor).unwrap_or(0);
+            // Anchor on the LoRA's existing placement so transient sibling activity within
+            // this tick cannot move a LoRA whose own inputs are unchanged (preserves the HRW
+            // churn-minimization guarantee while still charging residual capacity below).
+            let prior: Vec<WorkerWithDpRank> = current
+                .as_ref()
+                .map(|c| c.replica_set.clone())
+                .unwrap_or_default();
+
+            let final_replicas =
+                self.apply_hysteresis(lora_name, *desired_replicas, current_replicas);
+
+            // Discount this LoRA's OWN already-loaded slots before the fullness check: a worker
+            // that currently hosts this adapter is not "full" with respect to re-placing the same
+            // adapter (retaining it consumes no new slot). Without this, a LoRA pinned to a worker
+            // that is full largely because of itself (e.g. cap=1) would be evicted and moved every
+            // tick — defeating the sticky placement. Charging (below) still uses the undiscounted
+            // shared residual so sibling LoRAs see true remaining capacity.
+            let own_loaded = self.state_tracker.get_loaded_workers(lora_name);
+            let mut eff_usage = residual_usage.clone();
+            for w in &own_loaded {
+                if let Some(usage) = eff_usage.get_mut(w) {
+                    usage.0 = usage.0.saturating_sub(1);
+                }
+            }
+
+            let replica_set = self.allocator.compute_replica_set_with_slots_sticky(
+                lora_name,
+                workers,
+                final_replicas,
+                &eff_usage,
+                &prior,
+            );
+
+            // Charge this LoRA's placements against the shared residual capacity for later LoRAs,
+            // but ONLY for workers where it is not already loaded: an already-loaded placement is
+            // already counted in the base `worker_slot_usage`, so charging it again would
+            // double-count and make the worker look full to subsequent same-worker LoRAs (e.g. a
+            // cap=2 worker hosting A and B: charging A's retained slot would push B off it).
+            for w in &replica_set {
+                if own_loaded.contains(w) {
+                    continue;
+                }
+                if let Some(usage) = residual_usage.get_mut(w) {
+                    usage.0 += 1;
+                }
+            }
+
+            // Store the EFFECTIVE replica count (the set the allocator actually returned), not the
+            // desired `final_replicas`. Under partial-capacity pressure the slot-aware allocator
+            // returns a smaller-than-requested set, so using `final_replicas` would make
+            // LoraReplicaConfig::replica_factor overstate replica_set.len() — wrong for the
+            // replica-factor gauge and any consumer of that field. The router already narrows by
+            // the set itself.
+            if self.update_routing_entry(lora_name, replica_set.len(), replica_set.clone(), true) {
+                tracing::info!(
+                    lora = lora_name,
+                    desired = final_replicas,
+                    replicas = replica_set.len(),
+                    workers = ?replica_set.iter().map(|w| w.worker_id).collect::<Vec<_>>(),
+                    "Updated active LoRA allocation"
+                );
+            }
+        }
+
+        // Inactive LoRAs: single HRW-pinned cold-start replica
+        for lora_name in inactive_loras {
+            let pin = self.allocator.compute_replica_set(lora_name, workers, 1);
+            if pin.is_empty() {
+                continue;
+            }
+            let pinned_worker = pin.first().map(|w| w.worker_id);
+            // Store the effective set size (not a literal 1): the per-LoRA allocators return one
+            // worker for HRW/MCF cold-start, but the test-only Random allocator returns every
+            // worker regardless of the requested count, so replica_factor must track the set.
+            if self.update_routing_entry(lora_name, pin.len(), pin, false) {
+                tracing::info!(
+                    lora = lora_name,
+                    pinned_worker_id = ?pinned_worker,
+                    "Inactive LoRA allocation (cold-start pin)"
+                );
+            }
+            self.hysteresis.remove(lora_name);
+        }
+    }
+
+    /// Workers that changed since the previous MCF tick: those added or removed (set difference)
+    /// AND those whose per-worker LoRA capacity changed. The MCF delta solver only reconsiders
+    /// workers it is told changed, so a capacity change (e.g. a base-card `max_gpu_lora_count`
+    /// update, or a worker gaining/losing slots) must be reported here — otherwise its frozen
+    /// placements stay stale in delta mode and the solver never uses new headroom. (Capacity
+    /// shrink past current usage is also caught by the solver's over-commit unfreeze, but increases
+    /// and non-overcommitting shrinks rely on this signal.)
+    fn compute_changed_workers(
+        current_workers: &HashSet<WorkerWithDpRank>,
+        prev_workers: &HashSet<WorkerWithDpRank>,
+        current_caps: &HashMap<WorkerWithDpRank, u32>,
+        prev_caps: &HashMap<WorkerWithDpRank, u32>,
+    ) -> HashSet<WorkerWithDpRank> {
+        let mut changed: HashSet<WorkerWithDpRank> = current_workers
+            .symmetric_difference(prev_workers)
+            .copied()
+            .collect();
+        for w in current_workers {
+            if current_caps.get(w).copied().unwrap_or(0) != prev_caps.get(w).copied().unwrap_or(0) {
+                changed.insert(*w);
+            }
+        }
+        changed
+    }
+
+    /// Global MCF allocation path: solves all LoRA placements simultaneously.
+    fn recompute_mcf(
+        &mut self,
+        workers: &[WorkerWithDpRank],
+        all_loras: &[String],
+        active_loras: &[(String, usize)],
+        inactive_loras: &[String],
+        active_replica_counts: &HashMap<String, usize>,
+    ) {
+        let churn_weight = self.config.mcf.churn_weight_default;
+        let capacities = self.state_tracker.get_worker_capacities();
+
+        // R3-7: reset churn/overflow gauges at tick start so a failed MCF solve does not leave
+        // stale values from a prior successful tick; the success branch sets the actual diff.
+        crate::http::service::metrics::LORA_CHURN_LOADS_GAUGE.set(0);
+        crate::http::service::metrics::LORA_CHURN_UNLOADS_GAUGE.set(0);
+        crate::http::service::metrics::LORA_OVERFLOW_COUNT_GAUGE.set(0);
+
+        // Build worker inputs
+        let worker_inputs: Vec<WorkerInput> = workers
+            .iter()
+            .map(|w| WorkerInput {
+                worker: *w,
+                capacity: capacities.get(w).copied().unwrap_or(0) as usize,
+            })
+            .collect();
+
+        // Build LoRA inputs: active with proportional replicas, inactive with 1
+        let mut lora_inputs: Vec<LoraInput> = Vec::new();
+        for (lora_name, desired_replicas) in active_replica_counts {
+            let current = self.routing_table.get_config(lora_name);
+            let current_replicas = current.as_ref().map(|c| c.replica_factor).unwrap_or(0);
+            let final_replicas =
+                self.apply_hysteresis(lora_name, *desired_replicas, current_replicas);
+            lora_inputs.push(LoraInput {
+                name: lora_name.clone(),
+                replicas: final_replicas,
+                churn_weight,
+            });
+        }
+        for lora_name in inactive_loras {
+            lora_inputs.push(LoraInput {
+                name: lora_name.clone(),
+                replicas: 1,
+                churn_weight,
+            });
+            self.hysteresis.remove(lora_name);
+        }
+
+        // Deterministic solver input order across router instances (RR3-2): active inputs are
+        // built by iterating a HashMap, so sort by name before the MCF solve.
+        lora_inputs.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // Detect changes for delta solving
+        let current_workers: HashSet<WorkerWithDpRank> = workers.iter().copied().collect();
+        // Worker-set changes (added/removed) AND per-worker capacity changes both count as worker
+        // changes for the MCF delta solver (see compute_changed_workers).
+        let changed_workers = Self::compute_changed_workers(
+            &current_workers,
+            &self.prev_workers,
+            &capacities,
+            &self.prev_worker_capacities,
+        );
+
+        let mut changed_loras: HashSet<String> = HashSet::new();
+        // New or removed LoRAs
+        let current_lora_set: HashSet<&str> = all_loras.iter().map(|s| s.as_str()).collect();
+        let prev_lora_set: HashSet<&str> =
+            self.prev_assignment.keys().map(|s| s.as_str()).collect();
+        for l in current_lora_set.difference(&prev_lora_set) {
+            changed_loras.insert(l.to_string());
+        }
+        for l in prev_lora_set.difference(&current_lora_set) {
+            changed_loras.insert(l.to_string());
+        }
+        // Replica count changes
+        for li in &lora_inputs {
+            let prev_rep = self.prev_replica_counts.get(&li.name).copied().unwrap_or(0);
+            if li.replicas != prev_rep {
+                changed_loras.insert(li.name.clone());
+            }
+        }
+
+        let use_delta = !self.prev_assignment.is_empty();
+        let (changed_l, changed_w) = if use_delta {
+            (Some(&changed_loras), Some(&changed_workers))
+        } else {
+            (None, None)
+        };
+
+        // Borrow solver separately to avoid conflicting borrows on self
+        let solver = self.mcf_solver.as_ref().expect("mcf_solver must be Some");
+        let solve_result = solver.solve(
+            &worker_inputs,
+            &lora_inputs,
+            &self.prev_assignment,
+            changed_l,
+            changed_w,
+        );
+
+        match solve_result {
+            Ok(result) => {
+                let total_loads: usize = result.loads.values().map(|s| s.len()).sum();
+                let total_unloads: usize = result.unloads.values().map(|s| s.len()).sum();
+
+                if total_loads > 0 || total_unloads > 0 {
+                    tracing::info!(
+                        tick = self.tick,
+                        total_loads,
+                        total_unloads,
+                        overflow = result.overflow_count,
+                        "MCF placement diff"
+                    );
+                }
+
+                // N7: export churn + overflow gauges (registered but previously never set).
+                crate::http::service::metrics::LORA_CHURN_LOADS_GAUGE.set(total_loads as i64);
+                crate::http::service::metrics::LORA_CHURN_UNLOADS_GAUGE.set(total_unloads as i64);
+                crate::http::service::metrics::LORA_OVERFLOW_COUNT_GAUGE
+                    .set(result.overflow_count as i64);
+
+                // Update routing table from MCF result
+                let active_set: HashSet<&str> =
+                    active_loras.iter().map(|(n, _)| n.as_str()).collect();
+
+                for (lora_name, hosts) in &result.assignment {
+                    let replica_set: Vec<WorkerWithDpRank> = {
+                        let mut v: Vec<_> = hosts.iter().copied().collect();
+                        v.sort();
+                        v
+                    };
+                    let is_active = active_set.contains(lora_name.as_str());
+
+                    if self.update_routing_entry(
+                        lora_name,
+                        replica_set.len(),
+                        replica_set.clone(),
+                        is_active,
+                    ) {
+                        tracing::info!(
+                            lora = lora_name,
+                            replicas = replica_set.len(),
+                            workers = ?replica_set.iter().map(|w| w.worker_id).collect::<Vec<_>>(),
+                            is_active,
+                            "MCF updated LoRA allocation"
+                        );
+                    }
+                }
+
+                // F8: the MCF solver omits fully-overflowed LoRAs from `assignment`. A
+                // still-loaded LoRA left unplaced must stay routable (REQ 7) without thrashing
+                // the routing table or polluting the solver's keep/delta state:
+                //   * Continuity first — if the LoRA already has a routing entry (it was placed
+                //     on a recent tick, so its adapter is likely still warm there), leave it
+                //     untouched. No write means no churn, and the prior workers remain a valid
+                //     route. The filter's runtime loaded-worker fallback (N5) also keeps these
+                //     reachable.
+                //   * Only a brand-new unplaced LoRA (no entry at all) gets a deterministic HRW
+                //     cold-start pin so it has at least one home.
+                //   * Crucially, fallback pins are NEVER inserted into `result.assignment`: that
+                //     value becomes `prev_assignment`, and feeding it phantom (non-MCF) placements
+                //     corrupts the keep-reward/delta logic on the next tick and inflates churn.
+                // LoRAs intentionally dropped by the capacity cap (active but truncated out of
+                // active_replica_counts) must NOT be re-pinned (RR3-1) — they rely on the runtime
+                // loaded-worker fallback, exactly as in the HRW path.
+                let intended: std::collections::HashSet<&str> = active_replica_counts
+                    .keys()
+                    .map(String::as_str)
+                    .chain(inactive_loras.iter().map(String::as_str))
+                    .collect();
+                let unplaced: Vec<String> = all_loras
+                    .iter()
+                    .filter(|n| {
+                        intended.contains(n.as_str()) && !result.assignment.contains_key(*n)
+                    })
+                    .cloned()
+                    .collect();
+                for lora_name in unplaced {
+                    let is_active = active_set.contains(lora_name.as_str());
+                    // The solver produced NO placement for this LoRA (capacity overflow), but it
+                    // must stay routable (REQ 7) without bypassing that decision. We must NOT keep
+                    // its full prior entry: the filter's tier-2 lazy-load path (`replica_set ∩
+                    // available`) would reload the adapter onto a still-live replica it was evicted
+                    // from, defeating the overflow cap. So narrow any existing entry to the workers
+                    // where it is STILL warm (prior set ∩ loaded ∩ live) — pure existing routes, no
+                    // new load. If nothing is warm, fall back to a single deterministic HRW
+                    // cold-start pin (bounded, cross-instance-consistent). Fallback pins are never
+                    // inserted into `result.assignment`, so `prev_assignment` stays the pure solver
+                    // output.
+                    let loaded = self.state_tracker.get_loaded_workers(&lora_name);
+                    let warm: Vec<WorkerWithDpRank> = self
+                        .routing_table
+                        .get_config(&lora_name)
+                        .map(|c| c.replica_set)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|w| current_workers.contains(w) && loaded.contains(w))
+                        .collect();
+
+                    let chosen = if !warm.is_empty() {
+                        warm
+                    } else {
+                        self.allocator.compute_replica_set(&lora_name, workers, 1)
+                    };
+                    if chosen.is_empty() {
+                        // No live worker at all — drop any stale entry rather than keep a dead route.
+                        self.routing_table.remove_lora(&lora_name);
+                        self.hysteresis.remove(&lora_name);
+                        continue;
+                    }
+                    if self.update_routing_entry(
+                        &lora_name,
+                        chosen.len(),
+                        chosen.clone(),
+                        is_active,
+                    ) {
+                        tracing::warn!(
+                            lora = %lora_name,
+                            workers = ?chosen.iter().map(|w| w.worker_id).collect::<Vec<_>>(),
+                            "MCF left LoRA unplaced (capacity overflow); narrowed to warm workers or HRW pin"
+                        );
+                    }
+                }
+
+                // Store state for next tick (pure MCF assignment; no fallback pins injected)
+                self.prev_assignment = result.assignment;
+                self.prev_workers = current_workers;
+                self.prev_worker_capacities = capacities;
+                self.prev_replica_counts = lora_inputs
+                    .iter()
+                    .map(|li| (li.name.clone(), li.replicas))
+                    .collect();
+            }
+            Err(e) => {
+                tracing::error!(
+                    tick = self.tick,
+                    error = %e,
+                    "MCF solver failed; keeping current routes but resetting delta baseline so the next tick re-solves from scratch"
+                );
+                // F6: the solve failed, so prev_* still describes the LAST SUCCESSFUL assignment —
+                // one this tick did NOT apply. Keeping it would make the next tick's delta solve
+                // diff against a stale baseline and could freeze placements indefinitely (new
+                // in-budget LoRAs never reconsidered; removed workers stay frozen-in). Drop the
+                // delta state so the next tick runs a full (non-delta) solve from current cluster
+                // state. Existing routing-table entries are left intact for continuity; the
+                // post-branch cleanup in recompute_allocations still prunes stale/dropped entries.
+                self.prev_assignment.clear();
+                self.prev_workers.clear();
+                self.prev_worker_capacities.clear();
+                self.prev_replica_counts.clear();
+            }
+        }
+    }
+
+    /// Apply scale-down hysteresis to a desired replica count.
+    fn apply_hysteresis(
+        &mut self,
+        lora_name: &str,
+        desired_replicas: usize,
+        current_replicas: usize,
+    ) -> usize {
+        if desired_replicas < current_replicas {
+            if let Some(hyst) = self.hysteresis.get(lora_name) {
+                let ticks_since = self.tick.saturating_sub(hyst.last_scale_down_tick);
+                if ticks_since < self.config.scale_down_cooldown_ticks as u64 {
+                    tracing::debug!(
+                        lora = lora_name,
+                        desired = desired_replicas,
+                        current = current_replicas,
+                        cooldown_remaining =
+                            self.config.scale_down_cooldown_ticks as u64 - ticks_since,
+                        "Scale-down deferred by hysteresis"
+                    );
+                    return current_replicas;
+                }
+                desired_replicas
+            } else {
+                self.hysteresis.insert(
+                    lora_name.to_string(),
+                    HysteresisState {
+                        last_scale_down_tick: self.tick,
+                    },
+                );
+                current_replicas
+            }
+        } else {
+            self.hysteresis.remove(lora_name);
+            desired_replicas
+        }
+    }
+
+    fn update_routing_entry(
+        &self,
+        lora_name: &str,
+        replica_factor: usize,
+        replica_set: Vec<WorkerWithDpRank>,
+        is_active: bool,
+    ) -> bool {
+        let current = self.routing_table.get_config(lora_name);
+        let changed = current
+            .as_ref()
+            .map(|c| {
+                c.replica_set != replica_set
+                    || c.replica_factor != replica_factor
+                    || c.is_active != is_active
+            })
+            .unwrap_or(true);
+
+        if changed {
+            self.routing_table.update_allocation(
+                lora_name.to_string(),
+                LoraReplicaConfig {
+                    lora_name: lora_name.to_string(),
+                    replica_factor,
+                    replica_set,
+                    updated_at: Instant::now(),
+                    is_active,
+                },
+            );
+        }
+        changed
+    }
+
+    fn update_prometheus_metrics(
+        &self,
+        table_snapshot: &[(String, LoraReplicaConfig)],
+        loads: &HashMap<String, usize>,
+        raw_arrival_counts: &HashMap<String, u64>,
+    ) {
+        use crate::http::service::metrics::{
+            LORA_ACTIVE_REQUESTS_GAUGE, LORA_ESTIMATED_LOAD_GAUGE, LORA_IS_ACTIVE_GAUGE,
+            LORA_RAW_ARRIVAL_COUNT_GAUGE, LORA_REPLICA_FACTOR_GAUGE,
+        };
+
+        LORA_REPLICA_FACTOR_GAUGE.reset();
+        LORA_IS_ACTIVE_GAUGE.reset();
+        LORA_RAW_ARRIVAL_COUNT_GAUGE.reset();
+        LORA_ESTIMATED_LOAD_GAUGE.reset();
+        LORA_ACTIVE_REQUESTS_GAUGE.reset();
+
+        for (lora_name, config) in table_snapshot {
+            LORA_REPLICA_FACTOR_GAUGE
+                .with_label_values(&[lora_name])
+                .set(config.replica_factor as i64);
+            LORA_IS_ACTIVE_GAUGE
+                .with_label_values(&[lora_name])
+                .set(if config.is_active { 1 } else { 0 });
+            let raw_count = raw_arrival_counts.get(lora_name).copied().unwrap_or(0);
+            LORA_RAW_ARRIVAL_COUNT_GAUGE
+                .with_label_values(&[lora_name])
+                .set(raw_count as i64);
+            let load = loads.get(lora_name).copied().unwrap_or(0);
+            LORA_ESTIMATED_LOAD_GAUGE
+                .with_label_values(&[lora_name])
+                .set(load as i64);
+        }
+
+        let inflight = self.load_estimator.get_inflight_counts();
+        for (lora_name, count) in &inflight {
+            LORA_ACTIVE_REQUESTS_GAUGE
+                .with_label_values(&[lora_name.as_str()])
+                .set(*count as i64);
+        }
+    }
+
+    /// Clear all LoRA routing state and reset every LoRA gauge.
+    ///
+    /// Called when the cluster has no live workers (a full drain). Every routing entry is then
+    /// stale — its replica set points at gone workers — and such an entry makes `LoraFilter` fall
+    /// back to all available workers (none), so dropping the entries and resetting the gauges
+    /// (which would otherwise show phantom allocations) is correct. The separate zero-capacity
+    /// path (workers live, no slots) instead prunes/rebinds routes against the live worker set,
+    /// since those entries can still name live workers.
+    fn clear_lora_routing_and_metrics(&mut self) {
+        use crate::http::service::metrics::{
+            LORA_ACTIVE_REQUESTS_GAUGE, LORA_CHURN_LOADS_GAUGE, LORA_CHURN_UNLOADS_GAUGE,
+            LORA_ESTIMATED_LOAD_GAUGE, LORA_IS_ACTIVE_GAUGE, LORA_OVERFLOW_COUNT_GAUGE,
+            LORA_RAW_ARRIVAL_COUNT_GAUGE, LORA_REPLICA_FACTOR_GAUGE,
+        };
+
+        for (name, _) in self.routing_table.snapshot_configs() {
+            self.routing_table.remove_lora(&name);
+        }
+        self.hysteresis.clear();
+        // Drop MCF delta state so a later recovery re-solves from scratch rather than against a
+        // phantom prior assignment referencing gone workers.
+        self.prev_assignment.clear();
+        self.prev_workers.clear();
+        self.prev_worker_capacities.clear();
+        self.prev_replica_counts.clear();
+
+        LORA_REPLICA_FACTOR_GAUGE.reset();
+        LORA_IS_ACTIVE_GAUGE.reset();
+        LORA_RAW_ARRIVAL_COUNT_GAUGE.reset();
+        LORA_ESTIMATED_LOAD_GAUGE.reset();
+        LORA_CHURN_LOADS_GAUGE.set(0);
+        LORA_CHURN_UNLOADS_GAUGE.set(0);
+        LORA_OVERFLOW_COUNT_GAUGE.set(0);
+
+        // In-flight requests can still be draining even with no workers; keep reporting them
+        // (reset then repopulate from the estimator, matching the normal metrics path) rather than
+        // forcing the gauge to zero.
+        LORA_ACTIVE_REQUESTS_GAUGE.reset();
+        for (lora_name, count) in &self.load_estimator.get_inflight_counts() {
+            LORA_ACTIVE_REQUESTS_GAUGE
+                .with_label_values(&[lora_name.as_str()])
+                .set(*count as i64);
+        }
+    }
+
+    /// Compute proportional replica counts for active LoRAs.
+    fn compute_active_replica_counts(
+        active_loras: &[(String, usize)],
+        total_load: usize,
+        total_slots: usize,
+        num_workers: usize,
+    ) -> HashMap<String, usize> {
+        let mut result = HashMap::new();
+
+        if active_loras.is_empty() || total_load == 0 || total_slots == 0 {
+            return result;
+        }
+
+        // R3-1: when there are more active LoRAs than the cluster slot budget, we cannot give
+        // every active LoRA a replica without overcommitting workers (the min-1 floor below
+        // would otherwise sum past `total_slots`). Rank by load (desc, tie by name for
+        // determinism) and keep only the top `total_slots`; the remainder get no allocation
+        // here and rely on the runtime loaded-worker fallback. This avoids forcing min-1
+        // placements onto already-full workers, and (by keeping the placed set to a stable
+        // top-by-load) also stabilizes the MCF solver's input across ticks.
+        let mut ranked: Vec<(String, usize)> = active_loras.to_vec();
+        ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        if ranked.len() > total_slots {
+            ranked.truncate(total_slots);
+        }
+        let eff_total_load: usize = ranked.iter().map(|(_, l)| *l).sum();
+        if eff_total_load == 0 {
+            return result;
+        }
+
+        let mut raw_counts: Vec<(String, f64)> = ranked
+            .iter()
+            .map(|(name, load)| {
+                let fraction = *load as f64 / eff_total_load as f64;
+                let raw = (fraction * total_slots as f64).ceil().max(1.0);
+                (name.clone(), raw)
+            })
+            .collect();
+
+        for (_, count) in raw_counts.iter_mut() {
+            *count = count.min(num_workers as f64);
+        }
+
+        // Budget normalization if sum exceeds total_slots
+        let sum: f64 = raw_counts.iter().map(|(_, c)| *c).sum();
+        if sum > total_slots as f64 {
+            let scale = total_slots as f64 / sum;
+            for (_, count) in raw_counts.iter_mut() {
+                *count = (*count * scale).max(1.0);
+            }
+
+            let mut floored: Vec<(String, usize, f64)> = raw_counts
+                .iter()
+                .map(|(name, c)| {
+                    let f = c.floor().max(1.0) as usize;
+                    let remainder = *c - f as f64;
+                    (name.clone(), f, remainder)
+                })
+                .collect();
+
+            let floored_sum: usize = floored.iter().map(|(_, f, _)| *f).sum();
+            let mut leftover = total_slots.saturating_sub(floored_sum);
+
+            // Sort by fractional remainder descending, breaking ties by LoRA name so the
+            // largest-remainder distribution is deterministic across all router instances.
+            floored.sort_by(|a, b| {
+                b.2.partial_cmp(&a.2)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.0.cmp(&b.0))
+            });
+            for (_, count, _) in floored.iter_mut() {
+                if leftover == 0 {
+                    break;
+                }
+                if *count < num_workers {
+                    *count += 1;
+                    leftover -= 1;
+                }
+            }
+
+            for (name, count, _) in floored {
+                result.insert(name, count.max(1).min(num_workers));
+            }
+        } else {
+            for (name, count) in raw_counts {
+                result.insert(name, (count as usize).max(1).min(num_workers));
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lora::load_estimator::LoadEstimator;
+    use crate::lora::routing::table::LoraRoutingTable;
+    use crate::lora::state_tracker::LoraStateTracker;
+    use crate::model_card::LoraInfo;
+
+    fn make_worker(id: u64) -> WorkerWithDpRank {
+        WorkerWithDpRank::new(id, 0)
+    }
+
+    fn make_lora_info(name: &str, cap: u32) -> LoraInfo {
+        LoraInfo {
+            name: name.to_string(),
+            max_gpu_lora_count: Some(cap),
+        }
+    }
+
+    fn setup_controller() -> (
+        LoraController,
+        LoraStateTracker,
+        Arc<LoadEstimator>,
+        LoraRoutingTable,
+    ) {
+        let config = LoraAllocationConfig::default();
+        let routing_table = LoraRoutingTable::new();
+        let state_tracker = LoraStateTracker::new();
+        let load_estimator = Arc::new(LoadEstimator::new());
+        let controller = LoraController::new(
+            config,
+            routing_table.clone(),
+            state_tracker.clone(),
+            load_estimator.clone(),
+        );
+        (controller, state_tracker, load_estimator, routing_table)
+    }
+
+    #[test]
+    fn test_no_workers_skips_recompute() {
+        let (mut controller, _st, _le, rt) = setup_controller();
+        controller.recompute_now();
+        assert!(rt.is_empty());
+    }
+
+    #[test]
+    fn test_inactive_lora_gets_single_pin() {
+        let (mut controller, st, _le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 4));
+        st.handle_mdc_addition(w2, &make_lora_info("lora-a", 4));
+
+        controller.recompute_now();
+
+        let config = rt.get_config("lora-a").unwrap();
+        assert!(!config.is_active);
+        assert_eq!(config.replica_factor, 1);
+        assert_eq!(config.replica_set.len(), 1);
+    }
+
+    #[test]
+    fn test_active_lora_gets_proportional_allocation() {
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        let w3 = make_worker(3);
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 4));
+        st.handle_mdc_addition(w2, &make_lora_info("lora-b", 4));
+        st.handle_mdc_addition(w3, &make_lora_info("lora-a", 4));
+
+        le.increment_load("lora-a");
+        le.increment_load("lora-a");
+        le.increment_load("lora-a");
+
+        controller.recompute_now();
+
+        let config = rt.get_config("lora-a").unwrap();
+        assert!(config.is_active);
+        assert!(config.replica_factor >= 1);
+    }
+
+    #[test]
+    fn test_proportional_allocation_math() {
+        let active = vec![
+            ("lora-a".to_string(), 60),
+            ("lora-b".to_string(), 30),
+            ("lora-c".to_string(), 10),
+        ];
+        let result = LoraController::compute_active_replica_counts(&active, 100, 12, 5);
+
+        assert!(result["lora-a"] >= 1 && result["lora-a"] <= 5);
+        assert!(result["lora-b"] >= 1);
+        assert!(result["lora-c"] >= 1);
+        assert!(result["lora-a"] >= result["lora-b"]);
+        assert!(result["lora-b"] >= result["lora-c"]);
+    }
+
+    #[test]
+    fn test_budget_normalization() {
+        let active = vec![("lora-a".to_string(), 50), ("lora-b".to_string(), 50)];
+        let result = LoraController::compute_active_replica_counts(&active, 100, 2, 10);
+
+        assert_eq!(result["lora-a"], 1);
+        assert_eq!(result["lora-b"], 1);
+    }
+
+    #[test]
+    fn test_cleanup_removes_stale_entries() {
+        let (mut controller, st, _le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 4));
+
+        controller.recompute_now();
+        assert!(rt.get_config("lora-a").is_some());
+
+        st.handle_mdc_removal(w1, "lora-a");
+        controller.recompute_now();
+
+        assert!(rt.get_config("lora-a").is_none());
+    }
+
+    #[test]
+    fn test_capacity_one_worker_sticky_no_eviction() {
+        // F1: a LoRA pinned to a cap=1 worker is "full" only because of itself. The fullness
+        // check must discount the LoRA's own loaded slot, or sticky placement would evict it and
+        // scatter it across other workers (here w2 is full with a different adapter, so without
+        // the discount the empty-result fallback would return the full HRW set [w1, w2]).
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 1));
+        st.handle_mdc_addition(w2, &make_lora_info("lora-b", 1)); // w2 full with a different adapter
+        le.increment_load("lora-a");
+
+        controller.recompute_now();
+        let set1: Vec<u64> = rt
+            .get_config("lora-a")
+            .unwrap()
+            .replica_set
+            .iter()
+            .map(|w| w.worker_id)
+            .collect();
+        assert_eq!(
+            set1,
+            vec![1],
+            "lora-a must stay on its only non-full home w1, not scatter onto the full w2"
+        );
+
+        // Nothing changed → placement must be identical across ticks (no eviction/churn).
+        controller.recompute_now();
+        let set2: Vec<u64> = rt
+            .get_config("lora-a")
+            .unwrap()
+            .replica_set
+            .iter()
+            .map(|w| w.worker_id)
+            .collect();
+        assert_eq!(
+            set2, set1,
+            "stable LoRA on a cap=1 worker must not move across ticks"
+        );
+    }
+
+    #[test]
+    fn test_two_adapters_share_cap2_worker_neither_evicted() {
+        // N1: a cap=2 worker hosting two of its own adapters must keep BOTH. The shared residual
+        // must not be charged for already-loaded placements; otherwise placing the first adapter
+        // pushes residual to 3, the second adapter's own-slot discount only brings it back to cap,
+        // and sticky evicts the second one onto another worker (churn from the fix itself).
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        // w1 hosts A,B; w2 hosts C,D (both cap=2, both full with their own adapters).
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 2));
+        st.handle_mdc_addition(w1, &make_lora_info("lora-b", 2));
+        st.handle_mdc_addition(w2, &make_lora_info("lora-c", 2));
+        st.handle_mdc_addition(w2, &make_lora_info("lora-d", 2));
+        // All four active with equal load => proportional gives each replica_factor 1.
+        for n in ["lora-a", "lora-b", "lora-c", "lora-d"] {
+            le.increment_load(n);
+        }
+
+        controller.recompute_now();
+
+        let set_ids = |name: &str| -> Vec<u64> {
+            rt.get_config(name)
+                .unwrap()
+                .replica_set
+                .iter()
+                .map(|w| w.worker_id)
+                .collect()
+        };
+        assert_eq!(set_ids("lora-a"), vec![1], "A keeps its warm worker w1");
+        assert_eq!(
+            set_ids("lora-b"),
+            vec![1],
+            "B must NOT be evicted from the shared cap=2 worker w1"
+        );
+    }
+
+    #[test]
+    fn test_capacity_dropped_active_lora_without_warm_worker_is_pinned() {
+        // F2 + N2: an active LoRA truncated out of the slot budget (capacity-dropped) must NOT
+        // keep a stale replica-set entry pointing at workers where it is no longer loaded — the
+        // filter would lazy-load it there (a new load that defeats the cap) or widen to all
+        // workers. With no warm worker, the entry is replaced with a single deterministic HRW pin
+        // (bounded, REQ 7), NOT removed (which would scatter via the filter's no-table path) and
+        // NOT left stale.
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        // Only w1 is a live worker (cap=1 → total budget = 1). lora-a is the high-load adapter.
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 1));
+        // Seed a STALE entry for lora-b pointing at w2 (not live, lora-b not loaded anywhere).
+        rt.update_allocation(
+            "lora-b".to_string(),
+            LoraReplicaConfig {
+                lora_name: "lora-b".to_string(),
+                replica_factor: 1,
+                replica_set: vec![w2],
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+        // Both active; lora-a outranks lora-b by load, so the budget=1 cap drops lora-b.
+        for _ in 0..5 {
+            le.increment_load("lora-a");
+        }
+        le.increment_load("lora-b");
+
+        controller.recompute_now();
+
+        assert!(
+            rt.get_config("lora-a").is_some(),
+            "the in-budget LoRA keeps its allocation"
+        );
+        let cfg_b = rt.get_config("lora-b").expect(
+            "capacity-dropped LoRA stays routable via a bounded pin, not removed/scattered",
+        );
+        assert_eq!(
+            cfg_b.replica_set.len(),
+            1,
+            "no-warm cap-dropped LoRA must be pinned to a single worker, not scattered"
+        );
+        assert_eq!(
+            cfg_b.replica_set[0].worker_id, 1,
+            "pinned to the only live worker w1, not the stale w2"
+        );
+        assert!(cfg_b.is_active, "the LoRA is still active");
+    }
+
+    #[test]
+    fn test_new_cap_dropped_active_lora_without_entry_is_pinned_not_scattered() {
+        // R3-1: a brand-new active LoRA that is dropped by the budget cap and has NO routing entry
+        // must still get a single bounded pin — not be skipped (which would let the filter's
+        // no-table path scatter it across all workers).
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        // Two cap=1 workers (budget = 2). lora-a and lora-c are the high-load in-budget adapters;
+        // lora-b is new, low-load, no prior entry, not loaded anywhere.
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 1));
+        st.handle_mdc_addition(w2, &make_lora_info("lora-c", 1));
+        for _ in 0..5 {
+            le.increment_load("lora-a");
+            le.increment_load("lora-c");
+        }
+        le.increment_load("lora-b"); // active but lowest load -> dropped by the budget=2 cap
+
+        controller.recompute_now();
+
+        let cfg_b = rt
+            .get_config("lora-b")
+            .expect("new cap-dropped active LoRA must get a bounded pin, not be skipped");
+        assert_eq!(
+            cfg_b.replica_set.len(),
+            1,
+            "must be pinned to a single worker, not scattered across all"
+        );
+        assert!(cfg_b.is_active);
+    }
+
+    #[test]
+    fn test_worker_drain_clears_stale_routes() {
+        // P1: when the cluster loses all workers, the controller must clear the routing table
+        // instead of leaving stale entries that point at gone workers (which would make the
+        // filter scatter LoRA traffic to all available workers).
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        st.handle_mdc_addition(w1, &make_lora_info("lora-a", 4));
+        le.increment_load("lora-a");
+        controller.recompute_now();
+        assert!(
+            rt.get_config("lora-a").is_some(),
+            "LoRA placed while a worker exists"
+        );
+
+        // Drain the cluster.
+        st.handle_worker_removal(w1);
+        controller.recompute_now();
+        assert!(
+            rt.get_config("lora-a").is_none(),
+            "stale routing entry must be cleared after a full worker drain"
+        );
+    }
+
+    #[test]
+    fn test_zero_capacity_rebinds_dead_route_to_live_worker() {
+        // P1 follow-up: with live workers but zero LoRA capacity, a route pointing only at a
+        // now-removed worker must be rebound to a live worker (bounded), not left pointing at the
+        // gone worker (which makes the filter scatter to all available workers).
+        let (mut controller, _st, _le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        // w1 is live with zero capacity; w2 is never registered (gone).
+        _st.set_worker_capacity(w1, 0);
+        rt.update_allocation(
+            "lora-a".to_string(),
+            LoraReplicaConfig {
+                lora_name: "lora-a".to_string(),
+                replica_factor: 1,
+                replica_set: vec![w2],
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+
+        controller.recompute_now(); // exercises the total_slots == 0 path
+
+        let cfg = rt
+            .get_config("lora-a")
+            .expect("route should be rebound to a live worker, not dropped to scatter");
+        assert_eq!(
+            cfg.replica_set,
+            vec![w1],
+            "dead route must be rebound to the live worker w1, not left at the gone w2"
+        );
+    }
+
+    #[test]
+    fn test_replica_factor_matches_set_under_partial_capacity() {
+        // P1/P2: under partial-capacity pressure the slot-aware allocator returns fewer workers
+        // than desired. The stored replica_factor must equal the actual replica_set length, not
+        // the (larger) desired count.
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        st.set_worker_capacity(w1, 4); // free
+        st.handle_mdc_addition(w2, &make_lora_info("lora-b", 1)); // w2 full (1/1) with lora-b
+        // lora-a is the only active LoRA; its proportional desired is 2, but w2 is full so the
+        // allocator can only place it on w1.
+        le.increment_load("lora-a");
+        le.increment_load("lora-a");
+
+        controller.recompute_now();
+
+        let cfg = rt.get_config("lora-a").unwrap();
+        assert_eq!(
+            cfg.replica_factor,
+            cfg.replica_set.len(),
+            "replica_factor must equal the actual replica_set size"
+        );
+        assert!(
+            !cfg.replica_set.iter().any(|w| w.worker_id == 2),
+            "must not place on the full worker w2"
+        );
+    }
+
+    #[test]
+    fn test_idle_capacity_only_worker_is_placement_target() {
+        // jh-nv (watcher base-card seeding): a LoRA-capable worker with NO adapter loaded yet —
+        // capacity seeded from the base MDC via set_worker_capacity — must be visible to the
+        // controller and eligible for placement, instead of being excluded until some request has
+        // already lazy-loaded an adapter onto it. Without the seeding, list_workers() would be
+        // empty here and recompute would clear/return with no placement at all.
+        let (mut controller, st, le, rt) = setup_controller();
+        let w1 = make_worker(1);
+        // Capacity-only registration: the worker advertises 4 LoRA slots, no adapter loaded.
+        st.set_worker_capacity(w1, 4);
+        assert_eq!(
+            st.list_workers(),
+            vec![w1],
+            "capacity-only worker must be visible to the controller"
+        );
+        assert_eq!(
+            st.total_lora_slots(),
+            4,
+            "its slots must count toward budget"
+        );
+
+        // A request arrives for lora-a (active), but no adapter is loaded anywhere yet.
+        le.increment_load("lora-a");
+        controller.recompute_now();
+
+        let cfg = rt
+            .get_config("lora-a")
+            .expect("active LoRA must be placed on the idle capacity-only worker");
+        assert_eq!(
+            cfg.replica_set,
+            vec![w1],
+            "placement must target the idle-but-capable worker w1"
+        );
+        assert!(cfg.is_active);
+    }
+
+    #[test]
+    fn test_mcf_changed_workers_includes_capacity_changes() {
+        // MCF delta mode only reconsiders workers reported as changed. A capacity change on an
+        // existing worker (same id, same LoRA set, same replica counts) must mark that worker
+        // changed — otherwise delta MCF leaves its frozen placements stale and never uses the new
+        // headroom.
+        let w1 = make_worker(1);
+        let w2 = make_worker(2);
+        let workers: HashSet<WorkerWithDpRank> = [w1, w2].into_iter().collect();
+        let prev_caps: HashMap<WorkerWithDpRank, u32> = [(w1, 2), (w2, 2)].into_iter().collect();
+        // Identical worker set; w1 capacity grew 2 -> 4, w2 unchanged.
+        let cur_caps: HashMap<WorkerWithDpRank, u32> = [(w1, 4), (w2, 2)].into_iter().collect();
+
+        let changed =
+            LoraController::compute_changed_workers(&workers, &workers, &cur_caps, &prev_caps);
+        assert!(
+            changed.contains(&w1),
+            "a capacity change must mark the worker changed for delta MCF"
+        );
+        assert!(
+            !changed.contains(&w2),
+            "an unchanged-capacity worker must not be marked changed"
+        );
+
+        // No id or capacity change -> nothing changed.
+        assert!(
+            LoraController::compute_changed_workers(&workers, &workers, &prev_caps, &prev_caps)
+                .is_empty(),
+            "no id/capacity change must yield no changed workers"
+        );
+    }
+}

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -273,6 +273,73 @@ impl LoadEstimator {
         }
     }
 
+    /// Replace the full estimator config at runtime (rate window, bucket granularity,
+    /// predictor type/alpha).
+    ///
+    /// Rebuilds EXISTING per-LoRA counters under the new bucket geometry when `rate_window` or
+    /// `buckets_per_second` changes, and clears predictors when the geometry or the predictor
+    /// type/alpha changes. The load-feed path can create counters BEFORE the controller applies
+    /// its config (e.g. a KV active-sequence event arriving before `start_lora_controller` runs),
+    /// so without this rebuild those early counters would keep the default bucketing forever.
+    /// `active_count` (in-flight requests) is preserved; the windowed arrival history is restarted
+    /// because it was measured against the old window. (Mirrors `set_rate_window`, but covers the
+    /// full config.)
+    pub fn set_config(&self, config: LoadEstimatorConfig) {
+        let mut cfg = self.config.write();
+        let old = cfg.clone();
+        let geometry_changed = old.rate_window != config.rate_window
+            || old.buckets_per_second != config.buckets_per_second;
+        let predictor_changed = old.predictor_type != config.predictor_type
+            || (old.ema_alpha - config.ema_alpha).abs() > f64::EPSILON;
+        *cfg = config;
+        let num_buckets = cfg.num_buckets();
+        let bucket_duration = cfg.bucket_duration();
+        drop(cfg);
+
+        if geometry_changed {
+            let now = Instant::now();
+            for mut entry in self.data.iter_mut() {
+                let old_active = entry.value().active_count.load(Ordering::Relaxed);
+                *entry.value_mut() = LoraLoadData {
+                    active_count: AtomicUsize::new(old_active),
+                    rate_counter: BucketedRateCounter::new(num_buckets, bucket_duration, now),
+                };
+            }
+        }
+        // Predictors built under the old window/params are meaningless once the geometry or the
+        // predictor type/alpha changes; clear them so smoothing restarts from scratch.
+        if geometry_changed || predictor_changed {
+            self.predictors
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+        }
+
+        tracing::info!(
+            num_buckets,
+            geometry_changed,
+            predictor_changed,
+            "LoadEstimator config updated"
+        );
+    }
+
+    /// Prune tracking data (and predictors) for any LoRA not in `known`. Bounds memory
+    /// against unloaded adapters and unknown/typo request names that never get allocated.
+    pub fn retain_known(&self, known: &std::collections::HashSet<&str>) {
+        // Keep an entry if it is known OR still has in-flight requests. Pruning a LoRA with a
+        // nonzero active_count (e.g. one whose arrival raced this controller tick, before its MDC
+        // reached the state tracker) would drop live tracking and make the matching LoadGuard /
+        // Free-event decrement a silent no-op, losing that arrival. Unknown/typo names with no
+        // in-flight requests are still pruned, so memory stays bounded.
+        self.data.retain(|name, data| {
+            known.contains(name.as_str()) || data.active_count.load(Ordering::Relaxed) > 0
+        });
+        self.predictors
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .retain(|name, _| known.contains(name.as_str()) || self.data.contains_key(name));
+    }
+
     /// Update the rate window at runtime.
     pub fn set_rate_window(&self, window: Duration) {
         let mut cfg = self.config.write();
@@ -349,16 +416,37 @@ impl LoadEstimator {
         self: Arc<Self>,
         component: Component,
     ) -> tokio::task::JoinHandle<()> {
+        let cancel_token = component.drt().child_token();
         tokio::spawn(async move {
-            if let Err(e) = self.subscribe_to_events(component).await {
-                tracing::error!("Error in LORA load event subscription: {}", e);
+            // Durable feed: reconnect on transient errors / stream end with capped backoff,
+            // stopping only on cancellation. A failed subscribe must not silently disable KV
+            // load tracking for the lifetime of the process.
+            let mut backoff = Duration::from_secs(1);
+            while !cancel_token.is_cancelled() {
+                match self.subscribe_to_events(&component, &cancel_token).await {
+                    Ok(()) => break, // cancelled cleanly
+                    Err(e) => {
+                        tracing::warn!(
+                            "LORA load event subscription error: {e}; reconnecting in {backoff:?}"
+                        );
+                        tokio::select! {
+                            _ = cancel_token.cancelled() => break,
+                            _ = tokio::time::sleep(backoff) => {}
+                        }
+                        backoff = (backoff * 2).min(Duration::from_secs(30));
+                    }
+                }
             }
+            tracing::debug!("LORA load event subscription task exiting");
         })
     }
 
-    async fn subscribe_to_events(&self, component: Component) -> anyhow::Result<()> {
-        let cancel_token = component.drt().child_token();
-        let mut subscriber = EventSubscriber::for_component(&component, ACTIVE_SEQUENCES_SUBJECT)
+    async fn subscribe_to_events(
+        &self,
+        component: &Component,
+        cancel_token: &tokio_util::sync::CancellationToken,
+    ) -> anyhow::Result<()> {
+        let mut subscriber = EventSubscriber::for_component(component, ACTIVE_SEQUENCES_SUBJECT)
             .await?
             .typed::<ActiveSequenceEvent>();
 
@@ -366,10 +454,7 @@ impl LoadEstimator {
 
         loop {
             tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    tracing::debug!("LORA load event subscription cancelled");
-                    break;
-                }
+                _ = cancel_token.cancelled() => return Ok(()),
                 result = subscriber.next() => {
                     match result {
                         Some(Ok((_envelope, event))) => {
@@ -378,16 +463,11 @@ impl LoadEstimator {
                         Some(Err(e)) => {
                             tracing::warn!("Error receiving LORA load event: {}", e);
                         }
-                        None => {
-                            tracing::warn!("LORA load event stream ended");
-                            break;
-                        }
+                        None => anyhow::bail!("LORA load event stream ended"),
                     }
                 }
             }
         }
-
-        Ok(())
     }
 
     fn handle_event(&self, event: ActiveSequenceEvent) {
@@ -451,6 +531,17 @@ impl LoadEstimator {
                     Some(v.saturating_sub(1))
                 })
                 .ok();
+        }
+    }
+
+    /// Remove all tracking data for a LoRA. After this call the LoRA will no
+    /// longer appear in [`get_current_load`] results. Useful when a LoRA is
+    /// permanently unloaded and its stale rate-counter / predictor entries
+    /// should be purged.
+    pub fn remove_lora(&self, lora_name: &str) {
+        self.data.remove(lora_name);
+        if let Ok(mut predictors) = self.predictors.lock() {
+            predictors.remove(lora_name);
         }
     }
 
@@ -602,6 +693,40 @@ impl Default for LoadEstimator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn set_config_rebuilds_existing_counter_geometry() {
+        // The load-feed path can create a counter before the controller applies its config, so
+        // set_config must rebuild EXISTING counters under the new bucket geometry (preserving the
+        // in-flight active_count), not only counters created afterward.
+        let est = LoadEstimator::with_config(LoadEstimatorConfig {
+            rate_window: Duration::from_secs(10),
+            buckets_per_second: 1,
+            ..Default::default()
+        });
+        // Counter for "lora-a" created under the OLD geometry (10s @ 1/s = 10 buckets), with one
+        // in-flight request.
+        est.increment_load("lora-a");
+        assert_eq!(est.data.get("lora-a").unwrap().rate_counter.num_buckets, 10);
+
+        // Apply a finer bucket geometry at runtime.
+        est.set_config(LoadEstimatorConfig {
+            rate_window: Duration::from_secs(10),
+            buckets_per_second: 4,
+            ..Default::default()
+        });
+
+        let entry = est.data.get("lora-a").unwrap();
+        assert_eq!(
+            entry.rate_counter.num_buckets, 40,
+            "existing counter must adopt the new geometry (10s @ 4/s = 40 buckets)"
+        );
+        assert_eq!(
+            entry.active_count.load(Ordering::Relaxed),
+            1,
+            "in-flight active_count must survive the rebuild"
+        );
+    }
 
     #[test]
     fn test_bucketed_rate_counter_basic() {

--- a/lib/llm/src/lora/routing/hrw.rs
+++ b/lib/llm/src/lora/routing/hrw.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::LoraAllocator;
 use dynamo_kv_router::protocols::WorkerWithDpRank;
@@ -36,8 +36,16 @@ impl RendezvousHasher {
             .map(|&w| (w, Self::compute_score(lora_name, w)))
             .collect();
 
-        // Sort by score descending (highest score first)
-        scores.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
+        // Sort by score descending (highest score first). Break score ties deterministically by
+        // (worker_id, dp_rank) so that equal HRW scores can never produce different rankings
+        // across router instances — worker input order is not guaranteed (it can come from
+        // DashMap iteration), and determinism is a hard requirement for coordination-free
+        // placement.
+        scores.sort_by(|(wa, sa), (wb, sb)| {
+            sb.cmp(sa)
+                .then_with(|| wa.worker_id.cmp(&wb.worker_id))
+                .then_with(|| wa.dp_rank.cmp(&wb.dp_rank))
+        });
         scores
     }
 }
@@ -88,17 +96,71 @@ impl LoraAllocator for RendezvousHasher {
             result.push(*worker);
         }
 
-        // If we couldn't fill due to capacity constraints, fall back to basic HRW
-        if result.len() < replica_factor && result.len() < workers.len() {
-            let basic = self.compute_replica_set(lora_name, workers, replica_factor);
-            for w in basic {
-                if result.len() >= replica_factor {
-                    break;
-                }
-                if !result.contains(&w) {
-                    result.push(w);
-                }
+        // We placed on every non-full worker up to `replica_factor`. If that under-filled
+        // the count, accept the smaller set rather than placing on at-capacity workers
+        // (REQ 6: skip full workers). Only when EVERY worker is full (result is empty) do we
+        // fall back to basic HRW, so the LoRA still has at least one routable home (REQ 7).
+        if result.is_empty() {
+            return self.compute_replica_set(lora_name, workers, replica_factor);
+        }
+
+        result
+    }
+
+    fn compute_replica_set_with_slots_sticky(
+        &self,
+        lora_name: &str,
+        workers: &[WorkerWithDpRank],
+        replica_factor: usize,
+        worker_slot_usage: &HashMap<WorkerWithDpRank, (usize, usize)>,
+        prior: &[WorkerWithDpRank],
+    ) -> Vec<WorkerWithDpRank> {
+        if workers.is_empty() || replica_factor == 0 {
+            return Vec::new();
+        }
+
+        let ranked = Self::rank_workers(lora_name, workers);
+        let prior_set: HashSet<WorkerWithDpRank> = prior.iter().copied().collect();
+        let mut result = Vec::with_capacity(replica_factor);
+        let mut chosen: HashSet<WorkerWithDpRank> = HashSet::new();
+
+        let is_full = |w: &WorkerWithDpRank| {
+            worker_slot_usage
+                .get(w)
+                .map(|&(used, cap)| used >= cap)
+                .unwrap_or(false)
+        };
+
+        // Pass 1 (stickiness): retain workers the LoRA already occupies, in HRW-ranked order,
+        // as long as they are still present and not full. This anchors a stable LoRA on its
+        // existing placement so flickering sibling activity within the tick cannot move it.
+        for (worker, _score) in &ranked {
+            if result.len() >= replica_factor {
+                break;
             }
+            if prior_set.contains(worker) && !is_full(worker) {
+                result.push(*worker);
+                chosen.insert(*worker);
+            }
+        }
+
+        // Pass 2: fill any remaining slots from the HRW-ranked list, skipping full and
+        // already-chosen workers (REQ 6: skip workers at capacity).
+        for (worker, _score) in &ranked {
+            if result.len() >= replica_factor {
+                break;
+            }
+            if chosen.contains(worker) || is_full(worker) {
+                continue;
+            }
+            result.push(*worker);
+            chosen.insert(*worker);
+        }
+
+        // Only when EVERY worker is full do we fall back to basic HRW so the LoRA keeps at
+        // least one routable home (REQ 7).
+        if result.is_empty() {
+            return self.compute_replica_set(lora_name, workers, replica_factor);
         }
 
         result
@@ -237,5 +299,88 @@ mod tests {
 
         let result = hasher.compute_replica_set_with_slots("test-lora", &workers, 2, &usage);
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_ranking_equal_scores_tie_break_is_deterministic() {
+        // Score ties must break by (worker_id, dp_rank), independent of input order, so all
+        // router instances converge on the same ranking even when worker input order varies.
+        let workers_fwd = vec![
+            WorkerWithDpRank::new(10, 0),
+            WorkerWithDpRank::new(10, 1),
+            WorkerWithDpRank::new(7, 0),
+            WorkerWithDpRank::new(7, 1),
+        ];
+        let mut workers_rev = workers_fwd.clone();
+        workers_rev.reverse();
+
+        // Force an all-ties scenario by ranking with a constant score via identical names is not
+        // possible (score depends on worker), so instead assert that ranking a set and its reverse
+        // yields identical order — the tie-break (and full ordering) must be input-order-invariant.
+        let r1: Vec<_> = RendezvousHasher::rank_workers("lora-x", &workers_fwd)
+            .into_iter()
+            .map(|(w, _)| (w.worker_id, w.dp_rank))
+            .collect();
+        let r2: Vec<_> = RendezvousHasher::rank_workers("lora-x", &workers_rev)
+            .into_iter()
+            .map(|(w, _)| (w.worker_id, w.dp_rank))
+            .collect();
+        assert_eq!(r1, r2, "ranking must be invariant to worker input order");
+    }
+
+    #[test]
+    fn test_sticky_retains_prior_placement() {
+        // Stickiness: when the LoRA's prior workers are still present and not full, the sticky
+        // variant keeps them even though a clean HRW pass would pick a different (top-ranked)
+        // set. This is what prevents transient sibling activity from moving a stable LoRA.
+        let hasher = RendezvousHasher;
+        let workers = make_workers(5);
+        let usage: HashMap<_, _> = workers.iter().map(|w| (*w, (0usize, 4usize))).collect();
+
+        // Natural slot-aware top-2 (no prior hint).
+        let natural = hasher.compute_replica_set_with_slots("lora-x", &workers, 2, &usage);
+        assert_eq!(natural.len(), 2);
+
+        // Choose a prior set of two workers that are NOT the natural top-2.
+        let prior: Vec<_> = workers
+            .iter()
+            .filter(|w| !natural.contains(w))
+            .copied()
+            .take(2)
+            .collect();
+        assert_eq!(prior.len(), 2);
+
+        let sticky =
+            hasher.compute_replica_set_with_slots_sticky("lora-x", &workers, 2, &usage, &prior);
+        let sset: HashSet<_> = sticky.iter().copied().collect();
+        let pset: HashSet<_> = prior.iter().copied().collect();
+        assert_eq!(
+            sset, pset,
+            "sticky must retain the prior (non-full) placement"
+        );
+    }
+
+    #[test]
+    fn test_sticky_replaces_full_prior_worker() {
+        // A prior worker that is now at capacity must be dropped and replaced; a non-full prior
+        // worker is retained. Capacity safety (REQ 6) is preserved alongside stickiness.
+        let hasher = RendezvousHasher;
+        let workers = make_workers(5);
+        let prior = vec![workers[0], workers[1]];
+
+        let mut usage: HashMap<_, _> = workers.iter().map(|w| (*w, (0usize, 4usize))).collect();
+        usage.insert(workers[0], (4, 4)); // prior[0] is full
+
+        let sticky =
+            hasher.compute_replica_set_with_slots_sticky("lora-x", &workers, 2, &usage, &prior);
+        assert_eq!(sticky.len(), 2);
+        assert!(
+            !sticky.contains(&workers[0]),
+            "a full prior worker must be dropped"
+        );
+        assert!(
+            sticky.contains(&workers[1]),
+            "a non-full prior worker must be retained"
+        );
     }
 }

--- a/lib/llm/src/lora/routing/mod.rs
+++ b/lib/llm/src/lora/routing/mod.rs
@@ -42,22 +42,45 @@ pub trait LoraAllocator: Send + Sync {
         self.compute_replica_set(lora_name, workers, replica_factor)
     }
 
+    /// Stability-preserving slot-aware variant: like [`compute_replica_set_with_slots`],
+    /// but retains workers from `prior` (the LoRA's current placement) when they are still
+    /// present and not at capacity, before filling remaining slots from the ranked list.
+    ///
+    /// This keeps per-worker capacity safety (the caller charges residual usage across
+    /// LoRAs within a tick) without letting transient sibling activity move a LoRA whose
+    /// own inputs are unchanged — preserving the HRW churn-minimization guarantee.
+    ///
+    /// Default implementation ignores `prior` and delegates to the non-sticky variant.
+    fn compute_replica_set_with_slots_sticky(
+        &self,
+        lora_name: &str,
+        workers: &[WorkerWithDpRank],
+        replica_factor: usize,
+        worker_slot_usage: &HashMap<WorkerWithDpRank, (usize, usize)>,
+        _prior: &[WorkerWithDpRank],
+    ) -> Vec<WorkerWithDpRank> {
+        self.compute_replica_set_with_slots(lora_name, workers, replica_factor, worker_slot_usage)
+    }
+
     /// Name of this algorithm (for logging/metrics)
     fn name(&self) -> &str;
 }
 
 /// Per-LoRA allocation algorithm selectable via `DYN_LORA_ALLOCATION_ALGORITHM`.
 ///
-/// `MinCostFlow` is intentionally absent: `McfPlacementSolver` operates as a
-/// standalone global solver and has no `LoraAllocator` adapter yet. Accepting
-/// the config string while silently running HRW was misleading; it will be
-/// re-added here once the integration is complete.
+/// `MinCostFlow` selects the global `McfPlacementSolver` churn-aware placement
+/// path, which is driven by `LoraController` (see `controller.rs`). The per-LoRA
+/// `LoraAllocator` returned by [`create_lora_allocator`] for this variant is only
+/// used as a cold-start / fallback allocator; the actual global solve happens in
+/// the controller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AllocationAlgorithmType {
     /// Rendezvous (Highest Random Weight) hashing
     Hrw,
     /// Random selection (for testing)
     Random,
+    /// Min-Cost Flow global placement (churn-aware bipartite assignment)
+    MinCostFlow,
 }
 
 impl FromStr for AllocationAlgorithmType {
@@ -67,11 +90,7 @@ impl FromStr for AllocationAlgorithmType {
         match s.to_lowercase().as_str() {
             "hrw" => Ok(Self::Hrw),
             "random" => Ok(Self::Random),
-            "mcf" | "min_cost_flow" | "mincostflow" => Err(
-                "MCF placement is not yet available as a per-LoRA allocator config value; \
-                 use McfPlacementSolver directly for global MCF placement"
-                    .to_string(),
-            ),
+            "mcf" | "min_cost_flow" | "mincostflow" => Ok(Self::MinCostFlow),
             _ => Err(format!("Unknown allocation algorithm type: {s}")),
         }
     }
@@ -82,6 +101,9 @@ pub fn create_lora_allocator(algo_type: AllocationAlgorithmType) -> Box<dyn Lora
     match algo_type {
         AllocationAlgorithmType::Hrw => Box::new(RendezvousHasher),
         AllocationAlgorithmType::Random => Box::new(RandomAllocation),
+        // MCF uses its own global solver (McfPlacementSolver) in the controller;
+        // the per-LoRA allocator here is only a cold-start / fallback path.
+        AllocationAlgorithmType::MinCostFlow => Box::new(RendezvousHasher),
     }
 }
 
@@ -118,16 +140,15 @@ mod tests {
     }
 
     #[test]
-    fn test_mcf_config_string_is_rejected() {
+    fn test_mcf_config_string_parses_to_min_cost_flow() {
+        // PR4 wires MCF into the controller (McfPlacementSolver), so the config
+        // string is now accepted and maps to the MinCostFlow variant.
         for s in &["mcf", "MCF", "min_cost_flow", "mincostflow"] {
             let result = AllocationAlgorithmType::from_str(s);
-            assert!(
-                result.is_err(),
-                "'{s}' should be rejected until MCF is wired into the allocator path"
-            );
-            assert!(
-                result.unwrap_err().contains("not yet available"),
-                "error message should explain why mcf is rejected"
+            assert_eq!(
+                result,
+                Ok(AllocationAlgorithmType::MinCostFlow),
+                "'{s}' should parse to MinCostFlow"
             );
         }
     }

--- a/lib/llm/src/lora/state_tracker.rs
+++ b/lib/llm/src/lora/state_tracker.rs
@@ -117,22 +117,21 @@ impl LoraStateTracker {
             .or_default()
             .insert(lora_name);
 
-        let capacity = lora
-            .max_gpu_lora_count
-            .unwrap_or(DEFAULT_MAX_GPU_LORA_COUNT);
-        if let Some(prev) = self.worker_capacity.get(&worker)
-            && *prev != capacity
-        {
+        let capacity = lora.max_gpu_lora_count.unwrap_or_else(|| {
             tracing::warn!(
                 worker_id = worker.worker_id,
                 dp_rank = worker.dp_rank,
                 lora_name = lora.name,
-                previous_capacity = *prev,
-                new_capacity = capacity,
-                "Worker capacity changed across MDC updates"
+                default = DEFAULT_MAX_GPU_LORA_COUNT,
+                "LoRA MDC carries no max_gpu_lora_count; using default for placement capacity. \
+                 The worker backend should publish its configured per-worker LoRA slot count \
+                 (e.g. vLLM --max-loras) so allocation reflects real capacity."
             );
-        }
-        self.worker_capacity.insert(worker, capacity);
+            DEFAULT_MAX_GPU_LORA_COUNT
+        });
+        // record_worker_capacity warns on a same-worker capacity change (shared with the
+        // base-card path in set_worker_capacity so both registration paths honor the invariant).
+        self.record_worker_capacity(worker, capacity);
 
         tracing::debug!(
             worker_id = worker.worker_id,
@@ -141,6 +140,37 @@ impl LoraStateTracker {
             capacity = capacity,
             "LoRA state tracker: MDC addition"
         );
+    }
+
+    /// Set a worker's LoRA slot capacity directly, without registering any adapter on it.
+    ///
+    /// Capacity-only counterpart to [`handle_mdc_addition`] (which records a loaded adapter AND
+    /// sets capacity). Makes the worker appear in [`list_workers`] with the given capacity and no
+    /// loaded LoRAs, so callers can establish cluster topology / per-worker `max_gpu_lora_count`
+    /// without consuming a slot with a phantom adapter.
+    pub fn set_worker_capacity(&self, worker: WorkerWithDpRank, capacity: u32) {
+        let _guard = self.lock_writes();
+        self.record_worker_capacity(worker, capacity);
+    }
+
+    /// Record a worker's LoRA slot capacity, warning if it changes a previously-recorded value.
+    /// The caller must hold the write lock. Shared by
+    /// [`handle_mdc_addition`](Self::handle_mdc_addition) (adapter cards) and
+    /// [`set_worker_capacity`](Self::set_worker_capacity) (base-card capacity seeding) so a
+    /// same-worker capacity change is logged regardless of which path set it.
+    fn record_worker_capacity(&self, worker: WorkerWithDpRank, capacity: u32) {
+        if let Some(prev) = self.worker_capacity.get(&worker)
+            && *prev != capacity
+        {
+            tracing::warn!(
+                worker_id = worker.worker_id,
+                dp_rank = worker.dp_rank,
+                previous_capacity = *prev,
+                new_capacity = capacity,
+                "Worker LoRA capacity changed across registrations"
+            );
+        }
+        self.worker_capacity.insert(worker, capacity);
     }
 
     /// Handle an MDC removal event: a worker unregistered a LoRA adapter.

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -309,8 +309,13 @@ pub mod llm {
     /// Enable the LoRA allocation controller (set to "true" to enable)
     pub const DYN_LORA_ALLOCATION_ENABLED: &str = "DYN_LORA_ALLOCATION_ENABLED";
 
-    /// LoRA allocation algorithm ("hrw" or "random")
+    /// LoRA allocation algorithm ("hrw", "random", or "mcf")
     pub const DYN_LORA_ALLOCATION_ALGORITHM: &str = "DYN_LORA_ALLOCATION_ALGORITHM";
+
+    /// JSON configuration for the MCF (min-cost flow) placement solver.
+    /// Example: '{"candidate_m":16,"gamma_load":2000,"beta_keep":500}'
+    /// Omitted fields use defaults. Only relevant when algorithm is "mcf".
+    pub const DYN_LORA_MCF_CONFIG: &str = "DYN_LORA_MCF_CONFIG";
 
     /// LoRA allocation controller recompute interval in seconds
     pub const DYN_LORA_ALLOCATION_TIMESTEP_SECS: &str = "DYN_LORA_ALLOCATION_TIMESTEP_SECS";
@@ -649,6 +654,7 @@ mod tests {
             llm::DYN_LORA_ALLOCATION_BUCKETS_PER_SECOND,
             llm::DYN_LORA_ALLOCATION_PREDICTOR_TYPE,
             llm::DYN_LORA_ALLOCATION_EMA_ALPHA,
+            llm::DYN_LORA_MCF_CONFIG,
             llm::metrics::DYN_METRICS_PREFIX,
             llm::audit::DYN_AUDIT_SINKS,
             llm::audit::DYN_AUDIT_FORCE_LOGGING,

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -305,6 +305,15 @@ pub mod frontend_service {
     /// Number of in-flight (active) requests for a LoRA adapter
     pub const LORA_ACTIVE_REQUESTS: &str = "lora_active_requests";
 
+    /// Total LoRA loads (new placements) this controller tick
+    pub const LORA_CHURN_LOADS_TOTAL: &str = "lora_churn_loads_total";
+
+    /// Total LoRA unloads (removed placements) this controller tick
+    pub const LORA_CHURN_UNLOADS_TOTAL: &str = "lora_churn_unloads_total";
+
+    /// MCF solver overflow count (unplaceable replicas)
+    pub const LORA_OVERFLOW_COUNT: &str = "lora_overflow_count";
+
     /// Label name for the type of migration
     pub const MIGRATION_TYPE_LABEL: &str = "migration_type";
 


### PR DESCRIPTION
Splits #8180 into a reviewable 3-PR train — **part 1 of 3**.

### This PR: LoRA allocation controller core
- `LoraController` periodic allocation loop: load-fraction proportional active placement, deterministic HRW cold-start pins for inactive LoRAs, scale-down hysteresis, slot-budget cap (largest-remainder), capacity-dropped re-pinning, worker-drain / zero-capacity pruning; per-LoRA (HRW/Random) and global MCF paths.
- Slot-aware HRW allocator methods (`compute_replica_set_with_slots[_sticky]`).
- `LoadEstimator` extensions: bucketed-rate-counter config, KV active-sequence event subscription, `retain_known` memory bounding, inflight counts.
- `LoraAllocationConfig` (`DYN_LORA_*` env) + Prometheus LoRA gauges and metric-name constants.

Also folds in two fixes from the #8180 review pass: controller-loop **panic supervision** (a recompute panic no longer silently freezes allocation) and **MCF delta-baseline reset** on solver error.

Followed by **(2/3)** filter + filtered router and **(3/3)** frontend integration. Compiles and passes `lora::controller` tests independently.