### PR TITLE
docs: add nemotron-3-ultra recipes to release branch

### DIFF
--- a/recipes/nemotron-3-ultra/README.md
+++ b/recipes/nemotron-3-ultra/README.md
@@ -1,0 +1,205 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Nemotron-3-Ultra Recipes
+
+Recipes for **nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4** — a ~550B hybrid Mamba/Attention/MoE model (~55B active).
+
+We ship Dynamo + vLLM deployment profiles across B200 and H200, with aggregated and disaggregated serving modes.
+
+Runtime image:
+
+```text
+nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+```
+
+The recipes pin `VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel` and pass `--no-enable-flashinfer-autotune` on vLLM workers. These settings select the non-FlashInfer FP8 linear kernel path used for the B200 benchmark rows and avoid the measured vLLM 0.22 FlashInfer FP8 regression.
+
+## Configurations
+
+|                          | B200 chat | H200 chat | B200 agentic | H200 agentic | B200 disaggregated agentic |
+|--------------------------|-----------|-----------|--------------|--------------|-----------------------------|
+| **GPU**                  | 4× B200 | 8× H200 | 4× B200 | 8× H200 | 4× B200 prefill + 4× B200 decode |
+| **Mode**                 | aggregated | aggregated | aggregated | aggregated | disaggregated |
+| **Framework**            | Dynamo + vLLM | Dynamo + vLLM | Dynamo + vLLM | Dynamo + vLLM | Dynamo + vLLM |
+| **Precision**            | NVFP4 + FP8 | NVFP4 + FP8 | NVFP4 + FP8 | NVFP4 + FP8 | NVFP4 + FP8 |
+| **Parallelism**          | TP4 + EP | TP8 + EP | TP4 + EP | TP8 + EP | TP4 prefill + TP4 decode |
+| **Routing**              | KV-aware | KV-aware | KV-aware | KV-aware | KV-aware + P/D transfer |
+| **Speculative decoding** | MTP, 1 token | MTP, 1 token | MTP, 1 token | MTP, 1 token | no MTP |
+| **Max model length**     | 262144 | 262144 | 262144 | 262144 | 262144 |
+| **Max sequences**        | 64 | 16 | 24 | 32 | 32 |
+| **Max batched tokens**   | 32768 | 32768 | 32768 | 32768 | 32768 |
+| **Block size**           | 64 | 64 | 64 | 64 | 64 |
+| **Reference concurrency** | 18 | 10 | 20 | 8 | 32 |
+| **Manifest**             | `vllm/agg/ultra_agg_b200_chat_mtp.yaml` | `vllm/agg/ultra_agg_h200_chat_mtp.yaml` | `vllm/agg/ultra_agg_b200_agentic_mtp.yaml` | `vllm/agg/ultra_agg_h200_agentic_mtp.yaml` | `vllm/disagg/ultra_1p1d_b200_agentic_nomtp.yaml` |
+
+Aggregated no-MTP fallback manifests are also included under `vllm/agg/*_nomtp.yaml`.
+
+## Supported Features
+
+- Text-only chat
+- Reasoning control through `chat_template_kwargs`
+- Tool calling with `qwen3_coder`
+- Ultra reasoning parser support through the model-local `ultra_v3_reasoning_parser.py`
+- Raw Moontrace replay through AIPerf
+
+## Prerequisites
+
+1. **Dynamo Platform installed** on the target cluster with DGD CRDs served.
+2. **NGC image pull secret** named `nvcr-secret`.
+3. **Hugging Face token secret** named `hf-token-secret` when using the model download Job:
+   ```bash
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN="$HF_TOKEN" \
+     -n ${NAMESPACE}
+   ```
+4. A `shared-model-cache` PVC containing the tokenizer-patched Ultra model view, or permission to create and populate it with the manifests in `model-cache/`.
+
+## Quick Start
+
+```bash
+export NAMESPACE=your-namespace
+```
+
+### 1. Create or Validate Model Cache
+
+If the namespace does not already provide `shared-model-cache`, edit the storage class in `model-cache/model-cache.yaml`, then create and populate the PVC:
+
+```bash
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/nemotron-ultra-model-download -n ${NAMESPACE} --timeout=12h
+```
+
+Validate the patched model view before deploying a server:
+
+```bash
+kubectl apply -f model-cache/model-validate.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/nemotron-ultra-model-validate -n ${NAMESPACE} --timeout=30m
+```
+
+### 2. Deploy the DGD
+
+Pick the SKU, use-case, and speculative decoding mode for an aggregated recipe:
+
+```bash
+SKU=b200       # or h200
+USECASE=chat   # or agentic
+SPEC=mtp       # or nomtp
+
+kubectl apply -f vllm/agg/ultra_agg_${SKU}_${USECASE}_${SPEC}.yaml -n ${NAMESPACE}
+```
+
+The DGD name includes the `-nomtp` suffix only for no-MTP recipes:
+
+```bash
+DGD=ultra-agg-${SKU}-${USECASE}-${SPEC}
+kubectl get dgd ${DGD} -n ${NAMESPACE} -w
+```
+
+Disaggregated recipes are currently agentic b200, no-MTP only.
+
+```bash
+kubectl apply -f vllm/disagg/ultra_1p1d_b200_agentic_nomtp.yaml -n ${NAMESPACE}
+```
+
+### 3. Smoke Test
+
+```bash
+kubectl port-forward svc/${DGD}-frontend 8000:8000 -n ${NAMESPACE}
+
+MODEL_ID=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+
+curl http://localhost:8000/v1/models
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"${MODEL_ID}\",
+       \"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],
+       \"max_tokens\":64,
+       \"chat_template_kwargs\":{\"enable_thinking\":false,\"force_nonempty_content\":true}}"
+```
+
+### 4. Benchmark
+
+See [`perf/README.md`](perf/README.md) for the full benchmark workflow — staging Moontrace-format traces on the PVC, running the AIPerf trace-replay Job ([`perf/perf.yaml`](perf/perf.yaml)), running a concurrency sweep, and fetching artifacts.
+
+## Benchmark Results
+
+B200 rows use 15% raw Moontrace replay with `raw_direct_no_filter` trace semantics. H200 rows use 300-sample replay evidence. All rows should be treated together with their matching recipe, image, trace, and server-shape artifacts.
+
+The B200 rows below point at the actual recipe manifests in this tree. `User output tok/s` is Gen TPS/user p50 from AIPerf; `System output tok/s/GPU` is TPS/GPU.
+
+| Recipe | GPU | Topology | Workload | MTP | Concurrency | User output tok/s | System output tok/s/GPU |
+|--------|-----|----------|----------|-----|-------------|-------------------|-------------------------|
+| `vllm/agg/ultra_agg_b200_agentic_mtp.yaml` | B200 | AGG | agentic | yes | 20 | 80.6 | 310.8 |
+| `vllm/agg/ultra_agg_b200_agentic_nomtp.yaml` | B200 | AGG | agentic | no | 8 | 99.5 | 175.9 |
+| `vllm/agg/ultra_agg_b200_chat_mtp.yaml` | B200 | AGG | chat | yes | 18 | 52.0 | 201.4 |
+| `vllm/agg/ultra_agg_b200_chat_nomtp.yaml` | B200 | AGG | chat | no | 16 | 51.0 | 181.3 |
+| `vllm/disagg/ultra_1p1d_b200_agentic_nomtp.yaml` | B200 | 1P1D | agentic | no | 32 | 61.6 | 231.1 |
+| `vllm/agg/ultra_agg_h200_agentic_mtp.yaml` | H200 | AGG | agentic | yes | 8 | 53.2 | 27.4 |
+| `vllm/agg/ultra_agg_h200_agentic_nomtp.yaml` | H200 | AGG | agentic | no | 8 | 52.3 | 26.5 |
+| `vllm/agg/ultra_agg_h200_chat_mtp.yaml` | H200 | AGG | chat | yes | 10 | 58.7 | 46.8 |
+| `vllm/agg/ultra_agg_h200_chat_nomtp.yaml` | H200 | AGG | chat | no | 8 | 54.2 | 43.0 |
+
+
+## Reasoning Controls
+
+Ultra no-thinking request control:
+
+```json
+{
+  "chat_template_kwargs": {
+    "enable_thinking": false,
+    "force_nonempty_content": true
+  }
+}
+```
+
+Ultra reasoning budget request control:
+
+```json
+{
+  "nvext": {
+    "max_thinking_tokens": 10
+  }
+}
+```
+
+Do not send `force_nonempty_content` as a top-level request parameter.
+
+## Known Issues
+
+1. Optional OpenAI/vLLM/NIM API fields are shared Dynamo API compatibility gaps, not Ultra recipe-specific failures.
+2. Top-level reasoning controls such as `include_reasoning`, `thinking_token_budget`, `reasoning_effort`, and `usage.reasoning_tokens` are part of that shared API compatibility work. Use the Ultra-specific `chat_template_kwargs` and `nvext` controls above as the current model-specific workaround.
+3. Do not remove `VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel` or `--no-enable-flashinfer-autotune` from the vLLM worker commands unless rerunning the benchmark qualification. These are part of the performance recipe.
+4. Raw Moontrace replay may contain over-context or pathological long-generation rows. Do not drop those rows silently; preserve them as HTTP/error evidence or classify the run accordingly.
+
+## File Layout
+
+```text
+recipes/nemotron-3-ultra/
+  README.md
+  model-cache/
+    README.md
+    model-cache.yaml          # PVC
+    model-download.yaml       # Job: populate patched Ultra model view
+    model-validate.yaml       # Job: validate model/tokenizer/parser files
+  vllm/
+    agg/
+      ultra_agg_b200_chat_mtp.yaml
+      ultra_agg_b200_chat_nomtp.yaml
+      ultra_agg_b200_agentic_mtp.yaml
+      ultra_agg_b200_agentic_nomtp.yaml
+      ultra_agg_h200_chat_mtp.yaml
+      ultra_agg_h200_chat_nomtp.yaml
+      ultra_agg_h200_agentic_mtp.yaml
+      ultra_agg_h200_agentic_nomtp.yaml
+    disagg/
+      ultra_1p1d_b200_agentic_nomtp.yaml
+  perf/
+    README.md                 # benchmark workflow
+    perf.yaml                 # AIPerf trace-replay Job
+    traces/                   # 15%, 30%, and full Moontrace JSONL assets
+```

--- a/recipes/nemotron-3-ultra/model-cache/README.md
+++ b/recipes/nemotron-3-ultra/model-cache/README.md
@@ -1,0 +1,59 @@
+# Nemotron Ultra Model Cache
+
+## Required Model View
+
+Expected worker path (all B200 + H200 recipes share this):
+
+```text
+/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+```
+
+Source repo and revision:
+
+```text
+nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+revision: main, or set `MODEL_REVISION` to the release-pinned commit when provided
+```
+
+The DGD recipes expose the same public model ID as the served model name:
+
+```text
+nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+```
+
+Minimum files validated before vLLM startup:
+
+```text
+config.json
+tokenizer.json
+tokenizer_config.json
+generation_config.json
+ultra_v3_reasoning_parser.py
+```
+
+## Manifests
+
+| Manifest | Purpose |
+|---|---|
+| `model-cache.yaml` | Namespace-local PVC contract for fresh namespaces. Edit `storageClassName` for the target cluster before apply. Do not apply over an existing platform-managed `shared-model-cache` PVC because PVC storage class and capacity are immutable. |
+| `model-download.yaml` | No-GPU model population job. Downloads the pinned revision into the exact patched model path. |
+| `model-validate.yaml` | No-GPU validation job. Fails with an actionable message if the model view is missing. |
+
+## Usage
+
+Then dry-run and apply in the target namespace. If the namespace already has a platform-managed `shared-model-cache`, skip `model-cache.yaml`; server-side dry-run against the existing PVC may warn about immutable field changes even though the platform cache itself is valid.
+
+```bash
+kubectl -n "${NAMESPACE}" apply --dry-run=server -f model-cache.yaml
+kubectl -n "${NAMESPACE}" apply --dry-run=server -f model-download.yaml
+kubectl -n "${NAMESPACE}" apply --dry-run=server -f model-validate.yaml
+
+kubectl -n "${NAMESPACE}" apply -f model-cache.yaml
+kubectl -n "${NAMESPACE}" apply -f model-download.yaml
+kubectl -n "${NAMESPACE}" wait --for=condition=Complete job/nemotron-ultra-model-download --timeout=12h
+kubectl -n "${NAMESPACE}" apply -f model-validate.yaml
+kubectl -n "${NAMESPACE}" wait --for=condition=Complete job/nemotron-ultra-model-validate --timeout=30m
+```
+
+If the platform already provides `shared-model-cache`, skip `model-cache.yaml` and `model-download.yaml`, then run `model-validate.yaml` before applying a server recipe.

--- a/recipes/nemotron-3-ultra/model-cache/model-cache.yaml
+++ b/recipes/nemotron-3-ultra/model-cache/model-cache.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-model-cache
+  labels:
+    app.kubernetes.io/name: nemotron-ultra-model-cache
+    app.kubernetes.io/part-of: nemotron-ultra
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: your-storage-class-name
+  resources:
+    requests:
+      storage: 1200Gi

--- a/recipes/nemotron-3-ultra/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-ultra/model-cache/model-download.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemotron-ultra-model-download
+  labels:
+    app.kubernetes.io/name: nemotron-ultra-model-download
+    app.kubernetes.io/part-of: nemotron-ultra
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nemotron-ultra-model-download
+        app.kubernetes.io/part-of: nemotron-ultra
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: download
+          image: python:3.10-slim
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -Eeuo pipefail
+              python3 -m pip install --no-cache-dir -U huggingface_hub
+              export HF_HOME=/opt/models
+              python3 - <<'PY'
+              import os
+              from huggingface_hub import snapshot_download
+
+              model_repo = "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
+              model_revision = os.environ.get("MODEL_REVISION", "main")
+
+              model_path = "/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
+              os.makedirs(model_path, exist_ok=True)
+              snapshot_download(
+                  repo_id=model_repo,
+                  revision=model_revision,
+                  local_dir=model_path,
+              )
+              print(f"MODEL_DOWNLOAD_SNAPSHOT_DONE repo={model_repo} path={model_path}")
+              PY
+              MODEL_PATH="/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
+              test -r "${MODEL_PATH}/config.json"
+              test -r "${MODEL_PATH}/tokenizer.json"
+              test -r "${MODEL_PATH}/tokenizer_config.json"
+              test -r "${MODEL_PATH}/generation_config.json"
+              test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py"
+              echo "MODEL_DOWNLOAD_PASS path=${MODEL_PATH}"
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /opt/models
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/nemotron-3-ultra/model-cache/model-validate.yaml
+++ b/recipes/nemotron-3-ultra/model-cache/model-validate.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemotron-ultra-model-validate
+  labels:
+    app.kubernetes.io/name: nemotron-ultra-model-validate
+    app.kubernetes.io/part-of: nemotron-ultra
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nemotron-ultra-model-validate
+        app.kubernetes.io/part-of: nemotron-ultra
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: validate
+          image: python:3.10-slim
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -Eeuo pipefail
+              required=(
+                config.json
+                tokenizer.json
+                tokenizer_config.json
+                generation_config.json
+                ultra_v3_reasoning_parser.py
+              )
+              MODEL_PATH="/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
+              if [ ! -d "${MODEL_PATH}" ]; then
+                echo "MODEL_VALIDATE_FAIL class=model_path_missing path=${MODEL_PATH}"
+                echo "Run model-download.yaml or bind a platform shared-model-cache PVC containing the patched Ultra model view."
+                exit 42
+              fi
+              for rel in "${required[@]}"; do
+                if [ ! -r "${MODEL_PATH}/${rel}" ]; then
+                  echo "MODEL_VALIDATE_FAIL class=model_required_file_missing path=${MODEL_PATH}/${rel}"
+                  echo "Run model-download.yaml or fix the platform shared-model-cache contents."
+                  exit 43
+                fi
+              done
+              python3 - <<'PY'
+              import json
+              from pathlib import Path
+              model_path = Path("/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4")
+              config = json.loads((model_path / "config.json").read_text())
+              print(
+                  "MODEL_VALIDATE_PASS",
+                  "hf_model=nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+                  "model_type=" + str(config.get("model_type")),
+                  "path=" + str(model_path),
+              )
+              PY
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /opt/models
+              readOnly: true
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/nemotron-3-ultra/perf/README.md
+++ b/recipes/nemotron-3-ultra/perf/README.md
@@ -1,0 +1,167 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Nemotron-3-Ultra Benchmark Recipe
+
+A single AIPerf trace-replay Job — [perf.yaml](perf.yaml) — covers the Nemotron-3-Ultra DGD variants. The benchmark is identical across variants; change `ENDPOINT`, `TRACE_FILE`, `CONCURRENCY`, and `TARGET_MODEL` in the Job env block to target a specific server.
+
+The Job waits for `GET /v1/models` on the DGD frontend to return `TARGET_MODEL`, runs a short warmup, then replays the configured Mooncake-format trace at one `CONCURRENCY` value. Artifacts are written to the shared model-cache PVC under `/opt/models/perf`.
+
+Benchmark rows assume the vLLM DGD manifests in this recipe, including the CUDA13 image and worker runtime settings:
+
+```text
+image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel
+--no-enable-flashinfer-autotune
+```
+
+The bench pod is co-located with the DGD frontend through pod affinity on the frontend host. If you run more than one benchmark in the same namespace, also update `metadata.name` and `labels.app` so Jobs and artifact directories stay distinct.
+
+## Targeting a Variant
+
+Edit the `env` block in [perf.yaml](perf.yaml):
+
+| Variant target | `ENDPOINT` | `TARGET_MODEL` | `TRACE_FILE` | Typical `CONCURRENCY` |
+|---|---|---|---|---:|
+| B200 AGG chat MTP | `ultra-agg-b200-chat-mtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | 18 |
+| B200 AGG chat no-MTP | `ultra-agg-b200-chat-nomtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | 16 |
+| B200 AGG agentic MTP | `ultra-agg-b200-agentic-mtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 20 |
+| B200 AGG agentic no-MTP | `ultra-agg-b200-agentic-nomtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 8 |
+| B200 1P1D agentic no-MTP | `ultra-disagg-b200-1p1d-agentic-nomtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 32 |
+| H200 AGG chat MTP | `ultra-agg-h200-chat-mtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | 10 |
+| H200 AGG chat no-MTP | `ultra-agg-h200-chat-nomtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | 8 |
+| H200 AGG agentic MTP | `ultra-agg-h200-agentic-mtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 8 |
+| H200 AGG agentic no-MTP | `ultra-agg-h200-agentic-nomtp-frontend:8000` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | `/opt/models/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 8 |
+
+The default Job is configured for the B200 AGG chat MTP 15% trace at concurrency 18. For other release-style benchmark rows, use the trace/concurrency pair that matches the recipe row being reported.
+
+## Dataset
+
+The benchmark replays a Mooncake-format trace through `aiperf --custom-dataset-type mooncake_trace`. Each JSONL line describes one request with fields such as `input_length`, `output_length`, and `hash_ids`.
+
+Trace files included in this recipe:
+
+| Trace | Rows |
+|---|---:|
+| `traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | 1805 |
+| `traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl` | 3609 |
+| `traces/nim_turbo_8k_1k_70kv_chat_new_noschedule.jsonl` | 12031 |
+| `traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 3541 |
+| `traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_30perc.jsonl` | 7082 |
+| `traces/nim_turbo_64k_400_90kv_agent_new_noschedule.jsonl` | 23608 |
+
+The 15% and 30% traces are prefix slices, not random samples, so they preserve trace order and cache warmup behavior.
+
+## Replay Policy
+
+The intended replay policy is raw direct Moontrace replay:
+
+- No context-length filtering.
+- No OSL clipping.
+- No synthetic output-length substitution.
+- No `--export-http-trace`.
+- No `bad_words` guard.
+- `ignore_eos:true` is the only extra input.
+- HTTP400 and no-content rows remain benchmark failure evidence.
+
+## Workflow
+
+```bash
+export NAMESPACE=your-namespace
+```
+
+### 1. Deploy the DGD
+
+See instructions in the [recipe README](../README.md).
+
+### 2. Stage the Traces on the PVC
+
+Spin up a short-lived helper pod that mounts `shared-model-cache` at `/opt/models`, then copy the bundled traces in:
+
+```bash
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/opt/models"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"shared-model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl exec -n ${NAMESPACE} pvc-helper -- mkdir -p /opt/models/traces
+kubectl cp traces/. ${NAMESPACE}/pvc-helper:/opt/models/traces/
+```
+
+Keep `pvc-helper` around for fetching artifacts later, or delete it once staging is complete.
+
+### 3. Run the Benchmark
+
+```bash
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+
+kubectl logs -n ${NAMESPACE} -l job-name=ultra-bench -f
+
+kubectl wait --for=condition=Complete \
+  job/ultra-bench \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+### 4. Fetch Artifacts
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/opt/models/perf/<epoch>_ultra-bench ./results
+```
+
+### 5. Cleanup
+
+```bash
+kubectl delete job ultra-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+## Running a Concurrency Sweep
+
+`perf.yaml` runs a single `CONCURRENCY` value. To measure multiple concurrencies, clear server state between runs so residual KV cache and prefix-cache hits from the previous run do not skew results.
+
+For each concurrency value:
+
+```bash
+kubectl delete job ultra-bench -n ${NAMESPACE} --ignore-not-found
+
+DGD=ultra-agg-b200-chat-mtp
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/ultra-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+The Job's `wait_for_model_ready` loop handles the worker restart window by polling `/v1/models` until the frontend reports the target model.
+
+## Tunable Environment Variables
+
+Edit the `env` block on the Job:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `ENDPOINT` | `ultra-agg-b200-chat-mtp-frontend:8000` | DGD frontend service:port |
+| `TRACE_FILE` | `/opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl` | Swap to chat or agentic 15%, 30%, or full trace |
+| `CONCURRENCY` | `18` | Single value; see [Running a Concurrency Sweep](#running-a-concurrency-sweep) |
+| `TARGET_MODEL` | `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | Must match the served model name on the DGD frontend |
+| `TOKENIZER_PATH` | `/opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4` | Used by AIPerf tokenization |
+| `AIPERF_VERSION` | `0.8.0` | Matches the saved Ultra benchmark profile exports |
+| `ROOT_ARTIFACT_DIR` | `/opt/models/perf` | Shared PVC artifact root |
+
+## Artifacts
+
+Results are written to:
+
+```text
+/opt/models/perf/<epoch>_<job-name>/
+  trace_replay_manifest.json
+  warmup/
+  NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```
+
+For release evidence, preserve the AIPerf output directory, Job logs, DGD manifest, image digest, trace SHA, server-shape evidence, and model-cache validation proof.

--- a/recipes/nemotron-3-ultra/perf/perf.yaml
+++ b/recipes/nemotron-3-ultra/perf/perf.yaml
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AIPerf raw trace-replay benchmark for Nemotron Ultra DGDs.
+#
+# One Job covers the Ultra DGD variants. To target a specific DGD, edit the
+# env values below and, when running multiple jobs in one namespace, also edit
+# metadata.name and labels.app.
+#
+# Trace policy: raw_direct_no_filter. Do not drop over-context rows, clip OSL,
+# synthesize output lengths, or export HTTP traces. HTTP400/no-content rows are
+# benchmark failure evidence.
+#
+# Results: /opt/models/perf/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ultra-bench
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 7200
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: ultra-bench
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: nvidia.com/dynamo-component-type
+                operator: In
+                values:
+                - frontend
+              - key: nvidia.com/dynamo-graph-deployment-name
+                operator: In
+                values:
+                - ultra-agg-b200-chat-mtp
+                - ultra-agg-b200-agentic-mtp
+                - ultra-agg-b200-chat-nomtp
+                - ultra-agg-b200-agentic-nomtp
+                - ultra-agg-h200-chat-mtp
+                - ultra-agg-h200-agentic-mtp
+                - ultra-agg-h200-chat-nomtp
+                - ultra-agg-h200-agentic-nomtp
+                - ultra-disagg-b200-1p1d-agentic-nomtp
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: perf
+        image: python:3.12-slim
+        imagePullPolicy: IfNotPresent
+        workingDir: /workspace
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          ulimit -n 600000
+          apt-get update && apt-get install -y curl jq procps git coreutils && apt-get clean
+          pip install "aiperf==${AIPERF_VERSION}" protobuf "transformers==4.57.3" "tiktoken==0.13.0"
+          sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
+          export COLUMNS=200
+          EPOCH=$(date +%s)
+
+          wait_for_model_ready() {
+            local max_attempts=${WAIT_FOR_MODEL_MAX_ATTEMPTS:-720}
+            local attempt=0
+            echo "Waiting for model '${TARGET_MODEL}' at ${ENDPOINT}/v1/models (max ${max_attempts} attempts) ..."
+            while ! curl -sf "http://${ENDPOINT}/v1/models" | jq -e --arg m "${TARGET_MODEL}" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do
+              attempt=$((attempt + 1))
+              if [ "${attempt}" -ge "${max_attempts}" ]; then
+                echo "ERROR: model '${TARGET_MODEL}' did not become ready after ${max_attempts} attempts."
+                exit 1
+              fi
+              echo "[$(date '+%H:%M:%S')] not ready (attempt ${attempt}/${max_attempts}), sleeping 5s"
+              sleep 5
+            done
+            curl -s "http://${ENDPOINT}/v1/models" | jq .
+          }
+
+          if [ ! -f "${TRACE_FILE}" ]; then
+            echo "ERROR: trace file not found at ${TRACE_FILE}"
+            exit 1
+          fi
+          if [ ! -f "${TOKENIZER_PATH}/tokenizer.json" ]; then
+            echo "ERROR: tokenizer not found at ${TOKENIZER_PATH}/tokenizer.json"
+            exit 1
+          fi
+
+          REQUEST_COUNT=$(wc -l < "${TRACE_FILE}" | tr -d ' ')
+          if [ "${REQUEST_COUNT}" -le 0 ]; then
+            echo "ERROR: trace file is empty: ${TRACE_FILE}"
+            exit 1
+          fi
+
+          wait_for_model_ready
+          ROOT_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          mkdir -p "${ROOT_DIR}"
+          jq -n \
+            --arg trace_file "${TRACE_FILE}" \
+            --arg request_count "${REQUEST_COUNT}" \
+            --arg concurrency "${CONCURRENCY}" \
+            --arg target_model "${TARGET_MODEL}" \
+            --arg endpoint "http://${ENDPOINT}" \
+            '{
+              trace_file: $trace_file,
+              request_count: ($request_count | tonumber),
+              concurrency: ($concurrency | tonumber),
+              target_model: $target_model,
+              endpoint: $endpoint,
+              context_filtering: false,
+              osl_clipping: false,
+              output_length_substitution: false,
+              export_http_trace: false
+            }' | tee "${ROOT_DIR}/trace_replay_manifest.json"
+
+          echo "=============================================="
+          echo "Trace Replay Benchmark (AIPerf)"
+          echo "=============================================="
+          echo "Endpoint:      http://${ENDPOINT}"
+          echo "Model:         ${TARGET_MODEL}"
+          echo "Trace file:    ${TRACE_FILE}"
+          echo "Request count: ${REQUEST_COUNT}"
+          echo "Concurrency:   ${CONCURRENCY}"
+          echo "Artifact root: ${ROOT_DIR}"
+          echo "=============================================="
+
+          WARMUP_DIR="${ROOT_DIR}/warmup"
+          mkdir -p "${WARMUP_DIR}"
+          aiperf profile \
+            -m "${TARGET_MODEL}" \
+            --tokenizer "${TOKENIZER_PATH}" \
+            --tokenizer-trust-remote-code \
+            --url "http://${ENDPOINT}" \
+            --streaming \
+            --ui simple \
+            --isl 8000 \
+            --osl 1000 \
+            --concurrency 1 \
+            --request-count 5 \
+            --artifact-dir "${WARMUP_DIR}"
+          echo "Warmup complete"
+
+          MODEL_BASE="${TARGET_MODEL##*/}"
+          TS=$(date +'%Y%m%d_%H%M%S')
+          RUN_DIR="${ROOT_DIR}/${MODEL_BASE}_trace_c${CONCURRENCY}_${TS}"
+          mkdir -p "${RUN_DIR}"
+          aiperf profile \
+            -m "${TARGET_MODEL}" \
+            --tokenizer "${TOKENIZER_PATH}" \
+            --tokenizer-trust-remote-code \
+            --input-file "${TRACE_FILE}" \
+            --custom-dataset-type mooncake_trace \
+            --num-requests $(wc -l < "${TRACE_FILE}") \
+            --prompt-input-tokens-block-size 512 \
+            --url "http://${ENDPOINT}" \
+            --streaming \
+            --use-server-token-count \
+            --extra-inputs ignore_eos:true \
+            --concurrency "${CONCURRENCY}" \
+            --random-seed 42 \
+            --ui simple \
+            --artifact-dir "${RUN_DIR}" \
+            --request-timeout-seconds 1200 \
+            --workers-max "${CONCURRENCY}"
+          echo "Concurrency ${CONCURRENCY} complete; artifacts in ${RUN_DIR}"
+          ls -la "${RUN_DIR}" || true
+          echo "Done. Root: ${ROOT_DIR}"
+        env:
+        - name: ENDPOINT
+          value: ultra-agg-b200-chat-mtp-frontend:8000
+        - name: TRACE_FILE
+          value: /opt/models/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
+        - name: CONCURRENCY
+          value: "18"
+        - name: TARGET_MODEL
+          value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+        - name: TOKENIZER_PATH
+          value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "200"
+        - name: AIPERF_VERSION
+          value: "0.8.0"
+        - name: AIPERF_HTTP_SO_RCVTIMEO
+          value: "120"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /opt/models/perf
+        - name: HF_HOME
+          value: /opt/models
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /opt/models
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: shared-model-cache

--- a/recipes/nemotron-3-ultra/perf/traces/.gitattributes
+++ b/recipes/nemotron-3-ultra/perf/traces/.gitattributes
@@ -1,0 +1,1 @@
+*.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/recipes/nemotron-3-ultra/perf/traces/nim_turbo_64k_400_90kv_agent_new_noschedule.jsonl
+++ b/recipes/nemotron-3-ultra/perf/traces/nim_turbo_64k_400_90kv_agent_new_noschedule.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0a64efcad575a01949e46e28dded094f20733db8708e0bc91b88ce9981fed6
+size 17623982

--- a/recipes/nemotron-3-ultra/perf/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+++ b/recipes/nemotron-3-ultra/perf/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20d3f2bc83dd1306cda659fbe34e7c4d85ca5497626c98bc0b1c4d2211379d0
+size 2722326

--- a/recipes/nemotron-3-ultra/perf/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
+++ b/recipes/nemotron-3-ultra/perf/traces/nim_turbo_64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dae61f92fee05038f1dcb76474dba83c1b3c174f3d187589c7d0a16a7012eb79
+size 5401776

--- a/recipes/nemotron-3-ultra/perf/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule.jsonl
+++ b/recipes/nemotron-3-ultra/perf/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f369eb75ce639ad8b05cc209bb534bfedd627e9f7b923de32888155b4c9085a
+size 5648304

--- a/recipes/nemotron-3-ultra/perf/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
+++ b/recipes/nemotron-3-ultra/perf/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1221bca72b69f842897f339624306a84857f1b55ea0d866525f94d9ceb9b871
+size 894687

--- a/recipes/nemotron-3-ultra/perf/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl
+++ b/recipes/nemotron-3-ultra/perf/traces/nim_turbo_8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6de2a977b40dba8735a70aa5f9ab0d84e32530d7cf1fc9d24efc631c341f9c17
+size 1790696

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_agentic_mtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_agentic_mtp.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-b200-agentic-mtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-b200-agentic-mtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp4-mtp1
+    nemotron-ultra.nvidia.com/workload: agentic
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=agentic ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 4 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=agentic visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=agentic dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=agentic"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=agentic"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 4 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 24 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.9 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --spec-method nemotron_h_mtp \
+                    --spec-tokens 1 \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_agentic_nomtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_agentic_nomtp.yaml
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-b200-agentic-nomtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-b200-agentic-nomtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp4-nomtp
+    nemotron-ultra.nvidia.com/workload: agentic
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=agentic ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 4 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=agentic visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=agentic dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=agentic"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=agentic"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 4 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 65536 \
+                    --gpu-memory-utilization 0.9 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_chat_mtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_chat_mtp.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-b200-chat-mtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-b200-chat-mtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp4-mtp1
+    nemotron-ultra.nvidia.com/workload: chat
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=chat ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 4 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=chat visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=chat dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=chat"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=chat"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 4 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 64 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.9 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --spec-method nemotron_h_mtp \
+                    --spec-tokens 1 \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_chat_nomtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_b200_chat_nomtp.yaml
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-b200-chat-nomtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-b200-chat-nomtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp4-nomtp
+    nemotron-ultra.nvidia.com/workload: chat
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 32
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=chat ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 4 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=chat visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=chat dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=chat"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=chat"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 4 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 40 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.9 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 32 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_agentic_mtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_agentic_mtp.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-h200-agentic-mtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-h200-agentic-mtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp8
+    nemotron-ultra.nvidia.com/workload: agentic
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-H200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=agentic ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 8 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=agentic visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=agentic dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=agentic"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=agentic"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 8 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.85 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --spec-method nemotron_h_mtp \
+                    --spec-tokens 1 \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "8"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_agentic_nomtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_agentic_nomtp.yaml
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-h200-agentic-nomtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-h200-agentic-nomtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp8-nomtp
+    nemotron-ultra.nvidia.com/workload: agentic
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: agentic
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-H200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=agentic ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 8 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=agentic visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=agentic dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=agentic"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=agentic"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 8 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.85 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "8"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_chat_mtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_chat_mtp.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-h200-chat-mtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-h200-chat-mtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp8
+    nemotron-ultra.nvidia.com/workload: chat
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-H200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=chat ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 8 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=chat visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=chat dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=chat"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=chat"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 8 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 16 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.85 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --spec-method nemotron_h_mtp \
+                    --spec-tokens 1 \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "8"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_chat_nomtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/agg/ultra_agg_h200_chat_nomtp.yaml
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-agg-h200-chat-nomtp
+  labels:
+    app.kubernetes.io/name: ultra-agg-h200-chat-nomtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: agg1-tp8-nomtp
+    nemotron-ultra.nvidia.com/workload: chat
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: NCCL_IB_DISABLE
+      value: "1"
+    - name: NCCL_CUMEM_ENABLE
+      value: "1"
+    - name: NCCL_NVLS_ENABLE
+      value: "1"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmWorker
+      type: worker
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: aggregate-worker
+            nemotron-ultra.nvidia.com/workload: chat
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-H200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=agg workload=chat ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 8 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=agg workload=chat visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=agg workload=chat dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=agg workload=chat"
+                    exit 98
+                  fi
+                  echo "PRESTART_GPU_GUARD_PASS role=agg workload=chat"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 8 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.85 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "8"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+                failureThreshold: 30
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              emptyDir: {}
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory

--- a/recipes/nemotron-3-ultra/vllm/disagg/ultra_1p1d_b200_agentic_nomtp.yaml
+++ b/recipes/nemotron-3-ultra/vllm/disagg/ultra_1p1d_b200_agentic_nomtp.yaml
@@ -1,0 +1,441 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: ultra-disagg-b200-1p1d-agentic-nomtp
+  labels:
+    app.kubernetes.io/name: ultra-disagg-b200-1p1d-agentic-nomtp
+    app.kubernetes.io/part-of: nemotron-ultra
+    nemotron-ultra.nvidia.com/backend: vllm
+    nemotron-ultra.nvidia.com/topology: 1p1d-tp4-tp4
+    nemotron-ultra.nvidia.com/workload: agentic
+spec:
+  backendFramework: vllm
+  env:
+    - name: HF_HOME
+      value: /opt/models
+    - name: HF_HUB_CACHE
+      value: /opt/models/hub
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: TRANSFORMERS_OFFLINE
+      value: "1"
+    - name: SERVED_MODEL_NAME
+      value: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: MODEL_PATH
+      value: /opt/models/patched/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+    - name: LOG_DIR
+      value: /artifacts/logs
+    - name: HOME
+      value: /tmp
+    - name: HF_MODULES_CACHE
+      value: /tmp/hf_modules
+    - name: XDG_CACHE_HOME
+      value: /tmp/cache
+    - name: TORCH_EXTENSIONS_DIR
+      value: /tmp/torch_extensions
+    - name: TRITON_CACHE_DIR
+      value: /tmp/triton
+    - name: VLLM_CACHE_ROOT
+      value: /tmp/vllm
+    - name: PYTHONHASHSEED
+      value: "0"
+    - name: VLLM_LOGGING_LEVEL
+      value: INFO
+    - name: VLLM_WORKER_MULTIPROC_METHOD
+      value: spawn
+    - name: VLLM_ALLREDUCE_USE_SYMM_MEM
+      value: "0"
+    - name: VLLM_DISABLED_KERNELS
+      value: FlashInferFP8ScaledMMLinearKernel
+    - name: VLLM_SSM_CONV_STATE_LAYOUT
+      value: DS
+    - name: VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE
+      value: "1"
+    - name: DYN_VLLM_APPEND_PREFILL_OUTPUT_TOKENS
+      value: "0"
+    - name: DYN_LOG
+      value: info,dynamo_kv_router=debug,dynamo_llm::kv_router=debug
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: frontend
+            nemotron-ultra.nvidia.com/topology: 1p1d-tp4-tp4
+            nemotron-ultra.nvidia.com/recipe: ultra-disagg-b200-1p1d-agentic-nomtp
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  mkdir -p "${LOG_DIR:-/tmp/nemotron-ultra}/status"
+                  frontend_args=(
+                    --router-mode kv
+                    --router-kv-events
+                    --kv-cache-block-size 64
+                    --router-reset-states
+                    --http-host 0.0.0.0
+                    --http-port 8000
+                  )
+                  printf '%q ' python3 -m dynamo.frontend "${frontend_args[@]}" >"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  printf '\n' >>"${LOG_DIR:-/tmp/nemotron-ultra}/status/vllm_frontend_command.txt"
+                  exec python3 -m dynamo.frontend "${frontend_args[@]}"
+              ports:
+                - name: http
+                  containerPort: 8000
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 10
+                failureThreshold: 360
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: http
+                periodSeconds: 10
+                timeoutSeconds: 3
+                failureThreshold: 3
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              persistentVolumeClaim:
+                claimName: nemotron-ultra-aiperf-artifacts
+            - name: runtime-tmp
+              emptyDir: {}
+    - name: VllmPrefillWorker
+      type: prefill
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: prefill
+            nemotron-ultra.nvidia.com/topology: 1p1d-tp4-tp4
+            nemotron-ultra.nvidia.com/recipe: ultra-disagg-b200-1p1d-agentic-nomtp
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=prefill ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 4 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=prefill visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=prefill dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=prefill"
+                    exit 98
+                  fi
+                  ls -l /dev/infiniband || true
+                  echo "PRESTART_GPU_GUARD_PASS role=prefill"
+                  export ULTRA_NIXL_XFER_DEBUG_JSONL="/artifacts/runs/nemotron-ultra-1p1d/native/prefill/${HOSTNAME}.jsonl"
+                  mkdir -p "$(dirname "${ULTRA_NIXL_XFER_DEBUG_JSONL}")"
+                  echo "ULTRA_NIXL_XFER_DEBUG_JSONL=${ULTRA_NIXL_XFER_DEBUG_JSONL} schema=${ULTRA_NIXL_XFER_DEBUG_SCHEMA}"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 4 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.9 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager \
+                    --disaggregation-mode prefill \
+                    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5571","enable_kv_cache_events":true}'
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              env:
+                - name: UCX_TLS
+                  value: rc_x,rc,cuda_copy,cuda_ipc
+                - name: UCX_NET_DEVICES
+                  value: mlx5_0:1
+                - name: UCX_IB_ADDR_TYPE
+                  value: eth
+                - name: UCX_RNDV_SCHEME
+                  value: get_zcopy
+                - name: UCX_RNDV_THRESH
+                  value: "0"
+                - name: UCX_RC_TIMEOUT
+                  value: 600s
+                - name: UCX_KEEPALIVE_INTERVAL
+                  value: 300s
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: NCCL_SOCKET_IFNAME
+                  value: eth0
+                - name: GLOO_SOCKET_IFNAME
+                  value: eth0
+                - name: NCCL_STORE_TIMEOUT
+                  value: "7200"
+                - name: NIXL_LOG_LEVEL
+                  value: INFO
+                - name: ULTRA_NIXL_XFER_DEBUG_SCHEMA
+                  value: ULTRA_NIXL_NATIVE_XFER_DEBUG_V1
+                - name: ULTRA_NIXL_XFER_DEBUG_ACTION_ID
+                  value: TURBO_NEMOTRON_ULTRA_1P1D_B200
+                - name: ULTRA_NIXL_XFER_DEBUG_ROLE
+                  value: prefill
+                - name: ULTRA_NIXL_XFER_DEBUG_RUN_DIR
+                  value: nemotron-ultra-1p1d
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              persistentVolumeClaim:
+                claimName: nemotron-ultra-aiperf-artifacts
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory
+    - name: VllmDecodeWorker
+      type: decode
+      replicas: 1
+      sharedMemorySize: 64Gi
+      podTemplate:
+        metadata:
+          labels:
+            nemotron-ultra.nvidia.com/role: decode
+            nemotron-ultra.nvidia.com/topology: 1p1d-tp4-tp4
+            nemotron-ultra.nvidia.com/recipe: ultra-disagg-b200-1p1d-agentic-nomtp
+        spec:
+          imagePullSecrets:
+            - name: nvcr-secret
+          runtimeClassName: nvidia
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-ultra-dev.1
+              imagePullPolicy: IfNotPresent
+              workingDir: /workspace
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -Eeuo pipefail
+                  test -r "${MODEL_PATH}/config.json" || { echo "MODEL_PREFLIGHT_FAIL class=model_config_missing path=${MODEL_PATH}/config.json"; exit 42; }
+                  test -r "${MODEL_PATH}/ultra_v3_reasoning_parser.py" || { echo "MODEL_PREFLIGHT_FAIL class=reasoning_parser_missing path=${MODEL_PATH}/ultra_v3_reasoning_parser.py"; exit 43; }
+                  echo "PRESTART_GPU_GUARD_BEGIN role=decode ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  nvidia-smi -L
+                  nvidia-smi --query-gpu=index,uuid,memory.total,memory.used,memory.free,utilization.gpu --format=csv,noheader,nounits
+                  visible_count="$(nvidia-smi -L | grep -c '^GPU ')"
+                  if [ "${visible_count}" -ne 4 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_visibility_count_mismatch role=decode visible_count=${visible_count}"
+                    exit 96
+                  fi
+                  mem_rows="$(nvidia-smi --query-gpu=index,uuid,memory.used,utilization.gpu --format=csv,noheader,nounits)"
+                  echo "${mem_rows}"
+                  dirty_count="$(printf '%s\n' "${mem_rows}" | awk -F',' '{gsub(/ /,"",$3); if (($3+0)>1024) c++} END{print c+0}')"
+                  if [ "${dirty_count}" -ne 0 ]; then
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_memory_dirty role=decode dirty_count=${dirty_count}"
+                    exit 97
+                  fi
+                  compute_apps="$(nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory --format=csv,noheader,nounits || true)"
+                  if [ -n "${compute_apps}" ]; then
+                    printf '%s\n' "${compute_apps}"
+                    echo "PRESTART_GPU_GUARD_FAIL class=prestart_gpu_compute_apps_visible role=decode"
+                    exit 98
+                  fi
+                  ls -l /dev/infiniband || true
+                  echo "PRESTART_GPU_GUARD_PASS role=decode"
+                  export ULTRA_NIXL_XFER_DEBUG_JSONL="/artifacts/runs/nemotron-ultra-1p1d/native/decode/${HOSTNAME}.jsonl"
+                  mkdir -p "$(dirname "${ULTRA_NIXL_XFER_DEBUG_JSONL}")"
+                  echo "ULTRA_NIXL_XFER_DEBUG_JSONL=${ULTRA_NIXL_XFER_DEBUG_JSONL} schema=${ULTRA_NIXL_XFER_DEBUG_SCHEMA}"
+                  ulimit -l unlimited
+                  exec python3 -m dynamo.vllm \
+                    --model "${MODEL_PATH}" \
+                    --served-model-name "${SERVED_MODEL_NAME}" \
+                    --tensor-parallel-size 4 \
+                    --trust-remote-code \
+                    --max-model-len 262144 \
+                    --max-num-seqs 32 \
+                    --max-num-batched-tokens 32768 \
+                    --gpu-memory-utilization 0.9 \
+                    --no-enable-flashinfer-autotune \
+                    --block-size 64 \
+                    --enable-expert-parallel \
+                    --mamba-cache-mode align \
+                    --enable-prefix-caching \
+                    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+                    --dyn-tool-call-parser qwen3_coder \
+                    --dyn-reasoning-parser nemotron3 \
+                    --reasoning-parser-plugin "${MODEL_PATH}/ultra_v3_reasoning_parser.py" \
+                    --reasoning-parser nemotron_v3 \
+                    --no-disable-hybrid-kv-cache-manager \
+                    --disaggregation-mode decode
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              env:
+                - name: UCX_TLS
+                  value: rc_x,rc,cuda_copy,cuda_ipc
+                - name: UCX_NET_DEVICES
+                  value: mlx5_0:1
+                - name: UCX_IB_ADDR_TYPE
+                  value: eth
+                - name: UCX_RNDV_SCHEME
+                  value: get_zcopy
+                - name: UCX_RNDV_THRESH
+                  value: "0"
+                - name: UCX_RC_TIMEOUT
+                  value: 600s
+                - name: UCX_KEEPALIVE_INTERVAL
+                  value: 300s
+                - name: NCCL_IB_DISABLE
+                  value: "0"
+                - name: NCCL_SOCKET_IFNAME
+                  value: eth0
+                - name: GLOO_SOCKET_IFNAME
+                  value: eth0
+                - name: NCCL_STORE_TIMEOUT
+                  value: "7200"
+                - name: NIXL_LOG_LEVEL
+                  value: INFO
+                - name: ULTRA_NIXL_XFER_DEBUG_SCHEMA
+                  value: ULTRA_NIXL_NATIVE_XFER_DEBUG_V1
+                - name: ULTRA_NIXL_XFER_DEBUG_ACTION_ID
+                  value: TURBO_NEMOTRON_ULTRA_1P1D_B200
+                - name: ULTRA_NIXL_XFER_DEBUG_ROLE
+                  value: decode
+                - name: ULTRA_NIXL_XFER_DEBUG_RUN_DIR
+                  value: nemotron-ultra-1p1d
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+                  memory: 750Gi
+                  ephemeral-storage: 20Gi
+                limits:
+                  nvidia.com/gpu: "4"
+                  rdma/ib: "4"
+              securityContext:
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_RESOURCE
+                runAsUser: 0
+                runAsGroup: 0
+              volumeMounts:
+                - name: shared-model-cache
+                  mountPath: /opt/models
+                  readOnly: true
+                - name: artifact-root
+                  mountPath: /artifacts
+                - name: runtime-tmp
+                  mountPath: /tmp
+                - name: flashinfer-cubins
+                  mountPath: /usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer
+          volumes:
+            - name: shared-model-cache
+              persistentVolumeClaim:
+                claimName: shared-model-cache
+            - name: artifact-root
+              persistentVolumeClaim:
+                claimName: nemotron-ultra-aiperf-artifacts
+            - name: runtime-tmp
+              emptyDir: {}
+            - name: flashinfer-cubins
+              emptyDir:
+                medium: Memory


### PR DESCRIPTION
Cherry-picks #10303 (`002cf02ce2`) onto `release/1.3.0-nemotron-ultra-dev.1` so the release branch carries the Nemotron-3-Ultra recipes matching the published container. Recipe folder only; cherry-picked with -x -s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->