### PR TITLE
docs: remove stale disagg readiness DEP link

### DIFF
--- a/docs/proposals/health-disagg-readiness.md
+++ b/docs/proposals/health-disagg-readiness.md
@@ -2,7 +2,7 @@
 
 **Author:** Jie Hao
 **Date:** 2026-03-24 (updated 2026-05-22)
-**Status:** Approved — See [DEP-0014](https://github.com/ai-dynamo/enhancements/deps/0014-health-endpoint-disagg-readiness.md) and tracking issue [#7787](https://github.com/ai-dynamo/dynamo/issues/7787). PR 1, PR 2a–d landed; PR 3 in progress.
+**Status:** Approved — See tracking issue [#7787](https://github.com/ai-dynamo/dynamo/issues/7787). PR 1, PR 2a–d landed; PR 3 in progress.
 
 ## Problem
 


### PR DESCRIPTION
## Summary
- remove the stale DEP-0014 link from docs/proposals/health-disagg-readiness.md
- keep the valid tracking issue reference for #7787

## Why
The lychee documentation link check fails because https://github.com/ai-dynamo/enhancements/deps/0014-health-endpoint-disagg-readiness.md returns 404. I could not find that exact DEP path in the public ai-dynamo/enhancements history; only a related draft, deps/0000-health-endpoint-disagg-readiness.md, appears on the jihao/service_readiness branch.

## Validation
- git diff --check
- confirmed the stale URL no longer appears in docs/proposals/health-disagg-readiness.md

Note: local pre-commit failed in the pytest-marker-report hook due to an unrelated environment issue: ImportError importing run_slot_tracker from the local dynamo._core extension.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated proposal status documentation to clarify rollout progress, reflecting recently completed milestones and currently in-progress work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->