### PR TITLE
fix(runtime): honor TCP stream buffer options

### DIFF
--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -39,6 +39,7 @@ use prometheus::{CounterVec, Histogram, IntCounter, IntCounterVec, IntGauge};
 
 /// Shared default maximum TCP message size across request-plane components.
 pub(crate) const DEFAULT_TCP_MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+pub(crate) const DEFAULT_STREAM_BUFFER_COUNT: usize = 64;
 
 static TCP_MAX_MESSAGE_SIZE: OnceLock<usize> = OnceLock::new();
 
@@ -364,6 +365,7 @@ pub struct ConnectionInfo {
 /// connections to the server. Internally, we may use bcast channels to coordinate the
 /// internal control messages between the sender and receiver socket connections.
 #[derive(Clone, Builder)]
+#[builder(build_fn(validate = "Self::validate"))]
 pub struct StreamOptions {
     /// Context
     pub context: Arc<dyn AsyncEngineContext>,
@@ -379,11 +381,11 @@ pub struct StreamOptions {
     pub enable_response_stream: bool,
 
     /// The number of messages to buffer before blocking
-    #[builder(default = "8")]
+    #[builder(default = "DEFAULT_STREAM_BUFFER_COUNT")]
     pub send_buffer_count: usize,
 
     /// The number of messages to buffer before blocking
-    #[builder(default = "8")]
+    #[builder(default = "DEFAULT_STREAM_BUFFER_COUNT")]
     pub recv_buffer_count: usize,
 }
 
@@ -393,13 +395,29 @@ impl StreamOptions {
     }
 }
 
+impl StreamOptionsBuilder {
+    fn validate(&self) -> Result<(), String> {
+        if matches!(self.send_buffer_count, Some(0)) {
+            return Err("send_buffer_count must be greater than zero".to_string());
+        }
+        if matches!(self.recv_buffer_count, Some(0)) {
+            return Err("recv_buffer_count must be greater than zero".to_string());
+        }
+        Ok(())
+    }
+}
+
 pub struct Egress<Req: PipelineIO, Resp: PipelineIO> {
     transport_engine: Arc<dyn AsyncTransportEngine<Req, Resp>>,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RequestControlMessage, RequestType, ResponseType};
+    use super::{
+        DEFAULT_STREAM_BUFFER_COUNT, RequestControlMessage, RequestType, ResponseType,
+        StreamOptions,
+    };
+    use crate::pipeline::Context;
 
     #[test]
     fn request_control_message_defaults_missing_metadata() {
@@ -423,6 +441,45 @@ mod tests {
         assert_eq!(message.connection_info.info, "{}");
         assert!(message.metadata.is_empty());
         assert!(message.frontend_send_ts_ns.is_none());
+    }
+
+    #[test]
+    fn stream_options_default_to_legacy_buffer_count() {
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(true)
+            .enable_response_stream(true)
+            .build()
+            .unwrap();
+
+        assert_eq!(options.send_buffer_count, DEFAULT_STREAM_BUFFER_COUNT);
+        assert_eq!(options.recv_buffer_count, DEFAULT_STREAM_BUFFER_COUNT);
+    }
+
+    #[test]
+    fn stream_options_reject_zero_buffer_counts() {
+        let context = Context::new(());
+        let err = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(true)
+            .enable_response_stream(true)
+            .send_buffer_count(0)
+            .build()
+            .err()
+            .expect("zero send buffer count should be rejected");
+        assert!(err.to_string().contains("send_buffer_count"));
+
+        let context = Context::new(());
+        let err = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(true)
+            .enable_response_stream(true)
+            .recv_buffer_count(0)
+            .build()
+            .err()
+            .expect("zero receive buffer count should be rejected");
+        assert!(err.to_string().contains("recv_buffer_count"));
     }
 }
 

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -447,7 +447,7 @@ mod tests {
     fn stream_options_default_to_legacy_buffer_count() {
         let context = Context::new(());
         let options = StreamOptions::builder()
-            .context(context.context())
+            .context(context.content())
             .enable_request_stream(true)
             .enable_response_stream(true)
             .build()
@@ -461,7 +461,7 @@ mod tests {
     fn stream_options_reject_zero_buffer_counts() {
         let context = Context::new(());
         let err = StreamOptions::builder()
-            .context(context.context())
+            .context(context.content())
             .enable_request_stream(true)
             .enable_response_stream(true)
             .send_buffer_count(0)
@@ -472,7 +472,7 @@ mod tests {
 
         let context = Context::new(());
         let err = StreamOptions::builder()
-            .context(context.context())
+            .context(context.content())
             .enable_request_stream(true)
             .enable_response_stream(true)
             .recv_buffer_count(0)

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -417,6 +417,7 @@ mod tests {
         DEFAULT_STREAM_BUFFER_COUNT, RequestControlMessage, RequestType, ResponseType,
         StreamOptions,
     };
+    use crate::engine::AsyncEngineContextProvider;
     use crate::pipeline::Context;
 
     #[test]
@@ -447,7 +448,7 @@ mod tests {
     fn stream_options_default_to_legacy_buffer_count() {
         let context = Context::new(());
         let options = StreamOptions::builder()
-            .context(context.content())
+            .context(context.context())
             .enable_request_stream(true)
             .enable_response_stream(true)
             .build()
@@ -461,7 +462,7 @@ mod tests {
     fn stream_options_reject_zero_buffer_counts() {
         let context = Context::new(());
         let err = StreamOptions::builder()
-            .context(context.content())
+            .context(context.context())
             .enable_request_stream(true)
             .enable_response_stream(true)
             .send_buffer_count(0)
@@ -472,7 +473,7 @@ mod tests {
 
         let context = Context::new(());
         let err = StreamOptions::builder()
-            .context(context.content())
+            .context(context.context())
             .enable_request_stream(true)
             .enable_response_stream(true)
             .recv_buffer_count(0)

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -494,6 +494,18 @@ impl ResponseService for TcpStreamServer {
     }
 }
 
+fn stream_channel<T>(
+    buffer_count: usize,
+    stream_kind: &str,
+) -> Result<(mpsc::Sender<T>, mpsc::Receiver<T>)> {
+    if buffer_count == 0 {
+        return Err(error!(
+            "{stream_kind} stream buffer count must be greater than zero"
+        ));
+    }
+    Ok(mpsc::channel(buffer_count))
+}
+
 // this method listens on a tcp port for incoming connections
 // new connections are expected to send a protocol specific handshake
 // for us to determine the subject they are interested in, in this case,
@@ -659,7 +671,7 @@ async fn tcp_listener(
             buffer_count,
         } = request_stream;
 
-        let (request_tx, request_rx) = mpsc::channel(buffer_count);
+        let (request_tx, request_rx) = stream_channel(buffer_count, "request")?;
 
         if connection
             .send(Ok(crate::pipeline::network::StreamSender {
@@ -811,7 +823,7 @@ async fn tcp_listener(
             return Err(error!("Received error prologue: {}", error));
         }
 
-        let (response_tx, response_rx) = mpsc::channel(buffer_count);
+        let (response_tx, response_rx) = stream_channel(buffer_count, "response")?;
 
         if connection
             .send(Ok(crate::pipeline::network::StreamReceiver {
@@ -1740,10 +1752,16 @@ mod tests {
     type TestFramedWrite = FramedWrite<WriteHalf<TcpStream>, TwoPartCodec>;
     type TestResponseStream = (TestFramedRead, TestFramedWrite, StreamReceiver);
 
+    async fn open_registered_response_stream() -> TestResponseStream {
+        open_registered_response_stream_with_buffer_count(64).await
+    }
+
     /// Stand up a TcpStreamServer, register a response stream, connect a
     /// client, drive the handshake + prologue, and return the client-side
     /// framed reader/writer along with the receiver.
-    async fn open_registered_response_stream() -> TestResponseStream {
+    async fn open_registered_response_stream_with_buffer_count(
+        recv_buffer_count: usize,
+    ) -> TestResponseStream {
         let options = ServerOptions::builder().port(0).build().unwrap();
         let server = TcpStreamServer::new_with_resolver(options, FailingIpResolver)
             .await
@@ -1753,6 +1771,7 @@ mod tests {
             .context(context.context())
             .enable_request_stream(false)
             .enable_response_stream(true)
+            .recv_buffer_count(recv_buffer_count)
             .build()
             .unwrap();
         let pending_connection = server.register(stream_options).await;
@@ -1793,6 +1812,14 @@ mod tests {
             .expect("response stream should be accepted");
 
         (framed_reader, framed_writer, receiver)
+    }
+
+    #[tokio::test]
+    async fn test_response_stream_uses_registered_buffer_count() {
+        let (_framed_reader, _framed_writer, receiver) =
+            open_registered_response_stream_with_buffer_count(5).await;
+
+        assert_eq!(receiver.rx.max_capacity(), 5);
     }
 
     async fn recv_control_message(framed_reader: &mut TestFramedRead) -> ControlMessage {
@@ -1952,11 +1979,23 @@ mod tests {
         super::StreamSender,
         Arc<dyn AsyncEngineContext>,
     ) {
+        register_and_dial_request_stream_with_buffer_count(server, 64).await
+    }
+
+    async fn register_and_dial_request_stream_with_buffer_count(
+        server: &TcpStreamServer,
+        send_buffer_count: usize,
+    ) -> (
+        FramedRead<tokio::io::ReadHalf<TcpStream>, TwoPartCodec>,
+        super::StreamSender,
+        Arc<dyn AsyncEngineContext>,
+    ) {
         let upstream_ctx = Context::new(()).context();
         let options = StreamOptions::builder()
             .context(upstream_ctx.clone())
             .enable_request_stream(true)
             .enable_response_stream(false)
+            .send_buffer_count(send_buffer_count)
             .build()
             .unwrap();
 
@@ -1983,6 +2022,15 @@ mod tests {
 
         let sender = send_provider.await.unwrap().unwrap();
         (framed_reader, sender, upstream_ctx)
+    }
+
+    #[tokio::test]
+    async fn test_request_stream_uses_registered_buffer_count() {
+        let server = test_server().await;
+        let (_reader, sender, _ctx) =
+            register_and_dial_request_stream_with_buffer_count(&server, 3).await;
+
+        assert_eq!(sender.tx.max_capacity(), 3);
     }
 
     /// Pull frames off the raw client reader until the first `ControlMessage`

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -103,11 +103,13 @@ pub struct TcpStreamServer {
 struct RequestedSendConnection {
     context: Arc<dyn AsyncEngineContext>,
     connection: oneshot::Sender<Result<StreamSender, String>>,
+    buffer_count: usize,
 }
 
 struct RequestedRecvConnection {
     context: Arc<dyn AsyncEngineContext>,
     connection: oneshot::Sender<Result<StreamReceiver, String>>,
+    buffer_count: usize,
 }
 
 // /// When registering a new TcpStream on the server, the registration method will return a [`Connections`] object.
@@ -396,6 +398,7 @@ impl ResponseService for TcpStreamServer {
             let connection_info = RequestedSendConnection {
                 context: options.context.clone(),
                 connection: pending_sender_tx,
+                buffer_count: options.send_buffer_count,
             };
 
             let mut state = self.state.lock().await;
@@ -443,6 +446,7 @@ impl ResponseService for TcpStreamServer {
             let connection_info = RequestedRecvConnection {
                 context: options.context.clone(),
                 connection: pending_recver_tx,
+                buffer_count: options.recv_buffer_count,
             };
 
             let mut state = self.state.lock().await;
@@ -652,11 +656,10 @@ async fn tcp_listener(
         let RequestedSendConnection {
             context,
             connection,
+            buffer_count,
         } = request_stream;
 
-        // Buffer size matches `process_response_stream`; both should be driven
-        // by the registration options rather than hard-coded. See #10293.
-        let (request_tx, request_rx) = mpsc::channel(64);
+        let (request_tx, request_rx) = mpsc::channel(buffer_count);
 
         if connection
             .send(Ok(crate::pipeline::network::StreamSender {
@@ -769,6 +772,7 @@ async fn tcp_listener(
         let RequestedRecvConnection {
             context,
             connection,
+            buffer_count,
         } = response_stream;
 
         // the [`Prologue`]
@@ -807,9 +811,7 @@ async fn tcp_listener(
             return Err(error!("Received error prologue: {}", error));
         }
 
-        // Buffer size should be driven by the registration options rather than
-        // hard-coded; the same applies to `process_request_stream`. See #10293.
-        let (response_tx, response_rx) = mpsc::channel(64);
+        let (response_tx, response_rx) = mpsc::channel(buffer_count);
 
         if connection
             .send(Ok(crate::pipeline::network::StreamReceiver {
@@ -1139,6 +1141,56 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_register_records_stream_buffer_counts() {
+        let server = test_server().await;
+        let context = Context::new(());
+        let options = StreamOptions::builder()
+            .context(context.context())
+            .enable_request_stream(true)
+            .enable_response_stream(true)
+            .send_buffer_count(3)
+            .recv_buffer_count(5)
+            .build()
+            .unwrap();
+
+        let pending = server.register(options).await;
+        let send_info: TcpStreamConnectionInfo = pending
+            .send_stream
+            .as_ref()
+            .unwrap()
+            .connection_info
+            .clone()
+            .try_into()
+            .unwrap();
+        let recv_info: TcpStreamConnectionInfo = pending
+            .recv_stream
+            .as_ref()
+            .unwrap()
+            .connection_info
+            .clone()
+            .try_into()
+            .unwrap();
+
+        let state = server.state.lock().await;
+        assert_eq!(
+            state
+                .tx_subjects
+                .get(&send_info.subject)
+                .expect("request stream should be registered")
+                .buffer_count,
+            3
+        );
+        assert_eq!(
+            state
+                .rx_subjects
+                .get(&recv_info.subject)
+                .expect("response stream should be registered")
+                .buffer_count,
+            5
+        );
     }
 
     /// Helper: register a response stream and extract its subject string.


### PR DESCRIPTION
## Summary
- carry `StreamOptions` buffer counts through TCP stream registration
- use the registered request/response buffer counts when creating data-plane mpsc channels
- cover the registration plumbing for both request and response stream buffers

Fixes #10293

## Tests
- `rustfmt --edition 2024 --check lib/runtime/src/pipeline/network/tcp/server.rs`
- `cargo test -p dynamo-runtime pipeline::network::tcp::server::tests::test_register_records_stream_buffer_counts -- --nocapture`
- `cargo test -p dynamo-runtime pipeline::network::tcp::server::tests -- --nocapture`
- `cargo test -p dynamo-runtime pipeline::network::tcp -- --nocapture`
- `git diff --no-index --check <upstream server.rs> lib/runtime/src/pipeline/network/tcp/server.rs`

Note: the first cargo test attempt failed before building this crate because `protoc` was not installed locally for the `etcd-client` build script. I installed `protobuf` via Homebrew, then the targeted and broader TCP tests passed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TCP server now supports configurable per-stream buffer counts for both request and response traffic, allowing fine-tuned performance optimization instead of using fixed buffer sizes.

* **Tests**
  * Added test coverage to verify per-stream buffer configuration is correctly stored and applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->