### PR TITLE
fix: truncated TCP response stream completion

### DIFF
--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -340,6 +340,13 @@ impl StreamSender {
 
 pub struct StreamReceiver {
     rx: tokio::sync::mpsc::Receiver<Bytes>,
+    terminal: Option<tokio::sync::oneshot::Receiver<StreamTerminal>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamTerminal {
+    Clean,
+    Truncated,
 }
 
 /// Connection Info is encoded as JSON and then again serialized has part of the Transport

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -29,6 +29,7 @@ use crate::pipeline::network::StreamOptions;
 use crate::pipeline::network::StreamProvider;
 use crate::pipeline::network::StreamReceiver;
 use crate::pipeline::network::StreamSender;
+use crate::pipeline::network::StreamTerminal;
 use crate::pipeline::network::TwoPartCodec;
 use crate::pipeline::network::codec::TwoPartMessage;
 use crate::pipeline::network::tcp;
@@ -48,8 +49,21 @@ use tracing::Instrument;
 /// - emits TTFT and transport-roundtrip metrics on first response
 /// - hands off the `InflightGuard` to a stream-lifetime `InflightDecStream` so
 ///   the inflight gauge stays accurate for the whole response lifetime.
+fn response_stream_terminal(
+    terminal_rx: &mut Option<tokio::sync::oneshot::Receiver<StreamTerminal>>,
+) -> StreamTerminal {
+    match terminal_rx {
+        Some(rx) => match rx.try_recv() {
+            Ok(terminal) => terminal,
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => StreamTerminal::Truncated,
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => StreamTerminal::Truncated,
+        },
+        None => StreamTerminal::Truncated,
+    }
+}
+
 fn decode_response_stream<U>(
-    response_rx: tokio::sync::mpsc::Receiver<bytes::Bytes>,
+    response_stream: StreamReceiver,
     engine_ctx: Arc<dyn crate::engine::AsyncEngineContext>,
     queue_start: Instant,
     tx_start: Instant,
@@ -58,6 +72,10 @@ fn decode_response_stream<U>(
 where
     U: Data + for<'de> Deserialize<'de> + MaybeError,
 {
+    let StreamReceiver {
+        rx: response_rx,
+        mut terminal,
+    } = response_stream;
     let engine_ctx_for_stream = engine_ctx.clone();
     let mut is_complete_final = false;
     let mut first_response = true;
@@ -95,7 +113,9 @@ where
                     Some(U::from_err(DynamoError::msg(err.to_string())))
                 }
             }
-        } else if is_complete_final {
+        } else if response_stream_terminal(&mut terminal) == StreamTerminal::Clean
+            && is_complete_final
+        {
             None
         } else if engine_ctx_for_stream.is_stopped() {
             tracing::debug!("Request cancelled and then trying to read a response");
@@ -574,7 +594,7 @@ impl AddressedPushRouter {
         drop(_nvtx_wait);
 
         Ok(decode_response_stream(
-            response_stream.rx,
+            response_stream,
             engine_ctx,
             queue_start,
             tx_start,
@@ -677,10 +697,42 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        CONTROL_MESSAGE_MAX_BYTES, ConnectionInfo, RequestControlMessage, RequestType,
-        ResponseType, serialize_control_message,
+        CONTROL_MESSAGE_MAX_BYTES, ConnectionInfo, InflightGuard, RequestControlMessage,
+        RequestType, ResponseType, decode_response_stream, serialize_control_message,
     };
+    use crate::engine::AsyncEngineContextProvider;
+    use crate::error::DynamoError;
+    use crate::metrics::request_plane::REQUEST_PLANE_INFLIGHT;
+    use crate::pipeline::Context;
+    use crate::pipeline::network::{NetworkStreamWrapper, StreamReceiver, StreamTerminal};
+    use crate::protocols::maybe_error::MaybeError;
+    use bytes::Bytes;
+    use serde::{Deserialize, Serialize};
     use std::collections::BTreeMap;
+    use std::time::Instant;
+    use tokio::sync::{mpsc, oneshot};
+    use tokio_stream::StreamExt;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestResponse {
+        value: Option<String>,
+        error: Option<String>,
+    }
+
+    impl MaybeError for TestResponse {
+        fn from_err(err: impl std::error::Error + 'static) -> Self {
+            Self {
+                value: None,
+                error: Some(err.to_string()),
+            }
+        }
+
+        fn err(&self) -> Option<DynamoError> {
+            self.error
+                .as_ref()
+                .map(|message| DynamoError::msg(message.clone()))
+        }
+    }
 
     fn base_control_message(metadata: BTreeMap<String, String>) -> RequestControlMessage {
         RequestControlMessage {
@@ -720,5 +772,47 @@ mod tests {
             .to_string();
         assert!(err.contains("request control message too large"));
         assert!(err.contains(&CONTROL_MESSAGE_MAX_BYTES.to_string()));
+    }
+
+    #[tokio::test]
+    async fn decode_response_stream_rejects_complete_final_on_truncated_wire_close() {
+        let (tx, rx) = mpsc::channel(4);
+        let (terminal_tx, terminal_rx) = oneshot::channel();
+        let complete_final = NetworkStreamWrapper::<TestResponse> {
+            data: None,
+            complete_final: true,
+        };
+
+        tx.send(Bytes::from(serde_json::to_vec(&complete_final).unwrap()))
+            .await
+            .unwrap();
+        terminal_tx.send(StreamTerminal::Truncated).unwrap();
+        drop(tx);
+
+        REQUEST_PLANE_INFLIGHT.inc();
+        let stream_receiver = StreamReceiver {
+            rx,
+            terminal: Some(terminal_rx),
+        };
+        let engine_ctx = Context::new(()).context();
+        let mut decoded = decode_response_stream::<TestResponse>(
+            stream_receiver,
+            engine_ctx,
+            Instant::now(),
+            Instant::now(),
+            InflightGuard::new(),
+        );
+
+        let item = decoded
+            .next()
+            .await
+            .expect("truncated close after complete_final should emit an error item");
+        let err = item.err().expect("decoded item should carry an error");
+        assert!(
+            err.to_string()
+                .contains("Stream ended before generation completed"),
+            "unexpected error: {err}"
+        );
+        assert!(decoded.next().await.is_none());
     }
 }

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -239,7 +239,10 @@ impl TcpClient {
             cancellation_counter,
         ));
 
-        Ok(StreamReceiver { rx: bytes_rx })
+        Ok(StreamReceiver {
+            rx: bytes_rx,
+            terminal: None,
+        })
     }
 }
 

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -40,7 +40,7 @@ use crate::engine::AsyncEngineContext;
 use crate::pipeline::{
     PipelineError,
     network::{
-        ResponseService, ResponseStreamPrologue,
+        ResponseService, ResponseStreamPrologue, StreamTerminal,
         codec::{TwoPartMessage, TwoPartMessageType},
         tcp::StreamType,
     },
@@ -810,10 +810,12 @@ async fn tcp_listener(
         // Buffer size should be driven by the registration options rather than
         // hard-coded; the same applies to `process_request_stream`. See #10293.
         let (response_tx, response_rx) = mpsc::channel(64);
+        let (terminal_tx, terminal_rx) = oneshot::channel();
 
         if connection
             .send(Ok(crate::pipeline::network::StreamReceiver {
                 rx: response_rx,
+                terminal: Some(terminal_rx),
             }))
             .is_err()
         {
@@ -834,6 +836,7 @@ async fn tcp_listener(
             reader,
             response_tx,
             control_tx,
+            terminal_tx,
             context.clone(),
         ));
 
@@ -850,22 +853,26 @@ async fn tcp_listener(
         mut framed_reader: FramedRead<tokio::io::ReadHalf<tokio::net::TcpStream>, TwoPartCodec>,
         response_tx: mpsc::Sender<Bytes>,
         control_tx: mpsc::Sender<ControlMessage>,
+        terminal_tx: oneshot::Sender<StreamTerminal>,
         context: Arc<dyn AsyncEngineContext>,
     ) {
         // loop over reading the tcp stream and checking if the writer is closed
         let mut can_stop = true;
+        let mut terminal_tx = Some(terminal_tx);
         loop {
             tokio::select! {
                 biased;
 
                 _ = response_tx.closed() => {
                     tracing::trace!("response channel closed before the client finished writing data");
+                    send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                     let _ = control_tx.send(ControlMessage::Kill).await;
                     break;
                 }
 
                 _ = context.killed() => {
                     tracing::trace!("context kill signal received; shutting down");
+                    send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                     let _ = control_tx.send(ControlMessage::Kill).await;
                     break;
                 }
@@ -873,6 +880,7 @@ async fn tcp_listener(
                 _ = context.stopped(), if can_stop => {
                     tracing::trace!("context stop signal received; shutting down");
                     can_stop = false;
+                    send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                     let _ = control_tx.send(ControlMessage::Stop).await;
                 }
 
@@ -894,16 +902,19 @@ async fn tcp_listener(
                                                 data_len = data.len(),
                                                 "client sent Sentinel with data (protocol violation); killing stream"
                                             );
+                                            send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                                             let _ = control_tx.send(ControlMessage::Kill).await;
                                             break;
                                         }
                                         tracing::trace!("received sentinel message; shutting down");
+                                        send_stream_terminal(&mut terminal_tx, StreamTerminal::Clean);
                                         break;
                                     }
                                     Err(e) => {
                                         // Malformed control message — kill only
                                         // this stream.
                                         tracing::warn!(err = ?e, "malformed control message, closing connection");
+                                        send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                                         let _ = control_tx.send(ControlMessage::Kill).await;
                                         break;
                                     }
@@ -913,6 +924,7 @@ async fn tcp_listener(
                             if !data.is_empty()
                                 && let Err(err) = response_tx.send(data).await {
                                     tracing::debug!(?err, "forwarding body/data to response channel failed");
+                                    send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                                     let _ = control_tx.send(ControlMessage::Kill).await;
                                     break;
                                 };
@@ -921,22 +933,28 @@ async fn tcp_listener(
                             // TCP RST or decode error from worker — kill only
                             // this stream.
                             tracing::warn!(err = ?e, "tcp stream read error from worker, closing connection");
+                            send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                             let _ = control_tx.send(ControlMessage::Kill).await;
                             break;
                         }
                         None => {
-                            // this is allowed but we try to avoid it
-                            // the logic is that the client will tell us when its is done and the server
-                            // will close the connection naturally when the sentinel message is received
-                            // the client closing early represents a transport error outside the control of the
-                            // transport library
-                            tracing::trace!("tcp stream was closed by client");
+                            tracing::trace!("tcp response stream closed before Sentinel");
+                            send_stream_terminal(&mut terminal_tx, StreamTerminal::Truncated);
                             break;
                         }
                     }
                 }
 
             }
+        }
+    }
+
+    fn send_stream_terminal(
+        terminal_tx: &mut Option<oneshot::Sender<StreamTerminal>>,
+        terminal: StreamTerminal,
+    ) {
+        if let Some(tx) = terminal_tx.take() {
+            let _ = tx.send(terminal);
         }
     }
 
@@ -1756,6 +1774,19 @@ mod tests {
         serde_json::from_slice(header.expect("control header missing").as_ref()).unwrap()
     }
 
+    async fn recv_stream_terminal(receiver: &mut StreamReceiver) -> StreamTerminal {
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            receiver
+                .terminal
+                .take()
+                .expect("response stream should carry a terminal marker"),
+        )
+        .await
+        .expect("terminal marker should arrive")
+        .expect("terminal marker sender should not be dropped")
+    }
+
     /// Sending an unexpected control message (Stop or Kill from the data
     /// direction) is a protocol violation. The server's
     /// network_receive_handler must reply with ControlMessage::Kill on
@@ -1819,6 +1850,97 @@ mod tests {
             recv_control_message(&mut framed_reader).await,
             ControlMessage::Kill,
             "Sentinel with data should kill only this stream"
+        );
+    }
+
+    /// A header-only Sentinel from the worker is the clean response-stream
+    /// terminator: payload frames already delivered stay readable, then the
+    /// StreamReceiver closes.
+    #[tokio::test]
+    async fn test_tcp_stream_server_closes_response_receiver_on_clean_sentinel() {
+        let (_framed_reader, mut framed_writer, mut receiver) =
+            open_registered_response_stream().await;
+
+        framed_writer
+            .send(TwoPartMessage::from_data(Bytes::from_static(
+                b"final chunk",
+            )))
+            .await
+            .unwrap();
+        framed_writer
+            .send(TwoPartMessage::from_header(
+                serde_json::to_vec(&ControlMessage::Sentinel)
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+
+        let data = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.rx.recv())
+            .await
+            .expect("response data should arrive")
+            .expect("receiver should not close before data");
+        assert_eq!(data.as_ref(), b"final chunk");
+
+        let end = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.rx.recv())
+            .await
+            .expect("receiver should close after clean Sentinel");
+        assert!(end.is_none(), "clean Sentinel should close the receiver");
+        assert_eq!(
+            recv_stream_terminal(&mut receiver).await,
+            StreamTerminal::Clean,
+            "clean Sentinel should mark the response stream as clean"
+        );
+    }
+
+    /// TCP EOF without a header-only Sentinel is a truncated response stream.
+    /// This matters even when data was delivered first: the typed response
+    /// decoder must not confuse app-level complete bytes with the wire-level
+    /// terminal frame.
+    #[tokio::test]
+    async fn test_tcp_stream_server_marks_response_eof_without_sentinel_truncated() {
+        let (_framed_reader, mut framed_writer, mut receiver) =
+            open_registered_response_stream().await;
+
+        framed_writer
+            .send(TwoPartMessage::from_data(Bytes::from_static(
+                b"complete-final-like-bytes",
+            )))
+            .await
+            .unwrap();
+        let mut raw_writer = framed_writer.into_inner();
+        raw_writer.shutdown().await.unwrap();
+
+        let data = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.rx.recv())
+            .await
+            .expect("response data should arrive")
+            .expect("receiver should not close before data");
+        assert_eq!(data.as_ref(), b"complete-final-like-bytes");
+
+        let end = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.rx.recv())
+            .await
+            .expect("receiver should close after TCP EOF");
+        assert!(end.is_none(), "TCP EOF should close the receiver");
+        assert_eq!(
+            recv_stream_terminal(&mut receiver).await,
+            StreamTerminal::Truncated,
+            "TCP EOF without Sentinel must be visible as truncation"
+        );
+    }
+
+    /// If the response consumer is dropped while the worker is still attached,
+    /// the server must notify that worker with Kill so it can stop producing
+    /// into an abandoned stream.
+    #[tokio::test]
+    async fn test_tcp_stream_server_sends_kill_when_response_receiver_dropped() {
+        let (mut framed_reader, _framed_writer, receiver) = open_registered_response_stream().await;
+
+        drop(receiver);
+
+        assert_eq!(
+            recv_control_message(&mut framed_reader).await,
+            ControlMessage::Kill,
+            "dropping response receiver should notify the worker with Kill"
         );
     }
 


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream termination tracking to distinguish between clean and truncated response completions.
  * Enhanced validation to detect and properly handle incomplete response streams.

* **Tests**
  * Added tests verifying stream termination signal delivery and error detection across various stream closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->