### PR TITLE
fix(frontend): chat_template.json fallback for vllm + sglang tool calling

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -628,7 +628,7 @@ class SglangEngineFactory:
         # blake3-verified copies; this path duplicates the download.
         source_path = mdc.source_path()
         if not os.path.exists(source_path):
-            await fetch_model(source_path, ignore_weights=True)
+            source_path = await fetch_model(source_path, ignore_weights=True)
 
         logger.info("Loading SGLang tokenizer from %s", source_path)
         tokenizer = _load_tokenizer(source_path, self.trust_remote_code)

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -39,10 +39,20 @@ from .utils import (
     make_internal_error,
     nvext_extra_field_requested,
     random_uuid,
+    resolve_chat_template,
     worker_warmup,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _load_tokenizer(source_path: str, trust_remote_code: bool):
+    """Load the SGLang tokenizer, falling back to an on-disk chat template
+    (e.g. chat_template.json) when the tokenizer defines none."""
+    tokenizer = get_tokenizer(source_path, trust_remote_code=trust_remote_code)
+    if getattr(tokenizer, "chat_template", None) is None:
+        tokenizer.chat_template = resolve_chat_template(source_path)
+    return tokenizer
 
 
 def _runtime_config_parser_name(
@@ -125,7 +135,7 @@ def _init_worker(
     """Initialize a worker process with its own tokenizer."""
     global _w_tokenizer, _w_tool_call_parser_name, _w_reasoning_parser_name
     global _w_exclude_tools_when_tool_choice_none, _w_template_force_reasoning
-    _w_tokenizer = get_tokenizer(model_path, trust_remote_code=trust_remote_code)
+    _w_tokenizer = _load_tokenizer(model_path, trust_remote_code)
     _w_tool_call_parser_name = tool_call_parser_name
     _w_reasoning_parser_name = reasoning_parser_name
     _w_exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
@@ -621,7 +631,7 @@ class SglangEngineFactory:
             await fetch_model(source_path, ignore_weights=True)
 
         logger.info("Loading SGLang tokenizer from %s", source_path)
-        tokenizer = get_tokenizer(source_path, trust_remote_code=self.trust_remote_code)
+        tokenizer = _load_tokenizer(source_path, self.trust_remote_code)
 
         eos_token_id = getattr(tokenizer, "eos_token_id", None)
 

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -21,13 +21,16 @@ def resolve_chat_template(source_path: str) -> str | None:
     """
     jinja_path = os.path.join(source_path, "chat_template.jinja")
     if os.path.exists(jinja_path):
-        with open(jinja_path) as f:
+        with open(jinja_path, encoding="utf-8") as f:
             return f.read()
 
     json_path = os.path.join(source_path, "chat_template.json")
     if os.path.exists(json_path):
-        with open(json_path) as f:
-            return json.load(f).get("chat_template")
+        with open(json_path, encoding="utf-8") as f:
+            try:
+                return json.load(f).get("chat_template")
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Malformed JSON in {json_path}: {e}") from e
 
     return None
 

--- a/components/src/dynamo/frontend/utils.py
+++ b/components/src/dynamo/frontend/utils.py
@@ -3,11 +3,33 @@
 
 """Shared utilities for frontend chat processors (vLLM, SGLang)."""
 
+import json
 import logging
+import os
 import uuid
 from typing import Any
 
 _MASK_64_BITS = (1 << 64) - 1
+
+
+def resolve_chat_template(source_path: str) -> str | None:
+    """Return a chat template stored beside the model, or None.
+
+    Covers models (e.g. Qwen3-Omni) whose template lives in chat_template.json
+    or chat_template.jinja rather than tokenizer_config.json, which the HF
+    tokenizer does not merge.
+    """
+    jinja_path = os.path.join(source_path, "chat_template.jinja")
+    if os.path.exists(jinja_path):
+        with open(jinja_path) as f:
+            return f.read()
+
+    json_path = os.path.join(source_path, "chat_template.json")
+    if os.path.exists(json_path):
+        with open(json_path) as f:
+            return json.load(f).get("chat_template")
+
+    return None
 
 
 def random_uuid() -> str:

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -793,12 +793,12 @@ class EngineFactory:
         tokenizer = input_processor.get_tokenizer()
 
         # vLLM's renderer skips its AutoProcessor fallback when tools are present,
-        # so tool calls crash unless the tokenizer has an inline template.
+        # so tool calls crash unless tokenizer.chat_template is set; load from disk.
         if tokenizer.chat_template is None:
             tokenizer.chat_template = resolve_chat_template(source_path)
 
-        # --chat-template overrides; load_chat_template accepts a path or an
-        # inline Jinja literal.
+        # --chat-template overrides; load_chat_template accepts either a file path
+        # or an inline Jinja template string.
         chat_template_flag = getattr(self.flags, "chat_template", None)
         if chat_template_flag:
             tokenizer.chat_template = load_chat_template(chat_template_flag)

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -6,6 +6,7 @@
 #
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -789,6 +790,36 @@ class EngineFactory:
 
         input_processor = InputProcessor(vllm_config)
         tokenizer = input_processor.get_tokenizer()
+
+        # Some models (e.g. Qwen3-Omni) ship their chat template in a separate
+        # chat_template.json rather than tokenizer_config.json. The HF tokenizer
+        # loaded above does not merge that file, so tokenizer.chat_template is
+        # None. vLLM's renderer skips the AutoProcessor fallback when tools are
+        # present, so tool-calling requests then crash with
+        # ChatTemplateResolutionError. fetch_model already downloads
+        # chat_template.json into source_path, so load it as a fallback.
+        if tokenizer.chat_template is None:
+            chat_template_json = os.path.join(source_path, "chat_template.json")
+            if os.path.exists(chat_template_json):
+                try:
+                    with open(chat_template_json) as f:
+                        tokenizer.chat_template = json.load(f).get("chat_template")
+                    logger.info("Loaded chat template from %s", chat_template_json)
+                except (OSError, ValueError) as e:
+                    logger.warning(
+                        "Failed to load chat template from %s: %s",
+                        chat_template_json,
+                        e,
+                    )
+
+        # Honor the --chat-template flag. It is parsed into self.flags by vLLM's
+        # FrontendArgs but was previously never applied here. An explicit flag
+        # overrides any template discovered above.
+        chat_template_flag = getattr(self.flags, "chat_template", None)
+        if chat_template_flag:
+            with open(chat_template_flag) as f:
+                tokenizer.chat_template = f.read()
+            logger.info("Applied --chat-template from %s", chat_template_flag)
 
         # Resolve stream_interval: env var override > backend config > default (20)
         stream_interval = self.stream_interval

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -751,7 +751,7 @@ class EngineFactory:
         # blake3-verified copies; this path duplicates the download.
         source_path = mdc.source_path()
         if not os.path.exists(source_path):
-            await fetch_model(source_path, ignore_weights=True)
+            source_path = await fetch_model(source_path, ignore_weights=True)
 
         tokenizer_mode = getattr(self.flags, "tokenizer_mode", None) or "auto"
         config_format = getattr(self.flags, "config_format", None) or "auto"

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -6,7 +6,6 @@
 #
 
 import asyncio
-import json
 import logging
 import os
 import time
@@ -16,6 +15,7 @@ from typing import Any
 
 from msgspec.structs import replace as msgspec_replace
 from vllm.config import CacheConfig, LoadConfig, ModelConfig, VllmConfig
+from vllm.entrypoints.chat_utils import load_chat_template
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tasks import GENERATION_TASKS
@@ -43,6 +43,7 @@ from .utils import (
     handle_engine_error,
     make_internal_error,
     random_uuid,
+    resolve_chat_template,
 )
 
 logger = logging.getLogger(__name__)
@@ -791,35 +792,16 @@ class EngineFactory:
         input_processor = InputProcessor(vllm_config)
         tokenizer = input_processor.get_tokenizer()
 
-        # Some models (e.g. Qwen3-Omni) ship their chat template in a separate
-        # chat_template.json rather than tokenizer_config.json. The HF tokenizer
-        # loaded above does not merge that file, so tokenizer.chat_template is
-        # None. vLLM's renderer skips the AutoProcessor fallback when tools are
-        # present, so tool-calling requests then crash with
-        # ChatTemplateResolutionError. fetch_model already downloads
-        # chat_template.json into source_path, so load it as a fallback.
+        # vLLM's renderer skips its AutoProcessor fallback when tools are present,
+        # so tool calls crash unless the tokenizer has an inline template.
         if tokenizer.chat_template is None:
-            chat_template_json = os.path.join(source_path, "chat_template.json")
-            if os.path.exists(chat_template_json):
-                try:
-                    with open(chat_template_json) as f:
-                        tokenizer.chat_template = json.load(f).get("chat_template")
-                    logger.info("Loaded chat template from %s", chat_template_json)
-                except (OSError, ValueError) as e:
-                    logger.warning(
-                        "Failed to load chat template from %s: %s",
-                        chat_template_json,
-                        e,
-                    )
+            tokenizer.chat_template = resolve_chat_template(source_path)
 
-        # Honor the --chat-template flag. It is parsed into self.flags by vLLM's
-        # FrontendArgs but was previously never applied here. An explicit flag
-        # overrides any template discovered above.
+        # --chat-template overrides; load_chat_template accepts a path or an
+        # inline Jinja literal.
         chat_template_flag = getattr(self.flags, "chat_template", None)
         if chat_template_flag:
-            with open(chat_template_flag) as f:
-                tokenizer.chat_template = f.read()
-            logger.info("Applied --chat-template from %s", chat_template_flag)
+            tokenizer.chat_template = load_chat_template(chat_template_flag)
 
         # Resolve stream_interval: env var override > backend config > default (20)
         stream_interval = self.stream_interval


### PR DESCRIPTION
#### Overview
Some models (e.g. Qwen3-Omni) ship their chat template in `chat_template.json` instead of `tokenizer_config.json`.

The vLLM and SGLang chat processors each build their own HF tokenizer, which doesn't load that file, so `tokenizer.chat_template` is `None` and any tool-calling request crashes.

This adds a shared fallback that reads the template from disk when the tokenizer has none, used by both processors. It also fixes vLLM's `--chat-template` flag, which was ignored (and, once applied, only accepted file paths, not inline templates).

**Repro**
```
python -m dynamo.frontend \
  --dyn-chat-processor vllm \    # or: sglang
  --model Qwen/Qwen3-Omni-30B-A3B-Instruct
# then send a chat request that includes "tools": [...]
```

**Before / After** (tool-calling request, Qwen3-Omni):
```
BEFORE: ChatTemplateResolutionError: As of transformers v4.44, default chat
        template is no longer allowed, so you must provide a chat template if
        the tokenizer does not define one.
AFTER:  request renders and is served normally.
```

#### Test Plan
Verified in vLLM (0.21.0) and SGLang (0.5.11) dev containers against the real factory + renderer (metadata only, no weights):

- Qwen3-Omni tool call: crashed before, renders after, on both vLLM and SGLang.
- `--chat-template` accepts a file path or an inline Jinja literal (the literal previously raised `FileNotFoundError`).
- Regression: a model with its template in `tokenizer_config.json` (Qwen2.5) is untouched, since the fallback runs only when the tokenizer has none.

#### Related Issues
- Resolves #10391