### PR TITLE
fix(gaie): update dependency to v1.5.0

### DIFF
--- a/deploy/inference-gateway/epp/go.mod
+++ b/deploy/inference-gateway/epp/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/go-logr/logr v1.4.3
 	sigs.k8s.io/controller-runtime v0.23.3
-	sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260603065144-7c1f1994dbff
+	sigs.k8s.io/gateway-api-inference-extension v1.5.0
 )
 
 require (

--- a/deploy/inference-gateway/epp/go.sum
+++ b/deploy/inference-gateway/epp/go.sum
@@ -345,8 +345,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
-sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260603065144-7c1f1994dbff h1:bKAxHdYKUROm52GySV1e2qtd2D7qFe79CNH6yBKOyDI=
-sigs.k8s.io/gateway-api-inference-extension v0.0.0-20260603065144-7c1f1994dbff/go.mod h1:hTbTVVcHGJDNYSluS9EBDUstZdSDhGn4phDe3Zuzu9k=
+sigs.k8s.io/gateway-api-inference-extension v1.5.0 h1:w9Awt60cmI1vM7Y6N81h8wDCBP0WkmxpdI7GKY0v070=
+sigs.k8s.io/gateway-api-inference-extension v1.5.0/go.mod h1:ZeIlzI43XH2qWKipFq/Qa12yB2s/D+Xp1XJVlpMxklA=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
@@ -50,7 +50,7 @@ const (
 var _ schedtypes.Scorer = &DynDecodeScorer{}
 var _ plugins.Plugin = &DynDecodeScorer{}
 var _ rc.PreRequest = &DynDecodeScorer{}
-var _ rc.ResponseBodyProcessor = &DynDecodeScorer{}
+var _ rc.ResponseBody = &DynDecodeScorer{}
 
 // DecodeRoutingState holds routing information passed from Score() to PreRequest().
 type DecodeRoutingState struct {
@@ -131,7 +131,7 @@ func (s *DynDecodeScorer) Category() schedtypes.ScorerCategory {
 }
 
 // Score scores endpoints for decode suitability.
-func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.CycleState, req *schedtypes.InferenceRequest, endpoints []schedtypes.Endpoint) map[schedtypes.Endpoint]float64 {
+func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.CycleState, req *schedtypes.LLMRequest, endpoints []schedtypes.Endpoint) map[schedtypes.Endpoint]float64 {
 	logger := log.FromContext(ctx)
 
 	isDisaggregated := readPrefillEnabled(cycleState)
@@ -199,7 +199,7 @@ func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.Cycl
 }
 
 // PreRequest registers the request with the Dynamo router's bookkeeping.
-func (s *DynDecodeScorer) PreRequest(ctx context.Context, request *schedtypes.InferenceRequest, _ *schedtypes.SchedulingResult) {
+func (s *DynDecodeScorer) PreRequest(ctx context.Context, request *schedtypes.LLMRequest, _ *schedtypes.SchedulingResult) {
 	logger := log.FromContext(ctx)
 
 	if request == nil || request.RequestId == "" {
@@ -247,7 +247,7 @@ func (s *DynDecodeScorer) PreRequest(ctx context.Context, request *schedtypes.In
 
 // ResponseBody handles streaming chunks and end-of-stream cleanup.
 // On the first token it marks prefill as complete; on EndOfStream it frees the request.
-func (s *DynDecodeScorer) ResponseBody(ctx context.Context, request *schedtypes.InferenceRequest, response *rc.Response, _ *fwkdl.EndpointMetadata) {
+func (s *DynDecodeScorer) ResponseBody(ctx context.Context, request *schedtypes.LLMRequest, response *rc.Response, _ *fwkdl.EndpointMetadata) {
 	if request == nil || request.RequestId == "" {
 		return
 	}

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/prefill_scorer.go
@@ -86,7 +86,7 @@ func (s *DynPrefillScorer) Category() schedtypes.ScorerCategory {
 }
 
 // Score scores endpoints for prefill suitability.
-func (s *DynPrefillScorer) Score(ctx context.Context, cycleState *schedtypes.CycleState, req *schedtypes.InferenceRequest, endpoints []schedtypes.Endpoint) map[schedtypes.Endpoint]float64 {
+func (s *DynPrefillScorer) Score(ctx context.Context, cycleState *schedtypes.CycleState, req *schedtypes.LLMRequest, endpoints []schedtypes.Endpoint) map[schedtypes.Endpoint]float64 {
 	logger := log.FromContext(ctx)
 
 	if !readPrefillEnabled(cycleState) {

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/profile_handler.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/profile_handler.go
@@ -74,7 +74,7 @@ func (h *DisaggProfileHandler) WithName(name string) *DisaggProfileHandler {
 }
 
 // Pick selects which profiles to run in the current iteration.
-func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.CycleState, _ *schedtypes.InferenceRequest,
+func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.CycleState, _ *schedtypes.LLMRequest,
 	profiles map[string]schedtypes.SchedulerProfile, profileResults map[string]*schedtypes.ProfileRunResult) map[string]schedtypes.SchedulerProfile {
 
 	logger := log.FromContext(ctx).V(logutil.VERBOSE)
@@ -117,7 +117,7 @@ func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.
 }
 
 // ProcessResults aggregates the profile run results and designates the primary profile.
-func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.CycleState, _ *schedtypes.InferenceRequest,
+func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.CycleState, _ *schedtypes.LLMRequest,
 	profileResults map[string]*schedtypes.ProfileRunResult) (*schedtypes.SchedulingResult, error) {
 
 	if len(profileResults) == 0 {

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
@@ -102,9 +102,9 @@ func uniformScores(endpoints []schedtypes.Endpoint, score float64) map[schedtype
 	return out
 }
 
-// setTokenizedPrompt stores pre-computed token IDs on the LLMRequest and
+// setTokenizedPrompt stores pre-computed token IDs on the GAIE LLMRequest and
 // injects nvext.token_data into the PayloadMap so it is forwarded to the
-// worker in the request body.
+// Dynamo frontend in the request body.
 //
 // The GAIE framework re-serializes the PayloadMap after scheduling/PreRequest
 // plugins run (PR #2854), so this mutation is included in the forwarded body.
@@ -117,6 +117,10 @@ func setTokenizedPrompt(req *schedtypes.LLMRequest, tokens []int64, logger logr.
 	tokenIDs := make([]uint32, len(tokens))
 	for i, t := range tokens {
 		tokenIDs[i] = uint32(t)
+	}
+
+	req.TokenizedPrompt = &schedtypes.TokenizedPrompt{
+		TokenIDs: tokenIDs,
 	}
 
 	// Inject into the PayloadMap so the body includes nvext.token_data.

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
@@ -36,7 +36,6 @@ import (
 	"github.com/go-logr/logr"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
 	plugins "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/plugin"
-	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 
 	dynscorer "github.com/nvidia/dynamo/deploy/inference-gateway/pkg/plugins/dynamo_kv_scorer"
@@ -70,7 +69,7 @@ func readPrefillEnabled(cycleState *schedtypes.CycleState) bool {
 }
 
 // buildRequestJSON builds an OpenAI-compatible JSON string from a GAIE LLMRequest.
-func buildRequestJSON(req *schedtypes.InferenceRequest) (string, error) {
+func buildRequestJSON(req *schedtypes.LLMRequest) (string, error) {
 	requestBody, err := dynscorer.BuildOpenAIRequest(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to build OpenAI request: %w", err)
@@ -109,7 +108,7 @@ func uniformScores(endpoints []schedtypes.Endpoint, score float64) map[schedtype
 //
 // The GAIE framework re-serializes the PayloadMap after scheduling/PreRequest
 // plugins run (PR #2854), so this mutation is included in the forwarded body.
-func setTokenizedPrompt(req *schedtypes.InferenceRequest, tokens []int64, logger logr.Logger) {
+func setTokenizedPrompt(req *schedtypes.LLMRequest, tokens []int64, logger logr.Logger) {
 	if req == nil || len(tokens) == 0 {
 		logger.V(logutil.DEFAULT).Info("[EPP-INJECT] No tokens to inject (empty token list)")
 		return
@@ -120,16 +119,10 @@ func setTokenizedPrompt(req *schedtypes.InferenceRequest, tokens []int64, logger
 		tokenIDs[i] = uint32(t)
 	}
 
-	if req.Body != nil {
-		req.Body.TokenizedPrompt = &schedtypes.TokenizedPrompt{
-			TokenIDs: tokenIDs,
-		}
-	}
-
 	// Inject into the PayloadMap so the body includes nvext.token_data.
 	payloadInjected := false
 	if req.Body != nil {
-		if pm, ok := req.Body.Payload.(fwkrh.PayloadMap); ok {
+		if pm, ok := req.Body.Payload.(schedtypes.PayloadMap); ok {
 			nvext, _ := pm["nvext"].(map[string]any)
 			if nvext == nil {
 				nvext = map[string]any{}

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/shared_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/shared_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 NVIDIA Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disagg
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
+)
+
+func TestSetTokenizedPromptStoresGAIEFieldAndNvextTokenData(t *testing.T) {
+	req := &schedtypes.LLMRequest{
+		RequestId: "req-1",
+		Body: &schedtypes.LLMRequestBody{
+			Payload: schedtypes.PayloadMap{},
+		},
+	}
+
+	setTokenizedPrompt(req, []int64{101, 102, 103}, logr.Discard())
+
+	if req.TokenizedPrompt == nil {
+		t.Fatal("expected TokenizedPrompt to be set")
+	}
+	if got := req.TokenizedPrompt.TokenIDs; len(got) != 3 || got[0] != 101 || got[1] != 102 || got[2] != 103 {
+		t.Fatalf("expected TokenizedPrompt token IDs [101 102 103], got %#v", got)
+	}
+
+	payload, ok := req.Body.Payload.(schedtypes.PayloadMap)
+	if !ok {
+		t.Fatalf("expected PayloadMap, got %T", req.Body.Payload)
+	}
+	nvext, ok := payload["nvext"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nvext map, got %#v", payload["nvext"])
+	}
+	tokenData, ok := nvext["token_data"].([]uint32)
+	if !ok {
+		t.Fatalf("expected nvext.token_data []uint32, got %#v", nvext["token_data"])
+	}
+	if len(tokenData) != 3 || tokenData[0] != 101 || tokenData[1] != 102 || tokenData[2] != 103 {
+		t.Fatalf("expected nvext.token_data [101 102 103], got %#v", tokenData)
+	}
+}

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -288,7 +288,9 @@ func BuildOpenAIRequest(req *schedtypes.LLMRequest) (map[string]any, error) {
 		return nil, fmt.Errorf("missing request body")
 	}
 
-	if req.Body.ChatCompletions != nil && len(req.Body.ChatCompletions.Messages) > 0 {
+	if hasTokenizedPrompt(req) {
+		addTokenizedPrompt(requestBody, req.TokenizedPrompt.TokenIDs)
+	} else if req.Body.ChatCompletions != nil && len(req.Body.ChatCompletions.Messages) > 0 {
 		messages := make([]map[string]any, 0, len(req.Body.ChatCompletions.Messages))
 		anyNonEmpty := false
 		for _, msg := range req.Body.ChatCompletions.Messages {
@@ -329,8 +331,18 @@ func BuildOpenAIRequest(req *schedtypes.LLMRequest) (map[string]any, error) {
 	return requestBody, nil
 }
 
+func addTokenizedPrompt(requestBody map[string]any, tokenIDs []uint32) {
+	prompt := make([]uint32, len(tokenIDs))
+	copy(prompt, tokenIDs)
+	requestBody["prompt"] = prompt
+}
+
+func hasTokenizedPrompt(req *schedtypes.LLMRequest) bool {
+	return req != nil && req.TokenizedPrompt != nil && len(req.TokenizedPrompt.TokenIDs) > 0
+}
+
 func addCompletionPrompt(requestBody map[string]any, prompt schedtypes.Prompt) {
-	// Keep non-token completions on the legacy chat-shaped scorer path.
+	// Keep text completions on the legacy chat-shaped scorer path.
 	requestBody["messages"] = []map[string]any{
 		{
 			"role":    "user",

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -108,7 +108,6 @@ import (
 	"unsafe"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
@@ -282,7 +281,7 @@ func SerializeEndpointsToJSON(endpoints []schedtypes.Endpoint) (string, error) {
 	return string(data), nil
 }
 
-func BuildOpenAIRequest(req *schedtypes.InferenceRequest) (map[string]any, error) {
+func BuildOpenAIRequest(req *schedtypes.LLMRequest) (map[string]any, error) {
 	requestBody := make(map[string]any)
 
 	if req == nil || req.Body == nil {
@@ -330,14 +329,7 @@ func BuildOpenAIRequest(req *schedtypes.InferenceRequest) (map[string]any, error
 	return requestBody, nil
 }
 
-func addCompletionPrompt(requestBody map[string]any, prompt fwkrh.Prompt) {
-	if len(prompt.TokenIDs) > 0 {
-		tokenIDs := make([]uint32, len(prompt.TokenIDs))
-		copy(tokenIDs, prompt.TokenIDs)
-		requestBody["prompt"] = tokenIDs
-		return
-	}
-
+func addCompletionPrompt(requestBody map[string]any, prompt schedtypes.Prompt) {
 	// Keep non-token completions on the legacy chat-shaped scorer path.
 	requestBody["messages"] = []map[string]any{
 		{
@@ -352,8 +344,8 @@ func addCompletionPrompt(requestBody map[string]any, prompt fwkrh.Prompt) {
 //
 // This is how routing hints — most notably nvext.agent_hints.priority — reach
 // the Rust router via the FFI JSON.
-func extractNvext(payload fwkrh.RequestPayload) map[string]any {
-	pm, ok := payload.(fwkrh.PayloadMap)
+func extractNvext(payload schedtypes.RequestPayload) map[string]any {
+	pm, ok := payload.(schedtypes.PayloadMap)
 	if !ok {
 		return nil
 	}
@@ -361,8 +353,8 @@ func extractNvext(payload fwkrh.RequestPayload) map[string]any {
 	return nvext
 }
 
-func extractTopLevelCacheSalt(payload fwkrh.RequestPayload) string {
-	pm, ok := payload.(fwkrh.PayloadMap)
+func extractTopLevelCacheSalt(payload schedtypes.RequestPayload) string {
+	pm, ok := payload.(schedtypes.PayloadMap)
 	if !ok {
 		return ""
 	}

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
@@ -115,6 +115,41 @@ func TestBuildOpenAIRequest_CompletionsTextPromptKeepsLegacyMessageShape(t *test
 	}
 }
 
+func TestBuildOpenAIRequest_TokenizedPromptUsesCompletionPromptShape(t *testing.T) {
+	req := &schedtypes.LLMRequest{
+		TargetModel: "test-model",
+		TokenizedPrompt: &schedtypes.TokenizedPrompt{
+			TokenIDs: []uint32{101, 102, 103},
+		},
+		Body: &schedtypes.LLMRequestBody{
+			Completions: &schedtypes.CompletionsRequest{
+				Prompt: schedtypes.Prompt{Raw: "hello"},
+			},
+		},
+	}
+
+	body, err := BuildOpenAIRequest(req)
+	if err != nil {
+		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
+	}
+
+	prompt, ok := body["prompt"].([]uint32)
+	if !ok {
+		t.Fatalf("expected tokenized prompt shape, got %#v", body["prompt"])
+	}
+	if len(prompt) != 3 || prompt[0] != 101 || prompt[1] != 102 || prompt[2] != 103 {
+		t.Fatalf("expected prompt token IDs [101 102 103], got %#v", prompt)
+	}
+	if _, ok := body["messages"]; ok {
+		t.Fatalf("did not expect tokenized prompt to also include messages: %v", body["messages"])
+	}
+
+	req.TokenizedPrompt.TokenIDs[0] = 999
+	if prompt[0] != 101 {
+		t.Fatalf("expected BuildOpenAIRequest to copy token IDs, got %#v", prompt)
+	}
+}
+
 func TestBuildOpenAIRequest_CompletionsStringArrayPromptKeepsLegacyMessageShape(t *testing.T) {
 	req := &schedtypes.LLMRequest{
 		TargetModel: "test-model",

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
@@ -17,10 +17,8 @@ limitations under the License.
 package dynamo_kv_scorer
 
 import (
-	"reflect"
 	"testing"
 
-	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
@@ -30,15 +28,15 @@ import (
 // the router falls back to priority_jump=0.0 for every request and queue
 // ordering silently regresses.
 func TestBuildOpenAIRequest_ForwardsAgentHintsPriority(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
+	req := &schedtypes.LLMRequest{
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			ChatCompletions: &fwkrh.ChatCompletionsRequest{
-				Messages: []fwkrh.Message{
-					{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
+		Body: &schedtypes.LLMRequestBody{
+			ChatCompletions: &schedtypes.ChatCompletionsRequest{
+				Messages: []schedtypes.Message{
+					{Role: "user", Content: schedtypes.Content{Raw: "hi"}},
 				},
 			},
-			Payload: fwkrh.PayloadMap{
+			Payload: schedtypes.PayloadMap{
 				"messages": []any{map[string]any{"role": "user", "content": "hi"}},
 				"model":    "test-model",
 				"nvext":    map[string]any{"agent_hints": map[string]any{"priority": 7}},
@@ -65,15 +63,15 @@ func TestBuildOpenAIRequest_ForwardsAgentHintsPriority(t *testing.T) {
 }
 
 func TestBuildOpenAIRequest_ForwardsLegacyTopLevelCacheSalt(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
+	req := &schedtypes.LLMRequest{
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			ChatCompletions: &fwkrh.ChatCompletionsRequest{
-				Messages: []fwkrh.Message{
-					{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
+		Body: &schedtypes.LLMRequestBody{
+			ChatCompletions: &schedtypes.ChatCompletionsRequest{
+				Messages: []schedtypes.Message{
+					{Role: "user", Content: schedtypes.Content{Raw: "hi"}},
 				},
 			},
-			Payload: fwkrh.PayloadMap{
+			Payload: schedtypes.PayloadMap{
 				"messages":   []any{map[string]any{"role": "user", "content": "hi"}},
 				"model":      "test-model",
 				"cache_salt": "tenant-legacy",
@@ -90,38 +88,12 @@ func TestBuildOpenAIRequest_ForwardsLegacyTopLevelCacheSalt(t *testing.T) {
 	}
 }
 
-func TestBuildOpenAIRequest_CompletionsTokenPromptUsesPromptIDs(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
-		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{TokenIDs: []uint32{101, 102, 103}},
-			},
-		},
-	}
-
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
-
-	if _, ok := body["messages"]; ok {
-		t.Fatalf("did not expect token-id completions to synthesize messages: %v", body["messages"])
-	}
-	if got := body["prompt"]; !reflect.DeepEqual(got, []uint32{101, 102, 103}) {
-		t.Fatalf("expected prompt token IDs, got %#v", got)
-	}
-	if got := body["model"]; got != "test-model" {
-		t.Fatalf("expected model=test-model, got %v", got)
-	}
-}
-
 func TestBuildOpenAIRequest_CompletionsTextPromptKeepsLegacyMessageShape(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
+	req := &schedtypes.LLMRequest{
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{Raw: "hello"},
+		Body: &schedtypes.LLMRequestBody{
+			Completions: &schedtypes.CompletionsRequest{
+				Prompt: schedtypes.Prompt{Raw: "hello"},
 			},
 		},
 	}
@@ -144,11 +116,11 @@ func TestBuildOpenAIRequest_CompletionsTextPromptKeepsLegacyMessageShape(t *test
 }
 
 func TestBuildOpenAIRequest_CompletionsStringArrayPromptKeepsLegacyMessageShape(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
+	req := &schedtypes.LLMRequest{
 		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{Strings: []string{"hello", "world"}},
+		Body: &schedtypes.LLMRequestBody{
+			Completions: &schedtypes.CompletionsRequest{
+				Prompt: schedtypes.Prompt{Strings: []string{"hello", "world"}},
 			},
 		},
 	}

--- a/deploy/inference-gateway/epp/pkg/plugins/label_filter/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/label_filter/plugin.go
@@ -86,7 +86,7 @@ func (f *LabelFilter) WithName(name string) *LabelFilter {
 }
 
 // Filter returns only the endpoints whose label matches one of the configured valid values.
-func (f *LabelFilter) Filter(_ context.Context, _ *schedtypes.CycleState, _ *schedtypes.InferenceRequest, endpoints []schedtypes.Endpoint) []schedtypes.Endpoint {
+func (f *LabelFilter) Filter(_ context.Context, _ *schedtypes.CycleState, _ *schedtypes.LLMRequest, endpoints []schedtypes.Endpoint) []schedtypes.Endpoint {
 	filtered := make([]schedtypes.Endpoint, 0, len(endpoints))
 	for _, ep := range endpoints {
 		if ep == nil || ep.GetMetadata() == nil {

--- a/deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
+++ b/deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
@@ -32,7 +32,7 @@ kubectl apply --server-side --force-conflicts \
   -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
 
 # Install the Inference Extension CRDs.
-IGW_LATEST_RELEASE=v1.2.1
+IGW_LATEST_RELEASE=v1.5.0
 kubectl apply \
   -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/${IGW_LATEST_RELEASE}/manifests.yaml"
 

--- a/docs/kubernetes/gateway-api/README.mdx
+++ b/docs/kubernetes/gateway-api/README.mdx
@@ -258,7 +258,7 @@ EPP, and runtime images on the same Dynamo release line.
 | Component | Default shown here | Notes |
 |---|---|---|
 | Gateway API CRDs | `v1.5.1` | Installed from the upstream Gateway API release. |
-| GAIE CRDs | `v1.2.1` | Installed from the upstream Gateway API Inference Extension release. |
+| GAIE CRDs | `v1.5.0` | Installed from the upstream Gateway API Inference Extension release. |
 | agentgateway | `v1.0.0` | Installed with `inferenceExtension.enabled=true`. |
 | Istio | `1.29.2` | Install with `ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true`. |
 | Dynamo images | `1.2.1` | Use one Dynamo release line for the platform chart, EPP image, and runtime images. |

--- a/recipes/gaie_checks.sh
+++ b/recipes/gaie_checks.sh
@@ -50,7 +50,6 @@ GAIE_CRDS=(
   inferenceobjectives.inference.networking.x-k8s.io
   inferencepoolimports.inference.networking.x-k8s.io
   inferencepools.inference.networking.k8s.io
-  inferencepools.inference.networking.x-k8s.io
 )
 
 info "Checking GAIE (Inference Extension) CRDs…"


### PR DESCRIPTION
#### Overview:

Update the Dynamo EPP integration to build against Gateway API Inference Extension v1.5.0.

#### Details:

* Bump `sigs.k8s.io/gateway-api-inference-extension` to v1.5.0.
* Port EPP plugins to GAIE's `LLMRequest` and scheduling payload interfaces.
* Update the response-body plugin assertion to the v1.5.0 interface name.
* Align GAIE install and docs references on final v1.5.0.

#### Where should the reviewer start?

Start with `deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go` and `deploy/inference-gateway/epp/pkg/plugins/disagg/` for the API migration, then check the version alignment in the installer and docs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Fixes: ai-dynamo/dynamo#7612

#### Testing:

* `git diff --check`
* `go test ./pkg/plugins/label_filter`
* `go test ./pkg/plugins/disagg`

`go test ./...` compiles `cmd/epp`, `disagg`, and `label_filter`, but local verification is blocked for `dynamo_kv_scorer` because `pkg/plugins/dynamo_kv_scorer/lib/libdynamo_llm_capi.a` is missing. Attempting `make dynamo-lib` failed while building `modelexpress-common` because `protoc` reported `Unknown flag: --experimental_allow_proto3_optional`.

---

[![Open in Devin Review](https://uploads.linear.app/4b55b3e6-cef7-4cb1-9342-85566ca665d9/1e43ad4f-92d3-4849-b4f8-604cfebfb419/f846637c-225e-425d-abfd-6455e3fd284d?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzRiNTViM2U2LWNlZjctNGNiMS05MzQyLTg1NTY2Y2E2NjVkOS8xZTQzYWQ0Zi05MmQzLTQ4NDktYjRmOC02MDRjZmViZmI0MTkvZjg0NjYzN2MtMjI1ZS00MjVkLWFiZmQtNjQ1NWUzZmQyODRkIiwiaWF0IjoxNzg0MTM0MjY0LCJleHAiOjE4MTU3MDQ4MjR9.WN3vgZCdAF76jTONhRLcOeQ0KcJAdpfdjV27QVZGpyQ)](<https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10417>)

## Summary by CodeRabbit

* **Chores**
  * Upgraded Gateway API Inference Extension dependency to v1.5.0
  * Updated installation scripts to use the latest extension version
* **Documentation**
  * Updated Kubernetes integration documentation to reflect Gateway API Inference Extension v1.5.0