### PR TITLE
docs: fix broken DEP-0014 link in disagg readiness proposal

### DIFF
--- a/docs/proposals/health-disagg-readiness.md
+++ b/docs/proposals/health-disagg-readiness.md
@@ -2,7 +2,7 @@
 
 **Author:** Jie Hao
 **Date:** 2026-03-24 (updated 2026-05-22)
-**Status:** Approved — See [DEP-0014](https://github.com/ai-dynamo/enhancements/deps/0014-health-endpoint-disagg-readiness.md) and tracking issue [#7787](https://github.com/ai-dynamo/dynamo/issues/7787). PR 1, PR 2a–d landed; PR 3 in progress.
+**Status:** Approved — See tracking issue [DEP-0014 (#7787)](https://github.com/ai-dynamo/dynamo/issues/7787). PR 1, PR 2a–d landed; PR 3 in progress.
 
 ## Problem
 


### PR DESCRIPTION
#### Overview:

The repo-wide **Docs link check** (lychee) is currently failing on every branch due to a single broken link, which blocks link-check on all open PRs.

#### Details:

`docs/proposals/health-disagg-readiness.md` (added in #9815) linked `DEP-0014` to a malformed `ai-dynamo/enhancements` file URL (`.../enhancements/deps/0014-health-endpoint-disagg-readiness.md` — no `/blob/<branch>/` segment, and no such file exists), which returns 404 and is the sole lychee error.

The DEP is tracked as issue #7787 ("DEP: Disaggregated Topology Readiness"), which the same Status line already links separately. This consolidates the duplicate into a single working link.

Verified locally: `lychee` on the file now reports **0 errors** (2 OK, 3 excluded).

#### Where should the reviewer start?

`docs/proposals/health-disagg-readiness.md` — a one-line change to the Status line (line 5).

#### Related Issues:

- Relates to #7787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
