### PR TITLE
feat: Define conversion webhook for dynamographdeployment

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
     helm.sh/resource-policy: keep
+    dynamo.nvidia.com/add-conversion: "true"
   name: dynamographdeployments.nvidia.com
 spec:
   group: nvidia.com
@@ -21200,3 +21201,13 @@ spec:
       storage: false
       subresources:
         status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: dynamo-operator-webhook-service
+          namespace: dynamo-operator
+          path: /convert
+      conversionReviewVersions:
+        - v1

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
@@ -1,16 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    dynamo.nvidia.com/add-conversion: "true"
     controller-gen.kubebuilder.io/version: v0.16.4
     helm.sh/resource-policy: keep
-    dynamo.nvidia.com/add-conversion: "true"
   name: dynamographdeployments.nvidia.com
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: dynamo-operator-webhook-service
+          namespace: dynamo-operator
+          path: /convert
+      conversionReviewVersions:
+        - v1
   group: nvidia.com
   names:
     kind: DynamoGraphDeployment
@@ -21201,13 +21210,3 @@ spec:
       storage: false
       subresources:
         status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: dynamo-operator-webhook-service
-          namespace: dynamo-operator
-          path: /convert
-      conversionReviewVersions:
-        - v1

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           - "--version={{ .Chart.AppVersion }}"
           - --webhook-service={{ include "dynamo-operator.fullname" . }}-webhook-service
         {{- if .Values.webhook.certManager.enabled }}
-          - --webhook-cert={{ include "dynamo-operator.fullname" . }}-serving-cert
+          - --webhook-cert={{ .Release.Namespace }}/{{ include "dynamo-operator.fullname" . }}-serving-cert
         {{- end }}
         {{- if and (not .Values.webhook.certManager.enabled) .Values.webhook.certificateSecret.external }}
           - --webhook-ca

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -79,6 +79,8 @@ spec:
       - args:
         - --config=/etc/dynamo-operator/config.yaml
         - --operator-version={{ .Chart.AppVersion }}
+        - --webhook-service="{{ include "dynamo-operator.fullname" . }}-webhook-service"
+        - --namespace={{ .Release.Namespace }}
         command:
         - /manager
         env:

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -75,6 +75,13 @@ spec:
           - "--crds-dir=/opt/dynamo-operator/crds/"
           - "--version={{ .Chart.AppVersion }}"
           - --webhook-service={{ include "dynamo-operator.fullname" . }}-webhook-service
+        {{- if .Values.webhook.certManager.enabled }}
+          - --webhook-cert={{ include "dynamo-operator.fullname" . }}-serving-cert
+        {{- end }}
+        {{- if and (not .Values.webhook.certManager.enabled) .Values.webhook.certificateSecret.external }}
+          - --webhook-ca
+          - "{{ .Values.webhook.caBundle }}"
+        {{- end }}
           - --namespace={{ .Release.Namespace }}
       {{- end }}
       containers:

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -74,13 +74,13 @@ spec:
         args:
           - "--crds-dir=/opt/dynamo-operator/crds/"
           - "--version={{ .Chart.AppVersion }}"
+          - --webhook-service="{{ include "dynamo-operator.fullname" . }}-webhook-service"
+          - --namespace={{ .Release.Namespace }}
       {{- end }}
       containers:
       - args:
         - --config=/etc/dynamo-operator/config.yaml
         - --operator-version={{ .Chart.AppVersion }}
-        - --webhook-service="{{ include "dynamo-operator.fullname" . }}-webhook-service"
-        - --namespace={{ .Release.Namespace }}
         command:
         - /manager
         env:

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         args:
           - "--crds-dir=/opt/dynamo-operator/crds/"
           - "--version={{ .Chart.AppVersion }}"
-          - --webhook-service="{{ include "dynamo-operator.fullname" . }}-webhook-service"
+          - --webhook-service={{ include "dynamo-operator.fullname" . }}-webhook-service
           - --namespace={{ .Release.Namespace }}
       {{- end }}
       containers:

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -90,6 +90,11 @@ manifests: controller-gen yq ## Generate WebhookConfiguration, ClusterRole and C
 	for file in config/crd/bases/*.yaml; do \
 		$(YQ) eval '(.. | select(has("parameters")) | .parameters | select(has("format") and .format == "byte")) |= (del(.format) | del(.type) | .x-kubernetes-preserve-unknown-fields = true)' -i --indent 2 $$file || exit 1; \
 	done
+	echo "Add conversion webhook"
+	$(YQ) eval-all -i '(... comments="" | select(fileIndex == 1)) * select(fileIndex == 0)' \
+		config/crd/bases/nvidia.com_dynamographdeployments.yaml \
+		config/crd/convert-patch.yaml
+
 	echo "Adding NVIDIA header to CRD files"
 	for file in config/crd/bases/*.yaml; do \
 		if ! head -20 "$$file" | grep -q "NVIDIA CORPORATION"; then \
@@ -107,8 +112,6 @@ manifests: controller-gen yq ## Generate WebhookConfiguration, ClusterRole and C
 			$(YQ) eval '.metadata.annotations."helm.sh/resource-policy" = "keep"' -i "$$file"; \
 		fi; \
 	done
-	echo "Add conversion webhook"
-	yq -i '. *= load("config/crd/convert-patch.yaml")' config/crd/bases/nvidia.com_dynamographdeployments.yaml
 	echo "Copying CRD files to operator Helm chart crds/ directory"
 	mkdir -p ../helm/charts/platform/components/operator/crds/
 	cp config/crd/bases/*.yaml ../helm/charts/platform/components/operator/crds/

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -107,6 +107,8 @@ manifests: controller-gen yq ## Generate WebhookConfiguration, ClusterRole and C
 			$(YQ) eval '.metadata.annotations."helm.sh/resource-policy" = "keep"' -i "$$file"; \
 		fi; \
 	done
+	echo "Add conversion webhook"
+	yq -i '. *= load("config/crd/convert-patch.yaml")' config/crd/bases/nvidia.com_dynamographdeployments.yaml
 	echo "Copying CRD files to operator Helm chart crds/ directory"
 	mkdir -p ../helm/charts/platform/components/operator/crds/
 	cp config/crd/bases/*.yaml ../helm/charts/platform/components/operator/crds/

--- a/deploy/operator/cmd/crd-apply/main.go
+++ b/deploy/operator/cmd/crd-apply/main.go
@@ -27,12 +27,15 @@ const (
 	fieldManager      = "dynamo-crd-apply"
 	versionAnnotation = "dynamo.nvidia.com/operator-version"
 	addConvAnnotation = "dynamo.nvidia.com/add-conversion"
+	caAnnotation      = "cert-manager.io/inject-ca-from"
 )
 
 func main() {
 	crdsDir := flag.String("crds-dir", "/opt/dynamo-operator/crds/", "Directory containing CRD YAML files")
 	version := flag.String("version", "", "Operator version to stamp on CRDs")
 	webhookService := flag.String("webhook-service", "", "Operator webhook service name")
+	webhookCert := flag.String("webhook-cert", "", "Webhook certificate")
+	webhookCA := flag.String("webhook-ca", "", "The CA bundle when using external CA")
 	namespace := flag.String("namespace", "", "Operator webhook namespace")
 	flag.Parse()
 
@@ -91,6 +94,15 @@ func main() {
 			}
 			if namespace != nil && *namespace != "" {
 				crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace = *namespace
+			}
+			if webhookCert != nil && *webhookCert != "" {
+				if crd.Annotations == nil {
+					crd.Annotations = make(map[string]string)
+				}
+				crd.Annotations[caAnnotation] = *webhookCert
+			}
+			if webhookCA != nil && *webhookCA != "" {
+				crd.Spec.Conversion.Webhook.ClientConfig.CABundle = []byte(*webhookCA)
 			}
 		}
 

--- a/deploy/operator/cmd/crd-apply/main.go
+++ b/deploy/operator/cmd/crd-apply/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"os"
@@ -102,7 +103,12 @@ func main() {
 				crd.Annotations[caAnnotation] = *webhookCert
 			}
 			if webhookCA != nil && *webhookCA != "" {
-				crd.Spec.Conversion.Webhook.ClientConfig.CABundle = []byte(*webhookCA)
+				caBundle, err := base64.StdEncoding.DecodeString(*webhookCA)
+				if err != nil {
+					log.Error(err, "unable to decode the webhook-ca")
+					os.Exit(1)
+				}
+				crd.Spec.Conversion.Webhook.ClientConfig.CABundle = caBundle
 			}
 		}
 

--- a/deploy/operator/cmd/crd-apply/main.go
+++ b/deploy/operator/cmd/crd-apply/main.go
@@ -86,8 +86,12 @@ func main() {
 		}
 
 		if val, ok := crd.Annotations[addConvAnnotation]; ok && val == "true" {
-			crd.Spec.Conversion.Webhook.ClientConfig.Service.Name = *webhookService
-			crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace = *namespace
+			if webhookService != nil && *webhookService != "" {
+				crd.Spec.Conversion.Webhook.ClientConfig.Service.Name = *webhookService
+			}
+			if namespace != nil && *namespace != "" {
+				crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace = *namespace
+			}
 		}
 
 		patchData, err := yaml.Marshal(crd)

--- a/deploy/operator/cmd/crd-apply/main.go
+++ b/deploy/operator/cmd/crd-apply/main.go
@@ -26,11 +26,14 @@ import (
 const (
 	fieldManager      = "dynamo-crd-apply"
 	versionAnnotation = "dynamo.nvidia.com/operator-version"
+	addConvAnnotation = "dynamo.nvidia.com/add-conversion"
 )
 
 func main() {
 	crdsDir := flag.String("crds-dir", "/opt/dynamo-operator/crds/", "Directory containing CRD YAML files")
 	version := flag.String("version", "", "Operator version to stamp on CRDs")
+	webhookService := flag.String("webhook-service", "", "Operator webhook service name")
+	namespace := flag.String("namespace", "", "Operator webhook namespace")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -80,6 +83,11 @@ func main() {
 				crd.Annotations = make(map[string]string)
 			}
 			crd.Annotations[versionAnnotation] = *version
+		}
+
+		if val, ok := crd.Annotations[addConvAnnotation]; ok && val == "true" {
+			crd.Spec.Conversion.Webhook.ClientConfig.Service.Name = *webhookService
+			crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace = *namespace
 		}
 
 		patchData, err := yaml.Marshal(crd)

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
     helm.sh/resource-policy: keep
+    dynamo.nvidia.com/add-conversion: "true"
   name: dynamographdeployments.nvidia.com
 spec:
   group: nvidia.com
@@ -21200,3 +21201,13 @@ spec:
       storage: false
       subresources:
         status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: dynamo-operator-webhook-service
+          namespace: dynamo-operator
+          path: /convert
+      conversionReviewVersions:
+        - v1

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -1,16 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    dynamo.nvidia.com/add-conversion: "true"
     controller-gen.kubebuilder.io/version: v0.16.4
     helm.sh/resource-policy: keep
-    dynamo.nvidia.com/add-conversion: "true"
   name: dynamographdeployments.nvidia.com
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: dynamo-operator-webhook-service
+          namespace: dynamo-operator
+          path: /convert
+      conversionReviewVersions:
+        - v1
   group: nvidia.com
   names:
     kind: DynamoGraphDeployment
@@ -21201,13 +21210,3 @@ spec:
       storage: false
       subresources:
         status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: dynamo-operator-webhook-service
-          namespace: dynamo-operator
-          path: /convert
-      conversionReviewVersions:
-        - v1

--- a/deploy/operator/config/crd/convert-patch.yaml
+++ b/deploy/operator/config/crd/convert-patch.yaml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/deploy/operator/config/crd/convert-patch.yaml
+++ b/deploy/operator/config/crd/convert-patch.yaml
@@ -1,24 +1,13 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: dynamographdeployments.nvidia.com
   annotations:
     dynamo.nvidia.com/add-conversion: "true"
+  name: dynamographdeployments.nvidia.com
 spec:
   conversion:
     strategy: Webhook

--- a/deploy/operator/config/crd/convert-patch.yaml
+++ b/deploy/operator/config/crd/convert-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamographdeployments.nvidia.com
+  annotations:
+    dynamo.nvidia.com/add-conversion: "true"
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: dynamo-operator-webhook-service
+          namespace: dynamo-operator
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/deploy/operator/config/crd/kustomization.yaml
+++ b/deploy/operator/config/crd/kustomization.yaml
@@ -23,7 +23,9 @@ resources:
 - bases/nvidia.com_dynamocheckpoints.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patches: []
+patches:
+- path: convert-patch.yaml
+
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
@@ -36,5 +38,5 @@ patches: []
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 
-#configurations:
-#- kustomizeconfig.yaml
+configurations:
+- kustomizeconfig.yaml


### PR DESCRIPTION
#### Overview:

Add conversion for dynamographdeployment so that v1beta1 can be used

#### Details:

Allow v1beta1 conversion to v1alpha1 using webhook

#### Where should the reviewer start?


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Fixes #10419


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator now supports webhook-based conversion for custom resource definitions with configurable webhook service and namespace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->