### PR TITLE
feat(lora): 2-stage LoRA filter + filtered router + push_router direct_within (2/3)

### DIFF
--- a/lib/llm/src/lora.rs
+++ b/lib/llm/src/lora.rs
@@ -12,6 +12,8 @@ mod cache;
 pub mod config;
 pub mod controller;
 mod downloader;
+pub mod filter;
+pub mod filtered_router;
 pub mod load_estimator;
 pub mod predictor;
 pub mod routing;
@@ -22,6 +24,8 @@ pub use cache::LoRACache;
 pub use config::{LoraAllocationConfig, McfConfig};
 pub use controller::LoraController;
 pub use downloader::LoRADownloader;
+pub use filter::LoraFilter;
+pub use filtered_router::LoraFilteredRouter;
 pub use load_estimator::{LoadEstimator, LoadEstimatorConfig};
 pub use routing::{
     AllocationAlgorithmType, LoraAllocator, LoraReplicaConfig, LoraRoutingTable,

--- a/lib/llm/src/lora/filter.rs
+++ b/lib/llm/src/lora/filter.rs
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! LoRA Filter
+//!
+//! Pre-filters the set of eligible workers for a LoRA request based on the routing
+//! table and loaded state.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::local_model::runtime_config::ModelRuntimeConfig;
+use crate::lora::routing::table::LoraRoutingTable;
+use crate::lora::state_tracker::LoraStateTracker;
+
+type WorkerId = u64;
+
+/// Filters workers for LoRA-aware routing.
+#[derive(Clone)]
+pub struct LoraFilter {
+    routing_table: LoraRoutingTable,
+    state_tracker: LoraStateTracker,
+}
+
+impl LoraFilter {
+    pub fn new(routing_table: LoraRoutingTable, state_tracker: LoraStateTracker) -> Self {
+        Self {
+            routing_table,
+            state_tracker,
+        }
+    }
+
+    /// Filter available worker IDs for a LoRA request.
+    ///
+    /// Logic:
+    /// - `lora_name` is None: return all workers (base model request)
+    /// - Active entry: prefer loaded workers in replica set, fall back to full replica set
+    /// - Inactive entry: return single HRW-pinned worker (cold-start determinism)
+    /// - Not in routing table: prefer known-loaded workers, fall back to all workers
+    pub fn filter_worker_ids_for_lora(
+        &self,
+        lora_name: Option<&str>,
+        available: &[u64],
+    ) -> Vec<u64> {
+        let Some(lora_name) = lora_name else {
+            return available.to_vec();
+        };
+
+        let Some(config) = self.routing_table.get_config(lora_name) else {
+            // No routing-table entry yet (controller disabled, or before the first tick).
+            // Prefer workers that actually have this adapter loaded (from the state tracker)
+            // so we don't scatter to every worker; fall back to all available only when none
+            // are known-loaded. This makes the "loaded-worker fallback" real even when dynamic
+            // allocation (the controller) is disabled.
+            let loaded = self.state_tracker.get_loaded_workers(lora_name);
+            if !loaded.is_empty() {
+                // O(1) membership instead of scanning `loaded` per available worker
+                // (this fallback runs on every LoRA request when allocation is disabled).
+                let loaded_ids_set: HashSet<u64> = loaded.iter().map(|w| w.worker_id).collect();
+                let loaded_ids: Vec<u64> = available
+                    .iter()
+                    .copied()
+                    .filter(|id| loaded_ids_set.contains(id))
+                    .collect();
+                if !loaded_ids.is_empty() {
+                    tracing::debug!(
+                        lora = lora_name,
+                        count = loaded_ids.len(),
+                        "LoRA not in routing table; narrowed to known-loaded workers"
+                    );
+                    return loaded_ids;
+                }
+            }
+            tracing::debug!(
+                lora = lora_name,
+                "LoRA not in routing table and not known-loaded, returning all workers"
+            );
+            return available.to_vec();
+        };
+
+        let replica_id_set: HashSet<u64> = config.replica_set.iter().map(|w| w.worker_id).collect();
+
+        if config.is_active {
+            let loaded = self.state_tracker.get_loaded_workers(lora_name);
+            let loaded_ids: HashSet<u64> = loaded.iter().map(|w| w.worker_id).collect();
+
+            // Prefer: replica set ∩ loaded ∩ available
+            let loaded_in_set: Vec<u64> = available
+                .iter()
+                .copied()
+                .filter(|id| replica_id_set.contains(id) && loaded_ids.contains(id))
+                .collect();
+            if !loaded_in_set.is_empty() {
+                tracing::debug!(
+                    lora = lora_name,
+                    count = loaded_in_set.len(),
+                    "Filtered to loaded workers in replica set"
+                );
+                return loaded_in_set;
+            }
+
+            // Fall back: replica set ∩ available (lazy load)
+            let replica_set: Vec<u64> = available
+                .iter()
+                .copied()
+                .filter(|id| replica_id_set.contains(id))
+                .collect();
+            if !replica_set.is_empty() {
+                tracing::debug!(
+                    lora = lora_name,
+                    count = replica_set.len(),
+                    "LoRA not loaded yet, returning full replica set for lazy load"
+                );
+                return replica_set;
+            }
+
+            tracing::warn!(
+                lora = lora_name,
+                "Replica set workers not available, falling back to all workers"
+            );
+            available.to_vec()
+        } else {
+            // Inactive: cold-start pin
+            if let Some(pin_id) = config.replica_set.first().map(|w| w.worker_id)
+                && available.contains(&pin_id)
+            {
+                tracing::debug!(
+                    lora = lora_name,
+                    worker_id = pin_id,
+                    "Cold-start: routing to HRW-pinned worker"
+                );
+                return vec![pin_id];
+            }
+            tracing::warn!(
+                lora = lora_name,
+                "Cold-start pin worker not available, falling back to all workers"
+            );
+            available.to_vec()
+        }
+    }
+
+    /// Filter workers for a LoRA request (HashMap variant for KV routing).
+    pub fn filter_workers_for_lora(
+        &self,
+        lora_name: Option<&str>,
+        workers: &HashMap<WorkerId, ModelRuntimeConfig>,
+    ) -> HashMap<WorkerId, ModelRuntimeConfig> {
+        let available_ids: Vec<u64> = workers.keys().copied().collect();
+        let selected_ids = self.filter_worker_ids_for_lora(lora_name, &available_ids);
+
+        if selected_ids.len() == available_ids.len() {
+            return workers.clone();
+        }
+
+        let selected_set: HashSet<u64> = selected_ids.into_iter().collect();
+        workers
+            .iter()
+            .filter(|(wid, _)| selected_set.contains(wid))
+            .map(|(k, v)| (*k, v.clone()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kv_router::protocols::WorkerWithDpRank;
+    use crate::lora::routing::table::{LoraReplicaConfig, LoraRoutingTable};
+    use crate::lora::state_tracker::LoraStateTracker;
+    use crate::model_card::LoraInfo;
+    use std::time::Instant;
+
+    fn make_workers_map(ids: &[u64]) -> HashMap<WorkerId, ModelRuntimeConfig> {
+        ids.iter()
+            .map(|&id| (id, ModelRuntimeConfig::default()))
+            .collect()
+    }
+
+    fn make_worker(id: u64) -> WorkerWithDpRank {
+        WorkerWithDpRank::new(id, 0)
+    }
+
+    fn make_lora_info(name: &str) -> LoraInfo {
+        LoraInfo {
+            name: name.to_string(),
+            max_gpu_lora_count: Some(4),
+        }
+    }
+
+    #[test]
+    fn test_no_lora_returns_all_workers() {
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(None, &workers);
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_not_in_routing_table_returns_all() {
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("unknown-lora"), &workers);
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_not_in_routing_table_narrows_to_loaded_workers() {
+        // No routing-table entry (controller disabled / pre-first-tick), but the state
+        // tracker knows the adapter is loaded on a subset of workers. The fallback must
+        // narrow to those known-loaded workers rather than scattering to all available.
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+        st.handle_mdc_addition(make_worker(2), &make_lora_info("lora-a"));
+
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("lora-a"), &workers);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&2));
+    }
+
+    #[test]
+    fn test_not_in_routing_table_loaded_worker_unavailable_falls_back_to_all() {
+        // The adapter is known-loaded, but on a worker that is not in the available set.
+        // With no usable loaded worker, the fallback returns all available workers so the
+        // request stays routable.
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+        st.handle_mdc_addition(make_worker(9), &make_lora_info("lora-a"));
+
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("lora-a"), &workers);
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_active_lora_filters_to_loaded_workers() {
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+
+        rt.update_allocation(
+            "lora-a".to_string(),
+            LoraReplicaConfig {
+                lora_name: "lora-a".to_string(),
+                replica_factor: 2,
+                replica_set: vec![make_worker(1), make_worker(2)],
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+        st.handle_mdc_addition(make_worker(1), &make_lora_info("lora-a"));
+
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("lora-a"), &workers);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&1));
+    }
+
+    #[test]
+    fn test_active_lora_falls_back_to_replica_set() {
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+
+        rt.update_allocation(
+            "lora-a".to_string(),
+            LoraReplicaConfig {
+                lora_name: "lora-a".to_string(),
+                replica_factor: 2,
+                replica_set: vec![make_worker(1), make_worker(2)],
+                updated_at: Instant::now(),
+                is_active: true,
+            },
+        );
+
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("lora-a"), &workers);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&1));
+        assert!(result.contains_key(&2));
+    }
+
+    #[test]
+    fn test_inactive_lora_cold_start_pin() {
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+
+        rt.update_allocation(
+            "lora-b".to_string(),
+            LoraReplicaConfig {
+                lora_name: "lora-b".to_string(),
+                replica_factor: 1,
+                replica_set: vec![make_worker(2)],
+                updated_at: Instant::now(),
+                is_active: false,
+            },
+        );
+
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("lora-b"), &workers);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&2));
+    }
+
+    #[test]
+    fn test_inactive_pin_worker_unavailable_falls_back() {
+        let rt = LoraRoutingTable::new();
+        let st = LoraStateTracker::new();
+
+        rt.update_allocation(
+            "lora-b".to_string(),
+            LoraReplicaConfig {
+                lora_name: "lora-b".to_string(),
+                replica_factor: 1,
+                replica_set: vec![make_worker(5)],
+                updated_at: Instant::now(),
+                is_active: false,
+            },
+        );
+
+        let filter = LoraFilter::new(rt, st);
+        let workers = make_workers_map(&[1, 2, 3]);
+
+        let result = filter.filter_workers_for_lora(Some("lora-b"), &workers);
+        assert_eq!(result.len(), 3);
+    }
+}

--- a/lib/llm/src/lora/filtered_router.rs
+++ b/lib/llm/src/lora/filtered_router.rs
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! LoRA-filtered router wrapper for non-KV routing modes.
+//!
+//! Implements 2-stage routing:
+//!   Stage 1 — LoRA filter narrows the candidate worker set.
+//!   Stage 2 — The inner PushRouter selects from candidates.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+
+use async_trait::async_trait;
+use futures::Stream;
+use rand::Rng;
+
+use dynamo_runtime::{
+    engine::{
+        AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, AsyncEngineStream, Data,
+    },
+    pipeline::{Error, ManyOut, RouterMode, SingleIn, network::egress::push_router::PushRouter},
+    protocols::annotated::Annotated,
+};
+
+use crate::lora::filter::LoraFilter;
+use crate::lora::load_estimator::LoadEstimator;
+use crate::preprocessor::PreprocessedRequest;
+use crate::protocols::common::llm_backend::LLMEngineOutput;
+
+/// Decrements the [`LoadEstimator`] counter for a LoRA when dropped.
+struct LoadGuard {
+    estimator: Arc<LoadEstimator>,
+    lora_name: String,
+}
+
+impl Drop for LoadGuard {
+    fn drop(&mut self) {
+        self.estimator.decrement_load(&self.lora_name);
+    }
+}
+
+/// Thin wrapper around the inner response stream that holds a [`LoadGuard`].
+struct LoadTrackingStream<S> {
+    inner: S,
+    _guard: LoadGuard,
+}
+
+impl<S> std::fmt::Debug for LoadTrackingStream<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoadTrackingStream")
+            .field("lora", &self._guard.lora_name)
+            .finish()
+    }
+}
+
+impl<S> Stream for LoadTrackingStream<S>
+where
+    S: Stream + Unpin,
+{
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<S> AsyncEngineContextProvider for LoadTrackingStream<S>
+where
+    S: AsyncEngineContextProvider + Unpin,
+{
+    fn context(&self) -> Arc<dyn AsyncEngineContext> {
+        self.inner.context()
+    }
+}
+
+impl<T: Data, S> AsyncEngineStream<T> for LoadTrackingStream<S> where
+    S: Stream<Item = T> + AsyncEngineContextProvider + Send + Unpin
+{
+}
+
+/// Wraps a `PushRouter` with a LoRA pre-filter stage and load tracking.
+pub struct LoraFilteredRouter {
+    inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+    filter: Arc<LoraFilter>,
+    load_estimator: Arc<LoadEstimator>,
+    router_mode: RouterMode,
+    round_robin_counter: AtomicU64,
+}
+
+impl LoraFilteredRouter {
+    pub fn new(
+        inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+        filter: Arc<LoraFilter>,
+        load_estimator: Arc<LoadEstimator>,
+        router_mode: RouterMode,
+    ) -> Self {
+        tracing::info!(
+            ?router_mode,
+            "LoRA-filtered router created (2-stage: LoRA filter → {:?})",
+            router_mode
+        );
+        Self {
+            inner,
+            filter,
+            load_estimator,
+            router_mode,
+            round_robin_counter: AtomicU64::new(0),
+        }
+    }
+
+    fn select_from(&self, candidates: &[u64]) -> Option<u64> {
+        if candidates.is_empty() {
+            return None;
+        }
+        match self.router_mode {
+            RouterMode::RoundRobin => {
+                let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
+                Some(candidates[counter % candidates.len()])
+            }
+            RouterMode::Random => {
+                let idx = rand::rng().random::<u64>() as usize;
+                Some(candidates[idx % candidates.len()])
+            }
+            // Direct, KV, and advanced modes are never routed through LoraFilteredRouter
+            // (Direct uses DirectRoutingRouter; KV uses KvPushRouter; advanced modes
+            // bypass LoRA filtering in common.rs). These arms exist only for match
+            // exhaustiveness.
+            RouterMode::Direct
+            | RouterMode::PowerOfTwoChoices
+            | RouterMode::LeastLoaded
+            | RouterMode::DeviceAwareWeighted => {
+                tracing::warn!(
+                    ?self.router_mode,
+                    "LoraFilteredRouter::select_from called with unexpected router mode, using first candidate"
+                );
+                Some(candidates[0])
+            }
+            RouterMode::KV => {
+                tracing::error!("LoraFilteredRouter should not be used with KV routing mode");
+                Some(candidates[0])
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+    for LoraFilteredRouter
+{
+    async fn generate(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+        let lora_name = request
+            .routing
+            .as_ref()
+            .and_then(|r| r.lora_name.as_deref())
+            .map(|s| s.to_string());
+
+        // Base-model (non-LoRA) request: nothing to filter or load-track. Delegate straight to
+        // the inner load-aware push router so base traffic on a LoRA-enabled deployment keeps the
+        // unmodified hot path (no avail/free scans, no set allocation, no LoadGuard).
+        let Some(lora_name) = lora_name else {
+            return self.inner.generate(request).await;
+        };
+
+        self.load_estimator.increment_load(&lora_name);
+        let guard = LoadGuard {
+            estimator: self.load_estimator.clone(),
+            lora_name: lora_name.clone(),
+        };
+
+        // Stage 1: narrow to the LoRA's replica set against the FULL routable set, so the
+        // intended replicas are always represented even when they are currently busy.
+        //
+        // Filtering the "free" subset first would be wrong: if a LoRA's replicas are all busy
+        // but some unrelated worker is free, the filter would see no replica intersection in the
+        // free set and fall back to returning those unrelated free workers — scattering adapter
+        // traffic off the replica set exactly when it is saturated (and forcing a cold adapter
+        // load on a non-replica worker). Filtering the routable set keeps the replica constraint.
+        let routable = self.inner.client.instance_ids_avail();
+        let replica_candidates = self
+            .filter
+            .filter_worker_ids_for_lora(Some(lora_name.as_str()), &routable);
+
+        // Stage 2: among the replica candidates, prefer free (non-overloaded) workers to match
+        // PushRouter's load-aware selection. Only when every replica candidate is busy do we fall
+        // back to the (busy) replica set itself, rather than degrading to non-replica workers —
+        // so the replica-set constraint is preserved even under saturation.
+        let free: std::collections::HashSet<u64> =
+            self.inner.client.instance_ids_free().into_iter().collect();
+        let free_replica_candidates: Vec<u64> = replica_candidates
+            .iter()
+            .copied()
+            .filter(|id| free.contains(id))
+            .collect();
+        let candidates = if free_replica_candidates.is_empty() {
+            replica_candidates
+        } else {
+            free_replica_candidates
+        };
+
+        if candidates.is_empty() {
+            return Err(anyhow::anyhow!(
+                "No workers available after LoRA filtering (lora={})",
+                lora_name
+            ));
+        }
+
+        let target = self
+            .select_from(&candidates)
+            .expect("candidates is non-empty");
+        tracing::debug!(
+            lora = %lora_name,
+            worker_id = target,
+            candidates = candidates.len(),
+            routable = routable.len(),
+            free = free.len(),
+            "LoRA-filtered router selected worker"
+        );
+
+        // Constrain the inner router's vanished-target fallback to the LoRA candidate set, so a
+        // race where `target` disappears mid-dispatch reselects another replica-set worker rather
+        // than escaping to an arbitrary worker outside the placement table.
+        let candidate_set: std::collections::HashSet<u64> = candidates.iter().copied().collect();
+        let response_stream = self
+            .inner
+            .direct_within(request, target, Some(&candidate_set))
+            .await?;
+        let tracking = LoadTrackingStream {
+            inner: response_stream,
+            _guard: guard,
+        };
+        Ok(Box::pin(tracking))
+    }
+}

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -331,7 +331,6 @@ impl RoutingInstancesState {
         self.snapshot().routable_ids().to_vec()
     }
 
-    #[cfg(test)]
     fn free_ids(&self) -> Vec<u64> {
         self.snapshot().free_ids.clone()
     }
@@ -462,8 +461,9 @@ impl Client {
         self.routing_instances.routable_ids()
     }
 
-    #[cfg(test)]
-    pub(crate) fn instance_ids_free(&self) -> Vec<u64> {
+    /// Routable instance ids excluding those currently flagged overloaded — the set used
+    /// for load-aware (random / round-robin) worker selection.
+    pub fn instance_ids_free(&self) -> Vec<u64> {
         self.routing_instances.free_ids()
     }
 

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -517,7 +517,7 @@ where
         };
         tracing::trace!("round robin router selected {instance_id}");
 
-        self.generate_with_fault_detection(instance_id, request)
+        self.generate_with_fault_detection(instance_id, request, None)
             .await
     }
 
@@ -534,7 +534,7 @@ where
         };
         tracing::trace!("random router selected {instance_id}");
 
-        self.generate_with_fault_detection(instance_id, request)
+        self.generate_with_fault_detection(instance_id, request, None)
             .await
     }
 
@@ -553,7 +553,7 @@ where
         let permit = OccupancyPermit::new(state, instance_id);
 
         match self
-            .generate_with_fault_detection(instance_id, request)
+            .generate_with_fault_detection(instance_id, request, None)
             .await
         {
             Ok(stream) => Ok(permit.into_tracked_stream(stream)),
@@ -566,6 +566,19 @@ where
         &self,
         request: SingleIn<T>,
         instance_id: u64,
+    ) -> anyhow::Result<ManyOut<U>> {
+        self.direct_within(request, instance_id, None).await
+    }
+
+    /// Like [`direct`], but if the selected instance disappears between selection and dispatch,
+    /// the internal reselection is constrained to `allowed_fallback` (when `Some`). Callers that
+    /// pre-narrowed the candidate set (e.g. LoRA replica-set filtering) pass that set so the
+    /// vanished-instance fallback cannot escape it and route to an arbitrary worker.
+    pub async fn direct_within(
+        &self,
+        request: SingleIn<T>,
+        instance_id: u64,
+        allowed_fallback: Option<&std::collections::HashSet<u64>>,
     ) -> anyhow::Result<ManyOut<U>> {
         // When fault detection is disabled, check the raw discovery list
         // (not filtered by report_instance_down) so transient failures
@@ -586,7 +599,7 @@ where
             ));
         }
 
-        self.generate_with_fault_detection(instance_id, request)
+        self.generate_with_fault_detection(instance_id, request, allowed_fallback)
             .await
     }
 
@@ -648,7 +661,7 @@ where
         );
 
         match self
-            .generate_with_fault_detection(instance_id, request)
+            .generate_with_fault_detection(instance_id, request, None)
             .await
         {
             Ok(stream) => Ok(permit.into_tracked_stream(stream)),
@@ -672,7 +685,7 @@ where
         );
 
         match self
-            .generate_with_fault_detection(instance_id, request)
+            .generate_with_fault_detection(instance_id, request, None)
             .await
         {
             Ok(stream) => Ok(permit.into_tracked_stream(stream)),
@@ -770,6 +783,7 @@ where
         &self,
         instance_id: u64,
         request: SingleIn<T>,
+        allowed_fallback: Option<&std::collections::HashSet<u64>>,
     ) -> anyhow::Result<ManyOut<U>> {
         let route_start = Instant::now();
         let request_id = request.id().to_string();
@@ -787,7 +801,7 @@ where
         self.check_workers_available(instance_id, &request_id)?;
 
         let (instance_id, address, transport_kind, instance) =
-            self.resolve_transport(instance_id)?;
+            self.resolve_transport(instance_id, allowed_fallback)?;
 
         let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
@@ -855,6 +869,7 @@ where
     fn resolve_transport(
         &self,
         instance_id: u64,
+        allowed_fallback: Option<&std::collections::HashSet<u64>>,
     ) -> anyhow::Result<(u64, String, &'static str, Instance)> {
         use crate::component::TransportType;
 
@@ -879,11 +894,12 @@ where
         }
 
         let routing_instances = self.client.routing_instances();
-        let fallback_id = routing_instances
-            .free_ids()
-            .iter()
-            .copied()
-            .find(|&id| id != instance_id);
+        // When the caller pre-narrowed the candidate set (e.g. LoRA replica-set
+        // filtering), the vanished-instance fallback must stay within it so we never
+        // route off the allowed set to an arbitrary worker.
+        let fallback_id = routing_instances.free_ids().iter().copied().find(|&id| {
+            id != instance_id && allowed_fallback.is_none_or(|allowed| allowed.contains(&id))
+        });
         match fallback_id {
             Some(id) => {
                 tracing::warn!(
@@ -1033,7 +1049,7 @@ where
 
         self.check_workers_available(instance_id, &request_id)?;
         let (instance_id, address, transport_kind, instance) =
-            self.resolve_transport(instance_id)?;
+            self.resolve_transport(instance_id, None)?;
 
         STAGE_DURATION_SECONDS
             .with_label_values(&[STAGE_ROUTE])


### PR DESCRIPTION
Splits #8180 into a reviewable 3-PR train — **part 2 of 3**. Stacked on #10385.

### This PR: request-path LoRA filtering (non-KV)
- `LoraFilter`: 3-tier worker narrowing (replica∩loaded∩available → replica∩available lazy-load → all; inactive → single HRW pin).
- `LoraFilteredRouter`: 2-stage `AsyncEngine` wrapper around `PushRouter` for Random/RoundRobin — narrows to the replica set, prefers free replicas, load-tracks each request via a drop-guard.
- `PushRouter::direct_within` + a candidate-set-constrained vanished-target fallback (`resolve_transport` now honors an `allowed_fallback` set); `Client::instance_ids_free` made public.

KV-path narrowing + the `ModelManager`/entrypoint wiring that activates all of this land in **(3/3)**. Compiles and passes `lora::filter` tests on top of #10385.