### PR TITLE
fix(kv-router): keep worker monitoring after skipped startup wait

### DIFF
--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -65,6 +65,23 @@ where
             .collect()
     }
 
+    fn reconcile_worker_configs(
+        slots: &ActiveSequencesMultiWorker<P>,
+        current_workers: HashMap<WorkerId, C>,
+        last_workers: &mut Option<HashMap<WorkerId, C>>,
+    ) {
+        if last_workers.as_ref() == Some(&current_workers) {
+            return;
+        }
+
+        let dp_ranges = Self::worker_dp_ranges(&current_workers);
+        if let Err(error) = slots.reconcile_workers(dp_ranges) {
+            tracing::error!(%error, "Invalid worker topology update");
+            return;
+        }
+        *last_workers = Some(current_workers);
+    }
+
     /// Construct a scheduler with dequeue-time overlap refresh.
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_overlap_refresh(
@@ -87,10 +104,15 @@ where
         if monitor_worker_configs {
             let slots_monitor = Arc::clone(&slots);
             let mut monitor_rx = workers_with_configs.clone();
-            let mut last_workers = monitor_rx.borrow().clone();
             let monitor_cancel_token = cancellation_token.clone();
             tokio::spawn(async move {
                 tracing::trace!("LocalScheduler workers monitoring task started");
+                let mut last_workers = None;
+                Self::reconcile_worker_configs(
+                    &slots_monitor,
+                    monitor_rx.borrow_and_update().clone(),
+                    &mut last_workers,
+                );
 
                 loop {
                     tokio::select! {
@@ -107,16 +129,11 @@ where
                     }
 
                     let current_workers = monitor_rx.borrow_and_update().clone();
-                    if current_workers == last_workers {
-                        continue;
-                    }
-
-                    let dp_ranges = Self::worker_dp_ranges(&current_workers);
-                    if let Err(error) = slots_monitor.reconcile_workers(dp_ranges) {
-                        tracing::error!(%error, "Invalid worker topology update");
-                        continue;
-                    }
-                    last_workers = current_workers;
+                    Self::reconcile_worker_configs(
+                        &slots_monitor,
+                        current_workers,
+                        &mut last_workers,
+                    );
                 }
             });
         }
@@ -1263,6 +1280,144 @@ mod tests {
         })
         .await
         .unwrap();
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_worker_watch_reconciles_current_snapshot_on_start() {
+        let mut initial_workers = HashMap::new();
+        initial_workers.insert(0, SimpleWorkerConfig::default());
+        let dp_range = initial_workers
+            .iter()
+            .map(|(&id, cfg)| (id, (cfg.data_parallel_start_rank, cfg.data_parallel_size)))
+            .collect();
+        let slots = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            64,
+            dp_range,
+            false,
+            0,
+            "test",
+        ));
+        let (cfg_tx, cfg_rx) = watch::channel(initial_workers);
+
+        let mut updated_workers = HashMap::new();
+        updated_workers.insert(0, SimpleWorkerConfig::default());
+        updated_workers.insert(1, SimpleWorkerConfig::default());
+        cfg_tx.send(updated_workers).unwrap();
+
+        let cancel_token = CancellationToken::new();
+        let scheduler = LocalScheduler::new_without_overlap_refresh(
+            Arc::clone(&slots),
+            cfg_rx,
+            None,
+            crate::scheduling::config::RouterQueueDepthTiers::unbounded_cap(),
+            64,
+            DefaultWorkerSelector::new(None, "test"),
+            FcfsPolicy,
+            None,
+            Duration::from_secs(60),
+            true,
+            cancel_token.clone(),
+            "test",
+            true,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if scheduler
+                    .get_potential_loads(None, 64, HashMap::new(), true)
+                    .iter()
+                    .any(|load| load.worker_id == 1)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_worker_watch_reconciles_empty_snapshot_on_start() {
+        let mut initial_workers = HashMap::new();
+        initial_workers.insert(0, SimpleWorkerConfig::default());
+        let dp_range = initial_workers
+            .iter()
+            .map(|(&id, cfg)| (id, (cfg.data_parallel_start_rank, cfg.data_parallel_size)))
+            .collect();
+        let slots = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            64,
+            dp_range,
+            false,
+            0,
+            "test",
+        ));
+        let (cfg_tx, cfg_rx) = watch::channel(initial_workers);
+        cfg_tx.send(HashMap::new()).unwrap();
+
+        let cancel_token = CancellationToken::new();
+        let scheduler = LocalScheduler::new_without_overlap_refresh(
+            Arc::clone(&slots),
+            cfg_rx,
+            None,
+            crate::scheduling::config::RouterQueueDepthTiers::unbounded_cap(),
+            64,
+            DefaultWorkerSelector::new(None, "test"),
+            FcfsPolicy,
+            None,
+            Duration::from_secs(60),
+            true,
+            cancel_token.clone(),
+            "test",
+            true,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if scheduler
+                    .get_potential_loads(None, 64, HashMap::new(), true)
+                    .is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_worker_watch_disabled_freezes_slot_ranges() {
+        let mut workers = HashMap::new();
+        workers.insert(0, SimpleWorkerConfig::default());
+        let (scheduler, _slots, cfg_tx, cancel_token) = make_scheduler(workers, None, false, None);
+
+        assert_eq!(
+            scheduler
+                .get_potential_loads(None, 64, HashMap::new(), true)
+                .len(),
+            1
+        );
+
+        let mut updated_workers = HashMap::new();
+        updated_workers.insert(0, SimpleWorkerConfig::default());
+        updated_workers.insert(1, SimpleWorkerConfig::default());
+        cfg_tx.send(updated_workers).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let loads = scheduler.get_potential_loads(None, 64, HashMap::new(), true);
+        assert_eq!(loads.len(), 1);
+        assert_eq!(loads[0].worker_id, 0);
 
         cancel_token.cancel();
     }

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -82,10 +82,9 @@ where
         .await
         .map_err(|e| KvSchedulerError::InitFailed(e.to_string()))?;
 
-        let watch_worker_configs = !kv_router_config.skip_initial_worker_wait;
-        if !watch_worker_configs {
-            tracing::info!("skipping discovery-based worker monitoring");
-        }
+        // `skip_initial_worker_wait` only controls boot-time blocking. The scheduler must
+        // keep monitoring runtime config changes so late-joining workers enter routing.
+        let watch_worker_configs = true;
 
         let policy = RouterSchedulingPolicy::new(kv_router_config.router_queue_policy);
         tracing::info!(
@@ -312,5 +311,80 @@ where
 fn router_backpressure_reason_label(reason: &RouterBackpressureReason) -> &'static str {
     match reason {
         RouterBackpressureReason::MaxQueuedIslTokensExceeded => "max_queued_isl_tokens_exceeded",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
+    use tokio::sync::watch;
+
+    async fn make_test_component(name: &str) -> Component {
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let namespace = drt.namespace(format!("test-ns-{name}")).unwrap();
+        namespace
+            .component(format!("test-component-{name}"))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn skip_initial_worker_wait_still_monitors_worker_config_updates() {
+        let component = make_test_component("skip-initial-worker-watch").await;
+        let mut workers = HashMap::new();
+        workers.insert(0, ModelRuntimeConfig::default());
+        let (cfg_tx, cfg_rx) = watch::channel(workers);
+        let config = KvRouterConfig {
+            skip_initial_worker_wait: true,
+            use_kv_events: false,
+            router_track_active_blocks: false,
+            ..Default::default()
+        };
+
+        let scheduler = KvScheduler::start(
+            component.clone(),
+            64,
+            cfg_rx,
+            DefaultWorkerSelector::new(Some(config.clone()), "decode"),
+            &config,
+            None,
+            None::<Arc<NoopOverlapScoresRefresh>>,
+            None,
+            "decode",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            scheduler
+                .get_potential_loads(None, 64, HashMap::new(), true)
+                .len(),
+            1
+        );
+
+        let mut updated_workers = HashMap::new();
+        updated_workers.insert(0, ModelRuntimeConfig::default());
+        updated_workers.insert(1, ModelRuntimeConfig::default());
+        cfg_tx.send(updated_workers).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if scheduler
+                    .get_potential_loads(None, 64, HashMap::new(), true)
+                    .iter()
+                    .any(|load| load.worker_id == 1)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        component.drt().primary_token().cancel();
     }
 }


### PR DESCRIPTION
## Summary
- Keep scheduler worker-config monitoring enabled even when `skip_initial_worker_wait` is set.
- Add direct coverage for the EPP-style `skip_initial_worker_wait=true` path.
- Add lower-level coverage documenting that disabling `LocalScheduler` monitoring freezes the slot table.

## Why
EPP sets `skip_initial_worker_wait=true` so router construction does not block on boot-time worker discovery. Current `KvScheduler::start` also uses that flag to disable runtime worker monitoring, so late decode workers can publish discovery/runtime config updates but never reconcile into the scheduler slot table until EPP restarts.

## Credits
Reported by @veeresh-angadi in #8534.

This follows the same fix direction proposed by @yankay in the earlier draft PR #10039; this PR rebuilds that approach on current `origin/main` with focused regression coverage.

## Testing
- `cargo test -p dynamo-llm kv_router::scheduler::tests::skip_initial_worker_wait_still_monitors_worker_config_updates --lib`
- `cargo test -p dynamo-kv-router scheduling::local::tests::test_worker_watch --lib`

Relates to #8534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for disabled worker configuration monitoring.
  * Added test coverage for runtime worker discovery with deferred initial wait.

* **Bug Fixes**
  * Scheduler now continuously monitors runtime worker configuration changes to ensure late-joining workers are properly discovered and routed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->