### PR TITLE
build(container): backport EFA build fixes (#9705, #9727) to release/1.2.1

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -31,7 +31,8 @@ dynamo:
   nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.2
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
-  nixl_libfabric_ref: v2.3.0
+  nixl_libfabric_repo: https://github.com/ofiwg/libfabric.git
+  nixl_libfabric_ref: v2.5.1
   enable_kvbm: "true"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -29,7 +29,7 @@ dynamo:
 
   nixl_ref: 0.10.1
   nixl_ucx_ref: v1.20.x
-  nixl_gdrcopy_ref: v2.5.1
+  nixl_gdrcopy_ref: v2.5.2
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0
   enable_kvbm: "true"

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -74,6 +74,7 @@ ARG NIXL_REF={{ context[framework].nixl_ref }}
 {% endif -%}
 {% if device == "cuda" %}
 ARG NIXL_GDRCOPY_REF={{ context.dynamo.nixl_gdrcopy_ref }}
+ARG NIXL_LIBFABRIC_REPO={{ context.dynamo.nixl_libfabric_repo }}
 ARG NIXL_LIBFABRIC_REF={{ context.dynamo.nixl_libfabric_ref }}
 {% endif %}
 

--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -36,13 +36,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
     rm -rf /tmp/efa && \
-    # Disable the EFA installer's aws-ofi-nccl plugin: it crashes TRT-LLM at engine init.
-    # The plugin is installed at /opt/amazon/ofi-nccl (no `aws-` prefix), but ld.so picks
-    # it up via /etc/ld.so.conf.d/aws-ofi-nccl.conf (which DOES carry the `aws-` prefix).
-    # Remove both, and also the cuda-dl-base location /opt/amazon/aws-ofi-nccl if present,
-    # before re-running ldconfig.
-    rm -rf /opt/amazon/aws-ofi-nccl /opt/amazon/ofi-nccl \
-           /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
+    rm -rf /opt/amazon/aws-ofi-nccl /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
     ldconfig
 
 ENV EFA_VERSION="${EFA_VERSION}"
@@ -61,11 +55,11 @@ RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric
     if [ -n "$EFA_LIBFABRIC_VER" ] && [ -n "$REF_VER" ] && \
        [ "$(printf '%s\n' "$EFA_LIBFABRIC_VER" "$REF_VER" | sort -V | head -n1)" = "$EFA_LIBFABRIC_VER" ] && \
        [ "$EFA_LIBFABRIC_VER" != "$REF_VER" ]; then \
-        cp -Pf /tmp/libfabric_build/lib/libfabric.so* /opt/amazon/efa/lib/ && \
-        if [ -d /opt/amazon/efa/lib64 ]; then \
-            cp -Pf /tmp/libfabric_build/lib/libfabric.so* /opt/amazon/efa/lib64/; \
-        fi && \
-        cp -f /tmp/libfabric_build/bin/fi_info /opt/amazon/efa/bin/fi_info && \
+        rm -rf /opt/amazon/efa && \
+        cp -Pfr /tmp/libfabric_build /opt/amazon/efa && \
+        sed -i 's|^prefix=.*|prefix=/opt/amazon/efa|' /opt/amazon/efa/lib/pkgconfig/libfabric.pc && \
+        echo "/opt/amazon/efa/lib" > /etc/ld.so.conf.d/000_efa.conf && \
+        rm -f /etc/ld.so.conf.d/efa.conf && \
         ldconfig && \
         echo "[aws] libfabric overlay: ${REF_VER} (overwrites EFA stock ${EFA_LIBFABRIC_RAW})"; \
     else \
@@ -84,18 +78,15 @@ RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric
 # Dynamo-built NIXL 0.10.1 plugins). LIBFABRIC goes through libfabric directly
 # (not UCX), so it is unaffected by the UCX 1.20.0 hang that LD_PRELOAD works
 # around — and LIBFABRIC is the recommended backend for EFA.
-RUN set -e && \
-    arch_libdir=$(find /opt/nvidia/nvda_nixl/lib -maxdepth 1 -type d -name '*-linux-gnu' | head -1) && \
-    [ -n "$arch_libdir" ] || { echo "ERROR: no arch-specific NIXL plugin dir under /opt/nvidia/nvda_nixl/lib" >&2; exit 1; } && \
-    venv_lf=$(find /opt/dynamo/venv -path '*.nixl_cu13.mesonpy.libs/plugins/libplugin_LIBFABRIC.so' | head -1) && \
-    [ -n "$venv_lf" ] || { echo "ERROR: no libplugin_LIBFABRIC.so under /opt/dynamo/venv" >&2; exit 1; } && \
-    cp -Pf "$venv_lf" "$arch_libdir/plugins/" && \
-    ln -sfT "$arch_libdir/plugins" /opt/nvidia/nvda_nixl/plugins && \
-    [ -f /opt/nvidia/nvda_nixl/plugins/libplugin_LIBFABRIC.so ] || { echo "ERROR: LIBFABRIC plugin not visible via /opt/nvidia/nvda_nixl/plugins" >&2; ls -la /opt/nvidia/nvda_nixl/plugins/ >&2; exit 1; } && \
-    echo "[aws] NIXL plugins consolidated under /opt/nvidia/nvda_nixl/plugins -> $arch_libdir/plugins"
+RUN --mount=from=wheel_builder,source=/opt/nvidia/nvda_nixl,target=/tmp/nvda_nixl \
+    rm -rf /opt/nvidia/nvda_nixl && \
+    cp -Pfr /tmp/nvda_nixl /opt/nvidia/nvda_nixl && \
+    export LD_PRELOAD=/opt/nvidia/nvda_nixl/lib64/libnixl.so && \
+    export NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins && \
+    ldconfig
 
-ENV LD_PRELOAD=""
-ENV NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/plugins
+ENV LD_PRELOAD=/opt/nvidia/nvda_nixl/lib64/libnixl.so
+ENV NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
 {% endif %}
 
 {% if target == "runtime" %}

--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -36,14 +36,68 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
     rm -rf /tmp/efa && \
-    rm -rf /opt/amazon/aws-ofi-nccl && \
+    # Disable the EFA installer's aws-ofi-nccl plugin: it crashes TRT-LLM at engine init.
+    # The plugin is installed at /opt/amazon/ofi-nccl (no `aws-` prefix), but ld.so picks
+    # it up via /etc/ld.so.conf.d/aws-ofi-nccl.conf (which DOES carry the `aws-` prefix).
+    # Remove both, and also the cuda-dl-base location /opt/amazon/aws-ofi-nccl if present,
+    # before re-running ldconfig.
+    rm -rf /opt/amazon/aws-ofi-nccl /opt/amazon/ofi-nccl \
+           /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
     ldconfig
 
 ENV EFA_VERSION="${EFA_VERSION}"
 
+ARG NIXL_LIBFABRIC_REF
+
+# Copy the wheel_builder-built libfabric and register it with the dynamic linker
+# ONLY if the EFA-bundled libfabric is older than NIXL_LIBFABRIC_REF.
+# When a future EFA installer ships libfabric >= the version we build, the
+# version comparison evaluates to false and this becomes a no-op automatically.
+RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric_build \
+    EFA_PC=$(find /opt/amazon/efa -path '*/pkgconfig/libfabric.pc' 2>/dev/null | head -n1) && \
+    EFA_LIBFABRIC_RAW=$(cat "$EFA_PC" 2>/dev/null | grep '^Version:' | awk '{print $2}') && \
+    EFA_LIBFABRIC_VER=$(echo "$EFA_LIBFABRIC_RAW" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?') && \
+    REF_VER=$(echo "${NIXL_LIBFABRIC_REF}" | sed 's/^v//') && \
+    if [ -n "$EFA_LIBFABRIC_VER" ] && [ -n "$REF_VER" ] && \
+       [ "$(printf '%s\n' "$EFA_LIBFABRIC_VER" "$REF_VER" | sort -V | head -n1)" = "$EFA_LIBFABRIC_VER" ] && \
+       [ "$EFA_LIBFABRIC_VER" != "$REF_VER" ]; then \
+        cp -Pf /tmp/libfabric_build/lib/libfabric.so* /opt/amazon/efa/lib/ && \
+        if [ -d /opt/amazon/efa/lib64 ]; then \
+            cp -Pf /tmp/libfabric_build/lib/libfabric.so* /opt/amazon/efa/lib64/; \
+        fi && \
+        cp -f /tmp/libfabric_build/bin/fi_info /opt/amazon/efa/bin/fi_info && \
+        ldconfig && \
+        echo "[aws] libfabric overlay: ${REF_VER} (overwrites EFA stock ${EFA_LIBFABRIC_RAW})"; \
+    else \
+        echo "[aws] libfabric overlay: skipped (EFA stock ${EFA_LIBFABRIC_RAW:-unknown} >= ${REF_VER})"; \
+    fi
+
+{% if framework == "trtllm" %}
+# After the upstream mesonpy refactor, libplugin_LIBFABRIC.so lands under the
+# Dynamo venv while the rest of the NIXL plugin set (GDS/UCX/POSIX) remains at
+# the canonical arch-specific location. Copy LIBFABRIC alongside the others so
+# NIXL_PLUGIN_DIR resolves every backend from a single directory, and expose a
+# stable arch-agnostic alias at /opt/nvidia/nvda_nixl/plugins.
+#
+# Also clear LD_PRELOAD (the upstream trtllm_runtime stage's ai-dynamo/nixl#1668
+# workaround force-loads TRT-LLM's bundled NIXL 0.9.0; that conflicts with the
+# Dynamo-built NIXL 0.10.1 plugins). LIBFABRIC goes through libfabric directly
+# (not UCX), so it is unaffected by the UCX 1.20.0 hang that LD_PRELOAD works
+# around — and LIBFABRIC is the recommended backend for EFA.
+RUN set -e && \
+    arch_libdir=$(find /opt/nvidia/nvda_nixl/lib -maxdepth 1 -type d -name '*-linux-gnu' | head -1) && \
+    [ -n "$arch_libdir" ] || { echo "ERROR: no arch-specific NIXL plugin dir under /opt/nvidia/nvda_nixl/lib" >&2; exit 1; } && \
+    venv_lf=$(find /opt/dynamo/venv -path '*.nixl_cu13.mesonpy.libs/plugins/libplugin_LIBFABRIC.so' | head -1) && \
+    [ -n "$venv_lf" ] || { echo "ERROR: no libplugin_LIBFABRIC.so under /opt/dynamo/venv" >&2; exit 1; } && \
+    cp -Pf "$venv_lf" "$arch_libdir/plugins/" && \
+    ln -sfT "$arch_libdir/plugins" /opt/nvidia/nvda_nixl/plugins && \
+    [ -f /opt/nvidia/nvda_nixl/plugins/libplugin_LIBFABRIC.so ] || { echo "ERROR: LIBFABRIC plugin not visible via /opt/nvidia/nvda_nixl/plugins" >&2; ls -la /opt/nvidia/nvda_nixl/plugins/ >&2; exit 1; } && \
+    echo "[aws] NIXL plugins consolidated under /opt/nvidia/nvda_nixl/plugins -> $arch_libdir/plugins"
+
+ENV LD_PRELOAD=""
+ENV NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/plugins
+{% endif %}
+
 {% if target == "runtime" %}
 USER dynamo
 {% endif %}
-
-ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
-CMD []

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -116,10 +116,13 @@ RUN apt-get update -y \
 {% if device == "cuda" %}
 # Install system dependencies
 # Cache dnf downloads; sharing=locked avoids dnf/rpm races with concurrent builds.
+# --setopt=tsflags=nocontexts: skip SELinux file-context labeling. The manylinux
+# image lacks the SELinux policy store that some compute nodes expect; without
+# this flag, dnf fails with "ValueError: SELinux policy is not managed".
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
-    dnf install -y almalinux-release-synergy && \
+    dnf install -y --setopt=tsflags=nocontexts almalinux-release-synergy && \
     dnf config-manager --set-enabled powertools && \
-    dnf install -y \
+    dnf install -y --setopt=tsflags=nocontexts \
         # Autotools (required for UCX, libfabric ./autogen.sh and ./configure)
         autoconf \
         automake \
@@ -273,7 +276,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     apt-get update -y && apt-get install -y build-essential pkg-config xz-utils git yasm; \
     apt-get clean && rm -rf /var/lib/apt/lists/*; \
     elif [ "$DEVICE" = "cuda" ]; then \
-    dnf install -y pkg-config xz git yasm; \
+    dnf install -y --setopt=tsflags=nocontexts pkg-config xz git yasm; \
     fi && \
     # nv-codec-headers: provides the NVENC/NVDEC API headers ffmpeg compiles against.
     # Header-only, no runtime dep here; libcuda/libnvidia-encode are loaded at runtime
@@ -388,6 +391,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
      ldconfig
 
 {% if device == "cuda" %}
+ARG NIXL_LIBFABRIC_REPO
 ARG NIXL_LIBFABRIC_REF
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
     --mount=type=secret,id=aws-role-arn,env=AWS_ROLE_ARN \
@@ -397,7 +401,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         eval $(/tmp/use-sccache.sh setup-env); \
     fi && \
     cd /usr/local/src && \
-    git clone https://github.com/ofiwg/libfabric.git && \
+    git clone "${NIXL_LIBFABRIC_REPO}" && \
     cd libfabric && \
     git checkout $NIXL_LIBFABRIC_REF && \
     ./autogen.sh && \
@@ -417,6 +421,8 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     /tmp/use-sccache.sh show-stats "LIBFABRIC" && \
     echo "/usr/local/libfabric/lib" > /etc/ld.so.conf.d/libfabric.conf && \
     ldconfig
+
+ENV PKG_CONFIG_PATH="/usr/local/libfabric/lib/pkgconfig:${PKG_CONFIG_PATH}"
 {% endif %}
 
 {% if framework == "vllm" and device == "cuda" %}


### PR DESCRIPTION
## Summary
Cherry-pick of two EFA container build fixes from `main` to `release/1.2.1`:

- **#9705** — `build(container): bump nixl_gdrcopy_ref to v2.5.2 (kernel >=6.15 fix)`
- **#9727** — `feat(container): configurable libfabric repo + v2.5.1 overlay for EFA`

Together these fix the Dynamo EFA container build (GDRCopy kernel ≥6.15 compatibility, configurable libfabric repo, and the libfabric v2.5.1 overlay needed for the EFA RDMA path).

## Original PRs
- #9705 — merge commit `fffea8cb4e0916fb35fc8491839cba893353180c`
- #9727 — merge commit `d515c5f8c78cbacdda1e67616cf4836ce0a29968`

## Conflicts resolved
Cherry-pick of #9727 conflicted in two files; resolved as follows:
- `container/context.yaml` — took the incoming side (configurable `nixl_libfabric_repo` + `nixl_libfabric_ref: v2.5.1`); this is the core of the fix.
- `container/templates/wheel_builder.Dockerfile` — combined both sides: kept release branch's `git yasm` (needed for the ffmpeg/libvpx build present on 1.2.x) **and** added #9727's `--setopt=tsflags=nocontexts`.

`#9705` applied cleanly.

## Test plan
- [ ] CI passes
- [ ] EFA container build succeeds (libfabric v2.5.1 + GDRCopy v2.5.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)