### PR TITLE
feat(ext-proc): runtime-free cross-replica load sync for the EPP (EndpointSlice + ZMQ)

### DIFF
--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -26,6 +26,7 @@ futures = { workspace = true }
 hyper-util = { workspace = true, features = ["tokio", "http2", "server-auto"] }
 k8s-openapi = { workspace = true }
 kube = { workspace = true }
+prometheus = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rcgen = { workspace = true }

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -35,6 +35,8 @@ rustls-pemfile = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+# ZMQ PUB/SUB transport for runtime-free cross-replica load sync (no NATS).
+tmq = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 # `net` for TcpListenerStream (serve_with_incoming), `sync` for ReceiverStream.

--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/README.md
@@ -1,0 +1,84 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Vanilla-vLLM P/D disaggregation behind the native EPP (no Dynamo runtime)
+
+This example runs **disaggregated prefill/decode (P/D) serving with stock
+`vllm serve`** — no Dynamo runtime (no etcd/NATS, no `dynamo.vllm` worker) —
+where the native Dynamo EPP makes the routing decision and a decode-side P/D
+routing sidecar executes vLLM's KV-transfer handshake.
+
+```
+client ─▶ gateway ─(ext_proc)─▶ native EPP
+                │  selects a decode worker + a prefill worker (KV-aware),
+                │  emits x-prefiller-host-port=<prefill pod ip:8000>
+                ▼
+        decode pod:  routing sidecar :8000 ─▶ local decode vLLM :8001
+                          │ 1) prefill request to x-prefiller-host-port
+                          ▼
+        prefill pod:  vLLM :8000  ─(NIXL KV transfer)─▶ decode vLLM
+```
+
+The EPP only **selects** (which decode worker, which prefill worker) and emits
+the prefill endpoint as a request header. The sidecar **executes** vLLM's
+mandatory two-step (`kv_transfer_params`) handshake; the KV cache moves
+prefill→decode over NIXL between the two GPUs.
+
+> The disaggregation routing sidecar container used in this example is the
+> llm-d routing sidecar (`ghcr.io/llm-d/llm-d-routing-sidecar`). Any sidecar
+> that reads the `x-prefiller-host-port` prefill-endpoint header works; the EPP
+> is sidecar-agnostic.
+
+## Files
+
+* `prefill-decode.yaml` — 1 prefill pod + 1 decode pod (sidecar + decode vLLM).
+  Both run stock `vllm serve` with `--kv-transfer-config NixlConnector` on an
+  image that ships NIXL/UCX. Labeled `app=epp-vanilla-vllm` (the InferencePool
+  selector) and `nvidia.com/dynamo-component-type=prefill|decode` (the EPP's
+  role partition).
+* `scale-2p2d.yaml` — a second prefill + second decode; the EPP discovers them
+  at runtime via its pod reflector (no restart).
+* `run-epp-disagg.sh` — launches the EPP in external mode with role-based P/D
+  partitioning and enforce-disagg.
+* `loadtest.sh` — functional + concurrency test through the gateway.
+
+## Prerequisites
+
+1. An `InferencePool` selecting `app=epp-vanilla-vllm`, `targetPorts: [8000]`,
+   `endpointPickerRef` → the EPP service, and an `HTTPRoute` attaching it to
+   your gateway (see the `vanilla-vllm/` example for the aggregated wiring).
+2. The EPP binary built with the disagg prefill header (`x-prefiller-host-port`).
+3. A P/D routing sidecar image (see note above).
+
+## Required environment specifics (and why)
+
+1. **GPU node taint toleration.** GPU nodes are tainted
+   `nvidia.com/gpu=true:NoSchedule`; the pods tolerate **only** that key — not
+   per-reservation taints — so they land on shared GPU nodes and avoid reserved
+   ones.
+2. **UCX transport.** vLLM's NixlConnector defaults to the RDMA/RoCE verbs path;
+   without RDMA device-plugin resources in the pod, KV registration fails
+   (`ibv_create_ah … No such device`). Setting
+   `UCX_TLS=tcp,cuda_copy,cuda_ipc,sm,self` + `UCX_NET_DEVICES=eth0` forces the
+   TCP+CUDA path (for production, give the pods real RoCE resources instead).
+3. **NIXL-capable image.** Stock `vllm/vllm-openai` does not ship NIXL/UCX; this
+   example uses `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0` but invokes the
+   **vanilla `vllm serve`** entrypoint — no Dynamo runtime is involved.
+
+## Run
+
+```bash
+kubectl apply -f prefill-decode.yaml
+# optional scale: kubectl apply -f scale-2p2d.yaml
+bash run-epp-disagg.sh 8790        # in the EPP pod: tokenizer sidecar + disagg EPP
+
+curl -s -X POST "http://<gateway>/v1/completions" -H "Host: epp-vanilla.local" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-0.6B","prompt":"The capital of France is","max_tokens":16}'
+```
+
+Confirm real disaggregation in the decode-pod vLLM log
+(`KV Transfer metrics: Num successful transfers=N …`) and a prefill dispatch
+(a `POST /v1/completions` from the decode pod's IP) in the prefill-pod log.

--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/loadtest.sh
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/loadtest.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Comprehensive edge-case + load suite for the disagg PD path (gateway -> EPP -> sidecar).
+GW="http://inference-gateway.agentgateway-system:80"
+H="Host: epp-vanilla.local"; CT="Content-Type: application/json"; M="Qwen/Qwen3-0.6B"
+PASS=0; FAIL=0
+chk() { # $1=label $2=expected-code $3=actual-code
+  if [ "$3" = "$2" ]; then echo "  PASS [$1] HTTP=$3"; PASS=$((PASS+1));
+  else echo "  FAIL [$1] HTTP=$3 (expected $2)"; FAIL=$((FAIL+1)); fi
+}
+post() { curl -s -o /tmp/o.out -w "%{http_code}" --max-time 90 -X POST "$GW/$1" -H "$H" -H "$CT" -d "$2"; }
+
+echo "=================== FUNCTIONAL + EDGE CASES ==================="
+chk "short"            200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"Hi\",\"max_tokens\":8}")"
+chk "max_tokens=1"     200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"The sky is\",\"max_tokens\":1}")"
+chk "max_tokens=256"   200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"Explain entropy:\",\"max_tokens\":256}")"
+LONG=$(python3 -c "print('The quick brown fox jumps over the lazy dog. '*200)")
+chk "long-multiblock"  200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"$LONG Summarize:\",\"max_tokens\":24}")"
+chk "repeat-prefix(cache)" 200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"$LONG Summarize:\",\"max_tokens\":24}")"
+chk "chat"             200 "$(post v1/chat/completions "{\"model\":\"$M\",\"messages\":[{\"role\":\"user\",\"content\":\"Name a fruit.\"}],\"max_tokens\":16}")"
+chk "unicode/emoji"    200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"Translate 你好 🌟 to English:\",\"max_tokens\":16}")"
+chk "stop-sequence"    200 "$(post v1/completions "{\"model\":\"$M\",\"prompt\":\"Count: 1 2 3 4\",\"max_tokens\":20,\"stop\":[\"5\"]}")"
+# streaming
+SC=$(curl -s -o /tmp/s.out -w "%{http_code}" --max-time 60 -X POST "$GW/v1/completions" -H "$H" -H "$CT" -d "{\"model\":\"$M\",\"prompt\":\"Count: 1 2 3\",\"max_tokens\":16,\"stream\":true}")
+chk "streaming(http)"  200 "$SC"; echo "    stream chunks=$(grep -c 'data:' /tmp/s.out)"
+# negative / error edges (worker/gateway should reject cleanly, not 5xx-crash)
+echo "  -- negative cases (expect 4xx, must not crash the path) --"
+post v1/completions "{bad json" >/tmp/n1; echo "    malformed-json -> HTTP=$(cat /tmp/n1)"
+post v1/completions "{\"model\":\"does-not-exist\",\"prompt\":\"x\",\"max_tokens\":4}" >/tmp/n2; echo "    unknown-model  -> HTTP=$(cat /tmp/n2)"
+
+echo ""
+echo "=================== PREFIX-AFFINITY (KV-aware) ==================="
+PFX=$(python3 -c "print('Shared context block alpha beta gamma. '*60)")
+for i in 1 2 3; do post v1/completions "{\"model\":\"$M\",\"prompt\":\"$PFX Q$i?\",\"max_tokens\":8}" >/dev/null; done
+echo "  3 requests with a shared long prefix sent (affinity verified via worker KV-cache logs)"
+
+echo ""
+echo "=================== LOAD: $2 total @ concurrency $1 ==================="
+N=${2:-200}; C=${1:-48}
+date +%s.%N > /tmp/t0
+seq 1 $N | xargs -P $C -I {} bash -c "
+  curl -s -o /dev/null -w '%{http_code}\n' --max-time 90 -X POST '$GW/v1/completions' -H '$H' -H '$CT' \
+    -d '{\"model\":\"$M\",\"prompt\":\"Req {} : a short fact about the number {} please.\",\"max_tokens\":24,\"temperature\":0.7}'
+" > /tmp/codes.txt 2>/dev/null
+T=$(python3 -c "print(round($(date +%s.%N)-$(cat /tmp/t0),2))")
+n200=$(grep -c '^200$' /tmp/codes.txt); ntot=$(wc -l </tmp/codes.txt)
+echo "  total=$ntot HTTP200=$n200 non200=$((ntot-n200))  wall=${T}s  approx_rps=$(python3 -c "print(round($ntot/$T,1))")"
+echo "  code histogram:"; sort /tmp/codes.txt | uniq -c | sed 's/^/     /'
+
+echo ""
+echo "=================== SUMMARY ==================="
+echo "  functional/edge PASS=$PASS FAIL=$FAIL ; load 200-success=$n200/$ntot"

--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/prefill-decode.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/prefill-decode.yaml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Pod
+metadata:
+  name: epp-vanilla-pd-prefill
+  namespace: mkhadkevich-dev
+  labels:
+    app: epp-vanilla-vllm
+    nvidia.com/dynamo-component-type: prefill
+    owner: claude-epp
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: nvidia.com/gpu
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: vllm
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+    command: ["vllm", "serve", "Qwen/Qwen3-0.6B"]
+    args:
+    - --port=8000
+    - --gpu-memory-utilization=0.45
+    - --max-model-len=8192
+    - --enable-prefix-caching
+    - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_both"}
+    - --kv-events-config={"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}
+    env:
+    - name: POD_IP
+      valueFrom: {fieldRef: {fieldPath: status.podIP}}
+    - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+      value: "$(POD_IP)"
+    - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+      value: "5600"
+    - name: UCX_TLS
+      value: "tcp,cuda_copy,cuda_ipc,sm,self"
+    - name: UCX_NET_DEVICES
+      value: "eth0"
+    ports:
+    - {containerPort: 8000}
+    - {containerPort: 5557}
+    - {containerPort: 5600}
+    resources:
+      limits: {nvidia.com/gpu: "1"}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: epp-vanilla-pd-decode
+  namespace: mkhadkevich-dev
+  labels:
+    app: epp-vanilla-vllm
+    nvidia.com/dynamo-component-type: decode
+    owner: claude-epp
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: nvidia.com/gpu
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: sidecar
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.3.0
+    args: ["-port=8000", "-vllm-port=8001", "-connector=nixlv2", "-secure-proxy=false"]
+    ports:
+    - {containerPort: 8000}
+  - name: vllm
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+    command: ["vllm", "serve", "Qwen/Qwen3-0.6B"]
+    args:
+    - --port=8001
+    - --gpu-memory-utilization=0.45
+    - --max-model-len=8192
+    - --enable-prefix-caching
+    - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_both"}
+    - --kv-events-config={"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}
+    env:
+    - name: POD_IP
+      valueFrom: {fieldRef: {fieldPath: status.podIP}}
+    - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+      value: "$(POD_IP)"
+    - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+      value: "5600"
+    - name: UCX_TLS
+      value: "tcp,cuda_copy,cuda_ipc,sm,self"
+    - name: UCX_NET_DEVICES
+      value: "eth0"
+    ports:
+    - {containerPort: 8001}
+    - {containerPort: 5557}
+    - {containerPort: 5600}
+    resources:
+      limits: {nvidia.com/gpu: "1"}

--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/run-epp-disagg.sh
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/run-epp-disagg.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Launch the native EPP in external mode with role-based prefill/decode
+# partitioning, so it routes to a decode worker and emits x-prefiller-host-port
+# for the decode-side P/D routing sidecar to run vLLM's prefill->decode handshake.
+# Arg 1 = tokenizer-sidecar port (default 8790).
+cd /work
+export DYN_DISCOVERY_BACKEND=mem POD_NAMESPACE="${POD_NAMESPACE:-default}" DYN_EPP_EXTERNAL=true
+export DYN_MODEL_NAME="${DYN_MODEL_NAME:-Qwen/Qwen3-0.6B}" DYN_KV_CACHE_BLOCK_SIZE=16
+export DYN_EPP_INFERENCE_POOL="${DYN_EPP_INFERENCE_POOL:-epp-vanilla-pool}"
+export DYN_USE_KV_EVENTS=false DYN_SECURE_SERVING=true
+export DYN_EPP_PREFIX_MODE=precise DYN_EPP_TOKENIZE_URL="http://127.0.0.1:${1:-8790}/tokenize"
+export DYN_OVERLAP_SCORE_WEIGHT=1.0 DYN_EPP_KV_EVENTS=true DYN_EPP_KV_EVENT_PORT=5557
+export RUST_LOG="${RUST_LOG:-info}"
+# --- disagg role partitioning ---
+export DYN_EPP_ROLE_LABEL="nvidia.com/dynamo-component-type"
+export DYN_EPP_PREFILL_ROLE_VALUES=prefill
+export DYN_EPP_DECODE_ROLE_VALUES=decode
+export DYN_ENFORCE_DISAGG="${DYN_ENFORCE_DISAGG:-true}"
+exec -a dyn-epp-main /work/dynamo/target/release/dynamo-ext-proc

--- a/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/scale-2p2d.yaml
+++ b/deploy/inference-gateway/ext-proc/examples/vanilla-vllm-disagg/scale-2p2d.yaml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Pod
+metadata:
+  name: epp-vanilla-pd-prefill-b
+  namespace: mkhadkevich-dev
+  labels:
+    app: epp-vanilla-vllm
+    nvidia.com/dynamo-component-type: prefill
+    owner: claude-epp
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: nvidia.com/gpu
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: vllm
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+    command: ["vllm", "serve", "Qwen/Qwen3-0.6B"]
+    args:
+    - --port=8000
+    - --gpu-memory-utilization=0.45
+    - --max-model-len=8192
+    - --enable-prefix-caching
+    - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_both"}
+    - --kv-events-config={"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}
+    env:
+    - name: POD_IP
+      valueFrom: {fieldRef: {fieldPath: status.podIP}}
+    - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+      value: "$(POD_IP)"
+    - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+      value: "5600"
+    - name: UCX_TLS
+      value: "tcp,cuda_copy,cuda_ipc,sm,self"
+    - name: UCX_NET_DEVICES
+      value: "eth0"
+    ports:
+    - {containerPort: 8000}
+    - {containerPort: 5557}
+    - {containerPort: 5600}
+    resources:
+      limits: {nvidia.com/gpu: "1"}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: epp-vanilla-pd-decode-b
+  namespace: mkhadkevich-dev
+  labels:
+    app: epp-vanilla-vllm
+    nvidia.com/dynamo-component-type: decode
+    owner: claude-epp
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: nvidia.com/gpu
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: sidecar
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.3.0
+    args: ["-port=8000", "-vllm-port=8001", "-connector=nixlv2", "-secure-proxy=false"]
+    ports:
+    - {containerPort: 8000}
+  - name: vllm
+    image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+    command: ["vllm", "serve", "Qwen/Qwen3-0.6B"]
+    args:
+    - --port=8001
+    - --gpu-memory-utilization=0.45
+    - --max-model-len=8192
+    - --enable-prefix-caching
+    - --kv-transfer-config={"kv_connector":"NixlConnector","kv_role":"kv_both"}
+    - --kv-events-config={"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://*:5557"}
+    env:
+    - name: POD_IP
+      valueFrom: {fieldRef: {fieldPath: status.podIP}}
+    - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+      value: "$(POD_IP)"
+    - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+      value: "5600"
+    - name: UCX_TLS
+      value: "tcp,cuda_copy,cuda_ipc,sm,self"
+    - name: UCX_NET_DEVICES
+      value: "eth0"
+    ports:
+    - {containerPort: 8001}
+    - {containerPort: 5557}
+    - {containerPort: 5600}
+    resources:
+      limits: {nvidia.com/gpu: "1"}

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -22,9 +22,10 @@ use dynamo_llm::model_card::ModelDeploymentCard;
 use dynamo_llm::preprocessor::OpenAIPreprocessor;
 use dynamo_runtime::discovery::{DiscoveryInstance, DiscoveryQuery, hash_pod_name};
 use dynamo_runtime::pipeline::RouterMode;
-use dynamo_runtime::{DistributedRuntime, Runtime};
+use dynamo_runtime::{CancellationToken, DistributedRuntime, Runtime};
 
 use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo};
+use crate::replica_sync::ReplicaPublisher;
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -64,6 +65,10 @@ pub struct Router {
     tokenize_url: Option<String>,
     pod_store: kube::runtime::reflector::Store<k8s_openapi::api::core::v1::Pod>,
     pod_store_ready: Arc<AtomicBool>,
+    /// Publisher for cross-replica load sync; `None` when `DYN_EPP_REPLICA_SYNC`
+    /// is disabled. Active-sequence events for booked/freed requests are
+    /// mirrored to peer EPP replicas via this handle.
+    replica_publisher: Option<Arc<ReplicaPublisher>>,
 }
 
 impl Router {
@@ -224,6 +229,22 @@ impl Router {
             spawn_kv_event_reconciler(decode_router.clone(), pod_store.clone(), kv_port, kv_topic);
         }
 
+        // Optional runtime-free cross-replica load sync (EndpointSlice + ZMQ).
+        // Spawned background tasks clone what they need, so this survives `drt`
+        // being dropped at the end of this scope (same pattern as the
+        // reflectors above).
+        let replica_publisher = if parse_replica_sync_enabled() {
+            match spawn_replica_sync(&drt, &decode_router).await {
+                Ok(publisher) => Some(publisher),
+                Err(e) => {
+                    tracing::error!(error = %e, "cross-replica load sync disabled (setup failed)");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // `model_manager` and `drt` are intentionally not stored on the
         // Router. The KV chooser, prefill router, prefill discovery watcher,
         // and pod reflector all clone whatever they need from these
@@ -260,6 +281,7 @@ impl Router {
             tokenize_url,
             pod_store,
             pod_store_ready,
+            replica_publisher,
         })
     }
 
@@ -497,6 +519,7 @@ impl Router {
         dp_rank: u32,
     ) -> Result<()> {
         let decode_router = self.decode_router.clone();
+        let publisher = self.replica_publisher.clone();
         let request_id = request_id.to_owned();
         let tokens = tokens.to_vec();
         // Predict-on-route (approximate) crediting of the chosen worker. Can be
@@ -539,7 +562,7 @@ impl Router {
 
             decode_router
                 .add_request(
-                    request_id,
+                    request_id.clone(),
                     &tokens,
                     None,
                     cached_tokens,
@@ -550,6 +573,10 @@ impl Router {
                 )
                 .await;
 
+            if let Some(publisher) = &publisher {
+                publisher.on_add(&request_id, worker).await;
+            }
+
             Ok(())
         })
         .await
@@ -559,13 +586,18 @@ impl Router {
     /// Mark prefill as completed for a request.
     pub async fn mark_prefill_complete(&self, request_id: &str) -> Result<()> {
         let decode_router = self.decode_router.clone();
+        let publisher = self.replica_publisher.clone();
         let request_id = request_id.to_owned();
 
         tokio::time::timeout(BOOKKEEPING_TIMEOUT, async {
             decode_router
                 .mark_prefill_completed(&request_id)
                 .await
-                .map_err(|e| anyhow::anyhow!("mark_prefill_completed failed: {e}"))
+                .map_err(|e| anyhow::anyhow!("mark_prefill_completed failed: {e}"))?;
+            if let Some(publisher) = &publisher {
+                publisher.on_mark_prefill(&request_id).await;
+            }
+            Ok(())
         })
         .await
         .map_err(|_| anyhow::anyhow!("mark_prefill_complete timed out"))?
@@ -574,13 +606,18 @@ impl Router {
     /// Free a request from the router's bookkeeping.
     pub async fn free_request(&self, request_id: &str) -> Result<()> {
         let decode_router = self.decode_router.clone();
+        let publisher = self.replica_publisher.clone();
         let request_id = request_id.to_owned();
 
         tokio::time::timeout(BOOKKEEPING_TIMEOUT, async {
             decode_router
                 .free(&request_id)
                 .await
-                .map_err(|e| anyhow::anyhow!("free failed: {e}"))
+                .map_err(|e| anyhow::anyhow!("free failed: {e}"))?;
+            if let Some(publisher) = &publisher {
+                publisher.on_free(&request_id).await;
+            }
+            Ok(())
         })
         .await
         .map_err(|_| anyhow::anyhow!("free_request timed out"))?
@@ -601,6 +638,60 @@ impl Router {
     pub fn pod_store_ready(&self) -> Arc<AtomicBool> {
         self.pod_store_ready.clone()
     }
+}
+
+/// Whether `DYN_EPP_REPLICA_SYNC` enables runtime-free cross-replica load sync.
+fn parse_replica_sync_enabled() -> bool {
+    std::env::var("DYN_EPP_REPLICA_SYNC")
+        .ok()
+        .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// Set up EPP-managed (NATS-free, CRD-free) cross-replica load sync: bind the
+/// ZMQ PUB, start EndpointSlice peer discovery plus the SUB pump, and feed peer
+/// events into the decode router. Returns the publisher used to mirror this
+/// replica's own bookings. See ai-dynamo/dynamo#10384.
+async fn spawn_replica_sync(
+    drt: &DistributedRuntime,
+    decode_router: &Arc<KvRouter>,
+) -> Result<Arc<ReplicaPublisher>> {
+    let port: u16 = std::env::var("DYN_EPP_REPLICA_SYNC_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(9100);
+    let service = std::env::var("DYN_EPP_REPLICA_SYNC_SERVICE").map_err(|_| {
+        anyhow::anyhow!(
+            "DYN_EPP_REPLICA_SYNC_SERVICE not set: cross-replica sync needs the EPP \
+             Service name whose EndpointSlices enumerate peer replicas"
+        )
+    })?;
+    let namespace = std::env::var("POD_NAMESPACE")
+        .map_err(|_| anyhow::anyhow!("POD_NAMESPACE not set (downward API)"))?;
+    let self_pod_ip = std::env::var("POD_IP")
+        .map_err(|_| anyhow::anyhow!("POD_IP not set (downward API)"))?;
+
+    // Must match the decode router's own id so peers apply these events and
+    // this replica never re-applies its own.
+    let router_id = drt.discovery().instance_id();
+
+    // Process-scoped lifetime, matching the reflectors; intentionally not tied
+    // to `drt`, which is dropped at the end of `from_discovery`.
+    let cancel = CancellationToken::new();
+
+    let publisher = Arc::new(ReplicaPublisher::bind(port, router_id).await?);
+    let subscriber = crate::replica_sync::spawn_peer_sync(
+        service,
+        namespace,
+        self_pod_ip,
+        port,
+        cancel.clone(),
+    )
+    .await?;
+    decode_router.start_replica_sync(subscriber, cancel);
+
+    tracing::info!(port, router_id, "EPP cross-replica load sync enabled");
+    Ok(publisher)
 }
 
 /// Extract the router queue `priority_jump` from a chat completion request's

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -1802,6 +1802,16 @@ impl EndpointPicker for Router {
                 "x-prefill-instance-id".to_string(),
                 format!("{}", prefill_worker_id),
             ));
+            // Dialable prefill endpoint (host:port) for a decode-side P/D
+            // routing sidecar co-located with the decode pod, which reads
+            // `x-prefiller-host-port` and runs vLLM's prefill->decode handshake.
+            // This is additive: dynamo-mode DecodeWorkers resolve the
+            // instance-id above via discovery and do the handshake natively;
+            // vanilla vLLM + sidecar use this host:port instead. One EPP, both
+            // disagg paths.
+            if let Some(prefill_ep) = self.resolve_worker_endpoint(*prefill_worker_id) {
+                headers.push(("x-prefiller-host-port".to_string(), prefill_ep));
+            }
             if let Some(rank) = prefill_dp_rank {
                 headers.push(("x-prefill-dp-rank".to_string(), rank.to_string()));
             }

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -560,7 +560,7 @@ impl Router {
 
             let cached_tokens = overlap_blocks as usize * decode_router.block_size() as usize;
 
-            decode_router
+            let booked = decode_router
                 .add_request(
                     request_id.clone(),
                     &tokens,
@@ -573,8 +573,10 @@ impl Router {
                 )
                 .await;
 
-            if let Some(publisher) = &publisher {
-                publisher.on_add(&request_id, worker).await;
+            if let Some(publisher) = &publisher
+                && let Some(req) = &booked
+            {
+                publisher.on_add(req).await;
             }
 
             Ok(())

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -29,6 +29,47 @@ use crate::replica_sync::ReplicaPublisher;
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Disaggregation role discovery, driven by a Kubernetes pod label (no Dynamo
+/// runtime required). Configurable so operators can point at their existing
+/// labels; defaults to the Dynamo-native convention
+/// (`nvidia.com/dynamo-component-type` with values `prefill`/`decode`).
+struct RoleConfig {
+    label: String,
+    prefill: HashSet<String>,
+    decode: HashSet<String>,
+    both: HashSet<String>,
+}
+
+/// Parse the role-discovery config from env once.
+fn role_config() -> &'static RoleConfig {
+    static CFG: std::sync::OnceLock<RoleConfig> = std::sync::OnceLock::new();
+    CFG.get_or_init(|| {
+        let values = |key: &str, default: &str| -> HashSet<String> {
+            std::env::var(key)
+                .unwrap_or_else(|_| default.to_string())
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        let cfg = RoleConfig {
+            label: std::env::var("DYN_EPP_ROLE_LABEL")
+                .unwrap_or_else(|_| "nvidia.com/dynamo-component-type".to_string()),
+            prefill: values("DYN_EPP_PREFILL_ROLE_VALUES", "prefill"),
+            decode: values("DYN_EPP_DECODE_ROLE_VALUES", "decode"),
+            both: values("DYN_EPP_BOTH_ROLE_VALUES", "both"),
+        };
+        tracing::info!(
+            role_label = %cfg.label,
+            prefill = ?cfg.prefill,
+            decode = ?cfg.decode,
+            both = ?cfg.both,
+            "Disaggregation role discovery (K8s label) configured"
+        );
+        cfg
+    })
+}
+
 /// Name of the inference-serving HTTP port on a Dynamo worker pod.
 ///
 /// Mirrors `commonconsts.DynamoContainerPortName` in
@@ -198,7 +239,21 @@ impl Router {
             enable_eagle,
         );
 
-        spawn_prefill_discovery_watcher(drt.clone(), actual_namespace.clone(), prefill_tx);
+        if external_mode {
+            // K8s-native disaggregation (no Dynamo runtime): activate the prefill
+            // router eagerly with a synthetic endpoint. Prefill workers are then
+            // registered from the pod reflector by Dynamo role label (see
+            // `route_prefill`). The chooser is built via `kv_chooser_for` — the
+            // same path the decode router above uses, which already works without
+            // Dynamo-registered workers. Dynamo-worker mode keeps discovering
+            // prefill via the published model card.
+            let prefill_endpoint = component_handle.endpoint("prefill");
+            if prefill_tx.send(prefill_endpoint).is_err() {
+                tracing::warn!("prefill router activation receiver dropped");
+            }
+        } else {
+            spawn_prefill_discovery_watcher(drt.clone(), actual_namespace.clone(), prefill_tx);
+        }
 
         // Endpoint discovery. External (GIE) mode scans the referenced
         // InferencePool for its selector + targetPort; dynamo-worker mode uses
@@ -422,6 +477,51 @@ impl Router {
             }
         }
         ids
+    }
+
+    /// Partition an allowed worker set into (prefill, decode) by the Dynamo
+    /// role label (`role_config`). A pod whose role is in the `prefill` set goes
+    /// to prefill; `both` goes to both; everything else — including the common
+    /// case of an unlabeled aggregated pool — goes to decode, so existing
+    /// (non-disaggregated) deployments are unaffected. Reading the role from a
+    /// Kubernetes label is what lets the EPP do disaggregated routing without
+    /// the Dynamo runtime.
+    fn partition_worker_roles(&self, allowed: &HashSet<u64>) -> (HashSet<u64>, HashSet<u64>) {
+        let cfg = role_config();
+        let mut prefill = HashSet::new();
+        let mut decode = HashSet::new();
+        for pod in self.pod_store.state() {
+            let Some(pod_name) = pod.metadata.name.as_deref() else {
+                continue;
+            };
+            let wid = hash_pod_name(pod_name);
+            if !allowed.contains(&wid) {
+                continue;
+            }
+            let role = pod
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(cfg.label.as_str()))
+                .map(|s| s.as_str());
+            match role {
+                Some(r) if cfg.both.contains(r) => {
+                    prefill.insert(wid);
+                    decode.insert(wid);
+                }
+                Some(r) if cfg.prefill.contains(r) => {
+                    prefill.insert(wid);
+                }
+                Some(r) if cfg.decode.contains(r) => {
+                    decode.insert(wid);
+                }
+                // Unlabeled / unknown role: treat as decode (aggregated default).
+                _ => {
+                    decode.insert(wid);
+                }
+            }
+        }
+        (prefill, decode)
     }
 
     /// Route a prefill request. Returns (worker_id, dp_rank).
@@ -1569,9 +1669,24 @@ impl EndpointPicker for Router {
         // * `enforce_disagg = true`: surface the error to Envoy and let the
         //   request fail. Silently downgrading to aggregated would defeat
         //   the operator's explicit "strict disagg" policy.
-        let prefill_result = self
-            .route_prefill(&tokens, priority_jump, allowed_worker_ids.clone())
-            .await;
+        // Partition candidates into prefill/decode workers by the Dynamo role
+        // label (K8s-native disaggregation, no runtime). An unlabeled or
+        // aggregated pool yields an empty prefill set, so prefill routing is
+        // skipped and we serve aggregated — unchanged behavior.
+        let (prefill_ids, decode_ids) = {
+            let base = match &allowed_worker_ids {
+                Some(ids) => ids.clone(),
+                None => self.all_ready_worker_ids(),
+            };
+            self.partition_worker_roles(&base)
+        };
+
+        let prefill_result = if prefill_ids.is_empty() {
+            Err(anyhow::anyhow!("no prefill-role workers in candidate set"))
+        } else {
+            self.route_prefill(&tokens, priority_jump, Some(prefill_ids))
+                .await
+        };
 
         let is_disaggregated = match &prefill_result {
             Ok(_) => true,
@@ -1595,7 +1710,7 @@ impl EndpointPicker for Router {
         };
 
         let (decode_worker, _overlap) = self
-            .route_decode(&tokens, is_disaggregated, priority_jump, allowed_worker_ids)
+            .route_decode(&tokens, is_disaggregated, priority_jump, Some(decode_ids))
             .await
             .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
 

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -364,9 +364,7 @@ impl Router {
             const AVG_CHARS_PER_TOKEN: usize = 4;
             // No tokenizer, but still honor nvext.agent_hints.priority so a
             // vanilla-vLLM request keeps its scheduler priority.
-            let priority_jump = serde_json::from_str::<serde_json::Value>(request_json)
-                .map(|v| extract_priority_jump_from_json(&v))
-                .unwrap_or(0.0);
+            let (priority_jump, _osl) = extract_hints(request_json);
             return Ok((
                 vec![0u32; (request_json.len() / AVG_CHARS_PER_TOKEN).max(1)],
                 priority_jump,
@@ -581,6 +579,7 @@ impl Router {
         tokens: &[u32],
         is_disaggregated: bool,
         priority_jump: f64,
+        expected_output_tokens: Option<u32>,
         allowed_worker_ids: Option<HashSet<u64>>,
     ) -> Result<(WorkerWithDpRank, u32)> {
         if let Some(ref ids) = allowed_worker_ids {
@@ -607,7 +606,7 @@ impl Router {
                 false,
                 None,
                 priority_jump,
-                None,
+                expected_output_tokens,
                 allowed_worker_ids,
                 RoutingConstraints::default(),
             )
@@ -622,6 +621,7 @@ impl Router {
         tokens: &[u32],
         worker_id: u64,
         dp_rank: u32,
+        expected_output_tokens: Option<u32>,
     ) -> Result<()> {
         let decode_router = self.decode_router.clone();
         let publisher = self.replica_publisher.clone();
@@ -671,7 +671,7 @@ impl Router {
                     &tokens,
                     None,
                     cached_tokens,
-                    None,
+                    expected_output_tokens,
                     worker,
                     None,
                     Some(&router_config_override),
@@ -899,19 +899,28 @@ async fn spawn_replica_sync(
 /// in `lib/llm/src/preprocessor.rs`). Falls back to the deprecated
 /// `latency_sensitivity` alias for callers still on the old field name.
 /// Returns `0.0` when `nvext` is absent.
-/// Extract `priority_jump` directly from a raw request body `Value`, for the
-/// external (no-`OpenAIPreprocessor`) paths that never deserialize into
-/// `NvCreateChatCompletionRequest`. Mirrors [`extract_priority_jump`].
-fn extract_priority_jump_from_json(body: &serde_json::Value) -> f64 {
-    body.get("nvext")
-        .and_then(|n| n.get("agent_hints"))
+/// Parse routing hints — `priority_jump` and expected output length (`osl`) —
+/// from `nvext.agent_hints`, directly from the raw request body so they survive
+/// both tokenization modes (the sidecar tokenizer returns tokens only) and both
+/// request shapes (chat + completion). Returns `(0.0, None)` on parse failure.
+fn extract_hints(body_str: &str) -> (f64, Option<u32>) {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(body_str) else {
+        return (0.0, None);
+    };
+    let hints = v.get("nvext").and_then(|n| n.get("agent_hints"));
+    let priority_jump = hints
         .and_then(|h| {
             h.get("priority")
                 .and_then(|p| p.as_i64())
                 .map(|p| p.max(0) as f64)
                 .or_else(|| h.get("latency_sensitivity").and_then(|l| l.as_f64()))
         })
-        .unwrap_or(0.0)
+        .unwrap_or(0.0);
+    let osl = hints
+        .and_then(|h| h.get("osl"))
+        .and_then(|o| o.as_u64())
+        .map(|o| o as u32);
+    (priority_jump, osl)
 }
 
 fn extract_priority_jump(
@@ -1642,19 +1651,20 @@ impl EndpointPicker for Router {
         // Precise external mode: tokenize via the sidecar (one local hop, not a
         // second round-trip to a worker). Otherwise tokenize locally (the
         // dynamo-worker preprocessor) or use the load-aware placeholder.
-        let (tokens, priority_jump) = if let Some(url) = self.tokenize_url.as_deref() {
-            let toks = remote_tokenize(&self.http_client, url, body_str)
+        // Routing hints (priority, expected output length / OSL) from
+        // nvext.agent_hints, parsed independently of the tokenization mode
+        // (sidecar tokenization returns tokens only and would otherwise drop
+        // them). OSL feeds the decode-load projection in the scheduler so a
+        // worker holding many long-output requests is scored as more loaded.
+        let (priority_jump, osl) = extract_hints(body_str);
+        let tokens = if let Some(url) = self.tokenize_url.as_deref() {
+            remote_tokenize(&self.http_client, url, body_str)
                 .await
-                .map_err(|e| PickError::TokenizationFailed(e.to_string()))?;
-            // The sidecar returns only tokens; recover the priority hint here so
-            // precise-mode requests keep their scheduler priority.
-            let priority_jump = serde_json::from_str::<serde_json::Value>(body_str)
-                .map(|v| extract_priority_jump_from_json(&v))
-                .unwrap_or(0.0);
-            (toks, priority_jump)
+                .map_err(|e| PickError::TokenizationFailed(e.to_string()))?
         } else {
             self.tokenize(body_str)
                 .map_err(|e| PickError::TokenizationFailed(e.to_string()))?
+                .0
         };
 
         // Try prefill routing first (disaggregated mode).
@@ -1710,7 +1720,7 @@ impl EndpointPicker for Router {
         };
 
         let (decode_worker, _overlap) = self
-            .route_decode(&tokens, is_disaggregated, priority_jump, Some(decode_ids))
+            .route_decode(&tokens, is_disaggregated, priority_jump, osl, Some(decode_ids))
             .await
             .map_err(|e| PickError::RoutingFailed(e.to_string()))?;
 
@@ -1746,6 +1756,7 @@ impl EndpointPicker for Router {
                     &tokens,
                     decode_worker.worker_id,
                     decode_worker.dp_rank,
+                    osl,
                 )
                 .await
         {

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -65,10 +65,14 @@ pub struct Router {
     tokenize_url: Option<String>,
     pod_store: kube::runtime::reflector::Store<k8s_openapi::api::core::v1::Pod>,
     pod_store_ready: Arc<AtomicBool>,
-    /// Publisher for cross-replica load sync; `None` when `DYN_EPP_REPLICA_SYNC`
-    /// is disabled. Active-sequence events for booked/freed requests are
-    /// mirrored to peer EPP replicas via this handle.
+    /// Publisher for cross-replica DECODE load sync; `None` when
+    /// `DYN_EPP_REPLICA_SYNC` is disabled. Active-sequence events for
+    /// booked/freed decode requests are mirrored to peer EPP replicas.
     replica_publisher: Option<Arc<ReplicaPublisher>>,
+    /// Publisher for cross-replica PREFILL load sync (disagg); `None` when
+    /// replica sync is disabled. Prefill bookings are freed on first response
+    /// token (prefill complete) and mirrored to peers on a second channel.
+    prefill_publisher: Option<Arc<ReplicaPublisher>>,
 }
 
 impl Router {
@@ -233,16 +237,16 @@ impl Router {
         // Spawned background tasks clone what they need, so this survives `drt`
         // being dropped at the end of this scope (same pattern as the
         // reflectors above).
-        let replica_publisher = if parse_replica_sync_enabled() {
-            match spawn_replica_sync(&drt, &decode_router).await {
-                Ok(publisher) => Some(publisher),
+        let (replica_publisher, prefill_publisher) = if parse_replica_sync_enabled() {
+            match spawn_replica_sync(&drt, &decode_router, &prefill_router).await {
+                Ok((decode_pub, prefill_pub)) => (Some(decode_pub), Some(prefill_pub)),
                 Err(e) => {
                     tracing::error!(error = %e, "cross-replica load sync disabled (setup failed)");
-                    None
+                    (None, None)
                 }
             }
         } else {
-            None
+            (None, None)
         };
 
         // `model_manager` and `drt` are intentionally not stored on the
@@ -282,6 +286,7 @@ impl Router {
             pod_store,
             pod_store_ready,
             replica_publisher,
+            prefill_publisher,
         })
     }
 
@@ -585,10 +590,52 @@ impl Router {
         .map_err(|_| anyhow::anyhow!("add_request timed out"))?
     }
 
+    /// Book prefill load on the prefill router (disagg) and mirror it to peer
+    /// replicas. No-op unless cross-replica sync is enabled and the prefill
+    /// router is in KV mode. The booking is released on prefill completion
+    /// (first response token) in `mark_prefill_complete`.
+    async fn book_prefill(&self, request_id: &str, tokens: &[u32], worker_id: u64, dp_rank: u32) {
+        let Some(publisher) = self.prefill_publisher.clone() else {
+            return;
+        };
+        let prefill_router = self.prefill_router.clone();
+        let request_id = request_id.to_owned();
+        let tokens = tokens.to_vec();
+        let _ = tokio::time::timeout(BOOKKEEPING_TIMEOUT, async move {
+            let worker = WorkerWithDpRank::new(worker_id, dp_rank);
+            // Track prefill-token load. Prefix-cache crediting on the prefill
+            // worker is left to its own KV events; cached_tokens = 0 here is a
+            // conservative upper bound on prefill cost.
+            let router_config_override = RouterConfigOverride {
+                track_prefill_tokens: Some(true),
+                assume_kv_reuse: Some(false),
+                ..Default::default()
+            };
+            let booked = prefill_router
+                .add_request(
+                    request_id,
+                    &tokens,
+                    None,
+                    0,
+                    None,
+                    worker,
+                    None,
+                    Some(&router_config_override),
+                )
+                .await;
+            if let Some(req) = &booked {
+                publisher.on_add(req).await;
+            }
+        })
+        .await;
+    }
+
     /// Mark prefill as completed for a request.
     pub async fn mark_prefill_complete(&self, request_id: &str) -> Result<()> {
         let decode_router = self.decode_router.clone();
         let publisher = self.replica_publisher.clone();
+        let prefill_router = self.prefill_router.clone();
+        let prefill_publisher = self.prefill_publisher.clone();
         let request_id = request_id.to_owned();
 
         tokio::time::timeout(BOOKKEEPING_TIMEOUT, async {
@@ -598,6 +645,12 @@ impl Router {
                 .map_err(|e| anyhow::anyhow!("mark_prefill_completed failed: {e}"))?;
             if let Some(publisher) = &publisher {
                 publisher.on_mark_prefill(&request_id).await;
+            }
+            // Disagg: the prefill worker is done once decode emits its first
+            // token — release the prefill booking and mirror the free to peers.
+            if let Some(prefill_publisher) = &prefill_publisher {
+                prefill_router.free(&request_id).await;
+                prefill_publisher.on_free(&request_id).await;
             }
             Ok(())
         })
@@ -651,13 +704,19 @@ fn parse_replica_sync_enabled() -> bool {
 }
 
 /// Set up EPP-managed (NATS-free, CRD-free) cross-replica load sync: bind the
-/// ZMQ PUB, start EndpointSlice peer discovery plus the SUB pump, and feed peer
-/// events into the decode router. Returns the publisher used to mirror this
-/// replica's own bookings. See ai-dynamo/dynamo#10384.
+/// ZMQ PUBs, start EndpointSlice peer discovery plus the SUB pumps, and feed
+/// peer events into the decode and prefill routers. Returns the (decode,
+/// prefill) publishers used to mirror this replica's own bookings.
+///
+/// Two independent channels share the EndpointSlice-discovered peer set: decode
+/// on `DYN_EPP_REPLICA_SYNC_PORT` (default 9100) and prefill on the next port
+/// (9101). Both are direct pod-IP ZMQ connects, so no extra Service/port config
+/// is needed. See ai-dynamo/dynamo#10384.
 async fn spawn_replica_sync(
     drt: &DistributedRuntime,
     decode_router: &Arc<KvRouter>,
-) -> Result<Arc<ReplicaPublisher>> {
+    prefill_router: &Arc<PrefillRouter>,
+) -> Result<(Arc<ReplicaPublisher>, Arc<ReplicaPublisher>)> {
     let port: u16 = std::env::var("DYN_EPP_REPLICA_SYNC_PORT")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -672,28 +731,64 @@ async fn spawn_replica_sync(
         .map_err(|_| anyhow::anyhow!("POD_NAMESPACE not set (downward API)"))?;
     let self_pod_ip = std::env::var("POD_IP")
         .map_err(|_| anyhow::anyhow!("POD_IP not set (downward API)"))?;
+    let prefill_port = port + 1;
 
-    // Must match the decode router's own id so peers apply these events and
-    // this replica never re-applies its own.
+    // Must match the routers' own id so peers apply these events and this
+    // replica never re-applies its own. Both routers share this drt's id.
     let router_id = drt.discovery().instance_id();
 
     // Process-scoped lifetime, matching the reflectors; intentionally not tied
     // to `drt`, which is dropped at the end of `from_discovery`.
     let cancel = CancellationToken::new();
 
-    let publisher = Arc::new(ReplicaPublisher::bind(port, router_id).await?);
-    let subscriber = crate::replica_sync::spawn_peer_sync(
-        service,
-        namespace,
-        self_pod_ip,
+    // --- decode channel (eager: decode_router always exists) ---
+    let decode_pub = Arc::new(ReplicaPublisher::bind(port, router_id).await?);
+    let decode_sub = crate::replica_sync::spawn_peer_sync(
+        service.clone(),
+        namespace.clone(),
+        self_pod_ip.clone(),
         port,
         cancel.clone(),
     )
     .await?;
-    decode_router.start_replica_sync(subscriber, cancel);
+    decode_router.start_replica_sync(decode_sub, cancel.clone());
 
-    tracing::info!(port, router_id, "EPP cross-replica load sync enabled");
-    Ok(publisher)
+    // --- prefill channel (disagg) ---
+    // The prefill router is activated lazily once prefill workers are
+    // discovered, so its subscriber is wired after activation. The SUB pump
+    // runs immediately and buffers peer events until then (empty in aggregated
+    // mode, where no peer publishes prefill events).
+    let prefill_pub = Arc::new(ReplicaPublisher::bind(prefill_port, router_id).await?);
+    let prefill_sub = crate::replica_sync::spawn_peer_sync(
+        service,
+        namespace,
+        self_pod_ip,
+        prefill_port,
+        cancel.clone(),
+    )
+    .await?;
+    {
+        let prefill_router = prefill_router.clone();
+        let cancel = cancel.clone();
+        tokio::spawn(async move {
+            while !prefill_router.is_activated() {
+                if cancel.is_cancelled() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            prefill_router.start_replica_sync(prefill_sub, cancel);
+            tracing::info!("EPP prefill cross-replica load sync wired (router activated)");
+        });
+    }
+
+    tracing::info!(
+        port,
+        prefill_port,
+        router_id,
+        "EPP cross-replica load sync enabled (decode + prefill)"
+    );
+    Ok((decode_pub, prefill_pub))
 }
 
 /// Extract the router queue `priority_jump` from a chat completion request's
@@ -1544,6 +1639,21 @@ impl EndpointPicker for Router {
                 error = %e,
                 "Failed to register request with router bookkeeping"
             );
+        }
+
+        // Disagg: also book prefill load on the selected prefill worker so peer
+        // replicas see it (released on prefill completion). No-op unless
+        // replica sync is enabled and the prefill router is in KV mode.
+        if let Ok((prefill_worker_id, prefill_dp_rank)) = &prefill_result
+            && !req.request_id.is_empty()
+        {
+            self.book_prefill(
+                &req.request_id,
+                &tokens,
+                *prefill_worker_id,
+                prefill_dp_rank.unwrap_or(0),
+            )
+            .await;
         }
 
         // Build routing headers matching the Go EPP's disagg plugin:

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -16,6 +16,7 @@ pub mod envoy_helpers;
 pub mod epp;
 pub mod picker;
 pub mod proto;
+pub mod replica_sync;
 pub mod server;
 
 pub use epp::Router;

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -17,10 +17,14 @@ use dynamo_ext_proc::{ExtProcServer, Router};
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
 
+mod metrics_server;
 mod tokenizer_server;
 
 const GRPC_PORT: u16 = 9002;
 const HEALTH_PORT: u16 = 9003;
+/// Default Prometheus `/metrics` port. Override with `DYN_EPP_METRICS_PORT`;
+/// set it to 0 to disable the metrics server.
+const METRICS_PORT: u16 = 9090;
 const HEALTH_SERVICE_NAME: &str = "inference-extension";
 /// Cap concurrent in-flight TLS handshakes + active gRPC streams. Prevents a
 /// connection flood from exhausting fds / memory. Tuned for an inference EPP
@@ -156,6 +160,17 @@ async fn main() -> Result<()> {
             .add_service(health_service)
             .serve(health_addr),
     );
+
+    // Optional Prometheus /metrics endpoint exposing the KV-router's per-worker
+    // load + scheduler-queue gauges — the same library gauges the standalone
+    // frontend serves. Lets an EPP replica's load view (incl. peer-synced load)
+    // be scraped like the standalone router.
+    let metrics_port = parse_env("DYN_EPP_METRICS_PORT", METRICS_PORT);
+    if metrics_port != 0 {
+        if let Err(e) = metrics_server::spawn_metrics_server(metrics_port).await {
+            tracing::warn!(error = %e, "failed to start EPP metrics server");
+        }
+    }
 
     tracing::info!("Initializing KV-aware router from discovery...");
     let router =

--- a/deploy/inference-gateway/ext-proc/src/metrics_server.rs
+++ b/deploy/inference-gateway/ext-proc/src/metrics_server.rs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal Prometheus `/metrics` endpoint for the EPP.
+//!
+//! The KV-router's per-worker load gauges (`worker_active_decode_blocks`,
+//! `worker_active_prefill_tokens`) and the scheduler queue gauges are defined
+//! and updated entirely in the shared library (`dynamo_llm::kv_router::metrics`)
+//! — the very same statics the standalone frontend serves on its HTTP metrics
+//! port (`lib/llm/src/http/service/service_v2.rs`). This module does not define
+//! or duplicate any metric: it reuses the library's registration functions and
+//! exposes the registry over HTTP, so an EPP replica's per-worker load view —
+//! including load synced from peer replicas (ai-dynamo/dynamo#10384) — is
+//! scrapeable exactly like the standalone router's.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+use dynamo_llm::kv_router::metrics::{register_router_queue_metrics, register_worker_load_metrics};
+use prometheus::{Encoder, Registry, TextEncoder};
+
+/// Encode the registry in Prometheus text exposition format (same encode path
+/// as `dynamo_runtime`'s metrics handler).
+async fn metrics_handler(registry: Arc<Registry>) -> impl IntoResponse {
+    let encoder = TextEncoder::new();
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&registry.gather(), &mut buffer) {
+        tracing::error!(error = %e, "failed to encode metrics");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to encode metrics".to_string(),
+        );
+    }
+    match String::from_utf8(buffer) {
+        Ok(body) => (StatusCode::OK, body),
+        Err(e) => {
+            tracing::error!(error = %e, "metrics output was not valid UTF-8");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "invalid metrics encoding".to_string(),
+            )
+        }
+    }
+}
+
+/// Bind an HTTP server on `0.0.0.0:port` serving `/metrics` with the KV-router
+/// worker-load and scheduler-queue gauges. Reuses the library registration
+/// functions so no metric definitions are duplicated here.
+pub async fn spawn_metrics_server(port: u16) -> Result<()> {
+    let registry = Registry::new();
+    register_worker_load_metrics(&registry)?;
+    register_router_queue_metrics(&registry)?;
+    let registry = Arc::new(registry);
+
+    let app = Router::new().route(
+        "/metrics",
+        get({
+            let registry = Arc::clone(&registry);
+            move || metrics_handler(Arc::clone(&registry))
+        }),
+    );
+
+    let addr = format!("0.0.0.0:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!(address = %addr, "EPP metrics server listening on /metrics");
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::error!(error = %e, "EPP metrics server exited");
+        }
+    });
+    Ok(())
+}

--- a/deploy/inference-gateway/ext-proc/src/replica_sync.rs
+++ b/deploy/inference-gateway/ext-proc/src/replica_sync.rs
@@ -1,0 +1,319 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Runtime-free cross-replica in-flight-load sync for the EPP router.
+//!
+//! When the EPP runs in vanilla (non-Dynamo-runtime) mode there is no NATS
+//! event plane and no `DynamoWorkerMetadata` CRD, so the standalone router's
+//! replica-sync mechanism (which discovers peer routers and exchanges
+//! `ActiveSequenceEvent`s over those) is unavailable. This module provides an
+//! equivalent that depends only on facilities already present in a GAIE
+//! deployment:
+//!
+//! - **Peer discovery** via the `EndpointSlice`s of the EPP's own Kubernetes
+//!   `Service` (one ready entry per EPP pod). The Downward-API `POD_IP`
+//!   excludes this replica from its own peer set.
+//! - **Transport** via a fixed-port ZMQ PUB/SUB mesh: each EPP binds a PUB on
+//!   `DYN_EPP_REPLICA_SYNC_PORT` and a single SUB socket connects (fan-in) to
+//!   every peer's PUB. ZMQ handles reconnection as peers come and go.
+//!
+//! The received events are fed into the decode router's active-sequence
+//! tracker via [`dynamo_llm::kv_router::KvRouter::start_replica_sync`], so a
+//! replica's projected load reflects requests booked on its peers.
+//!
+//! See ai-dynamo/dynamo#10384.
+//!
+//! ## v1 limitation
+//!
+//! Published `AddRequest` events carry `token_sequence: None`: the EPP books
+//! requests through [`crate::epp::Router::add_request`] but does not retain the
+//! router-internal block hashes. Peers therefore mirror in-flight request
+//! *count* per worker exactly, but the token-level prefill/decode load
+//! contribution of peer requests is approximated as zero until the events carry
+//! a token count or block hashes.
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use dynamo_kv_router::SequenceSubscriber;
+use dynamo_kv_router::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
+use dynamo_runtime::CancellationToken;
+use futures::{SinkExt, StreamExt};
+use std::collections::HashMap;
+use tmq::{AsZmqSocket, Context, Multipart, publish::Publish, subscribe::Subscribe};
+use tokio::sync::{Mutex, mpsc, watch};
+
+/// ZMQ topic shared by all EPP replicas for active-sequence events.
+const TOPIC: &[u8] = b"epp-replica-sync";
+
+/// Publishes this replica's active-sequence events to peer EPPs over a
+/// fixed-port ZMQ PUB socket.
+///
+/// `Free` and `MarkPrefillCompleted` are addressed to a worker, but the EPP
+/// call sites for those only carry a request id, so this tracks
+/// `request_id -> worker` (populated on `on_add`, consumed on `on_free`).
+pub struct ReplicaPublisher {
+    socket: Mutex<Publish>,
+    router_id: u64,
+    req_workers: Mutex<HashMap<String, WorkerWithDpRank>>,
+}
+
+impl ReplicaPublisher {
+    /// Bind the PUB socket on `0.0.0.0:port`. `router_id` must match the decode
+    /// router's own id (`drt.discovery().instance_id()`) so that peers apply
+    /// these events and this replica never re-applies its own.
+    pub async fn bind(port: u16, router_id: u64) -> Result<Self> {
+        let endpoint = format!("tcp://0.0.0.0:{port}");
+        let ctx = Context::new();
+        let socket = tmq::publish::publish(&ctx).bind(&endpoint)?;
+        tracing::info!(%endpoint, router_id, "EPP replica-sync PUB bound");
+        Ok(Self {
+            socket: Mutex::new(socket),
+            router_id,
+            req_workers: Mutex::new(HashMap::new()),
+        })
+    }
+
+    async fn send(&self, event: &ActiveSequenceEvent) {
+        let payload = match serde_json::to_vec(event) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to serialize replica-sync event");
+                return;
+            }
+        };
+        let frames = Multipart::from(vec![TOPIC.to_vec(), payload]);
+        if let Err(e) = self.socket.lock().await.send(frames).await {
+            tracing::warn!(error = %e, "failed to publish replica-sync event");
+        }
+    }
+
+    /// Mirror a freshly-booked request to peers.
+    pub async fn on_add(&self, request_id: &str, worker: WorkerWithDpRank) {
+        self.req_workers
+            .lock()
+            .await
+            .insert(request_id.to_string(), worker);
+        let event = ActiveSequenceEvent {
+            request_id: request_id.to_string(),
+            worker,
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: None,
+                track_prefill_tokens: false,
+                expected_output_tokens: None,
+                prefill_load_hint: None,
+            },
+            router_id: self.router_id,
+            lora_name: None,
+        };
+        self.send(&event).await;
+    }
+
+    /// Mirror a prefill-completion transition to peers.
+    pub async fn on_mark_prefill(&self, request_id: &str) {
+        let Some(worker) = self.req_workers.lock().await.get(request_id).copied() else {
+            return;
+        };
+        let event = ActiveSequenceEvent {
+            request_id: request_id.to_string(),
+            worker,
+            data: ActiveSequenceEventData::MarkPrefillCompleted,
+            router_id: self.router_id,
+            lora_name: None,
+        };
+        self.send(&event).await;
+    }
+
+    /// Mirror a request completion (free) to peers.
+    pub async fn on_free(&self, request_id: &str) {
+        let Some(worker) = self.req_workers.lock().await.remove(request_id) else {
+            return;
+        };
+        let event = ActiveSequenceEvent {
+            request_id: request_id.to_string(),
+            worker,
+            data: ActiveSequenceEventData::Free,
+            router_id: self.router_id,
+            lora_name: None,
+        };
+        self.send(&event).await;
+    }
+}
+
+/// [`SequenceSubscriber`] backed by an mpsc channel that the peer SUB pump
+/// feeds with decoded peer events.
+pub struct ReplicaSubscriber {
+    rx: mpsc::UnboundedReceiver<ActiveSequenceEvent>,
+}
+
+impl SequenceSubscriber for ReplicaSubscriber {
+    async fn next_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
+        self.rx.recv().await.map(Ok)
+    }
+}
+
+/// Start peer discovery (EndpointSlice reflector) plus the ZMQ SUB pump and
+/// return a [`ReplicaSubscriber`] yielding peer events. Wire the returned
+/// subscriber into `KvRouter::start_replica_sync`.
+pub async fn spawn_peer_sync(
+    service_name: String,
+    namespace: String,
+    self_pod_ip: String,
+    port: u16,
+    cancel: CancellationToken,
+) -> Result<ReplicaSubscriber> {
+    let peers_rx =
+        spawn_endpointslice_reflector(service_name, namespace, self_pod_ip, port).await?;
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    tokio::spawn(sub_manager(peers_rx, event_tx, cancel));
+    Ok(ReplicaSubscriber { rx: event_rx })
+}
+
+/// Watch the EndpointSlices of the EPP's Service and publish the current set of
+/// peer PUB endpoints (`tcp://ip:port`, self excluded) to a watch channel.
+async fn spawn_endpointslice_reflector(
+    service_name: String,
+    namespace: String,
+    self_pod_ip: String,
+    port: u16,
+) -> Result<watch::Receiver<Vec<String>>> {
+    use k8s_openapi::api::discovery::v1::EndpointSlice;
+    use kube::{Api, Client, runtime::reflector, runtime::watcher};
+
+    let client = Client::try_default().await?;
+    let api: Api<EndpointSlice> = Api::namespaced(client, &namespace);
+    let selector = format!("kubernetes.io/service-name={service_name}");
+    let cfg = watcher::Config::default().labels(&selector);
+
+    let (reader, writer) = reflector::store();
+    let stream = reflector::reflector(writer, watcher(api, cfg));
+    let (tx, rx) = watch::channel(Vec::new());
+
+    tracing::info!(
+        namespace = %namespace,
+        selector = %selector,
+        port,
+        "Starting EPP EndpointSlice reflector for peer discovery"
+    );
+
+    tokio::spawn(async move {
+        tokio::pin!(stream);
+        while stream.next().await.is_some() {
+            let peers = compute_peers(&reader, &self_pod_ip, port);
+            tracing::debug!(peer_count = peers.len(), peers = ?peers, "EPP peer set updated");
+            // Ignore send errors: a closed receiver means sync has shut down.
+            let _ = tx.send(peers);
+        }
+        tracing::warn!("EPP EndpointSlice reflector stream ended");
+    });
+
+    Ok(rx)
+}
+
+/// Collect ready peer endpoints from the EndpointSlice store, excluding self.
+fn compute_peers(
+    store: &kube::runtime::reflector::Store<k8s_openapi::api::discovery::v1::EndpointSlice>,
+    self_pod_ip: &str,
+    port: u16,
+) -> Vec<String> {
+    let mut peers = HashSet::new();
+    for slice in store.state() {
+        for endpoint in slice.endpoints.iter() {
+            let ready = endpoint
+                .conditions
+                .as_ref()
+                .and_then(|c| c.ready)
+                .unwrap_or(false);
+            if !ready {
+                continue;
+            }
+            for addr in endpoint.addresses.iter() {
+                if addr != self_pod_ip {
+                    peers.insert(format!("tcp://{addr}:{port}"));
+                }
+            }
+        }
+    }
+    let mut peers: Vec<String> = peers.into_iter().collect();
+    peers.sort();
+    peers
+}
+
+/// Rebuild the SUB socket whenever the peer set changes and pump decoded events
+/// into `event_tx`.
+async fn sub_manager(
+    mut peers_rx: watch::Receiver<Vec<String>>,
+    event_tx: mpsc::UnboundedSender<ActiveSequenceEvent>,
+    cancel: CancellationToken,
+) {
+    let ctx = Context::new();
+    loop {
+        let peers = peers_rx.borrow_and_update().clone();
+        let pump = if peers.is_empty() {
+            None
+        } else {
+            match build_sub(&ctx, &peers) {
+                Ok(sub) => {
+                    tracing::info!(peer_count = peers.len(), "EPP replica-sync SUB connected");
+                    Some(tokio::spawn(pump_sub(sub, event_tx.clone())))
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to build replica-sync SUB socket");
+                    None
+                }
+            }
+        };
+
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                if let Some(h) = pump { h.abort(); }
+                break;
+            }
+            changed = peers_rx.changed() => {
+                if let Some(h) = pump { h.abort(); }
+                if changed.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Build a single SUB socket connected (fan-in) to every peer PUB endpoint.
+fn build_sub(ctx: &Context, peers: &[String]) -> Result<Subscribe> {
+    let mut iter = peers.iter();
+    let first = iter
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("build_sub called with no peers"))?;
+    let sub = tmq::subscribe::subscribe(ctx)
+        .connect(first)?
+        .subscribe(TOPIC)?;
+    for endpoint in iter {
+        sub.get_socket().connect(endpoint)?;
+    }
+    Ok(sub)
+}
+
+/// Read multipart frames, decode the payload, and forward events.
+async fn pump_sub(mut sub: Subscribe, event_tx: mpsc::UnboundedSender<ActiveSequenceEvent>) {
+    while let Some(result) = sub.next().await {
+        let msg = match result {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::debug!(error = %e, "replica-sync SUB recv error");
+                continue;
+            }
+        };
+        let Some(payload) = msg.0.back() else {
+            continue;
+        };
+        match serde_json::from_slice::<ActiveSequenceEvent>(&payload[..]) {
+            Ok(event) => {
+                if event_tx.send(event).is_err() {
+                    break; // subscriber dropped
+                }
+            }
+            Err(e) => tracing::debug!(error = %e, "failed to decode replica-sync event"),
+        }
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/replica_sync.rs
+++ b/deploy/inference-gateway/ext-proc/src/replica_sync.rs
@@ -35,8 +35,8 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
-use dynamo_kv_router::SequenceSubscriber;
 use dynamo_kv_router::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
+use dynamo_kv_router::{SequenceRequest, SequenceSubscriber};
 use dynamo_runtime::CancellationToken;
 use futures::{SinkExt, StreamExt};
 use std::collections::HashMap;
@@ -88,23 +88,29 @@ impl ReplicaPublisher {
         }
     }
 
-    /// Mirror a freshly-booked request to peers.
-    pub async fn on_add(&self, request_id: &str, worker: WorkerWithDpRank) {
+    /// Mirror a freshly-booked request to peers, at full fidelity.
+    ///
+    /// Takes the exact [`SequenceRequest`] the router booked (returned by
+    /// `KvRouter::add_request`) so the published event carries the real token
+    /// hashes, prefill-token tracking flag, expected output tokens and
+    /// prefill-load hint — matching what the standalone router's own
+    /// replica-sync publisher would emit.
+    pub async fn on_add(&self, req: &SequenceRequest) {
         self.req_workers
             .lock()
             .await
-            .insert(request_id.to_string(), worker);
+            .insert(req.request_id.clone(), req.worker);
         let event = ActiveSequenceEvent {
-            request_id: request_id.to_string(),
-            worker,
+            request_id: req.request_id.clone(),
+            worker: req.worker,
             data: ActiveSequenceEventData::AddRequest {
-                token_sequence: None,
-                track_prefill_tokens: false,
-                expected_output_tokens: None,
-                prefill_load_hint: None,
+                token_sequence: req.token_sequence.clone(),
+                track_prefill_tokens: req.track_prefill_tokens,
+                expected_output_tokens: req.expected_output_tokens,
+                prefill_load_hint: req.prefill_load_hint,
             },
             router_id: self.router_id,
-            lora_name: None,
+            lora_name: req.lora_name.clone(),
         };
         self.send(&event).await;
     }

--- a/deploy/inference-gateway/ext-proc/src/replica_sync.rs
+++ b/deploy/inference-gateway/ext-proc/src/replica_sync.rs
@@ -149,7 +149,7 @@ impl ReplicaPublisher {
 /// [`SequenceSubscriber`] backed by an mpsc channel that the peer SUB pump
 /// feeds with decoded peer events.
 pub struct ReplicaSubscriber {
-    rx: mpsc::UnboundedReceiver<ActiveSequenceEvent>,
+    rx: mpsc::Receiver<ActiveSequenceEvent>,
 }
 
 impl SequenceSubscriber for ReplicaSubscriber {
@@ -157,6 +157,11 @@ impl SequenceSubscriber for ReplicaSubscriber {
         self.rx.recv().await.map(Ok)
     }
 }
+
+/// Bound on buffered peer events; under a burst or a stalled sequence-sync
+/// consumer the newest events are dropped (with a warning) rather than growing
+/// memory without limit.
+const REPLICA_SYNC_EVENT_BUFFER: usize = 8192;
 
 /// Start peer discovery (EndpointSlice reflector) plus the ZMQ SUB pump and
 /// return a [`ReplicaSubscriber`] yielding peer events. Wire the returned
@@ -170,7 +175,7 @@ pub async fn spawn_peer_sync(
 ) -> Result<ReplicaSubscriber> {
     let peers_rx =
         spawn_endpointslice_reflector(service_name, namespace, self_pod_ip, port).await?;
-    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let (event_tx, event_rx) = mpsc::channel(REPLICA_SYNC_EVENT_BUFFER);
     tokio::spawn(sub_manager(peers_rx, event_tx, cancel));
     Ok(ReplicaSubscriber { rx: event_rx })
 }
@@ -225,18 +230,29 @@ fn compute_peers(
     let mut peers = HashSet::new();
     for slice in store.state() {
         for endpoint in slice.endpoints.iter() {
+            // Kubernetes treats a missing `ready` condition as ready.
             let ready = endpoint
                 .conditions
                 .as_ref()
                 .and_then(|c| c.ready)
-                .unwrap_or(false);
+                .unwrap_or(true);
             if !ready {
                 continue;
             }
             for addr in endpoint.addresses.iter() {
-                if addr != self_pod_ip {
-                    peers.insert(format!("tcp://{addr}:{port}"));
+                if addr == self_pod_ip {
+                    continue;
                 }
+                // Bracket IPv6 literals so the ZMQ `tcp://` endpoint is valid.
+                let endpoint = match addr.parse::<std::net::IpAddr>() {
+                    Ok(std::net::IpAddr::V6(v6)) => format!("tcp://[{v6}]:{port}"),
+                    Ok(std::net::IpAddr::V4(v4)) => format!("tcp://{v4}:{port}"),
+                    Err(_) => {
+                        tracing::warn!(addr, "skipping unparsable peer address");
+                        continue;
+                    }
+                };
+                peers.insert(endpoint);
             }
         }
     }
@@ -249,7 +265,7 @@ fn compute_peers(
 /// into `event_tx`.
 async fn sub_manager(
     mut peers_rx: watch::Receiver<Vec<String>>,
-    event_tx: mpsc::UnboundedSender<ActiveSequenceEvent>,
+    event_tx: mpsc::Sender<ActiveSequenceEvent>,
     cancel: CancellationToken,
 ) {
     let ctx = Context::new();
@@ -301,7 +317,7 @@ fn build_sub(ctx: &Context, peers: &[String]) -> Result<Subscribe> {
 }
 
 /// Read multipart frames, decode the payload, and forward events.
-async fn pump_sub(mut sub: Subscribe, event_tx: mpsc::UnboundedSender<ActiveSequenceEvent>) {
+async fn pump_sub(mut sub: Subscribe, event_tx: mpsc::Sender<ActiveSequenceEvent>) {
     while let Some(result) = sub.next().await {
         let msg = match result {
             Ok(m) => m,
@@ -314,11 +330,13 @@ async fn pump_sub(mut sub: Subscribe, event_tx: mpsc::UnboundedSender<ActiveSequ
             continue;
         };
         match serde_json::from_slice::<ActiveSequenceEvent>(&payload[..]) {
-            Ok(event) => {
-                if event_tx.send(event).is_err() {
-                    break; // subscriber dropped
+            Ok(event) => match event_tx.try_send(event) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    tracing::warn!("replica-sync event buffer full; dropping peer event");
                 }
-            }
+                Err(mpsc::error::TrySendError::Closed(_)) => break, // subscriber dropped
+            },
             Err(e) => tracing::debug!(error = %e, "failed to decode replica-sync event"),
         }
     }

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -24,7 +24,7 @@ use crate::protocols::{LocalBlockHash, WorkerConfigLike, WorkerId, WorkerWithDpR
 use crate::sequences::topology::WorkerDpRange;
 use crate::sequences::{
     ActiveSequencesMultiWorker, PrefillTokenDeltas, SequenceError, SequencePublisher,
-    SequenceRequest,
+    SequenceRequest, SequenceSubscriber,
 };
 use dynamo_tokens::SequenceHash;
 
@@ -288,6 +288,21 @@ where
 
     pub fn register_workers(&self, worker_ids: &HashSet<WorkerId>) {
         self.queue.register_workers(worker_ids);
+    }
+
+    /// Drive cross-replica sequence sync from an externally-supplied subscriber.
+    ///
+    /// This lets an out-of-tree transport (e.g. the EPP's EndpointSlice + ZMQ
+    /// peer sync) feed peer `ActiveSequenceEvent`s into this scheduler's
+    /// active-sequence tracker without going through the NATS event-plane
+    /// subscriber created by `create_multi_worker_sequences`. Event application
+    /// is independent of the `replica_sync` publish flag, so callers can mirror
+    /// peer load even with the built-in publisher disabled.
+    pub fn start_replica_sync<Sub>(&self, subscriber: Sub, cancel_token: CancellationToken)
+    where
+        Sub: SequenceSubscriber + 'static,
+    {
+        self.slots.start_replica_sync(subscriber, cancel_token);
     }
 
     pub async fn add_request(&self, req: SequenceRequest) -> Result<(), SequenceError> {

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -125,6 +125,7 @@ pub enum SequenceError {
 }
 
 /// Bundled parameters for adding a request to the sequence tracker.
+#[derive(Clone)]
 pub struct SequenceRequest {
     pub request_id: RequestId,
     pub token_sequence: Option<Vec<SequenceHash>>,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -629,7 +629,7 @@ where
         worker: WorkerWithDpRank,
         lora_name: Option<String>,
         router_config_override: Option<&RouterConfigOverride>,
-    ) {
+    ) -> Option<SequenceRequest> {
         let isl_tokens = tokens.len();
         let hash_options = BlockHashOptions {
             block_mm_infos,
@@ -650,21 +650,25 @@ where
         let prefill_load_hint =
             self.prefill_load_hint_for(isl_tokens, cached_tokens, track_prefill_tokens);
 
-        if let Err(e) = self
-            .scheduler
-            .add_request(SequenceRequest {
-                request_id: request_id.clone(),
-                token_sequence: maybe_seq_hashes,
-                track_prefill_tokens,
-                expected_output_tokens,
-                prefill_load_hint,
-                worker,
-                lora_name,
-            })
-            .await
-        {
+        let request = SequenceRequest {
+            request_id: request_id.clone(),
+            token_sequence: maybe_seq_hashes,
+            track_prefill_tokens,
+            expected_output_tokens,
+            prefill_load_hint,
+            worker,
+            lora_name,
+        };
+        // Mirror copy so a caller managing its own cross-replica transport (the
+        // EPP) can publish the exact active-sequence event the router books — at
+        // full fidelity (token hashes + prefill-load hint), matching what the
+        // standalone router's own replica-sync publisher would emit.
+        let booked = request.clone();
+        if let Err(e) = self.scheduler.add_request(request).await {
             tracing::warn!("Failed to add request {request_id}: {e}");
+            return None;
         }
+        Some(booked)
     }
 
     pub async fn mark_prefill_completed(&self, request_id: &str) -> Result<(), SequenceError> {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -602,6 +602,22 @@ where
         self.scheduler.register_workers(worker_ids);
     }
 
+    /// Drive cross-replica sequence sync from an externally-supplied subscriber.
+    ///
+    /// Lets callers that manage their own peer discovery and transport (e.g. an
+    /// EPP using EndpointSlice + ZMQ instead of the NATS event plane) feed peer
+    /// `ActiveSequenceEvent`s into the active-sequence tracker so projected load
+    /// reflects requests booked on other router replicas.
+    pub fn start_replica_sync<Sub>(
+        &self,
+        subscriber: Sub,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) where
+        Sub: crate::kv_router::sequence::SequenceSubscriber + 'static,
+    {
+        self.scheduler.start_replica_sync(subscriber, cancel_token);
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn add_request(
         &self,

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -8,7 +8,8 @@ use futures::StreamExt;
 use tokio::sync::OwnedSemaphorePermit;
 use tracing::Instrument;
 
-use dynamo_kv_router::protocols::{BlockExtraInfo, RoutingConstraints, WorkerId};
+use dynamo_kv_router::protocols::{BlockExtraInfo, RoutingConstraints, WorkerId, WorkerWithDpRank};
+use dynamo_kv_router::{SequenceRequest, SequenceSubscriber, config::RouterConfigOverride};
 use dynamo_runtime::{pipeline::SingleIn, protocols::maybe_error::MaybeError};
 
 use super::{
@@ -414,6 +415,62 @@ impl PrefillRouter {
     pub fn register_workers(&self, worker_ids: &HashSet<WorkerId>) {
         if let Some(InnerPrefillRouter::KvRouter(r)) = self.prefill_router.get() {
             r.chooser.register_workers(worker_ids);
+        }
+    }
+
+    /// Book a request on the prefill router's slot tracker (load tracking) and
+    /// return the booked [`SequenceRequest`] so a caller can mirror it to peer
+    /// replicas at full fidelity. Returns `None` unless the prefill router is in
+    /// KV mode. Delegates to the inner [`KvRouter`](crate::kv_router::KvRouter).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn add_request(
+        &self,
+        request_id: String,
+        tokens: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        cached_tokens: usize,
+        expected_output_tokens: Option<u32>,
+        worker: WorkerWithDpRank,
+        lora_name: Option<String>,
+        router_config_override: Option<&RouterConfigOverride>,
+    ) -> Option<SequenceRequest> {
+        match self.prefill_router.get() {
+            Some(InnerPrefillRouter::KvRouter(r)) => {
+                r.chooser
+                    .add_request(
+                        request_id,
+                        tokens,
+                        block_mm_infos,
+                        cached_tokens,
+                        expected_output_tokens,
+                        worker,
+                        lora_name,
+                        router_config_override,
+                    )
+                    .await
+            }
+            _ => None,
+        }
+    }
+
+    /// Free a request from the prefill router's slot tracker. Quiet no-op for
+    /// requests that were never booked (e.g. aggregated requests).
+    pub async fn free(&self, request_id: &str) {
+        if let Some(InnerPrefillRouter::KvRouter(r)) = self.prefill_router.get()
+            && let Err(e) = r.chooser.free(request_id).await
+        {
+            tracing::trace!(request_id, "prefill free (likely not booked): {e}");
+        }
+    }
+
+    /// Drive cross-replica sequence sync for the prefill router's slot tracker
+    /// from an externally-supplied subscriber. No-op unless in KV mode.
+    pub fn start_replica_sync<S>(&self, subscriber: S, cancel_token: tokio_util::sync::CancellationToken)
+    where
+        S: SequenceSubscriber + 'static,
+    {
+        if let Some(InnerPrefillRouter::KvRouter(r)) = self.prefill_router.get() {
+            r.chooser.start_replica_sync(subscriber, cancel_token);
         }
     }
 

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -15,7 +15,8 @@ use dynamo_kv_router::selector::WorkerSelector as WorkerSelectorTrait;
 
 use super::metrics::ROUTER_QUEUE_METRICS;
 use super::sequence::{
-    RuntimeSequencePublisher, SequenceError, SequenceRequest, create_multi_worker_sequences,
+    RuntimeSequencePublisher, SequenceError, SequenceRequest, SequenceSubscriber,
+    create_multi_worker_sequences,
 };
 use crate::discovery::RuntimeConfigWatch;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
@@ -245,6 +246,18 @@ where
 
     pub fn register_workers(&self, worker_ids: &HashSet<WorkerId>) {
         self.inner.register_workers(worker_ids);
+    }
+
+    /// Drive cross-replica sequence sync from an externally-supplied subscriber
+    /// (see [`crate::kv_router::scheduling::LocalScheduler::start_replica_sync`]).
+    pub fn start_replica_sync<Sub>(
+        &self,
+        subscriber: Sub,
+        cancel_token: tokio_util::sync::CancellationToken,
+    ) where
+        Sub: SequenceSubscriber + 'static,
+    {
+        self.inner.start_replica_sync(subscriber, cancel_token);
     }
 
     pub async fn add_request(&self, req: SequenceRequest) -> Result<(), SequenceError> {


### PR DESCRIPTION
Stacked on top of the native-EPP implementation (#10339). Gives the EPP the standalone KV-router's cross-replica in-flight-load awareness **without NATS, the DynamoWorkerMetadata CRD, or the Dynamo runtime event plane** — using only facilities already present in a GAIE deployment.

Closes #10384.

## Commits

**1. `feat(kv-router): expose start_replica_sync for external transports`**
`start_replica_sync` forwarded through `LocalScheduler` → `KvScheduler` → `KvRouter`, letting a caller drive cross-replica active-sequence sync from an externally-supplied `SequenceSubscriber`. Event *application* (`run_replica_sync` / `apply_replica_event`) is independent of the `replica_sync` *publish* flag, so no event-plane subscriber is needed.

**2. `feat(ext-proc): runtime-free cross-replica load sync (EndpointSlice + ZMQ)`**
New `replica_sync` module:
- **Peer discovery** — reflector over the EndpointSlices of the EPP's own Service (`kubernetes.io/service-name=$DYN_EPP_REPLICA_SYNC_SERVICE`); Downward-API `POD_IP` excludes self. Mirrors the existing pod reflector.
- **Transport** — fixed-port ZMQ PUB/SUB mesh (`tmq`). Each EPP binds a PUB on `DYN_EPP_REPLICA_SYNC_PORT` (default 9100); a single SUB fans in to every peer's PUB and is rebuilt as the peer set changes.
- `ReplicaSubscriber` (impl `SequenceSubscriber`) feeds peer `ActiveSequenceEvent`s into the decode router via `KvRouter::start_replica_sync`.
- `Router::{add_request, mark_prefill_complete, free_request}` mirror this replica's own bookings to peers, tagged with the decode router's `instance_id` so peers apply them and self never re-applies.

## Config

Gated by `DYN_EPP_REPLICA_SYNC` (default off). Also reads `DYN_EPP_REPLICA_SYNC_SERVICE`, `DYN_EPP_REPLICA_SYNC_PORT` (9100), `POD_IP`, `POD_NAMESPACE`.

## v1 limitation

`AddRequest` events carry `token_sequence=None` — peers mirror in-flight request **count** per worker exactly, but approximate peer requests' token-level prefill/decode load as zero. Follow-up: carry a token count or block hashes.

## Validation

`cargo check` + `cargo clippy` clean, release binary links (built in-cluster on pinned 1.93.1). Live 2-replica convergence e2e tracked as the remaining step in #10384.
## Update — P/D disaggregation + example (this branch, on the gaie-4 stack)

Beyond cross-replica load sync, this branch now also carries the EPP-side support for **runtime-less vanilla-vLLM P/D disaggregation**:

- `/metrics` exposure of KV-router load.
- **K8s-native disagg prefill discovery** via Dynamo role labels (`nvidia.com/dynamo-component-type`), partitioning workers into prefill/decode.
- OSL (expected-output-length) plumbing into decode routing.
- **`x-prefiller-host-port` emission** — on disaggregated requests the EPP emits the selected prefill worker's dialable `host:port` (additive to the existing instance-id path), so a decode-side P/D routing sidecar runs vLLM's KV-transfer handshake for **stock `vllm serve`, no Dynamo worker**.
- `examples/vanilla-vllm-disagg/` reproducible example (prefill+decode manifests, 2P+2D scale variant, EPP launch script, functional+edge+load harness).

### Validation (real GPUs)
Stock `vllm serve` prefill+decode (NixlConnector) behind gateway+EPP: real NIXL KV transfer (decode-pod `KV Transfer metrics: Num successful transfers>0`), **no Dynamo runtime**. Scaled to 2 prefill + 2 decode (EPP discovers new workers at runtime). Comprehensive suite green — 9/9 functional+edge (short/long-multiblock/repeat-prefix/chat/unicode/stop-seq/streaming), clean 4xx on malformed/unknown-model, **200/200 under concurrency 48**, load-balanced across decode workers, prefill KV-aware selected, 0 prefill-routing failures, 0 aggregated fallbacks. The 2-replica cross-replica-sync convergence e2e also passed.

Worker-side header interop for SGLang/TRT-LLM is tracked separately (DEP-1015).

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
