### PR TITLE
feat(kv-router): add standalone slot-tracker replica sync

### DIFF
--- a/docs/components/router/standalone-slot-tracker.md
+++ b/docs/components/router/standalone-slot-tracker.md
@@ -16,8 +16,9 @@ The service accepts ordered final chained sequence hashes, one hash per prompt b
 Hashes are serialized as signed 64-bit JSON integers and reinterpreted bit-for-bit as internal
 unsigned hashes. Send hashes rather than prompt tokens.
 
-This first version intentionally excludes metrics, discovery-based registration, output
-block updates, replica synchronization, persistence, and peer recovery.
+The service optionally replicates lifecycle events directly between slot-tracker processes
+over ZMQ. It still excludes metrics, discovery-based worker registration, output block
+updates, persistence, and peer recovery.
 
 ## Build And Launch
 
@@ -34,6 +35,16 @@ Launch the service:
 .venv/bin/python -m dynamo.slot_tracker --port 8091
 ```
 
+Enable replica synchronization:
+
+```bash
+.venv/bin/python -m dynamo.slot_tracker \
+  --port 8091 \
+  --replica-sync-bind 'tcp://*:8092' \
+  --replica-sync-advertise 'tcp://slot-tracker-a:8092' \
+  --replica-sync-peers 'tcp://slot-tracker-b:8092'
+```
+
 The default port is `8091`. `GET /health` returns `200 OK` with an empty body as soon as
 the HTTP listener is ready. This endpoint is liveness-only. After a restart the registry
 is empty; consumers must re-register workers and replay active requests if they need
@@ -41,6 +52,40 @@ restored accounting.
 
 The service binds to `0.0.0.0` and does not provide authentication. Run it on a trusted
 internal network or place it behind an appropriate network policy.
+
+## Replica Synchronization
+
+`--replica-sync-bind` enables a ZMQ PUB endpoint and replica-event consumption. The
+service generates an ephemeral process identity internally; it is not a configuration
+parameter. `--replica-sync-advertise` is the externally reachable form of the local
+endpoint and prevents exact self-registration. `--replica-sync-peers` accepts a
+comma-separated list of peer PUB endpoints.
+
+Peer connections are directional. For bidirectional synchronization, configure each
+replica with the other replica's advertised endpoint. All replicas must independently
+receive the same worker registrations before lifecycle traffic begins. A replica event
+for an unknown `(model_name, tenant_id)`, block size, worker ID, or DP rank is dropped.
+Replica traffic never creates workers.
+
+The transport is bounded and best-effort. A full queue drops new events rather than
+blocking HTTP operations, and ZMQ subscription setup may lose events sent immediately
+after peer registration. There is no acknowledgement, replay, snapshot, or gap recovery.
+`/add`, `/prefill_complete`, and `/free` should normally remain sticky to the replica
+that accepted `/add`; replica synchronization provides advisory peer state rather than
+cross-replica lifecycle ownership.
+
+Peers may also be managed dynamically:
+
+```http
+POST /register_peer
+Content-Type: application/json
+
+{"url":"tcp://slot-tracker-b:8092"}
+```
+
+The same body is accepted by `POST /deregister_peer`. `GET /peers` returns the sorted
+configured endpoints. Registration confirms that the endpoint was accepted by the local
+SUB socket, not that the asynchronous ZMQ subscription handshake has completed.
 
 ## Common Responses
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -119,6 +119,18 @@ struct SlotTrackerCli {
     /// HTTP server port
     #[arg(long, default_value_t = 8091)]
     port: u16,
+
+    /// ZMQ PUB endpoint for replica-sync events
+    #[arg(long)]
+    replica_sync_bind: Option<String>,
+
+    /// Externally reachable local replica-sync endpoint
+    #[arg(long)]
+    replica_sync_advertise: Option<String>,
+
+    /// Comma-separated ZMQ PUB endpoints for peer slot trackers
+    #[arg(long, value_delimiter = ',')]
+    replica_sync_peers: Vec<String>,
 }
 
 pub fn run_slot_tracker_cli<I, T>(args: I) -> anyhow::Result<()>
@@ -138,6 +150,9 @@ where
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(slot_tracker::run_server(SlotTrackerConfig {
             port: cli.port,
+            replica_sync_bind: cli.replica_sync_bind,
+            replica_sync_advertise: cli.replica_sync_advertise,
+            replica_sync_peers: cli.replica_sync_peers,
         }))
     }
 

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -20,7 +20,7 @@ bench = []
 profile = []
 shard-metrics = []
 standalone-indexer = ["dep:axum", "dep:serde_json", "dep:reqwest", "dep:zmq"]
-standalone-slot-tracker = ["dep:axum", "dep:serde_json"]
+standalone-slot-tracker = ["dep:axum", "dep:serde_json", "dep:zmq"]
 
 [dependencies]
 # repo

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -35,8 +35,8 @@ pub mod test_utils;
 
 // Re-export key types for convenience
 pub use self::multi_worker_sequence::{
-    ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
-    SequenceSubscriber,
+    ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequenceError, SequencePublisher,
+    SequenceRequest, SequenceSubscriber,
 };
 pub use self::sequence::{ActiveSequences, RequestId};
 pub use self::sequences::PrefillTokenDeltas;

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -21,6 +21,7 @@ use super::types::{
 };
 use crate::protocols::RoutingConstraints;
 use crate::protocols::{LocalBlockHash, WorkerConfigLike, WorkerId, WorkerWithDpRank};
+use crate::sequences::topology::WorkerDpRange;
 use crate::sequences::{
     ActiveSequencesMultiWorker, PrefillTokenDeltas, SequenceError, SequencePublisher,
     SequenceRequest,
@@ -55,14 +56,11 @@ where
     Sel: WorkerSelector<C> + Send + Sync + 'static,
     RF: OverlapScoresRefresh + 'static,
 {
-    fn worker_dp_range(workers: &HashMap<WorkerId, C>) -> HashMap<WorkerId, (u32, u32)> {
+    fn worker_dp_ranges(workers: &HashMap<WorkerId, C>) -> Vec<WorkerDpRange> {
         workers
             .iter()
             .map(|(&id, cfg)| {
-                (
-                    id,
-                    (cfg.data_parallel_start_rank(), cfg.data_parallel_size()),
-                )
+                WorkerDpRange::new(id, cfg.data_parallel_start_rank(), cfg.data_parallel_size())
             })
             .collect()
     }
@@ -113,8 +111,11 @@ where
                         continue;
                     }
 
-                    let dp_range = Self::worker_dp_range(&current_workers);
-                    slots_monitor.update_workers(&dp_range);
+                    let dp_ranges = Self::worker_dp_ranges(&current_workers);
+                    if let Err(error) = slots_monitor.reconcile_workers(dp_ranges) {
+                        tracing::error!(%error, "Invalid worker topology update");
+                        continue;
+                    }
                     last_workers = current_workers;
                 }
             });

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -27,6 +27,7 @@ use super::types::{
 use crate::protocols::{
     LocalBlockHash, PrefillLoadHint, RouterBackpressureReason, WorkerConfigLike, WorkerId,
 };
+use crate::sequences::topology::WorkerDpRange;
 use crate::sequences::{ActiveSequencesMultiWorker, SequencePublisher, SequenceRequest};
 
 /// Large default for max_num_batched_tokens when not configured (effectively disables queueing for that worker)
@@ -273,22 +274,21 @@ impl<
     /// `(0, 1)` for workers not yet known to discovery.
     pub fn register_workers(&self, worker_ids: &std::collections::HashSet<u64>) {
         let discovery_workers = self.workers_with_configs.borrow();
-        let dp_range: std::collections::HashMap<u64, (u32, u32)> = worker_ids
-            .iter()
-            .map(|&id| {
-                let (dp_start, dp_size) = discovery_workers
-                    .get(&id)
-                    .map(|runtime_config| {
-                        (
-                            runtime_config.data_parallel_start_rank(),
-                            runtime_config.data_parallel_size(),
-                        )
-                    })
-                    .unwrap_or((0, 1));
-                (id, (dp_start, dp_size))
-            })
-            .collect();
-        self.slots.register_external_workers(&dp_range);
+        for &worker_id in worker_ids {
+            let (dp_start, dp_size) = discovery_workers
+                .get(&worker_id)
+                .map(|runtime_config| {
+                    (
+                        runtime_config.data_parallel_start_rank(),
+                        runtime_config.data_parallel_size(),
+                    )
+                })
+                .unwrap_or((0, 1));
+            let range = WorkerDpRange::new(worker_id, dp_start, dp_size);
+            if let Err(error) = self.slots.upsert_worker(range) {
+                tracing::warn!(worker_id, %error, "Invalid externally-provided worker topology");
+            }
+        }
     }
 
     /// Enqueue a new request.
@@ -1722,10 +1722,8 @@ mod tests {
         );
 
         // Lazily register two workers in the slot tracker (EPP supplies pod list)
-        let mut dp_range = std::collections::HashMap::new();
-        dp_range.insert(100_u64, (0_u32, 1_u32));
-        dp_range.insert(200_u64, (0_u32, 1_u32));
-        slots.register_external_workers(&dp_range);
+        slots.upsert_worker(WorkerDpRange::new(100, 0, 1)).unwrap();
+        slots.upsert_worker(WorkerDpRange::new(200, 0, 1)).unwrap();
 
         // Also update the config watch so the selector can see these workers
         let mut configs = HashMap::new();
@@ -1771,9 +1769,7 @@ mod tests {
         let (queue, slots, cfg_tx) = make_queue_with_sender(0, block_size, isl, None, None);
 
         // Register worker 10 in slots and config
-        let mut dp1 = std::collections::HashMap::new();
-        dp1.insert(10_u64, (0_u32, 1_u32));
-        slots.register_external_workers(&dp1);
+        slots.upsert_worker(WorkerDpRange::new(10, 0, 1)).unwrap();
 
         let mut configs = HashMap::new();
         configs.insert(
@@ -1786,9 +1782,7 @@ mod tests {
         cfg_tx.send(configs.clone()).unwrap();
 
         // Register worker 20 (worker 10 must NOT be evicted)
-        let mut dp2 = std::collections::HashMap::new();
-        dp2.insert(20_u64, (0_u32, 1_u32));
-        slots.register_external_workers(&dp2);
+        slots.upsert_worker(WorkerDpRange::new(20, 0, 1)).unwrap();
 
         configs.insert(
             20_u64,
@@ -1829,11 +1823,11 @@ mod tests {
         let (queue, slots, cfg_tx) = make_queue_with_sender(0, block_size, isl, None, None);
 
         // Register three workers
-        let mut dp = std::collections::HashMap::new();
-        dp.insert(1_u64, (0_u32, 1_u32));
-        dp.insert(2_u64, (0_u32, 1_u32));
-        dp.insert(3_u64, (0_u32, 1_u32));
-        slots.register_external_workers(&dp);
+        for worker_id in 1..=3 {
+            slots
+                .upsert_worker(WorkerDpRange::new(worker_id, 0, 1))
+                .unwrap();
+        }
 
         let mut configs = HashMap::new();
         for &id in &[1_u64, 2_u64, 3_u64] {

--- a/lib/kv-router/src/sequences/mod.rs
+++ b/lib/kv-router/src/sequences/mod.rs
@@ -9,7 +9,7 @@ mod prompt_registry;
 mod replica_sync;
 mod request_maps;
 pub mod single;
-mod topology;
+pub mod topology;
 
 pub use multi_worker::*;
 pub use prefill_tracker::PrefillTokenDeltas;

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -95,6 +95,15 @@ pub trait SequenceSubscriber: Send {
 // Types
 // ---------------------------------------------------------------------------
 
+/// Controls how replica-sync events handle workers missing from local topology.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicaWorkerPolicy {
+    /// Preserve the legacy router behavior by creating the exact missing worker rank.
+    LazyRegister,
+    /// Drop replica events until the worker rank has been registered locally.
+    RequireRegistered,
+}
+
 /// Errors that can occur during sequence management operations.
 #[derive(Debug, thiserror::Error)]
 pub enum SequenceError {
@@ -145,6 +154,7 @@ pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
     #[cfg(test)]
     remote_state_update_count: AtomicUsize,
     replica_sync: bool,
+    pub(super) replica_worker_policy: ReplicaWorkerPolicy,
     worker_type: &'static str,
 }
 
@@ -159,6 +169,27 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         replica_sync: bool,
         router_id: u64,
         worker_type: &'static str,
+    ) -> Self {
+        Self::new_with_replica_worker_policy(
+            publisher,
+            block_size,
+            dp_range,
+            replica_sync,
+            router_id,
+            worker_type,
+            ReplicaWorkerPolicy::LazyRegister,
+        )
+    }
+
+    /// Create a tracker with an explicit worker-admission policy for replica events.
+    pub fn new_with_replica_worker_policy(
+        publisher: P,
+        block_size: usize,
+        dp_range: HashMap<u64, (u32, u32)>,
+        replica_sync: bool,
+        router_id: u64,
+        worker_type: &'static str,
+        replica_worker_policy: ReplicaWorkerPolicy,
     ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
         let (remote_state_updates, _) = watch::channel(());
@@ -176,6 +207,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             #[cfg(test)]
             remote_state_update_count: AtomicUsize::new(0),
             replica_sync,
+            replica_worker_policy,
             worker_type,
         }
     }
@@ -2128,6 +2160,68 @@ mod tests {
         );
         assert!(!sequences.prompt_registry.is_block_index_empty());
         assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(3));
+    }
+
+    #[tokio::test]
+    async fn replica_sync_require_registered_drops_missing_worker() {
+        let sequences = ActiveSequencesMultiWorker::new_with_replica_worker_policy(
+            NoopSequencePublisher,
+            4,
+            HashMap::new(),
+            true,
+            0,
+            "test",
+            ReplicaWorkerPolicy::RequireRegistered,
+        );
+        let worker = WorkerWithDpRank::new(1, 0);
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(replica_add("req-1", worker, vec![1, 2, 3]))]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(sequences.num_workers(), 0);
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-1".to_string()),
+            None
+        );
+        assert!(sequences.prompt_registry.is_block_index_empty());
+    }
+
+    #[tokio::test]
+    async fn replica_sync_require_registered_drops_event_after_worker_removal() {
+        let sequences = ActiveSequencesMultiWorker::new_with_replica_worker_policy(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+            ReplicaWorkerPolicy::RequireRegistered,
+        );
+        let worker = WorkerWithDpRank::new(1, 0);
+        sequences.update_workers(&HashMap::new());
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(replica_add("req-1", worker, vec![1, 2, 3]))]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(sequences.num_workers(), 0);
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-1".to_string()),
+            None
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -29,9 +29,10 @@ use super::prompt_membership_trie::lookup_live_hashes;
 use super::prompt_registry::{PromptRegistry, WorkerLoadSnapshot};
 use super::request_maps::RequestIndex;
 use super::single::{ActiveSequences, PromptMembershipDelta, RequestId};
-use super::topology::WorkerTable;
+use super::topology::{WorkerDpRange, WorkerTable, WorkerTopologyChange, WorkerTopologyError};
 use crate::protocols::{
-    ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventData, PrefillLoadHint, WorkerWithDpRank,
+    ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventData, PrefillLoadHint, WorkerId,
+    WorkerWithDpRank,
 };
 
 // How often we force expire stale requests across all workers. See the comment
@@ -329,45 +330,92 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.remote_state_update_count.load(Ordering::Relaxed)
     }
 
-    /// Register externally-provided workers (e.g. from EPP) in the slot tracker,
-    /// adding any that are missing.
-    ///
-    /// Unlike [`update_workers`], this does not remove workers absent from the
-    /// input — it only adds new ones.  This is intentional: the EPP may send
-    /// different subsets of workers on different requests, and one routing call
-    /// must not evict workers registered by another.
-    ///
-    /// Worker removal in External mode will be handled separately via GAIE
-    /// lifecycle events (not yet implemented). TODO (atchernych) once we upgrade to GAIE latest.
-    pub fn register_external_workers(&self, dp_range: &HashMap<u64, (u32, u32)>) {
+    /// Register one worker and reject duplicate worker IDs.
+    pub fn register_worker(&self, range: WorkerDpRange) -> Result<(), WorkerTopologyError> {
         let change = {
             let mut table = self.workers.write();
-            table.register_external(self.block_size, dp_range)
+            table.register_worker(self.block_size, range)?
         };
 
         for worker in &change.added {
-            tracing::debug!("Lazily registering external worker {:?}", worker);
+            tracing::debug!("Registering worker {:?}", worker);
         }
-        self.prompt_registry.apply_topology_change(change);
+        self.apply_worker_topology_change(change);
+        Ok(())
     }
 
-    /// Update the set of workers, adding and removing as needed.
+    /// Add or update one worker without changing unrelated workers.
     ///
-    /// `new_dp_range` maps worker IDs to their data-parallel range (start, size).
-    pub fn update_workers(&self, new_dp_range: &HashMap<u64, (u32, u32)>) {
+    /// This supports external routing calls that provide different worker
+    /// subsets over time. Updating a worker replaces only that worker's DP
+    /// ranks and preserves unrelated lazily-created slots.
+    pub fn upsert_worker(&self, range: WorkerDpRange) -> Result<(), WorkerTopologyError> {
         let change = {
             let mut table = self.workers.write();
-            table.reconcile(self.block_size, new_dp_range)
+            table.upsert_worker(self.block_size, range)?
+        };
+
+        for removed in &change.removed {
+            tracing::debug!("Removing external worker rank {:?}", removed.worker);
+        }
+        for worker in &change.added {
+            tracing::debug!("Registering external worker rank {:?}", worker);
+        }
+        self.apply_worker_topology_change(change);
+        Ok(())
+    }
+
+    /// Unregister one worker and all of its DP ranks.
+    pub fn unregister_worker(&self, worker_id: WorkerId) -> Result<(), WorkerTopologyError> {
+        let change = {
+            let mut table = self.workers.write();
+            table.unregister_worker(self.block_size, worker_id)?
         };
 
         for removed in &change.removed {
             tracing::warn!("Removing worker {:?}", removed.worker);
-            self.request_index.remove_worker_requests(removed.worker);
+        }
+        self.apply_worker_topology_change(change);
+        Ok(())
+    }
+
+    /// Replace the complete authoritative worker topology.
+    ///
+    /// Workers absent from `ranges`, including lazily-created slots, are removed.
+    pub fn reconcile_workers(
+        &self,
+        ranges: impl IntoIterator<Item = WorkerDpRange>,
+    ) -> Result<(), WorkerTopologyError> {
+        let change = {
+            let mut table = self.workers.write();
+            table.reconcile(self.block_size, ranges.into_iter().collect())?
+        };
+
+        for removed in &change.removed {
+            tracing::warn!("Removing worker {:?}", removed.worker);
         }
         for worker in &change.added {
             tracing::warn!("Adding worker {:?}", worker);
         }
 
+        self.apply_worker_topology_change(change);
+        Ok(())
+    }
+
+    /// Return the authoritative worker ranges, sorted by worker ID.
+    pub fn worker_ranges(&self) -> Vec<WorkerDpRange> {
+        self.workers.read().worker_ranges()
+    }
+
+    /// Return whether the authoritative topology contains any workers.
+    pub fn has_registered_workers(&self) -> bool {
+        self.workers.read().has_registered_workers()
+    }
+
+    fn apply_worker_topology_change(&self, change: WorkerTopologyChange) {
+        for removed in &change.removed {
+            self.request_index.remove_worker_requests(removed.worker);
+        }
         self.prompt_registry.apply_topology_change(change);
     }
 
@@ -690,7 +738,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         let change = table.ensure_worker(self.block_size, worker);
         drop(table);
 
-        self.prompt_registry.apply_topology_change(change);
+        self.apply_worker_topology_change(change);
     }
 
     fn add_request_local(
@@ -2205,7 +2253,7 @@ mod tests {
             ReplicaWorkerPolicy::RequireRegistered,
         );
         let worker = WorkerWithDpRank::new(1, 0);
-        sequences.update_workers(&HashMap::new());
+        sequences.reconcile_workers([]).unwrap();
 
         sequences
             .run_replica_sync(
@@ -2245,12 +2293,14 @@ mod tests {
             )
             .unwrap();
 
-        sequences.update_workers(&HashMap::new());
+        sequences.reconcile_workers([]).unwrap();
         assert!(sequences.prompt_registry.is_block_index_empty());
         assert!(sequences.active_blocks().is_empty());
         assert!(sequences.request_index.is_empty());
 
-        sequences.update_workers(&HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        sequences
+            .reconcile_workers([WorkerDpRange::new(1, 0, 1)])
+            .unwrap();
         assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(0));
         assert!(sequences.prompt_registry.is_block_index_empty());
     }
@@ -2283,7 +2333,7 @@ mod tests {
         });
 
         ready.wait();
-        sequences.update_workers(&HashMap::new());
+        sequences.reconcile_workers([]).unwrap();
         proceed.wait();
         let result = add.join().unwrap();
 

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -9,7 +9,9 @@ use rustc_hash::FxHashMap;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
-use super::multi_worker::{ActiveSequencesMultiWorker, SequencePublisher, SequenceSubscriber};
+use super::multi_worker::{
+    ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequencePublisher, SequenceSubscriber,
+};
 use super::prompt_registry::WorkerLoadSnapshot;
 use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
 
@@ -167,12 +169,14 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 expected_output_tokens,
                 prefill_load_hint,
             } => {
-                self.ensure_worker_registered(event_worker);
+                if self.replica_worker_policy == ReplicaWorkerPolicy::LazyRegister {
+                    self.ensure_worker_registered(event_worker);
+                }
                 let table = self.workers.read();
                 let Some(&idx) = table.index.get(&event_worker) else {
-                    tracing::warn!(
-                        "Worker {:?} not found, cannot process AddRequest",
-                        event_worker
+                    tracing::debug!(
+                        worker = ?event_worker,
+                        "Dropping replica AddRequest for unregistered worker"
                     );
                     return;
                 };

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -1,15 +1,67 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::collections::HashMap;
 
 use super::prompt_membership_trie::WorkerLookup;
 use super::single::ActiveSequences;
-use crate::protocols::WorkerWithDpRank;
+use crate::protocols::{DpRank, WorkerId, WorkerWithDpRank};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerDpRange {
+    pub worker_id: WorkerId,
+    pub dp_start: DpRank,
+    pub dp_size: u32,
+}
+
+impl WorkerDpRange {
+    pub fn new(worker_id: WorkerId, dp_start: DpRank, dp_size: u32) -> Self {
+        Self {
+            worker_id,
+            dp_start,
+            dp_size,
+        }
+    }
+
+    pub fn validate(self) -> Result<Self, WorkerTopologyError> {
+        if self.dp_size == 0 {
+            return Err(WorkerTopologyError::InvalidDpSize {
+                worker_id: self.worker_id,
+            });
+        }
+        if self.dp_start.checked_add(self.dp_size).is_none() {
+            return Err(WorkerTopologyError::InvalidDpRange {
+                worker_id: self.worker_id,
+                dp_start: self.dp_start,
+                dp_size: self.dp_size,
+            });
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WorkerTopologyError {
+    #[error("dp_size must be greater than 0 for worker {worker_id}")]
+    InvalidDpSize { worker_id: WorkerId },
+
+    #[error("dp range overflows u32 for worker {worker_id}: start={dp_start} size={dp_size}")]
+    InvalidDpRange {
+        worker_id: WorkerId,
+        dp_start: DpRank,
+        dp_size: u32,
+    },
+
+    #[error("worker {worker_id} is already registered")]
+    DuplicateWorker { worker_id: WorkerId },
+
+    #[error("worker {worker_id} is not registered")]
+    WorkerNotFound { worker_id: WorkerId },
+}
 
 #[derive(Clone)]
 pub(super) struct RemovedWorkerState {
@@ -50,51 +102,148 @@ impl WorkerSlot {
 pub(super) struct WorkerTable {
     pub(super) slots: Vec<WorkerSlot>,
     pub(super) index: FxHashMap<WorkerWithDpRank, usize>,
+    worker_ranges: HashMap<WorkerId, WorkerDpRange>,
 }
 
 impl WorkerTable {
     pub(super) fn new(block_size: usize, dp_range: &HashMap<u64, (u32, u32)>) -> Self {
+        let worker_ranges: HashMap<WorkerId, WorkerDpRange> = dp_range
+            .iter()
+            .map(|(&worker_id, &(dp_start, dp_size))| {
+                let range = WorkerDpRange::new(worker_id, dp_start, dp_size);
+                range
+                    .validate()
+                    .expect("initial worker DP ranges must be valid");
+                (worker_id, range)
+            })
+            .collect();
         let mut slots = Vec::new();
         let mut index = FxHashMap::default();
-        for worker in workers_from_dp_range(dp_range) {
+        for worker in workers_from_ranges(worker_ranges.values().copied()) {
             let idx = slots.len();
             slots.push(WorkerSlot::new(worker, block_size));
             index.insert(worker, idx);
         }
-        Self { slots, index }
+        Self {
+            slots,
+            index,
+            worker_ranges,
+        }
     }
 
     pub(super) fn workers(&self) -> impl Iterator<Item = WorkerWithDpRank> + '_ {
         self.slots.iter().map(|slot| slot.worker)
     }
 
-    pub(super) fn register_external(
+    pub(super) fn register_worker(
         &mut self,
         block_size: usize,
-        dp_range: &HashMap<u64, (u32, u32)>,
-    ) -> WorkerTopologyChange {
-        let mut change = WorkerTopologyChange::default();
-        for worker in workers_from_dp_range(dp_range) {
-            if self.index.contains_key(&worker) {
-                continue;
-            }
-
-            let idx = self.slots.len();
-            self.slots.push(WorkerSlot::new(worker, block_size));
-            self.index.insert(worker, idx);
-            change.added.push(worker);
+        range: WorkerDpRange,
+    ) -> Result<WorkerTopologyChange, WorkerTopologyError> {
+        range.validate()?;
+        if self.worker_ranges.contains_key(&range.worker_id) {
+            return Err(WorkerTopologyError::DuplicateWorker {
+                worker_id: range.worker_id,
+            });
         }
-        change
+        self.worker_ranges.insert(range.worker_id, range);
+        Ok(self.reconcile_worker_slots(block_size, range.worker_id))
+    }
+
+    pub(super) fn upsert_worker(
+        &mut self,
+        block_size: usize,
+        range: WorkerDpRange,
+    ) -> Result<WorkerTopologyChange, WorkerTopologyError> {
+        range.validate()?;
+        if self.worker_ranges.get(&range.worker_id) == Some(&range) {
+            return Ok(WorkerTopologyChange::default());
+        }
+        self.worker_ranges.insert(range.worker_id, range);
+        Ok(self.reconcile_worker_slots(block_size, range.worker_id))
+    }
+
+    pub(super) fn unregister_worker(
+        &mut self,
+        block_size: usize,
+        worker_id: WorkerId,
+    ) -> Result<WorkerTopologyChange, WorkerTopologyError> {
+        if self.worker_ranges.remove(&worker_id).is_none() {
+            return Err(WorkerTopologyError::WorkerNotFound { worker_id });
+        }
+        Ok(self.reconcile_worker_slots(block_size, worker_id))
     }
 
     pub(super) fn reconcile(
         &mut self,
         block_size: usize,
-        new_dp_range: &HashMap<u64, (u32, u32)>,
-    ) -> WorkerTopologyChange {
-        let target_workers: FxHashSet<WorkerWithDpRank> =
-            workers_from_dp_range(new_dp_range).into_iter().collect();
+        ranges: Vec<WorkerDpRange>,
+    ) -> Result<WorkerTopologyChange, WorkerTopologyError> {
+        let mut worker_ranges = HashMap::with_capacity(ranges.len());
+        for range in ranges {
+            range.validate()?;
+            if worker_ranges.insert(range.worker_id, range).is_some() {
+                return Err(WorkerTopologyError::DuplicateWorker {
+                    worker_id: range.worker_id,
+                });
+            }
+        }
+        self.worker_ranges = worker_ranges;
+        Ok(self.reconcile_all_slots(block_size))
+    }
 
+    pub(super) fn worker_ranges(&self) -> Vec<WorkerDpRange> {
+        let mut ranges: Vec<_> = self.worker_ranges.values().copied().collect();
+        ranges.sort_by_key(|range| range.worker_id);
+        ranges
+    }
+
+    pub(super) fn has_registered_workers(&self) -> bool {
+        !self.worker_ranges.is_empty()
+    }
+
+    fn reconcile_worker_slots(
+        &mut self,
+        block_size: usize,
+        worker_id: WorkerId,
+    ) -> WorkerTopologyChange {
+        let target_workers: Vec<_> = self
+            .worker_ranges
+            .get(&worker_id)
+            .copied()
+            .into_iter()
+            .flat_map(workers_from_range)
+            .collect();
+        let mut old = FxHashMap::default();
+        let mut retained = Vec::with_capacity(self.slots.len());
+        for slot in self.slots.drain(..) {
+            if slot.worker.worker_id == worker_id {
+                old.insert(slot.worker, slot);
+            } else {
+                retained.push(slot);
+            }
+        }
+        self.slots = retained;
+
+        let mut added = Vec::new();
+        for worker in target_workers {
+            let slot = old.remove(&worker).unwrap_or_else(|| {
+                added.push(worker);
+                WorkerSlot::new(worker, block_size)
+            });
+            self.slots.push(slot);
+        }
+
+        let removed = old.into_values().map(RemovedWorkerState::from).collect();
+        self.rebuild_index();
+        WorkerTopologyChange { added, removed }
+    }
+
+    fn reconcile_all_slots(&mut self, block_size: usize) -> WorkerTopologyChange {
+        let target_workers: FxHashSet<WorkerWithDpRank> =
+            workers_from_ranges(self.worker_ranges.values().copied())
+                .into_iter()
+                .collect();
         let mut old: FxHashMap<WorkerWithDpRank, WorkerSlot> = self
             .slots
             .drain(..)
@@ -126,6 +275,16 @@ impl WorkerTable {
         WorkerTopologyChange { added, removed }
     }
 
+    fn rebuild_index(&mut self) {
+        self.index.clear();
+        self.index.extend(
+            self.slots
+                .iter()
+                .enumerate()
+                .map(|(idx, slot)| (slot.worker, idx)),
+        );
+    }
+
     pub(super) fn ensure_worker(
         &mut self,
         block_size: usize,
@@ -145,14 +304,26 @@ impl WorkerTable {
     }
 }
 
-fn workers_from_dp_range(dp_range: &HashMap<u64, (u32, u32)>) -> Vec<WorkerWithDpRank> {
-    let mut workers = Vec::new();
-    for (&worker_id, &(dp_start, dp_size)) in dp_range {
-        for dp_rank in dp_start..(dp_start + dp_size) {
-            workers.push(WorkerWithDpRank::new(worker_id, dp_rank));
+impl From<WorkerSlot> for RemovedWorkerState {
+    fn from(slot: WorkerSlot) -> Self {
+        Self {
+            worker: slot.worker,
+            trie_lookup: slot.trie_lookup,
         }
     }
+}
+
+fn workers_from_ranges(ranges: impl IntoIterator<Item = WorkerDpRange>) -> Vec<WorkerWithDpRank> {
+    let mut workers = Vec::new();
+    for range in ranges {
+        workers.extend(workers_from_range(range));
+    }
     workers
+}
+
+fn workers_from_range(range: WorkerDpRange) -> impl Iterator<Item = WorkerWithDpRank> {
+    (range.dp_start..(range.dp_start + range.dp_size))
+        .map(move |dp_rank| WorkerWithDpRank::new(range.worker_id, dp_rank))
 }
 
 #[cfg(test)]
@@ -179,19 +350,66 @@ mod tests {
         for worker in workers {
             assert!(table.index.contains_key(&worker));
         }
+        assert_eq!(
+            table.worker_ranges(),
+            vec![WorkerDpRange::new(7, 2, 3), WorkerDpRange::new(9, 0, 1)]
+        );
     }
 
     #[test]
-    fn register_external_only_adds_missing_workers() {
+    fn upsert_worker_updates_one_authoritative_range() {
         let mut table = WorkerTable::new(4, &HashMap::from([(1, (0, 1))]));
-        let change = table.register_external(4, &HashMap::from([(1, (0, 2)), (2, (0, 1))]));
+        let lazy_worker = worker(2, 0);
+        table.ensure_worker(4, lazy_worker);
+        let change = table.upsert_worker(4, WorkerDpRange::new(1, 0, 2)).unwrap();
 
-        assert_eq!(
-            change.added.into_iter().collect::<FxHashSet<_>>(),
-            FxHashSet::from_iter([worker(1, 1), worker(2, 0)])
-        );
+        assert_eq!(change.added, vec![worker(1, 1)]);
         assert!(change.removed.is_empty());
         assert_eq!(table.index.len(), 3);
+        assert!(table.index.contains_key(&lazy_worker));
+        assert_eq!(table.worker_ranges(), vec![WorkerDpRange::new(1, 0, 2)]);
+    }
+
+    #[test]
+    fn register_and_unregister_worker_are_strict() {
+        let mut table = WorkerTable::new(4, &HashMap::new());
+        let range = WorkerDpRange::new(1, 2, 2);
+
+        let change = table.register_worker(4, range).unwrap();
+        assert_eq!(
+            change.added.into_iter().collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([worker(1, 2), worker(1, 3)])
+        );
+        assert!(matches!(
+            table.register_worker(4, range),
+            Err(WorkerTopologyError::DuplicateWorker { worker_id: 1 })
+        ));
+
+        let change = table.unregister_worker(4, 1).unwrap();
+        assert_eq!(change.removed.len(), 2);
+        assert!(!table.has_registered_workers());
+        assert!(matches!(
+            table.unregister_worker(4, 1),
+            Err(WorkerTopologyError::WorkerNotFound { worker_id: 1 })
+        ));
+    }
+
+    #[test]
+    fn invalid_ranges_are_rejected() {
+        let mut table = WorkerTable::new(4, &HashMap::new());
+
+        assert!(matches!(
+            table.register_worker(4, WorkerDpRange::new(1, 0, 0)),
+            Err(WorkerTopologyError::InvalidDpSize { worker_id: 1 })
+        ));
+        assert!(matches!(
+            table.register_worker(4, WorkerDpRange::new(1, u32::MAX, 1)),
+            Err(WorkerTopologyError::InvalidDpRange {
+                worker_id: 1,
+                dp_start: u32::MAX,
+                dp_size: 1,
+            })
+        ));
     }
 
     #[test]
@@ -207,6 +425,27 @@ mod tests {
         assert!(second.added.is_empty());
         assert!(second.removed.is_empty());
         assert_eq!(table.index.len(), 2);
+    }
+
+    #[test]
+    fn full_reconcile_removes_unregistered_lazy_workers() {
+        let mut table = WorkerTable::new(4, &HashMap::from([(1, (0, 1))]));
+        let lazy_worker = worker(2, 0);
+        table.ensure_worker(4, lazy_worker);
+
+        let change = table
+            .reconcile(4, vec![WorkerDpRange::new(1, 0, 1)])
+            .unwrap();
+
+        assert_eq!(
+            change
+                .removed
+                .iter()
+                .map(|state| state.worker)
+                .collect::<Vec<_>>(),
+            vec![lazy_worker]
+        );
+        assert!(!table.index.contains_key(&lazy_worker));
     }
 
     #[test]
@@ -233,7 +472,12 @@ mod tests {
             assert_eq!(outcome.membership_delta.stores[0].hashes, vec![1, 2, 3],);
         }
 
-        let change = table.reconcile(4, &HashMap::from([(1, (0, 1)), (3, (0, 1))]));
+        let change = table
+            .reconcile(
+                4,
+                vec![WorkerDpRange::new(1, 0, 1), WorkerDpRange::new(3, 0, 1)],
+            )
+            .unwrap();
 
         assert_eq!(change.added, vec![added]);
         assert_eq!(

--- a/lib/kv-router/src/services/indexer/listener.rs
+++ b/lib/kv-router/src/services/indexer/listener.rs
@@ -13,7 +13,7 @@ use crate::zmq_wire::{ZmqEventNormalizer, decode_event_batch};
 
 use super::backend::Indexer;
 use super::registry::ListenerRecord;
-use super::zmq::{
+use crate::services::zmq::{
     MultipartMessage, SharedSocket, connect_dealer_socket, connect_sub_socket, recv_multipart,
     send_multipart,
 };
@@ -541,7 +541,7 @@ async fn connect_replay_socket(
 mod tests {
     use super::{WATERMARK_UNSET, cursor_from_watermark};
     use crate::recovery::CursorObservation;
-    use crate::services::indexer::zmq::{
+    use crate::services::zmq::{
         SharedSocket, bind_pub_socket, connect_sub_socket, recv_multipart, send_multipart,
     };
 

--- a/lib/kv-router/src/services/indexer/mod.rs
+++ b/lib/kv-router/src/services/indexer/mod.rs
@@ -29,7 +29,6 @@ pub mod metrics;
 pub mod recovery;
 pub mod registry;
 pub mod server;
-mod zmq;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -38,6 +37,7 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::min_initial_workers_from_env;
+use crate::services::zmq::validate_endpoint as validate_zmq_endpoint;
 use registry::WorkerRegistry;
 use server::{AppState, create_router};
 
@@ -49,42 +49,6 @@ pub struct IndexerConfig {
     pub model_name: String,
     pub tenant_id: String,
     pub peers: Option<String>,
-}
-
-pub(super) fn validate_zmq_endpoint(endpoint: &str) -> anyhow::Result<()> {
-    let (scheme, address) = endpoint
-        .split_once("://")
-        .ok_or_else(|| anyhow::anyhow!("invalid ZMQ endpoint `{endpoint}`: missing scheme"))?;
-
-    if address.is_empty() {
-        anyhow::bail!("invalid ZMQ endpoint `{endpoint}`: missing address");
-    }
-
-    match scheme {
-        "tcp" => {
-            let (host, port) = address.rsplit_once(':').ok_or_else(|| {
-                anyhow::anyhow!("invalid ZMQ endpoint `{endpoint}`: missing TCP port")
-            })?;
-            if host.is_empty() {
-                anyhow::bail!("invalid ZMQ endpoint `{endpoint}`: missing TCP host");
-            }
-            if host.starts_with('[') {
-                if !host.ends_with(']') {
-                    anyhow::bail!("invalid ZMQ endpoint `{endpoint}`: missing closing `]`");
-                }
-            } else if host.contains(':') {
-                anyhow::bail!("invalid ZMQ endpoint `{endpoint}`: missing TCP port");
-            }
-            port.parse::<u16>().map_err(|error| {
-                anyhow::anyhow!("invalid ZMQ endpoint `{endpoint}`: invalid TCP port: {error}")
-            })?;
-            Ok(())
-        }
-        "ipc" | "inproc" => Ok(()),
-        other => Err(anyhow::anyhow!(
-            "invalid ZMQ endpoint `{endpoint}`: unsupported scheme `{other}`"
-        )),
-    }
 }
 
 pub(super) fn validate_listener_endpoints(

--- a/lib/kv-router/src/services/mod.rs
+++ b/lib/kv-router/src/services/mod.rs
@@ -3,6 +3,9 @@
 
 //! Standalone services built from brokerless transport primitives.
 
+#[cfg(any(feature = "standalone-indexer", feature = "standalone-slot-tracker"))]
+pub(crate) mod zmq;
+
 #[cfg(feature = "standalone-indexer")]
 pub mod indexer;
 

--- a/lib/kv-router/src/services/slot_tracker/mod.rs
+++ b/lib/kv-router/src/services/slot_tracker/mod.rs
@@ -8,6 +8,7 @@
 //! stays independent of Dynamo runtime and LLM-layer dependencies.
 
 pub mod registry;
+mod replica_sync;
 pub mod server;
 
 use std::sync::Arc;
@@ -16,10 +17,14 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 use registry::SlotTrackerRegistry;
+use replica_sync::{PeerManager, generate_process_id, start_replica_publisher};
 use server::{AppState, create_router};
 
 pub struct SlotTrackerConfig {
     pub port: u16,
+    pub replica_sync_bind: Option<String>,
+    pub replica_sync_advertise: Option<String>,
+    pub replica_sync_peers: Vec<String>,
 }
 
 pub async fn run_server(config: SlotTrackerConfig) -> anyhow::Result<()> {
@@ -31,13 +36,48 @@ pub async fn run_server(config: SlotTrackerConfig) -> anyhow::Result<()> {
         shutdown_token.cancel();
     });
 
-    tracing::info!(
-        port = config.port,
-        "Starting standalone slot tracker (HTTP-only mode)"
-    );
+    let (registry, peer_manager) = if let Some(bind_endpoint) = &config.replica_sync_bind {
+        let process_id = generate_process_id();
+        let outbound_tx = start_replica_publisher(bind_endpoint, cancel_token.child_token())?;
+        let registry = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
+            cancel_token.clone(),
+            process_id,
+            outbound_tx,
+        ));
+        let peer_manager = PeerManager::start(
+            Arc::clone(&registry),
+            config.replica_sync_peers,
+            config.replica_sync_advertise.clone(),
+            cancel_token.child_token(),
+        )?;
+        tracing::info!(
+            port = config.port,
+            bind_endpoint,
+            advertised_endpoint = config.replica_sync_advertise.as_deref(),
+            process_id,
+            "Starting standalone slot tracker with replica sync"
+        );
+        (registry, Some(peer_manager))
+    } else {
+        if config.replica_sync_advertise.is_some() || !config.replica_sync_peers.is_empty() {
+            anyhow::bail!(
+                "--replica-sync-advertise and --replica-sync-peers require --replica-sync-bind"
+            );
+        }
+        tracing::info!(
+            port = config.port,
+            "Starting standalone slot tracker (HTTP-only mode)"
+        );
+        (
+            Arc::new(SlotTrackerRegistry::new(cancel_token.clone())),
+            None,
+        )
+    };
 
-    let registry = Arc::new(SlotTrackerRegistry::new(cancel_token.clone()));
-    let app = create_router(Arc::new(AppState { registry }));
+    let app = create_router(Arc::new(AppState {
+        registry,
+        peer_manager,
+    }));
     let listener = TcpListener::bind(("0.0.0.0", config.port)).await?;
     tracing::info!("HTTP server listening on 0.0.0.0:{}", config.port);
     axum::serve(listener, app)

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -15,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::protocols::{PrefillLoadHint, WorkerId, WorkerWithDpRank};
 use crate::scheduling::PotentialLoad;
+use crate::sequences::topology::{WorkerDpRange, WorkerTopologyError};
 use crate::sequences::{
     ActiveSequencesMultiWorker, PrefillTokenDeltas, ReplicaWorkerPolicy, SequenceError,
     SequenceRequest,
@@ -115,7 +115,7 @@ struct RegistryReplicaConfig {
 struct TrackerEntry {
     tracker: Arc<ActiveSequencesMultiWorker<ScopedSequencePublisher>>,
     pub block_size: u32,
-    worker_ranges: Mutex<HashMap<WorkerId, (u32, u32)>>,
+    lifecycle_lock: Mutex<()>,
     replica_tx: Option<mpsc::Sender<crate::protocols::ActiveSequenceEvent>>,
     cancel_token: CancellationToken,
 }
@@ -148,7 +148,7 @@ impl TrackerEntry {
         let tracker = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
             publisher,
             block_size as usize,
-            HashMap::new(),
+            Default::default(),
             replica_sync,
             router_id,
             "standalone",
@@ -165,7 +165,7 @@ impl TrackerEntry {
         Arc::new(Self {
             tracker,
             block_size,
-            worker_ranges: Mutex::new(HashMap::new()),
+            lifecycle_lock: Mutex::new(()),
             replica_tx,
             cancel_token,
         })
@@ -210,7 +210,10 @@ impl SlotTrackerRegistry {
         dp_start: u32,
         dp_size: u32,
     ) -> Result<(), RegistryError> {
-        validate_registration(block_size, dp_start, dp_size)?;
+        validate_block_size(block_size)?;
+        let range = WorkerDpRange::new(worker_id, dp_start, dp_size)
+            .validate()
+            .map_err(|error| topology_error(&key, error))?;
 
         loop {
             let entry = self
@@ -226,6 +229,10 @@ impl SlotTrackerRegistry {
                 })
                 .clone();
 
+            let _lifecycle = entry.lifecycle_lock.lock();
+            if !self.is_attached(&key, &entry) {
+                continue;
+            }
             if entry.block_size != block_size {
                 return Err(RegistryError::BlockSizeMismatch {
                     model_name: key.model_name,
@@ -235,20 +242,10 @@ impl SlotTrackerRegistry {
                 });
             }
 
-            let mut worker_ranges = entry.worker_ranges.lock();
-            if !self.is_attached(&key, &entry) {
-                continue;
-            }
-            if worker_ranges.contains_key(&worker_id) {
-                return Err(RegistryError::DuplicateWorker {
-                    worker_id,
-                    model_name: key.model_name,
-                    tenant_id: key.tenant_id,
-                });
-            }
-
-            worker_ranges.insert(worker_id, (dp_start, dp_size));
-            entry.tracker.update_workers(&worker_ranges);
+            entry
+                .tracker
+                .register_worker(range)
+                .map_err(|error| topology_error(&key, error))?;
             return Ok(());
         }
     }
@@ -267,20 +264,16 @@ impl SlotTrackerRegistry {
                 });
             };
 
-            let mut worker_ranges = entry.worker_ranges.lock();
+            let _lifecycle = entry.lifecycle_lock.lock();
             if !self.is_attached(key, &entry) {
                 continue;
             }
-            if worker_ranges.remove(&worker_id).is_none() {
-                return Err(RegistryError::WorkerNotFound {
-                    worker_id,
-                    model_name: key.model_name.clone(),
-                    tenant_id: key.tenant_id.clone(),
-                });
-            }
 
-            entry.tracker.update_workers(&worker_ranges);
-            if worker_ranges.is_empty()
+            entry
+                .tracker
+                .unregister_worker(worker_id)
+                .map_err(|error| topology_error(key, error))?;
+            if !entry.tracker.has_registered_workers()
                 && self
                     .trackers
                     .remove_if(key, |_, current| Arc::ptr_eq(current, &entry))
@@ -303,14 +296,14 @@ impl SlotTrackerRegistry {
             if !matches_filters(key, model_name, tenant_id) {
                 continue;
             }
-            for (&worker_id, &(dp_start, dp_size)) in entry.value().worker_ranges.lock().iter() {
+            for range in entry.value().tracker.worker_ranges() {
                 workers.push(WorkerInfo {
-                    worker_id,
+                    worker_id: range.worker_id,
                     model_name: key.model_name.clone(),
                     tenant_id: key.tenant_id.clone(),
                     block_size: entry.value().block_size,
-                    dp_start,
-                    dp_size,
+                    dp_start: range.dp_start,
+                    dp_size: range.dp_size,
                 });
             }
         }
@@ -516,21 +509,30 @@ pub enum ServiceError {
     Sequence(#[from] SequenceError),
 }
 
-fn validate_registration(
-    block_size: u32,
-    dp_start: u32,
-    dp_size: u32,
-) -> Result<(), RegistryError> {
+fn validate_block_size(block_size: u32) -> Result<(), RegistryError> {
     if block_size == 0 {
         return Err(RegistryError::InvalidBlockSize);
     }
-    if dp_size == 0 {
-        return Err(RegistryError::InvalidDpSize);
-    }
-    if dp_start.checked_add(dp_size).is_none() {
-        return Err(RegistryError::InvalidDpRange { dp_start, dp_size });
-    }
     Ok(())
+}
+
+fn topology_error(key: &TrackerKey, error: WorkerTopologyError) -> RegistryError {
+    match error {
+        WorkerTopologyError::InvalidDpSize { .. } => RegistryError::InvalidDpSize,
+        WorkerTopologyError::InvalidDpRange {
+            dp_start, dp_size, ..
+        } => RegistryError::InvalidDpRange { dp_start, dp_size },
+        WorkerTopologyError::DuplicateWorker { worker_id } => RegistryError::DuplicateWorker {
+            worker_id,
+            model_name: key.model_name.clone(),
+            tenant_id: key.tenant_id.clone(),
+        },
+        WorkerTopologyError::WorkerNotFound { worker_id } => RegistryError::WorkerNotFound {
+            worker_id,
+            model_name: key.model_name.clone(),
+            tenant_id: key.tenant_id.clone(),
+        },
+    }
 }
 
 fn matches_filters(key: &TrackerKey, model_name: Option<&str>, tenant_id: Option<&str>) -> bool {

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::future::{self, Future};
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -10,16 +9,20 @@ use dynamo_tokens::SequenceHash;
 use parking_lot::Mutex;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
+use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
-use crate::protocols::{
-    ActiveLoad, ActiveSequenceEvent, PrefillLoadHint, WorkerId, WorkerWithDpRank,
-};
+use crate::protocols::{PrefillLoadHint, WorkerId, WorkerWithDpRank};
 use crate::scheduling::PotentialLoad;
 use crate::sequences::{
-    ActiveSequencesMultiWorker, PrefillTokenDeltas, SequenceError, SequencePublisher,
+    ActiveSequencesMultiWorker, PrefillTokenDeltas, ReplicaWorkerPolicy, SequenceError,
     SequenceRequest,
+};
+
+use super::replica_sync::{
+    ChannelSequenceSubscriber, REPLICA_EVENT_CHANNEL_CAPACITY, ReplicaEventSender,
+    ScopedSequencePublisher, SlotReplicaEvent,
 };
 
 fn default_tenant() -> String {
@@ -103,51 +106,67 @@ pub enum RegistryError {
     },
 }
 
-pub struct StandaloneSequencePublisher;
-
-impl SequencePublisher for StandaloneSequencePublisher {
-    fn publish_event(
-        &self,
-        _event: &ActiveSequenceEvent,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send {
-        future::ready(Ok(()))
-    }
-
-    fn publish_load(&self, _load: ActiveLoad) {}
-
-    fn observe_load(
-        &self,
-        _worker: &WorkerWithDpRank,
-        _worker_type: &str,
-        _blocks: usize,
-        _tokens: usize,
-    ) {
-    }
+#[derive(Clone)]
+struct RegistryReplicaConfig {
+    process_id: u64,
+    outbound_tx: ReplicaEventSender,
 }
 
-pub struct TrackerEntry {
-    pub tracker: Arc<ActiveSequencesMultiWorker<StandaloneSequencePublisher>>,
+struct TrackerEntry {
+    tracker: Arc<ActiveSequencesMultiWorker<ScopedSequencePublisher>>,
     pub block_size: u32,
     worker_ranges: Mutex<HashMap<WorkerId, (u32, u32)>>,
+    replica_tx: Option<mpsc::Sender<crate::protocols::ActiveSequenceEvent>>,
     cancel_token: CancellationToken,
 }
 
 impl TrackerEntry {
-    fn new(block_size: u32, root_cancel_token: &CancellationToken) -> Arc<Self> {
+    fn new(
+        key: &TrackerKey,
+        block_size: u32,
+        root_cancel_token: &CancellationToken,
+        replica_config: Option<&RegistryReplicaConfig>,
+    ) -> Arc<Self> {
         let cancel_token = root_cancel_token.child_token();
-        let tracker = Arc::new(ActiveSequencesMultiWorker::new(
-            StandaloneSequencePublisher,
+        let (publisher, replica_sync, router_id, replica_channel) =
+            if let Some(replica_config) = replica_config {
+                let (replica_tx, replica_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
+                (
+                    ScopedSequencePublisher::enabled(
+                        Arc::from(key.model_name.as_str()),
+                        Arc::from(key.tenant_id.as_str()),
+                        block_size,
+                        replica_config.outbound_tx.clone(),
+                    ),
+                    true,
+                    replica_config.process_id,
+                    Some((replica_tx, replica_rx)),
+                )
+            } else {
+                (ScopedSequencePublisher::disabled(), false, 0, None)
+            };
+        let tracker = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
+            publisher,
             block_size as usize,
             HashMap::new(),
-            false,
-            0,
+            replica_sync,
+            router_id,
             "standalone",
+            ReplicaWorkerPolicy::RequireRegistered,
         ));
+        let replica_tx = replica_channel.map(|(replica_tx, replica_rx)| {
+            tracker.start_replica_sync(
+                ChannelSequenceSubscriber::new(replica_rx),
+                cancel_token.clone(),
+            );
+            replica_tx
+        });
         tracker.start_periodic_force_expiry_across_all_workers(cancel_token.clone());
         Arc::new(Self {
             tracker,
             block_size,
             worker_ranges: Mutex::new(HashMap::new()),
+            replica_tx,
             cancel_token,
         })
     }
@@ -156,6 +175,7 @@ impl TrackerEntry {
 pub struct SlotTrackerRegistry {
     trackers: DashMap<TrackerKey, Arc<TrackerEntry>>,
     root_cancel_token: CancellationToken,
+    replica_config: Option<RegistryReplicaConfig>,
 }
 
 impl SlotTrackerRegistry {
@@ -163,6 +183,22 @@ impl SlotTrackerRegistry {
         Self {
             trackers: DashMap::new(),
             root_cancel_token,
+            replica_config: None,
+        }
+    }
+
+    pub(crate) fn new_with_replica_sync(
+        root_cancel_token: CancellationToken,
+        process_id: u64,
+        outbound_tx: ReplicaEventSender,
+    ) -> Self {
+        Self {
+            trackers: DashMap::new(),
+            root_cancel_token,
+            replica_config: Some(RegistryReplicaConfig {
+                process_id,
+                outbound_tx,
+            }),
         }
     }
 
@@ -180,7 +216,14 @@ impl SlotTrackerRegistry {
             let entry = self
                 .trackers
                 .entry(key.clone())
-                .or_insert_with(|| TrackerEntry::new(block_size, &self.root_cancel_token))
+                .or_insert_with(|| {
+                    TrackerEntry::new(
+                        &key,
+                        block_size,
+                        &self.root_cancel_token,
+                        self.replica_config.as_ref(),
+                    )
+                })
                 .clone();
 
             if entry.block_size != block_size {
@@ -392,6 +435,61 @@ impl SlotTrackerRegistry {
             .collect())
     }
 
+    pub(crate) fn dispatch_replica_event(&self, envelope: SlotReplicaEvent) {
+        if self
+            .replica_config
+            .as_ref()
+            .is_some_and(|config| envelope.event.router_id == config.process_id)
+        {
+            return;
+        }
+
+        let key = TrackerKey::new(envelope.model_name, Some(envelope.tenant_id));
+        let Some(entry) = self
+            .trackers
+            .get(&key)
+            .map(|entry| Arc::clone(entry.value()))
+        else {
+            tracing::trace!(
+                model_name = %key.model_name,
+                tenant_id = %key.tenant_id,
+                "Dropping replica event for unknown slot tracker"
+            );
+            return;
+        };
+        if entry.block_size != envelope.block_size {
+            tracing::debug!(
+                model_name = %key.model_name,
+                tenant_id = %key.tenant_id,
+                expected_block_size = entry.block_size,
+                received_block_size = envelope.block_size,
+                "Dropping replica event with mismatched block size"
+            );
+            return;
+        }
+        let Some(replica_tx) = &entry.replica_tx else {
+            return;
+        };
+        match replica_tx.try_send(envelope.event) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(event)) => {
+                tracing::trace!(
+                    model_name = %key.model_name,
+                    tenant_id = %key.tenant_id,
+                    request_id = %event.request_id,
+                    "Replica subscriber channel full; dropping event"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::debug!(
+                    model_name = %key.model_name,
+                    tenant_id = %key.tenant_id,
+                    "Replica subscriber channel closed; dropping event"
+                );
+            }
+        }
+    }
+
     fn entry(&self, key: &TrackerKey) -> Result<Arc<TrackerEntry>, RegistryError> {
         self.trackers
             .get(key)
@@ -443,6 +541,7 @@ fn matches_filters(key: &TrackerKey, model_name: Option<&str>, tenant_id: Option
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData};
 
     fn registry() -> SlotTrackerRegistry {
         SlotTrackerRegistry::new(CancellationToken::new())
@@ -450,6 +549,31 @@ mod tests {
 
     fn key(tenant_id: &str) -> TrackerKey {
         TrackerKey::new("model".to_string(), Some(tenant_id.to_string()))
+    }
+
+    fn replica_event(
+        tenant_id: &str,
+        block_size: u32,
+        worker: WorkerWithDpRank,
+        router_id: u64,
+    ) -> SlotReplicaEvent {
+        SlotReplicaEvent {
+            model_name: "model".to_string(),
+            tenant_id: tenant_id.to_string(),
+            block_size,
+            event: ActiveSequenceEvent {
+                request_id: "replica-request".to_string(),
+                worker,
+                data: ActiveSequenceEventData::AddRequest {
+                    token_sequence: Some(vec![1, 2, 3]),
+                    track_prefill_tokens: false,
+                    expected_output_tokens: None,
+                    prefill_load_hint: None,
+                },
+                router_id,
+                lora_name: None,
+            },
+        }
     }
 
     #[tokio::test]
@@ -572,6 +696,76 @@ mod tests {
             assert_eq!(workers[0].worker_id, 2);
             registry.unregister(&key, 2).unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn replica_dispatch_requires_registered_worker_and_matching_configuration() {
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let registry =
+            SlotTrackerRegistry::new_with_replica_sync(CancellationToken::new(), 7, outbound_tx);
+        let key = key("default");
+        registry.register(key.clone(), 1, 16, 0, 1).unwrap();
+
+        registry.dispatch_replica_event(replica_event(
+            "default",
+            16,
+            WorkerWithDpRank::new(1, 1),
+            8,
+        ));
+        registry.dispatch_replica_event(replica_event(
+            "default",
+            32,
+            WorkerWithDpRank::new(1, 0),
+            8,
+        ));
+        registry.dispatch_replica_event(replica_event(
+            "default",
+            16,
+            WorkerWithDpRank::new(1, 0),
+            7,
+        ));
+        tokio::task::yield_now().await;
+        assert_eq!(registry.list_loads(None, None)[0].active_decode_blocks, 0);
+
+        registry.dispatch_replica_event(replica_event(
+            "default",
+            16,
+            WorkerWithDpRank::new(1, 0),
+            8,
+        ));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if registry.list_loads(None, None)[0].active_decode_blocks == 3 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn recreated_tracker_uses_a_fresh_replica_channel() {
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let registry =
+            SlotTrackerRegistry::new_with_replica_sync(CancellationToken::new(), 7, outbound_tx);
+        let key = key("default");
+        registry.register(key.clone(), 1, 16, 0, 1).unwrap();
+        let first = registry.entry(&key).unwrap();
+
+        registry.unregister(&key, 1).unwrap();
+        registry.register(key.clone(), 1, 16, 0, 1).unwrap();
+        let second = registry.entry(&key).unwrap();
+
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert!(
+            !first
+                .replica_tx
+                .as_ref()
+                .unwrap()
+                .same_channel(second.replica_tx.as_ref().unwrap())
+        );
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/services/slot_tracker/replica_sync.rs
+++ b/lib/kv-router/src/services/slot_tracker/replica_sync.rs
@@ -1,0 +1,554 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+use std::future::{self, Future};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use anyhow::{Context as _, Result, anyhow};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+use crate::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
+use crate::sequences::{SequencePublisher, SequenceSubscriber};
+use crate::services::zmq::{create_bound_pub_socket, create_sub_socket, validate_endpoint};
+
+use super::registry::SlotTrackerRegistry;
+
+pub(crate) const REPLICA_EVENT_CHANNEL_CAPACITY: usize = 100_000;
+const PEER_COMMAND_CHANNEL_CAPACITY: usize = 64;
+const REPLICA_TOPIC: &[u8] = b"dynamo.slot-tracker.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SlotReplicaEvent {
+    pub model_name: String,
+    pub tenant_id: String,
+    pub block_size: u32,
+    pub event: ActiveSequenceEvent,
+}
+
+pub(crate) type ReplicaEventSender = mpsc::Sender<SlotReplicaEvent>;
+
+#[derive(Clone)]
+pub(crate) struct ScopedSequencePublisher {
+    replica: Option<ScopedReplicaPublisher>,
+}
+
+#[derive(Clone)]
+struct ScopedReplicaPublisher {
+    model_name: Arc<str>,
+    tenant_id: Arc<str>,
+    block_size: u32,
+    tx: ReplicaEventSender,
+}
+
+impl ScopedSequencePublisher {
+    pub(crate) fn disabled() -> Self {
+        Self { replica: None }
+    }
+
+    pub(crate) fn enabled(
+        model_name: Arc<str>,
+        tenant_id: Arc<str>,
+        block_size: u32,
+        tx: ReplicaEventSender,
+    ) -> Self {
+        Self {
+            replica: Some(ScopedReplicaPublisher {
+                model_name,
+                tenant_id,
+                block_size,
+                tx,
+            }),
+        }
+    }
+}
+
+impl SequencePublisher for ScopedSequencePublisher {
+    fn publish_event(
+        &self,
+        event: &ActiveSequenceEvent,
+    ) -> impl Future<Output = Result<()>> + Send {
+        let Some(replica) = &self.replica else {
+            return future::ready(Ok(()));
+        };
+        let envelope = SlotReplicaEvent {
+            model_name: replica.model_name.to_string(),
+            tenant_id: replica.tenant_id.to_string(),
+            block_size: replica.block_size,
+            event: event.clone(),
+        };
+        let result = match replica.tx.try_send(envelope) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(event)) => {
+                tracing::trace!(
+                    model_name = %event.model_name,
+                    tenant_id = %event.tenant_id,
+                    request_id = %event.event.request_id,
+                    "Replica publisher channel full; dropping event"
+                );
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                Err(anyhow!("replica publisher channel is closed"))
+            }
+        };
+        future::ready(result)
+    }
+
+    fn publish_load(&self, _load: ActiveLoad) {}
+
+    fn observe_load(
+        &self,
+        _worker: &WorkerWithDpRank,
+        _worker_type: &str,
+        _blocks: usize,
+        _tokens: usize,
+    ) {
+    }
+}
+
+pub(crate) struct ChannelSequenceSubscriber {
+    rx: mpsc::Receiver<ActiveSequenceEvent>,
+}
+
+impl ChannelSequenceSubscriber {
+    pub(crate) fn new(rx: mpsc::Receiver<ActiveSequenceEvent>) -> Self {
+        Self { rx }
+    }
+}
+
+impl SequenceSubscriber for ChannelSequenceSubscriber {
+    async fn next_event(&mut self) -> Option<Result<ActiveSequenceEvent>> {
+        self.rx.recv().await.map(Ok)
+    }
+
+    fn poll_next_event(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<ActiveSequenceEvent>>> {
+        self.rx.poll_recv(cx).map(|event| event.map(Ok))
+    }
+}
+
+pub(crate) fn generate_process_id() -> u64 {
+    loop {
+        let id = rand::random();
+        if id != 0 {
+            return id;
+        }
+    }
+}
+
+pub(crate) fn start_replica_publisher(
+    bind_endpoint: &str,
+    cancel_token: CancellationToken,
+) -> Result<ReplicaEventSender> {
+    validate_endpoint(bind_endpoint)?;
+    let mut socket = create_bound_pub_socket(bind_endpoint)
+        .with_context(|| format!("failed to bind replica publisher to `{bind_endpoint}`"))?;
+    let (tx, mut rx) = mpsc::channel::<SlotReplicaEvent>(REPLICA_EVENT_CHANNEL_CAPACITY);
+
+    tokio::spawn(async move {
+        loop {
+            let event = tokio::select! {
+                _ = cancel_token.cancelled() => break,
+                event = rx.recv() => {
+                    let Some(event) = event else {
+                        break;
+                    };
+                    event
+                }
+            };
+
+            let request_id = event.event.request_id.clone();
+            let payload = match rmp_serde::to_vec_named(&event) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    tracing::error!(
+                        request_id = %request_id,
+                        "Failed to encode slot-tracker replica event: {error}"
+                    );
+                    continue;
+                }
+            };
+            if let Err(error) = socket
+                .send_multipart(vec![REPLICA_TOPIC.to_vec(), payload])
+                .await
+            {
+                tracing::error!(
+                    request_id = %request_id,
+                    "Failed to publish slot-tracker replica event: {error}"
+                );
+            }
+        }
+    });
+
+    Ok(tx)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PeerError {
+    #[error(transparent)]
+    InvalidEndpoint(#[from] anyhow::Error),
+
+    #[error("peer endpoint matches this replica's advertised endpoint")]
+    SelfEndpoint,
+
+    #[error("replica peer manager is unavailable")]
+    Unavailable,
+}
+
+#[derive(Clone)]
+pub(crate) struct PeerManager {
+    command_tx: mpsc::Sender<PeerCommand>,
+    peers: Arc<RwLock<HashSet<String>>>,
+    advertised_endpoint: Option<Arc<str>>,
+}
+
+enum PeerCommand {
+    Register {
+        endpoint: String,
+        response: oneshot::Sender<Result<bool>>,
+    },
+    Deregister {
+        endpoint: String,
+        response: oneshot::Sender<Result<bool>>,
+    },
+}
+
+impl PeerManager {
+    pub(crate) fn start(
+        registry: Arc<SlotTrackerRegistry>,
+        initial_peers: Vec<String>,
+        advertised_endpoint: Option<String>,
+        cancel_token: CancellationToken,
+    ) -> Result<Self> {
+        let advertised_endpoint = advertised_endpoint.map(Arc::<str>::from);
+        if let Some(endpoint) = advertised_endpoint.as_deref() {
+            validate_endpoint(endpoint)
+                .with_context(|| format!("invalid advertised replica endpoint `{endpoint}`"))?;
+        }
+        let mut socket = create_sub_socket(REPLICA_TOPIC)?;
+        let mut configured_peers = HashSet::new();
+        for endpoint in initial_peers {
+            validate_peer_endpoint(&endpoint, advertised_endpoint.as_deref())?;
+            if configured_peers.insert(endpoint.clone()) {
+                socket
+                    .connect(&endpoint)
+                    .with_context(|| format!("failed to register replica peer `{endpoint}`"))?;
+            }
+        }
+
+        let peers = Arc::new(RwLock::new(configured_peers));
+        let (command_tx, mut command_rx) = mpsc::channel(PEER_COMMAND_CHANNEL_CAPACITY);
+        let task_peers = Arc::clone(&peers);
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => break,
+                    command = command_rx.recv() => {
+                        let Some(command) = command else {
+                            break;
+                        };
+                        handle_peer_command(&socket, &task_peers, command);
+                    }
+                    message = socket.recv_multipart() => {
+                        match message {
+                            Ok(frames) => handle_replica_message(&registry, frames),
+                            Err(error) => {
+                                tracing::error!("Failed to receive slot-tracker replica event: {error}");
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            command_tx,
+            peers,
+            advertised_endpoint,
+        })
+    }
+
+    pub(crate) async fn register_peer(&self, endpoint: String) -> Result<bool, PeerError> {
+        validate_peer_endpoint(&endpoint, self.advertised_endpoint.as_deref())?;
+        let (response, result) = oneshot::channel();
+        self.command_tx
+            .send(PeerCommand::Register { endpoint, response })
+            .await
+            .map_err(|_| PeerError::Unavailable)?;
+        result
+            .await
+            .map_err(|_| PeerError::Unavailable)?
+            .map_err(PeerError::InvalidEndpoint)
+    }
+
+    pub(crate) async fn deregister_peer(&self, endpoint: String) -> Result<bool, PeerError> {
+        validate_endpoint(&endpoint).map_err(PeerError::InvalidEndpoint)?;
+        let (response, result) = oneshot::channel();
+        self.command_tx
+            .send(PeerCommand::Deregister { endpoint, response })
+            .await
+            .map_err(|_| PeerError::Unavailable)?;
+        result
+            .await
+            .map_err(|_| PeerError::Unavailable)?
+            .map_err(PeerError::InvalidEndpoint)
+    }
+
+    pub(crate) fn list_peers(&self) -> Vec<String> {
+        let mut peers: Vec<_> = self.peers.read().iter().cloned().collect();
+        peers.sort();
+        peers
+    }
+}
+
+fn validate_peer_endpoint(
+    endpoint: &str,
+    advertised_endpoint: Option<&str>,
+) -> Result<(), PeerError> {
+    validate_endpoint(endpoint).map_err(PeerError::InvalidEndpoint)?;
+    if advertised_endpoint.is_some_and(|advertised| endpoint == advertised) {
+        return Err(PeerError::SelfEndpoint);
+    }
+    Ok(())
+}
+
+fn handle_peer_command(
+    socket: &crate::services::zmq::ZmqSocket,
+    peers: &RwLock<HashSet<String>>,
+    command: PeerCommand,
+) {
+    match command {
+        PeerCommand::Register { endpoint, response } => {
+            if peers.read().contains(&endpoint) {
+                let _ = response.send(Ok(false));
+                return;
+            }
+            let result = socket
+                .connect(&endpoint)
+                .with_context(|| format!("failed to register replica peer `{endpoint}`"))
+                .map(|()| {
+                    peers.write().insert(endpoint);
+                    true
+                });
+            let _ = response.send(result);
+        }
+        PeerCommand::Deregister { endpoint, response } => {
+            if !peers.read().contains(&endpoint) {
+                let _ = response.send(Ok(false));
+                return;
+            }
+            let result = socket
+                .disconnect(&endpoint)
+                .with_context(|| format!("failed to deregister replica peer `{endpoint}`"))
+                .map(|()| {
+                    peers.write().remove(&endpoint);
+                    true
+                });
+            let _ = response.send(result);
+        }
+    }
+}
+
+fn handle_replica_message(
+    registry: &SlotTrackerRegistry,
+    frames: crate::services::zmq::MultipartMessage,
+) {
+    let [topic, payload] = frames.as_slice() else {
+        tracing::debug!(
+            frame_count = frames.len(),
+            "Dropping malformed slot-tracker replica message"
+        );
+        return;
+    };
+    if topic.as_slice() != REPLICA_TOPIC {
+        tracing::debug!("Dropping slot-tracker replica message with unexpected topic");
+        return;
+    }
+    let event: SlotReplicaEvent = match rmp_serde::from_slice(payload) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::debug!("Dropping malformed slot-tracker replica payload: {error}");
+            return;
+        }
+    };
+    registry.dispatch_replica_event(event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::{ActiveSequenceEventData, WorkerWithDpRank};
+    use crate::services::slot_tracker::registry::TrackerKey;
+
+    fn event() -> SlotReplicaEvent {
+        SlotReplicaEvent {
+            model_name: "model".to_string(),
+            tenant_id: "tenant".to_string(),
+            block_size: 16,
+            event: ActiveSequenceEvent {
+                request_id: "request".to_string(),
+                worker: WorkerWithDpRank::new(1, 0),
+                data: ActiveSequenceEventData::Free,
+                router_id: 42,
+                lora_name: None,
+            },
+        }
+    }
+
+    #[test]
+    fn replica_event_round_trips_named_messagepack() {
+        let encoded = rmp_serde::to_vec_named(&event()).unwrap();
+        let decoded: SlotReplicaEvent = rmp_serde::from_slice(&encoded).unwrap();
+
+        assert_eq!(decoded.model_name, "model");
+        assert_eq!(decoded.tenant_id, "tenant");
+        assert_eq!(decoded.block_size, 16);
+        assert_eq!(decoded.event.request_id, "request");
+    }
+
+    #[test]
+    fn process_identity_is_nonzero() {
+        assert_ne!(generate_process_id(), 0);
+    }
+
+    #[test]
+    fn advertised_endpoint_cannot_be_registered_as_peer() {
+        let error = validate_peer_endpoint("tcp://127.0.0.1:8092", Some("tcp://127.0.0.1:8092"))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("advertised endpoint"));
+    }
+
+    #[tokio::test]
+    async fn scoped_publisher_drops_when_outbound_channel_is_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let publisher =
+            ScopedSequencePublisher::enabled(Arc::from("model"), Arc::from("tenant"), 16, tx);
+        let event = event().event;
+
+        publisher.publish_event(&event).await.unwrap();
+        publisher.publish_event(&event).await.unwrap();
+
+        assert_eq!(rx.len(), 1);
+        assert_eq!(rx.recv().await.unwrap().event.request_id, "request");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn peer_manager_registers_and_deregisters_endpoints() {
+        let cancel_token = CancellationToken::new();
+        let registry = Arc::new(SlotTrackerRegistry::new(cancel_token.clone()));
+        let manager = PeerManager::start(
+            registry,
+            Vec::new(),
+            Some("tcp://127.0.0.1:8092".to_string()),
+            cancel_token.clone(),
+        )
+        .unwrap();
+        let endpoint = "tcp://127.0.0.1:8093".to_string();
+
+        assert!(manager.register_peer(endpoint.clone()).await.unwrap());
+        assert!(!manager.register_peer(endpoint.clone()).await.unwrap());
+        assert_eq!(manager.list_peers(), vec![endpoint.clone()]);
+        assert!(manager.deregister_peer(endpoint.clone()).await.unwrap());
+        assert!(!manager.deregister_peer(endpoint).await.unwrap());
+        assert!(manager.list_peers().is_empty());
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn zmq_replica_sync_propagates_request_lifecycle() {
+        let endpoint_a = reserve_tcp_endpoint();
+        let endpoint_b = reserve_tcp_endpoint();
+        let cancel_token = CancellationToken::new();
+        let outbound_a = start_replica_publisher(&endpoint_a, cancel_token.child_token()).unwrap();
+        let outbound_b = start_replica_publisher(&endpoint_b, cancel_token.child_token()).unwrap();
+        let registry_a = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
+            cancel_token.clone(),
+            11,
+            outbound_a,
+        ));
+        let registry_b = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
+            cancel_token.clone(),
+            22,
+            outbound_b,
+        ));
+        let _peer_b = PeerManager::start(
+            Arc::clone(&registry_b),
+            vec![endpoint_a],
+            Some(endpoint_b),
+            cancel_token.child_token(),
+        )
+        .unwrap();
+        let key = TrackerKey::new("model".to_string(), Some("tenant".to_string()));
+        registry_a.register(key.clone(), 1, 16, 0, 1).unwrap();
+        registry_b.register(key.clone(), 1, 16, 0, 1).unwrap();
+        let worker = WorkerWithDpRank::new(1, 0);
+
+        let mut warmup_requests = Vec::new();
+        for attempt in 0..40 {
+            let request_id = format!("warmup-{attempt}");
+            registry_a
+                .add_request(&key, request_id.clone(), worker, vec![attempt], 0)
+                .unwrap();
+            warmup_requests.push(request_id);
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            if registry_b.list_loads(None, None)[0].active_decode_blocks > 0 {
+                break;
+            }
+        }
+        assert!(registry_b.list_loads(None, None)[0].active_decode_blocks > 0);
+
+        for request_id in &warmup_requests {
+            registry_a.free(&key, request_id).unwrap();
+        }
+        wait_for_load(&registry_b, 0, 0).await;
+
+        registry_a
+            .add_request(&key, "target".to_string(), worker, vec![1, 2, 3], 8)
+            .unwrap();
+        wait_for_load(&registry_b, 3, 8).await;
+
+        registry_a.mark_prefill_completed(&key, "target").unwrap();
+        wait_for_load(&registry_b, 3, 0).await;
+
+        registry_a.free(&key, "target").unwrap();
+        wait_for_load(&registry_b, 0, 0).await;
+        cancel_token.cancel();
+    }
+
+    async fn wait_for_load(
+        registry: &SlotTrackerRegistry,
+        expected_blocks: usize,
+        expected_tokens: usize,
+    ) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let load = &registry.list_loads(None, None)[0];
+                if load.active_decode_blocks == expected_blocks
+                    && load.active_prefill_tokens == expected_tokens
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    fn reserve_tcp_endpoint() -> String {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("failed to reserve TCP port");
+        let endpoint = format!("tcp://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        drop(listener);
+        endpoint
+    }
+}

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -18,9 +18,11 @@ use crate::protocols::WorkerWithDpRank;
 use crate::sequences::SequenceError;
 
 use super::registry::{RegistryError, ServiceError, SlotTrackerRegistry, TrackerKey};
+use super::replica_sync::{PeerError, PeerManager};
 
 pub struct AppState {
     pub registry: Arc<SlotTrackerRegistry>,
+    pub(crate) peer_manager: Option<PeerManager>,
 }
 
 fn default_tenant() -> String {
@@ -83,6 +85,11 @@ struct PotentialLoadsRequest {
 struct FilterQuery {
     model_name: Option<String>,
     tenant_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PeerRequest {
+    url: String,
 }
 
 fn deserialize_sequence_hashes<'de, D>(deserializer: D) -> Result<Vec<SequenceHash>, D::Error>
@@ -245,6 +252,53 @@ async fn potential_loads(
     }
 }
 
+async fn register_peer(
+    State(state): State<Arc<AppState>>,
+    payload: Result<Json<PeerRequest>, JsonRejection>,
+) -> Response {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(error) => return json_rejection(error),
+    };
+    let Some(peer_manager) = &state.peer_manager else {
+        return json_error(StatusCode::CONFLICT, "replica sync is disabled");
+    };
+    match peer_manager.register_peer(req.url).await {
+        Ok(true) => json_ok(StatusCode::CREATED),
+        Ok(false) => json_ok(StatusCode::OK),
+        Err(error) => peer_error(error),
+    }
+}
+
+async fn deregister_peer(
+    State(state): State<Arc<AppState>>,
+    payload: Result<Json<PeerRequest>, JsonRejection>,
+) -> Response {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(error) => return json_rejection(error),
+    };
+    let Some(peer_manager) = &state.peer_manager else {
+        return json_error(StatusCode::CONFLICT, "replica sync is disabled");
+    };
+    match peer_manager.deregister_peer(req.url).await {
+        Ok(true) => json_ok(StatusCode::OK),
+        Ok(false) => json_error(StatusCode::NOT_FOUND, "peer not found"),
+        Err(error) => peer_error(error),
+    }
+}
+
+async fn list_peers(State(state): State<Arc<AppState>>) -> Response {
+    Json(
+        state
+            .peer_manager
+            .as_ref()
+            .map(PeerManager::list_peers)
+            .unwrap_or_default(),
+    )
+    .into_response()
+}
+
 async fn health() -> StatusCode {
     StatusCode::OK
 }
@@ -304,6 +358,14 @@ fn service_error(error: ServiceError) -> Response {
     }
 }
 
+fn peer_error(error: PeerError) -> Response {
+    let status = match error {
+        PeerError::InvalidEndpoint(_) | PeerError::SelfEndpoint => StatusCode::BAD_REQUEST,
+        PeerError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+    };
+    json_error(status, error)
+}
+
 pub fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/register", post(register))
@@ -314,6 +376,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/free", post(free))
         .route("/loads", get(list_loads))
         .route("/potential_loads", post(potential_loads))
+        .route("/register_peer", post(register_peer))
+        .route("/deregister_peer", post(deregister_peer))
+        .route("/peers", get(list_peers))
         .route("/health", get(health))
         .fallback(not_found)
         .method_not_allowed_fallback(method_not_allowed)
@@ -332,6 +397,7 @@ mod tests {
     fn app() -> Router {
         create_router(Arc::new(AppState {
             registry: Arc::new(SlotTrackerRegistry::new(CancellationToken::new())),
+            peer_manager: None,
         }))
     }
 
@@ -400,6 +466,36 @@ mod tests {
             .unwrap();
         assert_eq!(method_response.status(), StatusCode::METHOD_NOT_ALLOWED);
         assert!(response_json(method_response).await["error"].is_string());
+    }
+
+    #[tokio::test]
+    async fn peer_routes_report_disabled_replica_sync() {
+        let app = app();
+        let peers_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/peers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(peers_response.status(), StatusCode::OK);
+        assert_eq!(response_json(peers_response).await, serde_json::json!([]));
+
+        let register_response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/register_peer")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"url":"tcp://127.0.0.1:8092"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(register_response.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -359,7 +359,7 @@ fn service_error(error: ServiceError) -> Response {
 }
 
 fn peer_error(error: PeerError) -> Response {
-    let status = match error {
+    let status = match &error {
         PeerError::InvalidEndpoint(_) | PeerError::SelfEndpoint => StatusCode::BAD_REQUEST,
         PeerError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
     };

--- a/lib/kv-router/src/services/zmq.rs
+++ b/lib/kv-router/src/services/zmq.rs
@@ -4,14 +4,18 @@
 use std::collections::VecDeque;
 use std::future::poll_fn;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::Arc;
 use std::task::{Context, Poll, ready};
 
 use anyhow::{Result, anyhow};
-use tokio::{io::unix::AsyncFd, sync::Mutex};
+#[cfg(feature = "standalone-indexer")]
+use std::sync::Arc;
+use tokio::io::unix::AsyncFd;
+#[cfg(feature = "standalone-indexer")]
+use tokio::sync::Mutex;
 
-pub(super) type MultipartMessage = Vec<Vec<u8>>;
-pub(super) type SharedSocket = Arc<Mutex<ZmqSocket>>;
+pub(crate) type MultipartMessage = Vec<Vec<u8>>;
+#[cfg(feature = "standalone-indexer")]
+pub(crate) type SharedSocket = Arc<Mutex<ZmqSocket>>;
 
 const ZMQ_RCVTIMEOUT_MS: i32 = 100;
 const ZMQ_SNDTIMEOUT_MS: i32 = 0;
@@ -43,7 +47,7 @@ impl AsRawFd for SocketWrapper {
     }
 }
 
-pub(super) struct ZmqSocket(AsyncFd<SocketWrapper>);
+pub(crate) struct ZmqSocket(AsyncFd<SocketWrapper>);
 
 impl ZmqSocket {
     fn new(socket: zmq::Socket) -> Result<Self> {
@@ -52,6 +56,17 @@ impl ZmqSocket {
 
     fn socket(&self) -> &zmq::Socket {
         &self.0.get_ref().socket
+    }
+
+    pub(crate) fn connect(&self, endpoint: &str) -> Result<()> {
+        self.socket().connect(endpoint)?;
+        Ok(())
+    }
+
+    #[cfg(any(feature = "standalone-slot-tracker", test))]
+    pub(crate) fn disconnect(&self, endpoint: &str) -> Result<()> {
+        self.socket().disconnect(endpoint)?;
+        Ok(())
     }
 
     fn poll_socket_event(
@@ -132,6 +147,18 @@ impl ZmqSocket {
 
         Poll::Ready(Ok(()))
     }
+
+    pub(crate) async fn recv_multipart(&mut self) -> Result<MultipartMessage> {
+        poll_fn(|cx| self.poll_recv_multipart(cx)).await
+    }
+
+    pub(crate) async fn send_multipart(&mut self, frames: MultipartMessage) -> Result<()> {
+        let mut buffer = frames
+            .into_iter()
+            .map(zmq::Message::from)
+            .collect::<VecDeque<_>>();
+        poll_fn(|cx| self.poll_send_multipart(cx, &mut buffer)).await
+    }
 }
 
 fn configure_common_socket(socket: &zmq::Socket) -> Result<()> {
@@ -151,13 +178,14 @@ fn configure_receive_socket(socket: &zmq::Socket) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "standalone-indexer")]
 fn configure_bidirectional_socket(socket: &zmq::Socket) -> Result<()> {
     configure_receive_socket(socket)?;
     socket.set_sndtimeo(ZMQ_SNDTIMEOUT_MS)?;
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "standalone-slot-tracker", test))]
 fn configure_send_socket(socket: &zmq::Socket) -> Result<()> {
     configure_common_socket(socket)?;
     socket.set_sndtimeo(ZMQ_SNDTIMEOUT_MS)?;
@@ -174,16 +202,23 @@ where
     ZmqSocket::new(socket)
 }
 
-pub(super) fn connect_sub_socket(endpoint: &str) -> Result<SharedSocket> {
-    Ok(Arc::new(Mutex::new(build_socket(zmq::SUB, |socket| {
+pub(crate) fn create_sub_socket(topic: &[u8]) -> Result<ZmqSocket> {
+    build_socket(zmq::SUB, |socket| {
         configure_receive_socket(socket)?;
-        socket.set_subscribe(b"")?;
-        socket.connect(endpoint)?;
+        socket.set_subscribe(topic)?;
         Ok(())
-    })?)))
+    })
 }
 
-pub(super) fn connect_dealer_socket(endpoint: &str) -> Result<SharedSocket> {
+#[cfg(feature = "standalone-indexer")]
+pub(crate) fn connect_sub_socket(endpoint: &str) -> Result<SharedSocket> {
+    let socket = create_sub_socket(b"")?;
+    socket.connect(endpoint)?;
+    Ok(Arc::new(Mutex::new(socket)))
+}
+
+#[cfg(feature = "standalone-indexer")]
+pub(crate) fn connect_dealer_socket(endpoint: &str) -> Result<SharedSocket> {
     Ok(Arc::new(Mutex::new(build_socket(zmq::DEALER, |socket| {
         configure_bidirectional_socket(socket)?;
         socket.connect(endpoint)?;
@@ -191,25 +226,72 @@ pub(super) fn connect_dealer_socket(endpoint: &str) -> Result<SharedSocket> {
     })?)))
 }
 
-#[cfg(test)]
-pub(super) fn bind_pub_socket(endpoint: &str) -> Result<SharedSocket> {
-    Ok(Arc::new(Mutex::new(build_socket(zmq::PUB, |socket| {
+#[cfg(any(feature = "standalone-slot-tracker", test))]
+pub(crate) fn create_bound_pub_socket(endpoint: &str) -> Result<ZmqSocket> {
+    build_socket(zmq::PUB, |socket| {
         configure_send_socket(socket)?;
         socket.bind(endpoint)?;
         Ok(())
-    })?)))
+    })
 }
 
-pub(super) async fn recv_multipart(socket: &SharedSocket) -> Result<MultipartMessage> {
-    let mut socket = socket.lock().await;
-    poll_fn(|cx| socket.poll_recv_multipart(cx)).await
+#[cfg(all(test, feature = "standalone-indexer"))]
+pub(crate) fn bind_pub_socket(endpoint: &str) -> Result<SharedSocket> {
+    Ok(Arc::new(Mutex::new(create_bound_pub_socket(endpoint)?)))
 }
 
-pub(super) async fn send_multipart(socket: &SharedSocket, frames: MultipartMessage) -> Result<()> {
+#[cfg(feature = "standalone-indexer")]
+pub(crate) async fn recv_multipart(socket: &SharedSocket) -> Result<MultipartMessage> {
     let mut socket = socket.lock().await;
-    let mut buffer = frames
-        .into_iter()
-        .map(zmq::Message::from)
-        .collect::<VecDeque<_>>();
-    poll_fn(|cx| socket.poll_send_multipart(cx, &mut buffer)).await
+    socket.recv_multipart().await
+}
+
+#[cfg(feature = "standalone-indexer")]
+pub(crate) async fn send_multipart(socket: &SharedSocket, frames: MultipartMessage) -> Result<()> {
+    let mut socket = socket.lock().await;
+    socket.send_multipart(frames).await
+}
+
+pub(crate) fn validate_endpoint(endpoint: &str) -> Result<()> {
+    let (scheme, address) = endpoint
+        .split_once("://")
+        .ok_or_else(|| anyhow!("invalid ZMQ endpoint `{endpoint}`: missing scheme"))?;
+
+    if address.is_empty() {
+        return Err(anyhow!(
+            "invalid ZMQ endpoint `{endpoint}`: missing address"
+        ));
+    }
+
+    match scheme {
+        "tcp" => {
+            let (host, port) = address
+                .rsplit_once(':')
+                .ok_or_else(|| anyhow!("invalid ZMQ endpoint `{endpoint}`: missing TCP port"))?;
+            if host.is_empty() {
+                return Err(anyhow!(
+                    "invalid ZMQ endpoint `{endpoint}`: missing TCP host"
+                ));
+            }
+            if host.starts_with('[') {
+                if !host.ends_with(']') {
+                    return Err(anyhow!(
+                        "invalid ZMQ endpoint `{endpoint}`: missing closing `]`"
+                    ));
+                }
+            } else if host.contains(':') {
+                return Err(anyhow!(
+                    "invalid ZMQ endpoint `{endpoint}`: missing TCP port"
+                ));
+            }
+            port.parse::<u16>().map_err(|error| {
+                anyhow!("invalid ZMQ endpoint `{endpoint}`: invalid TCP port: {error}")
+            })?;
+            Ok(())
+        }
+        "ipc" | "inproc" => Ok(()),
+        other => Err(anyhow!(
+            "invalid ZMQ endpoint `{endpoint}`: unsupported scheme `{other}`"
+        )),
+    }
 }

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -15,6 +15,7 @@ use dynamo_kv_router::protocols::{
 };
 use dynamo_kv_router::queue::DEFAULT_MAX_BATCHED_TOKENS;
 use dynamo_kv_router::scheduling::SchedulingContext;
+use dynamo_kv_router::sequences::topology::WorkerDpRange;
 use dynamo_kv_router::{
     ActiveSequencesMultiWorker, DefaultWorkerSelector, PrefillTokenDeltas, RadixTree,
     RouterSchedulingPolicy, SchedulingPolicy, SchedulingRequest, SequenceRequest, WorkerSelector,
@@ -357,8 +358,10 @@ impl OfflineReplayRouter {
         {
             return Err(anyhow!("router worker {worker_id} already exists"));
         }
-        let dp_range = HashMap::from([(wid, (0u32, 1u32))]);
-        self.slots.register_external_workers(&dp_range);
+        if let Err(error) = self.slots.upsert_worker(WorkerDpRange::new(wid, 0, 1)) {
+            self.workers_with_configs.remove(&wid);
+            return Err(error.into());
+        }
 
         Ok(())
     }
@@ -922,6 +925,24 @@ mod tests {
         assert_eq!(
             router.debug_snapshot(0.0).active_tokens_by_worker,
             vec![(0, 64), (1, 64), (2, 0)]
+        );
+    }
+
+    #[test]
+    fn test_readding_removed_worker_reuses_slot_state() {
+        let mut router =
+            OfflineReplayRouter::new(&queueing_args(), Some(queueing_router_config()), None, 1)
+                .unwrap();
+
+        router
+            .on_request_arrival(&request(1, 7), None, 0.0)
+            .unwrap();
+        router.remove_worker(0).unwrap();
+        router.add_worker(0).unwrap();
+
+        assert_eq!(
+            router.debug_snapshot(0.0).active_tokens_by_worker,
+            vec![(0, 64)]
         );
     }
 


### PR DESCRIPTION
Adds optional runtime-free ZMQ replica synchronization to the standalone slot tracker, including strict registered-worker admission, bounded lossy dispatch, dynamic peer management, and CLI configuration. Reuses the existing generic sequence publisher/subscriber abstractions and documents the advisory lifecycle contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone slot tracker can optionally replicate lifecycle events to peers via ZMQ PUB/SUB with configurable bind/advertise/peers and best-effort (bounded, non‑ack) delivery.
  * CLI flags added to enable replica sync and new HTTP routes: POST /register_peer, POST /deregister_peer, GET /peers.

* **Documentation**
  * Docs updated with replica synchronization details, launch instructions for the new flags, and peer-management semantics and endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->