### PR TITLE
fix: default nixl pip installs to cuda13

### DIFF
--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "nixl[cu12]==0.10.1",
+    "nixl[cu13]==0.10.1",
     "pydantic>=2.0"
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ trtllm =[
 
 vllm = [
     "uvloop",
-    "nixl[cu12]==1.1.0",
+    "nixl[cu13]==1.1.0",
     "vllm[flashinfer,runai,otel]==0.22.1",
     # vllm-omni is not part of ai-dynamo[vllm]: container builds inherit the
     # framework stack from vllm/vllm-openai, and pip/uv dependency resolution
@@ -69,7 +69,7 @@ sglang = [
     "sglang[diffusion]==0.5.12.post1",
     # sglang[diffusion] dropped accelerate in 0.5.12; diffusers still needs it.
     "accelerate>=0.17.0",
-    "nixl[cu12]>=1.0.0,<1.1.0",
+    "nixl[cu13]>=1.0.0,<1.1.0",
     "cupy-cuda12x>=13.0.0",
 ]
 


### PR DESCRIPTION
The container build path already defaults to CUDA 13 via CUDA_MAJOR, but the pip-install metadata still pinned nixl[cu12]. Flip the default vllm/sglang extras and the kvbm default dependency to nixl[cu13] so non-container installs match the CUDA-13 container default. The kvbm opt-in cu12 extra and the cpu/xpu nixl-cu12 line are intentionally left unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA runtime version from 12 to 13 across all project modules. This update affects core bindings and optional inference acceleration components. All CUDA-dependent modules now use a consistent version, providing improved compatibility, stability, and access to the latest CUDA toolkit features and optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->