### PR TITLE
fix(deepseek-v4): install distro in SGLang image (release branch)

### DIFF
--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
@@ -17,6 +17,8 @@ RUN pip uninstall -y black termplotlib \
     && apt list --upgradable 2>/dev/null | tail -n +2 | grep 'noble' | awk -F/ '{print $1}' | xargs -r apt-get install -y --only-upgrade \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python3 -m pip install --no-cache-dir --break-system-packages "distro>=1.7,<2"
+
 COPY --from=dynamo_src /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_src /usr/local/bin/etcd /usr/local/bin/etcd
 ENV PATH=/usr/local/bin/etcd:${PATH}

--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
@@ -16,6 +16,8 @@ RUN pip uninstall -y black termplotlib \
     && apt list --upgradable 2>/dev/null | tail -n +2 | grep 'noble' | awk -F/ '{print $1}' | xargs -r apt-get install -y --only-upgrade \
     && rm -rf /var/lib/apt/lists/*
 
+RUN python3 -m pip install --no-cache-dir --break-system-packages "distro>=1.7,<2"
+
 COPY --from=dynamo_src /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_src /usr/local/bin/etcd /usr/local/bin/etcd
 ENV PATH=/usr/local/bin/etcd:${PATH}


### PR DESCRIPTION
Cherry-picks #10085 onto `release/1.3.0-deepseek-v4-dev.1` so the release branch carries the deepseek-v4 recipes matching the published container. Recipe folder only; cherry-picked with -x -s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)