### PR TITLE
docs: add nemotron-3-super recipes to release branch

### DIFF
--- a/recipes/nemotron-3-super/README.md
+++ b/recipes/nemotron-3-super/README.md
@@ -1,0 +1,149 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Nemotron-3-Super Recipes
+
+Recipes for **nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4** (B200) and **nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8** (H200) — a ~120B hybrid Mamba/Attention/MoE model (~12B active).
+
+We ship Dynamo + vLLM deployment profiles across two GPU SKUs and two serving modes.
+
+## Configurations
+
+|                          | B200 chat                    | H200 chat                     | B200 agentic                 | H200 agentic                 |
+|--------------------------|------------------------------|-------------------------------|------------------------------|------------------------------|
+| **GPU** (per worker)     | 4× B200                      | 4× H200                       | 4× B200                      | 4× H200                      |
+| **Mode**                 | aggregated                   | aggregated                    | aggregated                   | aggregated                   |
+| **Framework**            | vLLM 0.21.0                  | vLLM 0.21.0                   | vLLM 0.21.0                  | vLLM 0.21.0                  |
+| **Precision**            | NVFP4 + FP8 KV               | FP8 + FP8 KV                  | NVFP4 + FP8 KV               | FP8 + FP8 KV                 |
+| **Parallelism**          | TP4 + EP                     | TP4 + EP                      | TP4 + EP                     | TP4 + EP                     |
+| **MoE backend**          | FLASHINFER_TRTLLM            | FLASHINFER_CUTLASS (default)  | FLASHINFER_TRTLLM            | FLASHINFER_CUTLASS (default) |
+| **Attention backend**    | FLASH_ATTN                   | FLASH_ATTN (default)          | FLASH_ATTN                   | FLASH_ATTN (default)         |
+| **AllReduce backend**    | FlashInfer TRTLLM            | FlashInfer TRTLLM (default)   | FlashInfer TRTLLM            | FlashInfer TRTLLM (default)  |
+| **All2All backend**      | DeepEP high-throughput       | FlashInfer NVLink one-sided   | DeepEP low-latency           | DeepEP high-throughput       |
+| **Routing**              | KV-aware                     | KV-aware                      | KV-aware                     | KV-aware                     |
+| **Speculative decoding** | MTP (DL=3)                   | MTP (DL=3)                    | MTP (DL=3)                   | MTP (DL=3)                   |
+
+## Supported features
+
+- Text-only chat
+- Reasoning (`enable_thinking: true|false` via `chat_template_kwargs`)
+- Tool calling
+- Function calling with JSON arguments
+
+## Prerequisites
+
+1. **Dynamo Platform installed** on the target cluster (DGD CRDs registered with `nvidia.com/v1beta1` served).
+2. **Namespace labeled for KAI**:
+   ```bash
+   export NAMESPACE=your-namespace
+   kubectl create namespace ${NAMESPACE}
+   kubectl label namespace ${NAMESPACE} kai.scheduler/enabled=true
+   ```
+   Without this label, pods sit `SchedulingGated` indefinitely because KAI's `pod-grouper` filters by namespace label.
+3. **HuggingFace token secret** with access to `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` (B200) and/or `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8` (H200):
+   ```bash
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN="$HF_TOKEN" \
+     -n ${NAMESPACE}
+   ```
+
+## Quick Start
+
+### 1. Create storage
+
+> **Note:** edit `model-cache/model-cache.yaml` first and set `storageClassName` to match your cluster (`kubectl get storageclass`).
+
+```bash
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 2. Download model
+
+Two Jobs share the same PVC. Each pulls into the default HF cache layout (`HF_HOME=/model-cache`, files end up at `/model-cache/hub/models--nvidia--<repo>/snapshots/<sha>/`). Apply only the one your target SKU needs (or both — note PVC sizing).
+
+```bash
+# B200 — NVFP4 checkpoint (~80 GB, ~80 s on Vast)
+kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=1800s
+
+# H200 — FP8 checkpoint (~120 GB)
+kubectl apply -f model-cache/model-download-fp8.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download-fp8 -n ${NAMESPACE} --timeout=3600s
+```
+
+> **Note:** running both Jobs lands ~200 GB on the PVC, which is the default size in `model-cache.yaml`. Bump `storage:` in that file before downloading both.
+
+### 3. Deploy the DGD
+
+Pick the use-case variant and apply:
+
+```bash
+SKU=b200       # or h200
+USECASE=chat   # or agentic
+
+kubectl apply -f vllm/nemotron_3_super_agg_${SKU}_${USECASE}.yaml -n ${NAMESPACE}
+kubectl get dgd nemotron-3-super-${SKU}-${USECASE} -n ${NAMESPACE} -w
+```
+
+Two worker replicas, 4× B200/H200 each (half a node). First-time boot per worker ≈ 6–9 min (image pull + vLLM engine init + Inductor + CUDA graph capture up to size 512).
+
+### 4. Smoke test
+
+```bash
+kubectl port-forward svc/nemotron-3-super-${SKU}-${USECASE}-frontend 8000:8000 -n ${NAMESPACE}
+
+# B200 uses the NVFP4 model id; H200 uses the FP8 model id
+MODEL_ID=nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4   # or -FP8 for H200
+
+curl http://localhost:8000/v1/models
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d "{\"model\":\"${MODEL_ID}\",
+       \"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}],
+       \"max_tokens\":64,
+       \"chat_template_kwargs\":{\"enable_thinking\":false}}"
+```
+
+### 5. Benchmark
+
+See [`perf/README.md`](perf/README.md) for the full benchmark workflow — staging Mooncake-format traces on the PVC, running the AIPerf trace-replay Job ([`perf/perf.yaml`](perf/perf.yaml)), running a concurrency sweep, and fetching artifacts.
+
+## Performance results
+
+| Recipe               | SKU  | # of worker replicas | Concurrency | User output tok/s | System output tok/s/gpu |
+|----------------------|------|----------------------|-------------|-------------------|-------------------------|
+| Chat (15% subset)    | B200 | 2                    | 128         | 61.25             | 844.5                   |
+| Agentic (15% subset) | B200 | 2                    | 192         | 63.16             | 1388.4                  |
+| Chat (15% subset)    | H200 | 2                    | 64          | 56.07             | 404.6                   |
+| Agentic (15% subset) | H200 | 2                    | 128         | 62.94             | 851.0                   |
+
+## Spec-dec toggle (B200)
+
+B200 chat and agentic ship with **MTP spec-dec ON by default** — DL=3, `moe_backend=triton`, stripped `compilation-config`, and `MAX_NUM_BATCHED_TOKENS=65536`.
+
+To turn MTP off, remove the `- --speculative-config=$(SPECULATIVE_CONFIG)` line from worker args. With the extra memory headroom freed up, you can optionally bump `MAX_NUM_BATCHED_TOKENS` to `"131072"` and switch the `COMPILATION_CONFIG` env to the `compilation-config-fused` ConfigMap key (which enables `use_inductor_graph_partition` + `fuse_allreduce_rms` + `fuse_attn_quant`) for better throughput.
+
+## Known issues
+
+1. Some 400 HTTP errors raised by the workers on invalid inputs are surfaced as **500** errors through the Dynamo frontend (the proxy does not always preserve the worker's original status code).
+
+## File layout
+
+```text
+recipes/nemotron-3-super/
+  README.md
+  model-cache/
+    model-cache.yaml          # PVC (RWX, 200Gi on storageClass vast)
+    model-download.yaml       # Job: hf download NVFP4 checkpoint (B200)
+    model-download-fp8.yaml   # Job: hf download FP8 checkpoint (H200)
+  vllm/
+    nemotron_3_super_agg_b200_chat.yaml      # DGD: B200×4, NVFP4, DeepEP high-throughput
+    nemotron_3_super_agg_b200_agentic.yaml   # DGD: B200×4, NVFP4, DeepEP low-latency
+    nemotron_3_super_agg_h200_chat.yaml      # DGD: H200×4, FP8, FlashInfer NVLink one-sided, MTP spec-dec
+    nemotron_3_super_agg_h200_agentic.yaml   # DGD: H200×4, FP8, DeepEP high-throughput, MTP spec-dec
+  perf/
+    README.md                 # benchmark workflow
+    perf.yaml                 # AIPerf trace-replay Job
+```

--- a/recipes/nemotron-3-super/model-cache/model-cache.yaml
+++ b/recipes/nemotron-3-super/model-cache/model-cache.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared model cache for the Nemotron-3-Super checkpoints
+# (NVFP4 for B200, FP8 for H200).
+# Weights are stored in the default HF cache layout (HF_HOME=/model-cache);
+# workers keep --model as the HF ID and resolve weights from this cache.
+#
+# Edit storageClassName to match your cluster:
+#   kubectl get storageclass
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: "vast"

--- a/recipes/nemotron-3-super/model-cache/model-download-fp8.yaml
+++ b/recipes/nemotron-3-super/model-cache/model-download-fp8.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Downloads the FP8 Nemotron-3-Super checkpoint into the PVC using the
+# default HF cache layout (HF_HOME=/model-cache, files end up at
+# /model-cache/hub/models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-FP8/snapshots/<sha>/).
+#
+# Sibling of model-download.yaml — that one is the NVFP4 checkpoint for B200;
+# this one is the FP8 checkpoint for H200. Apply whichever your target SKU
+# needs (or both, but verify the PVC has ~200 GiB free for both).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download-fp8
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download-fp8
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download-fp8
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download "$MODEL_NAME"
+              ls /model-cache/hub/models--*/snapshots/*/ | head
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/recipes/nemotron-3-super/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-super/model-cache/model-download.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Downloads the NVFP4 Nemotron-3-Super checkpoint into the PVC using the
+# default HF cache layout (HF_HOME=/model-cache, files end up at
+# /model-cache/hub/models--nvidia--NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/snapshots/<sha>/).
+#
+# Reason for HF cache layout (instead of --local-dir): the worker keeps --model as an
+# HF ID so the Dynamo frontend's discovery watcher can fetch model metadata
+# from HuggingFace, while the actual weights are still resolved from the
+# local cache (no runtime network pull). Using --local-dir instead would
+# break frontend model registration (it issues hub::from_hf(<--model value>)
+# which 404s when --model is a filesystem path).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: MODEL_NAME
+              value: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download "$MODEL_NAME"
+              ls /model-cache/hub/models--*/snapshots/*/ | head
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/recipes/nemotron-3-super/perf/README.md
+++ b/recipes/nemotron-3-super/perf/README.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Nemotron-3-Super Benchmark Recipe
+
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job — [perf.yaml](perf.yaml) — covers every Nemotron-3-Super DGD variant (B200/H200 × chat/agent traces). The benchmark is identical across variants; only `ENDPOINT`, `TRACE_FILE`, and `TARGET_MODEL` need to change.
+
+The Job waits for `GET /v1/models` on the DGD frontend to return the configured `TARGET_MODEL` (up to ~1h by default), runs a short warmup, then replays the configured trace at a single `CONCURRENCY` value and writes raw artifacts to the shared `model-cache` PVC.
+
+The bench pod is **co-located with the DGD frontend** (`podAffinity` on the frontend's host) so client → server traffic stays on a single node.
+
+## Targeting a variant
+
+Edit the `env` block in [perf.yaml](perf.yaml):
+
+| Variant target           | `ENDPOINT`                                            | `TARGET_MODEL`                                            | `TRACE_FILE` (chat / agent)                                             |
+| ------------------------ | ----------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| B200 agg, chat workload  | `nemotron-3-super-b200-chat-frontend:8000`      | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`    |
+| B200 agg, agent workload | `nemotron-3-super-b200-agentic-frontend:8000`   | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl` |
+| H200 agg, chat workload  | `nemotron-3-super-h200-chat-frontend:8000`      | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8`   | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`    |
+| H200 agg, agent workload | `nemotron-3-super-h200-agentic-frontend:8000`   | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8`   | `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl` |
+
+Both DGDs of a given SKU serve the same `--served-model-name`, so either trace can be replayed against either DGD by swapping `TRACE_FILE`. `TARGET_MODEL` only changes between B200 (NVFP4) and H200 (FP8).
+
+If you run more than one benchmark in the same namespace, also update `metadata.name` / `labels.app` so jobs and artifact directories stay distinct.
+
+## Dataset
+
+The benchmark replays a [Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace via `aiperf --custom-dataset-type mooncake_trace`. Each JSONL line describes one request (`input_length`, `output_length`, `hash_ids`).
+
+Trace flavours expected on the PVC:
+
+- **Chat** — `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`
+- **Agent** — `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl`
+
+For shorter runs (smoke tests, faster iteration), point `TRACE_FILE` at a smaller variant of the same trace rather than capping run time. Typical staging:
+
+```
+/model-cache/traces/<flavour>.jsonl                 # full
+/model-cache/traces/<flavour>_short_30perc.jsonl    # ~30% subset
+/model-cache/traces/<flavour>_short_15perc.jsonl    # ~15% subset
+```
+
+These are workload-shape traces (not model-specific). Stage your own Mooncake-format JSONLs at the path you set in `TRACE_FILE`.
+
+## Workflow
+
+```bash
+export NAMESPACE=your-namespace
+```
+
+### 1. Deploy the DGD
+
+See instructions in the [recipe README](../README.md).
+
+Before deploying, do these adjustments to the DGD:
+- (H200 only) Change the `SPECULATIVE_CONFIG` env to point to `key: speculative-config-synthetic` if you want a fixed-AL synthetic MTP run.
+- Modify the worker `replicas` to match your desired target.
+
+### 2. Stage the trace on the PVC
+
+Spin up a short-lived helper pod that mounts `model-cache`, then `kubectl cp` the traces in:
+
+```bash
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl cp ./traces ${NAMESPACE}/pvc-helper:/model-cache/
+```
+
+Keep `pvc-helper` around for fetching artifacts later, or `kubectl delete pod pvc-helper -n ${NAMESPACE}` once you're done staging.
+
+### 3. Run the benchmark
+
+```bash
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+
+# Stream logs
+kubectl logs -n ${NAMESPACE} -l job-name=nemotron-3-super-bench -f
+
+# Wait for completion (2h hard cap on the Job)
+kubectl wait --for=condition=Complete \
+  job/nemotron-3-super-bench \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+### 4. Fetch artifacts
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_nemotron-3-super-bench ./results
+```
+
+### 5. Cleanup
+
+```bash
+kubectl delete job nemotron-3-super-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}   # if you kept it around
+```
+
+## Running a concurrency sweep
+
+`perf.yaml` runs a **single** `CONCURRENCY` value. To measure multiple concurrencies you must clear server state between runs — otherwise residual KV cache / prefix-cache hits from the previous run skew results.
+
+For each concurrency value you want to measure:
+
+```bash
+# 1. Delete the previous bench job
+kubectl delete job nemotron-3-super-bench -n ${NAMESPACE} --ignore-not-found
+
+# 2. Drop KV / prefix-cache by deleting the worker pods; Grove respawns them
+#    (Dynamo workers are PodClique pods, not k8s Deployments — `kubectl rollout
+#    restart deployment ...` is a silent no-op against the Grove resource chain.)
+DGD=nemotron-3-super-b200-chat   # or any of the four variants
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+
+# 3. Bump CONCURRENCY in perf.yaml, then re-apply
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/nemotron-3-super-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+(The bench Job's `wait_for_model_ready` loop handles the worker restart window — it re-polls `/v1/models` until the frontend reports ready again.)
+
+## Tunable environment variables
+
+Edit the `env` block on the `Job` to adjust:
+
+| Variable       | Default                                                          | Notes                                                                           |
+| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `ENDPOINT`     | `nemotron-3-super-b200-chat-frontend:8000`                 | DGD frontend service:port — change per variant                                  |
+| `TRACE_FILE`   | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl` | Swap to agent or to a smaller subset (`...short_15perc.jsonl`) for shorter runs |
+| `CONCURRENCY`  | `24`                                                             | Single value — see [Running a concurrency sweep](#running-a-concurrency-sweep)  |
+| `TARGET_MODEL` | `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4`                 | Must match `--served-model-name` on the DGD frontend (NVFP4 for B200, FP8 for H200) |
+
+## Artifacts
+
+Results are written to:
+
+```
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```

--- a/recipes/nemotron-3-super/perf/perf.yaml
+++ b/recipes/nemotron-3-super/perf/perf.yaml
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AIPerf trace-replay benchmark for Nemotron-3-Super DGDs.
+#
+# One Job covers every variant (B200/H200 × chat/agent traces) — the
+# benchmark itself is identical regardless of GPU SKU. To target a specific
+# DGD, edit the env values below (and `metadata.name` / `labels.app` if you
+# run multiple jobs in the same namespace).
+#
+# Runs a single concurrency value. To sweep concurrencies, restart the DGD
+# workers between runs so KV cache and prefix-cache state are reset — see
+# README.md "Running a concurrency sweep".
+#
+# Prerequisites:
+# - Target DGD is Ready (see ../README.md)
+# - model-cache PVC mounted in the namespace and contains TRACE_FILE
+# - TARGET_MODEL matches the served-model-name on the DGD (NVFP4 for B200,
+#   FP8 for H200)
+#
+# Results: /model-cache/perf/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nemotron-3-super-bench
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 7200 # 2h hard cap on the Job
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: nemotron-3-super-bench
+    spec:
+      # Co-locate the bench pod with the DGD frontend to minimise client/server
+      # network overhead.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: nvidia.com/dynamo-component-type
+                operator: In
+                values:
+                - frontend
+              - key: nvidia.com/dynamo-graph-deployment-name
+                operator: In
+                values:
+                - nemotron-3-super-b200-chat
+                - nemotron-3-super-b200-agentic
+                - nemotron-3-super-h200-chat
+                - nemotron-3-super-h200-agentic
+            topologyKey: kubernetes.io/hostname
+      # tolerations: # uncomment to populate any tolerations for the gpu nodes
+      containers:
+      - name: perf
+        image: python:3.12-slim
+        imagePullPolicy: IfNotPresent
+        workingDir: /workspace
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          ulimit -n 600000
+          apt-get update && apt-get install -y curl jq procps git && apt-get clean
+          pip install "aiperf==0.7.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
+          sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
+          export COLUMNS=200
+          EPOCH=$(date +%s)
+          wait_for_model_ready() {
+            local max_attempts=${WAIT_FOR_MODEL_MAX_ATTEMPTS:-720} # 720 * 5s = 1h default
+            local attempt=0
+            echo "Waiting for model '$TARGET_MODEL' at $ENDPOINT/v1/models (max ${max_attempts} attempts) ..."
+            while ! curl -sf "http://$ENDPOINT/v1/models" | jq -e --arg m "$TARGET_MODEL" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do
+              attempt=$((attempt + 1))
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "ERROR: model '$TARGET_MODEL' did not become ready after ${max_attempts} attempts. Aborting."
+                exit 1
+              fi
+              echo "[$(date '+%H:%M:%S')] not ready (attempt ${attempt}/${max_attempts}), sleeping 5s"
+              sleep 5
+            done
+            curl -s "http://$ENDPOINT/v1/models" | jq .
+          }
+          if [ ! -f "${TRACE_FILE}" ]; then
+            echo "ERROR: trace file not found at ${TRACE_FILE}"
+            echo "Copy it onto the PVC via a helper pod, e.g.:"
+            echo " kubectl cp <local_trace.jsonl> <ns>/<helper-pod>:${TRACE_FILE}"
+            exit 1
+          fi
+          wait_for_model_ready
+          ROOT_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          mkdir -p "$ROOT_DIR"
+          echo "=============================================="
+          echo "Trace Replay Benchmark (aiperf)"
+          echo "=============================================="
+          echo "Endpoint:     http://${ENDPOINT}"
+          echo "Model:        ${TARGET_MODEL}"
+          echo "Trace file:   ${TRACE_FILE}"
+          echo "Concurrency:  ${CONCURRENCY}"
+          echo "Artifact root:${ROOT_DIR}"
+          echo "=============================================="
+          # Warmup
+          WARMUP_DIR="${ROOT_DIR}/warmup"
+          mkdir -p "$WARMUP_DIR"
+          aiperf profile \
+          -m "${TARGET_MODEL}" \
+          --tokenizer "${TARGET_MODEL}" \
+          --tokenizer-trust-remote-code \
+          --url "http://${ENDPOINT}" \
+          --streaming \
+          --ui simple \
+          --isl 8000 \
+          --osl 1000 \
+          --concurrency 1 \
+          --request-count 5 \
+          --artifact-dir "${WARMUP_DIR}"
+          echo "Warmup complete"
+          MODEL_BASE="${TARGET_MODEL##*/}"
+          TS=$(date +'%Y%m%d_%H%M%S')
+          RUN_DIR="${ROOT_DIR}/${MODEL_BASE}_trace_c${CONCURRENCY}_${TS}"
+          mkdir -p "$RUN_DIR"
+          aiperf profile \
+          -m "${TARGET_MODEL}" \
+          --tokenizer "${TARGET_MODEL}" \
+          --tokenizer-trust-remote-code \
+          --input-file "${TRACE_FILE}" \
+          --custom-dataset-type mooncake_trace \
+          --num-requests $(wc -l < "${TRACE_FILE}") \
+          --prompt-input-tokens-block-size 512 \
+          --url "http://${ENDPOINT}" \
+          --streaming \
+          --use-server-token-count \
+          --extra-inputs ignore_eos:true \
+          --concurrency "${CONCURRENCY}" \
+          --random-seed 42 \
+          --ui simple \
+          --artifact-dir "${RUN_DIR}" \
+          --request-timeout-seconds 1200 \
+          --workers-max "${CONCURRENCY}" \
+          --export-http-trace
+          echo "Concurrency ${CONCURRENCY} complete; artifacts in ${RUN_DIR}"
+          ls -la "${RUN_DIR}" || true
+          echo ""
+          echo "Done. Root: ${ROOT_DIR}"
+        env:
+        # --- Edit these to target the DGD + trace you want to benchmark ---
+        - name: ENDPOINT
+          value: nemotron-3-super-b200-chat-frontend:8000
+        - name: TRACE_FILE
+          value: /model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl  # use /model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl for agent
+        - name: CONCURRENCY
+          value: "24"
+        # B200 deploys serve the NVFP4 model id; H200 deploys serve FP8 — swap
+        # TARGET_MODEL to match the DGD's --served-model-name.
+        - name: TARGET_MODEL
+          value: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4  # H200: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+        # --- The remainder is shared across all variants ---
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "200"
+        - name: AIPERF_HTTP_SO_RCVTIMEO
+          value: "120"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /model-cache/perf
+        - name: HF_HOME
+          value: /model-cache
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/nemotron-3-super/perf/traces/.gitattributes
+++ b/recipes/nemotron-3-super/perf/traces/.gitattributes
@@ -1,0 +1,6 @@
+64k_400_90kv_agent_new_noschedule.jsonl filter=lfs diff=lfs merge=lfs -text
+64k_400_90kv_agent_new_noschedule_short_15perc.jsonl filter=lfs diff=lfs merge=lfs -text
+64k_400_90kv_agent_new_noschedule_short_30perc.jsonl filter=lfs diff=lfs merge=lfs -text
+8k_1k_70kv_chat_new_noschedule.jsonl filter=lfs diff=lfs merge=lfs -text
+8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl filter=lfs diff=lfs merge=lfs -text
+8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/recipes/nemotron-3-super/perf/traces/64k_400_90kv_agent_new_noschedule.jsonl
+++ b/recipes/nemotron-3-super/perf/traces/64k_400_90kv_agent_new_noschedule.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0a64efcad575a01949e46e28dded094f20733db8708e0bc91b88ce9981fed6
+size 17623982

--- a/recipes/nemotron-3-super/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+++ b/recipes/nemotron-3-super/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20d3f2bc83dd1306cda659fbe34e7c4d85ca5497626c98bc0b1c4d2211379d0
+size 2722326

--- a/recipes/nemotron-3-super/perf/traces/64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
+++ b/recipes/nemotron-3-super/perf/traces/64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dae61f92fee05038f1dcb76474dba83c1b3c174f3d187589c7d0a16a7012eb79
+size 5401776

--- a/recipes/nemotron-3-super/perf/traces/8k_1k_70kv_chat_new_noschedule.jsonl
+++ b/recipes/nemotron-3-super/perf/traces/8k_1k_70kv_chat_new_noschedule.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f369eb75ce639ad8b05cc209bb534bfedd627e9f7b923de32888155b4c9085a
+size 5648304

--- a/recipes/nemotron-3-super/perf/traces/8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
+++ b/recipes/nemotron-3-super/perf/traces/8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1221bca72b69f842897f339624306a84857f1b55ea0d866525f94d9ceb9b871
+size 894687

--- a/recipes/nemotron-3-super/perf/traces/8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl
+++ b/recipes/nemotron-3-super/perf/traces/8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6de2a977b40dba8735a70aa5f9ab0d84e32530d7cf1fc9d24efc631c341f9c17
+size 1790696

--- a/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_b200_agentic.yaml
+++ b/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_b200_agentic.yaml
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated NVFP4 deployment of NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 on
+# B200x4 (TP=4) tuned for the agentic-coding workload: DeepEP low-latency
+# all-to-all and FP8 KV cache (fp8_e4m3) to minimise ITL/TTFT spikes
+# during short-burst tool/code edits.
+#
+# Cluster requirements: see nemotron_3_super_agg_b200_chat.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nemotron-3-super-b200-agentic-config
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-b200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  # Stripped compilation passes for the spec-dec path (no inductor graph
+  # partitioning, no fuse passes — they don't compose with the MTP draft
+  # model's compile graph yet). This is what worker env COMPILATION_CONFIG
+  # points at by default.
+  compilation-config: |-
+    {
+      "max_cudagraph_capture_size": 512
+    }
+  # Fused compilation passes — for non-spec-dec runs only. Point
+  # COMPILATION_CONFIG at this key (configMapKeyRef.key) when running
+  # without --speculative-config.
+  compilation-config-fused: |-
+    {
+      "use_inductor_graph_partition": true,
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+  # MTP speculative decoding. moe_backend=triton on B200 because the
+  # default FlashInfer-TRTLLM MoE path isn't supported in the spec-dec
+  # draft model loop yet.
+  speculative-config: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3,
+      "moe_backend": "triton"
+    }
+  # Benchmarking-only: synthetic rejection sampling with a fixed AL.
+  # Switch SPECULATIVE_CONFIG env to this key to bench MTP at a known
+  # acceptance length without running the actual draft head.
+  speculative-config-synthetic: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3,
+      "moe_backend": "triton",
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.82
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: nemotron-3-super-b200-agentic
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-b200-agentic
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              resources: {}
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                periodSeconds: 10
+                timeoutSeconds: 60
+                failureThreshold: 60
+
+    - name: agg
+      type: worker
+      replicas: 2
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 16Gi
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              args:
+                - --model
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+                - --served-model-name
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+                - --trust-remote-code
+                - --tensor-parallel-size
+                - "4"
+                - --enable-expert-parallel
+                - --moe-backend
+                - flashinfer_trtllm
+                - --enable-flashinfer-autotune
+                - --enable-prefix-caching
+                - --enable-chunked-prefill
+                - --max-model-len
+                - "131072"
+                - --max-num-batched-tokens=$(MAX_NUM_BATCHED_TOKENS)
+                - --all2all-backend
+                - deepep_low_latency
+                - --kv-cache-dtype
+                - fp8_e4m3
+                - --mamba-ssm-cache-dtype
+                - float16
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --dyn-tool-call-parser
+                - nemotron_nano
+                - --dyn-reasoning-parser
+                - nemotron_nano
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-b200-agentic-config
+                      key: compilation-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-b200-agentic-config
+                      key: speculative-config
+                # Tracks the spec-dec mode: 65536 when --speculative-config is
+                # active, 131072 when running without spec-dec. Update this
+                # value (and remove --speculative-config from args) to disable.
+                - name: MAX_NUM_BATCHED_TOKENS
+                  value: "65536"
+                - name: VLLM_FLASHINFER_ALLREDUCE_BACKEND
+                  value: "trtllm"
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "42"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: "256Gi"
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 30
+                timeoutSeconds: 20
+                failureThreshold: 60
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /model-cache
+                - name: dshm
+                  mountPath: /dev/shm
+              workingDir: /workspace/

--- a/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_b200_chat.yaml
+++ b/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_b200_chat.yaml
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated NVFP4 deployment of NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 on
+# B200x4 (TP=4) with Expert Parallel + DeepEP high-throughput all-to-all.
+#
+# Cluster requirements:
+#   - Namespace must carry label kai.scheduler/enabled=true so KAI's
+#     pod-grouper picks up the pods.
+#   - hf-token-secret (Opaque, key HF_TOKEN) must exist in the namespace.
+#   - storageClass with ReadWriteMany support (vast on Dynamo Nscale dev).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nemotron-3-super-b200-chat-config
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-b200-chat
+    app.kubernetes.io/part-of: dynamo
+data:
+  # Stripped compilation passes for the spec-dec path (no inductor graph
+  # partitioning, no fuse passes — they don't compose with the MTP draft
+  # model's compile graph yet). This is what worker env COMPILATION_CONFIG
+  # points at by default.
+  compilation-config: |-
+    {
+      "max_cudagraph_capture_size": 512
+    }
+  # Fused compilation passes — for non-spec-dec runs only. Point
+  # COMPILATION_CONFIG at this key (configMapKeyRef.key) when running
+  # without --speculative-config.
+  compilation-config-fused: |-
+    {
+      "use_inductor_graph_partition": true,
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+  # MTP speculative decoding. moe_backend=triton on B200 because the
+  # default FlashInfer-TRTLLM MoE path isn't supported in the spec-dec
+  # draft model loop yet.
+  speculative-config: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3,
+      "moe_backend": "triton"
+    }
+  # Benchmarking-only: synthetic rejection sampling with a fixed AL.
+  # Switch SPECULATIVE_CONFIG env to this key to bench MTP at a known
+  # acceptance length without running the actual draft head.
+  speculative-config-synthetic: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3,
+      "moe_backend": "triton",
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.82
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: nemotron-3-super-b200-chat
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-b200-chat
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              resources: {}
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                periodSeconds: 10
+                timeoutSeconds: 60
+                failureThreshold: 60
+
+    - name: agg
+      type: worker
+      replicas: 2
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 16Gi
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              args:
+                - --model
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+                - --served-model-name
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+                - --trust-remote-code
+                - --tensor-parallel-size
+                - "4"
+                - --enable-expert-parallel
+                - --moe-backend
+                - flashinfer_trtllm
+                - --enable-flashinfer-autotune
+                - --enable-prefix-caching
+                - --enable-chunked-prefill
+                - --max-model-len
+                - "131072"
+                - --max-num-batched-tokens=$(MAX_NUM_BATCHED_TOKENS)
+                - --all2all-backend
+                - deepep_high_throughput
+                - --kv-cache-dtype
+                - fp8_e4m3
+                - --mamba-ssm-cache-dtype
+                - float16
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --dyn-tool-call-parser
+                - nemotron_nano
+                - --dyn-reasoning-parser
+                - nemotron_nano
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-b200-chat-config
+                      key: compilation-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-b200-chat-config
+                      key: speculative-config
+                # Tracks the spec-dec mode: 65536 when --speculative-config is
+                # active, 131072 when running without spec-dec. Update this
+                # value (and remove --speculative-config from args) to disable.
+                - name: MAX_NUM_BATCHED_TOKENS
+                  value: "65536"
+                - name: VLLM_FLASHINFER_ALLREDUCE_BACKEND
+                  value: "trtllm"
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "42"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: "256Gi"
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 30
+                timeoutSeconds: 20
+                failureThreshold: 60
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /model-cache
+                - name: dshm
+                  mountPath: /dev/shm
+              workingDir: /workspace/

--- a/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_h200_agentic.yaml
+++ b/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_h200_agentic.yaml
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated FP8 deployment of NVIDIA-Nemotron-3-Super-120B-A12B-FP8 on
+# H200x4 (TP=4) with Expert Parallel + DeepEP high-throughput all-to-all.
+# Differs from the chat variant (nemotron_3_super_agg_h200_chat.yaml),
+# which uses the FlashInfer NVLink one-sided all-to-all backend; see that
+# file for the rationale on dropped Blackwell-specific NCCL env.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nemotron-3-super-h200-agentic-config
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-h200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  compilation-config: |-
+    {
+      "use_inductor_graph_partition": true,
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+  speculative-config: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3
+    }
+  # Benchmarking-only: synthetic rejection sampling with a fixed AL
+  # (matches the speculative-config-synthetic pattern in Alexandre's k26
+  # recipes). Switch SPECULATIVE_CONFIG env to this key to bench MTP
+  # at a known acceptance length without running the actual draft head.
+  speculative-config-synthetic: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.82
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: nemotron-3-super-h200-agentic
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-h200-agentic
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              resources: {}
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                periodSeconds: 10
+                timeoutSeconds: 60
+                failureThreshold: 60
+
+    - name: agg
+      type: worker
+      replicas: 2
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 16Gi
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              args:
+                - --model
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+                - --served-model-name
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+                - --trust-remote-code
+                - --tensor-parallel-size
+                - "4"
+                - --enable-expert-parallel
+                - --enable-flashinfer-autotune
+                - --enable-prefix-caching
+                - --enable-chunked-prefill
+                - --max-model-len
+                - "131072"
+                - --max-num-batched-tokens
+                - "16384"
+                - --all2all-backend
+                - deepep_high_throughput
+                - --kv-cache-dtype
+                - fp8_e4m3
+                - --mamba-ssm-cache-dtype
+                - float16
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --dyn-tool-call-parser
+                - nemotron_nano
+                - --dyn-reasoning-parser
+                - nemotron_nano
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-h200-agentic-config
+                      key: compilation-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-h200-agentic-config
+                      key: speculative-config
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "42"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: "256Gi"
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 30
+                timeoutSeconds: 20
+                failureThreshold: 60
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /model-cache
+                - name: dshm
+                  mountPath: /dev/shm
+              workingDir: /workspace/

--- a/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_h200_chat.yaml
+++ b/recipes/nemotron-3-super/vllm/nemotron_3_super_agg_h200_chat.yaml
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated FP8 deployment of NVIDIA-Nemotron-3-Super-120B-A12B-FP8 on
+# H200x4 (TP=4) with Expert Parallel + FlashInfer NVLink one-sided all-to-all.
+# Hopper variant — drops Blackwell-specific NCCL SHARP / symmetric-memory
+# env vars and the FlashInfer NVFP4 MoE backend (those are B200-only).
+#
+# Cluster requirements (same as B200): see nemotron_3_super_agg_b200_chat.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nemotron-3-super-h200-chat-config
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-h200-chat
+    app.kubernetes.io/part-of: dynamo
+data:
+  compilation-config: |-
+    {
+      "use_inductor_graph_partition": true,
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+  speculative-config: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3
+    }
+  # Benchmarking-only: synthetic rejection sampling with a fixed AL
+  # (matches the speculative-config-synthetic pattern in Alexandre's k26
+  # recipes). Switch SPECULATIVE_CONFIG env to this key to bench MTP
+  # at a known acceptance length without running the actual draft head.
+  speculative-config-synthetic: |-
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 3,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.82
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: nemotron-3-super-h200-chat
+  labels:
+    app.kubernetes.io/name: nemotron-3-super-h200-chat
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      replicas: 1
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              resources: {}
+              startupProbe:
+                httpGet:
+                  path: /health
+                  port: 8000
+                periodSeconds: 10
+                timeoutSeconds: 60
+                failureThreshold: 60
+
+    - name: agg
+      type: worker
+      replicas: 2
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 16Gi
+          containers:
+            - name: main
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-nemotron-super-dev.1
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              args:
+                - --model
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+                - --served-model-name
+                - nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
+                - --trust-remote-code
+                - --tensor-parallel-size
+                - "4"
+                - --enable-expert-parallel
+                - --enable-flashinfer-autotune
+                - --enable-prefix-caching
+                - --enable-chunked-prefill
+                - --max-model-len
+                - "131072"
+                - --max-num-batched-tokens
+                - "16384"
+                - --all2all-backend
+                - flashinfer_nvlink_one_sided
+                - --kv-cache-dtype
+                - fp8_e4m3
+                - --mamba-ssm-cache-dtype
+                - float16
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --dyn-tool-call-parser
+                - nemotron_nano
+                - --dyn-reasoning-parser
+                - nemotron_nano
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-h200-chat-config
+                      key: compilation-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nemotron-3-super-h200-chat-config
+                      key: speculative-config
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "42"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: "256Gi"
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 30
+                timeoutSeconds: 20
+                failureThreshold: 60
+              volumeMounts:
+                - name: model-cache
+                  mountPath: /model-cache
+                - name: dshm
+                  mountPath: /dev/shm
+              workingDir: /workspace/


### PR DESCRIPTION
Cherry-picks #10223 onto `release/1.3.0-nemotron-super-dev.1` so the release branch carries the nemotron-3-super recipes matching the published container. Recipe folder only; cherry-picked with -x -s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->