### PR TITLE
feat(recipes): Qwen3.5 GSM8K async-scheduling agg-vs-disagg repro (vLLM #42182)

### DIFF
--- a/recipes/qwen3.5-27b-gsm8k-async/README.md
+++ b/recipes/qwen3.5-27b-gsm8k-async/README.md
@@ -1,0 +1,87 @@
+# Qwen3.5 — `--async-scheduling` GSM8K agg-vs-disagg (vLLM #42182)
+
+Reproduces the setup of vLLM issue
+[#42182](https://github.com/vllm-project/vllm/issues/42182) and checks whether the
+reported accuracy collapse still occurs on the Dynamo disagg path. The issue:
+`Qwen/Qwen3.5-27B` (a Gated-Delta-Net + full-attention **hybrid**) showed a GSM8K
+accuracy **collapse** (~0.12 strict, ~35% invalid) when `--async-scheduling` was
+enabled — but **only in disaggregated (P/D) serving**, where the GDN conv/recurrent
+state is transferred over the NIXL connector (tracking issue #37285). The original
+repro was a vLLM `0.20.2rc1` build (2026-05-12) using vLLM-native
+`toy_proxy_server.py` on GB200.
+
+The recipe runs GSM8K on the **same** model/image/config across agg vs disagg and
+async on/off, isolating the trigger. It is **parametrized** by model (`MODEL=` env,
+default `Qwen/Qwen3.5-27B`) and tensor-parallel size (`[TP]` arg, default 1).
+
+GSM8K: full **1319** questions @ concurrency **64** (`lm-eval[api]`, pulls
+`openai/gsm8k`), greedy, `max_gen_toks=2048`. Per-server flags mirror the issue:
+bf16 KV cache, prefix caching OFF, `--generation-config vllm`, `NixlConnector`
+(`kv_both`, `kv_load_failure_policy:fail`), `VLLM_SSM_CONV_STATE_LAYOUT=DS`,
+`--max-num-seqs 256` (GDN: each decode seq needs a Mamba cache block, so the
+default 1024 exceeds available blocks and aborts CUDA-graph capture).
+
+## Findings (aws-dev-02, H100, vLLM 0.22.0 from Dynamo main)
+
+**The collapse did NOT reproduce on the Dynamo disagg path.** Across both models,
+agg vs disagg, and TP=1 vs TP=2, async-on tracked its async-off control within
+~1 pp (≈1 stderr). GSM8K exact-match (strict-match):
+
+| model | agg async-on | disagg async-on | disagg async-off (ctrl) |
+|-------|:---:|:---:|:---:|
+| Qwen3.5-27B (dense, bf16)      | 0.779 | 0.780 (TP1) · 0.772 (TP2) | 0.785 (TP1) · 0.782 (TP2) |
+| Qwen3.5-35B-A3B-FP8 (MoE, fp8) | 0.597–0.614 (TP1/TP2) | 0.613 (TP2) | 0.597 (TP2) |
+
+Disagg genuinely exercised the NIXL path (disagg runs ~1.8× slower than agg from the
+prefill→decode hop; `kv_load_failure_policy:fail` requests completed cleanly, so the
+GDN conv-state + KV transfer was correct). The 35B-A3B disagg numbers match its own
+agg numbers — no silent corruption. (35B absolute is lower than 27B due to a uniform
+thinking-output / answer-extraction artifact; the async-vs-control comparison is the
+gate and holds.)
+
+**Most likely why it didn't reproduce** (unverified, ranked): (1) fixed in vLLM
+0.22.0 — the issue's repro was a ~3-week-older `0.20.2rc1` build; (2) Dynamo's disagg
+path (frontend + workers) differs from the issue's vLLM-native `toy_proxy_server`;
+(3) GB200/aarch64 (issue) vs H100/x86 (here). The decisive next test is replicating
+the issue's exact stack (native vLLM proxy on the `0.20.2rc1` build / GB200).
+
+## Run
+
+```bash
+# 1. Download the model (once; public repo). 27B ~54 GB bf16.
+kubectl -n qiwa apply -f model-cache/model-download.yaml
+
+# 2. Deploy + eval. Args: <agg|disagg> <DGD_NAME> <ASYNC_FLAG> <RUN_LABEL> [TP]
+#    Model via MODEL= env (default Qwen/Qwen3.5-27B).
+./run-config.sh agg    q27-agg-async      --async-scheduling    agg-async
+./run-config.sh disagg q27-disagg-async   --async-scheduling    disagg-async
+./run-config.sh disagg q27-disagg-noasync --no-async-scheduling disagg-noasync
+# TP=2 disagg:
+./run-config.sh disagg q27-disagg-async-tp2 --async-scheduling disagg-async-tp2 2
+# A different model (must be on the PVC):
+MODEL=Qwen/Qwen3.5-35B-A3B-FP8 ./run-config.sh disagg q35-disagg-async-tp2 --async-scheduling q35-disagg-async-tp2 2
+
+# 3. Watch / collect
+kubectl -n qiwa logs <label>-acc -f
+kubectl -n qiwa cp <label>-acc:/perf-cache/accuracy/<label> ./results-<label>
+```
+
+`run-config.sh` renders the YAML via envsubst (`hw/h100.env` supplies `VLLM_IMAGE` +
+selectors + pull secret), patches the DGD ServiceAccount with `ngc-pull-secret`,
+waits for all components Ready, then launches the GSM8K accuracy pod against the
+frontend.
+
+## Teardown
+
+```bash
+kubectl -n qiwa delete dynamographdeployment <DGD_NAME>
+kubectl -n qiwa delete pod <RUN_LABEL>-acc --ignore-not-found
+```
+
+## Files
+- `model-cache/model-download.yaml` — HF download (`Qwen/Qwen3.5-27B` by default).
+- `deploy/agg.yaml` — aggregated worker (envsubst: `$MODEL $TP $GPU_COUNT $ASYNC_FLAG`).
+- `deploy/disagg.yaml` — 1P1D NixlConnector + GDN conv-state (same envsubst params).
+- `accuracy-job.yaml` — GSM8K 1319 @ conc 64 via `lm-eval[api]`.
+- `hw/h100.env` — image / node selector / pull secret.
+- `run-config.sh` — deploy + SA patch + readiness wait + accuracy launch.

--- a/recipes/qwen3.5-27b-gsm8k-async/accuracy-job.yaml
+++ b/recipes/qwen3.5-27b-gsm8k-async/accuracy-job.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# GSM8K accuracy run for the #42182 repro. Full 1319-question test set @
+# concurrency 64 (the load that triggers the disagg collapse; a small run
+# stays healthy). lm-eval gsm8k pulls openai/gsm8k. NOTE: lm-eval needs the
+# [api] extra (tenacity) for local-chat-completions.
+#
+#   export BENCH_ACC_POD=disagg-async-acc BENCH_FRONTEND=<dgd>-frontend BENCH_RUN_LABEL=disagg-async
+#   envsubst '$HW_NODE_SELECTOR $HW_TOLERATIONS $BENCH_ACC_POD $BENCH_FRONTEND $BENCH_RUN_LABEL' \
+#     < accuracy-job.yaml | kubectl -n qiwa apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${BENCH_ACC_POD}
+  labels:
+    app.kubernetes.io/name: qwen3.5-27b-gsm8k-async
+    app.kubernetes.io/component: accuracy
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  restartPolicy: Never
+  nodeSelector: ${HW_NODE_SELECTOR}
+  tolerations: ${HW_TOLERATIONS}
+  containers:
+    - name: accuracy
+      image: python:3.11
+      command:
+        - /bin/bash
+        - -lc
+        - |
+          set -euo pipefail
+          apt update && apt install -y --no-install-recommends curl jq
+          pip install --no-cache-dir 'lm-eval[api]'
+
+          echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models ..."
+          until curl -s "http://${FRONTEND}:8000/v1/models" \
+              | jq -e --arg m "${MODEL_NAME}" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do
+            echo "[$(date '+%H:%M:%S')] not ready, sleeping 10s"
+            sleep 10
+          done
+          echo "Model '${MODEL_NAME}' is ready."
+
+          OUT="/perf-cache/accuracy/${RUN_LABEL}"
+          mkdir -p "${OUT}"
+          echo "GSM8K (limit=${LIMIT}, conc=${ACC_CONCURRENCY}, max_gen_toks=${MAX_GEN_TOKS}) against ${FRONTEND} -> ${OUT}"
+
+          lm_eval \
+            --model local-chat-completions \
+            --model_args "model=${MODEL_NAME},base_url=http://${FRONTEND}:8000/v1/chat/completions,num_concurrent=${ACC_CONCURRENCY},timeout=600,max_retries=3,tokenized_requests=False" \
+            --tasks gsm8k \
+            --limit "${LIMIT}" \
+            --gen_kwargs "max_gen_toks=${MAX_GEN_TOKS}" \
+            --apply_chat_template \
+            --output_path "${OUT}"
+
+          echo "===== GSM8K result (${RUN_LABEL}) ====="
+          find "${OUT}" -name 'results*.json' -exec cat {} \; | jq '.results.gsm8k'
+          echo "Accuracy run complete. Results in ${OUT}"
+          sleep 3600
+      env:
+        - name: MODEL_NAME
+          value: ${MODEL}
+        - name: FRONTEND
+          value: ${BENCH_FRONTEND}
+        - name: RUN_LABEL
+          value: ${BENCH_RUN_LABEL}
+        - name: LIMIT
+          value: "1319"
+        - name: ACC_CONCURRENCY
+          value: "64"
+        - name: MAX_GEN_TOKS
+          value: "2048"
+      resources:
+        requests:
+          cpu: "4"
+          memory: 8Gi
+        limits:
+          cpu: "8"
+          memory: 16Gi
+      volumeMounts:
+        - name: shared-model-cache
+          mountPath: /perf-cache
+          subPath: qwen35-27b-gsm8k/perf-cache
+  volumes:
+    - name: shared-model-cache
+      persistentVolumeClaim:
+        claimName: shared-model-cache

--- a/recipes/qwen3.5-27b-gsm8k-async/deploy/agg.yaml
+++ b/recipes/qwen3.5-27b-gsm8k-async/deploy/agg.yaml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Qwen/Qwen3.5-27B — AGGREGATED single-worker (TP=1). The CORRECT reference
+# for the vLLM #42182 comparison: in agg there is no NIXL conv-state transfer,
+# so --async-scheduling holds accuracy. Config mirrors the issue's per-server
+# flags (bf16 KV, prefix caching OFF, generation-config vllm) minus the
+# disagg/NIXL bits.
+#
+# Templated (envsubst allow-list): $VLLM_IMAGE $HW_NODE_SELECTOR
+#   $HW_TOLERATIONS $DGD_NAME $ASYNC_FLAG   (in-pod ${MODEL_NAME} stays literal)
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DGD_NAME}
+  labels:
+    app.kubernetes.io/name: qwen3.5-27b-gsm8k-async
+    app.kubernetes.io/component: agg
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backendFramework: vllm
+  pvcs:
+    - create: false
+      name: shared-model-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+        - name: DYN_REQUEST_PLANE
+          value: tcp
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          cpu: "8"
+          memory: 32Gi
+      subComponentType: null
+
+    VllmWorker:
+      componentType: worker
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface
+      sharedMemory:
+        size: 32Gi
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              python3 -m dynamo.vllm \
+                --model "${MODEL_NAME}" \
+                --tensor-parallel-size ${TP} \
+                --data-parallel-size 1 \
+                --generation-config vllm \
+                --kv-cache-dtype bfloat16 \
+                --no-enable-prefix-caching \
+                --max-model-len 8192 \
+                --max-num-seqs 256 \
+                ${ASYNC_FLAG} \
+                --no-enable-log-requests
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_NAME
+              value: "${MODEL}"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+          workingDir: /workspace
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+      replicas: 1
+      resources:
+        requests:
+          gpu: "${GPU_COUNT}"
+        limits:
+          gpu: "${GPU_COUNT}"
+      subComponentType: null

--- a/recipes/qwen3.5-27b-gsm8k-async/deploy/disagg.yaml
+++ b/recipes/qwen3.5-27b-gsm8k-async/deploy/disagg.yaml
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Qwen/Qwen3.5-27B — prefill/decode (1P1D) DISAGGREGATION. This is the
+# vLLM issue #42182 repro topology: a GDN-hybrid whose decode worker must
+# receive the GDN conv/recurrent state over the NIXL connector. With
+# --async-scheduling ON (ASYNC_FLAG=--async-scheduling) the conv-state /
+# KV blocks misalign and GSM8K accuracy COLLAPSES; with
+# --no-async-scheduling it is healthy (the control).
+#
+# Per-worker flags mirror the issue: TP=1, bf16 KV, prefix caching OFF,
+# generation-config vllm, NixlConnector kv_both + kv_load_failure_policy:fail,
+# VLLM_SSM_CONV_STATE_LAYOUT=DS (3-read GDN conv transfer; workers crash-loop
+# without it). 27B bf16 (~54 GB) fits TP=1 on one H100; prefill + decode are
+# 1 GPU each. NIXL falls back to TCP on AWS without EFA — fine for an
+# ACCURACY repro (correctness bug is transport-independent).
+#
+# Templated (envsubst allow-list): $VLLM_IMAGE $HW_NODE_SELECTOR
+#   $HW_TOLERATIONS $DGD_NAME $ASYNC_FLAG   (in-pod ${MODEL_NAME} stays literal)
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: ${DGD_NAME}
+  labels:
+    app.kubernetes.io/name: qwen3.5-27b-gsm8k-async
+    app.kubernetes.io/component: disagg
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backendFramework: vllm
+  pvcs:
+    - create: false
+      name: shared-model-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+        - name: DYN_REQUEST_PLANE
+          value: tcp
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          cpu: "8"
+          memory: 32Gi
+      subComponentType: null
+
+    VllmPrefillWorker:
+      componentType: worker
+      subComponentType: prefill
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface
+      sharedMemory:
+        size: 32Gi
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              python3 -m dynamo.vllm \
+                --model "${MODEL_NAME}" \
+                --tensor-parallel-size ${TP} \
+                --data-parallel-size 1 \
+                --disaggregation-mode prefill \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail"}' \
+                --generation-config vllm \
+                --kv-cache-dtype bfloat16 \
+                --no-enable-prefix-caching \
+                --max-model-len 8192 \
+                --max-num-seqs 256 \
+                ${ASYNC_FLAG} \
+                --no-enable-log-requests
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_NAME
+              value: "${MODEL}"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            - name: VLLM_SSM_CONV_STATE_LAYOUT
+              value: DS
+          workingDir: /workspace
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+      replicas: 1
+      resources:
+        requests:
+          gpu: "${GPU_COUNT}"
+        limits:
+          gpu: "${GPU_COUNT}"
+
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface
+      sharedMemory:
+        size: 32Gi
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              python3 -m dynamo.vllm \
+                --model "${MODEL_NAME}" \
+                --tensor-parallel-size ${TP} \
+                --data-parallel-size 1 \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail"}' \
+                --generation-config vllm \
+                --kv-cache-dtype bfloat16 \
+                --no-enable-prefix-caching \
+                --max-model-len 8192 \
+                --max-num-seqs 256 \
+                ${ASYNC_FLAG} \
+                --no-enable-log-requests
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_NAME
+              value: "${MODEL}"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            - name: VLLM_SSM_CONV_STATE_LAYOUT
+              value: DS
+          workingDir: /workspace
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+      replicas: 1
+      resources:
+        requests:
+          gpu: "${GPU_COUNT}"
+        limits:
+          gpu: "${GPU_COUNT}"

--- a/recipes/qwen3.5-27b-gsm8k-async/hw/h100.env
+++ b/recipes/qwen3.5-27b-gsm8k-async/hw/h100.env
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Hardware target: H100 (x86) on aws-dev-02, namespace qiwa.
+#
+# Image is the runtime image baked from Dynamo main (vLLM 0.22.0 + nixl
+# 1.1.0), which carries vLLM PR #41869 (GDN P/D conv-state transfer over
+# NIXL) — required for the Qwen3.5 hybrid disagg path. PRIVATE nvstaging
+# tag: after deploy, patch the DGD's ServiceAccount with ${IMAGE_PULL_SECRET}.
+export VLLM_IMAGE="nvcr.io/nvstaging/ai-dynamo/vllm-runtime:qiwa-efa-vllm-x86-06-05"
+
+# Empty selector: each worker requests gpu:"1" (TP=1), so the scheduler
+# bin-packs them onto free H100s. No hostname pin needed for 27B at TP=1.
+export HW_NODE_SELECTOR='{}'
+export HW_TOLERATIONS='[]'
+
+# Secret (in the target namespace) holding nvcr.io/nvstaging pull creds.
+export IMAGE_PULL_SECRET="ngc-pull-secret"

--- a/recipes/qwen3.5-27b-gsm8k-async/model-cache/model-download.yaml
+++ b/recipes/qwen3.5-27b-gsm8k-async/model-cache/model-download.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Download Qwen/Qwen3.5-27B (~54 GB bf16, 11 shards) into shared-model-cache
+# at the standard HF_HOME path, so weights land at
+# /home/dynamo/.cache/huggingface/hub/models--Qwen--Qwen3.5-27B/
+# and the worker pods (HF_HUB_OFFLINE=1) find them there.
+#
+# This is the exact model from vLLM issue #42182 (Qwen3.5-27B GDN-hybrid
+# disagg + async-scheduling GSM8K collapse). Public repo, not gated.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen35-27b-model-download
+  labels:
+    app.kubernetes.io/name: qwen3.5-27b-gsm8k-async
+    app.kubernetes.io/component: model-download
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen3.5-27b-gsm8k-async
+        app.kubernetes.io/component: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen3.5-27B"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+            - name: MODEL_REVISION
+              value: "main"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.11.0
+              # Use the Python API, not the `hf` CLI: hf_hub 1.11.0's CLI
+              # entrypoint imports `click`, which isn't a dependency in this
+              # slim image (ModuleNotFoundError: click).
+              python -c "from huggingface_hub import snapshot_download; snapshot_download('$MODEL_NAME', revision='$MODEL_REVISION')"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "64Gi"
+            limits:
+              cpu: "8"
+              memory: "64Gi"
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /home/dynamo/.cache/huggingface
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/qwen3.5-27b-gsm8k-async/run-config.sh
+++ b/recipes/qwen3.5-27b-gsm8k-async/run-config.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy one Qwen3.5-27B config (agg or disagg) + launch its GSM8K accuracy job.
+# Usage: ./run-config.sh <agg|disagg> <DGD_NAME> <ASYNC_FLAG> <RUN_LABEL> [TP]
+#   ./run-config.sh agg    q27-agg-async     --async-scheduling    agg-async
+#   ./run-config.sh disagg q27-disagg-async  --async-scheduling    disagg-async
+#   ./run-config.sh disagg q27-disagg-noasync --no-async-scheduling disagg-noasync
+#   ./run-config.sh disagg q27-disagg-async-tp2 --async-scheduling  disagg-async-tp2 2
+# TP defaults to 1; GPUs/worker = TP (disagg = 2 workers => 2*TP GPUs total).
+set -euo pipefail
+
+MODE="${1:?mode: agg|disagg}"; DGD_NAME="${2:?DGD_NAME}"
+ASYNC_FLAG="${3:?ASYNC_FLAG}"; RUN_LABEL="${4:?RUN_LABEL}"; TP="${5:-1}"; GPU_COUNT="$TP"
+MODEL="${MODEL:-Qwen/Qwen3.5-27B}"   # override via env, e.g. MODEL=Qwen/Qwen3.5-35B-A3B-FP8
+
+NS=qiwa
+CTX=nv-prd-dgxc.teleport.sh-dynamo-aws-dev-02
+KC="kubectl --context=$CTX -n $NS"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+case "$MODE" in
+  agg)    YAML="$HERE/deploy/agg.yaml";    NEED="frontend vllmworker" ;;
+  disagg) YAML="$HERE/deploy/disagg.yaml"; NEED="frontend vllmprefillworker vllmdecodeworker" ;;
+  *) echo "mode must be agg|disagg"; exit 2 ;;
+esac
+
+set -a; . "$HERE/hw/h100.env"; set +a   # VLLM_IMAGE, selectors, IMAGE_PULL_SECRET
+export DGD_NAME ASYNC_FLAG TP GPU_COUNT MODEL
+
+echo "[deploy] $MODE  $DGD_NAME  MODEL=$MODEL  TP=$TP  async='$ASYNC_FLAG'  image=$VLLM_IMAGE"
+envsubst '$VLLM_IMAGE $HW_NODE_SELECTOR $HW_TOLERATIONS $DGD_NAME $ASYNC_FLAG $TP $GPU_COUNT $MODEL' \
+  < "$YAML" | $KC apply -f -
+
+# --- patch the operator-stamped SA with the private-registry pull secret ---
+SA="${DGD_NAME}-k8s-service-discovery"
+echo "[sa] waiting for $SA ..."
+for _ in $(seq 1 60); do
+  if $KC get sa "$SA" >/dev/null 2>&1; then
+    $KC patch sa "$SA" -p "{\"imagePullSecrets\":[{\"name\":\"$IMAGE_PULL_SECRET\"}]}" >/dev/null
+    echo "[sa] patched $SA -> $IMAGE_PULL_SECRET"; break
+  fi
+  sleep 2
+done
+
+# --- wait for every required component Ready (model load); fix ImagePull once ---
+SEL='nvidia.com/dynamo-graph-deployment-name='"$DGD_NAME"
+echo "[wait] components Ready: $NEED (model load ~3-6 min)..."
+DEADLINE=$(( $(date +%s) + 1500 ))
+while true; do
+  line=$($KC get pods -l "$SEL" --no-headers 2>/dev/null || true)
+  printf '%s\n' "$line"
+  printf '%s\n' "$line" | awk '$3 ~ /ImagePull|ErrImage/ {print $1}' | while read -r p; do
+    [ -n "$p" ] && $KC delete pod "$p" --wait=false >/dev/null 2>&1 || true
+  done
+  all_ok=1
+  for comp in $NEED; do
+    ok=$(printf '%s\n' "$line" | grep -i "$comp" | awk '$3=="Running"{split($2,a,"/"); if(a[1]==a[2]&&a[2]>0) print 1}' | head -1)
+    [ "${ok:-0}" = "1" ] || all_ok=0
+  done
+  if [ "$all_ok" = "1" ]; then echo "[wait] all Ready"; break; fi
+  if [ "$(date +%s)" -gt "$DEADLINE" ]; then echo "[wait] TIMEOUT"; $KC get pods -l "$SEL"; exit 1; fi
+  sleep 15
+done
+
+# --- frontend service: operator names it <dgd>-frontend (no DGD-name label) ---
+FE="${DGD_NAME}-frontend"
+$KC get svc "$FE" >/dev/null 2>&1 || { echo "[frontend] svc $FE not found"; $KC get svc | grep "$DGD_NAME" || true; exit 1; }
+echo "[frontend] service = $FE"
+
+# --- launch the GSM8K accuracy job ---
+export BENCH_ACC_POD="${RUN_LABEL}-acc" BENCH_FRONTEND="$FE" BENCH_RUN_LABEL="$RUN_LABEL"
+envsubst '$HW_NODE_SELECTOR $HW_TOLERATIONS $BENCH_ACC_POD $BENCH_FRONTEND $BENCH_RUN_LABEL $MODEL' \
+  < "$HERE/accuracy-job.yaml" | $KC apply -f -
+echo "[acc] launched ${RUN_LABEL}-acc -> $FE   (poll: $KC logs ${RUN_LABEL}-acc -f)"
+echo "DONE $MODE / $DGD_NAME / $RUN_LABEL / frontend=$FE"


### PR DESCRIPTION
## Why

vLLM [#42182](https://github.com/vllm-project/vllm/issues/42182) reports Qwen3.5
(a Gated-Delta-Net + attention hybrid) collapsing on GSM8K (~0.12 strict, ~35%
invalid) under `--async-scheduling`, reported as disaggregated-only — the GDN
conv-state transferred over NIXL (tracking vllm #37285). Dynamo's recipes had no
way to check whether this hits the Dynamo disagg path or which serving configs are
safe. This recipe reproduces the issue's setup and bounds it across agg/disagg and
tensor-parallel size. Finding: on the Dynamo disagg path with vLLM 0.22.0 on H100
the collapse does **not** reproduce — across Qwen3.5-27B and 35B-A3B-FP8, agg vs
disagg, TP=1/TP=2, async-on stays within ~1pp of its async-off control. Most likely
fixed since the issue's older `0.20.2rc1` / GB200 / native-proxy repro.

## What Change

- Parametrized recipe (`MODEL=`, `[TP]`) running GSM8K across agg vs disagg, async on/off.
- Mirrors issue flags: bf16 KV, prefix-cache off, NixlConnector + GDN conv-state layout.
- GSM8K via `lm-eval[api]` (1319 @ conc 64); deploy then SA-patch then wait then eval driver.

## Test Plan

- Ran 27B {agg, disagg×TP1/TP2} + 35B-A3B {agg, disagg TP2}; all held (~0.78 / ~0.61 strict), no collapse.
- `./run-config.sh disagg q27-disagg-async --async-scheduling disagg-async`
