### PR TITLE
feat(lora): frontend integration — ModelManager, discovery, KV router, bindings (3/3)

### DIFF
--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -176,6 +176,8 @@ async def init_decode(
                 readiness_gate=ready_event,
                 worker_type=decode_worker_type,
                 needs=decode_needs,
+                # Decode workers serve the LoRA load endpoints, so they may advertise capacity.
+                serves_lora_load=True,
             ),
         ]
         if getattr(server_args, "enable_streaming_session", False):
@@ -317,6 +319,9 @@ async def init_prefill(
                 readiness_gate=ready_event,
                 worker_type=WorkerType.Prefill,
                 needs=[[WorkerType.Decode]],
+                # Prefill workers also serve the LoRA load endpoints (init_prefill), so they may
+                # advertise capacity.
+                serves_lora_load=True,
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -59,6 +59,7 @@ async def _register_model_with_runtime_config(
     *,
     worker_type: WorkerType,
     needs: Optional[List[List[WorkerType]]] = None,
+    serves_lora_load: bool = False,
 ) -> bool:
     """Register LLM with the Dynamo runtime.
 
@@ -96,6 +97,23 @@ async def _register_model_with_runtime_config(
     if getattr(dynamo_args, "frontend_decoding", False):
         media_decoder, media_fetcher = _build_media_decoder_and_fetcher()
 
+    # Advertise the worker's LoRA slot budget on the BASE registration so the frontend allocator
+    # can place adapters onto idle-but-LoRA-capable workers before any adapter is loaded here.
+    # Only workers that actually SERVE the LoRA load endpoints (init_decode / init_prefill, which
+    # pass serves_lora_load=True) may advertise capacity. Other worker modes (embedding, diffusion,
+    # multimodal-encode) register through this same wrapper but do not serve load_lora, so they
+    # must never advertise capacity they cannot fulfill -- hence an explicit allowlist flag rather
+    # than an output_type denylist.
+    lora_enabled = bool(
+        getattr(server_args, "enable_lora", None)
+        or getattr(server_args, "lora_paths", None)
+    )
+    max_gpu_lora_count = (
+        getattr(server_args, "max_loras_per_batch", None)
+        if (serves_lora_load and lora_enabled)
+        else None
+    )
+
     try:
         await register_model(
             input_type,
@@ -111,6 +129,7 @@ async def _register_model_with_runtime_config(
             media_fetcher=media_fetcher,
             worker_type=worker_type,
             needs=needs,
+            max_gpu_lora_count=max_gpu_lora_count,
         )
         logging.info("Successfully registered LLM with runtime config")
         return True
@@ -401,6 +420,7 @@ async def register_model_with_readiness_gate(
     *,
     worker_type: WorkerType,
     needs: Optional[List[List[WorkerType]]] = None,
+    serves_lora_load: bool = False,
 ) -> None:
     """Wrapper function to register LLM with the Dynamo runtime and use optional readiness gate to signal success.
 
@@ -427,6 +447,7 @@ async def register_model_with_readiness_gate(
         output_type,
         worker_type=worker_type,
         needs=needs,
+        serves_lora_load=serves_lora_load,
     )
     if not registration_success:
         logging.error("Model registration failed; shutting down")

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -421,6 +421,12 @@ class LoraMixin:
                                 base_model_path=self.config.server_args.model_path,
                                 worker_type=lora_worker_type,
                                 needs=lora_needs,
+                                # Publish the worker's per-worker LoRA slot budget so the frontend
+                                # allocator sizes placement against real capacity instead of the
+                                # hard-coded default.
+                                max_gpu_lora_count=getattr(
+                                    self.config.server_args, "max_loras_per_batch", None
+                                ),
                             )
                             logger.info(
                                 f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1309,6 +1309,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 base_model_path=self.config.model,
                                 worker_type=lora_worker_type,
                                 needs=lora_needs,
+                                # Publish the worker's per-worker LoRA slot budget so the frontend
+                                # allocator sizes placement against real capacity instead of the
+                                # hard-coded default.
+                                max_gpu_lora_count=getattr(
+                                    self.config.engine_args, "max_loras", None
+                                ),
                             )
                             logger.info(
                                 f"Successfully published LoRA '{lora_name}' ModelDeploymentCard"

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -759,6 +759,21 @@ async def register_vllm_model(
         media_fetcher=media_fetcher,
         worker_type=worker_type,
         needs=needs,
+        # Advertise the worker's LoRA slot budget on the BASE registration so the frontend
+        # allocator can place adapters onto idle-but-LoRA-capable workers before any adapter is
+        # loaded here. Only generative decode/aggregated workers serve the LoRA load endpoints
+        # (load_lora/unload_lora). Prefill and embedding workers register through this same path
+        # but do NOT serve them, so they must not advertise capacity they cannot fulfill — gate on
+        # the model type rather than worker_type (vLLM embedding registers as Aggregated). None
+        # (no capacity) for non-LoRA, prefill, or embedding workers.
+        max_gpu_lora_count=(
+            config.engine_args.max_loras
+            if (
+                getattr(config.engine_args, "enable_lora", False)
+                and model_type not in (ModelType.Prefill, ModelType.Embedding)
+            )
+            else None
+        ),
     )
 
 

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -328,7 +328,7 @@ fn resolve_routing_image_token_id(model_id: &str, model_dir: &str) -> Option<u32
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, worker_type=None, needs=None, self_host_metadata=None, max_gpu_lora_count=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -350,6 +350,7 @@ fn register_model<'p>(
     worker_type: Option<WorkerType>,
     needs: Option<Vec<Vec<WorkerType>>>,
     self_host_metadata: Option<bool>,
+    max_gpu_lora_count: Option<u32>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Every worker registers with an explicit `worker_type`. Reject `None`
     // outright — a missing role would produce a card whose readiness math
@@ -549,7 +550,16 @@ fn register_model<'p>(
             .context_length(context_length)
             .kv_cache_block_size(kv_cache_block_size)
             .router_config(explicit_router_config.clone())
-            .runtime_config(runtime_config.unwrap_or_default().inner)
+            .runtime_config({
+                let mut rc = runtime_config.unwrap_or_default().inner;
+                // The base worker registration carries the worker's LoRA slot capacity so the
+                // frontend allocator sees idle-but-LoRA-capable workers before any adapter is
+                // loaded. Adapter registrations (lora_name set) carry it via LoraInfo instead.
+                if lora_identifier.is_none() {
+                    rc.max_gpu_lora_count = max_gpu_lora_count;
+                }
+                rc
+            })
             .user_data(user_data_json)
             .custom_template_path(custom_template_path_owned)
             .media_decoder(media_decoder.map(|m| m.inner))
@@ -566,7 +576,7 @@ fn register_model<'p>(
             .as_ref()
             .map(|name| llm_rs::model_card::LoraInfo {
                 name: name.clone(),
-                max_gpu_lora_count: None,
+                max_gpu_lora_count,
             });
 
         local_model

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2079,6 +2079,7 @@ async def register_model(
     lora_name: Optional[str] = None,
     base_model_path: Optional[str] = None,
     needs: Optional[List[List[WorkerType]]] = None,
+    max_gpu_lora_count: Optional[int] = None,
 ) -> None:
     """
     Attach the model at path to the given endpoint, and advertise it as model_type.

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -156,6 +156,22 @@ class frontend_service:
     WORKER_LAST_INTER_TOKEN_LATENCY_SECONDS = "worker_last_inter_token_latency_seconds"
     # Number of requests pending in the router's scheduler queue (gauge per worker_type)
     ROUTER_QUEUE_PENDING_REQUESTS = "router_queue_pending_requests"
+    # Number of replicas allocated for a LoRA adapter
+    LORA_REPLICA_FACTOR = "lora_replica_factor"
+    # Whether a LoRA adapter is actively receiving traffic (1=active, 0=inactive)
+    LORA_IS_ACTIVE = "lora_is_active"
+    # Estimated load (windowed request count) for a LoRA adapter
+    LORA_ESTIMATED_LOAD = "lora_estimated_load"
+    # Raw arrival count (windowed rate counter) for a LoRA adapter
+    LORA_RAW_ARRIVAL_COUNT = "lora_raw_arrival_count"
+    # Number of in-flight (active) requests for a LoRA adapter
+    LORA_ACTIVE_REQUESTS = "lora_active_requests"
+    # Total LoRA loads (new placements) this controller tick
+    LORA_CHURN_LOADS_TOTAL = "lora_churn_loads_total"
+    # Total LoRA unloads (removed placements) this controller tick
+    LORA_CHURN_UNLOADS_TOTAL = "lora_churn_unloads_total"
+    # MCF solver overflow count (unplaceable replicas)
+    LORA_OVERFLOW_COUNT = "lora_overflow_count"
     # Label name for the type of migration
     MIGRATION_TYPE_LABEL = "migration_type"
     # Label name for tokenizer operation

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -30,6 +30,7 @@ use crate::{
         shared_cache::HicacheSharedKvCache,
     },
     local_model::runtime_config::{DisaggregatedEndpoint, ModelRuntimeConfig, topology_taint},
+    lora::{LoraFilter, LoraRoutingTable, LoraStateTracker, load_estimator::LoadEstimator},
     model_card::ModelDeploymentCard,
     types::{
         RealtimeBidirectionalEngine,
@@ -102,6 +103,20 @@ pub struct ModelManager {
 
     /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
+
+    // LoRA allocation state. The state objects are always created so discovery can
+    // populate them, but `lora_filter()` only hands out the filter when LoRA serving is
+    // enabled (DYN_LORA_ENABLED) — so non-LoRA deployments keep the unmodified routing
+    // path. The controller is additionally gated on the allocation config.
+    lora_routing_table: LoraRoutingTable,
+    lora_state_tracker: LoraStateTracker,
+    lora_load_estimator: Arc<LoadEstimator>,
+    lora_filter: Arc<LoraFilter>,
+    lora_enabled: bool,
+    /// Per-decode-component LoRA load-feed subscription handles, so we start exactly one feed
+    /// per component and can restart it if the previous one exited (avoids double counting on
+    /// rebuilds while keeping the feed durable).
+    lora_load_feeds: DashMap<String, tokio::task::JoinHandle<()>>,
 }
 
 impl Default for ModelManager {
@@ -112,11 +127,24 @@ impl Default for ModelManager {
 
 impl ModelManager {
     pub fn new() -> Self {
+        let lora_routing_table = LoraRoutingTable::new();
+        let lora_state_tracker = LoraStateTracker::new();
+        let lora_filter = Arc::new(LoraFilter::new(
+            lora_routing_table.clone(),
+            lora_state_tracker.clone(),
+        ));
+
         Self {
             models: DashMap::new(),
             cards: DashMap::new(),
             prefill_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
+            lora_routing_table,
+            lora_state_tracker,
+            lora_load_estimator: Arc::new(LoadEstimator::new()),
+            lora_filter,
+            lora_enabled: crate::lora::lora_serving_enabled(),
+            lora_load_feeds: DashMap::new(),
         }
     }
 
@@ -178,6 +206,10 @@ impl ModelManager {
     }
 
     /// Remove and return model card for this instance's key. We do this when the instance stops.
+    pub fn get_model_card(&self, key: &str) -> Option<ModelDeploymentCard> {
+        self.cards.get(key).map(|r| r.value().clone())
+    }
+
     pub fn remove_model_card(&self, key: &str) -> Option<ModelDeploymentCard> {
         self.cards.remove(key).map(|(_, v)| v)
     }
@@ -700,6 +732,18 @@ impl ModelManager {
 
     // -- KV Router creation --
 
+    /// Whether to start the LoRA load-estimator feed for a KV router being built for `worker_type`.
+    ///
+    /// The feed must run for the worker mode that carries the routable request load. In dynamo's
+    /// KV path that is `WORKER_TYPE_DECODE`, which the binding assigns to BOTH aggregated and
+    /// disaggregated-decode endpoints (any non-prefill endpoint that tracks active blocks; see
+    /// `create_kv_router_from_endpoint`). Only disaggregated PREFILL is excluded, so its transient
+    /// load does not double-count the decode component's active sequences. Returns false when LoRA
+    /// serving is disabled.
+    fn should_start_lora_load_feed(lora_enabled: bool, worker_type: &str) -> bool {
+        lora_enabled && worker_type == crate::protocols::common::timing::WORKER_TYPE_DECODE
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn kv_chooser_for(
         &self,
@@ -769,8 +813,65 @@ impl ModelManager {
             model_name,
             is_eagle,
             shared_cache,
+            self.lora_filter(),
         )
         .await?;
+
+        // F2: feed the LoRA LoadEstimator in KV mode. Start exactly one active-sequence
+        // subscription per "decode" component. WORKER_TYPE_DECODE is the routing path for BOTH
+        // aggregated and disaggregated-decode deployments: the binding maps any non-prefill,
+        // active-block-tracking endpoint to WORKER_TYPE_DECODE (see create_kv_router_from_endpoint
+        // in bindings/python/rust/llm/kv.rs), so aggregated KV feeds load here too. Only
+        // disaggregated PREFILL is excluded — its load is transient and would double-count the
+        // decode component's active sequences. Without this feed the estimator is never fed in KV
+        // mode and every LoRA stays "inactive" forever. (Edge case specific to the Python KV path:
+        // create_kv_router_from_endpoint infers WORKER_TYPE_PREFILL for a non-prefill endpoint when
+        // router_track_active_blocks=false, so that aggregated worker would skip this feed and KV
+        // routing is not load-aware — dynamic LoRA allocation then degrades to cold-start pins while
+        // the filter still routes by loaded worker. Constructors that pass WORKER_TYPE_DECODE
+        // directly, e.g. the watcher / C bindings, are unaffected.)
+        if Self::should_start_lora_load_feed(self.lora_enabled, worker_type) {
+            let feed_key = format!("{}/{}", endpoint.id().namespace, endpoint.id().component);
+            // Start a feed if none runs for this component yet, or restart it if the previous
+            // one exited (so a dead subscription does not permanently disable load tracking).
+            //
+            // Use the DashMap entry API so the check-and-insert is atomic per key: two
+            // concurrent `kv_chooser_for` calls for the same component otherwise both observe
+            // "no feed" and each spawn a subscription, double-counting active sequences.
+            // Holding the entry lock across the spawn serializes them — the loser sees the
+            // winner's live handle and skips.
+            let started = match self.lora_load_feeds.entry(feed_key) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get().is_finished() {
+                        // Previous feed exited; replace it (aborting the dead handle is a no-op).
+                        let handle = self
+                            .lora_load_estimator
+                            .clone()
+                            .start_event_subscription(endpoint.component().clone());
+                        entry.insert(handle);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let handle = self
+                        .lora_load_estimator
+                        .clone()
+                        .start_event_subscription(endpoint.component().clone());
+                    entry.insert(handle);
+                    true
+                }
+            };
+            if started {
+                tracing::info!(
+                    namespace = %endpoint.id().namespace,
+                    component = %endpoint.id().component,
+                    "Started decode-side LoRA load feed (KV active-sequence subscription)"
+                );
+            }
+        }
+
         Ok(Arc::new(chooser))
     }
 
@@ -782,6 +883,75 @@ impl ModelManager {
     /// and registration guards.
     pub(crate) fn model_namespace_key(model_name: &str, namespace: &str) -> String {
         format!("{}:{}", model_name, namespace)
+    }
+
+    // ── LoRA allocation accessors ───────────────────────────────────────
+
+    pub fn lora_routing_table(&self) -> &LoraRoutingTable {
+        &self.lora_routing_table
+    }
+
+    pub fn lora_state_tracker(&self) -> &LoraStateTracker {
+        &self.lora_state_tracker
+    }
+
+    pub fn lora_load_estimator(&self) -> &Arc<LoadEstimator> {
+        &self.lora_load_estimator
+    }
+
+    pub fn lora_filter(&self) -> Option<Arc<LoraFilter>> {
+        // Only expose the filter when LoRA serving is enabled, so non-LoRA deployments
+        // keep the unmodified routing path (no wrapper, no avail-vs-free regression).
+        self.lora_enabled.then(|| self.lora_filter.clone())
+    }
+
+    /// Start the LoRA allocation controller background loop.
+    pub fn start_lora_controller(
+        &self,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let config = crate::lora::LoraAllocationConfig::from_env();
+
+        // F10: respect the allocation-enabled config (DYN_LORA_ALLOCATION_ENABLED). When
+        // disabled, skip the controller entirely — routing still works via the filter's
+        // loaded-worker fallback, just without dynamic replica recomputation.
+        if !config.enabled {
+            tracing::info!(
+                "LoRA allocation controller disabled (DYN_LORA_ALLOCATION_ENABLED=false); \
+                 routing uses the loaded-worker fallback without dynamic allocation"
+            );
+            return tokio::spawn(async {});
+        }
+
+        let rate_window_secs = config.effective_rate_window_secs();
+        // F11: apply the full estimator config (rate window + bucket granularity +
+        // predictor type/alpha), not just the rate window.
+        self.lora_load_estimator
+            .set_config(crate::lora::LoadEstimatorConfig {
+                rate_window: std::time::Duration::from_secs(rate_window_secs),
+                buckets_per_second: config.buckets_per_second,
+                predictor_type: config.predictor_type,
+                ema_alpha: config.ema_alpha,
+                ..Default::default()
+            });
+
+        tracing::info!(
+            enabled = config.enabled,
+            algorithm = ?config.algorithm,
+            timestep_secs = config.timestep_secs,
+            rate_window_secs = rate_window_secs,
+            rate_window_multiplier = config.rate_window_multiplier,
+            buckets_per_second = config.buckets_per_second,
+            predictor_type = ?config.predictor_type,
+            "Starting LoRA allocation controller"
+        );
+        crate::lora::LoraController::start(
+            config,
+            self.lora_routing_table.clone(),
+            self.lora_state_tracker.clone(),
+            self.lora_load_estimator.clone(),
+            cancel_token,
+        )
     }
 
     /// Register a prefill router for a decode WorkerSet. Returns a receiver that will be
@@ -1226,6 +1396,30 @@ mod tests {
             .topology_domains
             .insert("zone".to_string(), "us-east-1a".to_string());
         config
+    }
+
+    #[test]
+    fn lora_load_feed_starts_for_aggregated_and_decode_not_prefill() {
+        use crate::protocols::common::timing::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
+        // Aggregated and disaggregated-decode deployments both route via WORKER_TYPE_DECODE
+        // (create_kv_router_from_endpoint maps any non-prefill, active-block-tracking endpoint to
+        // it), so the LoRA load feed must start for that worker type — otherwise the controller
+        // would treat every adapter as inactive and never run dynamic allocation.
+        assert!(
+            ModelManager::should_start_lora_load_feed(true, WORKER_TYPE_DECODE),
+            "decode/aggregated KV must start the LoRA load feed"
+        );
+        // Disaggregated prefill load is fed via the decode component, so prefill must NOT start its
+        // own feed (avoids double-counting active sequences).
+        assert!(
+            !ModelManager::should_start_lora_load_feed(true, WORKER_TYPE_PREFILL),
+            "prefill KV must not start its own LoRA load feed"
+        );
+        // LoRA serving disabled: never start the feed.
+        assert!(
+            !ModelManager::should_start_lora_load_feed(false, WORKER_TYPE_DECODE),
+            "no feed when LoRA serving is disabled"
+        );
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -134,6 +134,11 @@ pub struct ModelWatcher {
     /// Tracks in-flight `handle_put` tasks by instance path so that `handle_delete`
     /// can await a racing put before proceeding with cleanup.
     pending_puts: DashMap<String, JoinHandle<()>>,
+    /// Maps an MDC instance path to the LoRA adapter name recorded in the pre-spawn state-tracker
+    /// addition, so a removal whose model card was never durably saved (handle_put failed before
+    /// save) can still remove exactly that adapter from the tracker instead of leaving phantom
+    /// state or wiping a live worker (R4-2 / RR3-3).
+    pending_lora_adds: DashMap<String, String>,
     /// Frontend's `--model-path`. Threaded into `download_config` so
     /// `file://` slots can fall back here when the worker's path is
     /// unreachable on this host.
@@ -217,6 +222,7 @@ impl ModelWatcher {
             registering_worker_sets: DashSet::new(),
             registration_notify: Notify::new(),
             pending_puts: DashMap::new(),
+            pending_lora_adds: DashMap::new(),
             local_model_path: None,
         }
     }
@@ -329,6 +335,26 @@ impl ModelWatcher {
                         continue;
                     }
 
+                    // Feed the LoRA state tracker for every worker registration (before the spawn
+                    // below, so `card` is read before it is moved into the task). An adapter card
+                    // registers the loaded adapter (+capacity); a base card advertising
+                    // runtime_config.max_gpu_lora_count seeds capacity-only so idle LoRA-capable
+                    // workers are visible to the controller before any adapter is loaded there.
+                    {
+                        use crate::kv_router::protocols::WorkerWithDpRank;
+                        let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
+                        if let Some(adapter_name) = seed_lora_state_from_card(
+                            self.manager.lora_state_tracker(),
+                            worker,
+                            &card,
+                        ) {
+                            // Record the adapter name keyed by instance path so a later removal
+                            // whose card was never durably saved can still remove exactly this
+                            // adapter (R4-2).
+                            self.pending_lora_adds.insert(mcid.to_path(), adapter_name);
+                        }
+                    }
+
                     // Spawn each handle_put into its own task so that a slow
                     // HuggingFace config download for one model cannot block
                     // discovery events for all subsequent models.
@@ -388,6 +414,9 @@ impl ModelWatcher {
                         }
                     };
 
+                    // LoRA state-tracker cleanup runs inside handle_delete, after it waits for
+                    // any in-flight handle_put, so the card is reliably present even when a
+                    // Removed event races an in-flight add (N2).
                     match self
                         .handle_delete(model_card_instance_id, &namespace_filter)
                         .await
@@ -441,14 +470,67 @@ impl ModelWatcher {
         let card = match self.manager.remove_model_card(&key) {
             Some(card) => card,
             None => {
+                // The card was never durably saved (e.g. an Added event whose handle_put failed
+                // before save, after the pre-spawn tracker addition). Reconcile tracker state at
+                // the right granularity:
+                //   - base worker card (`model_suffix == None`): the worker instance is gone, so
+                //     clear it entirely;
+                //   - LoRA-adapter card (`model_suffix == Some`): remove ONLY that adapter, using
+                //     the name recorded in `pending_lora_adds`, so a still-live worker's other
+                //     adapters/capacity are untouched (RR3-3 / R4-2).
+                use crate::kv_router::protocols::WorkerWithDpRank;
+                let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
+                if mcid.model_suffix.is_none() {
+                    self.manager
+                        .lora_state_tracker()
+                        .handle_worker_removal(worker);
+                    // Sweep any pending fallback entries for this worker's LoRA cards so they
+                    // can't linger if their own remove events never arrive (RF-2).
+                    let prefix = format!("{}/", mcid.to_path());
+                    self.pending_lora_adds
+                        .retain(|k, _| !k.starts_with(&prefix));
+                } else if let Some((_, lora_name)) = self.pending_lora_adds.remove(&key) {
+                    self.manager
+                        .lora_state_tracker()
+                        .handle_mdc_removal(worker, &lora_name);
+                }
                 tracing::warn!(
                     key = %key,
-                    "ModelDeploymentCard already absent during removal; ignoring duplicate or stale remove event"
+                    "ModelDeploymentCard absent during removal; reconciled LoRA tracker state from pending add"
                 );
                 return Ok(None);
             }
         };
         let model_name = card.name().to_string();
+
+        // Feed the LoRA state tracker now that any in-flight handle_put has completed and the
+        // card is available (N2 — avoids the race where a Removed event outran the add). A LoRA
+        // adapter card unregisters just that adapter; the base worker card means the worker
+        // instance is gone, so drop its capacity + all loaded-LoRA bookkeeping (F4/F5).
+        {
+            use crate::kv_router::protocols::WorkerWithDpRank;
+            let worker = WorkerWithDpRank::new(mcid.instance_id, 0);
+            match card.lora {
+                Some(ref lora_info) => self
+                    .manager
+                    .lora_state_tracker()
+                    .handle_mdc_removal(worker, &lora_info.name),
+                None => self
+                    .manager
+                    .lora_state_tracker()
+                    .handle_worker_removal(worker),
+            }
+        }
+        // The card-based cleanup above is authoritative; drop the pending fallback entry for a
+        // LoRA card, or sweep all of this worker's suffixed entries for a base card (RF-2).
+        if card.lora.is_some() {
+            self.pending_lora_adds.remove(&key);
+        } else {
+            let prefix = format!("{}/", mcid.to_path());
+            self.pending_lora_adds
+                .retain(|k, _| !k.starts_with(&prefix));
+        }
+
         let worker_namespace = &mcid.namespace;
         let worker_component = &mcid.component;
         let ws_key = worker_set_key(&mcid.namespace, card.model_type, card.worker_type);
@@ -1311,9 +1393,106 @@ impl ModelWatcher {
     }
 }
 
+/// Seed the LoRA state tracker from a worker's MDC.
+///
+/// - Adapter card (`card.lora` is `Some`): register the loaded adapter (which also records the
+///   worker's capacity) and return the adapter name so the caller can track it for failed-save
+///   removal reconciliation.
+/// - Base worker card advertising `runtime_config.max_gpu_lora_count`: seed capacity-only (no
+///   phantom adapter) so the controller sees idle-but-LoRA-capable workers before the first
+///   adapter load. Returns `None`.
+/// - Otherwise (non-LoRA worker): no-op, returns `None`.
+///
+/// Split out of the discovery loop so the base-card capacity data flow is unit-testable without
+/// constructing a full `ModelWatcher`.
+fn seed_lora_state_from_card(
+    state_tracker: &crate::lora::LoraStateTracker,
+    worker: crate::kv_router::protocols::WorkerWithDpRank,
+    card: &ModelDeploymentCard,
+) -> Option<String> {
+    if let Some(lora_info) = card.lora.as_ref() {
+        state_tracker.handle_mdc_addition(worker, lora_info);
+        Some(lora_info.name.clone())
+    } else if let Some(capacity) = card.runtime_config.max_gpu_lora_count {
+        state_tracker.set_worker_capacity(worker, capacity);
+        None
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::discovery::WorkerSet;
+    use crate::model_card::ModelDeploymentCard;
+
+    #[test]
+    fn base_card_with_capacity_seeds_idle_lora_capable_worker() {
+        // jh-nv (watcher base-card seeding): a base worker card (lora=None) carrying
+        // runtime_config.max_gpu_lora_count must seed capacity-only so the controller sees the
+        // idle LoRA-capable worker before any adapter loads. Pins the base-card -> capacity flow
+        // that the discovery loop relies on.
+        let st = crate::lora::LoraStateTracker::new();
+        let worker = crate::kv_router::protocols::WorkerWithDpRank::new(7, 0);
+        let mut card = ModelDeploymentCard::with_name_only("base-model");
+        card.runtime_config.max_gpu_lora_count = Some(4);
+        assert!(card.lora.is_none());
+
+        let adapter = seed_lora_state_from_card(&st, worker, &card);
+        assert_eq!(adapter, None, "a base card registers no adapter name");
+        assert_eq!(
+            st.list_workers(),
+            vec![worker],
+            "idle LoRA-capable worker must be visible to the controller"
+        );
+        assert_eq!(st.total_lora_slots(), 4);
+    }
+
+    #[test]
+    fn base_card_without_capacity_seeds_nothing() {
+        // A non-LoRA base card must not seed any worker capacity.
+        let st = crate::lora::LoraStateTracker::new();
+        let card = ModelDeploymentCard::with_name_only("base-model");
+        assert!(card.runtime_config.max_gpu_lora_count.is_none());
+
+        let adapter = seed_lora_state_from_card(
+            &st,
+            crate::kv_router::protocols::WorkerWithDpRank::new(1, 0),
+            &card,
+        );
+        assert_eq!(adapter, None);
+        assert!(
+            st.list_workers().is_empty(),
+            "a non-LoRA base card must not seed capacity"
+        );
+    }
+
+    #[test]
+    fn adapter_card_registers_adapter_and_returns_name() {
+        // An adapter card registers the loaded adapter (+capacity) and returns its name so the
+        // caller can track it in pending_lora_adds.
+        let st = crate::lora::LoraStateTracker::new();
+        let worker = crate::kv_router::protocols::WorkerWithDpRank::new(3, 0);
+        let mut card = ModelDeploymentCard::with_name_only("base-model");
+        card.lora = Some(crate::model_card::LoraInfo {
+            name: "adapter-x".to_string(),
+            max_gpu_lora_count: Some(2),
+        });
+
+        let adapter = seed_lora_state_from_card(&st, worker, &card);
+        assert_eq!(adapter.as_deref(), Some("adapter-x"));
+        assert!(st.is_loaded("adapter-x", &worker));
+        assert_eq!(st.total_lora_slots(), 2);
+    }
+
+    fn make_worker_set(namespace: &str) -> WorkerSet {
+        WorkerSet::new(
+            namespace.to_string(),
+            "test-checksum".to_string(),
+            ModelDeploymentCard::default(),
+        )
+    }
 
     #[test]
     fn test_is_model_type_list_empty_on_empty_manager() {

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -15,6 +15,7 @@ use crate::{
     kv_router::{
         DirectRoutingRouter, KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics,
     },
+    lora::LoraFilteredRouter,
     migration::Migration,
     model_card::ModelDeploymentCard,
     namespace::NamespaceFilter,
@@ -112,17 +113,61 @@ fn router_client(
     }
 }
 
+/// LoRA-aware routing is only implemented for the KV, Random, and RoundRobin modes. `Direct`
+/// dispatches to a caller-chosen worker and bypasses both the LoRA filter and non-KV load
+/// tracking; the advanced load-based modes (`PowerOfTwoChoices`, `LeastLoaded`,
+/// `DeviceAwareWeighted`) have no 2-stage LoRA filtering. Reject those combinations so a
+/// misconfiguration fails fast — at startup, before the initial-worker wait — instead of
+/// silently mis-routing adapter traffic to a worker without the adapter.
+fn validate_router_mode_for_lora(
+    router_mode: RouterMode,
+    lora_enabled: bool,
+) -> anyhow::Result<()> {
+    if !lora_enabled {
+        return Ok(());
+    }
+    match router_mode {
+        RouterMode::KV | RouterMode::Random | RouterMode::RoundRobin => Ok(()),
+        RouterMode::Direct
+        | RouterMode::PowerOfTwoChoices
+        | RouterMode::LeastLoaded
+        | RouterMode::DeviceAwareWeighted => anyhow::bail!(
+            "LoRA serving (DYN_LORA_ENABLED) is not supported with router mode {router_mode:?}; \
+             use KV, Random, or RoundRobin for LoRA-aware routing, or disable LoRA serving."
+        ),
+    }
+}
+
 fn preprocessed_backend_engine(
     router: LlmPushRouter,
     router_mode: RouterMode,
     chooser: Option<Arc<KvRouter>>,
+    model_manager: &Arc<crate::discovery::ModelManager>,
 ) -> anyhow::Result<ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>
 {
+    // Reject LoRA + unsupported-mode combinations up front (single source of truth, shared with
+    // the fail-fast check in `build_preprocessed_routing`). After this, the Direct and advanced
+    // arms below are only reached with LoRA serving disabled.
+    validate_router_mode_for_lora(router_mode, model_manager.lora_filter().is_some())?;
+
     let engine: ServiceEngine<_, _> = match router_mode {
+        // Direct dispatches to a caller-supplied worker id and calls inner.direct(); reached only
+        // with LoRA disabled (validated above).
         RouterMode::Direct => Arc::new(DirectRoutingRouter::new(router)),
-        RouterMode::Random
-        | RouterMode::RoundRobin
-        | RouterMode::PowerOfTwoChoices
+        RouterMode::Random | RouterMode::RoundRobin => match model_manager.lora_filter() {
+            // LoRA serving enabled: 2-stage routing (filter -> select). With no LoRAs
+            // registered the filter is a transparent pass-through.
+            Some(lora_filter) => Arc::new(LoraFilteredRouter::new(
+                router,
+                lora_filter,
+                model_manager.lora_load_estimator().clone(),
+                router_mode,
+            )),
+            // LoRA serving disabled: unchanged PushRouter path (no regression).
+            None => Arc::new(router),
+        },
+        // Advanced non-KV modes are not LoRA-aware; reached only with LoRA disabled (validated above).
+        RouterMode::PowerOfTwoChoices
         | RouterMode::LeastLoaded
         | RouterMode::DeviceAwareWeighted => Arc::new(router),
         RouterMode::KV => {
@@ -146,6 +191,11 @@ pub async fn build_preprocessed_routing(
     prefill_chooser: Option<Arc<PrefillRouter>>,
     enforce_disagg: bool,
 ) -> anyhow::Result<PreprocessedRouting> {
+    // Fail fast on an unsupported LoRA + router-mode combination BEFORE waiting for the initial
+    // worker set, so a misconfiguration surfaces immediately at startup rather than after the
+    // (possibly long) DYN_ROUTER_MIN_INITIAL_WORKERS wait.
+    validate_router_mode_for_lora(router_mode, model_manager.lora_filter().is_some())?;
+
     let min_initial_workers = min_initial_workers_from_env()?;
     let router_client = router_client(client, router_mode, chooser.as_ref())?;
 
@@ -163,10 +213,10 @@ pub async fn build_preprocessed_routing(
     // OnceLock), which covers the standalone router path as well.
     RouterRequestMetrics::from_component(client.endpoint.component());
 
+    let backend_engine = preprocessed_backend_engine(router, router_mode, chooser, &model_manager)?;
+
     let prefill_router = prefill_chooser
         .unwrap_or_else(|| PrefillRouter::disabled(model_manager, router_mode, enforce_disagg));
-
-    let backend_engine = preprocessed_backend_engine(router, router_mode, chooser)?;
 
     Ok(PreprocessedRouting {
         backend_engine,
@@ -393,5 +443,51 @@ impl PreprocessedRouting {
             .link(frontend)?;
 
         Ok(engine)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_router_mode_for_lora() {
+        use RouterMode::*;
+        let all = [
+            Direct,
+            KV,
+            Random,
+            RoundRobin,
+            PowerOfTwoChoices,
+            LeastLoaded,
+            DeviceAwareWeighted,
+        ];
+
+        // LoRA disabled: every mode is allowed (the unmodified routing path).
+        for m in all {
+            assert!(
+                validate_router_mode_for_lora(m, false).is_ok(),
+                "{m:?} must be allowed when LoRA serving is disabled"
+            );
+        }
+
+        // LoRA enabled: only the LoRA-aware modes are accepted.
+        for m in [KV, Random, RoundRobin] {
+            assert!(
+                validate_router_mode_for_lora(m, true).is_ok(),
+                "{m:?} must be supported for LoRA-aware routing"
+            );
+        }
+
+        // LoRA enabled: Direct + the advanced load-based modes are rejected with a clear error.
+        for m in [Direct, PowerOfTwoChoices, LeastLoaded, DeviceAwareWeighted] {
+            let err = validate_router_mode_for_lora(m, true)
+                .expect_err("must reject unsupported LoRA router mode")
+                .to_string();
+            assert!(
+                err.contains("not supported with router mode"),
+                "{m:?} rejection must explain the unsupported mode, got: {err}"
+            );
+        }
     }
 }

--- a/lib/llm/src/entrypoint/input/grpc.rs
+++ b/lib/llm/src/entrypoint/input/grpc.rs
@@ -127,6 +127,13 @@ async fn run_watcher(
     prefill_load_estimator: Option<Arc<dyn dynamo_kv_router::PrefillLoadEstimator>>,
     local_model_path: Option<PathBuf>,
 ) -> anyhow::Result<()> {
+    // Start the LoRA allocation controller when LoRA serving is enabled (mirrors http.rs;
+    // additionally gated on DYN_LORA_ALLOCATION_ENABLED inside start_lora_controller). Without
+    // this, gRPC LoRA deployments would never get dynamic placement (N3).
+    if crate::lora::lora_serving_enabled() {
+        let _controller_handle = model_manager.start_lora_controller(runtime.primary_token());
+    }
+
     // Create metrics for migration tracking (not exposed via /metrics in gRPC mode)
     let metrics = Arc::new(Metrics::new());
     let mut watch_obj = ModelWatcher::new(

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -179,6 +179,14 @@ async fn run_watcher(
     prefill_load_estimator: Option<Arc<dyn dynamo_kv_router::PrefillLoadEstimator>>,
     local_model_path: Option<PathBuf>,
 ) -> anyhow::Result<()> {
+    // Start the LoRA allocation controller when LoRA serving is enabled. The
+    // controller itself is additionally gated on the allocation config
+    // (DYN_LORA_ALLOCATION_ENABLED) inside `start_lora_controller`.
+    if crate::lora::lora_serving_enabled() {
+        let cancel_token = runtime.primary_token();
+        let _controller_handle = model_manager.start_lora_controller(cancel_token);
+    }
+
     let mut watch_obj = ModelWatcher::new(
         runtime.clone(),
         model_manager,

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -15,7 +15,7 @@ use axum::http::Response;
 use super::Metrics;
 use super::RouteDoc;
 use super::metrics;
-use super::metrics::register_worker_timing_metrics;
+use super::metrics::{register_lora_allocation_metrics, register_worker_timing_metrics};
 use crate::discovery::ModelManager;
 use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
@@ -561,6 +561,9 @@ impl HttpServiceConfigBuilder {
         }
         if let Err(e) = ensure_transport_metrics_registered_prometheus(&registry) {
             tracing::warn!("Failed to register transport metrics: {}", e);
+        }
+        if let Err(e) = register_lora_allocation_metrics(&registry) {
+            tracing::warn!("Failed to register LoRA allocation metrics: {}", e);
         }
 
         let mut all_docs = Vec::new();

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -202,6 +202,10 @@ where
     /// Optional external shared KV cache pool. When present, `find_best_match`
     /// queries it in parallel with the indexer and factors shared hits into scoring.
     shared_cache: Option<Box<dyn SharedKvCache>>,
+    /// Optional LoRA filter. When present (LoRA serving enabled), candidate workers are
+    /// narrowed to the LoRA's allocated/loaded replicas inside `find_best_match_details`,
+    /// covering both the decode and prefill routers (both built via `kv_chooser_for`).
+    lora_filter: Option<Arc<crate::lora::LoraFilter>>,
 }
 
 impl<Sel> KvRouter<Sel>
@@ -221,6 +225,7 @@ where
         model_name: Option<String>,
         is_eagle: bool,
         shared_cache: Option<Box<dyn SharedKvCache>>,
+        lora_filter: Option<Arc<crate::lora::LoraFilter>>,
     ) -> Result<Self> {
         let kv_router_config = kv_router_config.unwrap_or_default();
         kv_router_config.validate()?;
@@ -316,6 +321,7 @@ where
             is_eagle,
             _served_indexer_handle: served_indexer_handle,
             shared_cache,
+            lora_filter,
         })
     }
 
@@ -375,6 +381,53 @@ where
             .await
     }
 
+    /// Narrow the candidate workers to this LoRA's allocated/loaded replicas, staying strictly
+    /// within the existing candidate universe (never widening). Returns the (possibly narrowed)
+    /// `allowed_worker_ids` to pass to the scheduler.
+    ///
+    /// - No filter (LoRA serving disabled) or base-model request (`lora_name` is `None`):
+    ///   returns `allowed_worker_ids` unchanged.
+    /// - Pinned worker: KV-cache correctness wins — it is always retained even if not in the
+    ///   LoRA replica set (the worker lazy-loads the adapter).
+    /// - If narrowing would exclude every candidate, falls back to the original set so the
+    ///   request stays routable (lazy-load path) rather than failing.
+    fn narrow_allowed_by_lora(
+        &self,
+        lora_name: Option<&str>,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        pinned_worker: Option<&WorkerWithDpRank>,
+    ) -> Option<HashSet<WorkerId>> {
+        let (Some(filter), Some(lora_name)) = (self.lora_filter.as_ref(), lora_name) else {
+            return allowed_worker_ids;
+        };
+        // Base candidate universe: explicit allow-set if present, else all current workers.
+        let base: Vec<WorkerId> = match &allowed_worker_ids {
+            Some(allowed) => allowed.iter().copied().collect(),
+            None => self.workers_with_configs.borrow().keys().copied().collect(),
+        };
+        if base.is_empty() {
+            return allowed_worker_ids;
+        }
+        let mut narrowed: HashSet<WorkerId> = filter
+            .filter_worker_ids_for_lora(Some(lora_name), &base)
+            .into_iter()
+            .collect();
+        // Retain a pinned worker only if it is already within the candidate universe — never
+        // widen the caller's `allowed_worker_ids` (KV-cache / EPP / migration invariants depend
+        // on that set). If the filter excluded an in-universe pinned worker, re-add it so the
+        // pin still wins for cache correctness; if the pin is outside the universe, honor the
+        // caller's constraint and drop it.
+        if let Some(p) = pinned_worker
+            && base.contains(&p.worker_id)
+        {
+            narrowed.insert(p.worker_id);
+        }
+        if narrowed.is_empty() {
+            return allowed_worker_ids;
+        }
+        Some(narrowed)
+    }
+
     /// Give these tokens, find the worker with the best weighted cache hit.
     /// Returns the full match details for the selected worker.
     ///
@@ -401,7 +454,7 @@ where
         let start = Instant::now();
 
         if update_states && context_id.is_none() {
-            anyhow::bail!("context_id must be provided when update_states is true");
+            anyhow::bail!("context_id must be provided if update_states is true");
         }
 
         let isl_tokens = tokens.len();
@@ -465,6 +518,15 @@ where
         // scheduling returns, since `overlap_blocks` isn't known until then.
         let num_blocks = isl_tokens / self.block_size as usize;
         let sc_hits_for_metrics = shared_cache_hits.clone();
+
+        // LoRA-aware candidate narrowing: restrict to this LoRA's allocated/loaded replicas,
+        // strictly within the existing candidate universe (never widening). Covers both the
+        // decode and prefill routers, since both flow through this method.
+        let allowed_worker_ids = self.narrow_allowed_by_lora(
+            lora_name.as_deref(),
+            allowed_worker_ids,
+            pinned_worker.as_ref(),
+        );
 
         let response = match self
             .scheduler
@@ -1219,6 +1281,7 @@ mod tests {
             None,
             false,
             shared_cache,
+            None,
         )
         .await
         .unwrap()

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -155,6 +155,14 @@ pub struct ModelRuntimeConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0, max = 1.0))]
     pub kv_transfer_preferred_weight: Option<f32>,
+
+    /// Per-worker LoRA adapter slot capacity (e.g. vLLM `--max-loras`, SGLang
+    /// `--max-loras-per-batch`), advertised on the BASE worker registration so the LoRA
+    /// allocation controller can see idle-but-LoRA-capable workers before any adapter is
+    /// loaded on them. `None` for non-LoRA workers. Adapter (`card.lora`) registrations carry
+    /// the same value via `LoraInfo::max_gpu_lora_count`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_gpu_lora_count: Option<u32>,
 }
 
 const fn default_data_parallel_start_rank() -> u32 {
@@ -202,6 +210,7 @@ impl Default for ModelRuntimeConfig {
             kv_transfer_domain: None,
             kv_transfer_enforcement: None,
             kv_transfer_preferred_weight: None,
+            max_gpu_lora_count: None,
         }
     }
 }
@@ -458,6 +467,27 @@ mod tests {
             cfg.populate_stable_routing_id_from_env();
             assert!(cfg.stable_routing_id.is_none());
         });
+    }
+
+    #[test]
+    fn max_gpu_lora_count_roundtrips_and_is_omitted_when_none() {
+        // Worker LoRA capacity must survive the MDC -> discovery -> watcher wire so the frontend
+        // can seed set_worker_capacity for idle LoRA-capable workers.
+        let cfg = ModelRuntimeConfig {
+            max_gpu_lora_count: Some(8),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("\"max_gpu_lora_count\":8"));
+        let parsed: ModelRuntimeConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.max_gpu_lora_count, Some(8));
+
+        // Omitted from the wire (and defaults to None on read) for non-LoRA workers, so older
+        // payloads without the field stay backward-compatible.
+        let none_json = serde_json::to_string(&ModelRuntimeConfig::default()).unwrap();
+        assert!(!none_json.contains("max_gpu_lora_count"));
+        let from_legacy: ModelRuntimeConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(from_legacy.max_gpu_lora_count, None);
     }
 
     #[test]

--- a/lib/llm/src/lora.rs
+++ b/lib/llm/src/lora.rs
@@ -34,3 +34,13 @@ pub use routing::{
 };
 pub use source::{LoRASource, LocalLoRASource, S3LoRASource};
 pub use state_tracker::LoraStateTracker;
+
+/// Returns true when LoRA serving is enabled via the `DYN_LORA_ENABLED` env var
+/// (`true`/`1`/`yes`, case-insensitive). This gates the request-time LoRA filter on
+/// both the KV and non-KV routing paths, so non-LoRA deployments keep the unmodified
+/// routing path with zero added overhead.
+pub fn lora_serving_enabled() -> bool {
+    std::env::var(dynamo_runtime::config::environment_names::llm::DYN_LORA_ENABLED)
+        .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1" | "yes"))
+        .unwrap_or(false)
+}


### PR DESCRIPTION
Splits #8180 into a reviewable 3-PR train — **part 3 of 3**. Stacked on #10386.

### This PR: turn it on (frontend integration)
- `ModelManager`: LoRA state objects, `lora_filter()` gate (`DYN_LORA_ENABLED`), `start_lora_controller`, decode-side load-feed subscription (atomic per-component start).
- Discovery `watcher`: seed loaded adapters + base-card LoRA capacity (so idle LoRA-capable workers are visible); failed-save removal reconciliation.
- `KvRouter`: LoRA-aware candidate narrowing in `find_best_match_details` (never widens; pin/empty fallbacks).
- Entrypoints: `LoraFilteredRouter` wiring for Random/RoundRobin, fail-fast on unsupported LoRA + router-mode combos; controller start.
- Bindings (`register_model` `max_gpu_lora_count`), Python prometheus names, and vLLM/SGLang backends publishing per-worker LoRA slot budgets.

Tip tree is byte-identical to the original #8180 content rebased on current `main`. `git diff origin/main...` = the full 30-file scope; supersedes #8180. Compiles; all 128 `lora` unit tests pass.