### PR TITLE
fix(docs): remove duplicate H1 on v1.2.0 getting-started pages

### DIFF
--- a/fern/pages-v1.2.0/getting-started/building-from-source.md
+++ b/fern/pages-v1.2.0/getting-started/building-from-source.md
@@ -9,8 +9,6 @@ description: Build Dynamo from source for development and contributions
   <a href="./building-from-source.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
 
-# Building from Source
-
 Build Dynamo from source when you want to contribute code, test features on the development branch, or customize the build. If you just want to run Dynamo, the [Local Installation](local-installation.md) guide is faster.
 
 This guide covers Ubuntu and macOS. For a containerized dev environment that handles all of this automatically, see [DevContainer](#devcontainer).

--- a/fern/pages-v1.2.0/getting-started/introduction.md
+++ b/fern/pages-v1.2.0/getting-started/introduction.md
@@ -1,14 +1,13 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+title: Introduction to Dynamo
 sidebar-title: Introduction
 ---
 
 <p align="left">
   <a href="./introduction.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
-
-# Introduction to Dynamo
 
 Dynamo is an open-source, high-throughput, low-latency inference framework, designed to serve generative AI workloads in distributed environments and optimized for production deployments on Kubernetes. This page gives an overview of Dynamo's design principles, performance benefits, and production-grade features.
 

--- a/fern/pages-v1.2.0/getting-started/local-installation.md
+++ b/fern/pages-v1.2.0/getting-started/local-installation.md
@@ -9,8 +9,6 @@ description: Install and run Dynamo on a local machine or VM with containers or 
   <a href="./local-installation.zh-CN.md" hreflang="zh-CN"><img src="../assets/img/readme-zh-cn-link.svg" alt="简体中文" height="28" /></a>
 </p>
 
-# Local Installation
-
 This guide walks through installing and running Dynamo on a local machine or VM with one or more GPUs. By the end, you'll have a working OpenAI-compatible endpoint serving a model.
 
 For production multi-node clusters, see the [Kubernetes Deployment Guide](../kubernetes/README.md). To build from source for development, see [Building from Source](building-from-source.md).


### PR DESCRIPTION
## What

Fern auto-generates each page's H1 from the nav `page:` value in `fern/versions/v1.2.0.yml`. Per Fern's docs: *"since the `<h1>` is generated automatically, you should begin your page content with `<h2>` headers instead of `<h1>`."* The v1.2.0 getting-started pages also carried a body `# H1`, rendering a **second, duplicate title**.

## Change

Removed the body `# H1` from the three nav-referenced getting-started pages:

- `introduction.md` — keeps its descriptive title via frontmatter `title: Introduction to Dynamo` (sidebar stays `Introduction`)
- `local-installation.md` — H1 now from the nav label `Local Installation`
- `building-from-source.md` — H1 now from the nav label `Building from Source`

The `.zh-CN` variants are standalone (not in any nav, no Fern localization configured), so their body `# H1` is the sole page title and is **left intact**.

## Scope note

The same duplication exists on ~34 other v1.2.0 pages and on `main`'s `docs/` source. This PR is scoped to getting-started; a follow-up will address the rest plus the docs style guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/10420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->