### PR TITLE
docs: add kimi-k2.6 recipes to release branch

### DIFF
--- a/recipes/kimi-k2.6/README.md
+++ b/recipes/kimi-k2.6/README.md
@@ -1,0 +1,113 @@
+# Kimi-K2.6 Recipes
+
+Recipes for **moonshotai/Kimi-K2.6**.
+
+## Configurations
+
+Dynamo + vLLM deployment profiles across two GPU SKUs and two target workloads:
+
+|                          | B200 chat                             | H200 chat                             | B200 agentic                         | H200 agentic                         |
+|--------------------------|---------------------------------------|---------------------------------------|--------------------------------------|--------------------------------------|
+| **GPU** (per worker)                  | 4x B200                               | 8x H200                               | 4x B200                              | 8x H200                              |
+| **Mode**                 | aggregated                            | aggregated                            | aggregated                           | aggregated                           |
+| **Framework**            | vLLM 0.21.0                           | vLLM 0.21.0                           | vLLM 0.21.0                          | vLLM 0.21.0                          |
+| **Precision**            | NVFP4 + FP8 KV                        | INT4                                  | NVFP4 + FP8 KV                       | INT4                                 |
+| **Parallelism**          | TP4                                   | TP8                                   | TP4                                  | TP8                                  |
+| **MoE backend**          | FLASHINFER_TRTLLM                     | MARLIN                                | FLASHINFER_TRTLLM                    | MARLIN                               |
+| **Attention backend**    | TOKENSPEED_MLA                        | FLASH_ATTN_MLA                        | TOKENSPEED_MLA                       | FLASH_ATTN_MLA                       |
+| **AllReduce backend**    | NCCL symmetric memory                 | NCCL                                  | NCCL symmetric memory                | NCCL                                 |
+| **All2All backend**      | N/A                                   | N/A                                   | N/A                                  | N/A                                  |
+| **Routing**              | KV-aware                              | KV-aware                              | KV-aware                             | KV-aware                             |
+| **Speculative decoding** | EAGLE3 MLA (DL=3, SpeedBench AL=2.49) | EAGLE3 MLA (DL=3, SpeedBench AL=2.49) | EAGLE3 MLA (DL=3, SpeedBench AL=2.49) | EAGLE3 MLA (DL=3, SpeedBench AL=2.49) |
+| **KV cache offloading**  | LMCache CPU                           | LMCache CPU                           | LMCache CPU                          | LMCache CPU                          |
+
+
+## Supported features
+
+- Modalities: Text + Image
+- Reasoning
+- Tool calling
+
+
+## Prerequisites
+
+1. **Dynamo Platform installed** — see [Kubernetes Deployment Guide](../../docs/kubernetes/README.md).
+2. **HuggingFace token** with access to `nvidia/Kimi-K2.6-NVFP4`, `moonshotai/Kimi-K2.6` and `lightseekorg/kimi-k2.6-eagle3-mla`:
+   ```bash
+   export NAMESPACE=your-namespace
+   kubectl create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN="your-token" \
+     -n ${NAMESPACE}
+   ```
+
+
+## Quick Start
+
+### 1. Create namespace
+
+```
+export NAMESPACE=your-namespace
+kubectl create namespace ${NAMESPACE}
+```
+
+### 2. Create Storage
+
+> **Note:** Edit `model-cache/model-cache.yaml` first and update `storageClassName` to match your cluster (`kubectl get storageclass`).
+
+```bash
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 3. Download model + EAGLE3 head
+
+> **Note:** Edit `model-cache/model-download.yaml` first and remove the `hf download` lines that do not apply to your deployment (For H200, remove the NVFP4 download, for B200, remove the native INT4 download).
+
+```bash
+kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=3600s
+```
+
+### 4. Deploy the DGD
+
+Deploy the target DGD:
+
+```bash
+SKU=b200 # or h200
+USECASE=chat # or agentic
+
+kubectl apply -f vllm/agg-${SKU}-${USECASE}/deploy.yaml -n ${NAMESPACE}
+```
+
+
+### 5. Benchmark
+
+See [`perf/README.md`](perf/README.md) for the full benchmark workflow — trace staging on the PVC, running the AIPerf trace-replay Job ([`perf/perf.yaml`](perf/perf.yaml)), running a concurrency sweep, and fetching artifacts.
+
+
+## Optimization targets
+
+Recipes are optimized for the following configurations, at the target user interactivity:
+
+| Workload                 | Median ISL | Median OSL | KV cache hit rate | User output tok/s |
+|------------------------|------------|------------|----------------|------------|
+| Chat                   |      1k      | 1k        |  70%       | 50        |
+| Agentic                  |      64k      | 400        | 90%        | 50        |
+
+
+Modified Mooncake traces are provided to showcase the value of KV-aware routing and CPU offloading, see [perf/README.md](./perf/README.md) for details.
+
+
+## Performance results
+
+| Recipe                 | SKU | # of worker replicas | Concurrency | User output tok/s | System output tok/s/gpu |
+|------------------------|------------|------------|----------------|------------|------------|
+| Chat (15% subset)                   |      B200      | 4        |   48      |    	49.86     |  107.8 |
+| Agentic (15% subset)                 |      B200      | 4        | 64        |  55.50       | 166.5 |
+| Chat (15% subset)                  |      H200      | 4        |    32     |   	54.86      | 38.7 |
+| Agentic (15% subset)                 |      H200      | 4        |    48     |   	56.06       | 66.5 |
+
+
+## Known issues
+
+1. Dynamo's KV cache router does not support all LMCache KV events, so routing can be sub-optimal
+2. Some 400 HTTP errors from the workers on invalid inputs can be raised as 500 errors through the frontend

--- a/recipes/kimi-k2.6/model-cache/model-cache.yaml
+++ b/recipes/kimi-k2.6/model-cache/model-cache.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1200Gi
+  # Edit this
+  storageClassName: "your-storage-class-name"

--- a/recipes/kimi-k2.6/model-cache/model-download.yaml
+++ b/recipes/kimi-k2.6/model-cache/model-download.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          # Edit this, only pull the checkpoints you need, NVFP4 or native INT4
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download nvidia/Kimi-K2.6-NVFP4
+              hf download moonshotai/Kimi-K2.6
+              hf download lightseekorg/kimi-k2.6-eagle3-mla
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/kimi-k2.6/perf/README.md
+++ b/recipes/kimi-k2.6/perf/README.md
@@ -1,0 +1,155 @@
+# Kimi-K2.6 Benchmark Recipe
+
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job — [perf.yaml](perf.yaml) — covers every Kimi-K2.6 DGD variant (B200/H200 × chat/agent traces). The benchmark is identical across variants; only `ENDPOINT` and `TRACE_FILE` need to change.
+
+The Job waits for `GET /v1/models` on the DGD frontend to return `moonshotai/Kimi-K2.6` (up to ~1h by default), runs a short warmup, then replays the configured trace at a single `CONCURRENCY` value and writes raw artifacts to the shared `model-cache` PVC.
+
+The bench pod is **co-located with the DGD frontend** (`podAffinity` on the frontend's host) so client → server traffic stays on a single node.
+
+## Targeting a variant
+
+Edit the `env` block in [perf.yaml](perf.yaml):
+
+
+| Variant target           | `ENDPOINT`                                      | `TRACE_FILE` (chat / agent)                                             |
+| ------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------- |
+| B200 agg, chat workload  | `kimi-k26-agg-b200-chat-frontend:8000`    | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`    |
+| B200 agg, agent workload | `kimi-k26-agg-b200-agentic-frontend:8000` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl` |
+| H200 agg, chat workload  | `kimi-k26-agg-h200-chat-frontend:8000`    | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`    |
+| H200 agg, agent workload | `kimi-k26-agg-h200-agentic-frontend:8000` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl` |
+
+
+The chat- and agent-tuned DGDs both serve `moonshotai/Kimi-K2.6`, so either trace can be replayed against either DGD by swapping `TRACE_FILE`.
+
+If you run more than one benchmark in the same namespace, also update `metadata.name` / `labels.app` so jobs and artifact directories stay distinct.
+
+## Dataset
+
+The benchmark replays a [Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace via `aiperf --custom-dataset-type mooncake_trace`. Each JSONL line describes one request (`input_length`, `output_length`, `hash_ids`).
+
+Trace flavours expected on the PVC:
+
+- **Chat** — `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl`
+- **Agent** — `/model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl`
+
+For shorter runs (smoke tests, faster iteration), point `TRACE_FILE` at a smaller variant of the same trace rather than capping run time. We typically stage 15% and 30% subsets alongside the full dataset, e.g.:
+
+```
+/model-cache/traces/<flavour>.jsonl                 # full
+/model-cache/traces/<flavour>_short_30perc.jsonl    # ~30% subset
+/model-cache/traces/<flavour>_short_15perc.jsonl    # ~15% subset
+```
+
+The Dynamo Kimi-K2.5 recipe is the closest reference for trace handling — see [its README](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.5/README.md#dataset-agentic-coding-workflow) and [perf.yaml](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/perf.yaml).
+
+## Workflow
+
+```bash
+export NAMESPACE=your-namespace
+```
+
+### 1. Deploy the DGD
+
+See instructions in the [README](../README.md).
+
+Before deploying, do these adjustments to the DGD:
+- Change the `SPECULATIVE_CONFIG` variable to point to `key: speculative-config-synthetic`.
+- Modify the worker `replicas` to match your desired target
+
+
+### 2. Stage the trace on the PVC
+
+Spin up a short-lived helper pod that mounts `model-cache`, then `kubectl cp` the traces in:
+
+```bash
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+kubectl cp ./traces ${NAMESPACE}/pvc-helper:/model-cache/
+```
+
+Keep `pvc-helper` around for fetching artifacts later, or `kubectl delete pod pvc-helper -n ${NAMESPACE}` once you're done staging.
+
+### 3. Run the benchmark
+
+```bash
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+
+# Stream logs
+kubectl logs -n ${NAMESPACE} -l job-name=kimi-k26-bench -f
+
+# Wait for completion (2h hard cap on the Job)
+kubectl wait --for=condition=Complete \
+  job/kimi-k26-bench \
+  -n ${NAMESPACE} --timeout=7200s
+```
+
+### 4. Fetch artifacts
+
+```bash
+kubectl cp ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_kimi-k26-bench ./results
+```
+
+### 5. Cleanup
+
+```bash
+kubectl delete job kimi-k26-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}   # if you kept it around
+```
+
+## Running a concurrency sweep
+
+`perf.yaml` runs a **single** `CONCURRENCY` value. To measure multiple concurrencies you must clear server state between runs — otherwise residual KV cache / prefix-cache hits from the previous run skew results.
+
+For each concurrency value you want to measure:
+
+```bash
+# 1. Delete the previous bench job
+kubectl delete job kimi-k26-bench -n ${NAMESPACE} --ignore-not-found
+
+# 2. Delete the DGD worker pods to drop KV / prefix-cache state.
+#    DGDs are Grove-managed (DGD → PodCliqueSet → PodClique → Pod), not Deployments,
+#    so `kubectl rollout restart deployment` won't match anything — delete the pods
+#    directly and let Grove recreate them.
+DGD=kimi-k26-agg-b200-chat
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker
+kubectl wait --for=condition=Ready pod -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD},nvidia.com/dynamo-component-type=worker \
+  --timeout=900s
+
+# 3. Bump CONCURRENCY in perf.yaml (or use kubectl create -f perf.yaml \
+#    with `--dry-run=client -o yaml | yq '.spec.template.spec.containers[0].env[] |= ...'`)
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/kimi-k26-bench -n ${NAMESPACE} --timeout=7200s
+```
+
+(The bench Job's `wait_for_model_ready` loop handles the worker restart window — it re-polls `/v1/models` until the frontend reports ready again.)
+
+## Tunable environment variables
+
+Edit the `env` block on the `Job` to adjust:
+
+
+| Variable       | Default                                             | Notes                                                                           |
+| -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `ENDPOINT`     | `kimi-k26-agg-b200-chat-frontend:8000`        | DGD frontend service:port — change per variant                                  |
+| `TRACE_FILE`   | `/model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl` | Swap to agent or to a smaller subset (`...short_15perc.jsonl`) for shorter runs |
+| `CONCURRENCY`  | `24`                                                | Single value — see [Running a concurrency sweep](#running-a-concurrency-sweep)  |
+| `TARGET_MODEL` | `moonshotai/Kimi-K2.6`                              | Must match `--served-model-name` on the DGD frontend                            |
+
+
+## Artifacts
+
+Results are written to:
+
+```
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  Kimi-K2.6_trace_c<concurrency>_<timestamp>/
+    profile_export.json
+    inputs.json
+    ...
+```

--- a/recipes/kimi-k2.6/perf/perf.yaml
+++ b/recipes/kimi-k2.6/perf/perf.yaml
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# AIPerf trace-replay benchmark for Kimi-K2.6 DGDs.
+#
+# One Job covers every variant (B200/H200 × chat/agent traces) — the
+# benchmark itself is identical regardless of GPU SKU. To target a specific
+# DGD, edit the env values below (and `metadata.name` / `labels.app` if you
+# run multiple jobs in the same namespace).
+#
+# Runs a single concurrency value. To sweep concurrencies, restart the DGD
+# workers between runs so KV cache and prefix-cache state are reset — see
+# README.md "Running a concurrency sweep".
+#
+# Prerequisites:
+# - Target DGD is Ready (see ../README.md)
+# - model-cache PVC mounted in the namespace and contains TRACE_FILE
+#
+# Results: /model-cache/perf/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kimi-k26-bench
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 7200 # 2h hard cap on the Job
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: kimi-k26-bench
+    spec:
+      # Co-locate the bench pod with the DGD frontend to minimise client/server
+      # network overhead. Update `values:` to the DGD you are benchmarking.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: nvidia.com/dynamo-component-type
+                operator: In
+                values:
+                - frontend
+              - key: nvidia.com/dynamo-graph-deployment-name
+                operator: In
+                values:
+                - kimi-k26-agg-b200-chat
+                - kimi-k26-agg-b200-agentic
+                - kimi-k26-agg-h200-chat
+                - kimi-k26-agg-h200-agentic
+            topologyKey: kubernetes.io/hostname
+      # tolerations: # uncomment to populate any tolerations for the gpu nodes
+      containers:
+      - name: perf
+        image: python:3.12-slim
+        imagePullPolicy: IfNotPresent
+        workingDir: /workspace
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          ulimit -n 600000
+          apt-get update && apt-get install -y curl jq procps git && apt-get clean
+          pip install "aiperf==0.7.0" "protobuf==7.35.0" "transformers==4.57.3" "tiktoken==0.13.0"
+          sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
+          export COLUMNS=200
+          EPOCH=$(date +%s)
+          wait_for_model_ready() {
+            local max_attempts=${WAIT_FOR_MODEL_MAX_ATTEMPTS:-720} # 720 * 5s = 1h default
+            local attempt=0
+            echo "Waiting for model '$TARGET_MODEL' at $ENDPOINT/v1/models (max ${max_attempts} attempts) ..."
+            while ! curl -sf "http://$ENDPOINT/v1/models" | jq -e --arg m "$TARGET_MODEL" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do
+              attempt=$((attempt + 1))
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "ERROR: model '$TARGET_MODEL' did not become ready after ${max_attempts} attempts. Aborting."
+                exit 1
+              fi
+              echo "[$(date '+%H:%M:%S')] not ready (attempt ${attempt}/${max_attempts}), sleeping 5s"
+              sleep 5
+            done
+            curl -s "http://$ENDPOINT/v1/models" | jq .
+          }
+          if [ ! -f "${TRACE_FILE}" ]; then
+            echo "ERROR: trace file not found at ${TRACE_FILE}"
+            echo "Copy it onto the PVC via a helper pod, e.g.:"
+            echo " kubectl cp <local_trace.jsonl> <ns>/<helper-pod>:${TRACE_FILE}"
+            exit 1
+          fi
+          wait_for_model_ready
+          ROOT_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          mkdir -p "$ROOT_DIR"
+          echo "=============================================="
+          echo "Trace Replay Benchmark (aiperf)"
+          echo "=============================================="
+          echo "Endpoint:     http://${ENDPOINT}"
+          echo "Model:        ${TARGET_MODEL}"
+          echo "Trace file:   ${TRACE_FILE}"
+          echo "Concurrency:  ${CONCURRENCY}"
+          echo "Artifact root:${ROOT_DIR}"
+          echo "=============================================="
+          # Warmup
+          WARMUP_DIR="${ROOT_DIR}/warmup"
+          mkdir -p "$WARMUP_DIR"
+          aiperf profile \
+          -m "${TARGET_MODEL}" \
+          --tokenizer "${TARGET_MODEL}" \
+          --tokenizer-trust-remote-code \
+          --url "http://${ENDPOINT}" \
+          --streaming \
+          --ui simple \
+          --isl 8000 \
+          --osl 1000 \
+          --concurrency 1 \
+          --request-count 5 \
+          --artifact-dir "${WARMUP_DIR}"
+          echo "Warmup complete"
+          MODEL_BASE="${TARGET_MODEL##*/}"
+          TS=$(date +'%Y%m%d_%H%M%S')
+          RUN_DIR="${ROOT_DIR}/${MODEL_BASE}_trace_c${CONCURRENCY}_${TS}"
+          mkdir -p "$RUN_DIR"
+          aiperf profile \
+          -m "${TARGET_MODEL}" \
+          --tokenizer "${TARGET_MODEL}" \
+          --tokenizer-trust-remote-code \
+          --input-file "${TRACE_FILE}" \
+          --custom-dataset-type mooncake_trace \
+          --num-requests $(wc -l < "${TRACE_FILE}") \
+          --prompt-input-tokens-block-size 512 \
+          --url "http://${ENDPOINT}" \
+          --streaming \
+          --use-server-token-count \
+          --extra-inputs ignore_eos:true \
+          --concurrency "${CONCURRENCY}" \
+          --random-seed 42 \
+          --ui simple \
+          --artifact-dir "${RUN_DIR}" \
+          --request-timeout-seconds 1200 \
+          --workers-max "${CONCURRENCY}" \
+          --export-http-trace
+          echo "Concurrency ${CONCURRENCY} complete; artifacts in ${RUN_DIR}"
+          ls -la "${RUN_DIR}" || true
+          echo ""
+          echo "Done. Root: ${ROOT_DIR}"
+        env:
+        # --- Edit these to target the DGD + trace you want to benchmark ---
+        - name: ENDPOINT
+          value: kimi-k26-agg-b200-chat-frontend:8000
+        - name: TRACE_FILE
+          value: /model-cache/traces/8k_1k_70kv_chat_new_noschedule.jsonl  # use /model-cache/traces/64k_400_90kv_agent_new_noschedule.jsonl for agent
+        - name: CONCURRENCY
+          value: "24"
+        # --- The remainder is shared across all variants ---
+        - name: TARGET_MODEL
+          value: moonshotai/Kimi-K2.6
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "200"
+        - name: AIPERF_HTTP_SO_RCVTIMEO
+          value: "120"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /model-cache/perf
+        - name: HF_HOME
+          value: /model-cache
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/kimi-k2.6/perf/traces/.gitattributes
+++ b/recipes/kimi-k2.6/perf/traces/.gitattributes
@@ -1,0 +1,6 @@
+64k_400_90kv_agent_new_noschedule.jsonl filter=lfs diff=lfs merge=lfs -text
+64k_400_90kv_agent_new_noschedule_short_15perc.jsonl filter=lfs diff=lfs merge=lfs -text
+64k_400_90kv_agent_new_noschedule_short_30perc.jsonl filter=lfs diff=lfs merge=lfs -text
+8k_1k_70kv_chat_new_noschedule.jsonl filter=lfs diff=lfs merge=lfs -text
+8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl filter=lfs diff=lfs merge=lfs -text
+8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule.jsonl
+++ b/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0a64efcad575a01949e46e28dded094f20733db8708e0bc91b88ce9981fed6
+size 17623982

--- a/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+++ b/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20d3f2bc83dd1306cda659fbe34e7c4d85ca5497626c98bc0b1c4d2211379d0
+size 2722326

--- a/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
+++ b/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_30perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dae61f92fee05038f1dcb76474dba83c1b3c174f3d187589c7d0a16a7012eb79
+size 5401776

--- a/recipes/kimi-k2.6/perf/traces/8k_1k_70kv_chat_new_noschedule.jsonl
+++ b/recipes/kimi-k2.6/perf/traces/8k_1k_70kv_chat_new_noschedule.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f369eb75ce639ad8b05cc209bb534bfedd627e9f7b923de32888155b4c9085a
+size 5648304

--- a/recipes/kimi-k2.6/perf/traces/8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
+++ b/recipes/kimi-k2.6/perf/traces/8k_1k_70kv_chat_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1221bca72b69f842897f339624306a84857f1b55ea0d866525f94d9ceb9b871
+size 894687

--- a/recipes/kimi-k2.6/perf/traces/8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl
+++ b/recipes/kimi-k2.6/perf/traces/8k_1k_70kv_chat_new_noschedule_short_30perc.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6de2a977b40dba8735a70aa5f9ab0d84e32530d7cf1fc9d24efc631c341f9c17
+size 1790696

--- a/recipes/kimi-k2.6/vllm/agg-b200-agentic/deploy.yaml
+++ b/recipes/kimi-k2.6/vllm/agg-b200-agentic/deploy.yaml
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kimi-k26-agg-b200-agentic-specdec-config
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-b200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  attention-config: |-
+    {
+      "backend": "TOKENSPEED_MLA",
+      "mla_prefill_backend": "TOKENSPEED_MLA",
+      "use_prefill_query_quantization": true
+    }
+  speculative-config-synthetic: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.49
+    }
+  speculative-config: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3
+    }
+  kv-transfer-config: |-
+    {
+      "kv_connector": "LMCacheConnectorV1",
+      "kv_role": "kv_both",
+      "kv_connector_extra_config": {
+        "lmcache.enable_kv_events": false,
+        "lmcache.local_cpu": true,
+        "lmcache.max_local_cpu_size": 500,
+        "lmcache.pre_caching_hash_algorithm": "sha256_cbor",
+        "lmcache.extra_config": {
+          "save_only_first_rank": true
+        }
+      }
+    }
+  compilation-config: |-
+    {
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k26-agg-b200-agentic
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-b200-agentic
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources: {}
+      replicas: 1
+
+    - name: agg
+      type: worker
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          containers:
+            - name: main
+              args:
+                - --model=nvidia/Kimi-K2.6-NVFP4
+                - --served-model-name=moonshotai/Kimi-K2.6
+                - --trust-remote-code
+                - --max-model-len=262144
+                - --kv-cache-dtype=fp8
+                - --gpu-memory-utilization=0.95
+                - --enable-flashinfer-autotune
+                - --moe-backend=flashinfer_trtllm
+                - --mm-encoder-tp-mode=data
+                - --tensor-parallel-size=4
+                  # - --enable-expert-parallel
+                  # - --all2all-backend deepep_low_latency
+                  # - --all2all-backend flashinfer_all2allv
+                - --attention-config=$(ATTENTION_CONFIG)
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --kv-transfer-config=$(KV_TRANSFER_CONFIG)
+                - --enable-multimodal
+                - --dyn-tool-call-parser
+                - kimi_k2
+                - --dyn-reasoning-parser
+                - kimi_k25
+                # - --no-async-scheduling
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: ATTENTION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-agentic-specdec-config
+                      key: attention-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-agentic-specdec-config
+                      key: speculative-config # speculative-config-synthetic for benchmarking
+                - name: KV_TRANSFER_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-agentic-specdec-config
+                      key: kv-transfer-config
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-agentic-specdec-config
+                      key: compilation-config
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                # consistent LMCache hashes across ranks
+                - name: PYTHONHASHSEED
+                  value: "42"
+                # NCCL symmetric AR backend with SHARP
+                - name: VLLM_USE_NCCL_SYMM_MEM
+                  value: "1"
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+                - name: NCCL_NVLS_ENABLE
+                  value: "1"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: "750Gi"
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1

--- a/recipes/kimi-k2.6/vllm/agg-b200-chat/deploy.yaml
+++ b/recipes/kimi-k2.6/vllm/agg-b200-chat/deploy.yaml
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kimi-k26-agg-b200-chat-specdec-config
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-b200-chat
+    app.kubernetes.io/part-of: dynamo
+data:
+  attention-config: |-
+    {
+      "backend": "TOKENSPEED_MLA",
+      "mla_prefill_backend": "TOKENSPEED_MLA",
+      "use_prefill_query_quantization": true
+    }
+  speculative-config-synthetic: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.49
+    }
+  speculative-config: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3
+    }
+  kv-transfer-config: |-
+    {
+      "kv_connector": "LMCacheConnectorV1",
+      "kv_role": "kv_both",
+      "kv_connector_extra_config": {
+        "lmcache.enable_kv_events": false,
+        "lmcache.local_cpu": true,
+        "lmcache.max_local_cpu_size": 500,
+        "lmcache.pre_caching_hash_algorithm": "sha256_cbor",
+        "lmcache.extra_config": {
+          "save_only_first_rank": true
+        }
+      }
+    }
+  compilation-config: |-
+    {
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k26-agg-b200-chat
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-b200-chat
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources: {}
+      replicas: 1
+
+    - name: agg
+      type: worker
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          containers:
+            - name: main
+              args:
+                - --model=nvidia/Kimi-K2.6-NVFP4
+                - --served-model-name=moonshotai/Kimi-K2.6
+                - --trust-remote-code
+                - --max-model-len=262144
+                - --kv-cache-dtype=fp8
+                - --gpu-memory-utilization=0.95
+                - --enable-flashinfer-autotune
+                - --moe-backend=flashinfer_trtllm
+                - --mm-encoder-tp-mode=data
+                - --tensor-parallel-size=4
+                  # - --enable-expert-parallel
+                  # - --all2all-backend deepep_low_latency
+                  # - --all2all-backend flashinfer_all2allv
+                - --attention-config=$(ATTENTION_CONFIG)
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --kv-transfer-config=$(KV_TRANSFER_CONFIG)
+                - --enable-multimodal
+                - --dyn-tool-call-parser
+                - kimi_k2
+                - --dyn-reasoning-parser
+                - kimi_k25
+                # - --no-async-scheduling
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: ATTENTION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-chat-specdec-config
+                      key: attention-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-chat-specdec-config
+                      key: speculative-config # speculative-config-synthetic for benchmarking
+                - name: KV_TRANSFER_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-chat-specdec-config
+                      key: kv-transfer-config
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-b200-chat-specdec-config
+                      key: compilation-config
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                # consistent LMCache hashes across ranks
+                - name: PYTHONHASHSEED
+                  value: "42"
+                # NCCL symmetric AR backend with SHARP
+                - name: VLLM_USE_NCCL_SYMM_MEM
+                  value: "1"
+                - name: NCCL_CUMEM_ENABLE
+                  value: "1"
+                - name: NCCL_NVLS_ENABLE
+                  value: "1"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: "750Gi"
+                limits:
+                  nvidia.com/gpu: "4"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1

--- a/recipes/kimi-k2.6/vllm/agg-h200-agentic/deploy.yaml
+++ b/recipes/kimi-k2.6/vllm/agg-h200-agentic/deploy.yaml
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kimi-k26-agg-h200-agentic-specdec-config
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-h200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  attention-config: |-
+    {
+    }
+  speculative-config-synthetic: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.49
+    }
+  speculative-config: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3
+    }
+  kv-transfer-config: |-
+    {
+      "kv_connector": "LMCacheConnectorV1",
+      "kv_role": "kv_both",
+      "kv_connector_extra_config": {
+        "lmcache.enable_kv_events": false,
+        "lmcache.local_cpu": true,
+        "lmcache.max_local_cpu_size": 500,
+        "lmcache.pre_caching_hash_algorithm": "sha256_cbor",
+        "lmcache.extra_config": {
+          "save_only_first_rank": true
+        }
+      }
+    }
+  compilation-config: |-
+    {
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k26-agg-h200-agentic
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-h200-agentic
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources: {}
+      replicas: 1
+
+    - name: agg
+      type: worker
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+          containers:
+            - name: main
+              args:
+                - --model=moonshotai/Kimi-K2.6
+                - --served-model-name=moonshotai/Kimi-K2.6
+                - --trust-remote-code
+                - --max-model-len=262144
+                - --gpu-memory-utilization=0.85
+                - --mm-encoder-tp-mode=data
+                - --tensor-parallel-size=8
+                - --attention-config=$(ATTENTION_CONFIG)
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --kv-transfer-config=$(KV_TRANSFER_CONFIG)
+                - --enable-multimodal
+                - --dyn-tool-call-parser
+                - kimi_k2
+                - --dyn-reasoning-parser
+                - kimi_k25
+                # - --no-async-scheduling
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: ATTENTION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-agentic-specdec-config
+                      key: attention-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-agentic-specdec-config
+                      key: speculative-config # speculative-config-synthetic for benchmarking
+                - name: KV_TRANSFER_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-agentic-specdec-config
+                      key: kv-transfer-config
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-agentic-specdec-config
+                      key: compilation-config
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "42"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: "750Gi"
+                limits:
+                  nvidia.com/gpu: "8"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1

--- a/recipes/kimi-k2.6/vllm/agg-h200-chat/deploy.yaml
+++ b/recipes/kimi-k2.6/vllm/agg-h200-chat/deploy.yaml
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kimi-k26-agg-h200-chat-specdec-config
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-h200-chat
+    app.kubernetes.io/part-of: dynamo
+data:
+  attention-config: |-
+    {
+    }
+  speculative-config-synthetic: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3,
+      "rejection_sample_method": "synthetic",
+      "synthetic_acceptance_length": 2.49
+    }
+  speculative-config: |-
+    {
+      "method": "eagle3",
+      "model": "lightseekorg/kimi-k2.6-eagle3-mla",
+      "num_speculative_tokens": 3
+    }
+  kv-transfer-config: |-
+    {
+      "kv_connector": "LMCacheConnectorV1",
+      "kv_role": "kv_both",
+      "kv_connector_extra_config": {
+        "lmcache.enable_kv_events": false,
+        "lmcache.local_cpu": true,
+        "lmcache.max_local_cpu_size": 500,
+        "lmcache.pre_caching_hash_algorithm": "sha256_cbor",
+        "lmcache.extra_config": {
+          "save_only_first_rank": true
+        }
+      }
+    }
+  compilation-config: |-
+    {
+      "pass_config": {
+        "fuse_allreduce_rms": true,
+        "fuse_attn_quant": true
+      },
+      "max_cudagraph_capture_size": 512
+    }
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k26-agg-h200-chat
+  labels:
+    app.kubernetes.io/name: kimi-k26-agg-h200-chat
+    app.kubernetes.io/part-of: dynamo
+spec:
+  backendFramework: vllm
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources: {}
+      replicas: 1
+
+    - name: agg
+      type: worker
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+          containers:
+            - name: main
+              args:
+                - --model=moonshotai/Kimi-K2.6
+                - --served-model-name=moonshotai/Kimi-K2.6
+                - --trust-remote-code
+                - --max-model-len=262144
+                - --gpu-memory-utilization=0.85
+                - --mm-encoder-tp-mode=data
+                - --tensor-parallel-size=8
+                - --attention-config=$(ATTENTION_CONFIG)
+                - --compilation-config=$(COMPILATION_CONFIG)
+                - --speculative-config=$(SPECULATIVE_CONFIG)
+                - --kv-transfer-config=$(KV_TRANSFER_CONFIG)
+                - --enable-multimodal
+                - --dyn-tool-call-parser
+                - kimi_k2
+                - --dyn-reasoning-parser
+                - kimi_k25
+                # - --no-async-scheduling
+              command:
+                - python3
+                - -m
+                - dynamo.vllm
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: TRITON_CACHE_DIR
+                  value: /tmp/.triton-cache
+                - name: VLLM_CONFIG_ROOT
+                  value: /tmp/vllm-config
+                - name: VLLM_CACHE_ROOT
+                  value: /tmp/vllm-cache
+                - name: HF_MODULES_CACHE
+                  value: /tmp/hf_modules
+                - name: ATTENTION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-chat-specdec-config
+                      key: attention-config
+                - name: SPECULATIVE_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-chat-specdec-config
+                      key: speculative-config # speculative-config-synthetic for benchmarking
+                - name: KV_TRANSFER_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-chat-specdec-config
+                      key: kv-transfer-config
+                - name: COMPILATION_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: kimi-k26-agg-h200-chat-specdec-config
+                      key: compilation-config
+                - name: NCCL_IB_DISABLE
+                  value: "1"
+                - name: PYTHONHASHSEED
+                  value: "42"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0-kimi-k2.6-dev.1
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: "750Gi"
+                limits:
+                  nvidia.com/gpu: "8"
+              securityContext:
+                runAsUser: 0
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1


### PR DESCRIPTION
Cherry-picks #10187 onto `release/1.3.0-kimi-k2.6-dev.1` so the release branch carries the kimi-k2.6 recipes matching the published container. Recipe folder only; cherry-picked with -x -s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->