### PR TITLE
fix(kv-router): stop waking idle metrics publisher

### DIFF
--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::time::Duration;
 
 use dynamo_kv_router::protocols::{ActiveLoad, DpRank};
 use dynamo_runtime::component::{Component, Namespace};
@@ -74,57 +75,47 @@ impl WorkerMetricsPublisher {
                 };
 
             let mut rx = nats_rx;
-            let mut last_metrics: Option<WorkerMetrics> = None;
-            let mut pending_publish: Option<WorkerMetrics> = None;
-            let mut publish_deadline: Option<tokio::time::Instant> = None;
+            let mut last_published: Option<WorkerMetrics> = None;
 
             loop {
-                let publish_ready = async move {
-                    if let Some(deadline) = publish_deadline {
-                        tokio::time::sleep_until(deadline).await;
-                    } else {
-                        std::future::pending::<()>().await;
-                    }
-                };
+                if rx.changed().await.is_err() {
+                    tracing::debug!(
+                        "Metrics publisher sender dropped, stopping NATS background task"
+                    );
+                    break;
+                }
 
-                tokio::select! {
-                    result = rx.changed() => {
-                        if result.is_err() {
+                let mut metrics = rx.borrow_and_update().clone();
+
+                loop {
+                    match tokio::time::timeout(Duration::from_millis(1), rx.changed()).await {
+                        Ok(Ok(())) => metrics = rx.borrow_and_update().clone(),
+                        Ok(Err(_)) => {
                             tracing::debug!(
                                 "Metrics publisher sender dropped, stopping NATS background task"
                             );
-                            break;
+                            return;
                         }
-
-                        let metrics = rx.borrow_and_update().clone();
-                        let has_changed = last_metrics.as_ref() != Some(&metrics);
-
-                        if has_changed {
-                            pending_publish = Some(metrics.clone());
-                            last_metrics = Some(metrics);
-                            publish_deadline = Some(
-                                tokio::time::Instant::now()
-                                    + tokio::time::Duration::from_millis(1),
-                            );
-                        }
-                    }
-                    _ = publish_ready => {
-                        publish_deadline = None;
-                        if let Some(metrics) = pending_publish.take() {
-                            let active_load = ActiveLoad {
-                                worker_id,
-                                dp_rank: metrics.dp_rank,
-                                active_decode_blocks: metrics.active_decode_blocks,
-                                active_prefill_tokens: None,
-                                kv_used_blocks: metrics.kv_used_blocks,
-                            };
-
-                            if let Err(e) = event_publisher.publish(&active_load).await {
-                                tracing::warn!("Failed to publish metrics: {}", e);
-                            }
-                        }
+                        Err(_) => break,
                     }
                 }
+
+                if last_published.as_ref() == Some(&metrics) {
+                    continue;
+                }
+
+                let active_load = ActiveLoad {
+                    worker_id,
+                    dp_rank: metrics.dp_rank,
+                    active_decode_blocks: metrics.active_decode_blocks,
+                    active_prefill_tokens: None,
+                    kv_used_blocks: metrics.kv_used_blocks,
+                };
+
+                if let Err(e) = event_publisher.publish(&active_load).await {
+                    tracing::warn!("Failed to publish metrics: {}", e);
+                }
+                last_published = Some(metrics);
             }
         });
     }

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use std::time::Duration;
 
 use dynamo_kv_router::protocols::{ActiveLoad, DpRank};
 use dynamo_runtime::component::{Component, Namespace};
@@ -75,47 +74,57 @@ impl WorkerMetricsPublisher {
                 };
 
             let mut rx = nats_rx;
-            let mut last_published: Option<WorkerMetrics> = None;
+            let mut last_metrics: Option<WorkerMetrics> = None;
+            let mut pending_publish: Option<WorkerMetrics> = None;
+            let mut publish_deadline: Option<tokio::time::Instant> = None;
 
             loop {
-                if rx.changed().await.is_err() {
-                    tracing::debug!(
-                        "Metrics publisher sender dropped, stopping NATS background task"
-                    );
-                    break;
-                }
+                let publish_ready = async move {
+                    if let Some(deadline) = publish_deadline {
+                        tokio::time::sleep_until(deadline).await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                };
 
-                let mut metrics = rx.borrow_and_update().clone();
-
-                loop {
-                    match tokio::time::timeout(Duration::from_millis(1), rx.changed()).await {
-                        Ok(Ok(())) => metrics = rx.borrow_and_update().clone(),
-                        Ok(Err(_)) => {
+                tokio::select! {
+                    result = rx.changed() => {
+                        if result.is_err() {
                             tracing::debug!(
                                 "Metrics publisher sender dropped, stopping NATS background task"
                             );
-                            return;
+                            break;
                         }
-                        Err(_) => break,
+
+                        let metrics = rx.borrow_and_update().clone();
+                        let has_changed = last_metrics.as_ref() != Some(&metrics);
+
+                        if has_changed {
+                            pending_publish = Some(metrics.clone());
+                            last_metrics = Some(metrics);
+                            publish_deadline = Some(
+                                tokio::time::Instant::now()
+                                    + tokio::time::Duration::from_millis(1),
+                            );
+                        }
+                    }
+                    _ = publish_ready => {
+                        publish_deadline = None;
+                        if let Some(metrics) = pending_publish.take() {
+                            let active_load = ActiveLoad {
+                                worker_id,
+                                dp_rank: metrics.dp_rank,
+                                active_decode_blocks: metrics.active_decode_blocks,
+                                active_prefill_tokens: None,
+                                kv_used_blocks: metrics.kv_used_blocks,
+                            };
+
+                            if let Err(e) = event_publisher.publish(&active_load).await {
+                                tracing::warn!("Failed to publish metrics: {}", e);
+                            }
+                        }
                     }
                 }
-
-                if last_published.as_ref() == Some(&metrics) {
-                    continue;
-                }
-
-                let active_load = ActiveLoad {
-                    worker_id,
-                    dp_rank: metrics.dp_rank,
-                    active_decode_blocks: metrics.active_decode_blocks,
-                    active_prefill_tokens: None,
-                    kv_used_blocks: metrics.kv_used_blocks,
-                };
-
-                if let Err(e) = event_publisher.publish(&active_load).await {
-                    tracing::warn!("Failed to publish metrics: {}", e);
-                }
-                last_published = Some(metrics);
             }
         });
     }

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -76,11 +76,17 @@ impl WorkerMetricsPublisher {
             let mut rx = nats_rx;
             let mut last_metrics: Option<WorkerMetrics> = None;
             let mut pending_publish: Option<WorkerMetrics> = None;
-            let mut publish_timer =
-                Box::pin(tokio::time::sleep(tokio::time::Duration::from_secs(0)));
-            publish_timer.as_mut().reset(tokio::time::Instant::now());
+            let mut publish_deadline: Option<tokio::time::Instant> = None;
 
             loop {
+                let publish_ready = async move {
+                    if let Some(deadline) = publish_deadline {
+                        tokio::time::sleep_until(deadline).await;
+                    } else {
+                        std::future::pending::<()>().await;
+                    }
+                };
+
                 tokio::select! {
                     result = rx.changed() => {
                         if result.is_err() {
@@ -96,13 +102,14 @@ impl WorkerMetricsPublisher {
                         if has_changed {
                             pending_publish = Some(metrics.clone());
                             last_metrics = Some(metrics);
-                            publish_timer.as_mut().reset(
+                            publish_deadline = Some(
                                 tokio::time::Instant::now()
-                                    + tokio::time::Duration::from_millis(1)
+                                    + tokio::time::Duration::from_millis(1),
                             );
                         }
                     }
-                    _ = &mut publish_timer => {
+                    _ = publish_ready => {
+                        publish_deadline = None;
                         if let Some(metrics) = pending_publish.take() {
                             let active_load = ActiveLoad {
                                 worker_id,
@@ -116,11 +123,6 @@ impl WorkerMetricsPublisher {
                                 tracing::warn!("Failed to publish metrics: {}", e);
                             }
                         }
-
-                        publish_timer.as_mut().reset(
-                            tokio::time::Instant::now()
-                                + tokio::time::Duration::from_secs(3600)
-                        );
                     }
                 }
             }

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -76,17 +76,10 @@ impl WorkerMetricsPublisher {
             let mut rx = nats_rx;
             let mut last_metrics: Option<WorkerMetrics> = None;
             let mut pending_publish: Option<WorkerMetrics> = None;
-            let mut publish_deadline: Option<tokio::time::Instant> = None;
+            let publish_timer = tokio::time::sleep(tokio::time::Duration::ZERO);
+            tokio::pin!(publish_timer);
 
             loop {
-                let publish_ready = async move {
-                    if let Some(deadline) = publish_deadline {
-                        tokio::time::sleep_until(deadline).await;
-                    } else {
-                        std::future::pending::<()>().await;
-                    }
-                };
-
                 tokio::select! {
                     result = rx.changed() => {
                         if result.is_err() {
@@ -102,14 +95,13 @@ impl WorkerMetricsPublisher {
                         if has_changed {
                             pending_publish = Some(metrics.clone());
                             last_metrics = Some(metrics);
-                            publish_deadline = Some(
+                            publish_timer.as_mut().reset(
                                 tokio::time::Instant::now()
-                                    + tokio::time::Duration::from_millis(1),
+                                    + tokio::time::Duration::from_millis(1)
                             );
                         }
                     }
-                    _ = publish_ready => {
-                        publish_deadline = None;
+                    _ = &mut publish_timer, if pending_publish.is_some() => {
                         if let Some(metrics) = pending_publish.take() {
                             let active_load = ActiveLoad {
                                 worker_id,

--- a/lib/llm/src/kv_router/publisher/worker_metrics.rs
+++ b/lib/llm/src/kv_router/publisher/worker_metrics.rs
@@ -90,16 +90,16 @@ impl WorkerMetricsPublisher {
                         }
 
                         let metrics = rx.borrow_and_update().clone();
-                        let has_changed = last_metrics.as_ref() != Some(&metrics);
-
-                        if has_changed {
-                            pending_publish = Some(metrics.clone());
-                            last_metrics = Some(metrics);
-                            publish_timer.as_mut().reset(
-                                tokio::time::Instant::now()
-                                    + tokio::time::Duration::from_millis(1)
-                            );
+                        if last_metrics.as_ref() == Some(&metrics) {
+                            continue;
                         }
+
+                        pending_publish = Some(metrics.clone());
+                        last_metrics = Some(metrics);
+                        publish_timer.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + tokio::time::Duration::from_millis(1)
+                        );
                     }
                     _ = &mut publish_timer, if pending_publish.is_some() => {
                         if let Some(metrics) = pending_publish.take() {


### PR DESCRIPTION
Remove the ineffective hourly timer from `WorkerMetricsPublisher` while preserving its resettable 1 ms debounce for changed metrics. The previous idle wakeup had no pending value to publish and only rearmed itself.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains an internal technical improvement to metrics publishing infrastructure with no user-facing changes.

* **Refactor**
  * Optimized metrics publishing mechanism for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->